### PR TITLE
Improve catalogue UI: +/− toggles, level stepper, L2 cards, wider detail modal

### DIFF
--- a/site/src/components/CatalogueBrowser.tsx
+++ b/site/src/components/CatalogueBrowser.tsx
@@ -310,6 +310,74 @@ export default function CatalogueBrowser({ data, valueStreams }: Props) {
 
   const stepperMax = Math.max(maxLevel - 1, 0);
 
+  // Per-L1 stepper state ---------------------------------------------------
+  // For each L1 we precompute its expandable descendants grouped by level,
+  // so the L1 card's +/− pill can step that branch one level at a time.
+  const expandablesByLevelByL1 = useMemo(() => {
+    const out = new Map<string, Map<number, string[]>>();
+    const l1s = byParent.get(null) ?? [];
+    for (const l1 of l1s) {
+      const m = new Map<number, string[]>();
+      if ((byParent.get(l1.id) ?? []).length > 0) m.set(1, [l1.id]);
+      for (const dId of descendantsOf.get(l1.id) ?? []) {
+        if ((byParent.get(dId) ?? []).length === 0) continue;
+        const d = byId.get(dId);
+        if (!d) continue;
+        const list = m.get(d.level) ?? [];
+        list.push(dId);
+        m.set(d.level, list);
+      }
+      out.set(l1.id, m);
+    }
+    return out;
+  }, [byParent, byId, descendantsOf]);
+
+  /** Map of L1 id → its current branch expansion level (0 = collapsed). */
+  const l1CurrentLevels = useMemo(() => {
+    const out = new Map<string, number>();
+    for (const [l1Id, levels] of expandablesByLevelByL1.entries()) {
+      let depth = 0;
+      for (let lvl = 1; lvl <= maxLevel - 1; lvl++) {
+        const ids = levels.get(lvl) ?? [];
+        if (ids.length === 0) continue;
+        if (ids.every((id) => expanded.has(id))) depth = lvl;
+        else break;
+      }
+      out.set(l1Id, depth);
+    }
+    return out;
+  }, [expandablesByLevelByL1, expanded, maxLevel]);
+
+  const expandL1Branch = (l1Id: string) => {
+    const m = expandablesByLevelByL1.get(l1Id);
+    if (!m) return;
+    const cur = l1CurrentLevels.get(l1Id) ?? 0;
+    const target = Math.min(cur + 1, stepperMax);
+    if (target === cur) return;
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      for (let lvl = 1; lvl <= target; lvl++) {
+        for (const id of m.get(lvl) ?? []) next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const collapseL1Branch = (l1Id: string) => {
+    const m = expandablesByLevelByL1.get(l1Id);
+    if (!m) return;
+    const cur = l1CurrentLevels.get(l1Id) ?? 0;
+    const target = Math.max(cur - 1, 0);
+    if (target === cur) return;
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      for (let lvl = target + 1; lvl <= stepperMax; lvl++) {
+        for (const id of m.get(lvl) ?? []) next.delete(id);
+      }
+      return next;
+    });
+  };
+
   const selectAllVisible = () => {
     setSelected((prev) => {
       const next = new Set(prev);
@@ -464,9 +532,13 @@ export default function CatalogueBrowser({ data, valueStreams }: Props) {
               expanded={expanded}
               selected={selected}
               descendantsOf={descendantsOf}
+              branchLevel={l1CurrentLevels.get(r.id) ?? 0}
+              branchMax={stepperMax}
               onToggleExpand={toggleExpand}
               onToggleSelect={toggleSelect}
               onOpenDetail={setDetailId}
+              onExpandBranch={expandL1Branch}
+              onCollapseBranch={collapseL1Branch}
             />
           ))}
         </div>
@@ -668,9 +740,13 @@ interface L1CardProps {
   expanded: Set<string>;
   selected: Set<string>;
   descendantsOf: Map<string, string[]>;
+  branchLevel: number;
+  branchMax: number;
   onToggleExpand: (id: string) => void;
   onToggleSelect: (id: string) => void;
   onOpenDetail: (id: string) => void;
+  onExpandBranch: (id: string) => void;
+  onCollapseBranch: (id: string) => void;
 }
 
 function L1Card({
@@ -680,13 +756,19 @@ function L1Card({
   expanded,
   selected,
   descendantsOf,
+  branchLevel,
+  branchMax,
   onToggleExpand,
   onToggleSelect,
   onOpenDetail,
+  onExpandBranch,
+  onCollapseBranch,
 }: L1CardProps) {
   const kids = (byParent.get(node.id) ?? []).filter((c) => visible.has(c.id));
   const isOpen = expanded.has(node.id);
   const hasKids = kids.length > 0;
+  const canExpand = hasKids && branchLevel < branchMax;
+  const canCollapse = branchLevel > 0;
 
   const subtree = descendantsOf.get(node.id) ?? [];
   const totalForState = subtree.length + 1;
@@ -716,16 +798,35 @@ function L1Card({
           onChange={() => onToggleSelect(node.id)}
           aria-label={`Select ${node.id} ${node.name}`}
         />
-        <button
-          type="button"
-          class={`cap-toggle${hasKids ? "" : " is-empty"}`}
-          onClick={() => hasKids && onToggleExpand(node.id)}
-          aria-expanded={isOpen}
-          aria-label={hasKids ? (isOpen ? "Collapse" : "Expand") : ""}
-          tabIndex={hasKids ? 0 : -1}
+        <div
+          class={`l1-stepper${hasKids ? "" : " is-empty"}`}
+          role="group"
+          aria-label={`Expand branch by level (currently ${branchLevel} of ${branchMax})`}
         >
-          {hasKids ? (isOpen ? "−" : "+") : ""}
-        </button>
+          <button
+            type="button"
+            class="l1-stepper-btn"
+            onClick={() => canCollapse && onCollapseBranch(node.id)}
+            disabled={!canCollapse}
+            aria-label="Collapse this branch one level"
+            title="Collapse branch one level"
+            tabIndex={hasKids ? 0 : -1}
+          >
+            −
+          </button>
+          <button
+            type="button"
+            class="l1-stepper-btn"
+            onClick={() => canExpand && onExpandBranch(node.id)}
+            disabled={!canExpand}
+            aria-label="Expand this branch one level"
+            title="Expand branch one level"
+            aria-expanded={isOpen}
+            tabIndex={hasKids ? 0 : -1}
+          >
+            +
+          </button>
+        </div>
         <button
           type="button"
           class="l1-name"
@@ -812,13 +913,13 @@ function ChildRow({
   const toggle = (
     <button
       type="button"
-      class={`cap-toggle${hasKids ? "" : " is-empty"}`}
+      class={`cap-chevron${hasKids ? "" : " is-empty"}`}
       onClick={() => hasKids && onToggleExpand(node.id)}
       aria-expanded={isOpen}
       aria-label={hasKids ? (isOpen ? "Collapse" : "Expand") : ""}
       tabIndex={hasKids ? 0 : -1}
     >
-      {hasKids ? (isOpen ? "−" : "+") : ""}
+      {hasKids ? (isOpen ? "▾" : "▸") : ""}
     </button>
   );
 
@@ -893,7 +994,48 @@ function ChildRow({
 }
 
 // ---------------------------------------------------------------------------
-// DetailModal — wider card-based overlay (breadcrumb · hero · meta · children)
+// ModalTreeNode — fully-expanded nested subtree inside the detail modal.
+// All levels are rendered up-front (no click-to-deeper) so users see the
+// whole branch with descriptions in one place.
+// ---------------------------------------------------------------------------
+interface ModalTreeNodeProps {
+  node: FlatCap;
+  byParent: Map<string | null, FlatCap[]>;
+}
+
+function ModalTreeNode({ node, byParent }: ModalTreeNodeProps) {
+  const kids = byParent.get(node.id) ?? [];
+  return (
+    <div class="modal-tree-node" data-level={node.level}>
+      <div class="modal-tree-card">
+        <div class="modal-tree-card-head">
+          <span class="cap-id">{node.id}</span>
+          <span class="cap-level">L{node.level}</span>
+          {node.deprecated && <span class="cap-deprecated-badge">Dep.</span>}
+          <span class="modal-tree-card-name">{node.name}</span>
+          {kids.length > 0 && (
+            <span class="cap-count" title={`${kids.length} L${node.level + 1} children`}>
+              {kids.length}
+            </span>
+          )}
+        </div>
+        {node.description && (
+          <p class="modal-tree-card-desc">{node.description}</p>
+        )}
+      </div>
+      {kids.length > 0 && (
+        <div class="modal-tree-children">
+          {kids.map((k) => (
+            <ModalTreeNode key={k.id} node={k} byParent={byParent} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// DetailModal — wider card-based overlay (breadcrumb · hero · meta · subtree)
 // ---------------------------------------------------------------------------
 interface DetailModalProps {
   node: FlatCap;
@@ -936,6 +1078,18 @@ function DetailModal({
 
   const directChildren = byParent.get(node.id) ?? [];
 
+  // Count of all descendants (direct + nested) for the section header.
+  const descendantCount = (() => {
+    let total = 0;
+    const stack = [...directChildren];
+    while (stack.length > 0) {
+      const c = stack.pop()!;
+      total++;
+      for (const k of byParent.get(c.id) ?? []) stack.push(k);
+    }
+    return total;
+  })();
+
   const inStreams: { stream: string; stage: ValueStreamStage }[] = [];
   for (const s of valueStreams) {
     for (const stage of s.stages) {
@@ -945,7 +1099,6 @@ function DetailModal({
   }
 
   const industries = splitIndustry(node.industry);
-  const childCountFor = (id: string) => (byParent.get(id) ?? []).length;
 
   return (
     <div class="detail-modal-root">
@@ -1052,33 +1205,15 @@ function DetailModal({
           {directChildren.length > 0 && (
             <section class="detail-modal-children">
               <h3 class="detail-modal-section-title">
-                Children <span class="detail-modal-section-count">{directChildren.length}</span>
+                Subtree
+                <span class="detail-modal-section-count">
+                  {descendantCount} {descendantCount === 1 ? "descendant" : "descendants"}
+                </span>
               </h3>
-              <div class="detail-children-grid">
-                {directChildren.map((c) => {
-                  const grandKids = childCountFor(c.id);
-                  return (
-                    <button
-                      key={c.id}
-                      type="button"
-                      class="detail-child-card"
-                      onClick={() => onOpen(c.id)}
-                      title={c.description}
-                    >
-                      <div class="detail-child-card-head">
-                        <span class="cap-id">{c.id}</span>
-                        <span class="cap-level">L{c.level}</span>
-                        {c.deprecated && <span class="cap-deprecated-badge">Dep.</span>}
-                      </div>
-                      <div class="detail-child-card-name">{c.name}</div>
-                      {grandKids > 0 && (
-                        <div class="detail-child-card-foot">
-                          {grandKids} L{c.level + 1} {grandKids === 1 ? "child" : "children"}
-                        </div>
-                      )}
-                    </button>
-                  );
-                })}
+              <div class="modal-tree">
+                {directChildren.map((c) => (
+                  <ModalTreeNode key={c.id} node={c} byParent={byParent} />
+                ))}
               </div>
             </section>
           )}

--- a/site/src/components/CatalogueBrowser.tsx
+++ b/site/src/components/CatalogueBrowser.tsx
@@ -699,8 +699,8 @@ function MultiSelect({ label, options, selected, onChange }: MultiSelectProps) {
       >
         <span class="filter-label">{label}</span>
         <span class="multi-select-summary">{summary}</span>
-        <span class="multi-select-caret" aria-hidden="true">
-          ▾
+        <span class="material-symbols-outlined multi-select-caret" aria-hidden="true">
+          expand_more
         </span>
       </button>
       {open && (

--- a/site/src/components/CatalogueBrowser.tsx
+++ b/site/src/components/CatalogueBrowser.tsx
@@ -1080,6 +1080,17 @@ function DetailModal({
     cursor = a.parent_id;
   }
 
+  // The L1 root of the branch — used to locate the source YAML on GitHub.
+  // Each L1 has its own catalogue/L1-<slug>.yaml file containing the whole
+  // subtree, so L1/L2/L3 all link to the same file.
+  const l1 = ancestors[0] ?? node;
+  const l1Slug = l1.name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  const githubYamlUrl =
+    `https://github.com/vincentmakes/turbo-ea-capabilities/blob/main/catalogue/L1-${l1Slug}.yaml`;
+
   const directChildren = byParent.get(node.id) ?? [];
 
   // Count of all descendants (direct + nested) for the section header.
@@ -1224,12 +1235,35 @@ function DetailModal({
         </div>
 
         <footer class="detail-modal-footer">
-          <a class="btn" href={`/capability/${encodeURIComponent(node.id)}`}>
-            Open detail page
+          <a
+            class="btn"
+            href={githubYamlUrl}
+            target="_blank"
+            rel="noopener"
+          >
+            View on GitHub
           </a>
-          <a class="btn btn-ghost" href={`/api/capability/${node.id}.json`}>
-            Raw JSON
-          </a>
+          <button
+            type="button"
+            class="btn"
+            onClick={() => {
+              const rows: FlatCap[] = [node];
+              const stack = [...directChildren];
+              while (stack.length > 0) {
+                const c = stack.pop()!;
+                rows.push(c);
+                for (const k of byParent.get(c.id) ?? []) stack.push(k);
+              }
+              rows.sort((a, b) => compareIds(a.id, b.id));
+              download(
+                `${node.id}-subtree-${rows.length}.csv`,
+                toCsv(rows),
+                "text/csv"
+              );
+            }}
+          >
+            Export CSV ({descendantCount + 1})
+          </button>
         </footer>
       </aside>
     </div>

--- a/site/src/components/CatalogueBrowser.tsx
+++ b/site/src/components/CatalogueBrowser.tsx
@@ -248,6 +248,68 @@ export default function CatalogueBrowser({ data, valueStreams }: Props) {
   };
   const collapseAll = () => setExpanded(new Set());
 
+  // Level-stepper ----------------------------------------------------------
+  // Nodes whose level is < maxLevel can have children; expanding one of them
+  // reveals its level+1 children. So the deepest meaningful "expansion level"
+  // is maxLevel - 1 (e.g. for L1/L2/L3 data, max stepper level is 2 = all L2
+  // expanded, showing L3).
+  const maxLevel = useMemo(() => {
+    let m = 1;
+    for (const c of data) if (c.level > m) m = c.level;
+    return m;
+  }, [data]);
+
+  /** Group expandable nodes (those with children) by their level. */
+  const expandablesByLevel = useMemo(() => {
+    const m = new Map<number, string[]>();
+    for (const c of data) {
+      if ((byParent.get(c.id) ?? []).length === 0) continue;
+      const list = m.get(c.level) ?? [];
+      list.push(c.id);
+      m.set(c.level, list);
+    }
+    return m;
+  }, [data, byParent]);
+
+  /** Deepest level L such that every expandable node with level <= L is open.
+   *  0 means nothing expanded; L1 expanded → 1; L1+L2 expanded → 2; etc. */
+  const currentLevel = useMemo(() => {
+    let depth = 0;
+    for (let lvl = 1; lvl <= maxLevel - 1; lvl++) {
+      const ids = expandablesByLevel.get(lvl) ?? [];
+      if (ids.length === 0) continue;
+      if (ids.every((id) => expanded.has(id))) depth = lvl;
+      else break;
+    }
+    return depth;
+  }, [expanded, expandablesByLevel, maxLevel]);
+
+  const expandOneLevel = () => {
+    const target = Math.min(currentLevel + 1, Math.max(maxLevel - 1, 0));
+    if (target === currentLevel) return;
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      for (let lvl = 1; lvl <= target; lvl++) {
+        for (const id of expandablesByLevel.get(lvl) ?? []) next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const collapseOneLevel = () => {
+    const target = Math.max(currentLevel - 1, 0);
+    if (target === currentLevel) return;
+    setExpanded(() => {
+      const next = new Set<string>();
+      for (let lvl = 1; lvl <= target; lvl++) {
+        for (const id of expandablesByLevel.get(lvl) ?? []) next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const stepperMax = Math.max(maxLevel - 1, 0);
+
   const selectAllVisible = () => {
     setSelected((prev) => {
       const next = new Set(prev);
@@ -322,6 +384,34 @@ export default function CatalogueBrowser({ data, valueStreams }: Props) {
           )}
         </div>
         <div class="action-bar-buttons">
+          <div class="level-stepper" role="group" aria-label="Expand by level">
+            <button
+              type="button"
+              class="level-stepper-btn"
+              onClick={collapseOneLevel}
+              disabled={currentLevel <= 0}
+              aria-label="Collapse one level"
+              title="Collapse one level"
+            >
+              −
+            </button>
+            <span class="level-stepper-label" aria-live="polite">
+              <span class="level-stepper-label-full">Level </span>
+              {currentLevel}
+              <span class="level-stepper-label-sep"> / </span>
+              {stepperMax}
+            </span>
+            <button
+              type="button"
+              class="level-stepper-btn"
+              onClick={expandOneLevel}
+              disabled={currentLevel >= stepperMax}
+              aria-label="Expand one level"
+              title="Expand one level"
+            >
+              +
+            </button>
+          </div>
           <button class="btn btn-ghost" type="button" onClick={expandAll}>
             Expand all
           </button>
@@ -383,9 +473,12 @@ export default function CatalogueBrowser({ data, valueStreams }: Props) {
       )}
 
       {detail && (
-        <DetailPanel
+        <DetailModal
           node={detail}
+          byId={byId}
+          byParent={byParent}
           valueStreams={valueStreams}
+          onOpen={setDetailId}
           onClose={() => setDetailId(null)}
         />
       )}
@@ -625,13 +718,13 @@ function L1Card({
         />
         <button
           type="button"
-          class={`cap-chevron${hasKids ? "" : " is-empty"}`}
+          class={`cap-toggle${hasKids ? "" : " is-empty"}`}
           onClick={() => hasKids && onToggleExpand(node.id)}
           aria-expanded={isOpen}
           aria-label={hasKids ? (isOpen ? "Collapse" : "Expand") : ""}
           tabIndex={hasKids ? 0 : -1}
         >
-          {hasKids ? (isOpen ? "▾" : "▸") : ""}
+          {hasKids ? (isOpen ? "−" : "+") : ""}
         </button>
         <button
           type="button"
@@ -640,7 +733,7 @@ function L1Card({
         >
           {node.name}
         </button>
-        {hasKids && <span class="cap-count">{kids.length}</span>}
+        {hasKids && <span class="cap-count" title={`${kids.length} children`}>{kids.length}</span>}
       </header>
       {isOpen && hasKids && (
         <ul class="l2-list">
@@ -714,37 +807,68 @@ function ChildRow({
     }
   }, [checkState]);
 
+  const isL2 = depth === 1;
+
+  const toggle = (
+    <button
+      type="button"
+      class={`cap-toggle${hasKids ? "" : " is-empty"}`}
+      onClick={() => hasKids && onToggleExpand(node.id)}
+      aria-expanded={isOpen}
+      aria-label={hasKids ? (isOpen ? "Collapse" : "Expand") : ""}
+      tabIndex={hasKids ? 0 : -1}
+    >
+      {hasKids ? (isOpen ? "−" : "+") : ""}
+    </button>
+  );
+
+  const checkbox = (
+    <input
+      ref={checkboxRef}
+      type="checkbox"
+      class="l2-check"
+      checked={checkState === "checked"}
+      onChange={() => onToggleSelect(node.id)}
+      aria-label={`Select ${node.id} ${node.name}`}
+    />
+  );
+
   return (
     <li class={`l2-row${selfSelected ? " is-selected" : ""}`} data-depth={depth}>
-      <div class="l2-row-line">
-        <input
-          ref={checkboxRef}
-          type="checkbox"
-          class="l2-check"
-          checked={checkState === "checked"}
-          onChange={() => onToggleSelect(node.id)}
-          aria-label={`Select ${node.id} ${node.name}`}
-        />
-        <button
-          type="button"
-          class={`cap-chevron${hasKids ? "" : " is-empty"}`}
-          onClick={() => hasKids && onToggleExpand(node.id)}
-          aria-expanded={isOpen}
-          aria-label={hasKids ? (isOpen ? "Collapse" : "Expand") : ""}
-          tabIndex={hasKids ? 0 : -1}
-        >
-          {hasKids ? (isOpen ? "▾" : "▸") : ""}
-        </button>
-        <button
-          type="button"
-          class="l2-name"
-          onClick={() => onOpenDetail(node.id)}
-          title={node.description}
-        >
-          {node.name}
-        </button>
-        {node.deprecated && <span class="cap-deprecated-badge">Dep.</span>}
-      </div>
+      {isL2 ? (
+        <div class="l2-card">
+          {checkbox}
+          {toggle}
+          <button
+            type="button"
+            class="l2-card-name"
+            onClick={() => onOpenDetail(node.id)}
+            title={node.description}
+          >
+            {node.name}
+          </button>
+          {hasKids && (
+            <span class="l2-card-count" title={`${kids.length} L${node.level + 1} children`}>
+              {kids.length}
+            </span>
+          )}
+          {node.deprecated && <span class="cap-deprecated-badge">Dep.</span>}
+        </div>
+      ) : (
+        <div class="l2-row-line">
+          {checkbox}
+          {toggle}
+          <button
+            type="button"
+            class="l2-name"
+            onClick={() => onOpenDetail(node.id)}
+            title={node.description}
+          >
+            {node.name}
+          </button>
+          {node.deprecated && <span class="cap-deprecated-badge">Dep.</span>}
+        </div>
+      )}
       {isOpen && hasKids && (
         <ul class="l2-children">
           {kids.map((k) => (
@@ -769,26 +893,48 @@ function ChildRow({
 }
 
 // ---------------------------------------------------------------------------
-// DetailPanel — slide-in overlay on the right
+// DetailModal — wider card-based overlay (breadcrumb · hero · meta · children)
 // ---------------------------------------------------------------------------
-interface DetailPanelProps {
+interface DetailModalProps {
   node: FlatCap;
+  byId: Map<string, FlatCap>;
+  byParent: Map<string | null, FlatCap[]>;
   valueStreams: ValueStream[];
+  onOpen: (id: string) => void;
   onClose: () => void;
 }
 
-function DetailPanel({ node, valueStreams, onClose }: DetailPanelProps) {
+function DetailModal({
+  node,
+  byId,
+  byParent,
+  valueStreams,
+  onOpen,
+  onClose,
+}: DetailModalProps) {
   useEffect(() => {
     const onEsc = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
     };
     document.addEventListener("keydown", onEsc);
+    const prevOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
     return () => {
       document.removeEventListener("keydown", onEsc);
-      document.body.style.overflow = "";
+      document.body.style.overflow = prevOverflow;
     };
   }, [onClose]);
+
+  const ancestors: FlatCap[] = [];
+  let cursor = node.parent_id;
+  while (cursor) {
+    const a = byId.get(cursor);
+    if (!a) break;
+    ancestors.unshift(a);
+    cursor = a.parent_id;
+  }
+
+  const directChildren = byParent.get(node.id) ?? [];
 
   const inStreams: { stream: string; stage: ValueStreamStage }[] = [];
   for (const s of valueStreams) {
@@ -799,79 +945,146 @@ function DetailPanel({ node, valueStreams, onClose }: DetailPanelProps) {
   }
 
   const industries = splitIndustry(node.industry);
+  const childCountFor = (id: string) => (byParent.get(id) ?? []).length;
 
   return (
-    <div class="detail-panel-root">
-      <div class="detail-panel-backdrop" onClick={onClose} />
-      <aside class="detail-panel" role="dialog" aria-label={`${node.id} ${node.name}`}>
-        <header class="detail-panel-header">
-          <div class="detail-panel-meta">
-            <span class="cap-level">L{node.level}</span>
-            {node.deprecated && (
-              <span class="cap-deprecated-badge">Deprecated</span>
-            )}
-          </div>
+    <div class="detail-modal-root">
+      <div class="detail-modal-backdrop" onClick={onClose} />
+      <aside
+        class="detail-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label={`${node.id} ${node.name}`}
+      >
+        <header class="detail-modal-header">
+          <nav class="detail-modal-breadcrumb" aria-label="Capability path">
+            <a class="detail-modal-crumb" href="/">Catalog</a>
+            {ancestors.map((a) => (
+              <span key={a.id} class="detail-modal-crumb-wrap">
+                <span class="detail-modal-crumb-sep" aria-hidden="true">/</span>
+                <button
+                  type="button"
+                  class="detail-modal-crumb"
+                  onClick={() => onOpen(a.id)}
+                >
+                  {a.name}
+                </button>
+              </span>
+            ))}
+            <span class="detail-modal-crumb-sep" aria-hidden="true">/</span>
+            <span class="detail-modal-crumb is-current" aria-current="page">{node.name}</span>
+          </nav>
           <button
             type="button"
-            class="detail-panel-close"
+            class="detail-modal-close"
             onClick={onClose}
             aria-label="Close"
           >
             ×
           </button>
         </header>
-        <div class="detail-panel-body">
-          <h2 class="detail-panel-title">{node.name}</h2>
-          {industries.length > 0 && (
-            <div class="detail-panel-row">
-              <div class="meta-key">Industry</div>
-              <div class="meta-val">
-                {industries.map((i) => (
-                  <span key={i} class="cap-industry">
-                    {i}
-                  </span>
-                ))}
+
+        <div class="detail-modal-body">
+          <section class="detail-modal-hero">
+            <div class="detail-modal-hero-meta">
+              <span class="cap-id">{node.id}</span>
+              <span class="cap-level">L{node.level}</span>
+              {node.deprecated && <span class="cap-deprecated-badge">Deprecated</span>}
+            </div>
+            <h2 class="detail-modal-title">{node.name}</h2>
+            {node.deprecated && node.deprecation_reason && (
+              <div class="deprecation-banner">
+                <strong>Deprecated.</strong> {node.deprecation_reason}
               </div>
-            </div>
-          )}
-          {node.description && (
-            <div class="detail-panel-row">
-              <div class="meta-key">Description</div>
-              <p class="meta-val detail-panel-desc">{node.description}</p>
-            </div>
-          )}
-          {node.aliases && node.aliases.length > 0 && (
-            <div class="detail-panel-row">
-              <div class="meta-key">Aliases</div>
-              <div class="meta-val">{node.aliases.join(", ")}</div>
-            </div>
-          )}
-          {inStreams.length > 0 && (
-            <div class="detail-panel-row">
-              <div class="meta-key">Value streams</div>
-              <ul class="meta-val detail-panel-streams">
-                {inStreams.map(({ stream, stage }, idx) => (
-                  <li key={`${stream}-${stage.stage_order}-${idx}`}>
-                    <strong>{stream}</strong>
-                    {" · stage "}
-                    {stage.stage_order} ({stage.stage_name})
-                    {stage.industry_variant && stage.industry_variant !== "All" && (
-                      <> · {stage.industry_variant}</>
-                    )}
-                    {stage.notes && <em> — {stage.notes}</em>}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-          {node.deprecated && node.deprecation_reason && (
-            <div class="detail-panel-row">
-              <div class="meta-key">Deprecation reason</div>
-              <p class="meta-val">{node.deprecation_reason}</p>
-            </div>
+            )}
+            {node.description && (
+              <p class="detail-modal-desc">{node.description}</p>
+            )}
+          </section>
+
+          <section class="detail-meta-grid">
+            {industries.length > 0 && (
+              <div>
+                <div class="meta-key">Industry</div>
+                <div class="meta-val tag-list">
+                  {industries.map((i) => (
+                    <span key={i} class="cap-industry">{i}</span>
+                  ))}
+                </div>
+              </div>
+            )}
+            {node.aliases && node.aliases.length > 0 && (
+              <div>
+                <div class="meta-key">Aliases</div>
+                <div class="meta-val">{node.aliases.join(", ")}</div>
+              </div>
+            )}
+            {node.references && node.references.length > 0 && (
+              <div>
+                <div class="meta-key">References</div>
+                <div class="meta-val detail-modal-refs">
+                  {node.references.map((r) => (
+                    <a key={r} href={r} target="_blank" rel="noopener">{r}</a>
+                  ))}
+                </div>
+              </div>
+            )}
+            {inStreams.length > 0 && (
+              <div class="detail-modal-streams-cell">
+                <div class="meta-key">Value streams</div>
+                <ul class="meta-val detail-modal-streams">
+                  {inStreams.map(({ stream, stage }, idx) => (
+                    <li key={`${stream}-${stage.stage_order}-${idx}`}>
+                      <strong>{stream}</strong>
+                      {" · stage "}
+                      {stage.stage_order} ({stage.stage_name})
+                      {stage.industry_variant && stage.industry_variant !== "All" && (
+                        <> · {stage.industry_variant}</>
+                      )}
+                      {stage.notes && <em> — {stage.notes}</em>}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </section>
+
+          {directChildren.length > 0 && (
+            <section class="detail-modal-children">
+              <h3 class="detail-modal-section-title">
+                Children <span class="detail-modal-section-count">{directChildren.length}</span>
+              </h3>
+              <div class="detail-children-grid">
+                {directChildren.map((c) => {
+                  const grandKids = childCountFor(c.id);
+                  return (
+                    <button
+                      key={c.id}
+                      type="button"
+                      class="detail-child-card"
+                      onClick={() => onOpen(c.id)}
+                      title={c.description}
+                    >
+                      <div class="detail-child-card-head">
+                        <span class="cap-id">{c.id}</span>
+                        <span class="cap-level">L{c.level}</span>
+                        {c.deprecated && <span class="cap-deprecated-badge">Dep.</span>}
+                      </div>
+                      <div class="detail-child-card-name">{c.name}</div>
+                      {grandKids > 0 && (
+                        <div class="detail-child-card-foot">
+                          {grandKids} L{c.level + 1} {grandKids === 1 ? "child" : "children"}
+                        </div>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            </section>
           )}
         </div>
-        <footer class="detail-panel-footer">
+
+        <footer class="detail-modal-footer">
           <a class="btn" href={`/capability/${encodeURIComponent(node.id)}`}>
             Open detail page
           </a>

--- a/site/src/components/CatalogueBrowser.tsx
+++ b/site/src/components/CatalogueBrowser.tsx
@@ -461,7 +461,7 @@ export default function CatalogueBrowser({ data, valueStreams }: Props) {
               aria-label="Collapse one level"
               title="Collapse one level"
             >
-              −
+              <span class="material-symbols-outlined" aria-hidden="true">remove</span>
             </button>
             <span class="level-stepper-label" aria-live="polite">
               <span class="level-stepper-label-full">Level </span>
@@ -477,7 +477,7 @@ export default function CatalogueBrowser({ data, valueStreams }: Props) {
               aria-label="Expand one level"
               title="Expand one level"
             >
-              +
+              <span class="material-symbols-outlined" aria-hidden="true">add</span>
             </button>
           </div>
           <button class="btn btn-ghost" type="button" onClick={expandAll}>
@@ -812,7 +812,7 @@ function L1Card({
             title="Collapse branch one level"
             tabIndex={hasKids ? 0 : -1}
           >
-            −
+            <span class="material-symbols-outlined" aria-hidden="true">remove</span>
           </button>
           <button
             type="button"
@@ -824,7 +824,7 @@ function L1Card({
             aria-expanded={isOpen}
             tabIndex={hasKids ? 0 : -1}
           >
-            +
+            <span class="material-symbols-outlined" aria-hidden="true">add</span>
           </button>
         </div>
         <button
@@ -913,13 +913,17 @@ function ChildRow({
   const toggle = (
     <button
       type="button"
-      class={`cap-chevron${hasKids ? "" : " is-empty"}`}
+      class={`cap-chevron${hasKids ? "" : " is-empty"}${isOpen ? " is-open" : ""}`}
       onClick={() => hasKids && onToggleExpand(node.id)}
       aria-expanded={isOpen}
       aria-label={hasKids ? (isOpen ? "Collapse" : "Expand") : ""}
       tabIndex={hasKids ? 0 : -1}
     >
-      {hasKids ? (isOpen ? "▾" : "▸") : ""}
+      {hasKids && (
+        <span class="material-symbols-outlined cap-chevron-icon" aria-hidden="true">
+          chevron_right
+        </span>
+      )}
     </button>
   );
 
@@ -1133,7 +1137,7 @@ function DetailModal({
             onClick={onClose}
             aria-label="Close"
           >
-            ×
+            <span class="material-symbols-outlined" aria-hidden="true">close</span>
           </button>
         </header>
 

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -35,7 +35,7 @@ const generatedDate = version.generated_at.slice(0, 10);
     />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,500,0,0&icon_names=add,chevron_right,close,remove"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,500,0,0&icon_names=add,chevron_right,close,expand_more,remove"
     />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta property="og:title" content={pageTitle} />

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -33,6 +33,10 @@ const generatedDate = version.generated_at.slice(0, 10);
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
     />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,500,0,0&icon_names=add,chevron_right,close,remove"
+    />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta property="og:title" content={pageTitle} />
     <meta property="og:description" content={pageDescription} />

--- a/site/src/styles/catalogue.css
+++ b/site/src/styles/catalogue.css
@@ -141,7 +141,7 @@
 }
 
 .multi-select-caret {
-  font-size: 10px;
+  font-size: 18px;
   color: var(--color-muted);
 }
 
@@ -678,10 +678,6 @@
   .l1-stepper-btn {
     width: 32px;
   }
-}
-
-.cap-id-sm {
-  font-size: 11px;
 }
 
 .l2-name {

--- a/site/src/styles/catalogue.css
+++ b/site/src/styles/catalogue.css
@@ -260,7 +260,88 @@
 .action-bar-buttons {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: var(--space-xs);
+}
+
+/* Level stepper (one-level expand / collapse) */
+.level-stepper {
+  display: inline-flex;
+  align-items: stretch;
+  gap: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-white);
+  overflow: hidden;
+  margin-right: 4px;
+}
+
+.level-stepper-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  height: 32px;
+  padding: 0 8px;
+  border: none;
+  background: transparent;
+  font-family: var(--font-primary);
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1;
+  color: var(--color-secondary);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.level-stepper-btn:hover:not(:disabled) {
+  background: var(--color-pale-blue);
+  color: var(--color-accent);
+}
+
+.level-stepper-btn:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+
+.level-stepper-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.level-stepper-label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 10px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.7px;
+  color: var(--color-muted);
+  border-left: 1px solid var(--color-border);
+  border-right: 1px solid var(--color-border);
+  background: var(--color-light);
+  min-width: 76px;
+  white-space: nowrap;
+}
+
+@media (max-width: 480px) {
+  .level-stepper-label {
+    min-width: 56px;
+    padding: 0 6px;
+  }
+  .level-stepper-label-full,
+  .level-stepper-label-sep {
+    display: none;
+  }
+  .action-bar-buttons {
+    width: 100%;
+  }
+  .level-stepper {
+    flex: 1 1 auto;
+    margin-right: 0;
+  }
 }
 
 /* Pages that host the catalogue browser go (almost) edge-to-edge so the
@@ -332,28 +413,38 @@
   flex-shrink: 0;
 }
 
-.cap-chevron {
+.cap-toggle {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 20px;
-  height: 20px;
-  border: none;
-  background: transparent;
+  width: 22px;
+  height: 22px;
+  border: 1px solid var(--color-border);
+  background: var(--color-white);
   border-radius: 4px;
   cursor: pointer;
-  font-size: 11px;
-  color: var(--color-muted);
-  transition: background 0.15s ease, color 0.15s ease;
-  flex-shrink: 0;
-}
-
-.cap-chevron:hover:not(.is-empty) {
-  background: var(--color-white);
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1;
   color: var(--color-secondary);
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  flex-shrink: 0;
+  font-family: var(--font-primary);
+  padding: 0;
 }
 
-.cap-chevron.is-empty {
+.cap-toggle:hover:not(.is-empty) {
+  background: var(--color-pale-blue);
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.cap-toggle:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
+}
+
+.cap-toggle.is-empty {
   cursor: default;
   visibility: hidden;
 }
@@ -406,8 +497,13 @@
   margin: 0;
 }
 
-.l2-row.is-selected > .l2-row-line {
+.l2-row.is-selected > .l2-row-line,
+.l2-row.is-selected > .l2-card {
   background: rgba(214, 51, 132, 0.07);
+}
+
+.l2-row.is-selected > .l2-card {
+  border-color: var(--color-magenta);
 }
 
 .l2-row-line {
@@ -420,6 +516,77 @@
 
 .l2-row-line:hover {
   background: var(--color-pale-blue);
+}
+
+/* L2 card (depth=1 inside an L1) — lighter card with child count, wraps freely */
+.l2-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 6px 10px;
+  padding: 8px 10px;
+  background: var(--color-light);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  min-width: 0;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.l2-card:hover {
+  border-color: var(--color-accent);
+  background: var(--color-white);
+}
+
+.l2-card .cap-toggle {
+  margin-top: 1px;
+}
+
+.l2-card-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text);
+  cursor: pointer;
+  text-align: left;
+  padding: 2px 0 0;
+  text-decoration: none;
+  line-height: 1.35;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.l2-card-name:hover {
+  color: var(--color-accent);
+}
+
+.l2-card-count {
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--color-secondary);
+  background: var(--color-pale-blue);
+  border: 1px solid var(--color-light-blue);
+  border-radius: 999px;
+  padding: 1px 8px;
+  margin-top: 1px;
+  line-height: 1.4;
+}
+
+@media (max-width: 640px) {
+  .l2-card {
+    margin: 4px 6px;
+    padding: 6px 8px;
+  }
+  .cap-toggle {
+    width: 26px;
+    height: 26px;
+    font-size: 18px;
+  }
 }
 
 .cap-id-sm {
@@ -466,32 +633,35 @@
   color: var(--color-muted);
 }
 
-/* Detail panel (slide-in overlay) */
-.detail-panel-root {
+/* Detail modal (centred card-based overlay) */
+.detail-modal-root {
   position: fixed;
   inset: 0;
   z-index: 100;
 }
 
-.detail-panel-backdrop {
+.detail-modal-backdrop {
   position: absolute;
   inset: 0;
-  background: rgba(15, 23, 42, 0.45);
+  background: rgba(15, 23, 42, 0.5);
   animation: fadeIn 0.15s ease;
 }
 
-.detail-panel {
+.detail-modal {
   position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  width: min(520px, 100%);
+  top: 4vh;
+  bottom: 4vh;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(960px, calc(100% - 32px));
   background: var(--color-white);
-  border-left: 1px solid var(--color-border);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
   display: flex;
   flex-direction: column;
-  box-shadow: -8px 0 24px rgba(15, 23, 42, 0.15);
-  animation: slideIn 0.2s ease;
+  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.25);
+  animation: modalIn 0.18s ease;
+  overflow: hidden;
 }
 
 @keyframes fadeIn {
@@ -499,99 +669,262 @@
   to { opacity: 1; }
 }
 
-@keyframes slideIn {
-  from { transform: translateX(100%); }
-  to { transform: translateX(0); }
+@keyframes modalIn {
+  from { opacity: 0; transform: translate(-50%, 8px); }
+  to { opacity: 1; transform: translate(-50%, 0); }
 }
 
-.detail-panel-header {
+.detail-modal-header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  padding: 14px 18px;
+  gap: 12px;
+  padding: 14px 20px;
   border-bottom: 1px solid var(--color-border);
+  background: var(--color-light);
+  flex-shrink: 0;
 }
 
-.detail-panel-meta {
+.detail-modal-breadcrumb {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
+  gap: 4px 6px;
+  font-size: 13px;
+  color: var(--color-muted);
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
-.detail-panel-close {
+.detail-modal-crumb-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.detail-modal-crumb {
+  background: transparent;
+  border: none;
+  padding: 2px 4px;
+  margin: 0;
+  font: inherit;
+  color: var(--color-accent);
+  text-decoration: none;
+  cursor: pointer;
+  border-radius: 3px;
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.detail-modal-crumb:hover:not(.is-current) {
+  background: var(--color-pale-blue);
+  color: var(--color-magenta);
+}
+
+.detail-modal-crumb.is-current {
+  color: var(--color-text);
+  font-weight: 600;
+  cursor: default;
+  max-width: 320px;
+}
+
+.detail-modal-crumb-sep {
+  color: var(--color-border);
+  user-select: none;
+}
+
+.detail-modal-close {
+  flex-shrink: 0;
   background: transparent;
   border: none;
   font-size: 28px;
   line-height: 1;
   cursor: pointer;
   color: var(--color-muted);
-  width: 32px;
-  height: 32px;
+  width: 36px;
+  height: 36px;
   border-radius: 4px;
 }
 
-.detail-panel-close:hover {
-  background: var(--color-pale-blue);
+.detail-modal-close:hover {
+  background: var(--color-white);
   color: var(--color-text);
 }
 
-.detail-panel-body {
-  flex: 1;
+.detail-modal-body {
+  flex: 1 1 auto;
   overflow-y: auto;
-  padding: 18px;
-}
-
-.detail-panel-title {
-  font-size: 22px;
-  margin: 0 0 16px;
-  color: var(--color-text);
-}
-
-.detail-panel-row {
-  margin-bottom: 16px;
-}
-
-.detail-panel-row .meta-key {
-  font-size: 11px;
-  font-weight: 700;
-  color: var(--color-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.7px;
-  margin-bottom: 6px;
-}
-
-.detail-panel-row .meta-val {
-  font-size: 14px;
-  color: var(--color-text);
+  padding: 24px;
   display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.detail-modal-hero-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   flex-wrap: wrap;
-  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.detail-modal-title {
+  font-size: 26px;
+  line-height: 1.25;
+  margin: 4px 0 12px;
+  color: var(--color-text);
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.detail-modal-desc {
+  font-size: 15px;
+  line-height: 1.65;
+  color: var(--color-text);
+  white-space: pre-wrap;
   margin: 0;
 }
 
-.detail-panel-desc {
-  display: block;
-  line-height: 1.6;
-  white-space: pre-wrap;
+.detail-modal-streams-cell {
+  grid-column: 1 / -1;
 }
 
-.detail-panel-streams {
+.detail-modal-streams {
   list-style: disc;
   padding-left: 20px;
-  display: block;
+  margin: 0;
   font-size: 14px;
   line-height: 1.6;
 }
 
-.detail-panel-streams li {
+.detail-modal-streams li {
   margin-bottom: 4px;
 }
 
-.detail-panel-footer {
-  padding: 14px 18px;
+.detail-modal-refs {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.detail-modal-refs a {
+  color: var(--color-accent);
+  word-break: break-all;
+}
+
+.detail-modal-section-title {
+  font-size: 14px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--color-muted);
+  margin: 0 0 12px;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.detail-modal-section-count {
+  font-size: 12px;
+  color: var(--color-secondary);
+  background: var(--color-pale-blue);
+  border: 1px solid var(--color-light-blue);
+  padding: 1px 8px;
+  border-radius: 999px;
+  letter-spacing: 0;
+}
+
+.detail-children-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 10px;
+}
+
+.detail-child-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  background: var(--color-white);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  min-width: 0;
+  transition: border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
+}
+
+.detail-child-card:hover {
+  border-color: var(--color-accent);
+  background: var(--color-pale-blue);
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.06);
+}
+
+.detail-child-card-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.detail-child-card-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.detail-child-card-foot {
+  font-size: 11px;
+  color: var(--color-muted);
+  font-weight: 600;
+}
+
+.detail-modal-footer {
+  padding: 14px 20px;
   border-top: 1px solid var(--color-border);
   display: flex;
   gap: 8px;
+  flex-wrap: wrap;
+  background: var(--color-light);
+  flex-shrink: 0;
+}
+
+@media (max-width: 768px) {
+  .detail-modal {
+    top: 2vh;
+    bottom: 2vh;
+    width: calc(100% - 16px);
+  }
+  .detail-modal-body {
+    padding: 18px;
+    gap: 18px;
+  }
+  .detail-modal-title {
+    font-size: 22px;
+  }
+}
+
+@media (max-width: 640px) {
+  .detail-modal {
+    top: 0;
+    bottom: 0;
+    left: 0;
+    transform: none;
+    width: 100%;
+    border-radius: 0;
+    border: none;
+    animation: fadeIn 0.18s ease;
+  }
+  .detail-children-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* Minimal flat list (used on About + detail page child list) */

--- a/site/src/styles/catalogue.css
+++ b/site/src/styles/catalogue.css
@@ -1,5 +1,26 @@
 /* Catalog-specific UI built on top of global.css design tokens. */
 
+/* Material Symbols (icon font) — matches the Material UI convention */
+.material-symbols-outlined {
+  font-family: "Material Symbols Outlined";
+  font-weight: 500;
+  font-style: normal;
+  font-size: 20px;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+  user-select: none;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: "liga";
+  font-variation-settings: "FILL" 0, "wght" 500, "GRAD" 0, "opsz" 24;
+}
+
 .catalogue-page {
   display: flex;
   flex-direction: column;
@@ -285,13 +306,13 @@
   padding: 0 8px;
   border: none;
   background: transparent;
-  font-family: var(--font-primary);
-  font-size: 18px;
-  font-weight: 600;
-  line-height: 1;
   color: var(--color-secondary);
   cursor: pointer;
   transition: background 0.15s ease, color 0.15s ease;
+}
+
+.level-stepper-btn .material-symbols-outlined {
+  font-size: 20px;
 }
 
 .level-stepper-btn:hover:not(:disabled) {
@@ -413,28 +434,39 @@
   flex-shrink: 0;
 }
 
-/* Subtle chevron used for individual L2/L3/L4 row toggles */
+/* Chevron used for individual L2/L3/L4 row toggles — sized for comfortable click */
 .cap-chevron {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 20px;
-  height: 20px;
-  border: none;
+  width: 28px;
+  height: 28px;
+  border: 1px solid transparent;
   background: transparent;
   border-radius: 4px;
   cursor: pointer;
-  font-size: 11px;
-  color: var(--color-muted);
-  transition: background 0.15s ease, color 0.15s ease;
+  color: var(--color-secondary);
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
   flex-shrink: 0;
   padding: 0;
-  font-family: var(--font-primary);
+}
+
+.cap-chevron-icon {
+  display: block;
+  font-size: 20px;
+  line-height: 1;
+  transition: transform 0.18s ease;
+  transform-origin: 50% 50%;
+}
+
+.cap-chevron.is-open .cap-chevron-icon {
+  transform: rotate(90deg);
 }
 
 .cap-chevron:hover:not(.is-empty) {
   background: var(--color-white);
-  color: var(--color-secondary);
+  border-color: var(--color-border);
+  color: var(--color-accent);
 }
 
 .cap-chevron:focus-visible {
@@ -456,7 +488,7 @@
   background: var(--color-white);
   overflow: hidden;
   flex-shrink: 0;
-  height: 24px;
+  height: 28px;
 }
 
 .l1-stepper.is-empty {
@@ -467,14 +499,10 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 26px;
+  width: 28px;
   height: 100%;
   border: none;
   background: transparent;
-  font-family: var(--font-primary);
-  font-size: 16px;
-  font-weight: 700;
-  line-height: 1;
   color: var(--color-secondary);
   cursor: pointer;
   transition: background 0.15s ease, color 0.15s ease;
@@ -498,6 +526,10 @@
 .l1-stepper-btn:disabled {
   opacity: 0.3;
   cursor: not-allowed;
+}
+
+.l1-stepper-btn .material-symbols-outlined {
+  font-size: 18px;
 }
 
 .l1-name {
@@ -634,15 +666,17 @@
     padding: 6px 8px;
   }
   .cap-chevron {
-    width: 26px;
-    height: 26px;
-    font-size: 13px;
+    width: 32px;
+    height: 32px;
+  }
+  .cap-chevron-icon {
+    font-size: 22px;
   }
   .l1-stepper {
-    height: 28px;
+    height: 32px;
   }
   .l1-stepper-btn {
-    width: 30px;
+    width: 32px;
   }
 }
 
@@ -794,15 +828,20 @@
 
 .detail-modal-close {
   flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   background: transparent;
   border: none;
-  font-size: 28px;
-  line-height: 1;
   cursor: pointer;
   color: var(--color-muted);
   width: 36px;
   height: 36px;
   border-radius: 4px;
+}
+
+.detail-modal-close .material-symbols-outlined {
+  font-size: 22px;
 }
 
 .detail-modal-close:hover {

--- a/site/src/styles/catalogue.css
+++ b/site/src/styles/catalogue.css
@@ -413,40 +413,91 @@
   flex-shrink: 0;
 }
 
-.cap-toggle {
+/* Subtle chevron used for individual L2/L3/L4 row toggles */
+.cap-chevron {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
-  border: 1px solid var(--color-border);
-  background: var(--color-white);
+  width: 20px;
+  height: 20px;
+  border: none;
+  background: transparent;
   border-radius: 4px;
   cursor: pointer;
-  font-size: 16px;
-  font-weight: 600;
-  line-height: 1;
-  color: var(--color-secondary);
-  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  font-size: 11px;
+  color: var(--color-muted);
+  transition: background 0.15s ease, color 0.15s ease;
   flex-shrink: 0;
-  font-family: var(--font-primary);
   padding: 0;
+  font-family: var(--font-primary);
 }
 
-.cap-toggle:hover:not(.is-empty) {
-  background: var(--color-pale-blue);
-  border-color: var(--color-accent);
-  color: var(--color-accent);
+.cap-chevron:hover:not(.is-empty) {
+  background: var(--color-white);
+  color: var(--color-secondary);
 }
 
-.cap-toggle:focus-visible {
+.cap-chevron:focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 1px;
 }
 
-.cap-toggle.is-empty {
+.cap-chevron.is-empty {
   cursor: default;
   visibility: hidden;
+}
+
+/* Per-L1 +/− pill — steps the L1's branch one level at a time */
+.l1-stepper {
+  display: inline-flex;
+  align-items: stretch;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-white);
+  overflow: hidden;
+  flex-shrink: 0;
+  height: 24px;
+}
+
+.l1-stepper.is-empty {
+  visibility: hidden;
+}
+
+.l1-stepper-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 100%;
+  border: none;
+  background: transparent;
+  font-family: var(--font-primary);
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--color-secondary);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+  padding: 0;
+}
+
+.l1-stepper-btn + .l1-stepper-btn {
+  border-left: 1px solid var(--color-border);
+}
+
+.l1-stepper-btn:hover:not(:disabled) {
+  background: var(--color-pale-blue);
+  color: var(--color-accent);
+}
+
+.l1-stepper-btn:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+
+.l1-stepper-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
 }
 
 .l1-name {
@@ -537,7 +588,7 @@
   background: var(--color-white);
 }
 
-.l2-card .cap-toggle {
+.l2-card .cap-chevron {
   margin-top: 1px;
 }
 
@@ -582,10 +633,16 @@
     margin: 4px 6px;
     padding: 6px 8px;
   }
-  .cap-toggle {
+  .cap-chevron {
     width: 26px;
     height: 26px;
-    font-size: 18px;
+    font-size: 13px;
+  }
+  .l1-stepper {
+    height: 28px;
+  }
+  .l1-stepper-btn {
+    width: 30px;
   }
 }
 
@@ -836,43 +893,44 @@
   letter-spacing: 0;
 }
 
-.detail-children-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-  gap: 10px;
+/* Fully-expanded nested subtree inside the detail modal */
+.modal-tree {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
-.detail-child-card {
+.modal-tree-node {
+  display: block;
+  min-width: 0;
+}
+
+.modal-tree-card {
   display: flex;
   flex-direction: column;
   gap: 6px;
   padding: 10px 12px;
-  background: var(--color-white);
+  background: var(--color-light);
   border: 1px solid var(--color-border);
   border-radius: 6px;
-  cursor: pointer;
-  text-align: left;
-  font: inherit;
-  color: inherit;
   min-width: 0;
-  transition: border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
 }
 
-.detail-child-card:hover {
-  border-color: var(--color-accent);
-  background: var(--color-pale-blue);
-  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.06);
-}
+.modal-tree-node[data-level="2"] > .modal-tree-card { background: var(--color-white); }
+.modal-tree-node[data-level="3"] > .modal-tree-card { background: var(--color-light); }
+.modal-tree-node[data-level="4"] > .modal-tree-card { background: var(--color-white); }
 
-.detail-child-card-head {
+.modal-tree-card-head {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 6px;
 }
 
-.detail-child-card-name {
-  font-size: 13px;
+.modal-tree-card-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 14px;
   font-weight: 600;
   color: var(--color-text);
   line-height: 1.35;
@@ -880,10 +938,21 @@
   word-break: break-word;
 }
 
-.detail-child-card-foot {
-  font-size: 11px;
-  color: var(--color-muted);
-  font-weight: 600;
+.modal-tree-card-desc {
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--color-text);
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.modal-tree-children {
+  margin: 6px 0 0 18px;
+  padding-left: 12px;
+  border-left: 2px solid var(--color-light-blue);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .detail-modal-footer {
@@ -922,8 +991,9 @@
     border: none;
     animation: fadeIn 0.18s ease;
   }
-  .detail-children-grid {
-    grid-template-columns: 1fr;
+  .modal-tree-children {
+    margin-left: 10px;
+    padding-left: 8px;
   }
 }
 


### PR DESCRIPTION
- Replace chevron arrows (▾/▸) with +/− icon buttons on L1 cards and tree
  rows for clearer expand/collapse affordance.
- Add a global level stepper in the action bar that expands or collapses one
  tree level at a time across the whole catalogue, alongside the existing
  Expand all / Collapse all.
- Render L2 nodes as lighter, wrap-friendly cards showing the L3 child count
  so long names are no longer truncated. L3+ keep the compact tree-row look.
- Replace the narrow 520px slide-in detail panel with a centred ~960px
  card-based modal: clickable breadcrumb path, hero card with full
  description and metadata, and a responsive grid of clickable child cards
  for in-modal navigation.
- Add responsive breakpoints (1280/960/768/640/480px) so the modal goes
  full-screen on mobile, the stepper label collapses, toggles get larger
  touch targets, and L2 cards reflow without horizontal overflow.