### PR TITLE
Normalize value streams to L1-only with auto-expanding UI

### DIFF
--- a/.claude/skills/generate-capability/SKILL.md
+++ b/.claude/skills/generate-capability/SKILL.md
@@ -31,7 +31,8 @@ If a name is ambiguous (substring match against multiple L1s, or a typo), show t
 1. Read **`business-capability-governance-model.md`** §3–§7 (levels, decomposition, naming, identifiers, metadata), §9.4 (lint rules), and §9.8 (reference frameworks — you will both *consult* and possibly *update* this section).
 2. Read **`schema/capability.schema.json`** to confirm the exact YAML shape and required fields.
 3. Read **`catalogue/_index.yaml`** to see all registered L1s.
-4. Identify the target industry. Read **2–3 peer L1s in the same industry** to absorb the local naming style, depth, and description tone. Examples:
+4. Read **`catalogue/_value-streams.yaml`** so you have the existing 24 streams in context for Step 7.5 (value-stream mapping). Skim the canonical + industry-specific stream tables in `.claude/skills/map-value-streams/SKILL.md` Step 2 — they're the cheatsheet you'll use to score fit.
+5. Identify the target industry. Read **2–3 peer L1s in the same industry** to absorb the local naming style, depth, and description tone. Examples:
    - Banking → `L1-banking-customer-management.yaml`, `L1-banking-credit-and-lending-management.yaml`
    - Pharma → `L1-pharmaceutical-manufacturing-management.yaml`, `L1-clinical-trials-management.yaml`
    - Manufacturing → `L1-manufacturing-operations-management.yaml`, `L1-production-planning-management.yaml`
@@ -237,12 +238,40 @@ Also confirm:
 - If Step 1.5 added a §9.8 entry, the new subsection is in alphabetical order, uses the existing format (`**<Standard>** — <one-line scope>.`), and is no longer listed under "Other industry anchors not yet exercised in the catalogue".
 - The new YAML's `references` field cites at least one anchor from the §9.8 entry you just added (otherwise the §9.8 update is dead weight).
 
+## Step 7.5 — Map to existing value streams (skip in Extend mode)
+
+After lint passes, every new L1 should be evaluated against the catalogue's value streams so coverage stays in sync with the capability set. Extending an existing L1 (Extend mode) doesn't change its stream membership, so skip this step.
+
+For each newly written L1:
+
+1. **Score fit against every stream in `catalogue/_value-streams.yaml`.** Use the canonical and industry-specific tables in `.claude/skills/map-value-streams/SKILL.md` Step 2 as the cheatsheet — do not duplicate them here. Apply the same heuristics as `map-value-streams` Step 3 (cross-industry L1s → canonical streams; industry-specific L1s → industry stream first, then canonical).
+2. **Decide stage placement.** For each fitting stream, choose `stage_order` and `stage_name` from the stream's existing stages. If the new L1 fits at a stage that doesn't yet exist, propose a new `stage_name` with the next sensible `stage_order`. Set `industry_variant` only when the L1 is industry-specific *and* the same stage already has a generic equivalent. Write a one-line `notes` per stage entry.
+3. **Flag coverage gaps.** When no existing stream covers the new L1's primary role, emit a Coverage-gap notice (same format used by `map-value-streams`):
+
+   ```
+   Coverage gap: <new L1 name> (<BC-id>)
+     No existing stream covers this capability's primary role of <one-sentence summary>.
+     Suggested new streams:
+       - <Suggested-Name-1> — <one-line rationale>
+       - <Suggested-Name-2> — <alternative framing>
+     Add via /map-value-streams or defer; the L1 is fully usable without a stream mapping.
+   ```
+
+   Limit suggestions to 1–2 names. **Do not draft stages for the suggested streams** — that's a separate, deliberate decision.
+4. **Present one batched proposal**, grouped by stream, in the same table format as `map-value-streams` Step 4. Include any Coverage-gap notices alongside. Ask once for approval; acceptable responses: *approve*, *approve except X*, *redo with Y different*, *skip mapping*.
+5. **On approval**, append the approved stages to `catalogue/_value-streams.yaml` (one entry per fit, dedupe within `stream + stage_order + stage_name + industry_variant`, merge notes with `;` if collapsing). Re-run `npm run lint` to confirm the L1-only rule and reference resolution still pass.
+6. **On skip / decline**, leave `_value-streams.yaml` untouched. Carry any Coverage gaps forward to the Step 8 hand-off so the user has a record.
+
+In **Industry mode**, batch all the new L1s into one proposal table (group by stream, then by L1 within each stream). The user gets one approval covering the whole industry's value-stream wiring.
+
 ## Step 8 — Hand off
 
-After lint passes, suggest the next step using *names* (not IDs):
+After lint passes (and Step 7.5 completed or was skipped), summarise using *names* (not IDs):
 
-- **Industry mode** — *"<N> L1s, <M> L2s, <K> L3s in place for <Industry>. Run `/map-value-streams --industry \"<Industry>\"` to wire all of them into value streams autonomously."*
-- **New L1 / Extend mode** — *"L1 / L2 / L3 in place. Run `/map-value-streams \"<L1 name>\"` to wire this capability into value streams."*
+- **Mappings written** — *"L1 / L2 / L3 in place for `<L1 name>`; mapped to `<N>` stream(s): `<comma-separated names>`. Open a PR; CODEOWNERS for `catalogue/` will be auto-requested."*
+- **Coverage gap logged** — repeat the gap notice from Step 7.5 and recommend either (a) adding a new stream now via a manual edit to `_value-streams.yaml` followed by `/map-value-streams "<L1 name>"`, or (b) merging the L1 first and revisiting the stream gap as a follow-up. Do not block on this.
+- **Mapping skipped** — *"L1 / L2 / L3 in place for `<L1 name>`; value-stream mapping skipped. Run `/map-value-streams \"<L1 name>\"` later when ready."*
+- **Extend mode** — *"L2 / L3 added under `<parent L1 name>`. Validation passed. Existing stream mappings on the parent are unchanged."*
 
 ## Anti-patterns to refuse
 

--- a/.claude/skills/map-value-streams/SKILL.md
+++ b/.claude/skills/map-value-streams/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: map-value-streams
-description: Autonomously propose stages in catalogue/_value-streams.yaml linking L1 capabilities (or all L1s of an industry) to end-to-end value streams. The skill decides which streams apply, picks the anchor L2/L3 for each stage, and presents ONE batched proposal — no per-stage interrogation. The user always speaks in NAMES; the skill resolves names to IDs internally.
+description: Autonomously propose stages in catalogue/_value-streams.yaml linking L1 capabilities (or all L1s of an industry) to end-to-end value streams. Stages map at L1 only; the skill decides which streams apply, flags coverage gaps when no stream fits, and presents ONE batched proposal — no per-stage interrogation. The user always speaks in NAMES; the skill resolves names to IDs internally.
 ---
 
 # map-value-streams
@@ -31,45 +31,71 @@ Only ask the user when:
 The user references capabilities by name; `_value-streams.yaml` stores `capability_id`. Resolve before writing:
 
 1. **L1 names** — read `catalogue/_index.yaml`, then each `L1-*.yaml`, and match the user's input against the top-level `name:` field. L1 names are globally unique.
-2. **L2 / L3 names** — when the user says *"map the KYC capability under Banking Customer Management to Onboard-to-Activate"*, resolve `Banking Customer Management` → its L1 file, then walk `children:` to find an L2 (or L3) named *"KYC & Customer Due Diligence Management"*. Anchor stages at L2 or L3, not L1, because L1s are usually too broad to be a single stage.
-3. **Industry filter** — when given `--industry "<name>"`, scan all L1 files where `industry:` matches (treat the field as `;`-separated) and process each in turn.
-4. If a name is ambiguous, list the closest 3–5 matches and ask the user to pick — do not guess.
-5. Show the resolved name → ID mapping once at the start of Step 4 as confirmation, then refer to capabilities by name everywhere else in the conversation.
+2. **Industry filter** — when given `--industry "<name>"`, scan all L1 files where `industry:` matches (treat the field as `;`-separated) and process each in turn.
+3. If a name is ambiguous, list the closest 3–5 matches and ask the user to pick — do not guess.
+4. Show the resolved name → ID mapping once at the start of Step 4 as confirmation, then refer to capabilities by name everywhere else in the conversation.
+
+Stages reference the **L1 only**. The lint rule (`scripts/lint.ts` `L1_ID_REGEX`) rejects any deeper `capability_id`. Sub-scope (e.g. *AR vs GL within Financial Management*) belongs in the stage's `notes` field, not in a more specific ID.
 
 ## Step 1 — Establish context
 
 1. Read **`catalogue/_value-streams.yaml`** in full to enumerate existing streams and the stages already mapped.
 2. Read **`business-capability-governance-model.md`** §2 (capabilities ≠ value streams) and §9.4 (lint rules).
