### PR TITLE
docs(governance): add Insurance subsection to §9.8 reference frameworks

### DIFF
--- a/business-capability-governance-model.md
+++ b/business-capability-governance-model.md
@@ -484,10 +484,20 @@ Where an industry reference framework exists, anchor the upper levels (L1 / L2) 
 - **IPMVP / ASHRAE Guideline 14** — measurement & verification of energy savings.
 - **EU EPBD, LEED, BREEAM, WELL, CIBSE Guides** — building energy regulation, green and wellness certifications, and services engineering guidance.
 
+**Insurance**
+
+- **ACORD (Reference Architecture, ACORD XML, ACORD AL3)** — insurance data and messaging standards.
+- **Solvency II (EU Directive 2009/138/EC) and NAIC RBC** — insurance capital adequacy and risk-based supervision.
+- **IFRS 17 / IFRS 9 (insurance contracts and financial instruments)** — insurance accounting and disclosure.
+- **IAIS Insurance Core Principles (ICPs) and ComFrame** — international supervisory and IAIG standards.
+- **ISO 31000** — risk management.
+- **Lloyd's Market Standards (ECF, Coverholder Atlas, Delegated Authority)** — London market practice.
+- **IDD (EU Directive 2016/97), NAIC Model Laws, and US state insurance regulations** — distribution and conduct.
+- **GDPR and HIPAA (where applicable)** — privacy and personal-data protection across underwriting and claims.
+
 **Other industry anchors not yet exercised in the catalogue but recommended for adoption**
 
 - **eTOM** — telecommunications.
-- **ACORD** — insurance.
 
 These references describe *what* organisations in a given industry typically do — useful as a starting point, but they must still be adapted to the enterprise's own context and re-expressed in conformant noun-phrase form where necessary. Citing a framework does not exempt a node from §5 (naming) or §4 (decomposition) — frameworks inform the *shape* of the model, not the *form* of its names.
 

--- a/catalogue/L1-actuarial-management.yaml
+++ b/catalogue/L1-actuarial-management.yaml
@@ -1,0 +1,216 @@
+# Actuarial Management
+id: BC-2180
+name: Actuarial Management
+level: 1
+industry: Insurance
+description: |
+  Pricing models, reserving, experience studies, capital and solvency
+  modelling, IFRS 17 actuarial reporting support, and catastrophe modelling.
+references:
+  - https://www.acord.org/standards/reference-architecture
+  - https://www.eiopa.europa.eu/regulation-supervision/insurance/solvency-ii_en
+  - https://www.ifrs.org/issued-standards/list-of-standards/ifrs-17-insurance-contracts/
+children:
+  - id: BC-2180.10
+    name: Pricing Actuarial Management
+    level: 2
+    industry: Insurance
+    description: |
+      Loss-cost modelling, pricing adequacy analysis, rate indication, and filed-rate documentation support.
+    children:
+      - id: BC-2180.10.10
+        name: Loss Cost Modelling
+        level: 3
+        industry: Insurance
+        description: |
+          Modelling of loss costs by segment, peril, and coverage.
+        children: []
+      - id: BC-2180.10.20
+        name: Pricing Adequacy Analysis
+        level: 3
+        industry: Insurance
+        description: |
+          Analysis of pricing adequacy against expected losses and expense loads.
+        children: []
+      - id: BC-2180.10.30
+        name: Rate Indication Production
+        level: 3
+        industry: Insurance
+        description: |
+          Production of rate indications for product and pricing committees.
+        children: []
+      - id: BC-2180.10.40
+        name: Filed Rate Documentation Support
+        level: 3
+        industry: Insurance
+        description: |
+          Production of actuarial memoranda and exhibits supporting rate filings.
+        children: []
+  - id: BC-2180.20
+    name: Reserving Actuarial Management
+    level: 2
+    industry: Insurance
+    description: |
+      Loss triangulation, IBNR estimation, ULAE and ALAE reserving, and reserving sign-off documentation.
+    children:
+      - id: BC-2180.20.10
+        name: Loss Triangulation and Development
+        level: 3
+        industry: Insurance
+        description: |
+          Loss triangle construction and development factor selection.
+        children: []
+      - id: BC-2180.20.20
+        name: IBNR Estimation
+        level: 3
+        industry: Insurance
+        description: |
+          Estimation of incurred-but-not-reported reserves across portfolios.
+        children: []
+      - id: BC-2180.20.30
+        name: ULAE and ALAE Reserving
+        level: 3
+        industry: Insurance
+        description: |
+          Reserving for unallocated and allocated loss adjustment expenses.
+        children: []
+      - id: BC-2180.20.40
+        name: Reserving Sign-Off Documentation
+        level: 3
+        industry: Insurance
+        description: |
+          Production of reserving committee documentation and statements of opinion.
+        children: []
+  - id: BC-2180.30
+    name: Capital and Solvency Modelling
+    level: 2
+    industry: Insurance
+    description: |
+      Internal capital model development, standard formula calculation, capital allocation, and ORSA support.
+    children:
+      - id: BC-2180.30.10
+        name: Internal Capital Model Development
+        level: 3
+        industry: Insurance
+        description: |
+          Development and maintenance of internal capital models for solvency and rating.
+        children: []
+      - id: BC-2180.30.20
+        name: Standard Formula Calculation
+        level: 3
+        industry: Insurance
+        description: |
+          Calculation of Solvency II standard formula and equivalent regulatory capital metrics.
+        children: []
+      - id: BC-2180.30.30
+        name: Capital Allocation
+        level: 3
+        industry: Insurance
+        description: |
+          Allocation of required capital to lines of business and segments.
+        children: []
+      - id: BC-2180.30.40
+        name: ORSA Modelling Support
+        level: 3
+        industry: Insurance
+        description: |
+          Modelling support for Own Risk and Solvency Assessment exercises.
+        children: []
+  - id: BC-2180.40
+    name: "Experience Studies & Assumption Management"
+    level: 2
+    industry: Insurance
+    description: |
+      Mortality, longevity, lapse, persistency, and morbidity studies, and assumption governance.
+    children:
+      - id: BC-2180.40.10
+        name: Mortality and Longevity Studies
+        level: 3
+        industry: Insurance
+        description: |
+          Mortality and longevity experience studies for life and pension portfolios.
+        children: []
+      - id: BC-2180.40.20
+        name: Lapse and Persistency Studies
+        level: 3
+        industry: Insurance
+        description: |
+          Lapse and persistency experience studies across product cohorts.
+        children: []
+      - id: BC-2180.40.30
+        name: Morbidity and Claim Frequency Studies
+        level: 3
+        industry: Insurance
+        description: |
+          Morbidity and claim-frequency experience studies for health and protection lines.
+        children: []
+      - id: BC-2180.40.40
+        name: Assumption Governance and Sign-Off
+        level: 3
+        industry: Insurance
+        description: |
+          Governance and sign-off of actuarial assumptions used in pricing, reserving, and reporting.
+        children: []
+  - id: BC-2180.50
+    name: IFRS 17 Actuarial Reporting Support
+    level: 2
+    industry: Insurance
+    description: |
+      Contractual service margin, risk adjustment, cohort construction, and IFRS 17 disclosure production.
+    children:
+      - id: BC-2180.50.10
+        name: CSM and Risk Adjustment Calculation
+        level: 3
+        industry: Insurance
+        description: |
+          Calculation of contractual service margin and risk adjustment for IFRS 17.
+        children: []
+      - id: BC-2180.50.20
+        name: Cohort and Group Construction
+        level: 3
+        industry: Insurance
+        description: |
+          Construction of insurance contract groups and annual cohorts.
+        children: []
+      - id: BC-2180.50.30
+        name: IFRS 17 Disclosure Production
+        level: 3
+        industry: Insurance
+        description: |
+          Production of actuarial inputs for IFRS 17 disclosures and reconciliations.
+        children: []
+  - id: BC-2180.60
+    name: Catastrophe Modelling
+    level: 2
+    industry: Insurance
+    description: |
+      CAT model vendor management, exposure data preparation, PML and AAL calculation, and model validation.
+    children:
+      - id: BC-2180.60.10
+        name: CAT Model Vendor Management
+        level: 3
+        industry: Insurance
+        description: |
+          Selection and management of CAT model vendors and licence portfolios.
+        children: []
+      - id: BC-2180.60.20
+        name: Exposure Data Preparation
+        level: 3
+        industry: Insurance
+        description: |
+          Preparation and conditioning of exposure data for CAT model runs.
+        children: []
+      - id: BC-2180.60.30
+        name: PML and AAL Calculation
+        level: 3
+        industry: Insurance
+        description: |
+          Calculation of probable maximum loss and average annual loss metrics.
+        children: []
+      - id: BC-2180.60.40
+        name: CAT Model Validation and Adjustment
+        level: 3
+        industry: Insurance
+        description: |
+          Validation and view-of-risk adjustment of CAT model outputs.
+        children: []

