### PR TITLE
Group value streams by industry

### DIFF
--- a/.claude/skills/map-value-streams/SKILL.md
+++ b/.claude/skills/map-value-streams/SKILL.md
@@ -43,11 +43,35 @@ Stages reference the **L1 only**. The lint rule (`scripts/lint.ts` `L1_ID_REGEX`
 2. Read **`business-capability-governance-model.md`** §2 (capabilities ≠ value streams) and §9.4 (lint rules).
 3. For each target L1 (resolved from the user's name), read its YAML file under `catalogue/L1-*.yaml` to understand its scope. The value-stream stage references the L1 itself; the site auto-expands to descendants when filtering, so sub-scope detail belongs in `notes`, not in a deeper `capability_id`.
 
+## Stream shape
+
+Every entry under `value_streams:` carries three top-level fields:
+
+```yaml
+- name: <Hyphenated-Stream-Name>
+  industries: [<one or more industries>]
+  stages: [...]
+```
+
+`industries` is **required, lint-enforced, and drawn from the canonical L1 industry vocabulary** (full names — never the short forms used in `industry_variant`):
+
+- `Cross-Industry` — applies to every industry. **Must be the only entry** when present (no `[Cross-Industry, Banking & Capital Markets]`).
+- `Air Traffic Control`
+- `Banking & Capital Markets`
+- `Defense & Aerospace`
+- `Electrical Components & Equipment`
+- `Engineering Services`
+- `HVAC & Building Automation Systems`
+- `Manufacturing & Industrial`
+- `Pharmaceuticals & Life Sciences`
+
+A stream that genuinely spans multiple named industries (e.g. *Maintenance-Request-to-Closure* across Manufacturing, HVAC, and Electrical) lists each one. The site groups streams by industry on the filter dropdown and on `/value-streams`, so the array is the user-visible categorisation — keep it accurate, not aspirational. If unsure between Cross-Industry and a single named industry, prefer the named industry; if unsure across two named industries, list both.
+
 ## Step 2 — Identify candidate streams
 
-Authoritative list lives in `catalogue/_value-streams.yaml`; read it at runtime for the source of truth. The tables below summarise the current 24 streams to help you spot fits quickly. Reuse these names exactly — never invent a near-synonym.
+Authoritative list lives in `catalogue/_value-streams.yaml`; read it at runtime for the source of truth (the `industries` array on each stream is the canonical industry assignment). The tables below summarise the current 24 streams to help you spot fits quickly. Reuse these names exactly — never invent a near-synonym.
 
-Cross-industry streams:
+Cross-industry streams (`industries: [Cross-Industry]`):
 
 | Stream | Typical L1 anchors |
 | --- | --- |
@@ -65,21 +89,21 @@ Cross-industry streams:
 | **Threat-to-Mitigation** | BC-620 Cybersecurity, BC-160 Business Continuity, BC-830 Knowledge |
 | **Prospect-to-Customer** | BC-400 Marketing, BC-410 Sales, BC-420 CRM, BC-430 Customer Service, BC-850 Corporate Communications |
 | **Opportunity-to-Order** | BC-410 Sales, BC-420 CRM, BC-440 Pricing, BC-150 Legal |
-| **Maintenance-Request-to-Closure** | BC-1030 Plant Maintenance, BC-1050 Field Service, BC-720 Quality, BC-200 Finance |
 | **Crisis-to-Recovery** | BC-160 Business Continuity, BC-620 Cybersecurity, BC-600 IT, BC-850 Corporate Communications, BC-830 Knowledge, BC-120 Enterprise Risk |
 | **ESG-to-Disclosure** | BC-740 Sustainability, BC-510 Supplier (ratings), BC-610 Information & Data, BC-140 Audit, BC-200 Finance, BC-240 Investor Relations |
-| **Concept-to-Manufacture** | BC-1120 Design, BC-1100 Engineering Discipline, BC-1020 Manufacturing Engineering, BC-820 PLM, BC-1000 Production, BC-1010 Mfg Operations, BC-720 Quality, BC-1130 Engineering Document |
 
-Industry-specific streams (use first when the L1 is industry-specific; canonical streams come second):
+Industry-specific streams (use first when the L1 is industry-specific; canonical streams come second). The `industries` column is what each stream declares in `_value-streams.yaml`:
 
-| Industry | Stream | Typical L1 anchors |
-| --- | --- | --- |
-| Banking | **Application-to-Funding** | BC-1320 Credit & Lending, BC-1300 Banking Customer, BC-1400 Financial Crime, BC-1310 Banking Product, BC-1340 Payments, BC-1410 Banking Risk |
-| Pharma | **Discovery-to-Approval** | BC-1500 Drug Discovery, BC-1510 Drug Development, BC-1520 Clinical Trials, BC-1530 Regulatory Affairs, BC-1580 Medical Affairs, BC-1590 Pharma Commercial, BC-1600 Market Access |
-| Pharma | **Adverse-Event-to-Action** | BC-1540 Pharmacovigilance, BC-1580 Medical Affairs, BC-1530 Regulatory Affairs, BC-850 Corporate Comms |
-| Defense | **Capture-to-Contract** | BC-1750 Defense Capture & Bid, BC-1730 Intelligence Ops, BC-1810 Classified Info Sec, BC-1140 Engineering Tendering, BC-1790 Export Control, BC-150 Legal, BC-1760 Defense Programme |
-| Defense | **Sustain-to-Disposition** | BC-1780 Defense Sustainment, BC-1720 Defense Logistics, BC-1060 Spare Parts, BC-1770 Defense Systems Engineering, BC-1800 Defense T&E, BC-1040 Physical Asset, BC-1810 Classified Info Sec |
-| ATC | **Flight-to-Settle** | BC-1230 Aeronautical Information, BC-1210 ATC Ops, BC-1220 ATC Flow, BC-1270 Route Charges, BC-200 Finance |
+| Industry | Stream | `industries` field | Typical L1 anchors |
+| --- | --- | --- | --- |
+| Banking | **Application-to-Funding** | `[Banking & Capital Markets]` | BC-1320 Credit & Lending, BC-1300 Banking Customer, BC-1400 Financial Crime, BC-1310 Banking Product, BC-1340 Payments, BC-1410 Banking Risk |
+| Pharma | **Discovery-to-Approval** | `[Pharmaceuticals & Life Sciences]` | BC-1500 Drug Discovery, BC-1510 Drug Development, BC-1520 Clinical Trials, BC-1530 Regulatory Affairs, BC-1580 Medical Affairs, BC-1590 Pharma Commercial, BC-1600 Market Access |
+| Pharma | **Adverse-Event-to-Action** | `[Pharmaceuticals & Life Sciences]` | BC-1540 Pharmacovigilance, BC-1580 Medical Affairs, BC-1530 Regulatory Affairs, BC-850 Corporate Comms |
+| Defense | **Capture-to-Contract** | `[Defense & Aerospace]` | BC-1750 Defense Capture & Bid, BC-1730 Intelligence Ops, BC-1810 Classified Info Sec, BC-1140 Engineering Tendering, BC-1790 Export Control, BC-150 Legal, BC-1760 Defense Programme |
+| Defense | **Sustain-to-Disposition** | `[Defense & Aerospace]` | BC-1780 Defense Sustainment, BC-1720 Defense Logistics, BC-1060 Spare Parts, BC-1770 Defense Systems Engineering, BC-1800 Defense T&E, BC-1040 Physical Asset, BC-1810 Classified Info Sec |
+| ATC | **Flight-to-Settle** | `[Air Traffic Control]` | BC-1230 Aeronautical Information, BC-1210 ATC Ops, BC-1220 ATC Flow, BC-1270 Route Charges, BC-200 Finance |
+| Mfg / HVAC / Electrical | **Maintenance-Request-to-Closure** | `[Manufacturing & Industrial, HVAC & Building Automation Systems, Electrical Components & Equipment]` | BC-1030 Plant Maintenance, BC-1050 Field Service, BC-720 Quality, BC-200 Finance |
+| Mfg / Eng Svcs / Electrical / HVAC / Defense | **Concept-to-Manufacture** | `[Manufacturing & Industrial, Engineering Services, Electrical Components & Equipment, HVAC & Building Automation Systems, Defense & Aerospace]` | BC-1120 Design, BC-1100 Engineering Discipline, BC-1020 Manufacturing Engineering, BC-820 PLM, BC-1000 Production, BC-1010 Mfg Operations, BC-720 Quality, BC-1130 Engineering Document |
 
 ### Coverage-gap detection
 
@@ -89,11 +113,18 @@ If a target L1's role is not represented by any of the streams above, do **not**
 Coverage gap: <L1 name> (<BC-id>)
   No existing stream covers this capability's primary role of <one-sentence summary>.
   Suggested new streams:
-    - <Suggested-Name-1> — <one-line rationale: what end-to-end flow it captures>
-    - <Suggested-Name-2> — <alternative framing>
+    - <Suggested-Name-1> — industries: [<from canonical vocabulary>] —
+      <one-line rationale: what end-to-end flow it captures>
+    - <Suggested-Name-2> — industries: [<…>] — <alternative framing>
   Continuing with the streams that do fit. Add a new stream as a follow-up
   (manual edit to _value-streams.yaml) if the suggestion is right.
 ```
+
+Always propose the `industries` array alongside the stream name so the user can approve the full shape in one step. Default heuristics for `industries`:
+
+- The new stream applies to every industry → `[Cross-Industry]`.
+- The triggering L1 is industry-specific (e.g. defined only in one L1 file with a single named industry) → list **only** that industry. Do not pre-emptively widen.
+- Two or more named industries genuinely share the flow → list each one, full names, no `Cross-Industry`.
 
 Continue with whatever streams *do* fit (often there will be a partial fit even when no stream is the primary one). The user can author the new stream manually or via a follow-up `/map-value-streams` invocation once defined.
 
@@ -150,7 +181,31 @@ Do **not** loop through stages asking for individual confirmation.
 
 - **Preserve YAML formatting and comments.** Use the same `yaml` Document approach as `scripts/cli/_shared.ts` if writing programmatically. For interactive edits, use the `Edit` tool to insert stages without reflowing the rest of the file.
 - Insert stages within the existing `stages:` array of the matching `value_streams` entry, **maintaining `stage_order` ascending**. If multiple entries share the same `stage_order`, group them together.
-- For a brand-new stream, append a new entry under `value_streams:` with at least `name` and `stages:`.
+- For a brand-new stream, append a new entry under `value_streams:` with **all three top-level fields**: `name`, `industries`, `stages`. The `industries` array is required and lint-enforced — see *Stream shape* above for the vocabulary and the `Cross-Industry`-stands-alone rule.
+
+  Inline form for a single industry:
+
+  ```yaml
+  - name: <New-Stream-Name>
+    industries: [<Industry Full Name>]
+    stages:
+      - stage_order: 1
+        stage_name: <…>
+        capability_id: BC-<L1>
+        notes: <…>
+  ```
+
+  Block form when multiple industries apply:
+
+  ```yaml
+  - name: <New-Stream-Name>
+    industries:
+      - <Industry A>
+      - <Industry B>
+      - <Industry C>
+    stages:
+      - …
+  ```
 
 ## Step 6 — Validate
 
@@ -163,6 +218,9 @@ If lint fails:
 
 - **Non-L1 capability_id** → the rule (`scripts/lint.ts` `L1_ID_REGEX`) requires L1 only. Truncate to the L1 prefix (e.g. `BC-300.10` → `BC-300`) and move the sub-scope into `notes`.
 - **Unresolved capability_id** → the ID does not exist in the catalogue. Verify against `catalogue/L1-*.yaml`. Do not invent IDs.
+- **Missing `industries` array** → every stream must declare `industries` as a non-empty array. Add it using the canonical L1 vocabulary (see *Stream shape*).
+- **Industry not in catalogue vocabulary** → check spelling and use the full name (e.g. `Pharmaceuticals & Life Sciences`, not `Pharma`; `Banking & Capital Markets`, not `Banking`).
+- **`Cross-Industry` mixed with named industries** → `Cross-Industry` must stand alone. Either drop it or drop the named industries.
 - **YAML parse error** → check indentation and quoting (use `"..."` for names containing `&` or `:`).
 
 ## What this skill must not do
@@ -170,6 +228,8 @@ If lint fails:
 - Add value-stream names *inside* the capability hierarchy. Value streams live only in `_value-streams.yaml` (§2, §5.3 of the governance model).
 - Reference a `capability_id` that doesn't exist — create the capability first via `/generate-capability`, then map it.
 - Edit `dist/api/value-streams.json` directly (build artefact, regenerated by `npm run build:api`).
+- Create a stream without an `industries` array, or with industries outside the canonical L1 vocabulary, or with `Cross-Industry` mixed alongside a named industry. Lint will reject it.
+- Use short forms (`Pharma`, `Banking`, `ATC`) in the stream-level `industries` array — those belong only in the per-stage `industry_variant` field. The stream-level vocabulary is full names.
 - Add an `industry_variant` purely to tag industry — it should reflect a real divergence in stage logic.
 - Bulk-rewrite existing stages without explicit user authorisation.
 

--- a/catalogue/_value-streams.yaml
+++ b/catalogue/_value-streams.yaml
@@ -1,8 +1,12 @@
 # Value Streams (orthogonal artefact, not part of the capability hierarchy).
 # Each stage links to an L1 capability; the site auto-expands to descendants
 # when filtering. Use 'notes' to capture sub-scope detail (e.g. "AR sub-capability").
+#
+# Each stream declares an `industries` array using the canonical L1 industry
+# vocabulary. `Cross-Industry`, when present, must be the only entry.
 value_streams:
   - name: Hire-to-Retire
+    industries: [Cross-Industry]
     stages:
       - stage_order: 1
         stage_name: Workforce Planning
@@ -60,6 +64,7 @@ value_streams:
         capability_id: BC-300
         notes: Separation processing
   - name: Issue-to-Resolution
+    industries: [Cross-Industry]
     stages:
       - stage_order: 1
         stage_name: Issue Capture (Audit)
@@ -208,6 +213,7 @@ value_streams:
         stage_name: Lessons Learned (Quality)
         capability_id: BC-830
   - name: Order-to-Cash
+    industries: [Cross-Industry]
     stages:
       - stage_order: 1
         stage_name: Lead Capture & Qualification
@@ -293,6 +299,7 @@ value_streams:
         capability_id: BC-200
         notes: Revenue posting; Reporting
   - name: Procure-to-Pay
+    industries: [Cross-Industry]
     stages:
       - stage_order: 1
         stage_name: Need Identification & Requisition
@@ -374,6 +381,7 @@ value_streams:
         industry_variant: Electrical Components & Equipment
         notes: Distributor performance, PCN/EOL handling
   - name: Idea-to-Market
+    industries: [Cross-Industry]
     stages:
       - stage_order: 1
         stage_name: Idea Capture
@@ -492,6 +500,7 @@ value_streams:
         industry_variant: Electrical Components & Equipment
         notes: Phase-in / phase-out, last-buy windows
   - name: Plan-to-Inventory
+    industries: [Cross-Industry]
     stages:
       - stage_order: 1
         stage_name: Demand Planning
@@ -545,6 +554,7 @@ value_streams:
         industry_variant: Electrical Components & Equipment
         notes: Component lifecycle & obsolescence risk
   - name: Record-to-Report
+    industries: [Cross-Industry]
     stages:
       - stage_order: 1
         stage_name: Transaction Capture
@@ -595,6 +605,7 @@ value_streams:
         capability_id: BC-140
         notes: Internal audit review
   - name: Acquire-to-Retire
+    industries: [Cross-Industry]
     stages:
       - stage_order: 1
         stage_name: Asset Need & Justification
@@ -696,6 +707,7 @@ value_streams:
         industry_variant: Electrical Components & Equipment
         notes: WEEE take-back, remanufacture, reuse
   - name: Strategy-to-Execution
+    industries: [Cross-Industry]
     stages:
       - stage_order: 1
         stage_name: Strategy Formulation
@@ -734,6 +746,7 @@ value_streams:
         capability_id: BC-920
         notes: Benefits tracking
   - name: Risk-to-Mitigation
+    industries: [Cross-Industry]
     stages:
       - stage_order: 1
         stage_name: Risk Appetite & Framework
@@ -788,6 +801,7 @@ value_streams:
         capability_id: BC-130
         notes: Regulatory disclosure where required
   - name: Audit-to-Action
+    industries: [Cross-Industry]
     stages:
       - stage_order: 1
         stage_name: Audit Universe & Plan
@@ -819,6 +833,7 @@ value_streams:
         capability_id: BC-140
         notes: QA review & maturation
   - name: Threat-to-Mitigation
+    industries: [Cross-Industry]
     stages:
       - stage_order: 1
         stage_name: Security Posture Definition
@@ -892,6 +907,7 @@ value_streams:
         capability_id: BC-830
         notes: Best-practice capture
   - name: Prospect-to-Customer
+    industries: [Cross-Industry]
     stages:
       - stage_order: 1
         stage_name: Market & Segment Strategy
@@ -948,6 +964,7 @@ value_streams:
         capability_id: BC-430
         notes: Customer feedback loop
   - name: Application-to-Funding
+    industries: [Banking & Capital Markets]
     stages:
       - stage_order: 1
         stage_name: Application Capture
@@ -1013,6 +1030,7 @@ value_streams:
         industry_variant: Banking
         notes: Banking risk overview
   - name: Discovery-to-Approval
+    industries: [Pharmaceuticals & Life Sciences]
     stages:
       - stage_order: 1
         stage_name: Target Discovery
@@ -1085,6 +1103,7 @@ value_streams:
         industry_variant: Pharma
         notes: Lifecycle maintenance
   - name: Adverse-Event-to-Action
+    industries: [Pharmaceuticals & Life Sciences]
     stages:
       - stage_order: 1
         stage_name: Case Intake
@@ -1136,6 +1155,7 @@ value_streams:
         industry_variant: Pharma
         notes: PV audit
   - name: Capture-to-Contract
+    industries: [Defense & Aerospace]
     stages:
       - stage_order: 1
         stage_name: Customer Intelligence
@@ -1195,6 +1215,7 @@ value_streams:
         industry_variant: Defense
         notes: Programme handover
   - name: Sustain-to-Disposition
+    industries: [Defense & Aerospace]
     stages:
       - stage_order: 1
         stage_name: Sustainment Planning
@@ -1250,6 +1271,7 @@ value_streams:
         industry_variant: Defense
         notes: Classified material destruction
   - name: Flight-to-Settle
+    industries: [Air Traffic Control]
     stages:
       - stage_order: 1
         stage_name: Flight Plan Filing
@@ -1295,6 +1317,10 @@ value_streams:
         capability_id: BC-200
         notes: GL posting
   - name: Maintenance-Request-to-Closure
+    industries:
+      - Manufacturing & Industrial
+      - HVAC & Building Automation Systems
+      - Electrical Components & Equipment
     stages:
       - stage_order: 1
         stage_name: Notification / Request
@@ -1390,6 +1416,7 @@ value_streams:
         industry_variant: HVAC & Building Automation Systems
         notes: Service KPIs, SLA reporting
   - name: Crisis-to-Recovery
+    industries: [Cross-Industry]
     stages:
       - stage_order: 1
         stage_name: Continuity Planning
@@ -1442,6 +1469,7 @@ value_streams:
         capability_id: BC-830
         notes: Lessons learned
   - name: ESG-to-Disclosure
+    industries: [Cross-Industry]
     stages:
       - stage_order: 1
         stage_name: ESG Strategy & Materiality
@@ -1514,6 +1542,12 @@ value_streams:
         capability_id: BC-100
         notes: Strategy execution feedback
   - name: Concept-to-Manufacture
+    industries:
+      - Manufacturing & Industrial
+      - Engineering Services
+      - Electrical Components & Equipment
+      - HVAC & Building Automation Systems
+      - Defense & Aerospace
     stages:
       - stage_order: 1
         stage_name: Concept Design
@@ -1678,6 +1712,7 @@ value_streams:
         industry_variant: Electrical Components & Equipment
         notes: Saleable variant baseline
   - name: Opportunity-to-Order
+    industries: [Cross-Industry]
     stages:
       - stage_order: 1
         stage_name: Opportunity Qualification

--- a/scripts/lib/load.ts
+++ b/scripts/lib/load.ts
@@ -75,6 +75,7 @@ export interface ValueStreamStage {
 
 export interface ValueStream {
   name: string;
+  industries: string[];
   stages: ValueStreamStage[];
 }
 

--- a/scripts/lint.ts
+++ b/scripts/lint.ts
@@ -192,11 +192,45 @@ for (const { file, node } of allFlat) {
 // 11. Value streams: stage capability_id must be L1, must resolve.
 // Sub-scope detail belongs in the 'notes' field; the site auto-expands an L1
 // to its descendants when filtering.
+//
+// Each stream must declare an `industries` array drawn from the catalogue's
+// L1 industry vocabulary (or `Cross-Industry`, which must stand alone).
 // ---------------------------------------------------------------------------
 const l1Set = new Set(
   allFlat.filter(({ node }) => node.level === 1).map(({ node }) => node.id)
 );
+const industryVocab = new Set<string>();
+for (const { node } of allFlat) {
+  if (node.level !== 1 || !node.industry) continue;
+  for (const part of node.industry.split(";").map((s) => s.trim()).filter(Boolean)) {
+    if (part !== "Cross-Industry") industryVocab.add(part);
+  }
+}
 for (const stream of loadValueStreams()) {
+  if (!Array.isArray(stream.industries) || stream.industries.length === 0) {
+    err(
+      "_value-streams.yaml",
+      `Stream '${stream.name}': missing required 'industries' array (use [Cross-Industry] for cross-industry streams)`
+    );
+  } else {
+    const inds = stream.industries.map((i) => i.trim());
+    if (inds.includes("Cross-Industry") && inds.length > 1) {
+      err(
+        "_value-streams.yaml",
+        `Stream '${stream.name}': 'Cross-Industry' must be the only entry in industries when present`
+      );
+    }
+    for (const ind of inds) {
+      if (ind === "Cross-Industry") continue;
+      if (!industryVocab.has(ind)) {
+        const valid = ["Cross-Industry", ...Array.from(industryVocab).sort()].join(", ");
+        err(
+          "_value-streams.yaml",
+          `Stream '${stream.name}': industry '${ind}' not in catalogue vocabulary; valid values: ${valid}`
+        );
+      }
+    }
+  }
   for (const stage of stream.stages) {
     const id = stage.capability_id;
     if (!L1_ID_REGEX.test(id)) {

--- a/site/src/components/CatalogueBrowser.tsx
+++ b/site/src/components/CatalogueBrowser.tsx
@@ -25,6 +25,7 @@ export interface ValueStreamStage {
 
 export interface ValueStream {
   name: string;
+  industries: string[];
   stages: ValueStreamStage[];
 }
 
@@ -151,6 +152,25 @@ export default function CatalogueBrowser({ data, valueStreams }: Props) {
     () => valueStreams.map((v) => v.name).sort(),
     [valueStreams]
   );
+
+  /**
+   * Industry → sorted list of stream names. Each stream lands under every
+   * industry it lists (multi-industry streams appear in each). Cross-Industry
+   * streams form their own bucket; they apply everywhere but are not
+   * duplicated under each named industry.
+   */
+  const valueStreamsByIndustry = useMemo(() => {
+    const map = new Map<string, string[]>();
+    for (const stream of valueStreams) {
+      for (const ind of stream.industries ?? []) {
+        const list = map.get(ind) ?? [];
+        list.push(stream.name);
+        map.set(ind, list);
+      }
+    }
+    for (const list of map.values()) list.sort();
+    return map;
+  }, [valueStreams]);
 
   /**
    * capabilityId → set of value-stream names containing it.
@@ -428,6 +448,27 @@ export default function CatalogueBrowser({ data, valueStreams }: Props) {
   const selectionCount = selected.size;
   const detail = detailId ? byId.get(detailId) ?? null : null;
 
+  /**
+   * Stream-filter dropdown groups, narrowed to the active industry filter.
+   * Cross-Industry streams always appear (they apply everywhere). When the
+   * Industry filter has selections, named-industry groups are limited to
+   * those selections; otherwise every industry that has streams is shown.
+   */
+  const valueStreamGroups = useMemo(() => {
+    const groups: { label: string; options: string[] }[] = [];
+    const cross = valueStreamsByIndustry.get("Cross-Industry") ?? [];
+    if (cross.length > 0) groups.push({ label: "Cross-Industry", options: cross });
+    const namedIndustries = Array.from(valueStreamsByIndustry.keys())
+      .filter((k) => k !== "Cross-Industry")
+      .filter((k) => industries.size === 0 || industries.has(k))
+      .sort();
+    for (const ind of namedIndustries) {
+      const opts = valueStreamsByIndustry.get(ind) ?? [];
+      if (opts.length > 0) groups.push({ label: ind, options: opts });
+    }
+    return groups;
+  }, [valueStreamsByIndustry, industries]);
+
   return (
     <div class="catalogue-page">
       <FilterBar
@@ -440,6 +481,7 @@ export default function CatalogueBrowser({ data, valueStreams }: Props) {
         industries={industries}
         onIndustries={setIndustries}
         valueStreamNames={valueStreamNames}
+        valueStreamGroups={valueStreamGroups}
         streams={streams}
         onStreams={setStreams}
         onReset={resetFilters}
@@ -581,6 +623,7 @@ interface FilterBarProps {
   industries: Set<string>;
   onIndustries: (s: Set<string>) => void;
   valueStreamNames: string[];
+  valueStreamGroups: { label: string; options: string[] }[];
   streams: Set<string>;
   onStreams: (s: Set<string>) => void;
   onReset: () => void;
@@ -596,6 +639,7 @@ function FilterBar({
   industries,
   onIndustries,
   valueStreamNames,
+  valueStreamGroups,
   streams,
   onStreams,
   onReset,
@@ -643,6 +687,7 @@ function FilterBar({
         <MultiSelect
           label="Value stream"
           options={valueStreamNames}
+          groups={valueStreamGroups}
           selected={streams}
           onChange={onStreams}
         />
@@ -661,11 +706,14 @@ function FilterBar({
 interface MultiSelectProps {
   label: string;
   options: string[];
+  /** When provided, options are rendered under industry-style group headers.
+   *  The flat `options` prop is still used for the trigger summary count. */
+  groups?: { label: string; options: string[] }[];
   selected: Set<string>;
   onChange: (next: Set<string>) => void;
 }
 
-function MultiSelect({ label, options, selected, onChange }: MultiSelectProps) {
+function MultiSelect({ label, options, groups, selected, onChange }: MultiSelectProps) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -724,16 +772,32 @@ function MultiSelect({ label, options, selected, onChange }: MultiSelectProps) {
               Clear ({selected.size})
             </button>
           )}
-          {options.map((opt) => (
-            <label key={opt} class="multi-select-option">
-              <input
-                type="checkbox"
-                checked={selected.has(opt)}
-                onChange={() => toggle(opt)}
-              />
-              <span>{opt}</span>
-            </label>
-          ))}
+          {groups && groups.length > 0
+            ? groups.map((g) => (
+                <div key={g.label} class="multi-select-group">
+                  <div class="multi-select-group-label">{g.label}</div>
+                  {g.options.map((opt) => (
+                    <label key={`${g.label}::${opt}`} class="multi-select-option">
+                      <input
+                        type="checkbox"
+                        checked={selected.has(opt)}
+                        onChange={() => toggle(opt)}
+                      />
+                      <span>{opt}</span>
+                    </label>
+                  ))}
+                </div>
+              ))
+            : options.map((opt) => (
+                <label key={opt} class="multi-select-option">
+                  <input
+                    type="checkbox"
+                    checked={selected.has(opt)}
+                    onChange={() => toggle(opt)}
+                  />
+                  <span>{opt}</span>
+                </label>
+              ))}
         </div>
       )}
     </div>

--- a/site/src/data/load.ts
+++ b/site/src/data/load.ts
@@ -33,6 +33,7 @@ export interface ValueStreamStage {
 
 export interface ValueStream {
   name: string;
+  industries: string[];
   stages: ValueStreamStage[];
 }
 

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -56,6 +56,7 @@ const generatedDate = version.generated_at.slice(0, 10);
         <div class="nav-links">
           <a href="/">Browse</a>
           <a href="/search">Search</a>
+          <a href="/value-streams">Value Streams</a>
           <a href="/api/capabilities.json">API</a>
           <a href="/about">About</a>
           <a

--- a/site/src/pages/value-streams.astro
+++ b/site/src/pages/value-streams.astro
@@ -1,0 +1,271 @@
+---
+import Base from "../layouts/Base.astro";
+import { valueStreams, getById, type ValueStream } from "../data/load.ts";
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+interface Group {
+  industry: string;
+  streams: ValueStream[];
+}
+
+const namedGroups = new Map<string, ValueStream[]>();
+const crossGroup: ValueStream[] = [];
+for (const stream of valueStreams) {
+  const inds = stream.industries ?? [];
+  if (inds.length === 1 && inds[0] === "Cross-Industry") {
+    crossGroup.push(stream);
+    continue;
+  }
+  for (const ind of inds) {
+    const list = namedGroups.get(ind) ?? [];
+    list.push(stream);
+    namedGroups.set(ind, list);
+  }
+}
+for (const list of namedGroups.values()) list.sort((a, b) => a.name.localeCompare(b.name));
+crossGroup.sort((a, b) => a.name.localeCompare(b.name));
+
+const groups: Group[] = [];
+if (crossGroup.length > 0) groups.push({ industry: "Cross-Industry", streams: crossGroup });
+for (const ind of Array.from(namedGroups.keys()).sort()) {
+  groups.push({ industry: ind, streams: namedGroups.get(ind)! });
+}
+---
+
+<Base
+  title="Value Streams"
+  description="Browse end-to-end value streams grouped by industry. Each stream lists its stages and the capabilities they exercise."
+>
+  <main class="main">
+    <div class="section-header">
+      <h2>Value Streams</h2>
+      <p class="section-sub">
+        End-to-end flows orthogonal to the capability hierarchy. Streams are grouped
+        by the industries they apply to; <strong>Cross-Industry</strong> streams apply
+        to every industry. A multi-industry stream appears once per industry it lists.
+      </p>
+    </div>
+
+    <nav class="vs-jumpnav" aria-label="Industries">
+      {groups.map((g) => (
+        <a href={`#${slugify(g.industry)}`} class="vs-jump-link">
+          {g.industry}
+          <span class="vs-jump-count">{g.streams.length}</span>
+        </a>
+      ))}
+    </nav>
+
+    {groups.map((g) => (
+      <section id={slugify(g.industry)} class="vs-section">
+        <h3 class="vs-section-title">{g.industry}</h3>
+        <div class="vs-grid">
+          {g.streams.map((stream) => {
+            const stageRows = stream.stages
+              .slice()
+              .sort((a, b) => a.stage_order - b.stage_order || a.stage_name.localeCompare(b.stage_name));
+            const streamSlug = `${slugify(g.industry)}--${slugify(stream.name)}`;
+            return (
+              <article id={streamSlug} class="vs-card">
+                <header class="vs-card-head">
+                  <h4 class="vs-card-title">
+                    <a href={`#${streamSlug}`}>{stream.name}</a>
+                  </h4>
+                  <div class="vs-industries tag-list">
+                    {(stream.industries ?? []).map((i) => (
+                      <span class="cap-industry">{i}</span>
+                    ))}
+                  </div>
+                </header>
+                <ol class="vs-stages">
+                  {stageRows.map((stage) => {
+                    const cap = getById(stage.capability_id);
+                    return (
+                      <li class="vs-stage">
+                        <span class="vs-stage-order">{stage.stage_order}</span>
+                        <div class="vs-stage-body">
+                          <div class="vs-stage-name">{stage.stage_name}</div>
+                          <div class="vs-stage-meta">
+                            <a class="vs-stage-cap" href={`/capability/${stage.capability_id}`}>
+                              {stage.capability_id}
+                              {cap ? ` · ${cap.name}` : ""}
+                            </a>
+                            {stage.industry_variant && (
+                              <span class="vs-stage-variant">{stage.industry_variant}</span>
+                            )}
+                          </div>
+                          {stage.notes && <div class="vs-stage-notes">{stage.notes}</div>}
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ol>
+              </article>
+            );
+          })}
+        </div>
+      </section>
+    ))}
+  </main>
+</Base>
+
+<style>
+  .section-sub {
+    margin: 8px 0 0;
+    color: var(--color-muted);
+    max-width: 720px;
+  }
+
+  .vs-jumpnav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin: 16px 0 24px;
+  }
+  .vs-jump-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    border-radius: 999px;
+    background: var(--color-pale-blue);
+    border: 1px solid var(--color-light-blue);
+    color: var(--color-secondary);
+    font-size: 13px;
+    font-weight: 500;
+    text-decoration: none;
+  }
+  .vs-jump-link:hover {
+    background: var(--color-light-blue);
+  }
+  .vs-jump-count {
+    font-size: 11px;
+    font-weight: 600;
+    background: rgba(255, 255, 255, 0.6);
+    padding: 1px 6px;
+    border-radius: 999px;
+  }
+
+  .vs-section {
+    margin-top: 32px;
+    scroll-margin-top: 80px;
+  }
+  .vs-section-title {
+    margin: 0 0 12px;
+    font-size: 18px;
+    font-weight: 700;
+    color: var(--color-dark);
+    padding-bottom: 6px;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .vs-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+    gap: 16px;
+  }
+
+  .vs-card {
+    background: var(--color-white);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm, 8px);
+    padding: 16px;
+    scroll-margin-top: 80px;
+  }
+  .vs-card-head {
+    margin-bottom: 12px;
+  }
+  .vs-card-title {
+    margin: 0 0 6px;
+    font-size: 16px;
+    font-weight: 700;
+  }
+  .vs-card-title a {
+    color: var(--color-dark);
+    text-decoration: none;
+  }
+  .vs-card-title a:hover {
+    color: var(--color-accent);
+  }
+  .vs-industries {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .vs-stages {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .vs-stage {
+    display: flex;
+    gap: 10px;
+    padding: 8px;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-pale-blue);
+  }
+  .vs-stage-order {
+    flex-shrink: 0;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: var(--color-secondary);
+    color: var(--color-white);
+    font-size: 12px;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .vs-stage-body {
+    flex: 1;
+    min-width: 0;
+  }
+  .vs-stage-name {
+    font-weight: 600;
+    font-size: 13px;
+    color: var(--color-dark);
+  }
+  .vs-stage-meta {
+    margin-top: 2px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+    font-size: 12px;
+  }
+  .vs-stage-cap {
+    color: var(--color-secondary);
+    text-decoration: none;
+    font-family: var(--font-mono, ui-monospace, monospace);
+  }
+  .vs-stage-cap:hover {
+    color: var(--color-accent);
+    text-decoration: underline;
+  }
+  .vs-stage-variant {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--color-accent);
+    background: var(--color-white);
+    border: 1px solid var(--color-light-blue);
+    padding: 0 6px;
+    border-radius: 3px;
+  }
+  .vs-stage-notes {
+    margin-top: 4px;
+    font-size: 12px;
+    color: var(--color-muted);
+    font-style: italic;
+  }
+</style>

--- a/site/src/styles/catalogue.css
+++ b/site/src/styles/catalogue.css
@@ -200,6 +200,21 @@
   height: 14px;
 }
 
+.multi-select-group + .multi-select-group {
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid var(--color-border, #e5e7eb);
+}
+
+.multi-select-group-label {
+  padding: 4px 8px 2px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-muted, #6b7280);
+}
+
 .btn {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
Tag every stream in _value-streams.yaml with an explicit `industries`
array drawn from the catalogue's L1 industry vocabulary. Cross-Industry
streams form their own bucket; multi-industry streams (e.g.
Maintenance-Request-to-Closure, Concept-to-Manufacture) list each
industry they apply to.

Surface this in two places:
- The existing Value stream MultiSelect on the home/search/L1 pages now
  groups options under industry headers, with Cross-Industry pinned
  first. When the Industry filter is active, named-industry groups
  narrow to those selections (Cross-Industry streams always remain).
- A new /value-streams page lists every stream as a card, grouped by
  industry with stage details, industry chips, and links to capability
  pages. Multi-industry streams appear under each of their industries.

Lint validates the new field: required non-empty array, each entry must
be Cross-Industry or appear in the L1 industry vocabulary, and
Cross-Industry must stand alone.