-3. For each target L1 (resolved from the user's name), read its YAML file under `catalogue/L1-*.yaml` to understand its L2 children — the natural "anchor points" for a stage are usually L2 or L3, not L1 itself.
+3. For each target L1 (resolved from the user's name), read its YAML file under `catalogue/L1-*.yaml` to understand its scope. The value-stream stage references the L1 itself; the site auto-expands to descendants when filtering, so sub-scope detail belongs in `notes`, not in a deeper `capability_id`.
 
 ## Step 2 — Identify candidate streams
 
-Canonical end-to-end streams (use existing names where possible to avoid duplication):
+Authoritative list lives in `catalogue/_value-streams.yaml`; read it at runtime for the source of truth. The tables below summarise the current 24 streams to help you spot fits quickly. Reuse these names exactly — never invent a near-synonym.
 
-| Stream | Typical capabilities exercised |
+Cross-industry streams:
+
+| Stream | Typical L1 anchors |
 | --- | --- |
-| **Hire-to-Retire** | Workforce planning, sourcing, selection, onboarding, performance, exit |
-| **Order-to-Cash** | Demand capture, order management, fulfilment, invoicing, collections |
-| **Procure-to-Pay** | Sourcing, contracting, requisition, receipt, AP, payment |
-| **Plan-to-Produce** *(manufacturing)* | Demand plan, MPS, MRP, work order, shop floor, finished goods |
-| **Idea-to-Market** | Ideation, R&D, design, validation, launch |
-| **Issue-to-Resolution** | Case capture, triage, resolution, knowledge update |
-| **Quote-to-Cash** | Lead, quote, contract, order, invoice, payment |
-| **Record-to-Report** | GL, intercompany, close, consolidation, statutory reporting |
-| **Acquire-to-Retire** *(asset)* | Asset acquisition, deployment, maintenance, disposal |
-| **Forecast-to-Stock** *(supply)* | Demand forecast, replenishment, inventory, fulfilment |
+| **Hire-to-Retire** | BC-300 Human Capital Management; BC-400 Marketing (employer brand only) |
+| **Order-to-Cash** | BC-410 Sales, BC-420 CRM, BC-440 Pricing, BC-200 Financial Management, BC-520 Supply Chain, BC-150 Legal |
+| **Procure-to-Pay** | BC-500 Procurement, BC-510 Supplier Management, BC-200 Financial Management |
+| **Issue-to-Resolution** | BC-140 Audit, BC-430 Customer Service, BC-720 Quality, BC-730 HSE, BC-620 Cybersecurity, BC-830 Knowledge |
+| **Idea-to-Market** | BC-800 Innovation, BC-810 R&D, BC-820 Product Lifecycle, BC-840 IP, BC-400 Marketing, BC-410 Sales |
+| **Plan-to-Inventory** | BC-520 Supply Chain, BC-530 Inventory, BC-1000 Production, BC-230 FP&A |
+| **Record-to-Report** | BC-200 Finance, BC-210 Treasury, BC-220 Tax, BC-230 FP&A, BC-240 Investor Relations, BC-140 Audit, BC-130 Compliance |
+| **Acquire-to-Retire** | BC-1040 Physical Asset, BC-1030 Plant Maintenance, BC-1110 Project Engineering, BC-1160 Commissioning, BC-200 Finance, BC-740 Sustainability |
+| **Strategy-to-Execution** | BC-100 Strategic Management, BC-900 Project Portfolio, BC-910 Change, BC-920 Transformation |
+| **Risk-to-Mitigation** | BC-120 Enterprise Risk, BC-130 Compliance, BC-520 Supply Chain (risk feed) |
+| **Audit-to-Action** | BC-140 Internal Audit |
+| **Threat-to-Mitigation** | BC-620 Cybersecurity, BC-160 Business Continuity, BC-830 Knowledge |
+| **Prospect-to-Customer** | BC-400 Marketing, BC-410 Sales, BC-420 CRM, BC-430 Customer Service, BC-850 Corporate Communications |
+| **Opportunity-to-Order** | BC-410 Sales, BC-420 CRM, BC-440 Pricing, BC-150 Legal |
+| **Maintenance-Request-to-Closure** | BC-1030 Plant Maintenance, BC-1050 Field Service, BC-720 Quality, BC-200 Finance |
+| **Crisis-to-Recovery** | BC-160 Business Continuity, BC-620 Cybersecurity, BC-600 IT, BC-850 Corporate Communications, BC-830 Knowledge, BC-120 Enterprise Risk |
+| **ESG-to-Disclosure** | BC-740 Sustainability, BC-510 Supplier (ratings), BC-610 Information & Data, BC-140 Audit, BC-200 Finance, BC-240 Investor Relations |
+| **Concept-to-Manufacture** | BC-1120 Design, BC-1100 Engineering Discipline, BC-1020 Manufacturing Engineering, BC-820 PLM, BC-1000 Production, BC-1010 Mfg Operations, BC-720 Quality, BC-1130 Engineering Document |
 
-Industry-specific streams (used only when the flow diverges materially from a canonical stream):
+Industry-specific streams (use first when the L1 is industry-specific; canonical streams come second):
 
-| Industry | Streams |
-| --- | --- |
-| Banking | *Apply-to-Fund* (lending), *Trade-to-Settle* (capital markets), *Onboard-to-Activate* (KYC) |
-| Pharma | *Discover-to-Approve* (drug development), *Trial-to-Submission* (clinical), *Adverse-Event-to-Action* (PV) |
-| Defense | *Capture-to-Award* (bid), *Programme-Start-to-Sustainment*, *Mission-Plan-to-Debrief* |
-| ATC | *Flight-Plan-to-Landing*, *Strip-to-Strip*, *Alert-to-Recovery* (SAR) |
-| Engineering Services | *Tender-to-Handover*, *Design-to-Construction* |
+| Industry | Stream | Typical L1 anchors |
+| --- | --- | --- |
+| Banking | **Application-to-Funding** | BC-1320 Credit & Lending, BC-1300 Banking Customer, BC-1400 Financial Crime, BC-1310 Banking Product, BC-1340 Payments, BC-1410 Banking Risk |
+| Pharma | **Discovery-to-Approval** | BC-1500 Drug Discovery, BC-1510 Drug Development, BC-1520 Clinical Trials, BC-1530 Regulatory Affairs, BC-1580 Medical Affairs, BC-1590 Pharma Commercial, BC-1600 Market Access |
+| Pharma | **Adverse-Event-to-Action** | BC-1540 Pharmacovigilance, BC-1580 Medical Affairs, BC-1530 Regulatory Affairs, BC-850 Corporate Comms |
+| Defense | **Capture-to-Contract** | BC-1750 Defense Capture & Bid, BC-1730 Intelligence Ops, BC-1810 Classified Info Sec, BC-1140 Engineering Tendering, BC-1790 Export Control, BC-150 Legal, BC-1760 Defense Programme |
+| Defense | **Sustain-to-Disposition** | BC-1780 Defense Sustainment, BC-1720 Defense Logistics, BC-1060 Spare Parts, BC-1770 Defense Systems Engineering, BC-1800 Defense T&E, BC-1040 Physical Asset, BC-1810 Classified Info Sec |
+| ATC | **Flight-to-Settle** | BC-1230 Aeronautical Information, BC-1210 ATC Ops, BC-1220 ATC Flow, BC-1270 Route Charges, BC-200 Finance |
 
-If no existing or canonical stream fits, propose a new one **with rationale** and confirm with the user before writing.
+### Coverage-gap detection
+
+If a target L1's role is not represented by any of the streams above, do **not** force a fit and do **not** silently invent a new stream. Instead, emit a Coverage-gap notice in this format:
+
+```
+Coverage gap: <L1 name> (<BC-id>)
+  No existing stream covers this capability's primary role of <one-sentence summary>.
+  Suggested new streams:
+    - <Suggested-Name-1> — <one-line rationale: what end-to-end flow it captures>
+    - <Suggested-Name-2> — <alternative framing>
+  Continuing with the streams that do fit. Add a new stream as a follow-up
+  (manual edit to _value-streams.yaml) if the suggestion is right.
+```
+
+Continue with whatever streams *do* fit (often there will be a partial fit even when no stream is the primary one). The user can author the new stream manually or via a follow-up `/map-value-streams` invocation once defined.
 
 ## Step 3 — Decide stages autonomously
 
@@ -77,8 +103,8 @@ For every target L1 (or every L1 in the industry), decide on your own which stre
 
 Heuristics — apply silently, don't ask:
 
-- **Anchor at L2 or L3.** A stream stage is one step. L1s are too broad. Pick the L2 (or L3) child whose scope matches the stage. If multiple children of the same L1 collaborate at a stage, emit multiple entries with the same `stage_order` (this is the documented pattern in existing Hire-to-Retire stages 2/3).
-- **Reuse existing streams** before inventing new ones. Only invent a new stream when no canonical or industry-specific stream in the tables above fits — and then emit it with a one-line rationale alongside the proposal.
+- **Anchor at L1.** Lint enforces L1-only `capability_id`s; sub-scope (e.g. AR vs GL within Financial Management) goes in `notes`. If multiple aspects of the same L1 collaborate at a stage, still emit a single L1 entry and merge the rationale in `notes` with `;` separators (e.g. `"Pay design; Payroll execution"`).
+- **Reuse existing streams** before flagging a gap. Use the Coverage-gap pattern from Step 2 when no stream fits — never invent a new stream silently.
 - **Cross-Industry L1s usually map to canonical streams** (Hire-to-Retire for HR, Order-to-Cash for Sales, Procure-to-Pay for Procurement, Record-to-Report for Financial Management). Don't ask — apply.
 - **Industry-specific L1s map first to industry-specific streams, then to canonical ones if relevant** (Banking Customer Management → Onboard-to-Activate primarily, Issue-to-Resolution secondarily).
 - **`industry_variant` rule** — set it only when the same `stream` / `stage_order` / `stage_name` already has (or will have) a non-variant entry, *and* the capability you're anchoring is industry-specific in a way that diverges from the generic stage. Otherwise skip the field. Never use it just to tag industry.
@@ -99,16 +125,16 @@ Present the **complete proposal in one go**, grouped by stream. Use the capabili
 
 ```
 Stream: Hire-to-Retire
-  stage_order  stage_name             capability                                   industry_variant  notes
-  1            Workforce Planning     Workforce Planning (BC-300.50)                                 Demand planning
-  2            Sourcing & Attraction  Talent Acquisition (BC-300.10)                                 Sourcing
-  3            Selection & Hire       Personnel Security Vetting (BC-1810.10)      Defense           Clearance verification
+  stage_order  stage_name             capability                                  industry_variant  notes
+  1            Workforce Planning     Human Capital Management (BC-300)                             Demand planning
+  2            Sourcing & Attraction  Human Capital Management (BC-300)                             Sourcing
+  3            Selection & Hire       Classified Information Security (BC-1810)   Defense           Clearance verification
   ...
 
-Stream: Onboard-to-Activate (Banking)
-  stage_order  stage_name             capability                                   industry_variant  notes
-  1            Application Capture    Application Capture (BC-1300.10.10)                            Initial intake
-  2            Identity Verification  Identity Verification (BC-1300.10.20)                          KYC docs
+Stream: Application-to-Funding (Banking)
+  stage_order  stage_name             capability                                  industry_variant  notes
+  1            Application Capture    Credit & Lending Management (BC-1320)       Banking           Origination intake
+  2            KYC & Due Diligence    Banking Customer Management (BC-1300)       Banking           KYC / CDD
   ...
 ```
 
@@ -135,6 +161,7 @@ npm run build:api     # rebuilds dist/api/value-streams.json; fails if any refer
 
 If lint fails:
 
+- **Non-L1 capability_id** → the rule (`scripts/lint.ts` `L1_ID_REGEX`) requires L1 only. Truncate to the L1 prefix (e.g. `BC-300.10` → `BC-300`) and move the sub-scope into `notes`.
 - **Unresolved capability_id** → the ID does not exist in the catalogue. Verify against `catalogue/L1-*.yaml`. Do not invent IDs.
 - **YAML parse error** → check indentation and quoting (use `"..."` for names containing `&` or `:`).
 

--- a/catalogue/_value-streams.yaml
+++ b/catalogue/_value-streams.yaml
@@ -1,238 +1,219 @@
 # Value Streams (orthogonal artefact, not part of the capability hierarchy).
-# Each entry links a capability to one stage of an end-to-end flow.
+# Each stage links to an L1 capability; the site auto-expands to descendants
+# when filtering. Use 'notes' to capture sub-scope detail (e.g. "AR sub-capability").
 value_streams:
   - name: Hire-to-Retire
     stages:
       - stage_order: 1
         stage_name: Workforce Planning
-        capability_id: BC-300.50
+        capability_id: BC-300
         notes: Demand planning
       - stage_order: 2
-        stage_name: "Sourcing & Attraction"
-        capability_id: BC-300.10
+        stage_name: Sourcing & Attraction
+        capability_id: BC-300
         notes: Sourcing
       - stage_order: 2
-        stage_name: "Sourcing & Attraction"
-        capability_id: BC-400.20
+        stage_name: Sourcing & Attraction
+        capability_id: BC-400
         notes: Employer brand
       - stage_order: 3
-        stage_name: "Selection & Hire"
-        capability_id: BC-1810.10
+        stage_name: Selection & Hire
+        capability_id: BC-1810
         industry_variant: Defense
         notes: Clearance verification
       - stage_order: 3
-        stage_name: "Selection & Hire"
-        capability_id: BC-300.10
+        stage_name: Selection & Hire
+        capability_id: BC-300
         notes: Selection
       - stage_order: 4
         stage_name: Onboarding
-        capability_id: BC-300.10
-        notes: Onboarding programme
-      - stage_order: 4
-        stage_name: Onboarding
-        capability_id: BC-300.70
-        notes: "Records, payroll setup"
+        capability_id: BC-300
+        notes: Onboarding programme; Records, payroll setup
       - stage_order: 5
-        stage_name: "Performance & Development"
+        stage_name: Performance & Development
         capability_id: BC-1290
         industry_variant: ATC
         notes: ATCO licensing track
       - stage_order: 5
-        stage_name: "Performance & Development"
+        stage_name: Performance & Development
         capability_id: BC-1560
         industry_variant: Pharma
         notes: GxP training records
       - stage_order: 5
-        stage_name: "Performance & Development"
-        capability_id: BC-300.20
-        notes: Performance reviews
-      - stage_order: 5
-        stage_name: "Performance & Development"
-        capability_id: BC-300.40
-        notes: Training
+        stage_name: Performance & Development
+        capability_id: BC-300
+        notes: Performance reviews; Training
       - stage_order: 6
-        stage_name: "Compensation & Benefits Administration"
-        capability_id: BC-300.30
-        notes: Pay design
-      - stage_order: 6
-        stage_name: "Compensation & Benefits Administration"
-        capability_id: BC-300.70
-        notes: Payroll execution
+        stage_name: Compensation & Benefits Administration
+        capability_id: BC-300
+        notes: Pay design; Payroll execution
       - stage_order: 7
-        stage_name: "Employee Experience & Engagement"
-        capability_id: BC-300.60
-        notes: Engagement
-      - stage_order: 7
-        stage_name: "Employee Experience & Engagement"
-        capability_id: BC-300.80
-        notes: "Grievances, works councils"
+        stage_name: Employee Experience & Engagement
+        capability_id: BC-300
+        notes: Engagement; Grievances, works councils
       - stage_order: 8
-        stage_name: "Internal Mobility & Career"
-        capability_id: BC-300.10
-        notes: Internal moves
-      - stage_order: 8
-        stage_name: "Internal Mobility & Career"
-        capability_id: BC-300.20
-        notes: Succession
+        stage_name: Internal Mobility & Career
+        capability_id: BC-300
+        notes: Internal moves; Succession
       - stage_order: 9
-        stage_name: "Offboarding & Alumni"
-        capability_id: BC-300.70
+        stage_name: Offboarding & Alumni
+        capability_id: BC-300
         notes: Separation processing
   - name: Issue-to-Resolution
     stages:
       - stage_order: 1
+        stage_name: Issue Capture (Audit)
+        capability_id: BC-140
+      - stage_order: 1
         stage_name: Issue Capture (Aviation Safety)
-        capability_id: BC-1280.30
+        capability_id: BC-1280
         industry_variant: ATC
       - stage_order: 1
-        stage_name: Issue Capture (Audit)
-        capability_id: BC-140.20
-      - stage_order: 1
         stage_name: Issue Capture (Banking Fin Crime)
-        capability_id: BC-1400.10
+        capability_id: BC-1400
         industry_variant: Banking
       - stage_order: 1
+        stage_name: Issue Capture (Customer)
+        capability_id: BC-430
+      - stage_order: 1
+        stage_name: Issue Capture (Defense Security)
+        capability_id: BC-1810
+        industry_variant: Defense
+      - stage_order: 1
+        stage_name: Issue Capture (HSE)
+        capability_id: BC-730
+      - stage_order: 1
+        stage_name: Issue Capture (IT/Security)
+        capability_id: BC-600
+      - stage_order: 1
+        stage_name: Issue Capture (IT/Security)
+        capability_id: BC-620
+      - stage_order: 1
         stage_name: Issue Capture (Pharma Reg)
-        capability_id: BC-1530.50
+        capability_id: BC-1530
         industry_variant: Pharma
       - stage_order: 1
         stage_name: Issue Capture (Pharmacovigilance)
-        capability_id: BC-1540.10
+        capability_id: BC-1540
         industry_variant: Pharma
-      - stage_order: 1
-        stage_name: Issue Capture (Defense Security)
-        capability_id: BC-1810.40
-        industry_variant: Defense
-      - stage_order: 1
-        stage_name: Issue Capture (Customer)
-        capability_id: BC-430.20
-      - stage_order: 1
-        stage_name: Issue Capture (IT/Security)
-        capability_id: BC-600.30
-      - stage_order: 1
-        stage_name: Issue Capture (IT/Security)
-        capability_id: BC-620.30
       - stage_order: 1
         stage_name: Issue Capture (Quality)
-        capability_id: BC-720.40
-      - stage_order: 1
-        stage_name: Issue Capture (HSE)
-        capability_id: BC-730.40
-      - stage_order: 3
-        stage_name: Investigation (Aviation Safety)
-        capability_id: BC-1280.40
-        industry_variant: ATC
+        capability_id: BC-720
       - stage_order: 3
         stage_name: Investigation (Audit)
-        capability_id: BC-140.20
+        capability_id: BC-140
+      - stage_order: 3
+        stage_name: Investigation (Aviation Safety)
+        capability_id: BC-1280
+        industry_variant: ATC
       - stage_order: 3
         stage_name: Investigation (Banking Fin Crime)
-        capability_id: BC-1400.30
+        capability_id: BC-1400
         industry_variant: Banking
-      - stage_order: 3
-        stage_name: Investigation (Pharmacovigilance)
-        capability_id: BC-1540.20
-        industry_variant: Pharma
-      - stage_order: 3
-        stage_name: Investigation (Pharma Reg)
-        capability_id: BC-1560.40
-        industry_variant: Pharma
-      - stage_order: 3
-        stage_name: Investigation (Defense Security)
-        capability_id: BC-1810.60
-        industry_variant: Defense
       - stage_order: 3
         stage_name: Investigation (Customer)
-        capability_id: BC-430.20
+        capability_id: BC-430
       - stage_order: 3
-        stage_name: Investigation (IT/Security)
-        capability_id: BC-620.30
-      - stage_order: 3
-        stage_name: Investigation (Quality)
-        capability_id: BC-720.40
-        notes: CAPA
+        stage_name: Investigation (Defense Security)
+        capability_id: BC-1810
+        industry_variant: Defense
       - stage_order: 3
         stage_name: Investigation (HSE)
-        capability_id: BC-730.40
-      - stage_order: 4
-        stage_name: Resolution (Aviation Safety)
-        capability_id: BC-1280.20
-        industry_variant: ATC
+        capability_id: BC-730
+      - stage_order: 3
+        stage_name: Investigation (IT/Security)
+        capability_id: BC-620
+      - stage_order: 3
+        stage_name: Investigation (Pharma Reg)
+        capability_id: BC-1560
+        industry_variant: Pharma
+      - stage_order: 3
+        stage_name: Investigation (Pharmacovigilance)
+        capability_id: BC-1540
+        industry_variant: Pharma
+      - stage_order: 3
+        stage_name: Investigation (Quality)
+        capability_id: BC-720
+        notes: CAPA
       - stage_order: 4
         stage_name: Resolution (Audit)
-        capability_id: BC-140.30
+        capability_id: BC-140
+      - stage_order: 4
+        stage_name: Resolution (Aviation Safety)
+        capability_id: BC-1280
+        industry_variant: ATC
       - stage_order: 4
         stage_name: Resolution (Banking Fin Crime)
-        capability_id: BC-1400.40
+        capability_id: BC-1400
         industry_variant: Banking
       - stage_order: 4
-        stage_name: Resolution (Pharmacovigilance)
-        capability_id: BC-1540.40
-        industry_variant: Pharma
-      - stage_order: 4
-        stage_name: Resolution (Pharma Reg)
-        capability_id: BC-1560.50
-        industry_variant: Pharma
-      - stage_order: 4
         stage_name: Resolution (Customer)
-        capability_id: BC-720.50
-      - stage_order: 4
-        stage_name: Resolution (Quality)
-        capability_id: BC-720.50
+        capability_id: BC-720
       - stage_order: 4
         stage_name: Resolution (Customer)
         capability_id: BC-910
+      - stage_order: 4
+        stage_name: Resolution (Pharma Reg)
+        capability_id: BC-1560
+        industry_variant: Pharma
+      - stage_order: 4
+        stage_name: Resolution (Pharmacovigilance)
+        capability_id: BC-1540
+        industry_variant: Pharma
+      - stage_order: 4
+        stage_name: Resolution (Quality)
+        capability_id: BC-720
       - stage_order: 6
         stage_name: Lessons Learned (Aviation Safety)
-        capability_id: BC-1280.60
+        capability_id: BC-1280
         industry_variant: ATC
       - stage_order: 6
+        stage_name: Lessons Learned (Generic)
+        capability_id: BC-830
+      - stage_order: 6
         stage_name: Lessons Learned (Pharma Reg)
-        capability_id: BC-1560.10
+        capability_id: BC-1560
         industry_variant: Pharma
       - stage_order: 6
-        stage_name: Lessons Learned (Generic)
-        capability_id: BC-830.10
-      - stage_order: 6
         stage_name: Lessons Learned (Quality)
-        capability_id: BC-830.40
+        capability_id: BC-830
   - name: Order-to-Cash
     stages:
       - stage_order: 1
-        stage_name: "Lead Capture & Qualification"
-        capability_id: BC-410.30
-        notes: "Lead intake, qualification"
+        stage_name: Lead Capture & Qualification
+        capability_id: BC-410
+        notes: Lead intake, qualification
       - stage_order: 1
-        stage_name: "Lead Capture & Qualification"
-        capability_id: BC-420.10
+        stage_name: Lead Capture & Qualification
+        capability_id: BC-420
         notes: Customer record creation
       - stage_order: 2
-        stage_name: "Quote & Configuration"
-        capability_id: BC-410.40
+        stage_name: Quote & Configuration
+        capability_id: BC-410
         notes: CPQ
       - stage_order: 2
-        stage_name: "Quote & Configuration"
-        capability_id: BC-440.30
+        stage_name: Quote & Configuration
+        capability_id: BC-440
         notes: Pricing application
       - stage_order: 3
-        stage_name: "Contract & Order Capture"
-        capability_id: BC-150.10
-        notes: "Master agreement, T&Cs"
+        stage_name: Contract & Order Capture
+        capability_id: BC-150
+        notes: Master agreement, T&Cs
       - stage_order: 3
-        stage_name: "Contract & Order Capture"
-        capability_id: BC-410.30
+        stage_name: Contract & Order Capture
+        capability_id: BC-410
         notes: Order entry
       - stage_order: 4
-        stage_name: "Order Promising & Allocation"
-        capability_id: BC-520.40
-        notes: "ATP/CTP, allocation"
+        stage_name: Order Promising & Allocation
+        capability_id: BC-520
+        notes: ATP/CTP, allocation
       - stage_order: 4
-        stage_name: "Order Promising & Allocation"
-        capability_id: BC-530.30
+        stage_name: Order Promising & Allocation
+        capability_id: BC-530
         notes: Stock reservation
       - stage_order: 5
         stage_name: Production / Service Delivery
-        capability_id: BC-1000.40
+        capability_id: BC-1000
         industry_variant: Manufacturing
       - stage_order: 5
         stage_name: Production / Service Delivery
@@ -240,7 +221,7 @@ value_streams:
         industry_variant: Manufacturing
       - stage_order: 5
         stage_name: Production / Service Delivery
-        capability_id: BC-1110.20
+        capability_id: BC-1110
         industry_variant: Engineering Services
       - stage_order: 5
         stage_name: Production / Service Delivery
@@ -253,298 +234,238 @@ value_streams:
         notes: Cold-chain variant
       - stage_order: 6
         stage_name: Outbound Logistics
-        capability_id: BC-520.50
+        capability_id: BC-520
         notes: Shipping
       - stage_order: 7
         stage_name: Customer Invoicing
-        capability_id: BC-200.30
+        capability_id: BC-200
         notes: Invoice generation
       - stage_order: 8
-        stage_name: "Cash Collection & Application"
-        capability_id: BC-200.30
+        stage_name: Cash Collection & Application
+        capability_id: BC-200
         notes: Collections
       - stage_order: 8
-        stage_name: "Cash Collection & Application"
-        capability_id: BC-210.10
+        stage_name: Cash Collection & Application
+        capability_id: BC-210
         notes: Cash positioning
       - stage_order: 9
         stage_name: Revenue Recognition
-        capability_id: BC-200.10
-        notes: Revenue posting
-      - stage_order: 9
-        stage_name: Revenue Recognition
-        capability_id: BC-200.60
-        notes: Reporting
+        capability_id: BC-200
+        notes: Revenue posting; Reporting
   - name: Procure-to-Pay
     stages:
       - stage_order: 1
-        stage_name: "Need Identification & Requisition"
-        capability_id: BC-500.40
+        stage_name: Need Identification & Requisition
+        capability_id: BC-500
         notes: Requisition intake
       - stage_order: 2
         stage_name: Sourcing
-        capability_id: BC-500.10
-        notes: "RFx, sourcing events"
-      - stage_order: 2
-        stage_name: Sourcing
-        capability_id: BC-500.50
-        notes: Category strategy
+        capability_id: BC-500
+        notes: RFx, sourcing events; Category strategy
       - stage_order: 3
-        stage_name: "Supplier Selection & Onboarding"
-        capability_id: BC-1560.60
+        stage_name: Supplier Selection & Onboarding
+        capability_id: BC-1560
         industry_variant: Pharma
         notes: GxP supplier qualification
       - stage_order: 3
-        stage_name: "Supplier Selection & Onboarding"
-        capability_id: BC-1810.10
+        stage_name: Supplier Selection & Onboarding
+        capability_id: BC-1810
         industry_variant: Defense
         notes: Cleared subcontractors
       - stage_order: 3
-        stage_name: "Supplier Selection & Onboarding"
-        capability_id: BC-510.10
-        notes: Qualification
-      - stage_order: 3
-        stage_name: "Supplier Selection & Onboarding"
-        capability_id: BC-510.30
-        notes: Pre-award risk check
+        stage_name: Supplier Selection & Onboarding
+        capability_id: BC-510
+        notes: Qualification; Pre-award risk check
       - stage_order: 4
-        stage_name: "Contract & Purchase Order"
-        capability_id: BC-1790.20
+        stage_name: Contract & Purchase Order
+        capability_id: BC-1790
         industry_variant: Defense
         notes: ITAR/EAR screening
       - stage_order: 4
-        stage_name: "Contract & Purchase Order"
-        capability_id: BC-500.20
-        notes: Contracting
-      - stage_order: 4
-        stage_name: "Contract & Purchase Order"
-        capability_id: BC-500.30
-        notes: PO issuance
+        stage_name: Contract & Purchase Order
+        capability_id: BC-500
+        notes: Contracting; PO issuance
       - stage_order: 5
         stage_name: Goods/Services Receipt
-        capability_id: BC-1010.50
+        capability_id: BC-1010
         industry_variant: Manufacturing
       - stage_order: 5
         stage_name: Goods/Services Receipt
-        capability_id: BC-500.40
+        capability_id: BC-500
         notes: GR/SR
       - stage_order: 6
-        stage_name: "Invoice Receipt & Verification"
-        capability_id: BC-200.20
+        stage_name: Invoice Receipt & Verification
+        capability_id: BC-200
         notes: 3-way match
       - stage_order: 7
         stage_name: Payment Execution
-        capability_id: BC-200.20
+        capability_id: BC-200
         notes: Payment run
       - stage_order: 7
         stage_name: Payment Execution
-        capability_id: BC-210.10
+        capability_id: BC-210
         notes: Payment funding
       - stage_order: 8
         stage_name: Reconciliation
-        capability_id: BC-200.10
-        notes: GL posting
-      - stage_order: 8
-        stage_name: Reconciliation
-        capability_id: BC-200.20
-        notes: Vendor account
+        capability_id: BC-200
+        notes: GL posting; Vendor account
       - stage_order: 9
         stage_name: Supplier Performance Monitoring
-        capability_id: BC-510.20
-        notes: Post-transaction loop
-      - stage_order: 9
-        stage_name: Supplier Performance Monitoring
-        capability_id: BC-510.50
-        notes: Strategic suppliers
+        capability_id: BC-510
+        notes: Post-transaction loop; Strategic suppliers
   - name: Idea-to-Market
     stages:
       - stage_order: 1
         stage_name: Idea Capture
-        capability_id: BC-800.10
-        notes: Idea & opportunity intake
-      - stage_order: 1
-        stage_name: Idea Capture
-        capability_id: BC-800.50
-        notes: Open innovation / external sourcing
+        capability_id: BC-800
+        notes: Idea & opportunity intake; Open innovation / external sourcing
       - stage_order: 2
         stage_name: Concept & Feasibility
-        capability_id: BC-800.30
+        capability_id: BC-230
+        notes: Business case
+      - stage_order: 2
+        stage_name: Concept & Feasibility
+        capability_id: BC-800
         notes: Incubation / acceleration
       - stage_order: 2
         stage_name: Concept & Feasibility
-        capability_id: BC-820.10
+        capability_id: BC-820
         notes: Product concept definition
-      - stage_order: 2
-        stage_name: Concept & Feasibility
-        capability_id: BC-230.50
-        notes: Business case
       - stage_order: 3
         stage_name: Research & Prototyping
-        capability_id: BC-810.10
-        notes: Research
-      - stage_order: 3
-        stage_name: Research & Prototyping
-        capability_id: BC-810.30
-        notes: Experimentation & prototyping
-      - stage_order: 3
-        stage_name: Research & Prototyping
-        capability_id: BC-1500.20
+        capability_id: BC-1500
         industry_variant: Pharma
         notes: Hit discovery
+      - stage_order: 3
+        stage_name: Research & Prototyping
+        capability_id: BC-810
+        notes: Research; Experimentation & prototyping
       - stage_order: 4
         stage_name: Portfolio Selection
-        capability_id: BC-800.20
+        capability_id: BC-800
         notes: Innovation portfolio
       - stage_order: 4
         stage_name: Portfolio Selection
-        capability_id: BC-810.40
+        capability_id: BC-810
         notes: R&D portfolio
-      - stage_order: 5
-        stage_name: Design & Development
-        capability_id: BC-820.20
-        notes: Product design
-      - stage_order: 5
-        stage_name: Design & Development
-        capability_id: BC-810.20
-        notes: Applied development
       - stage_order: 5
         stage_name: Design & Development
         capability_id: BC-1510
         industry_variant: Pharma
         notes: Drug development phases
+      - stage_order: 5
+        stage_name: Design & Development
+        capability_id: BC-810
+        notes: Applied development
+      - stage_order: 5
+        stage_name: Design & Development
+        capability_id: BC-820
+        notes: Product design
       - stage_order: 6
         stage_name: IP Protection
         capability_id: BC-840
         notes: Patents, trademarks
       - stage_order: 7
         stage_name: Launch Readiness
-        capability_id: BC-820.50
-        notes: Release & launch
+        capability_id: BC-400
+        notes: Demand generation
       - stage_order: 7
         stage_name: Launch Readiness
-        capability_id: BC-400.40
-        notes: Demand generation
+        capability_id: BC-820
+        notes: Release & launch
       - stage_order: 8
         stage_name: Market Introduction
-        capability_id: BC-410.10
-        notes: Sales strategy / GTM
-      - stage_order: 8
-        stage_name: Market Introduction
-        capability_id: BC-1530.20
+        capability_id: BC-1530
         industry_variant: Pharma
         notes: Regulatory submission & approval
+      - stage_order: 8
+        stage_name: Market Introduction
+        capability_id: BC-410
+        notes: Sales strategy / GTM
       - stage_order: 9
         stage_name: Post-Launch Performance
-        capability_id: BC-820.60
-        notes: Performance & feedback
-      - stage_order: 9
-        stage_name: Post-Launch Performance
-        capability_id: BC-820.70
-        notes: End-of-life planning
+        capability_id: BC-820
+        notes: Performance & feedback; End-of-life planning
   - name: Plan-to-Inventory
     stages:
       - stage_order: 1
         stage_name: Demand Planning
-        capability_id: BC-520.10
-        notes: Statistical forecast + consensus
+        capability_id: BC-400
+        notes: Market intelligence input
       - stage_order: 1
         stage_name: Demand Planning
-        capability_id: BC-400.30
-        notes: Market intelligence input
+        capability_id: BC-520
+        notes: Statistical forecast + consensus
       - stage_order: 2
         stage_name: Supply Planning
-        capability_id: BC-520.20
-        notes: Capacity / material plan
-      - stage_order: 2
-        stage_name: Supply Planning
-        capability_id: BC-1000.20
+        capability_id: BC-1000
         industry_variant: Manufacturing
         notes: Production planning
+      - stage_order: 2
+        stage_name: Supply Planning
+        capability_id: BC-520
+        notes: Capacity / material plan
       - stage_order: 3
         stage_name: S&OP Reconciliation
-        capability_id: BC-520.30
-        notes: Executive S&OP cycle
-      - stage_order: 3
-        stage_name: S&OP Reconciliation
-        capability_id: BC-230.20
+        capability_id: BC-230
         notes: Financial forecast alignment
+      - stage_order: 3
+        stage_name: S&OP Reconciliation
+        capability_id: BC-520
+        notes: Executive S&OP cycle
       - stage_order: 4
         stage_name: Inventory Positioning
-        capability_id: BC-530.10
-        notes: Stock level targets
-      - stage_order: 4
-        stage_name: Inventory Positioning
-        capability_id: BC-530.30
-        notes: Allocation across nodes
+        capability_id: BC-530
+        notes: Stock level targets; Allocation across nodes
       - stage_order: 5
         stage_name: Replenishment Execution
-        capability_id: BC-530.20
+        capability_id: BC-530
         notes: Auto-replenishment triggers
       - stage_order: 6
         stage_name: Inventory Health Monitoring
-        capability_id: BC-530.40
-        notes: Accuracy / cycle counting
-      - stage_order: 6
-        stage_name: Inventory Health Monitoring
-        capability_id: BC-530.50
-        notes: Slow-moving / obsolete review
-      - stage_order: 6
-        stage_name: Inventory Health Monitoring
-        capability_id: BC-520.60
+        capability_id: BC-520
         notes: Supply chain risk
+      - stage_order: 6
+        stage_name: Inventory Health Monitoring
+        capability_id: BC-530
+        notes: Accuracy / cycle counting; Slow-moving / obsolete review
   - name: Record-to-Report
     stages:
       - stage_order: 1
         stage_name: Transaction Capture
-        capability_id: BC-200.10
-        notes: GL posting from sub-ledgers
-      - stage_order: 1
-        stage_name: Transaction Capture
-        capability_id: BC-200.50
-        notes: Cost accounting allocations
+        capability_id: BC-200
+        notes: GL posting from sub-ledgers; Cost accounting allocations
       - stage_order: 2
         stage_name: Sub-Ledger Close
-        capability_id: BC-200.20
-        notes: AP cut-off
-      - stage_order: 2
-        stage_name: Sub-Ledger Close
-        capability_id: BC-200.30
-        notes: AR cut-off
-      - stage_order: 2
-        stage_name: Sub-Ledger Close
-        capability_id: BC-200.40
-        notes: Fixed asset depreciation run
+        capability_id: BC-200
+        notes: AP cut-off; AR cut-off; Fixed asset depreciation run
       - stage_order: 3
         stage_name: Reconciliation & Adjustments
-        capability_id: BC-200.10
+        capability_id: BC-200
         notes: Account reconciliations
       - stage_order: 3
         stage_name: Reconciliation & Adjustments
-        capability_id: BC-210.10
+        capability_id: BC-210
         notes: Bank reconciliation
       - stage_order: 4
         stage_name: Consolidation
-        capability_id: BC-200.60
+        capability_id: BC-200
         notes: Group consolidation
       - stage_order: 4
         stage_name: Consolidation
-        capability_id: BC-220.30
+        capability_id: BC-220
         notes: Transfer pricing adjustments
       - stage_order: 5
         stage_name: Management Reporting
-        capability_id: BC-230.30
-        notes: Internal management pack
-      - stage_order: 5
-        stage_name: Management Reporting
-        capability_id: BC-230.40
-        notes: Variance / performance analysis
+        capability_id: BC-230
+        notes: Internal management pack; Variance / performance analysis
       - stage_order: 6
         stage_name: Statutory & Regulatory Reporting
-        capability_id: BC-200.70
+        capability_id: BC-200
         notes: Statutory filings
       - stage_order: 6
         stage_name: Statutory & Regulatory Reporting
-        capability_id: BC-220.40
+        capability_id: BC-220
         notes: Tax filings
       - stage_order: 6
         stage_name: Statutory & Regulatory Reporting
@@ -552,31 +473,31 @@ value_streams:
         notes: Investor relations disclosures
       - stage_order: 7
         stage_name: Audit & Sign-Off
-        capability_id: BC-140.20
-        notes: Internal audit review
+        capability_id: BC-130
+        notes: Regulatory compliance sign-off
       - stage_order: 7
         stage_name: Audit & Sign-Off
-        capability_id: BC-130.10
-        notes: Regulatory compliance sign-off
+        capability_id: BC-140
+        notes: Internal audit review
   - name: Acquire-to-Retire
     stages:
       - stage_order: 1
         stage_name: Asset Need & Justification
-        capability_id: BC-1040.10
+        capability_id: BC-1040
         notes: Asset strategy / lifecycle plan
       - stage_order: 1
         stage_name: Asset Need & Justification
-        capability_id: BC-230.50
+        capability_id: BC-230
         notes: CAPEX business case
-      - stage_order: 2
-        stage_name: Acquisition
-        capability_id: BC-500.20
-        notes: Capital procurement
       - stage_order: 2
         stage_name: Acquisition
         capability_id: BC-1110
         industry_variant: Engineering Services
         notes: Project engineering for build assets
+      - stage_order: 2
+        stage_name: Acquisition
+        capability_id: BC-500
+        notes: Capital procurement
       - stage_order: 3
         stage_name: Commissioning & Capitalisation
         capability_id: BC-1160
@@ -584,247 +505,215 @@ value_streams:
         notes: Commissioning & handover
       - stage_order: 3
         stage_name: Commissioning & Capitalisation
-        capability_id: BC-200.40
+        capability_id: BC-200
         notes: Capitalisation / fixed asset register
       - stage_order: 4
         stage_name: Operate & Maintain
-        capability_id: BC-1030.20
-        notes: Preventive maintenance
+        capability_id: BC-1030
+        notes: Preventive maintenance; Predictive maintenance
       - stage_order: 4
         stage_name: Operate & Maintain
-        capability_id: BC-1030.40
-        notes: Predictive maintenance
-      - stage_order: 4
-        stage_name: Operate & Maintain
-        capability_id: BC-1040.20
+        capability_id: BC-1040
         notes: Asset performance monitoring
       - stage_order: 5
         stage_name: Risk & Reliability
-        capability_id: BC-1040.30
-        notes: Criticality / risk
-      - stage_order: 5
-        stage_name: Risk & Reliability
-        capability_id: BC-1030.70
+        capability_id: BC-1030
         notes: Reliability engineering
       - stage_order: 5
         stage_name: Risk & Reliability
-        capability_id: BC-1780.30
+        capability_id: BC-1040
+        notes: Criticality / risk
+      - stage_order: 5
+        stage_name: Risk & Reliability
+        capability_id: BC-1780
         industry_variant: Defense
         notes: RAM engineering
       - stage_order: 6
         stage_name: Asset Information Maintenance
-        capability_id: BC-1040.40
+        capability_id: BC-1040
         notes: Asset master data
       - stage_order: 7
         stage_name: Decommissioning & Disposal
-        capability_id: BC-1040.50
+        capability_id: BC-1040
         notes: Decommissioning / disposal
       - stage_order: 7
         stage_name: Decommissioning & Disposal
-        capability_id: BC-740.30
+        capability_id: BC-740
         notes: Circular economy / recycling
   - name: Strategy-to-Execution
     stages:
       - stage_order: 1
         stage_name: Strategy Formulation
-        capability_id: BC-100.10
-        notes: Strategic planning
-      - stage_order: 1
-        stage_name: Strategy Formulation
-        capability_id: BC-100.50
-        notes: Business model design
+        capability_id: BC-100
+        notes: Strategic planning; Business model design
       - stage_order: 2
         stage_name: Portfolio Definition
-        capability_id: BC-100.40
+        capability_id: BC-100
         notes: Strategic portfolio
       - stage_order: 2
         stage_name: Portfolio Definition
-        capability_id: BC-900.10
+        capability_id: BC-900
         notes: Project portfolio prioritisation
       - stage_order: 3
         stage_name: Programme & Project Setup
-        capability_id: BC-900.20
-        notes: Programme establishment
-      - stage_order: 3
-        stage_name: Programme & Project Setup
-        capability_id: BC-900.30
-        notes: Project initiation
+        capability_id: BC-900
+        notes: Programme establishment; Project initiation
       - stage_order: 4
         stage_name: Delivery & Governance
-        capability_id: BC-900.40
-        notes: Project governance
+        capability_id: BC-900
+        notes: Project governance; PMO operations
       - stage_order: 4
         stage_name: Delivery & Governance
-        capability_id: BC-900.50
-        notes: PMO operations
-      - stage_order: 4
-        stage_name: Delivery & Governance
-        capability_id: BC-920.10
+        capability_id: BC-920
         notes: Transformation programme execution
       - stage_order: 5
         stage_name: Change Adoption
-        capability_id: BC-910.20
-        notes: Stakeholder engagement
-      - stage_order: 5
-        stage_name: Change Adoption
-        capability_id: BC-910.30
-        notes: Communications & training
-      - stage_order: 5
-        stage_name: Change Adoption
-        capability_id: BC-910.40
-        notes: Adoption & reinforcement
+        capability_id: BC-910
+        notes: Stakeholder engagement; Communications & training; Adoption & reinforcement
       - stage_order: 6
         stage_name: Benefits Realisation
-        capability_id: BC-920.30
-        notes: Benefits tracking
-      - stage_order: 6
-        stage_name: Benefits Realisation
-        capability_id: BC-100.20
+        capability_id: BC-100
         notes: Strategy execution review
+      - stage_order: 6
+        stage_name: Benefits Realisation
+        capability_id: BC-920
+        notes: Benefits tracking
   - name: Risk-to-Mitigation
     stages:
       - stage_order: 1
         stage_name: Risk Appetite & Framework
-        capability_id: BC-120.10
+        capability_id: BC-120
         notes: Appetite statements
       - stage_order: 2
         stage_name: Risk Identification
-        capability_id: BC-120.20
+        capability_id: BC-120
         notes: Top-down + bottom-up scan
-      - stage_order: 2
-        stage_name: Risk Identification
-        capability_id: BC-520.60
-        notes: Supply chain risk feed
       - stage_order: 2
         stage_name: Risk Identification
         capability_id: BC-1410
         industry_variant: Banking
         notes: Banking risk taxonomy
+      - stage_order: 2
+        stage_name: Risk Identification
+        capability_id: BC-520
+        notes: Supply chain risk feed
       - stage_order: 3
         stage_name: Risk Assessment
-        capability_id: BC-120.20
+        capability_id: BC-120
         notes: Likelihood / impact scoring
       - stage_order: 3
         stage_name: Risk Assessment
-        capability_id: BC-1280.20
+        capability_id: BC-1280
         industry_variant: ATC
         notes: Aviation safety risk assessment
       - stage_order: 4
         stage_name: Treatment & Control Design
-        capability_id: BC-120.30
-        notes: Controls & mitigations
-      - stage_order: 4
-        stage_name: Treatment & Control Design
-        capability_id: BC-120.50
-        notes: Insurance transfer
+        capability_id: BC-120
+        notes: Controls & mitigations; Insurance transfer
       - stage_order: 5
         stage_name: Monitoring
-        capability_id: BC-120.40
+        capability_id: BC-120
         notes: KRIs / dashboards
       - stage_order: 5
         stage_name: Monitoring
-        capability_id: BC-1320.60
+        capability_id: BC-1320
         industry_variant: Banking
         notes: Credit risk modelling
       - stage_order: 6
         stage_name: Reporting & Escalation
-        capability_id: BC-120.40
+        capability_id: BC-120
         notes: Risk reporting to board
       - stage_order: 6
         stage_name: Reporting & Escalation
-        capability_id: BC-130.10
+        capability_id: BC-130
         notes: Regulatory disclosure where required
   - name: Audit-to-Action
     stages:
       - stage_order: 1
         stage_name: Audit Universe & Plan
-        capability_id: BC-140.10
+        capability_id: BC-140
         notes: Risk-based annual plan
       - stage_order: 2
         stage_name: Engagement Scoping
-        capability_id: BC-140.10
+        capability_id: BC-140
         notes: Scope, criteria, resources
       - stage_order: 3
         stage_name: Fieldwork
-        capability_id: BC-140.20
+        capability_id: BC-140
         notes: Testing & evidence
       - stage_order: 3
         stage_name: Fieldwork
-        capability_id: BC-1540.50
+        capability_id: BC-1540
         industry_variant: Pharma
         notes: GxP audit & inspection readiness
       - stage_order: 4
         stage_name: Findings & Reporting
-        capability_id: BC-140.30
+        capability_id: BC-140
         notes: Findings, ratings, report
       - stage_order: 5
         stage_name: Remediation Tracking
-        capability_id: BC-140.30
+        capability_id: BC-140
         notes: Action plan follow-up
       - stage_order: 6
         stage_name: Audit Quality Assurance
-        capability_id: BC-140.40
+        capability_id: BC-140
         notes: QA review & maturation
   - name: Threat-to-Mitigation
     stages:
       - stage_order: 1
         stage_name: Security Posture Definition
-        capability_id: BC-620.10
-        notes: Strategy & governance
-      - stage_order: 1
-        stage_name: Security Posture Definition
-        capability_id: BC-620.50
-        notes: Reference architecture
-      - stage_order: 2
-        stage_name: Threat Intelligence
-        capability_id: BC-620.30
-        notes: Threat feeds & intel
+        capability_id: BC-620
+        notes: Strategy & governance; Reference architecture
       - stage_order: 2
         stage_name: Threat Intelligence
         capability_id: BC-1740
         industry_variant: Defense
         notes: Cyber operations intel
+      - stage_order: 2
+        stage_name: Threat Intelligence
+        capability_id: BC-620
+        notes: Threat feeds & intel
       - stage_order: 3
         stage_name: Vulnerability Discovery
-        capability_id: BC-620.40
+        capability_id: BC-620
         notes: Scanning, pen test, bug bounty
       - stage_order: 4
         stage_name: Detection
-        capability_id: BC-620.30
+        capability_id: BC-620
         notes: SIEM / SOC monitoring
       - stage_order: 5
         stage_name: Incident Response
-        capability_id: BC-620.30
-        notes: Containment & eradication
+        capability_id: BC-160
+        notes: Disaster recovery activation
       - stage_order: 5
         stage_name: Incident Response
-        capability_id: BC-160.20
-        notes: Disaster recovery activation
+        capability_id: BC-620
+        notes: Containment & eradication
       - stage_order: 6
         stage_name: Identity & Access Hardening
-        capability_id: BC-620.20
+        capability_id: BC-620
         notes: IAM tightening
       - stage_order: 7
         stage_name: Awareness & Lessons Learned
-        capability_id: BC-620.60
+        capability_id: BC-620
         notes: Awareness campaigns
       - stage_order: 7
         stage_name: Awareness & Lessons Learned
-        capability_id: BC-830.40
+        capability_id: BC-830
         notes: Best-practice capture
   - name: Prospect-to-Customer
     stages:
       - stage_order: 1
         stage_name: Market & Segment Strategy
-        capability_id: BC-400.10
+        capability_id: BC-400
         notes: Marketing strategy
       - stage_order: 1
         stage_name: Market & Segment Strategy
-        capability_id: BC-420.20
+        capability_id: BC-420
         notes: Customer segmentation
       - stage_order: 2
         stage_name: Brand & Positioning
-        capability_id: BC-400.20
+        capability_id: BC-400
         notes: Brand management
       - stage_order: 2
         stage_name: Brand & Positioning
@@ -832,82 +721,69 @@ value_streams:
         notes: Corporate communications
       - stage_order: 3
         stage_name: Demand Generation
-        capability_id: BC-400.40
-        notes: Campaigns, content syndication
-      - stage_order: 3
-        stage_name: Demand Generation
-        capability_id: BC-400.60
-        notes: Digital marketing
-      - stage_order: 3
-        stage_name: Demand Generation
-        capability_id: BC-400.70
-        notes: Content marketing
+        capability_id: BC-400
+        notes: Campaigns, content syndication; Digital marketing; Content marketing
       - stage_order: 4
         stage_name: Lead Capture & Nurture
-        capability_id: BC-400.50
+        capability_id: BC-400
         notes: Marketing operations / MarOps
       - stage_order: 4
         stage_name: Lead Capture & Nurture
-        capability_id: BC-410.30
+        capability_id: BC-410
         notes: Pipeline handoff
       - stage_order: 5
         stage_name: Conversion
-        capability_id: BC-410.40
-        notes: Quote / CPQ
-      - stage_order: 5
-        stage_name: Conversion
-        capability_id: BC-1300.10
+        capability_id: BC-1300
         industry_variant: Banking
         notes: Customer onboarding
+      - stage_order: 5
+        stage_name: Conversion
+        capability_id: BC-410
+        notes: Quote / CPQ
       - stage_order: 6
         stage_name: Customer Onboarding
-        capability_id: BC-420.30
-        notes: Customer lifecycle activation
-      - stage_order: 6
-        stage_name: Customer Onboarding
-        capability_id: BC-1300.20
+        capability_id: BC-1300
         industry_variant: Banking
         notes: KYC & due diligence
+      - stage_order: 6
+        stage_name: Customer Onboarding
+        capability_id: BC-420
+        notes: Customer lifecycle activation
       - stage_order: 7
         stage_name: Retention & Advocacy
-        capability_id: BC-420.40
+        capability_id: BC-420
         notes: Loyalty & retention
       - stage_order: 7
         stage_name: Retention & Advocacy
-        capability_id: BC-430.50
+        capability_id: BC-430
         notes: Customer feedback loop
   - name: Application-to-Funding
     stages:
       - stage_order: 1
         stage_name: Application Capture
-        capability_id: BC-1320.10
-        industry_variant: Banking
-        notes: Origination intake
-      - stage_order: 1
-        stage_name: Application Capture
-        capability_id: BC-1300.50
+        capability_id: BC-1300
         industry_variant: Banking
         notes: Channel intake (digital, branch)
+      - stage_order: 1
+        stage_name: Application Capture
+        capability_id: BC-1320
+        industry_variant: Banking
+        notes: Origination intake
       - stage_order: 2
         stage_name: KYC & Due Diligence
-        capability_id: BC-1300.20
+        capability_id: BC-1300
         industry_variant: Banking
         notes: KYC / CDD
       - stage_order: 2
         stage_name: KYC & Due Diligence
-        capability_id: BC-1400.20
+        capability_id: BC-1400
         industry_variant: Banking
         notes: Sanctions screening
       - stage_order: 3
         stage_name: Underwriting & Decisioning
-        capability_id: BC-1320.20
+        capability_id: BC-1320
         industry_variant: Banking
-        notes: Credit decisioning
-      - stage_order: 3
-        stage_name: Underwriting & Decisioning
-        capability_id: BC-1320.60
-        industry_variant: Banking
-        notes: Credit risk model scoring
+        notes: Credit decisioning; Credit risk model scoring
       - stage_order: 4
         stage_name: Pricing & Offer
         capability_id: BC-1310
@@ -915,40 +791,30 @@ value_streams:
         notes: Banking product configuration
       - stage_order: 4
         stage_name: Pricing & Offer
-        capability_id: BC-440.30
+        capability_id: BC-440
         notes: Discount / promotional pricing
       - stage_order: 5
         stage_name: Documentation & Booking
-        capability_id: BC-150.10
-        notes: Loan agreement drafting
-      - stage_order: 5
-        stage_name: Documentation & Booking
-        capability_id: BC-1320.30
+        capability_id: BC-1320
         industry_variant: Banking
         notes: Loan booking
+      - stage_order: 5
+        stage_name: Documentation & Booking
+        capability_id: BC-150
+        notes: Loan agreement drafting
       - stage_order: 6
         stage_name: Disbursement
-        capability_id: BC-1340.10
+        capability_id: BC-1340
         industry_variant: Banking
-        notes: Payment initiation
-      - stage_order: 6
-        stage_name: Disbursement
-        capability_id: BC-1340.20
-        industry_variant: Banking
-        notes: Payment processing
+        notes: Payment initiation; Payment processing
       - stage_order: 7
         stage_name: Servicing & Collections
-        capability_id: BC-1320.30
+        capability_id: BC-1320
         industry_variant: Banking
-        notes: Loan servicing
-      - stage_order: 7
-        stage_name: Servicing & Collections
-        capability_id: BC-1320.40
-        industry_variant: Banking
-        notes: Collections & recoveries
+        notes: Loan servicing; Collections & recoveries
       - stage_order: 8
         stage_name: Portfolio Monitoring
-        capability_id: BC-1320.50
+        capability_id: BC-1320
         industry_variant: Banking
         notes: Loan portfolio health
       - stage_order: 8
@@ -960,99 +826,49 @@ value_streams:
     stages:
       - stage_order: 1
         stage_name: Target Discovery
-        capability_id: BC-1500.10
+        capability_id: BC-1500
         industry_variant: Pharma
         notes: Target identification & validation
       - stage_order: 2
         stage_name: Hit & Lead Discovery
-        capability_id: BC-1500.20
+        capability_id: BC-1500
         industry_variant: Pharma
-        notes: Hit discovery
-      - stage_order: 2
-        stage_name: Hit & Lead Discovery
-        capability_id: BC-1500.30
-        industry_variant: Pharma
-        notes: Lead optimisation
+        notes: Hit discovery; Lead optimisation
       - stage_order: 3
         stage_name: Pre-Clinical Development
-        capability_id: BC-1500.40
+        capability_id: BC-1500
         industry_variant: Pharma
         notes: Candidate selection
       - stage_order: 3
         stage_name: Pre-Clinical Development
-        capability_id: BC-1510.10
+        capability_id: BC-1510
         industry_variant: Pharma
-        notes: Pre-clinical studies
-      - stage_order: 3
-        stage_name: Pre-Clinical Development
-        capability_id: BC-1510.60
-        industry_variant: Pharma
-        notes: CMC development
+        notes: Pre-clinical studies; CMC development
       - stage_order: 4
         stage_name: Clinical Trial Design
-        capability_id: BC-1520.10
+        capability_id: BC-1520
         industry_variant: Pharma
         notes: Protocol design
       - stage_order: 4
         stage_name: Clinical Trial Design
-        capability_id: BC-1530.10
+        capability_id: BC-1530
         industry_variant: Pharma
         notes: Regulatory strategy
       - stage_order: 5
         stage_name: Clinical Trials Execution
-        capability_id: BC-1520.20
+        capability_id: BC-1520
         industry_variant: Pharma
-        notes: Site management
-      - stage_order: 5
-        stage_name: Clinical Trials Execution
-        capability_id: BC-1520.30
-        industry_variant: Pharma
-        notes: Subject management
-      - stage_order: 5
-        stage_name: Clinical Trials Execution
-        capability_id: BC-1520.40
-        industry_variant: Pharma
-        notes: Clinical data management
-      - stage_order: 5
-        stage_name: Clinical Trials Execution
-        capability_id: BC-1520.60
-        industry_variant: Pharma
-        notes: Trial supply
+        notes: Site management; Subject management; Clinical data management; Trial supply
       - stage_order: 6
         stage_name: Phase Progression
-        capability_id: BC-1510.20
+        capability_id: BC-1510
         industry_variant: Pharma
-        notes: Phase I
-      - stage_order: 6
-        stage_name: Phase Progression
-        capability_id: BC-1510.30
-        industry_variant: Pharma
-        notes: Phase II
-      - stage_order: 6
-        stage_name: Phase Progression
-        capability_id: BC-1510.40
-        industry_variant: Pharma
-        notes: Phase III
+        notes: Phase I; Phase II; Phase III
       - stage_order: 7
         stage_name: Regulatory Submission
-        capability_id: BC-1530.20
+        capability_id: BC-1530
         industry_variant: Pharma
-        notes: NDA / MAA submission
-      - stage_order: 7
-        stage_name: Regulatory Submission
-        capability_id: BC-1530.50
-        industry_variant: Pharma
-        notes: Agency interaction
-      - stage_order: 7
-        stage_name: Regulatory Submission
-        capability_id: BC-1530.60
-        industry_variant: Pharma
-        notes: Labelling
-      - stage_order: 8
-        stage_name: Approval & Launch Readiness
-        capability_id: BC-1600
-        industry_variant: Pharma
-        notes: Market access & reimbursement
+        notes: NDA / MAA submission; Agency interaction; Labelling
       - stage_order: 8
         stage_name: Approval & Launch Readiness
         capability_id: BC-1580
@@ -1063,26 +879,31 @@ value_streams:
         capability_id: BC-1590
         industry_variant: Pharma
         notes: Commercial readiness
+      - stage_order: 8
+        stage_name: Approval & Launch Readiness
+        capability_id: BC-1600
+        industry_variant: Pharma
+        notes: Market access & reimbursement
       - stage_order: 9
         stage_name: Post-Marketing Surveillance
-        capability_id: BC-1510.50
+        capability_id: BC-1510
         industry_variant: Pharma
         notes: Phase IV
       - stage_order: 9
         stage_name: Post-Marketing Surveillance
-        capability_id: BC-1530.40
+        capability_id: BC-1530
         industry_variant: Pharma
         notes: Lifecycle maintenance
   - name: Adverse-Event-to-Action
     stages:
       - stage_order: 1
         stage_name: Case Intake
-        capability_id: BC-1540.10
+        capability_id: BC-1540
         industry_variant: Pharma
         notes: Adverse event capture
       - stage_order: 2
         stage_name: Case Triage & Coding
-        capability_id: BC-1540.10
+        capability_id: BC-1540
         industry_variant: Pharma
         notes: MedDRA coding, seriousness assessment
       - stage_order: 3
@@ -1092,27 +913,27 @@ value_streams:
         notes: Medical affairs review
       - stage_order: 4
         stage_name: Signal Detection
-        capability_id: BC-1540.20
+        capability_id: BC-1540
         industry_variant: Pharma
         notes: Signal detection & evaluation
       - stage_order: 5
         stage_name: Risk Assessment & RMP Update
-        capability_id: BC-1540.40
+        capability_id: BC-1540
         industry_variant: Pharma
         notes: Risk management plan
       - stage_order: 6
         stage_name: Regulatory Reporting
-        capability_id: BC-1540.30
-        industry_variant: Pharma
-        notes: Periodic safety reports
-      - stage_order: 6
-        stage_name: Regulatory Reporting
-        capability_id: BC-1530.50
+        capability_id: BC-1530
         industry_variant: Pharma
         notes: Agency notification
+      - stage_order: 6
+        stage_name: Regulatory Reporting
+        capability_id: BC-1540
+        industry_variant: Pharma
+        notes: Periodic safety reports
       - stage_order: 7
         stage_name: Label & Communication Updates
-        capability_id: BC-1530.60
+        capability_id: BC-1530
         industry_variant: Pharma
         notes: Labelling change
       - stage_order: 7
@@ -1121,29 +942,29 @@ value_streams:
         notes: Stakeholder communications
       - stage_order: 8
         stage_name: Audit & Inspection Readiness
-        capability_id: BC-1540.50
+        capability_id: BC-1540
         industry_variant: Pharma
         notes: PV audit
   - name: Capture-to-Contract
     stages:
       - stage_order: 1
         stage_name: Customer Intelligence
-        capability_id: BC-1750.20
-        industry_variant: Defense
-        notes: Defense customer intel
-      - stage_order: 1
-        stage_name: Customer Intelligence
         capability_id: BC-1730
         industry_variant: Defense
         notes: Intelligence operations input
+      - stage_order: 1
+        stage_name: Customer Intelligence
+        capability_id: BC-1750
+        industry_variant: Defense
+        notes: Defense customer intel
       - stage_order: 2
         stage_name: Capture Strategy
-        capability_id: BC-1750.10
+        capability_id: BC-1750
         industry_variant: Defense
         notes: Capture management
       - stage_order: 3
         stage_name: Teaming & Subcontracting
-        capability_id: BC-1750.50
+        capability_id: BC-1750
         industry_variant: Defense
         notes: Teaming strategy
       - stage_order: 3
@@ -1153,14 +974,9 @@ value_streams:
         notes: Cleared subcontractor vetting
       - stage_order: 4
         stage_name: Bid & Proposal
-        capability_id: BC-1750.30
+        capability_id: BC-1750
         industry_variant: Defense
-        notes: Bid management
-      - stage_order: 4
-        stage_name: Bid & Proposal
-        capability_id: BC-1750.40
-        industry_variant: Defense
-        notes: Proposal development
+        notes: Bid management; Proposal development
       - stage_order: 5
         stage_name: Pricing & Cost Estimation
         capability_id: BC-1140
@@ -1168,20 +984,20 @@ value_streams:
         notes: Tendering & estimation
       - stage_order: 5
         stage_name: Pricing & Cost Estimation
-        capability_id: BC-440.10
+        capability_id: BC-440
         notes: Pricing strategy
+      - stage_order: 6
+        stage_name: Compliance & Export Review
+        capability_id: BC-130
+        notes: Regulatory compliance
       - stage_order: 6
         stage_name: Compliance & Export Review
         capability_id: BC-1790
         industry_variant: Defense
         notes: ITAR / EAR / export control
-      - stage_order: 6
-        stage_name: Compliance & Export Review
-        capability_id: BC-130.10
-        notes: Regulatory compliance
       - stage_order: 7
         stage_name: Contract Negotiation & Award
-        capability_id: BC-150.10
+        capability_id: BC-150
         notes: Contract negotiation
       - stage_order: 7
         stage_name: Contract Negotiation & Award
@@ -1192,46 +1008,41 @@ value_streams:
     stages:
       - stage_order: 1
         stage_name: Sustainment Planning
-        capability_id: BC-1780.10
+        capability_id: BC-1780
         industry_variant: Defense
-        notes: In-service support plan
-      - stage_order: 1
-        stage_name: Sustainment Planning
-        capability_id: BC-1780.30
-        industry_variant: Defense
-        notes: RAM engineering
-      - stage_order: 2
-        stage_name: Operate & Maintain
-        capability_id: BC-1780.20
-        industry_variant: Defense
-        notes: Depot maintenance
+        notes: In-service support plan; RAM engineering
       - stage_order: 2
         stage_name: Operate & Maintain
         capability_id: BC-1720
         industry_variant: Defense
         notes: Defense logistics
-      - stage_order: 3
-        stage_name: Spares & Repairs
-        capability_id: BC-1780.40
+      - stage_order: 2
+        stage_name: Operate & Maintain
+        capability_id: BC-1780
         industry_variant: Defense
-        notes: Spares & repair pipeline
+        notes: Depot maintenance
       - stage_order: 3
         stage_name: Spares & Repairs
         capability_id: BC-1060
         notes: Aftermarket parts
+      - stage_order: 3
+        stage_name: Spares & Repairs
+        capability_id: BC-1780
+        industry_variant: Defense
+        notes: Spares & repair pipeline
       - stage_order: 4
         stage_name: Technical Documentation
-        capability_id: BC-1780.50
+        capability_id: BC-1780
         industry_variant: Defense
         notes: Technical publications
       - stage_order: 5
         stage_name: Obsolescence Management
-        capability_id: BC-1780.60
+        capability_id: BC-1780
         industry_variant: Defense
         notes: DMSMS / obsolescence
       - stage_order: 6
         stage_name: Capability Upgrades
-        capability_id: BC-1770.50
+        capability_id: BC-1770
         industry_variant: Defense
         notes: Configuration management
       - stage_order: 6
@@ -1241,7 +1052,7 @@ value_streams:
         notes: Test & evaluation
       - stage_order: 7
         stage_name: Disposal & Disposition
-        capability_id: BC-1040.50
+        capability_id: BC-1040
         notes: Decommissioning
       - stage_order: 7
         stage_name: Disposal & Disposition
@@ -1257,7 +1068,7 @@ value_streams:
         notes: Aeronautical information / flight plan
       - stage_order: 2
         stage_name: Flight Operations
-        capability_id: BC-1210.10
+        capability_id: BC-1210
         industry_variant: ATC
         notes: En-route control
       - stage_order: 2
@@ -1267,118 +1078,113 @@ value_streams:
         notes: Flow management
       - stage_order: 3
         stage_name: Charge Determination
-        capability_id: BC-1270.10
+        capability_id: BC-1270
         industry_variant: ATC
-        notes: Charging zone resolution
-      - stage_order: 3
-        stage_name: Charge Determination
-        capability_id: BC-1270.20
-        industry_variant: ATC
-        notes: Route charge calculation
+        notes: Charging zone resolution; Route charge calculation
       - stage_order: 4
         stage_name: Invoicing
-        capability_id: BC-1270.40
+        capability_id: BC-1270
         industry_variant: ATC
         notes: Airline billing
       - stage_order: 4
         stage_name: Invoicing
-        capability_id: BC-200.30
+        capability_id: BC-200
         notes: AR processing
       - stage_order: 5
         stage_name: Collection
-        capability_id: BC-1270.30
+        capability_id: BC-1270
         industry_variant: ATC
         notes: Charges collection
       - stage_order: 6
         stage_name: Reconciliation & Reporting
-        capability_id: BC-1270.50
+        capability_id: BC-1270
         industry_variant: ATC
         notes: Charges reporting
       - stage_order: 6
         stage_name: Reconciliation & Reporting
-        capability_id: BC-200.10
+        capability_id: BC-200
         notes: GL posting
   - name: Maintenance-Request-to-Closure
     stages:
       - stage_order: 1
         stage_name: Notification / Request
-        capability_id: BC-1030.30
+        capability_id: BC-1030
         industry_variant: Manufacturing
         notes: Corrective maintenance notification
       - stage_order: 1
         stage_name: Notification / Request
-        capability_id: BC-1050.10
+        capability_id: BC-1050
         notes: Service request (field)
       - stage_order: 2
         stage_name: Triage & Planning
-        capability_id: BC-1030.50
+        capability_id: BC-1030
         industry_variant: Manufacturing
         notes: Maintenance work order planning
       - stage_order: 2
         stage_name: Triage & Planning
-        capability_id: BC-1050.20
+        capability_id: BC-1050
         notes: Dispatch & scheduling
       - stage_order: 3
         stage_name: Execution
-        capability_id: BC-1030.30
+        capability_id: BC-1030
         industry_variant: Manufacturing
         notes: Corrective maintenance execution
       - stage_order: 3
         stage_name: Execution
-        capability_id: BC-1050.30
+        capability_id: BC-1050
         notes: Field service execution
       - stage_order: 4
         stage_name: Parts & Logistics
-        capability_id: BC-1030.60
+        capability_id: BC-1030
         industry_variant: Manufacturing
         notes: Maintenance spares
       - stage_order: 4
         stage_name: Parts & Logistics
-        capability_id: BC-1050.40
+        capability_id: BC-1050
         notes: Service parts
       - stage_order: 5
         stage_name: Verification & Closure
-        capability_id: BC-720.30
-        notes: Quality control sign-off
-      - stage_order: 5
-        stage_name: Verification & Closure
-        capability_id: BC-1030.70
+        capability_id: BC-1030
         industry_variant: Manufacturing
         notes: Reliability data update
+      - stage_order: 5
+        stage_name: Verification & Closure
+        capability_id: BC-720
+        notes: Quality control sign-off
       - stage_order: 6
         stage_name: Performance & Cost Analysis
-        capability_id: BC-1050.60
+        capability_id: BC-1050
         notes: Field service KPIs
       - stage_order: 6
         stage_name: Performance & Cost Analysis
-        capability_id: BC-200.50
+        capability_id: BC-200
         notes: Maintenance cost posting
   - name: Crisis-to-Recovery
     stages:
       - stage_order: 1
         stage_name: Continuity Planning
-        capability_id: BC-160.10
+        capability_id: BC-160
         notes: BIA & continuity plans
       - stage_order: 2
         stage_name: Resilience Testing
-        capability_id: BC-160.40
-        notes: Exercises & drills
-      - stage_order: 2
-        stage_name: Resilience Testing
-        capability_id: BC-1280.50
+        capability_id: BC-1280
         industry_variant: ATC
         notes: Aviation safety performance drills
+      - stage_order: 2
+        stage_name: Resilience Testing
+        capability_id: BC-160
+        notes: Exercises & drills
       - stage_order: 3
         stage_name: Detection & Activation
-        capability_id: BC-160.30
+        capability_id: BC-160
         notes: Crisis declaration
       - stage_order: 3
         stage_name: Detection & Activation
-        capability_id: BC-620.30
+        capability_id: BC-620
         notes: Cyber incident trigger
       - stage_order: 4
         stage_name: Crisis Response
-        capability_id: BC-160.30
+        capability_id: BC-160
         notes: Crisis management cell
       - stage_order: 4
         stage_name: Crisis Response
@@ -1386,109 +1192,101 @@ value_streams:
         notes: Crisis communications
       - stage_order: 5
         stage_name: Disaster Recovery
-        capability_id: BC-160.20
+        capability_id: BC-160
         notes: IT/site DR
       - stage_order: 5
         stage_name: Disaster Recovery
-        capability_id: BC-600.40
+        capability_id: BC-600
         notes: IT operations failover
       - stage_order: 6
         stage_name: Restoration
-        capability_id: BC-1030.30
+        capability_id: BC-1030
         industry_variant: Manufacturing
         notes: Asset / line restart
       - stage_order: 7
         stage_name: Post-Crisis Review
-        capability_id: BC-830.40
-        notes: Lessons learned
+        capability_id: BC-120
+        notes: Risk reassessment
       - stage_order: 7
         stage_name: Post-Crisis Review
-        capability_id: BC-120.20
-        notes: Risk reassessment
+        capability_id: BC-830
+        notes: Lessons learned
   - name: ESG-to-Disclosure
     stages:
       - stage_order: 1
         stage_name: ESG Strategy & Materiality
-        capability_id: BC-740.10
+        capability_id: BC-740
         notes: ESG strategy & materiality
       - stage_order: 2
         stage_name: Data Collection
-        capability_id: BC-740.20
-        notes: Emissions / energy data
-      - stage_order: 2
-        stage_name: Data Collection
-        capability_id: BC-740.30
-        notes: Circular economy metrics
-      - stage_order: 2
-        stage_name: Data Collection
-        capability_id: BC-740.40
-        notes: Sustainable sourcing data
-      - stage_order: 2
-        stage_name: Data Collection
-        capability_id: BC-510.20
+        capability_id: BC-510
         notes: Supplier sustainability ratings
+      - stage_order: 2
+        stage_name: Data Collection
+        capability_id: BC-740
+        notes: Emissions / energy data; Circular economy metrics; Sustainable sourcing data
       - stage_order: 3
         stage_name: Data Quality & Assurance
-        capability_id: BC-610.30
-        notes: Data quality controls
-      - stage_order: 3
-        stage_name: Data Quality & Assurance
-        capability_id: BC-140.20
+        capability_id: BC-140
         notes: Internal assurance
+      - stage_order: 3
+        stage_name: Data Quality & Assurance
+        capability_id: BC-610
+        notes: Data quality controls
       - stage_order: 4
         stage_name: Reporting & Disclosure
-        capability_id: BC-740.10
-        notes: Sustainability report
-      - stage_order: 4
-        stage_name: Reporting & Disclosure
-        capability_id: BC-200.70
+        capability_id: BC-200
         notes: Statutory ESG filings
-      - stage_order: 5
-        stage_name: Stakeholder Engagement
-        capability_id: BC-740.50
-        notes: Investor / NGO engagement
+      - stage_order: 4
+        stage_name: Reporting & Disclosure
+        capability_id: BC-740
+        notes: Sustainability report
       - stage_order: 5
         stage_name: Stakeholder Engagement
         capability_id: BC-240
         notes: Investor relations briefings
+      - stage_order: 5
+        stage_name: Stakeholder Engagement
+        capability_id: BC-740
+        notes: Investor / NGO engagement
       - stage_order: 6
         stage_name: Improvement Targets
-        capability_id: BC-100.20
+        capability_id: BC-100
         notes: Strategy execution feedback
   - name: Concept-to-Manufacture
     stages:
       - stage_order: 1
         stage_name: Concept Design
-        capability_id: BC-1120.10
+        capability_id: BC-1120
         industry_variant: Engineering Services
         notes: Conceptual design
       - stage_order: 2
         stage_name: FEED & Specification
-        capability_id: BC-1120.20
+        capability_id: BC-1120
         industry_variant: Engineering Services
         notes: Front-end engineering design
       - stage_order: 2
         stage_name: FEED & Specification
-        capability_id: BC-820.30
+        capability_id: BC-820
         notes: Product specification
-      - stage_order: 3
-        stage_name: Detailed Design
-        capability_id: BC-1120.30
-        industry_variant: Engineering Services
-        notes: Detailed design
       - stage_order: 3
         stage_name: Detailed Design
         capability_id: BC-1100
         industry_variant: Engineering Services
         notes: Multi-discipline engineering
+      - stage_order: 3
+        stage_name: Detailed Design
+        capability_id: BC-1120
+        industry_variant: Engineering Services
+        notes: Detailed design
       - stage_order: 4
         stage_name: Design Review
-        capability_id: BC-1120.40
+        capability_id: BC-1120
         industry_variant: Engineering Services
         notes: Verification & validation
       - stage_order: 4
         stage_name: Design Review
-        capability_id: BC-1770.40
+        capability_id: BC-1770
         industry_variant: Defense
         notes: Defense V&V
       - stage_order: 5
@@ -1498,27 +1296,27 @@ value_streams:
         notes: Process design / industrialisation
       - stage_order: 5
         stage_name: Manufacturing Engineering
-        capability_id: BC-820.40
+        capability_id: BC-820
         notes: Configuration / variants
       - stage_order: 6
         stage_name: Production Ramp-Up
-        capability_id: BC-1000.20
+        capability_id: BC-1000
         industry_variant: Manufacturing
         notes: Production planning
       - stage_order: 6
         stage_name: Production Ramp-Up
-        capability_id: BC-1010.20
+        capability_id: BC-1010
         industry_variant: Manufacturing
         notes: Shop floor execution
       - stage_order: 7
         stage_name: Quality & Yield Stabilisation
-        capability_id: BC-720.30
-        notes: QC ramp-up
-      - stage_order: 7
-        stage_name: Quality & Yield Stabilisation
-        capability_id: BC-1000.50
+        capability_id: BC-1000
         industry_variant: Manufacturing
         notes: Production performance
+      - stage_order: 7
+        stage_name: Quality & Yield Stabilisation
+        capability_id: BC-720
+        notes: QC ramp-up
       - stage_order: 8
         stage_name: Configuration Baseline
         capability_id: BC-1130
@@ -1526,27 +1324,19 @@ value_streams:
         notes: Engineering document control
       - stage_order: 8
         stage_name: Configuration Baseline
-        capability_id: BC-1770.50
+        capability_id: BC-1770
         industry_variant: Defense
         notes: Configuration management
   - name: Opportunity-to-Order
     stages:
       - stage_order: 1
         stage_name: Opportunity Qualification
-        capability_id: BC-410.30
-        notes: BANT/MEDDIC qualification
+        capability_id: BC-410
+        notes: BANT/MEDDIC qualification; Account ownership
       - stage_order: 1
         stage_name: Opportunity Qualification
-        capability_id: BC-410.20
-        notes: Account ownership
-      - stage_order: 1
-        stage_name: Opportunity Qualification
-        capability_id: BC-420.10
+        capability_id: BC-420
         notes: Customer record lookup
-      - stage_order: 2
-        stage_name: Solution Scoping
-        capability_id: BC-410.30
-        notes: Solution design within opportunity
       - stage_order: 2
         stage_name: Solution Scoping
         capability_id: BC-1110
@@ -1559,68 +1349,60 @@ value_streams:
         notes: Tendering & estimation
       - stage_order: 2
         stage_name: Solution Scoping
-        capability_id: BC-1750.10
+        capability_id: BC-1750
         industry_variant: Defense
         notes: Capture management
+      - stage_order: 2
+        stage_name: Solution Scoping
+        capability_id: BC-410
+        notes: Solution design within opportunity
       - stage_order: 3
-        stage_name: "Quote & Configuration"
-        capability_id: BC-410.40
+        stage_name: Quote & Configuration
+        capability_id: BC-410
         notes: CPQ
       - stage_order: 3
-        stage_name: "Quote & Configuration"
-        capability_id: BC-440.20
+        stage_name: Quote & Configuration
+        capability_id: BC-440
         notes: Price list application
       - stage_order: 4
-        stage_name: "Pricing & Approvals"
-        capability_id: BC-440.10
-        notes: Pricing strategy / deal desk
-      - stage_order: 4
-        stage_name: "Pricing & Approvals"
-        capability_id: BC-440.30
-        notes: Discount & promotional pricing
-      - stage_order: 4
-        stage_name: "Pricing & Approvals"
-        capability_id: BC-440.40
-        notes: Price realisation / exception approval
+        stage_name: Pricing & Approvals
+        capability_id: BC-440
+        notes: Pricing strategy / deal desk; Discount & promotional pricing; Price realisation / exception approval
       - stage_order: 5
         stage_name: Proposal Development
-        capability_id: BC-410.30
-        notes: Proposal authoring
-      - stage_order: 5
-        stage_name: Proposal Development
-        capability_id: BC-1750.40
+        capability_id: BC-1750
         industry_variant: Defense
         notes: Defense proposal
+      - stage_order: 5
+        stage_name: Proposal Development
+        capability_id: BC-410
+        notes: Proposal authoring
       - stage_order: 6
         stage_name: Negotiation
-        capability_id: BC-410.20
-        notes: Executive negotiation
-      - stage_order: 6
-        stage_name: Negotiation
-        capability_id: BC-150.10
+        capability_id: BC-150
         notes: Legal terms negotiation
       - stage_order: 6
         stage_name: Negotiation
-        capability_id: BC-1750.30
+        capability_id: BC-1750
         industry_variant: Defense
         notes: Bid management & negotiation
+      - stage_order: 6
+        stage_name: Negotiation
+        capability_id: BC-410
+        notes: Executive negotiation
       - stage_order: 7
-        stage_name: "Contract & Order Booking"
-        capability_id: BC-150.10
+        stage_name: Contract & Order Booking
+        capability_id: BC-150
         notes: Master agreement execution
       - stage_order: 7
-        stage_name: "Contract & Order Booking"
-        capability_id: BC-410.30
+        stage_name: Contract & Order Booking
+        capability_id: BC-410
         notes: Order entry
       - stage_order: 8
         stage_name: Handover to Fulfilment
-        capability_id: BC-410.50
-        notes: Sales-to-delivery handover
+        capability_id: BC-410
+        notes: Sales-to-delivery handover; Sales performance / commission booking
       - stage_order: 8
         stage_name: Handover to Fulfilment
-        capability_id: BC-420.30
+        capability_id: BC-420
         notes: Customer lifecycle activation
-      - stage_order: 8
-        stage_name: Handover to Fulfilment
-        capability_id: BC-410.70
-        notes: Sales performance / commission booking

--- a/scripts/lint.ts
+++ b/scripts/lint.ts
@@ -18,10 +18,13 @@ import {
   l1Slug,
   listYamlFiles,
   loadL1File,
+  loadValueStreams,
   readIndex,
   type FlatCapability,
   type RawCapability,
 } from "./lib/load.ts";
+
+const L1_ID_REGEX = /^BC-\d+$/;
 
 interface LintError {
   file: string;
@@ -182,6 +185,32 @@ for (const { file, node } of allFlat) {
       file,
       `id ${node.id}: successor_id '${node.successor_id}' does not resolve to any catalogue node`
     );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 11. Value streams: stage capability_id must be L1, must resolve.
+// Sub-scope detail belongs in the 'notes' field; the site auto-expands an L1
+// to its descendants when filtering.
+// ---------------------------------------------------------------------------
+const l1Set = new Set(
+  allFlat.filter(({ node }) => node.level === 1).map(({ node }) => node.id)
+);
+for (const stream of loadValueStreams()) {
+  for (const stage of stream.stages) {
+    const id = stage.capability_id;
+    if (!L1_ID_REGEX.test(id)) {
+      err(
+        "_value-streams.yaml",
+        `Stream '${stream.name}' / stage '${stage.stage_name}': capability_id ${id} is not L1. ` +
+          `Use the L1 (e.g. ${id.split(".")[0]}) and put sub-scope in 'notes'.`
+      );
+    } else if (!l1Set.has(id)) {
+      err(
+        "_value-streams.yaml",
+        `Stream '${stream.name}' / stage '${stage.stage_name}': L1 ${id} not found in catalogue`
+      );
+    }
   }
 }
 

--- a/site/src/components/CatalogueBrowser.tsx
+++ b/site/src/components/CatalogueBrowser.tsx
@@ -152,18 +152,28 @@ export default function CatalogueBrowser({ data, valueStreams }: Props) {
     [valueStreams]
   );
 
-  /** capabilityId → set of value-stream names containing it. */
+  /**
+   * capabilityId → set of value-stream names containing it.
+   * Stages map to L1 capability_ids; this index expands each stage to the
+   * full subtree so any descendant is matched by the stream filter.
+   */
   const valueStreamsByCapability = useMemo(() => {
     const map = new Map<string, Set<string>>();
+    const add = (id: string, name: string) => {
+      const set = map.get(id) ?? new Set<string>();
+      set.add(name);
+      map.set(id, set);
+    };
     for (const stream of valueStreams) {
       for (const stage of stream.stages) {
-        const set = map.get(stage.capability_id) ?? new Set<string>();
-        set.add(stream.name);
-        map.set(stage.capability_id, set);
+        add(stage.capability_id, stream.name);
+        for (const d of descendantsOf.get(stage.capability_id) ?? []) {
+          add(d, stream.name);
+        }
       }
     }
     return map;
-  }, [valueStreams]);
+  }, [valueStreams, descendantsOf]);
 
   // Filters / state --------------------------------------------------------
   const [query, setQuery] = useState("");
@@ -1108,8 +1118,12 @@ function DetailModal({
   const inStreams: { stream: string; stage: ValueStreamStage }[] = [];
   for (const s of valueStreams) {
     for (const stage of s.stages) {
-      if (stage.capability_id === node.id)
+      if (
+        stage.capability_id === node.id ||
+        node.id.startsWith(stage.capability_id + ".")
+      ) {
         inStreams.push({ stream: s.name, stage });
+      }
     }
   }
 


### PR DESCRIPTION
Stages now reference only L1 capability_ids (e.g. BC-410 not BC-410.30). The site filter and detail panel walk the L1 subtree, so every L2/L3/L4 descendant of a mapped L1 is treated as belonging to the value stream.

Why: L1 names/IDs are stable, deeper IDs churn. Granular mapping was brittle and inconsistent across streams. Sub-scope detail (e.g. "AR sub-capability" inside BC-200) lives in the 'notes' field instead, where it can't be invalidated by a child rename.

Changes:
- catalogue/_value-streams.yaml: 368 → 317 stages (51 collapsed via dedup on stage_order + stage_name + capability_id + industry_variant; merged notes joined with "; ").
- scripts/lint.ts: new rule rejects any value-stream capability_id that is not L1 (^BC-\d+$) or doesn't resolve to an existing L1.
- site/src/components/CatalogueBrowser.tsx: stream filter index and DetailPanel match a capability if it equals or descends from a stage's L1 id, so filtering by a stream highlights the full subtree.

https://claude.ai/code/session_011iAm5Fg9ZueVtwmYehc3SN