--- a/catalogue/L1-insurance-claims-management.yaml
+++ b/catalogue/L1-insurance-claims-management.yaml
@@ -1,0 +1,287 @@
+# Insurance Claims Management
+id: BC-2160
+name: Insurance Claims Management
+level: 1
+industry: Insurance
+description: |
+  First notice of loss, triage, investigation, reserving, adjustment,
+  settlement, recovery and subrogation, litigation, fraud / SIU, and
+  catastrophe response across all insurance lines.
+references:
+  - https://www.acord.org/standards/reference-architecture
+  - https://www.iaisweb.org/icp-online-tool/
+  - https://www.lloyds.com/conducting-business/claims
+children:
+  - id: BC-2160.10
+    name: First Notice of Loss Management
+    level: 2
+    industry: Insurance
+    description: |
+      Multi-channel FNOL intake, coverage verification, registration, and acknowledgement.
+    children:
+      - id: BC-2160.10.10
+        name: FNOL Multi-Channel Intake
+        level: 3
+        industry: Insurance
+        description: |
+          Intake of first notice of loss across phone, digital, broker, and IoT channels.
+        children: []
+      - id: BC-2160.10.20
+        name: Initial Coverage Verification
+        level: 3
+        industry: Insurance
+        description: |
+          Verification that the loss falls within the coverage at the date of loss.
+        children: []
+      - id: BC-2160.10.30
+        name: Claim Registration
+        level: 3
+        industry: Insurance
+        description: |
+          Registration of new claims and assignment of claim identifiers.
+        children: []
+      - id: BC-2160.10.40
+        name: Acknowledgement and Communication
+        level: 3
+        industry: Insurance
+        description: |
+          Initial acknowledgement to claimant and ongoing claim status communication.
+        children: []
+  - id: BC-2160.20
+    name: "Claims Triage & Segmentation"
+    level: 2
+    industry: Insurance
+    description: |
+      Severity scoring, straight-through routing, adjuster assignment, and specialist routing.
+    children:
+      - id: BC-2160.20.10
+        name: Severity and Complexity Scoring
+        level: 3
+        industry: Insurance
+        description: |
+          Scoring of claim severity and complexity for routing decisions.
+        children: []
+      - id: BC-2160.20.20
+        name: Straight-Through Processing Routing
+        level: 3
+        industry: Insurance
+        description: |
+          Routing of low-severity claims through straight-through processing.
+        children: []
+      - id: BC-2160.20.30
+        name: Adjuster Assignment
+        level: 3
+        industry: Insurance
+        description: |
+          Assignment of claims to adjusters based on skill, capacity, and geography.
+        children: []
+      - id: BC-2160.20.40
+        name: Specialist and Litigation Routing
+        level: 3
+        industry: Insurance
+        description: |
+          Routing of complex, specialist, and litigated claims to dedicated teams.
+        children: []
+  - id: BC-2160.30
+    name: "Claims Investigation & Adjustment"
+    level: 2
+    industry: Insurance
+    description: |
+      Field and desk adjustment, damage assessment, liability determination, and SME consultation.
+    children:
+      - id: BC-2160.30.10
+        name: Field and Desk Adjustment
+        level: 3
+        industry: Insurance
+        description: |
+          Field and desk adjustment of claims, including site inspections.
+        children: []
+      - id: BC-2160.30.20
+        name: Damage and Loss Assessment
+        level: 3
+        industry: Insurance
+        description: |
+          Assessment of damage, loss quantum, and repair / replacement scope.
+        children: []
+      - id: BC-2160.30.30
+        name: Liability Determination
+        level: 3
+        industry: Insurance
+        description: |
+          Determination of liability and policy response on third-party claims.
+        children: []
+      - id: BC-2160.30.40
+        name: Subject-Matter Expert Consultation
+        level: 3
+        industry: Insurance
+        description: |
+          Consultation with surveyors, engineers, medical experts, and forensic accountants.
+        children: []
+  - id: BC-2160.40
+    name: Claims Reserving Management
+    level: 2
+    industry: Insurance
+    description: |
+      Initial case reserve setting, re-estimation, and IBNR coordination.
+    children:
+      - id: BC-2160.40.10
+        name: Initial Case Reserve Setting
+        level: 3
+        industry: Insurance
+        description: |
+          Setting of initial case reserves on registered claims.
+        children: []
+      - id: BC-2160.40.20
+        name: Reserve Re-Estimation
+        level: 3
+        industry: Insurance
+        description: |
+          Periodic re-estimation of case reserves as new information emerges.
+        children: []
+      - id: BC-2160.40.30
+        name: IBNR Coordination with Actuarial
+        level: 3
+        industry: Insurance
+        description: |
+          Coordination with actuarial on IBNR provisions for portfolio-level reserving.
+        children: []
+  - id: BC-2160.50
+    name: "Claims Settlement & Payment"
+    level: 2
+    industry: Insurance
+    description: |
+      Settlement negotiation, indemnity and expense payments, salvage, and recovery / subrogation.
+    children:
+      - id: BC-2160.50.10
+        name: Settlement Negotiation
+        level: 3
+        industry: Insurance
+        description: |
+          Negotiation of settlement amounts with claimants and third parties.
+        children: []
+      - id: BC-2160.50.20
+        name: Indemnity Payment Issuance
+        level: 3
+        industry: Insurance
+        description: |
+          Issuance of indemnity payments to insureds and third parties.
+        children: []
+      - id: BC-2160.50.30
+        name: Expense Payment Issuance
+        level: 3
+        industry: Insurance
+        description: |
+          Issuance of allocated and unallocated loss adjustment expense payments.
+        children: []
+      - id: BC-2160.50.40
+        name: Salvage Disposition
+        level: 3
+        industry: Insurance
+        description: |
+          Disposition and recovery of salvage on settled claims.
+        children: []
+      - id: BC-2160.50.50
+        name: Recovery and Subrogation
+        level: 3
+        industry: Insurance
+        description: |
+          Recovery and subrogation against third parties and other insurers.
+        children: []
+  - id: BC-2160.60
+    name: Claims Litigation Management
+    level: 2
+    industry: Insurance
+    description: |
+      Litigation strategy, defence counsel coordination, and litigation cost tracking.
+    children:
+      - id: BC-2160.60.10
+        name: Litigation Strategy
+        level: 3
+        industry: Insurance
+        description: |
+          Strategy setting on litigated claims and settlement vs trial decisions.
+        children: []
+      - id: BC-2160.60.20
+        name: Defence Counsel Coordination
+        level: 3
+        industry: Insurance
+        description: |
+          Coordination of panel and instructed defence counsel.
+        children: []
+      - id: BC-2160.60.30
+        name: Litigation Cost Tracking
+        level: 3
+        industry: Insurance
+        description: |
+          Tracking of litigation costs against panel rates and budgets.
+        children: []
+  - id: BC-2160.70
+    name: "Claims Fraud & SIU Management"
+    level: 2
+    industry: Insurance
+    description: |
+      Suspicious-claim detection, SIU investigation, fraud referral, and anti-fraud analytics.
+    children:
+      - id: BC-2160.70.10
+        name: Suspicious Claim Detection
+        level: 3
+        industry: Insurance
+        description: |
+          Detection of suspicious claims using rules, models, and red-flag indicators.
+        children: []
+      - id: BC-2160.70.20
+        name: SIU Investigation
+        level: 3
+        industry: Insurance
+        description: |
+          Special investigation unit casework on suspected fraudulent claims.
+        children: []
+      - id: BC-2160.70.30
+        name: Fraud Referral and Prosecution
+        level: 3
+        industry: Insurance
+        description: |
+          Referral of fraud cases to law enforcement and industry registries.
+        children: []
+      - id: BC-2160.70.40
+        name: Anti-Fraud Analytics
+        level: 3
+        industry: Insurance
+        description: |
+          Anti-fraud analytics on claim portfolios and network analysis.
+        children: []
+  - id: BC-2160.80
+    name: Catastrophe Claims Management
+    level: 2
+    industry: Insurance
+    description: |
+      CAT event activation, surge capacity, CAT claims tracking, and CAT recovery coordination.
+    children:
+      - id: BC-2160.80.10
+        name: CAT Event Activation
+        level: 3
+        industry: Insurance
+        description: |
+          Activation of catastrophe response procedures on declared events.
+        children: []
+      - id: BC-2160.80.20
+        name: Surge Capacity Mobilisation
+        level: 3
+        industry: Insurance
+        description: |
+          Mobilisation of surge adjusters, contractors, and call centre capacity.
+        children: []
+      - id: BC-2160.80.30
+        name: CAT Claims Triage and Tracking
+        level: 3
+        industry: Insurance
+        description: |
+          Triage and tracking of CAT-coded claims through to settlement.
+        children: []
+      - id: BC-2160.80.40
+        name: CAT Recovery Coordination
+        level: 3
+        industry: Insurance
+        description: |
+          Coordination of reinsurance and pool recoveries on CAT events.
+        children: []

--- a/catalogue/L1-insurance-customer-management.yaml
+++ b/catalogue/L1-insurance-customer-management.yaml
@@ -1,0 +1,187 @@
+# Insurance Customer Management
+id: BC-2120
+name: Insurance Customer Management
+level: 1
+industry: Insurance
+description: |
+  Policyholder identity, household and group aggregation, KYC, consents,
+  and lifecycle servicing of insurance customers across all channels.
+references:
+  - https://www.acord.org/standards/reference-architecture
+  - https://www.iaisweb.org/icp-online-tool/
+children:
+  - id: BC-2120.10
+    name: Policyholder Onboarding Management
+    level: 2
+    industry: Insurance
+    description: |
+      Application capture, identity verification, activation, and onboarding communications.
+    children:
+      - id: BC-2120.10.10
+        name: Application Capture
+        level: 3
+        industry: Insurance
+        description: |
+          Capture of new policyholder applications across channels.
+        children: []
+      - id: BC-2120.10.20
+        name: Identity and Beneficial Ownership Verification
+        level: 3
+        industry: Insurance
+        description: |
+          Identity verification and beneficial-ownership identification for individual and corporate policyholders.
+        children: []
+      - id: BC-2120.10.30
+        name: Policyholder Activation
+        level: 3
+        industry: Insurance
+        description: |
+          Activation of policyholder records, accounts, and channel access.
+        children: []
+      - id: BC-2120.10.40
+        name: Onboarding Communication
+        level: 3
+        industry: Insurance
+        description: |
+          Communication of onboarding status, welcome packs, and next steps.
+        children: []
+  - id: BC-2120.20
+    name: "Insurance KYC & Sanctions Management"
+    level: 2
+    industry: Insurance
+    description: |
+      Customer risk rating, KYC documentation, sanctions and PEP screening, and periodic refresh.
+    children:
+      - id: BC-2120.20.10
+        name: Customer Risk Rating
+        level: 3
+        industry: Insurance
+        description: |
+          Risk rating of insurance customers based on AML and conduct risk factors.
+        children: []
+      - id: BC-2120.20.20
+        name: KYC Document Collection
+        level: 3
+        industry: Insurance
+        description: |
+          Collection and validation of KYC documentation for insurance customers.
+        children: []
+      - id: BC-2120.20.30
+        name: Sanctions and PEP Screening
+        level: 3
+        industry: Insurance
+        description: |
+          Sanctions, PEP, and adverse-media screening of policyholders and beneficiaries.
+        children: []
+      - id: BC-2120.20.40
+        name: Periodic KYC Refresh
+        level: 3
+        industry: Insurance
+        description: |
+          Periodic refresh of KYC information and risk re-rating.
+        children: []
+  - id: BC-2120.30
+    name: Policyholder Servicing Management
+    level: 2
+    industry: Insurance
+    description: |
+      Self-service maintenance, inbound service requests, document provision, and beneficiary maintenance.
+    children:
+      - id: BC-2120.30.10
+        name: Self-Service Account Maintenance
+        level: 3
+        industry: Insurance
+        description: |
+          Self-service updates to address, contact, and preference data.
+        children: []
+      - id: BC-2120.30.20
+        name: Inbound Service Request Handling
+        level: 3
+        industry: Insurance
+        description: |
+          Handling of inbound policyholder service requests across channels.
+        children: []
+      - id: BC-2120.30.30
+        name: Document and Statement Provision
+        level: 3
+        industry: Insurance
+        description: |
+          Provision of policy documents, statements, and certificates of insurance.
+        children: []
+      - id: BC-2120.30.40
+        name: Beneficiary and Nominee Maintenance
+        level: 3
+        industry: Insurance
+        description: |
+          Capture and maintenance of beneficiaries and nominees on life and pension contracts.
+        children: []
+  - id: BC-2120.40
+    name: "Customer Information & Consent Management"
+    level: 2
+    industry: Insurance
+    description: |
+      Profile, household and group aggregation, consent management, and golden record.
+    children:
+      - id: BC-2120.40.10
+        name: Policyholder Profile Maintenance
+        level: 3
+        industry: Insurance
+        description: |
+          Maintenance of policyholder profile and demographic data.
+        children: []
+      - id: BC-2120.40.20
+        name: Household and Group Aggregation
+        level: 3
+        industry: Insurance
+        description: |
+          Aggregation of policyholders into households, groups, and corporate parents.
+        children: []
+      - id: BC-2120.40.30
+        name: Marketing and Data Sharing Consent
+        level: 3
+        industry: Insurance
+        description: |
+          Capture and enforcement of marketing and data-sharing consents.
+        children: []
+      - id: BC-2120.40.40
+        name: Customer Golden Record Management
+        level: 3
+        industry: Insurance
+        description: |
+          Maintenance of the policyholder golden record across systems.
+        children: []
+  - id: BC-2120.50
+    name: "Customer Experience & Retention Management"
+    level: 2
+    industry: Insurance
+    description: |
+      Feedback capture, loyalty programmes, complaint handling, and churn prediction.
+    children:
+      - id: BC-2120.50.10
+        name: Customer Feedback Capture
+        level: 3
+        industry: Insurance
+        description: |
+          Capture of customer feedback, NPS, and CSAT signals.
+        children: []
+      - id: BC-2120.50.20
+        name: Loyalty and Retention Programme Operations
+        level: 3
+        industry: Insurance
+        description: |
+          Operation of loyalty, retention, and tenure-based reward programmes.
+        children: []
+      - id: BC-2120.50.30
+        name: Complaint and Escalation Handling
+        level: 3
+        industry: Insurance
+        description: |
+          Handling of policyholder complaints, escalations, and ombudsman cases.
+        children: []
+      - id: BC-2120.50.40
+        name: Churn and Lapse Prediction
+        level: 3
+        industry: Insurance
+        description: |
+          Predictive analytics on churn and lapse risk for retention intervention.
+        children: []

--- a/catalogue/L1-insurance-distribution-management.yaml
+++ b/catalogue/L1-insurance-distribution-management.yaml
@@ -1,0 +1,231 @@
+# Insurance Distribution Management
+id: BC-2110
+name: Insurance Distribution Management
+level: 1
+industry: Insurance
+description: |
+  Producer, broker, agent, MGA, and direct channel relationships,
+  including appointments, commissions, licensing, delegated authorities,
+  and quote and submission flow into underwriting.
+references:
+  - https://www.acord.org/standards/reference-architecture
+  - https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32016L0097
+  - https://www.lloyds.com/conducting-business/delegated-authorities
+children:
+  - id: BC-2110.10
+    name: "Producer & Intermediary Management"
+    level: 2
+    industry: Insurance
+    description: |
+      Onboarding, hierarchy, performance tracking, and offboarding of producers and intermediaries.
+    children:
+      - id: BC-2110.10.10
+        name: Producer Onboarding
+        level: 3
+        industry: Insurance
+        description: |
+          Onboarding of producers, intermediaries, brokers, and MGAs.
+        children: []
+      - id: BC-2110.10.20
+        name: Producer Hierarchy and Account Maintenance
+        level: 3
+        industry: Insurance
+        description: |
+          Maintenance of producer hierarchy, account structures, and contact data.
+        children: []
+      - id: BC-2110.10.30
+        name: Producer Performance Tracking
+        level: 3
+        industry: Insurance
+        description: |
+          Tracking of producer production, loss ratio, and profitability.
+        children: []
+      - id: BC-2110.10.40
+        name: Producer Offboarding
+        level: 3
+        industry: Insurance
+        description: |
+          Offboarding of producers, run-off of in-force books, and final settlement.
+        children: []
+  - id: BC-2110.20
+    name: "Producer Licensing & Appointment Management"
+    level: 2
+    industry: Insurance
+    description: |
+      Licence verification, jurisdictional appointments, continuing education, and producer compliance.
+    children:
+      - id: BC-2110.20.10
+        name: Licence Verification
+        level: 3
+        industry: Insurance
+        description: |
+          Verification of producer licences against state and jurisdictional registries.
+        children: []
+      - id: BC-2110.20.20
+        name: Jurisdiction Appointment Management
+        level: 3
+        industry: Insurance
+        description: |
+          Management of state and jurisdictional appointments, terminations, and renewals.
+        children: []
+      - id: BC-2110.20.30
+        name: Continuing Education Tracking
+        level: 3
+        industry: Insurance
+        description: |
+          Tracking of producer continuing-education credits and renewal eligibility.
+        children: []
+      - id: BC-2110.20.40
+        name: Producer Compliance Monitoring
+        level: 3
+        industry: Insurance
+        description: |
+          Monitoring of producer conduct, complaints, and disciplinary actions.
+        children: []
+  - id: BC-2110.30
+    name: "Commission & Incentive Management"
+    level: 2
+    industry: Insurance
+    description: |
+      Commission schedule configuration, calculation, override and bonus, and statement generation.
+    children:
+      - id: BC-2110.30.10
+        name: Commission Schedule Configuration
+        level: 3
+        industry: Insurance
+        description: |
+          Configuration of commission schedules and rates by product and producer.
+        children: []
+      - id: BC-2110.30.20
+        name: Commission Calculation
+        level: 3
+        industry: Insurance
+        description: |
+          Calculation of commissions on premium events, including reversals on cancellation.
+        children: []
+      - id: BC-2110.30.30
+        name: Override and Bonus Calculation
+        level: 3
+        industry: Insurance
+        description: |
+          Calculation of overrides, profit-sharing, and incentive bonuses.
+        children: []
+      - id: BC-2110.30.40
+        name: Commission Statement Generation
+        level: 3
+        industry: Insurance
+        description: |
+          Generation and distribution of producer commission statements.
+        children: []
+  - id: BC-2110.40
+    name: Distribution Channel Management
+    level: 2
+    industry: Insurance
+    description: |
+      Operation of agent, broker, direct digital, bancassurance, affinity, and aggregator channels.
+    children:
+      - id: BC-2110.40.10
+        name: Agent Channel Operations
+        level: 3
+        industry: Insurance
+        description: |
+          Operation of tied and independent agent channels.
+        children: []
+      - id: BC-2110.40.20
+        name: Broker Channel Operations
+        level: 3
+        industry: Insurance
+        description: |
+          Operation of broker and wholesale broker channels.
+        children: []
+      - id: BC-2110.40.30
+        name: Direct Digital Channel Operations
+        level: 3
+        industry: Insurance
+        description: |
+          Operation of direct-to-customer digital insurance channels.
+        children: []
+      - id: BC-2110.40.40
+        name: Bancassurance and Affinity Channel Operations
+        level: 3
+        industry: Insurance
+        description: |
+          Operation of bancassurance partnerships and affinity-group channels.
+        children: []
+      - id: BC-2110.40.50
+        name: Aggregator and Comparison Channel Operations
+        level: 3
+        industry: Insurance
+        description: |
+          Operation of aggregator and price-comparison website channels.
+        children: []
+  - id: BC-2110.50
+    name: Delegated Authority Management
+    level: 2
+    industry: Insurance
+    description: |
+      Coverholder authority setup, performance monitoring, bordereau intake, and authority audit.
+    children:
+      - id: BC-2110.50.10
+        name: Delegated Authority Setup
+        level: 3
+        industry: Insurance
+        description: |
+          Setup of binding authorities and delegated underwriting agreements.
+        children: []
+      - id: BC-2110.50.20
+        name: Coverholder Performance Monitoring
+        level: 3
+        industry: Insurance
+        description: |
+          Monitoring of coverholder underwriting performance and adherence to authority.
+        children: []
+      - id: BC-2110.50.30
+        name: Bordereau Receipt and Reconciliation
+        level: 3
+        industry: Insurance
+        description: |
+          Receipt, ingestion, and reconciliation of premium and claim bordereaux.
+        children: []
+      - id: BC-2110.50.40
+        name: Authority Audit and Withdrawal
+        level: 3
+        industry: Insurance
+        description: |
+          Audit of coverholder operations and withdrawal of binding authority where required.
+        children: []
+  - id: BC-2110.60
+    name: "Quote & Submission Management"
+    level: 2
+    industry: Insurance
+    description: |
+      Submission intake, quote generation, comparison, and quote-to-bind conversion tracking.
+    children:
+      - id: BC-2110.60.10
+        name: Submission Intake
+        level: 3
+        industry: Insurance
+        description: |
+          Intake of insurance submissions across channels and broker portals.
+        children: []
+      - id: BC-2110.60.20
+        name: Quote Generation
+        level: 3
+        industry: Insurance
+        description: |
+          Generation of insurance quotes from product and rating configuration.
+        children: []
+      - id: BC-2110.60.30
+        name: Quote Comparison and Counter-Quote
+        level: 3
+        industry: Insurance
+        description: |
+          Multi-carrier quote comparison and counter-quote handling.
+        children: []
+      - id: BC-2110.60.40
+        name: Quote to Bind Conversion Tracking
+        level: 3
+        industry: Insurance
+        description: |
+          Tracking of quote-to-bind conversion rates and reasons for non-conversion.
+        children: []

--- a/catalogue/L1-insurance-investment-management.yaml
+++ b/catalogue/L1-insurance-investment-management.yaml
@@ -1,0 +1,189 @@
+# Insurance Investment Management
+id: BC-2200
+name: Insurance Investment Management
+level: 1
+industry: Insurance
+description: |
+  Asset-side management of insurance liabilities by an insurer-as-asset-owner -
+  investment policy, ALM, strategic and tactical asset allocation, manager
+  oversight, investment risk and compliance, and investment reporting.
+references:
+  - https://www.iaisweb.org/icp-online-tool/
+  - https://www.eiopa.europa.eu/regulation-supervision/insurance/solvency-ii_en
+  - https://www.acord.org/standards/reference-architecture
+children:
+  - id: BC-2200.10
+    name: "Investment Policy & Strategy Management"
+    level: 2
+    industry: Insurance
+    description: |
+      Investment policy statement, mandate definition, and ESG investment policy integration.
+    children:
+      - id: BC-2200.10.10
+        name: Investment Policy Statement Maintenance
+        level: 3
+        industry: Insurance
+        description: |
+          Maintenance of the investment policy statement and prudent person principle alignment.
+        children: []
+      - id: BC-2200.10.20
+        name: Investment Mandate Definition
+        level: 3
+        industry: Insurance
+        description: |
+          Definition of investment mandates by portfolio, line of business, and risk profile.
+        children: []
+      - id: BC-2200.10.30
+        name: ESG Investment Policy Integration
+        level: 3
+        industry: Insurance
+        description: |
+          Integration of ESG and stewardship policies into investment mandates.
+        children: []
+  - id: BC-2200.20
+    name: Asset Liability Management
+    level: 2
+    industry: Insurance
+    description: |
+      ALM modelling and cashflow matching, duration and convexity monitoring, and liquidity buffer sizing.
+    children:
+      - id: BC-2200.20.10
+        name: ALM Modelling and Cashflow Matching
+        level: 3
+        industry: Insurance
+        description: |
+          ALM modelling and cashflow matching of assets to insurance liabilities.
+        children: []
+      - id: BC-2200.20.20
+        name: Duration and Convexity Monitoring
+        level: 3
+        industry: Insurance
+        description: |
+          Monitoring of duration and convexity gaps between assets and liabilities.
+        children: []
+      - id: BC-2200.20.30
+        name: Liquidity Buffer Sizing
+        level: 3
+        industry: Insurance
+        description: |
+          Sizing of liquidity buffers to meet expected and stressed claim outflows.
+        children: []
+  - id: BC-2200.30
+    name: "Strategic & Tactical Asset Allocation"
+    level: 2
+    industry: Insurance
+    description: |
+      Strategic and tactical asset allocation decisions and rebalancing.
+    children:
+      - id: BC-2200.30.10
+        name: Strategic Asset Allocation Setting
+        level: 3
+        industry: Insurance
+        description: |
+          Setting of long-horizon strategic asset allocations across asset classes.
+        children: []
+      - id: BC-2200.30.20
+        name: Tactical Asset Allocation Decisioning
+        level: 3
+        industry: Insurance
+        description: |
+          Tactical allocation decisions within strategic ranges.
+        children: []
+      - id: BC-2200.30.30
+        name: Allocation Rebalancing
+        level: 3
+        industry: Insurance
+        description: |
+          Periodic and event-driven rebalancing back to target allocations.
+        children: []
+  - id: BC-2200.40
+    name: "Investment Mandate & Manager Oversight"
+    level: 2
+    industry: Insurance
+    description: |
+      External manager selection, mandate compliance, performance review, and manager fee oversight.
+    children:
+      - id: BC-2200.40.10
+        name: External Manager Selection
+        level: 3
+        industry: Insurance
+        description: |
+          Selection and onboarding of external investment managers.
+        children: []
+      - id: BC-2200.40.20
+        name: Mandate Compliance Monitoring
+        level: 3
+        industry: Insurance
+        description: |
+          Monitoring of mandate compliance and breach handling.
+        children: []
+      - id: BC-2200.40.30
+        name: Manager Performance Review
+        level: 3
+        industry: Insurance
+        description: |
+          Periodic performance review of external investment managers.
+        children: []
+      - id: BC-2200.40.40
+        name: Manager Fee Oversight
+        level: 3
+        industry: Insurance
+        description: |
+          Oversight of manager fees and value-for-money assessments.
+        children: []
+  - id: BC-2200.50
+    name: "Investment Risk & Compliance Monitoring"
+    level: 2
+    industry: Insurance
+    description: |
+      Investment limit monitoring, counterparty and issuer limits, and Solvency II asset eligibility.
+    children:
+      - id: BC-2200.50.10
+        name: Investment Limit Monitoring
+        level: 3
+        industry: Insurance
+        description: |
+          Monitoring of investment limits across asset classes and risk factors.
+        children: []
+      - id: BC-2200.50.20
+        name: Counterparty and Issuer Limit Monitoring
+        level: 3
+        industry: Insurance
+        description: |
+          Monitoring of counterparty and issuer concentration and limits.
+        children: []
+      - id: BC-2200.50.30
+        name: Solvency II Asset Eligibility Monitoring
+        level: 3
+        industry: Insurance
+        description: |
+          Monitoring of asset eligibility against Solvency II and equivalent rules.
+        children: []
+  - id: BC-2200.60
+    name: "Investment Performance & Reporting"
+    level: 2
+    industry: Insurance
+    description: |
+      Performance measurement, attribution, and investment reporting to board and regulator.
+    children:
+      - id: BC-2200.60.10
+        name: Portfolio Performance Measurement
+        level: 3
+        industry: Insurance
+        description: |
+          Measurement of portfolio performance against benchmarks and liabilities.
+        children: []
+      - id: BC-2200.60.20
+        name: Attribution Analysis
+        level: 3
+        industry: Insurance
+        description: |
+          Performance attribution by allocation, selection, and currency.
+        children: []
+      - id: BC-2200.60.30
+        name: Investment Reporting to Board and Regulator
+        level: 3
+        industry: Insurance
+        description: |
+          Production of investment reporting for board, ALCO, and regulator.
+        children: []

--- a/catalogue/L1-insurance-product-management.yaml
+++ b/catalogue/L1-insurance-product-management.yaml
@@ -1,0 +1,211 @@
+# Insurance Product Management
+id: BC-2100
+name: Insurance Product Management
+level: 1
+industry: Insurance
+description: |
+  Insurance product factory - coverage definitions, terms, rating tables,
+  bundles, and lifecycle for life, P&C, health, and specialty lines,
+  including the programme and coverholder product structures used in
+  delegated-authority markets.
+references:
+  - https://www.acord.org/standards/reference-architecture
+  - https://www.iaisweb.org/icp-online-tool/
+children:
+  - id: BC-2100.10
+    name: Insurance Product Catalogue Management
+    level: 2
+    industry: Insurance
+    description: |
+      Insurance product catalogue, master data, coverage and form library,
+      disclosure documentation, and catalogue publication.
+    children:
+      - id: BC-2100.10.10
+        name: Product Master Data Management
+        level: 3
+        industry: Insurance
+        description: |
+          Maintenance of insurance product master data and product hierarchies.
+        children: []
+      - id: BC-2100.10.20
+        name: Coverage and Form Library
+        level: 3
+        industry: Insurance
+        description: |
+          Maintenance of standardised coverage definitions, policy forms, and endorsement library.
+        children: []
+      - id: BC-2100.10.30
+        name: Product Disclosure Documentation
+        level: 3
+        industry: Insurance
+        description: |
+          Production and maintenance of product disclosure documents and key facts statements.
+        children: []
+      - id: BC-2100.10.40
+        name: Product Catalogue Publication
+        level: 3
+        industry: Insurance
+        description: |
+          Publication of the insurance product catalogue across channels and partners.
+        children: []
+  - id: BC-2100.20
+    name: "Product Rating & Pricing Configuration"
+    level: 2
+    industry: Insurance
+    description: |
+      Configuration of rating algorithms, factors, filed rates, discounts, and surcharges.
+    children:
+      - id: BC-2100.20.10
+        name: Rating Algorithm Configuration
+        level: 3
+        industry: Insurance
+        description: |
+          Configuration of rating algorithms and pricing models for insurance products.
+        children: []
+      - id: BC-2100.20.20
+        name: Rating Factor and Variable Maintenance
+        level: 3
+        industry: Insurance
+        description: |
+          Maintenance of rating factors, tables, and rating variables.
+        children: []
+      - id: BC-2100.20.30
+        name: Filed Rate Management
+        level: 3
+        industry: Insurance
+        description: |
+          Management of filed rates, deviations, and approvals across jurisdictions.
+        children: []
+      - id: BC-2100.20.40
+        name: Discount and Surcharge Configuration
+        level: 3
+        industry: Insurance
+        description: |
+          Configuration of premium discounts, surcharges, and credit programmes.
+        children: []
+  - id: BC-2100.30
+    name: "Product Eligibility & Underwriting Rule Configuration"
+    level: 2
+    industry: Insurance
+    description: |
+      Configuration of eligibility, underwriting guidelines, and referral and decline rules embedded in product.
+    children:
+      - id: BC-2100.30.10
+        name: Eligibility Rule Configuration
+        level: 3
+        industry: Insurance
+        description: |
+          Configuration of customer and risk eligibility rules per product.
+        children: []
+      - id: BC-2100.30.20
+        name: Underwriting Guideline Encoding
+        level: 3
+        industry: Insurance
+        description: |
+          Encoding of underwriting guidelines into product configuration.
+        children: []
+      - id: BC-2100.30.30
+        name: Referral and Decline Rule Configuration
+        level: 3
+        industry: Insurance
+        description: |
+          Configuration of automated referral and decline rules per product.
+        children: []
+  - id: BC-2100.40
+    name: Insurance Product Lifecycle Management
+    level: 2
+    industry: Insurance
+    description: |
+      New product introduction, regulatory filing, launch readiness, performance review, and withdrawal.
+    children:
+      - id: BC-2100.40.10
+        name: New Product Concept
+        level: 3
+        industry: Insurance
+        description: |
+          Concept definition for new insurance products and product committee governance.
+        children: []
+      - id: BC-2100.40.20
+        name: Product Filing and Approval
+        level: 3
+        industry: Insurance
+        description: |
+          Regulatory filing of insurance products and approval tracking across jurisdictions.
+        children: []
+      - id: BC-2100.40.30
+        name: Product Launch Readiness
+        level: 3
+        industry: Insurance
+        description: |
+          Operational and channel readiness for launch of insurance products.
+        children: []
+      - id: BC-2100.40.40
+        name: Product Performance Review
+        level: 3
+        industry: Insurance
+        description: |
+          Periodic performance and value-for-money reviews of insurance products.
+        children: []
+      - id: BC-2100.40.50
+        name: Product Withdrawal and Replacement
+        level: 3
+        industry: Insurance
+        description: |
+          Withdrawal, replacement, and policyholder migration to successor products.
+        children: []
+  - id: BC-2100.50
+    name: Insurance Product Bundling Management
+    level: 2
+    industry: Insurance
+    description: |
+      Multi-line bundles, package products, and bundle performance tracking.
+    children:
+      - id: BC-2100.50.10
+        name: Multi-Line Bundle Definition
+        level: 3
+        industry: Insurance
+        description: |
+          Definition of multi-line product bundles and packaging rules.
+        children: []
+      - id: BC-2100.50.20
+        name: Bundle Eligibility Rule Configuration
+        level: 3
+        industry: Insurance
+        description: |
+          Eligibility and qualification rules for insurance product bundles.
+        children: []
+      - id: BC-2100.50.30
+        name: Bundle Performance Tracking
+        level: 3
+        industry: Insurance
+        description: |
+          Tracking of bundle uptake, retention, and economics.
+        children: []
+  - id: BC-2100.60
+    name: "Specialty & Programme Product Management"
+    level: 2
+    industry: Insurance
+    description: |
+      Programme business definition, coverholder product authority, and specialty wording library.
+    children:
+      - id: BC-2100.60.10
+        name: Programme Definition
+        level: 3
+        industry: Insurance
+        description: |
+          Definition of programme business and binding-authority product structures.
+        children: []
+      - id: BC-2100.60.20
+        name: Coverholder Product Authority
+        level: 3
+        industry: Insurance
+        description: |
+          Definition of product scope and authority granted to coverholders.
+        children: []
+      - id: BC-2100.60.30
+        name: Specialty Wording and Endorsement Library
+        level: 3
+        industry: Insurance
+        description: |
+          Library of specialty wordings, manuscript endorsements, and market clauses.
+        children: []

--- a/catalogue/L1-insurance-risk-management.yaml
+++ b/catalogue/L1-insurance-risk-management.yaml
@@ -1,0 +1,240 @@
+# Insurance Risk Management
+id: BC-2190
+name: Insurance Risk Management
+level: 1
+industry: Insurance
+description: |
+  Insurance-specific risk types - underwriting, catastrophe and accumulation,
+  reserve, solvency and capital, reinsurance counterparty, life and longevity,
+  lapse, and insurance operational and conduct risk - distinct from generic
+  enterprise risk.
+references:
+  - https://www.iaisweb.org/icp-online-tool/
+  - https://www.eiopa.europa.eu/regulation-supervision/insurance/solvency-ii_en
+  - https://www.iso.org/iso-31000-risk-management.html
+  - https://content.naic.org/cipr-topics/risk-based-capital
+children:
+  - id: BC-2190.10
+    name: Underwriting Risk Management
+    level: 2
+    industry: Insurance
+    description: |
+      Underwriting risk appetite, limit monitoring, and adverse-selection surveillance.
+    children:
+      - id: BC-2190.10.10
+        name: Underwriting Risk Appetite
+        level: 3
+        industry: Insurance
+        description: |
+          Definition and articulation of underwriting risk appetite.
+        children: []
+      - id: BC-2190.10.20
+        name: Underwriting Limit Monitoring
+        level: 3
+        industry: Insurance
+        description: |
+          Monitoring of underwriting authority and aggregation limits.
+        children: []
+      - id: BC-2190.10.30
+        name: Adverse Selection Surveillance
+        level: 3
+        industry: Insurance
+        description: |
+          Surveillance for adverse selection and anti-selection patterns.
+        children: []
+  - id: BC-2190.20
+    name: "Catastrophe & Accumulation Risk Management"
+    level: 2
+    industry: Insurance
+    description: |
+      Exposure aggregation monitoring, PML and realistic disaster scenario management, and CAT mitigation planning.
+    children:
+      - id: BC-2190.20.10
+        name: Exposure Aggregation Monitoring
+        level: 3
+        industry: Insurance
+        description: |
+          Monitoring of exposure aggregation by peril, geography, and occupancy.
+        children: []
+      - id: BC-2190.20.20
+        name: PML and Realistic Disaster Scenario Management
+        level: 3
+        industry: Insurance
+        description: |
+          Management of PML and realistic disaster scenarios.
+        children: []
+      - id: BC-2190.20.30
+        name: CAT Risk Mitigation Planning
+        level: 3
+        industry: Insurance
+        description: |
+          Planning of mitigation actions including reinsurance and risk transfer.
+        children: []
+  - id: BC-2190.30
+    name: "Insurance Reserve & Reserving Risk Management"
+    level: 2
+    industry: Insurance
+    description: |
+      Reserve adequacy monitoring, reserve volatility analysis, and reserve risk stress testing.
+    children:
+      - id: BC-2190.30.10
+        name: Reserve Adequacy Monitoring
+        level: 3
+        industry: Insurance
+        description: |
+          Monitoring of reserve adequacy against best-estimate and external benchmarks.
+        children: []
+      - id: BC-2190.30.20
+        name: Reserve Volatility Analysis
+        level: 3
+        industry: Insurance
+        description: |
+          Analysis of reserve volatility and one-year reserve risk.
+        children: []
+      - id: BC-2190.30.30
+        name: Reserve Risk Stress Testing
+        level: 3
+        industry: Insurance
+        description: |
+          Stress and scenario testing of reserve adequacy.
+        children: []
+  - id: BC-2190.40
+    name: "Solvency & Capital Risk Management"
+    level: 2
+    industry: Insurance
+    description: |
+      Capital adequacy monitoring, ORSA operations, solvency stress testing, and recovery and resolution planning.
+    children:
+      - id: BC-2190.40.10
+        name: Capital Adequacy Monitoring
+        level: 3
+        industry: Insurance
+        description: |
+          Monitoring of solvency capital ratios and capital triggers.
+        children: []
+      - id: BC-2190.40.20
+        name: ORSA Operations
+        level: 3
+        industry: Insurance
+        description: |
+          Operation of the Own Risk and Solvency Assessment cycle.
+        children: []
+      - id: BC-2190.40.30
+        name: Solvency Stress and Scenario Testing
+        level: 3
+        industry: Insurance
+        description: |
+          Stress and reverse-stress testing of solvency positions.
+        children: []
+      - id: BC-2190.40.40
+        name: Recovery and Resolution Planning
+        level: 3
+        industry: Insurance
+        description: |
+          Recovery and resolution planning for insurer wind-down scenarios.
+        children: []
+  - id: BC-2190.50
+    name: "Reinsurance Counterparty & Credit Risk Management"
+    level: 2
+    industry: Insurance
+    description: |
+      Reinsurer counterparty monitoring, collateral adequacy, and counterparty default stress testing.
+    children:
+      - id: BC-2190.50.10
+        name: Reinsurer Counterparty Monitoring
+        level: 3
+        industry: Insurance
+        description: |
+          Monitoring of reinsurer financial strength and exposure concentration.
+        children: []
+      - id: BC-2190.50.20
+        name: Collateral and LoC Adequacy Monitoring
+        level: 3
+        industry: Insurance
+        description: |
+          Monitoring of collateral and letter-of-credit adequacy from reinsurers.
+        children: []
+      - id: BC-2190.50.30
+        name: Counterparty Default Stress Testing
+        level: 3
+        industry: Insurance
+        description: |
+          Stress testing of reinsurer default impacts on solvency.
+        children: []
+  - id: BC-2190.60
+    name: "Life & Longevity Risk Management"
+    level: 2
+    industry: Insurance
+    description: |
+      Mortality risk monitoring, longevity hedging oversight, and pandemic risk management.
+    children:
+      - id: BC-2190.60.10
+        name: Mortality Risk Monitoring
+        level: 3
+        industry: Insurance
+        description: |
+          Monitoring of mortality risk on life and protection portfolios.
+        children: []
+      - id: BC-2190.60.20
+        name: Longevity Risk Hedging Oversight
+        level: 3
+        industry: Insurance
+        description: |
+          Oversight of longevity hedging instruments and counterparty exposure.
+        children: []
+      - id: BC-2190.60.30
+        name: Pandemic Risk Management
+        level: 3
+        industry: Insurance
+        description: |
+          Management of pandemic and epidemic mortality and morbidity risk.
+        children: []
+  - id: BC-2190.70
+    name: "Lapse & Persistency Risk Management"
+    level: 2
+    industry: Insurance
+    description: |
+      Lapse risk monitoring and persistency stress testing.
+    children:
+      - id: BC-2190.70.10
+        name: Lapse Risk Monitoring
+        level: 3
+        industry: Insurance
+        description: |
+          Monitoring of lapse rates and lapse-driven losses on life and savings products.
+        children: []
+      - id: BC-2190.70.20
+        name: Persistency Stress Testing
+        level: 3
+        industry: Insurance
+        description: |
+          Stress testing of persistency assumptions and dynamic lapse behaviour.
+        children: []
+  - id: BC-2190.80
+    name: "Insurance Operational & Conduct Risk Management"
+    level: 2
+    industry: Insurance
+    description: |
+      Insurance conduct risk, claims-handling risk, and distribution risk monitoring.
+    children:
+      - id: BC-2190.80.10
+        name: Insurance Conduct Risk Monitoring
+        level: 3
+        industry: Insurance
+        description: |
+          Monitoring of conduct risk indicators across product, distribution, and claims.
+        children: []
+      - id: BC-2190.80.20
+        name: Claims Handling Risk Oversight
+        level: 3
+        industry: Insurance
+        description: |
+          Oversight of claims-handling risk and policyholder fairness outcomes.
+        children: []
+      - id: BC-2190.80.30
+        name: Distribution Risk Monitoring
+        level: 3
+        industry: Insurance
+        description: |
+          Monitoring of distribution risk including mis-selling and intermediary conduct.
+        children: []

--- a/catalogue/L1-insurance-underwriting-management.yaml
+++ b/catalogue/L1-insurance-underwriting-management.yaml
@@ -1,0 +1,210 @@
+# Insurance Underwriting Management
+id: BC-2130
+name: Insurance Underwriting Management
+level: 1
+industry: Insurance
+description: |
+  Risk evaluation, pricing, acceptance, declination, and binding of
+  insurance applications across personal, commercial, and specialty lines,
+  including underwriting authority enforcement and portfolio steering.
+references:
+  - https://www.acord.org/standards/reference-architecture
+  - https://www.iaisweb.org/icp-online-tool/
+  - https://www.lloyds.com/conducting-business/underwriting
+children:
+  - id: BC-2130.10
+    name: Underwriting Risk Intake
+    level: 2
+    industry: Insurance
+    description: |
+      Submission triage, risk data collection, loss-history retrieval, and third-party data enrichment.
+    children:
+      - id: BC-2130.10.10
+        name: Submission Triage
+        level: 3
+        industry: Insurance
+        description: |
+          Triage of underwriting submissions and routing to underwriting teams.
+        children: []
+      - id: BC-2130.10.20
+        name: Risk Data Collection
+        level: 3
+        industry: Insurance
+        description: |
+          Collection of risk-relevant data from applicant, broker, and survey sources.
+        children: []
+      - id: BC-2130.10.30
+        name: Loss History Retrieval
+        level: 3
+        industry: Insurance
+        description: |
+          Retrieval of loss histories from bureaux, prior carriers, and shared registries.
+        children: []
+      - id: BC-2130.10.40
+        name: Third-Party Data Enrichment
+        level: 3
+        industry: Insurance
+        description: |
+          Enrichment of submissions with third-party, telematics, and IoT data.
+        children: []
+  - id: BC-2130.20
+    name: "Risk Assessment & Selection"
+    level: 2
+    industry: Insurance
+    description: |
+      Risk scoring, exposure aggregation, loss-control surveys, and underwriting referrals.
+    children:
+      - id: BC-2130.20.10
+        name: Risk Scoring and Modelling
+        level: 3
+        industry: Insurance
+        description: |
+          Application of underwriting models, scorecards, and machine-learning risk scores.
+        children: []
+      - id: BC-2130.20.20
+        name: Exposure Aggregation Assessment
+        level: 3
+        industry: Insurance
+        description: |
+          Assessment of exposure aggregation against in-force portfolio.
+        children: []
+      - id: BC-2130.20.30
+        name: Loss Control Survey Coordination
+        level: 3
+        industry: Insurance
+        description: |
+          Coordination of loss-control surveys and risk engineering reports.
+        children: []
+      - id: BC-2130.20.40
+        name: Underwriting Referral Handling
+        level: 3
+        industry: Insurance
+        description: |
+          Handling of referrals to senior underwriters, line authorities, and reinsurers.
+        children: []
+  - id: BC-2130.30
+    name: Underwriting Pricing Management
+    level: 2
+    industry: Insurance
+    description: |
+      Manual rating, schedule rating credits, experience rating, and bespoke specialty pricing.
+    children:
+      - id: BC-2130.30.10
+        name: Manual Rating Application
+        level: 3
+        industry: Insurance
+        description: |
+          Application of manual rates from filed product configuration.
+        children: []
+      - id: BC-2130.30.20
+        name: Schedule Rating and Credit Application
+        level: 3
+        industry: Insurance
+        description: |
+          Application of schedule rating credits and debits.
+        children: []
+      - id: BC-2130.30.30
+        name: Experience Rating
+        level: 3
+        industry: Insurance
+        description: |
+          Experience-rated pricing using policyholder loss history.
+        children: []
+      - id: BC-2130.30.40
+        name: Specialty and Bespoke Pricing
+        level: 3
+        industry: Insurance
+        description: |
+          Bespoke pricing for specialty, large account, and complex risks.
+        children: []
+  - id: BC-2130.40
+    name: "Underwriting Decision & Authority Management"
+    level: 2
+    industry: Insurance
+    description: |
+      Acceptance and decline decisioning, term and condition setting, authority enforcement, and binding.
+    children:
+      - id: BC-2130.40.10
+        name: Acceptance and Decline Decisioning
+        level: 3
+        industry: Insurance
+        description: |
+          Decisioning on acceptance, decline, or counter-offer of submissions.
+        children: []
+      - id: BC-2130.40.20
+        name: Coverage Term and Condition Setting
+        level: 3
+        industry: Insurance
+        description: |
+          Setting of coverage terms, conditions, exclusions, and warranties.
+        children: []
+      - id: BC-2130.40.30
+        name: Underwriting Authority Enforcement
+        level: 3
+        industry: Insurance
+        description: |
+          Enforcement of underwriting authority limits and referral thresholds.
+        children: []
+      - id: BC-2130.40.40
+        name: Quote Issuance and Binding
+        level: 3
+        industry: Insurance
+        description: |
+          Issuance of binding quotes and confirmation of cover.
+        children: []
+  - id: BC-2130.50
+    name: Underwriting Portfolio Management
+    level: 2
+    industry: Insurance
+    description: |
+      Portfolio mix and limit monitoring, profitability analysis, and underwriting action planning.
+    children:
+      - id: BC-2130.50.10
+        name: Portfolio Mix and Limit Monitoring
+        level: 3
+        industry: Insurance
+        description: |
+          Monitoring of portfolio mix against appetite and concentration limits.
+        children: []
+      - id: BC-2130.50.20
+        name: Underwriting Profitability Analysis
+        level: 3
+        industry: Insurance
+        description: |
+          Analysis of underwriting profitability by segment, product, and producer.
+        children: []
+      - id: BC-2130.50.30
+        name: Underwriting Action Planning
+        level: 3
+        industry: Insurance
+        description: |
+          Planning of underwriting actions, remediation, and segment exits.
+        children: []
+  - id: BC-2130.60
+    name: "Underwriting Fraud & Misrepresentation Management"
+    level: 2
+    industry: Insurance
+    description: |
+      Application fraud screening, material misrepresentation investigation, and underwriting fraud reporting.
+    children:
+      - id: BC-2130.60.10
+        name: Application Fraud Screening
+        level: 3
+        industry: Insurance
+        description: |
+          Screening of insurance applications for fraud indicators.
+        children: []
+      - id: BC-2130.60.20
+        name: Material Misrepresentation Investigation
+        level: 3
+        industry: Insurance
+        description: |
+          Investigation of suspected material misrepresentation on applications.
+        children: []
+      - id: BC-2130.60.30
+        name: Underwriting Fraud Reporting
+        level: 3
+        industry: Insurance
+        description: |
+          Reporting of confirmed underwriting fraud to industry registries and regulators.
+        children: []

--- a/catalogue/L1-policy-administration-management.yaml
+++ b/catalogue/L1-policy-administration-management.yaml
@@ -1,0 +1,195 @@
+# Policy Administration Management
+id: BC-2140
+name: Policy Administration Management
+level: 1
+industry: Insurance
+description: |
+  Issuance, endorsements, mid-term adjustments, renewals, cancellations,
+  lapses, reinstatements, document management, and group / master-policy
+  administration of in-force insurance contracts.
+references:
+  - https://www.acord.org/standards/reference-architecture
+  - https://www.iaisweb.org/icp-online-tool/
+children:
+  - id: BC-2140.10
+    name: Policy Issuance Management
+    level: 2
+    industry: Insurance
+    description: |
+      Generation, assembly, and activation of new policy contracts and supporting documents.
+    children:
+      - id: BC-2140.10.10
+        name: Policy Document Generation
+        level: 3
+        industry: Insurance
+        description: |
+          Generation of policy documents from product templates and bound terms.
+        children: []
+      - id: BC-2140.10.20
+        name: Policy Schedule and Wording Assembly
+        level: 3
+        industry: Insurance
+        description: |
+          Assembly of policy schedules, wordings, and endorsements into the contract.
+        children: []
+      - id: BC-2140.10.30
+        name: Policy Activation
+        level: 3
+        industry: Insurance
+        description: |
+          Activation of new policies and notification to downstream systems.
+        children: []
+  - id: BC-2140.20
+    name: "Policy Endorsement & Mid-Term Adjustment"
+    level: 2
+    industry: Insurance
+    description: |
+      Capture, pricing, approval, and issuance of endorsements and mid-term adjustments.
+    children:
+      - id: BC-2140.20.10
+        name: Endorsement Request Capture
+        level: 3
+        industry: Insurance
+        description: |
+          Capture of endorsement requests from policyholders and producers.
+        children: []
+      - id: BC-2140.20.20
+        name: Endorsement Pricing and Approval
+        level: 3
+        industry: Insurance
+        description: |
+          Pricing of endorsements and underwriting approval where required.
+        children: []
+      - id: BC-2140.20.30
+        name: Endorsement Issuance and Communication
+        level: 3
+        industry: Insurance
+        description: |
+          Issuance of endorsement documents and communication to policyholder.
+        children: []
+  - id: BC-2140.30
+    name: Policy Renewal Management
+    level: 2
+    industry: Insurance
+    description: |
+      Renewal eligibility, repricing, offer generation, and non-renewal handling.
+    children:
+      - id: BC-2140.30.10
+        name: Renewal Eligibility Assessment
+        level: 3
+        industry: Insurance
+        description: |
+          Assessment of renewal eligibility based on loss experience and underwriting rules.
+        children: []
+      - id: BC-2140.30.20
+        name: Renewal Repricing
+        level: 3
+        industry: Insurance
+        description: |
+          Repricing of renewing policies under current rate filings and experience.
+        children: []
+      - id: BC-2140.30.30
+        name: Renewal Offer Generation
+        level: 3
+        industry: Insurance
+        description: |
+          Generation and despatch of renewal offers to policyholders.
+        children: []
+      - id: BC-2140.30.40
+        name: Non-Renewal Handling
+        level: 3
+        industry: Insurance
+        description: |
+          Handling of non-renewals, including notice periods and regulatory communications.
+        children: []
+  - id: BC-2140.40
+    name: "Policy Cancellation & Lapse Management"
+    level: 2
+    industry: Insurance
+    description: |
+      Cancellation processing, premium adjustment, lapse, and reinstatement.
+    children:
+      - id: BC-2140.40.10
+        name: Cancellation Request Processing
+        level: 3
+        industry: Insurance
+        description: |
+          Processing of cancellation requests from policyholders, producers, or carrier.
+        children: []
+      - id: BC-2140.40.20
+        name: Pro-Rata and Short-Rate Calculation
+        level: 3
+        industry: Insurance
+        description: |
+          Calculation of pro-rata and short-rate premium adjustments on cancellation.
+        children: []
+      - id: BC-2140.40.30
+        name: Lapse Handling
+        level: 3
+        industry: Insurance
+        description: |
+          Lapse processing for non-payment and notification to policyholder.
+        children: []
+      - id: BC-2140.40.40
+        name: Reinstatement Processing
+        level: 3
+        industry: Insurance
+        description: |
+          Reinstatement of lapsed or cancelled policies subject to underwriting checks.
+        children: []
+  - id: BC-2140.50
+    name: "Policy Document & Records Management"
+    level: 2
+    industry: Insurance
+    description: |
+      Repository of policy documents, regulatory records retention, and policy audit trails.
+    children:
+      - id: BC-2140.50.10
+        name: Policy Document Repository
+        level: 3
+        industry: Insurance
+        description: |
+          Repository of policy documents and supporting correspondence.
+        children: []
+      - id: BC-2140.50.20
+        name: Regulatory Records Retention
+        level: 3
+        industry: Insurance
+        description: |
+          Retention of policy records per insurance regulatory requirements.
+        children: []
+      - id: BC-2140.50.30
+        name: Policy Audit Trail Maintenance
+        level: 3
+        industry: Insurance
+        description: |
+          Maintenance of immutable audit trails on policy changes and decisions.
+        children: []
+  - id: BC-2140.60
+    name: "Group & Master Policy Administration"
+    level: 2
+    industry: Insurance
+    description: |
+      Group policy setup, certificate maintenance, and group renewal cycles.
+    children:
+      - id: BC-2140.60.10
+        name: Group Policy Setup
+        level: 3
+        industry: Insurance
+        description: |
+          Setup of group and master-policy contracts for employer and affinity schemes.
+        children: []
+      - id: BC-2140.60.20
+        name: Member and Certificate Maintenance
+        level: 3
+        industry: Insurance
+        description: |
+          Maintenance of group members, certificates, and dependents.
+        children: []
+      - id: BC-2140.60.30
+        name: Group Renewal Cycle Management
+        level: 3
+        industry: Insurance
+        description: |
+          Management of group renewal cycles, repricing, and member re-enrolment.
+        children: []

--- a/catalogue/L1-premium-accounting-management.yaml
+++ b/catalogue/L1-premium-accounting-management.yaml
@@ -1,0 +1,202 @@
+# Premium Accounting Management
+id: BC-2150
+name: Premium Accounting Management
+level: 1
+industry: Insurance
+description: |
+  Premium billing, cash collection, broker and commission account
+  settlement, premium reserve and earnings mechanics, dunning, and
+  insurance premium tax accounting.
+references:
+  - https://www.acord.org/standards/reference-architecture
+  - https://www.ifrs.org/issued-standards/list-of-standards/ifrs-17-insurance-contracts/
+children:
+  - id: BC-2150.10
+    name: Premium Billing Management
+    level: 2
+    industry: Insurance
+    description: |
+      Invoice generation, instalment scheduling, billing routing, and adjustments.
+    children:
+      - id: BC-2150.10.10
+        name: Premium Invoice Generation
+        level: 3
+        industry: Insurance
+        description: |
+          Generation of premium invoices and statements per billing cycle.
+        children: []
+      - id: BC-2150.10.20
+        name: Instalment Schedule Configuration
+        level: 3
+        industry: Insurance
+        description: |
+          Configuration of premium instalment schedules and finance charges.
+        children: []
+      - id: BC-2150.10.30
+        name: Direct-Bill and Agency-Bill Routing
+        level: 3
+        industry: Insurance
+        description: |
+          Routing of billing between direct-bill and agency-bill arrangements.
+        children: []
+      - id: BC-2150.10.40
+        name: Billing Adjustment and Credit Note
+        level: 3
+        industry: Insurance
+        description: |
+          Issuance of billing adjustments and credit notes following endorsements and cancellations.
+        children: []
+  - id: BC-2150.20
+    name: Premium Collection Management
+    level: 2
+    industry: Insurance
+    description: |
+      Receipt and application of payments, recurring payment operations, refunds, and lockbox.
+    children:
+      - id: BC-2150.20.10
+        name: Payment Receipt and Application
+        level: 3
+        industry: Insurance
+        description: |
+          Receipt of premium payments and application to policy accounts.
+        children: []
+      - id: BC-2150.20.20
+        name: Direct Debit and Recurring Payment Operations
+        level: 3
+        industry: Insurance
+        description: |
+          Operation of direct debit, recurring card, and standing-order schemes.
+        children: []
+      - id: BC-2150.20.30
+        name: Premium Refund Processing
+        level: 3
+        industry: Insurance
+        description: |
+          Processing of premium refunds following endorsements and cancellations.
+        children: []
+      - id: BC-2150.20.40
+        name: Lockbox and Cash Allocation
+        level: 3
+        industry: Insurance
+        description: |
+          Lockbox receipt, cash allocation, and exception handling.
+        children: []
+  - id: BC-2150.30
+    name: "Broker & Producer Account Settlement"
+    level: 2
+    industry: Insurance
+    description: |
+      Producer statements, premium-less-commission settlement, and trust-account reconciliation.
+    children:
+      - id: BC-2150.30.10
+        name: Producer Statement Generation
+        level: 3
+        industry: Insurance
+        description: |
+          Generation of premium and commission statements for producers.
+        children: []
+      - id: BC-2150.30.20
+        name: Premium-Less-Commission Settlement
+        level: 3
+        industry: Insurance
+        description: |
+          Settlement of premium net of commission to and from producers.
+        children: []
+      - id: BC-2150.30.30
+        name: Producer Trust Account Reconciliation
+        level: 3
+        industry: Insurance
+        description: |
+          Reconciliation of producer trust accounts and IBA balances.
+        children: []
+  - id: BC-2150.40
+    name: "Premium Reserve & Earnings Management"
+    level: 2
+    industry: Insurance
+    description: |
+      Unearned premium calculation, earned premium recognition, and deferred acquisition cost tracking.
+    children:
+      - id: BC-2150.40.10
+        name: Unearned Premium Calculation
+        level: 3
+        industry: Insurance
+        description: |
+          Calculation of unearned premium reserves on in-force policies.
+        children: []
+      - id: BC-2150.40.20
+        name: Earned Premium Recognition
+        level: 3
+        industry: Insurance
+        description: |
+          Recognition of earned premium per accounting period.
+        children: []
+      - id: BC-2150.40.30
+        name: Deferred Acquisition Cost Tracking
+        level: 3
+        industry: Insurance
+        description: |
+          Tracking of deferred acquisition costs (DAC) across product cohorts.
+        children: []
+  - id: BC-2150.50
+    name: "Collections & Dunning Management"
+    level: 2
+    industry: Insurance
+    description: |
+      Aged-receivable monitoring, dunning operations, cancellation for non-payment, and bad-debt write-off.
+    children:
+      - id: BC-2150.50.10
+        name: Aged Receivable Monitoring
+        level: 3
+        industry: Insurance
+        description: |
+          Monitoring of aged premium receivables across policyholders and producers.
+        children: []
+      - id: BC-2150.50.20
+        name: Dunning and Reminder Operations
+        level: 3
+        industry: Insurance
+        description: |
+          Dunning notices, reminders, and arrears communications.
+        children: []
+      - id: BC-2150.50.30
+        name: Cancellation for Non-Payment Handling
+        level: 3
+        industry: Insurance
+        description: |
+          Triggering of cancellation processes for unpaid premium.
+        children: []
+      - id: BC-2150.50.40
+        name: Bad Debt Write-Off
+        level: 3
+        industry: Insurance
+        description: |
+          Approval and posting of bad-debt write-offs on uncollectable premium.
+        children: []
+  - id: BC-2150.60
+    name: "Tax & Levy Accounting"
+    level: 2
+    industry: Insurance
+    description: |
+      Insurance premium tax calculation, stamp duty and levy collection, and premium tax filing support.
+    children:
+      - id: BC-2150.60.10
+        name: Insurance Premium Tax Calculation
+        level: 3
+        industry: Insurance
+        description: |
+          Calculation of insurance premium tax across jurisdictions and product types.
+        children: []
+      - id: BC-2150.60.20
+        name: Stamp Duty and Levy Collection
+        level: 3
+        industry: Insurance
+        description: |
+          Collection and remittance of stamp duties and statutory levies.
+        children: []
+      - id: BC-2150.60.30
+        name: Premium Tax Filing Support
+        level: 3
+        industry: Insurance
+        description: |
+          Production of underlying data and reconciliations for premium tax filings.
+        children: []

--- a/catalogue/L1-reinsurance-management.yaml
+++ b/catalogue/L1-reinsurance-management.yaml
@@ -1,0 +1,210 @@
+# Reinsurance Management
+id: BC-2170
+name: Reinsurance Management
+level: 1
+industry: Insurance
+description: |
+  Ceded and assumed reinsurance - treaty design, facultative placements,
+  bordereau, claim recoveries, accounting, and reinsurance counterparty
+  exposure management.
+references:
+  - https://www.acord.org/standards/reference-architecture
+  - https://www.iaisweb.org/icp-online-tool/
+  - https://www.lloyds.com/conducting-business/delegated-authorities
+children:
+  - id: BC-2170.10
+    name: Ceded Reinsurance Programme Design
+    level: 2
+    industry: Insurance
+    description: |
+      Reinsurance need analysis, programme structuring, and reinsurance broker coordination.
+    children:
+      - id: BC-2170.10.10
+        name: Reinsurance Need Analysis
+        level: 3
+        industry: Insurance
+        description: |
+          Analysis of reinsurance needs based on portfolio, risk appetite, and capital constraints.
+        children: []
+      - id: BC-2170.10.20
+        name: Treaty and Facultative Strategy
+        level: 3
+        industry: Insurance
+        description: |
+          Strategy on treaty vs facultative cessions and proportional vs non-proportional structures.
+        children: []
+      - id: BC-2170.10.30
+        name: Programme Structuring
+        level: 3
+        industry: Insurance
+        description: |
+          Structuring of reinsurance programmes, layers, and retentions.
+        children: []
+      - id: BC-2170.10.40
+        name: Reinsurance Broker Coordination
+        level: 3
+        industry: Insurance
+        description: |
+          Coordination with reinsurance brokers on placement and renewal.
+        children: []
+  - id: BC-2170.20
+    name: Treaty Reinsurance Administration
+    level: 2
+    industry: Insurance
+    description: |
+      Treaty onboarding, premium cession, bordereau production, and treaty claims recovery.
+    children:
+      - id: BC-2170.20.10
+        name: Treaty Onboarding and Renewal
+        level: 3
+        industry: Insurance
+        description: |
+          Onboarding and renewal of reinsurance treaties and slip placement.
+        children: []
+      - id: BC-2170.20.20
+        name: Treaty Premium Calculation and Cession
+        level: 3
+        industry: Insurance
+        description: |
+          Calculation of treaty premiums and cession to participating reinsurers.
+        children: []
+      - id: BC-2170.20.30
+        name: Treaty Bordereau Production
+        level: 3
+        industry: Insurance
+        description: |
+          Production of treaty premium and claim bordereaux per market practice.
+        children: []
+      - id: BC-2170.20.40
+        name: Treaty Claims Recovery
+        level: 3
+        industry: Insurance
+        description: |
+          Recovery of treaty claim payments from reinsurers.
+        children: []
+  - id: BC-2170.30
+    name: Facultative Reinsurance Administration
+    level: 2
+    industry: Insurance
+    description: |
+      Facultative submission, placement tracking, and premium and claim settlement.
+    children:
+      - id: BC-2170.30.10
+        name: Facultative Risk Submission
+        level: 3
+        industry: Insurance
+        description: |
+          Submission of individual risks for facultative placement.
+        children: []
+      - id: BC-2170.30.20
+        name: Facultative Placement Tracking
+        level: 3
+        industry: Insurance
+        description: |
+          Tracking of facultative placement signings and shares across reinsurers.
+        children: []
+      - id: BC-2170.30.30
+        name: Facultative Premium and Claim Settlement
+        level: 3
+        industry: Insurance
+        description: |
+          Settlement of facultative premium and claim recoveries.
+        children: []
+  - id: BC-2170.40
+    name: Assumed Reinsurance Management
+    level: 2
+    industry: Insurance
+    description: |
+      Inwards underwriting, premium booking, claims adjudication, and retrocession coordination.
+    children:
+      - id: BC-2170.40.10
+        name: Inwards Submission Underwriting
+        level: 3
+        industry: Insurance
+        description: |
+          Underwriting of inwards reinsurance submissions and risk acceptance.
+        children: []
+      - id: BC-2170.40.20
+        name: Inwards Premium Booking
+        level: 3
+        industry: Insurance
+        description: |
+          Booking of inwards reinsurance premium and adjustments.
+        children: []
+      - id: BC-2170.40.30
+        name: Inwards Claims Adjudication
+        level: 3
+        industry: Insurance
+        description: |
+          Adjudication of inwards reinsurance claims and recoveries.
+        children: []
+      - id: BC-2170.40.40
+        name: Retrocession Coordination
+        level: 3
+        industry: Insurance
+        description: |
+          Coordination of retrocession to second-tier reinsurers.
+        children: []
+  - id: BC-2170.50
+    name: "Reinsurance Accounting & Settlement"
+    level: 2
+    industry: Insurance
+    description: |
+      Cession accounting, recoverable tracking, statement reconciliation, and counterparty collateral.
+    children:
+      - id: BC-2170.50.10
+        name: Cession and Premium Accounting
+        level: 3
+        industry: Insurance
+        description: |
+          Accounting for ceded premium, commissions, and adjustments.
+        children: []
+      - id: BC-2170.50.20
+        name: Reinsurance Recoverable Tracking
+        level: 3
+        industry: Insurance
+        description: |
+          Tracking of reinsurance recoverables on paid and outstanding claims.
+        children: []
+      - id: BC-2170.50.30
+        name: Reinsurer Statement Reconciliation
+        level: 3
+        industry: Insurance
+        description: |
+          Reconciliation of reinsurer statements and resolution of disputes.
+        children: []
+      - id: BC-2170.50.40
+        name: Counterparty Collateral Management
+        level: 3
+        industry: Insurance
+        description: |
+          Management of letters of credit, trust funds, and collateral from reinsurers.
+        children: []
+  - id: BC-2170.60
+    name: Reinsurance Counterparty Risk Management
+    level: 2
+    industry: Insurance
+    description: |
+      Reinsurer credit assessment, counterparty limit monitoring, and default mitigation.
+    children:
+      - id: BC-2170.60.10
+        name: Reinsurer Credit Assessment
+        level: 3
+        industry: Insurance
+        description: |
+          Credit and financial-strength assessment of reinsurance counterparties.
+        children: []
+      - id: BC-2170.60.20
+        name: Concentration and Counterparty Limit Monitoring
+        level: 3
+        industry: Insurance
+        description: |
+          Monitoring of concentration and counterparty exposure limits.
+        children: []
+      - id: BC-2170.60.30
+        name: Reinsurer Default Mitigation
+        level: 3
+        industry: Insurance
+        description: |
+          Mitigation actions on reinsurer downgrade or default scenarios.
+        children: []

--- a/catalogue/_index.yaml
+++ b/catalogue/_index.yaml
@@ -118,3 +118,14 @@ files:
   - L1-building-systems-commissioning-management.yaml
   - L1-hvac-bas-service-operations-management.yaml
   - L1-building-performance-management.yaml
+  - L1-insurance-product-management.yaml
+  - L1-insurance-distribution-management.yaml
+  - L1-insurance-customer-management.yaml
+  - L1-insurance-underwriting-management.yaml
+  - L1-policy-administration-management.yaml
+  - L1-premium-accounting-management.yaml
+  - L1-insurance-claims-management.yaml
+  - L1-reinsurance-management.yaml
+  - L1-actuarial-management.yaml
+  - L1-insurance-risk-management.yaml
+  - L1-insurance-investment-management.yaml

--- a/catalogue/_value-streams.yaml
+++ b/catalogue/_value-streams.yaml
@@ -280,6 +280,11 @@ value_streams:
         stage_name: Customer Invoicing
         capability_id: BC-200
         notes: Invoice generation
+      - stage_order: 7
+        stage_name: Customer Invoicing
+        capability_id: BC-2150
+        industry_variant: Insurance
+        notes: Premium invoicing
       - stage_order: 8
         stage_name: Cash Collection & Application
         capability_id: BC-200
@@ -288,10 +293,20 @@ value_streams:
         stage_name: Cash Collection & Application
         capability_id: BC-210
         notes: Cash positioning
+      - stage_order: 8
+        stage_name: Cash Collection & Application
+        capability_id: BC-2150
+        industry_variant: Insurance
+        notes: Premium collection
       - stage_order: 9
         stage_name: Revenue Recognition
         capability_id: BC-200
         notes: Revenue posting; Reporting
+      - stage_order: 9
+        stage_name: Revenue Recognition
+        capability_id: BC-2150
+        industry_variant: Insurance
+        notes: Earned-premium recognition
   - name: Procure-to-Pay
     stages:
       - stage_order: 1
@@ -446,6 +461,11 @@ value_streams:
         capability_id: BC-2010
         industry_variant: HVAC & Building Automation Systems
         notes: BAS product NPD
+      - stage_order: 5
+        stage_name: Design & Development
+        capability_id: BC-2100
+        industry_variant: Insurance
+        notes: Insurance product design & wording
       - stage_order: 6
         stage_name: IP Protection
         capability_id: BC-840
@@ -463,6 +483,11 @@ value_streams:
         capability_id: BC-1940
         industry_variant: Electrical Components & Equipment
         notes: Saleable catalogue activation
+      - stage_order: 7
+        stage_name: Launch Readiness
+        capability_id: BC-2100
+        industry_variant: Insurance
+        notes: Filing & channel readiness
       - stage_order: 8
         stage_name: Market Introduction
         capability_id: BC-1530
@@ -482,6 +507,11 @@ value_streams:
         capability_id: BC-2030
         industry_variant: HVAC & Building Automation Systems
         notes: Performance & safety mark issuance for HVAC equipment
+      - stage_order: 8
+        stage_name: Market Introduction
+        capability_id: BC-2100
+        industry_variant: Insurance
+        notes: Regulatory rate filing & approval
       - stage_order: 9
         stage_name: Post-Launch Performance
         capability_id: BC-820
@@ -491,6 +521,11 @@ value_streams:
         capability_id: BC-1940
         industry_variant: Electrical Components & Equipment
         notes: Phase-in / phase-out, last-buy windows
+      - stage_order: 9
+        stage_name: Post-Launch Performance
+        capability_id: BC-2100
+        industry_variant: Insurance
+        notes: Product performance review
   - name: Plan-to-Inventory
     stages:
       - stage_order: 1
@@ -554,6 +589,11 @@ value_streams:
         stage_name: Sub-Ledger Close
         capability_id: BC-200
         notes: AP cut-off; AR cut-off; Fixed asset depreciation run
+      - stage_order: 2
+        stage_name: Sub-Ledger Close
+        capability_id: BC-2150
+        industry_variant: Insurance
+        notes: Premium earnings & DAC close
       - stage_order: 3
         stage_name: Reconciliation & Adjustments
         capability_id: BC-200
@@ -586,6 +626,11 @@ value_streams:
         stage_name: Statutory & Regulatory Reporting
         capability_id: BC-240
         notes: Investor relations disclosures
+      - stage_order: 6
+        stage_name: Statutory & Regulatory Reporting
+        capability_id: BC-2180
+        industry_variant: Insurance
+        notes: IFRS 17 & Solvency II reporting
       - stage_order: 7
         stage_name: Audit & Sign-Off
         capability_id: BC-130
@@ -752,6 +797,11 @@ value_streams:
         stage_name: Risk Identification
         capability_id: BC-520
         notes: Supply chain risk feed
+      - stage_order: 2
+        stage_name: Risk Identification
+        capability_id: BC-2190
+        industry_variant: Insurance
+        notes: Insurance risk taxonomy
       - stage_order: 3
         stage_name: Risk Assessment
         capability_id: BC-120
@@ -766,10 +816,20 @@ value_streams:
         capability_id: BC-1970
         industry_variant: Electrical Components & Equipment
         notes: Functional-safety risk assessment for products
+      - stage_order: 3
+        stage_name: Risk Assessment
+        capability_id: BC-2180
+        industry_variant: Insurance
+        notes: Capital & solvency modelling
       - stage_order: 4
         stage_name: Treatment & Control Design
         capability_id: BC-120
         notes: Controls & mitigations; Insurance transfer
+      - stage_order: 4
+        stage_name: Treatment & Control Design
+        capability_id: BC-2170
+        industry_variant: Insurance
+        notes: Reinsurance as risk transfer
       - stage_order: 5
         stage_name: Monitoring
         capability_id: BC-120
@@ -779,6 +839,11 @@ value_streams:
         capability_id: BC-1320
         industry_variant: Banking
         notes: Credit risk modelling
+      - stage_order: 5
+        stage_name: Monitoring
+        capability_id: BC-2190
+        industry_variant: Insurance
+        notes: ORSA monitoring
       - stage_order: 6
         stage_name: Reporting & Escalation
         capability_id: BC-120
@@ -921,6 +986,11 @@ value_streams:
         stage_name: Lead Capture & Nurture
         capability_id: BC-410
         notes: Pipeline handoff
+      - stage_order: 4
+        stage_name: Lead Capture & Nurture
+        capability_id: BC-2110
+        industry_variant: Insurance
+        notes: Quote / submission intake via producers
       - stage_order: 5
         stage_name: Conversion
         capability_id: BC-1300
@@ -930,6 +1000,11 @@ value_streams:
         stage_name: Conversion
         capability_id: BC-410
         notes: Quote / CPQ
+      - stage_order: 5
+        stage_name: Conversion
+        capability_id: BC-2120
+        industry_variant: Insurance
+        notes: Policyholder conversion
       - stage_order: 6
         stage_name: Customer Onboarding
         capability_id: BC-1300
@@ -939,6 +1014,11 @@ value_streams:
         stage_name: Customer Onboarding
         capability_id: BC-420
         notes: Customer lifecycle activation
+      - stage_order: 6
+        stage_name: Customer Onboarding
+        capability_id: BC-2120
+        industry_variant: Insurance
+        notes: Policyholder onboarding & KYC
       - stage_order: 7
         stage_name: Retention & Advocacy
         capability_id: BC-420
@@ -947,6 +1027,11 @@ value_streams:
         stage_name: Retention & Advocacy
         capability_id: BC-430
         notes: Customer feedback loop
+      - stage_order: 7
+        stage_name: Retention & Advocacy
+        capability_id: BC-2120
+        industry_variant: Insurance
+        notes: Policyholder retention
   - name: Application-to-Funding
     stages:
       - stage_order: 1
@@ -1470,6 +1555,11 @@ value_streams:
         capability_id: BC-2070
         industry_variant: HVAC & Building Automation Systems
         notes: Building energy & operational carbon telemetry
+      - stage_order: 2
+        stage_name: Data Collection
+        capability_id: BC-2200
+        industry_variant: Insurance
+        notes: Investment portfolio climate data
       - stage_order: 3
         stage_name: Data Quality & Assurance
         capability_id: BC-140


### PR DESCRIPTION
Promotes Insurance from "Other industry anchors not yet exercised" into
its own §9.8 subsection ahead of generating the Insurance L1 capability
set. Anchors: ACORD, Solvency II / NAIC RBC, IFRS 17 / IFRS 9, IAIS ICPs,
ISO 31000, Lloyd's Market Standards, IDD / NAIC, GDPR / HIPAA.

https://claude.ai/code/session_01UzAfUhjuUi3qjFGEqaaczW