### PR TITLE
feat(catalogue): add Retail & Consumer Goods L1 set (BC-2300-2380)

### DIFF
--- a/business-capability-governance-model.md
+++ b/business-capability-governance-model.md
@@ -495,6 +495,19 @@ Where an industry reference framework exists, anchor the upper levels (L1 / L2) 
 - **IDD (EU Directive 2016/97), NAIC Model Laws, and US state insurance regulations** — distribution and conduct.
 - **GDPR and HIPAA (where applicable)** — privacy and personal-data protection across underwriting and claims.
 
+**Retail & Consumer Goods**
+
+- **ARTS / NRF Reference Model** — retail data and process taxonomy.
+- **GS1 standards (GTIN, GLN, SSCC, GDTI)** — global identification of products, parties, and logistic units.
+- **GDSN (Global Data Synchronisation Network) and GS1 GPC** — product master-data exchange and classification.
+- **GS1 EPCIS** — event-based traceability for supply-chain visibility.
+- **EDI standards (EDIFACT, ANSI X12 — 850 PO, 810 invoice, 856 ASN, 832 catalogue)** — trading-partner messaging.
+- **PCI DSS** — payment-card data security at point of sale.
+- **VICS CPFR** — collaborative planning, forecasting, and replenishment with trading partners.
+- **Consumer Goods Forum (CGF)** — industry collaboration on traceability, safety, and sustainability.
+- **BRCGS, SQF, FSSC 22000, IFS Food, ISO 22000** — food-safety management systems and certification standards.
+- **OECD Due Diligence Guidance for the Garment & Footwear Sector, WRAP, SA8000** — ethical-sourcing and labour standards relevant to consumer-goods supply chains.
+
 **Other industry anchors not yet exercised in the catalogue but recommended for adoption**
 
 - **eTOM** — telecommunications.

--- a/catalogue/L1-food-safety-traceability-management.yaml
+++ b/catalogue/L1-food-safety-traceability-management.yaml
@@ -1,0 +1,203 @@
+# Food Safety & Traceability Management
+id: BC-2380
+name: "Food Safety & Traceability Management"
+level: 1
+industry: Retail & Consumer Goods
+description: |
+  Food-safety programmes, lot and batch traceability, recall coordination,
+  perishables shelf-life management, and cold-chain compliance for grocery
+  and food-manufacturing operations.
+references:
+  - https://www.fssc.com/scheme/fssc-22000/
+  - https://www.brcgs.com/our-standards/food-safety/
+  - https://www.gs1.org/standards/epcis
+children:
+  - id: BC-2380.10
+    name: Food Safety Programme Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Food-safety policy, HACCP, and certification programmes (BRCGS, SQF,
+      FSSC 22000, IFS Food, ISO 22000) governing food handling and supply.
+    in_scope:
+      - HACCP and food-safety policy
+      - Third-party certification (BRCGS, SQF, FSSC 22000, IFS Food)
+      - Food-safety incident management
+    out_of_scope:
+      - Generic quality management (BC-720)
+    children:
+      - id: BC-2380.10.10
+        name: Food Safety Policy Management
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Food-safety policy authoring and stewardship across the network.
+        children: []
+      - id: BC-2380.10.20
+        name: HACCP Plan Management
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          HACCP plan development, hazard analysis, and critical-control-point monitoring.
+        children: []
+      - id: BC-2380.10.30
+        name: Food Safety Certification Management
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Certification against BRCGS, SQF, FSSC 22000, IFS Food, and ISO 22000.
+        children: []
+      - id: BC-2380.10.40
+        name: Food Safety Incident Management
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Incident handling for food-safety events including pathogen detections.
+        children: []
+  - id: BC-2380.20
+    name: "Lot & Batch Traceability Management"
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      One-up / one-down lot and batch traceability across the supply chain
+      using GS1 EPCIS event capture and trading-partner data exchange.
+    children:
+      - id: BC-2380.20.10
+        name: Lot and Batch Coding
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Lot and batch code generation and printing per GS1 standards.
+        children: []
+      - id: BC-2380.20.20
+        name: EPCIS Event Capture
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Capture of EPCIS events (commission, ship, receive) across the supply chain.
+        children: []
+      - id: BC-2380.20.30
+        name: One-Up One-Down Trace
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          One-up / one-down trace of inputs and outputs at each handling node.
+        children: []
+      - id: BC-2380.20.40
+        name: Trading Partner Trace Data Exchange
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Exchange of trace data with suppliers and downstream trading partners.
+        children: []
+  - id: BC-2380.30
+    name: "Recall & Withdrawal Coordination Management"
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Coordination of food and consumer-goods recalls and withdrawals,
+      including regulator notification and consumer communication.
+    in_scope:
+      - Recall classification and decision-making
+      - Regulator notification and reporting
+      - Consumer and trading-partner communication
+    children:
+      - id: BC-2380.30.10
+        name: Recall Decision and Classification
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Decision and classification of recall scope and severity.
+        children: []
+      - id: BC-2380.30.20
+        name: Regulator Notification
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Notification of food-safety regulators per jurisdictional rules.
+        children: []
+      - id: BC-2380.30.30
+        name: Consumer and Trading Partner Communication
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Communication to consumers and trading partners about recall actions.
+        children: []
+      - id: BC-2380.30.40
+        name: Recall Effectiveness Verification
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Verification of recall effectiveness and recovery rates.
+        children: []
+  - id: BC-2380.40
+    name: "Perishables & Shelf-Life Management"
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Shelf-life monitoring, FEFO rotation, dating discipline, and waste
+      reduction across perishables categories.
+    children:
+      - id: BC-2380.40.10
+        name: Shelf Life and Date Coding
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Definition and printing of shelf-life and date codes per market rules.
+        children: []
+      - id: BC-2380.40.20
+        name: First-Expire-First-Out Rotation
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          FEFO rotation in stores and distribution centres.
+        children: []
+      - id: BC-2380.40.30
+        name: Perishables Markdown Coordination
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Coordination of perishables markdowns ahead of expiry to reduce waste.
+        children: []
+      - id: BC-2380.40.40
+        name: Food Waste Reduction Programmes
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Programmes for food-waste reduction, donation, and circular routing.
+        children: []
+  - id: BC-2380.50
+    name: Cold Chain Compliance Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Cold-chain integrity for chilled and frozen food including temperature
+      monitoring, excursion handling, and disposition decisions.
+    in_scope:
+      - Cold-chain temperature monitoring across nodes
+      - Excursion investigation and disposition
+      - Cold-chain SOPs and audits
+    out_of_scope:
+      - Pharmaceutical cold chain (BC-1570.10)
+    children:
+      - id: BC-2380.50.10
+        name: Cold Chain Temperature Monitoring
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          End-to-end temperature monitoring across the food cold chain.
+        children: []
+      - id: BC-2380.50.20
+        name: Cold Chain Excursion Disposition
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Investigation and disposition of cold-chain temperature excursions.
+        children: []
+      - id: BC-2380.50.30
+        name: Cold Chain Audit and Verification
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Audit and verification of cold-chain practices across the network.
+        children: []

--- a/catalogue/L1-merchandising-management.yaml
+++ b/catalogue/L1-merchandising-management.yaml
@@ -1,0 +1,253 @@
+# Merchandising Management
+id: BC-2300
+name: Merchandising Management
+level: 1
+industry: Retail & Consumer Goods
+description: |
+  Range, category, space, buying, private-label, and markdown decisions
+  that shape what products are sold to consumers, where, and at what depth
+  of choice.
+references:
+  - https://nrf.com/resources/retail-technology-standards
+  - https://www.gs1.org/standards/gpc
+children:
+  - id: BC-2300.10
+    name: "Assortment & Range Planning"
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Range architecture, choice counts, and store-cluster assortment plans
+      that translate strategy into the SKUs each location carries.
+    in_scope:
+      - Range architecture and good-better-best structure
+      - Cluster and channel assortment plans
+      - New-item introduction and discontinuation slots
+    out_of_scope:
+      - Generic product lifecycle management (BC-820)
+      - Demand forecasting (BC-520.10)
+    children:
+      - id: BC-2300.10.10
+        name: Range Architecture Definition
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Definition of range architecture, tiering, and good-better-best structure across categories.
+        children: []
+      - id: BC-2300.10.20
+        name: Store Cluster Assortment Planning
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Assortment plans tailored to store clusters by trade area and shopper mission.
+        children: []
+      - id: BC-2300.10.30
+        name: Choice Count Optimisation
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Optimisation of SKU count per category to balance variety, complexity, and margin.
+        children: []
+      - id: BC-2300.10.40
+        name: New Item Introduction Planning
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Slotting and ranging of new items including introduction cadence and replacement decisions.
+        children: []
+      - id: BC-2300.10.50
+        name: Discontinuation Planning
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Range exit decisions, replacement choices, and disposition of discontinued items.
+        children: []
+  - id: BC-2300.20
+    name: Category Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Category strategy, role definition, and performance management treating
+      each category as a business unit per CGF / ECR practice.
+    in_scope:
+      - Category strategy and role definition
+      - Category performance and scorecards
+      - Category-captain collaboration with suppliers
+    children:
+      - id: BC-2300.20.10
+        name: Category Strategy Definition
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Definition of category strategy, target shopper, and competitive positioning.
+        children: []
+      - id: BC-2300.20.20
+        name: Category Role Assignment
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Assignment of category roles such as destination, routine, convenience, or seasonal.
+        children: []
+      - id: BC-2300.20.30
+        name: Category Performance Analysis
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Category scorecards, share, growth, and margin analysis.
+        children: []
+      - id: BC-2300.20.40
+        name: Category Captain Engagement
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Engagement of supplier category captains with information-firewall controls.
+        children: []
+  - id: BC-2300.30
+    name: "Space & Planogram Management"
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Floor and shelf-space allocation, planograms, and fixture layouts that
+      translate the assortment plan into a physical or digital shelf.
+    children:
+      - id: BC-2300.30.10
+        name: Planogram Design
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Design of planograms by category, store cluster, and fixture type.
+        children: []
+      - id: BC-2300.30.20
+        name: Shelf Space Allocation
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Allocation of shelf space across categories and brands by performance.
+        children: []
+      - id: BC-2300.30.30
+        name: Fixture and Floor Layout
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Floor layout and fixture placement to support adjacencies and shopper flow.
+        children: []
+      - id: BC-2300.30.40
+        name: Planogram Compliance Tracking
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Tracking of planogram compliance via store audits and image-recognition feeds.
+        children: []
+  - id: BC-2300.40
+    name: "Buying & Open-to-Buy Management"
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Open-to-buy planning, buying-plan execution, and store allocation that
+      convert assortment plans into vendor purchase commitments.
+    in_scope:
+      - Open-to-buy budgets by department and season
+      - Buying plan execution with vendors
+      - Allocation of received goods across stores
+    out_of_scope:
+      - Generic procurement (BC-500)
+    children:
+      - id: BC-2300.40.10
+        name: Open-to-Buy Planning
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Open-to-buy budgeting by department, class, and season.
+        children: []
+      - id: BC-2300.40.20
+        name: Buying Plan Execution
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Execution of buying plans with vendors including style and SKU selection.
+        children: []
+      - id: BC-2300.40.30
+        name: Store and Channel Allocation
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Allocation of received goods to stores and channels by attribute and performance.
+        children: []
+      - id: BC-2300.40.40
+        name: Replenishment Buy Management
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Replenishment-buy decisions for staple and never-out-of-stock items.
+        children: []
+  - id: BC-2300.50
+    name: Private Label Development Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Strategy, specification, sourcing, and brand stewardship of own-brand
+      and private-label product lines.
+    children:
+      - id: BC-2300.50.10
+        name: Private Label Strategy
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Private-label portfolio strategy and tiering across own brands.
+        children: []
+      - id: BC-2300.50.20
+        name: Private Label Specification
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Product specifications, packaging briefs, and quality standards for own brands.
+        children: []
+      - id: BC-2300.50.30
+        name: Private Label Sourcing
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Sourcing of contract manufacturers and co-packers for own-brand production.
+        children: []
+      - id: BC-2300.50.40
+        name: Private Label Brand Stewardship
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Stewardship of own-brand identity, packaging governance, and equity.
+        children: []
+  - id: BC-2300.60
+    name: "Markdown & Stock Disposition Management"
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Markdown cadence, clearance, and disposition decisions that retire
+      excess and end-of-life retail stock.
+    in_scope:
+      - Markdown cadence and depth decisions
+      - End-of-season clearance plans
+      - Liquidation, outlet, donation, and destruction disposition
+    out_of_scope:
+      - Day-to-day price changes (BC-440.20.20)
+      - Promotional discounting (BC-440.30)
+    children:
+      - id: BC-2300.60.10
+        name: Markdown Strategy
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Strategy for markdown depth, cadence, and timing across categories.
+        children: []
+      - id: BC-2300.60.20
+        name: End-of-Season Clearance Planning
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          End-of-season clearance plans and exit-price management.
+        children: []
+      - id: BC-2300.60.30
+        name: Stock Disposition Routing
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Routing of residual stock to outlet, liquidation, donation, or destruction.
+        children: []

--- a/catalogue/L1-omnichannel-order-fulfilment-management.yaml
+++ b/catalogue/L1-omnichannel-order-fulfilment-management.yaml
@@ -1,0 +1,175 @@
+# Omnichannel Order & Fulfilment Management
+id: BC-2330
+name: "Omnichannel Order & Fulfilment Management"
+level: 1
+industry: Retail & Consumer Goods
+description: |
+  Cross-channel orchestration of consumer orders - capture in any channel,
+  promise from any node, and fulfilment via store, distribution centre,
+  marketplace, vendor drop-ship, or last-mile partner.
+references:
+  - https://nrf.com/resources/retail-technology-standards
+  - https://www.gs1.org/standards/edi
+children:
+  - id: BC-2330.10
+    name: Channel Orchestration Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Single view of consumer orders across channels, channel-mix routing,
+      and consistent status across digital, store, and marketplace.
+    in_scope:
+      - Channel-routing rules and node selection
+      - Single order view across channels
+      - Channel-mix economics and fulfilment cost trade-offs
+    out_of_scope:
+      - Generic order fulfilment (BC-520.40)
+    children:
+      - id: BC-2330.10.10
+        name: Channel Routing Rule Management
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Definition of routing rules selecting fulfilment node by cost and service.
+        children: []
+      - id: BC-2330.10.20
+        name: Cross-Channel Order View
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Unified view of orders, status, and history across channels.
+        children: []
+      - id: BC-2330.10.30
+        name: Channel Mix Economics
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Analysis of unit economics by channel and fulfilment route.
+        children: []
+  - id: BC-2330.20
+    name: Click-and-Collect Operations Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Buy-online-pick-up-in-store, kerbside, and locker collection operations
+      that bridge digital orders to physical pickup points.
+    children:
+      - id: BC-2330.20.10
+        name: Pick-and-Pack-in-Store Operations
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Picking and packing of online orders by store associates.
+        children: []
+      - id: BC-2330.20.20
+        name: Customer Pickup Handover
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Customer-pickup hand-off including identity check and exception handling.
+        children: []
+      - id: BC-2330.20.30
+        name: Kerbside and Locker Collection
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Kerbside hand-off and locker-based collection operations.
+        children: []
+  - id: BC-2330.30
+    name: Distributed Order Fulfilment Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Ship-from-store, dark-store, and vendor drop-ship fulfilment from a
+      distributed inventory pool to consumer destinations.
+    in_scope:
+      - Ship-from-store operations
+      - Dark-store and micro-fulfilment-centre operations
+      - Vendor drop-ship orchestration
+    children:
+      - id: BC-2330.30.10
+        name: Ship-from-Store Operations
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Picking, packing, and shipping of online orders from physical stores.
+        children: []
+      - id: BC-2330.30.20
+        name: Dark Store and Micro-Fulfilment Operations
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Operations of dark stores and micro-fulfilment centres for digital orders.
+        children: []
+      - id: BC-2330.30.30
+        name: Vendor Drop-Ship Orchestration
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Orchestration of vendor drop-ship including PO routing and tracking.
+        children: []
+  - id: BC-2330.40
+    name: Marketplace Seller Operations Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Operating retailer-as-seller listings on third-party marketplaces and
+      managing third-party sellers on a host marketplace.
+    children:
+      - id: BC-2330.40.10
+        name: Marketplace Listing Management
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Listing of items on third-party marketplaces including content adaptation.
+        children: []
+      - id: BC-2330.40.20
+        name: Marketplace Order Capture
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Capture and translation of marketplace orders into the host order pipeline.
+        children: []
+      - id: BC-2330.40.30
+        name: Third-Party Seller Onboarding
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Onboarding of third-party sellers onto the retailer's own marketplace.
+        children: []
+      - id: BC-2330.40.40
+        name: Third-Party Seller Performance Management
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Management of third-party seller performance and policy compliance.
+        children: []
+  - id: BC-2330.50
+    name: Consumer Delivery Slot Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Consumer-facing delivery slot booking, time-window pricing, and
+      courier dispatch coordination for home delivery.
+    children:
+      - id: BC-2330.50.10
+        name: Delivery Slot Booking
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Consumer booking of delivery slots with availability and capacity logic.
+        children: []
+      - id: BC-2330.50.20
+        name: Time Window Pricing
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Dynamic pricing of delivery time windows by demand and route density.
+        children: []
+      - id: BC-2330.50.30
+        name: Courier Dispatch Coordination
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Dispatch coordination with own and third-party last-mile couriers.
+        children: []

--- a/catalogue/L1-point-of-sale-operations-management.yaml
+++ b/catalogue/L1-point-of-sale-operations-management.yaml
@@ -1,0 +1,243 @@
+# Point of Sale Operations Management
+id: BC-2320
+name: Point of Sale Operations Management
+level: 1
+industry: Retail & Consumer Goods
+description: |
+  Customer-facing transaction layer of retail - sales rings, tender and
+  payment acceptance, returns and refunds, cash handling, POS configuration,
+  and continuity of selling during system outages.
+references:
+  - https://nrf.com/resources/retail-technology-standards
+  - https://www.pcisecuritystandards.org/
+children:
+  - id: BC-2320.10
+    name: Sales Transaction Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Capture of consumer sales transactions including basket build,
+      scanning, promotion application, tax handling, and digital receipts.
+    in_scope:
+      - Basket build and item scanning
+      - Promotion and loyalty application at the till
+      - Tax calculation and digital or paper receipts
+    out_of_scope:
+      - Promotion design (BC-440.30)
+      - E-commerce checkout (BC-2330)
+    children:
+      - id: BC-2320.10.10
+        name: Item Scanning and Basket Build
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Scanning of items and basket assembly at the till including weight items.
+        children: []
+      - id: BC-2320.10.20
+        name: Promotion and Loyalty Application
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Application of promotions, coupons, and loyalty redemptions during the sale.
+        children: []
+      - id: BC-2320.10.30
+        name: Sales Tax and VAT Handling
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Calculation of sales tax, VAT, and jurisdiction-specific rules at the till.
+        children: []
+      - id: BC-2320.10.40
+        name: Receipt and Digital Receipt Issuance
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Issuance of paper and digital receipts including consumer linking.
+        children: []
+  - id: BC-2320.20
+    name: Tender and Payment Acceptance Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Acceptance of payment tenders at the till including EMV, contactless,
+      mobile wallets, gift cards, and alternative payment methods, with
+      PCI-DSS compliance.
+    children:
+      - id: BC-2320.20.10
+        name: Card and Contactless Payment Acceptance
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          EMV, contactless, and mobile-wallet payment acceptance at retail tills.
+        children: []
+      - id: BC-2320.20.20
+        name: Cash and Cheque Acceptance
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Cash, coin, and cheque acceptance including denomination handling.
+        children: []
+      - id: BC-2320.20.30
+        name: Gift Card and Stored Value Acceptance
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Acceptance and issuance of gift cards and stored-value instruments.
+        children: []
+      - id: BC-2320.20.40
+        name: Alternative Payment Method Acceptance
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Acceptance of buy-now-pay-later, QR, and other alternative tenders.
+        children: []
+      - id: BC-2320.20.50
+        name: PCI-DSS Compliance Operations
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          PCI-DSS-compliant handling of cardholder data at the point of sale.
+        children: []
+  - id: BC-2320.30
+    name: "Returns, Refunds & Exchange Management"
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      In-store processing of consumer returns, refunds, and exchanges
+      including original-tender, store-credit, and cross-channel cases.
+    in_scope:
+      - In-store consumer returns and refunds
+      - Store-credit and exchange handling
+      - Cross-channel returns of online orders to store
+    out_of_scope:
+      - Reverse logistics back to DC (BC-520.40.40)
+    children:
+      - id: BC-2320.30.10
+        name: Consumer Return Acceptance
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Acceptance of consumer returns at the till against return policy.
+        children: []
+      - id: BC-2320.30.20
+        name: Refund and Store Credit Issuance
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Issuance of refunds to original tender or store-credit instruments.
+        children: []
+      - id: BC-2320.30.30
+        name: Exchange Transaction Handling
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Even and uneven exchange transactions including price reconciliation.
+        children: []
+      - id: BC-2320.30.40
+        name: Cross-Channel Return Processing
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Acceptance of online and other-channel orders for return at the store.
+        children: []
+  - id: BC-2320.40
+    name: POS Cash and Tender Handling
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Cash drawer, safe, deposit, and end-of-day tender reconciliation
+      processes that protect till takings.
+    children:
+      - id: BC-2320.40.10
+        name: Cash Drawer Management
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Opening, monitoring, and reconciliation of till cash drawers.
+        children: []
+      - id: BC-2320.40.20
+        name: Store Safe and Pickup Operations
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Safe management, mid-day pickups, and CIT preparation.
+        children: []
+      - id: BC-2320.40.30
+        name: End-of-Day Tender Reconciliation
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Reconciliation of all tenders against POS sales records at end of day.
+        children: []
+      - id: BC-2320.40.40
+        name: Bank Deposit Preparation
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Preparation of bank deposits and cash-in-transit handover.
+        children: []
+  - id: BC-2320.50
+    name: POS Configuration Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Configuration of tender types, tax rules, promotion logic, peripherals,
+      and till behaviour across the store estate.
+    children:
+      - id: BC-2320.50.10
+        name: Tender and Payment Configuration
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Configuration of accepted tenders, limits, and routing per store.
+        children: []
+      - id: BC-2320.50.20
+        name: Tax Rule Configuration
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Configuration of tax rules and jurisdictional overrides per store.
+        children: []
+      - id: BC-2320.50.30
+        name: Promotion Engine Configuration
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Configuration of POS promotion engine and offer prioritisation rules.
+        children: []
+      - id: BC-2320.50.40
+        name: POS Peripheral Configuration
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Configuration of scales, scanners, printers, and PIN pads at the till.
+        children: []
+  - id: BC-2320.60
+    name: "POS Resilience & Offline Operations"
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Continuity of selling during connectivity or system outage including
+      offline POS, store-and-forward, and queue management.
+    children:
+      - id: BC-2320.60.10
+        name: Offline POS Operation
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Continued operation of the POS during connectivity loss.
+        children: []
+      - id: BC-2320.60.20
+        name: Store-and-Forward Transaction Handling
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Storage and forwarding of offline transactions on reconnection.
+        children: []
+      - id: BC-2320.60.30
+        name: Outage Queue Management
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Customer queue management during checkout-system outage events.
+        children: []

--- a/catalogue/L1-product-information-management.yaml
+++ b/catalogue/L1-product-information-management.yaml
@@ -1,0 +1,178 @@
+# Product Information Management
+id: BC-2370
+name: Product Information Management
+level: 1
+industry: Retail & Consumer Goods
+description: |
+  Authoritative item attributes, marketing content, and channel-ready
+  product data - from item creation through GS1/GDSN synchronisation to
+  multi-channel syndication and content readiness.
+references:
+  - https://www.gs1.org/standards/gdsn
+  - https://www.gs1.org/standards/gpc
+children:
+  - id: BC-2370.10
+    name: Item Master Data Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Item master attributes, GTINs, hierarchies, and taxonomy that form
+      the canonical product record across the enterprise.
+    in_scope:
+      - Item creation and attribute maintenance
+      - GTIN, GLN, and packaging-level identification
+      - Product taxonomy and classification (e.g. GS1 GPC)
+    out_of_scope:
+      - Generic master-data governance (BC-610)
+    children:
+      - id: BC-2370.10.10
+        name: Item Creation and Attribution
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Creation of item records and authoring of attribute values.
+        children: []
+      - id: BC-2370.10.20
+        name: GTIN and Identifier Allocation
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Allocation of GTINs and packaging-level identifiers per GS1 rules.
+        children: []
+      - id: BC-2370.10.30
+        name: Product Hierarchy and Taxonomy
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Maintenance of product hierarchy and taxonomy (e.g. GS1 GPC).
+        children: []
+      - id: BC-2370.10.40
+        name: Item Status and Lifecycle State
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Tracking of item lifecycle states from concept to discontinued.
+        children: []
+  - id: BC-2370.20
+    name: Product Content Authoring Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Authoring of marketing copy, photography, video, and rich media
+      that turn an item record into a sellable consumer-facing product.
+    children:
+      - id: BC-2370.20.10
+        name: Marketing Copy Authoring
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Authoring of titles, descriptions, and selling copy per channel.
+        children: []
+      - id: BC-2370.20.20
+        name: Product Photography and Video Production
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Production of product photography, lifestyle imagery, and video.
+        children: []
+      - id: BC-2370.20.30
+        name: Rich Media and 3D Asset Production
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Production of 360-degree, AR, and 3D product assets.
+        children: []
+      - id: BC-2370.20.40
+        name: Translation and Localisation
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Translation and localisation of product content for target markets.
+        children: []
+  - id: BC-2370.30
+    name: Channel Syndication Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Publication of product content to owned channels, retailer feeds,
+      marketplaces, and trading partners with channel-specific adaptation.
+    children:
+      - id: BC-2370.30.10
+        name: Owned Channel Publishing
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Publishing of content to owned web, mobile, and store channels.
+        children: []
+      - id: BC-2370.30.20
+        name: Marketplace Feed Syndication
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Syndication of feeds to third-party marketplaces and aggregators.
+        children: []
+      - id: BC-2370.30.30
+        name: Retailer Feed and EDI 832 Catalogue
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Provision of EDI 832 product catalogues to retail trading partners.
+        children: []
+  - id: BC-2370.40
+    name: "GS1 / GDSN Synchronisation Management"
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Synchronisation of product master data with trading partners through
+      GDSN data pools, party registration, and recipient subscriptions.
+    children:
+      - id: BC-2370.40.10
+        name: GDSN Data Pool Operations
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Operation of the GDSN data pool relationship and submissions.
+        children: []
+      - id: BC-2370.40.20
+        name: Party and Recipient Registration
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Registration of parties and recipient subscriptions in the GDSN.
+        children: []
+      - id: BC-2370.40.30
+        name: GDSN Synchronisation Exception Management
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Management of GDSN sync exceptions and trading-partner mismatches.
+        children: []
+  - id: BC-2370.50
+    name: Product Content Quality Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Content readiness scoring, completeness measurement, and validation
+      against channel-specific quality standards.
+    children:
+      - id: BC-2370.50.10
+        name: Content Completeness Scoring
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Scoring of content completeness against channel readiness requirements.
+        children: []
+      - id: BC-2370.50.20
+        name: Content Validation and Compliance
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Validation of content against regulatory and channel rules.
+        children: []
+      - id: BC-2370.50.30
+        name: Content Quality Remediation
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Remediation workflow for items failing content quality checks.
+        children: []

--- a/catalogue/L1-retail-loss-prevention-management.yaml
+++ b/catalogue/L1-retail-loss-prevention-management.yaml
@@ -1,0 +1,172 @@
+# Retail Loss Prevention Management
+id: BC-2340
+name: Retail Loss Prevention Management
+level: 1
+industry: Retail & Consumer Goods
+description: |
+  Prevention, detection, investigation, and reduction of stock loss and
+  fraud across the retail estate - from shoplifting and organised retail
+  crime to internal theft and POS-level abuse.
+references:
+  - https://nrf.com/research-insights/loss-prevention
+children:
+  - id: BC-2340.10
+    name: Shrinkage Analysis Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Measurement, root-cause analysis, and reporting of stock shrinkage
+      across stores, channels, and categories.
+    in_scope:
+      - Stock-loss measurement against book inventory
+      - Shrink reporting by store, category, and cause
+      - Root-cause analysis of unknown loss
+    children:
+      - id: BC-2340.10.10
+        name: Shrink Measurement
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Measurement of shrink against book inventory and physical counts.
+        children: []
+      - id: BC-2340.10.20
+        name: Shrink Root-Cause Analysis
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Root-cause analysis of shrink across known and unknown loss.
+        children: []
+      - id: BC-2340.10.30
+        name: Shrink Reporting and Targets
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Shrink reporting and reduction-target setting by store and category.
+        children: []
+  - id: BC-2340.20
+    name: Internal Theft Investigation Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Detection, investigation, and resolution of dishonesty by employees
+      including disciplinary and recovery actions.
+    children:
+      - id: BC-2340.20.10
+        name: Employee Dishonesty Detection
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Detection of employee dishonesty via tip lines, analytics, and audits.
+        children: []
+      - id: BC-2340.20.20
+        name: Internal Investigation Casework
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Casework for internal investigations including evidence handling.
+        children: []
+      - id: BC-2340.20.30
+        name: Recovery and Disciplinary Coordination
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Coordination of recovery, disciplinary, and HR follow-through.
+        children: []
+  - id: BC-2340.30
+    name: External Theft and ORC Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Prevention and investigation of shoplifting and organised retail
+      crime including law-enforcement and industry-association liaison.
+    children:
+      - id: BC-2340.30.10
+        name: Shoplifting Prevention
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Prevention of shoplifting through deterrence, layout, and intervention.
+        children: []
+      - id: BC-2340.30.20
+        name: Organised Retail Crime Investigation
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Investigation of organised retail crime networks and patterns.
+        children: []
+      - id: BC-2340.30.30
+        name: Law Enforcement Liaison
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Liaison with police and industry forums on retail-crime cases.
+        children: []
+  - id: BC-2340.40
+    name: POS Fraud Prevention Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Detection and prevention of fraud at the point of sale including
+      refund fraud, sweethearting, and exception-based reporting.
+    in_scope:
+      - Refund and exchange fraud detection
+      - Sweethearting and discount-abuse detection
+      - POS exception-based reporting
+    children:
+      - id: BC-2340.40.10
+        name: Refund and Exchange Fraud Detection
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Detection of refund and exchange-based fraud patterns.
+        children: []
+      - id: BC-2340.40.20
+        name: Sweethearting and Discount Abuse Detection
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Detection of sweethearting and unauthorised discount application.
+        children: []
+      - id: BC-2340.40.30
+        name: POS Exception-Based Reporting
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Exception-based reporting on POS transactions to surface anomalies.
+        children: []
+  - id: BC-2340.50
+    name: "Physical Security & Surveillance Management"
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Store-level physical security including CCTV, EAS, access controls,
+      and guarding services.
+    children:
+      - id: BC-2340.50.10
+        name: Store CCTV Operations
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Operation, monitoring, and evidence management of in-store CCTV.
+        children: []
+      - id: BC-2340.50.20
+        name: Electronic Article Surveillance Operations
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Operation of EAS gates and tagging, including alarm response.
+        children: []
+      - id: BC-2340.50.30
+        name: Store Access Control
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Physical access control to stockrooms, cash offices, and back-of-house.
+        children: []
+      - id: BC-2340.50.40
+        name: Guard Service Management
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Deployment and management of in-store and contracted guard services.
+        children: []

--- a/catalogue/L1-retail-site-network-planning-management.yaml
+++ b/catalogue/L1-retail-site-network-planning-management.yaml
@@ -1,0 +1,169 @@
+# Retail Site & Network Planning Management
+id: BC-2350
+name: "Retail Site & Network Planning Management"
+level: 1
+industry: Retail & Consumer Goods
+description: |
+  Selection, sizing, and lifecycle of the physical retail network -
+  catchment analysis, format choice, white-space identification, and
+  store-by-store performance lifecycle decisions.
+references:
+  - https://nrf.com/research-insights
+children:
+  - id: BC-2350.10
+    name: "Trade Area & Catchment Analysis"
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Catchment definition, footfall and demographic micro-analysis, and
+      competitive density assessment for prospective and existing sites.
+    children:
+      - id: BC-2350.10.10
+        name: Catchment Definition
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Definition of catchment areas using drive time, density, and barriers.
+        children: []
+      - id: BC-2350.10.20
+        name: Demographic Micro-Analysis
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Micro-level demographic and lifestyle analysis of catchments.
+        children: []
+      - id: BC-2350.10.30
+        name: Footfall and Mobility Analysis
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Analysis of footfall patterns, mobility data, and pedestrian flow.
+        children: []
+      - id: BC-2350.10.40
+        name: Competitive Density Analysis
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Analysis of competitor density and trade-area share.
+        children: []
+  - id: BC-2350.20
+    name: Store Format Selection Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Selection of the appropriate store format - hyper, super, convenience,
+      specialty, dark store - for a given catchment and strategy.
+    in_scope:
+      - Format choice per catchment and shopper mission
+      - Format-mix portfolio across the network
+      - Sizing and footprint sizing per format
+    out_of_scope:
+      - Detailed store interior design (BC-2310.60)
+    children:
+      - id: BC-2350.20.10
+        name: Format Choice per Catchment
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Selection of store format per catchment based on shopper mission.
+        children: []
+      - id: BC-2350.20.20
+        name: Format Sizing and Footprint
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Sizing of selling floor, back-of-house, and overall footprint per format.
+        children: []
+      - id: BC-2350.20.30
+        name: Format Mix Portfolio Planning
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Planning of the network's format mix and migration between formats.
+        children: []
+  - id: BC-2350.30
+    name: Network Footprint Optimisation
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Optimisation of the network footprint across white-space identification,
+      cannibalisation, and overall coverage.
+    children:
+      - id: BC-2350.30.10
+        name: White-Space Identification
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Identification of underserved trade areas and white-space opportunity.
+        children: []
+      - id: BC-2350.30.20
+        name: Cannibalisation Modelling
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Modelling of new-store cannibalisation impact on existing stores.
+        children: []
+      - id: BC-2350.30.30
+        name: Coverage and Reach Optimisation
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Optimisation of coverage and reach across the target market.
+        children: []
+  - id: BC-2350.40
+    name: Store Performance Lifecycle Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Lifecycle decisions for each store - relocation, refurbishment,
+      down-format, or closure based on performance and trade-area shifts.
+    children:
+      - id: BC-2350.40.10
+        name: Store Performance Diagnostic
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Diagnostic of underperforming stores including catchment shifts.
+        children: []
+      - id: BC-2350.40.20
+        name: Store Relocation and Refurbishment Decisions
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Decisions on relocating or refurbishing stores against alternatives.
+        children: []
+      - id: BC-2350.40.30
+        name: Store Closure Decisioning
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Decisioning on store closure including stakeholder and stock impact.
+        children: []
+  - id: BC-2350.50
+    name: Retail Real Estate Brief Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Retail-specific real-estate briefs handed off to corporate real-estate
+      teams for site acquisition, lease negotiation, and exits.
+    in_scope:
+      - Retail-specific site briefs
+      - Hand-off to corporate real-estate acquisition (BC-710.20)
+      - Retail-specific exit briefs (e.g. trade restrictions)
+    out_of_scope:
+      - Lease negotiation and administration (BC-710.20, BC-710.30)
+    children:
+      - id: BC-2350.50.10
+        name: Retail Site Brief Authoring
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Authoring retail-specific site briefs including format and adjacency requirements.
+        children: []
+      - id: BC-2350.50.20
+        name: Retail Exit Brief Authoring
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Authoring retail-specific exit briefs including trade-restriction stance.
+        children: []

--- a/catalogue/L1-retail-store-operations-management.yaml
+++ b/catalogue/L1-retail-store-operations-management.yaml
@@ -1,0 +1,212 @@
+# Retail Store Operations Management
+id: BC-2310
+name: Retail Store Operations Management
+level: 1
+industry: Retail & Consumer Goods
+description: |
+  Day-to-day operation of physical retail stores - opening and closing
+  routines, in-store execution, store-level workforce, audits, fixture
+  care, and the consistent delivery of the store-format experience.
+references:
+  - https://nrf.com/resources/retail-technology-standards
+children:
+  - id: BC-2310.10
+    name: "Store Opening & Closing Operations"
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Daily store opening and closing routines including cash drawer
+      preparation, end-of-day reconciliation, and shift handover.
+    children:
+      - id: BC-2310.10.10
+        name: Store Opening Routine Execution
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Execution of store opening procedures including readiness checks.
+        children: []
+      - id: BC-2310.10.20
+        name: Store Closing Routine Execution
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          End-of-day closing routines including reconciliation and securing.
+        children: []
+      - id: BC-2310.10.30
+        name: Shift Handover Management
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Shift handover between teams with task and incident pass-through.
+        children: []
+  - id: BC-2310.20
+    name: In-Store Execution Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Execution of merchandising, promotion, signage, and replenishment
+      tasks at store level so the store reflects the head-office plan.
+    in_scope:
+      - Task management for store associates
+      - Planogram and signage execution
+      - In-store replenishment from back-of-house stock
+    out_of_scope:
+      - Planogram design (BC-2300.30.10)
+    children:
+      - id: BC-2310.20.10
+        name: Store Task Management
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Distribution and tracking of operational tasks to store teams.
+        children: []
+      - id: BC-2310.20.20
+        name: Planogram and Signage Execution
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          In-store execution of planograms, signage, and promotional set-up.
+        children: []
+      - id: BC-2310.20.30
+        name: In-Store Replenishment
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Replenishment of shelves from back-of-house and stockroom inventory.
+        children: []
+      - id: BC-2310.20.40
+        name: Stockroom and Backroom Operations
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Receiving, organisation, and management of stockroom and backroom inventory.
+        children: []
+  - id: BC-2310.30
+    name: Store Workforce Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Store-level labour scheduling, headcount-by-hour planning, and
+      associate performance management.
+    in_scope:
+      - Hourly labour forecasts driven by traffic and sales
+      - Shift scheduling and time-and-attendance
+      - Associate performance and coaching at store level
+    out_of_scope:
+      - Enterprise human capital management (BC-300)
+    children:
+      - id: BC-2310.30.10
+        name: Labour Demand Forecasting
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Forecasting of hourly labour demand by store and department.
+        children: []
+      - id: BC-2310.30.20
+        name: Store Shift Scheduling
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Scheduling of store shifts respecting fairness and labour rules.
+        children: []
+      - id: BC-2310.30.30
+        name: Time and Attendance Management
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Capture of clock-in, clock-out, and exception management.
+        children: []
+      - id: BC-2310.30.40
+        name: Associate Performance Coaching
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Coaching, recognition, and performance management of store associates.
+        children: []
+  - id: BC-2310.40
+    name: "Store Audit & Compliance Management"
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Operational audits, compliance walks, mystery shopping, and store
+      conformance to brand and operating standards.
+    children:
+      - id: BC-2310.40.10
+        name: Operational Audit Programme
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Programme of operational audits and walks against store standards.
+        children: []
+      - id: BC-2310.40.20
+        name: Mystery Shopping Programme
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Mystery-shopper programme to evaluate the customer experience.
+        children: []
+      - id: BC-2310.40.30
+        name: Store Standards Conformance
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Conformance to brand, safety, and operating standards by store.
+        children: []
+  - id: BC-2310.50
+    name: Store Asset Care Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Store-level care of fixtures, equipment, refrigeration, and
+      cleanliness to keep the store sales-ready.
+    children:
+      - id: BC-2310.50.10
+        name: Fixture and Equipment Maintenance
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Maintenance of in-store fixtures, racks, and equipment.
+        children: []
+      - id: BC-2310.50.20
+        name: Refrigeration Uptime Management
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Monitoring and uptime management of refrigeration in food retail.
+        children: []
+      - id: BC-2310.50.30
+        name: Store Housekeeping and Hygiene
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Cleanliness, housekeeping, and hygiene routines for the sales floor.
+        children: []
+  - id: BC-2310.60
+    name: "Store Format & Experience Management"
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Definition and stewardship of store-format experience standards
+      including service model, look-and-feel, and customer journey.
+    children:
+      - id: BC-2310.60.10
+        name: Store Format Standards
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Standards for each store format covering layout, service, and ambience.
+        children: []
+      - id: BC-2310.60.20
+        name: In-Store Customer Experience Design
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Design of the in-store customer journey and service interactions.
+        children: []
+      - id: BC-2310.60.30
+        name: Store Concept Refresh Planning
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Planning of store concept refreshes and pilot rollouts.
+        children: []

--- a/catalogue/L1-trade-promotion-management.yaml
+++ b/catalogue/L1-trade-promotion-management.yaml
@@ -1,0 +1,182 @@
+# Trade Promotion Management
+id: BC-2360
+name: Trade Promotion Management
+level: 1
+industry: Retail & Consumer Goods
+description: |
+  Consumer-goods discipline of trade investment with retail customers -
+  joint business plans, trade-spend budgeting, in-store event execution,
+  deduction handling, and post-event lift measurement.
+references:
+  - https://www.theconsumergoodsforum.com/
+  - https://www.gs1.org/standards/edi
+children:
+  - id: BC-2360.10
+    name: "Trade Promotion Strategy & Planning"
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Annual trade-promotion strategy, customer-level investment planning,
+      and joint business plans negotiated with retail customers.
+    in_scope:
+      - Annual trade-promotion calendar
+      - Customer-level joint business plans
+      - Slotting and listing-fee strategy
+    children:
+      - id: BC-2360.10.10
+        name: Annual Trade Plan Development
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Development of the annual trade-promotion plan and event calendar.
+        children: []
+      - id: BC-2360.10.20
+        name: Joint Business Planning with Customers
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Joint business planning with strategic retail customers.
+        children: []
+      - id: BC-2360.10.30
+        name: Slotting and Listing Fee Strategy
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Strategy and negotiation of slotting and listing fees for new items.
+        children: []
+  - id: BC-2360.20
+    name: Trade Spend Budget Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Trade-spend budgeting, accruals, allocation across customers, and
+      financial control of trade investments.
+    children:
+      - id: BC-2360.20.10
+        name: Trade Spend Budgeting
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Budgeting of trade spend by customer, brand, and event.
+        children: []
+      - id: BC-2360.20.20
+        name: Trade Spend Accrual Management
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Accrual of trade-spend liabilities by customer and event.
+        children: []
+      - id: BC-2360.20.30
+        name: Trade Spend Allocation
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Allocation of trade-spend pots across customers, regions, and events.
+        children: []
+      - id: BC-2360.20.40
+        name: Trade Spend Financial Control
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Financial control over trade spend including approval thresholds.
+        children: []
+  - id: BC-2360.30
+    name: Promotional Event Execution Management
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Execution of in-store and online promotional events including
+      perfect-store audits and field-team activation.
+    children:
+      - id: BC-2360.30.10
+        name: Event Setup with Customer
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Setup of promotional events with retail customer including artwork and forecasts.
+        children: []
+      - id: BC-2360.30.20
+        name: In-Store Activation and Display
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Activation of in-store displays, gondolas, and secondary placements.
+        children: []
+      - id: BC-2360.30.30
+        name: Perfect Store Audit Execution
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Field execution of perfect-store audits and image-recognition checks.
+        children: []
+      - id: BC-2360.30.40
+        name: Field Sales Team Activation
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Activation of field sales teams to drive event execution.
+        children: []
+  - id: BC-2360.40
+    name: "Deduction & Claim Management"
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Validation, dispute, and resolution of customer deductions and
+      promotional claims taken against invoices.
+    in_scope:
+      - Deduction intake and matching to events
+      - Validation against agreed terms
+      - Dispute resolution and recovery
+    out_of_scope:
+      - Generic AR collections (BC-200)
+    children:
+      - id: BC-2360.40.10
+        name: Deduction Intake and Matching
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Intake of customer deductions and matching to promotional events.
+        children: []
+      - id: BC-2360.40.20
+        name: Deduction Validation
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Validation of deductions against agreed terms, volumes, and prices.
+        children: []
+      - id: BC-2360.40.30
+        name: Dispute Resolution and Recovery
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Dispute resolution with customer and recovery of invalid deductions.
+        children: []
+  - id: BC-2360.50
+    name: Trade Promotion Effectiveness Measurement
+    level: 2
+    industry: Retail & Consumer Goods
+    description: |
+      Post-event measurement of promotional lift, baseline-vs-incremental
+      analysis, and ROI by event, customer, and brand.
+    children:
+      - id: BC-2360.50.10
+        name: Baseline and Lift Measurement
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Measurement of baseline sales and incremental lift from promotional events.
+        children: []
+      - id: BC-2360.50.20
+        name: Promotion ROI Analysis
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          ROI analysis of trade promotions by event, customer, and brand.
+        children: []
+      - id: BC-2360.50.30
+        name: Cannibalisation and Pull-Forward Analysis
+        level: 3
+        industry: Retail & Consumer Goods
+        description: |
+          Analysis of cannibalisation and demand pull-forward effects.
+        children: []

--- a/catalogue/_index.yaml
+++ b/catalogue/_index.yaml
@@ -129,3 +129,12 @@ files:
   - L1-actuarial-management.yaml
   - L1-insurance-risk-management.yaml
   - L1-insurance-investment-management.yaml
+  - L1-merchandising-management.yaml
+  - L1-retail-store-operations-management.yaml
+  - L1-point-of-sale-operations-management.yaml
+  - L1-omnichannel-order-fulfilment-management.yaml
+  - L1-retail-loss-prevention-management.yaml
+  - L1-retail-site-network-planning-management.yaml
+  - L1-trade-promotion-management.yaml
+  - L1-product-information-management.yaml
+  - L1-food-safety-traceability-management.yaml

--- a/catalogue/_value-streams.yaml
+++ b/catalogue/_value-streams.yaml
@@ -114,6 +114,16 @@ value_streams:
         capability_id: BC-2030
         industry_variant: HVAC & Building Automation Systems
         notes: Field safety / non-compliance intake
+      - stage_order: 1
+        stage_name: Issue Capture (Retail Loss Prevention)
+        capability_id: BC-2340
+        industry_variant: Retail & Consumer Goods
+        notes: Shrink, theft, POS fraud intake
+      - stage_order: 1
+        stage_name: Issue Capture (Food Safety)
+        capability_id: BC-2380
+        industry_variant: Retail & Consumer Goods
+        notes: Food-safety incident intake
       - stage_order: 3
         stage_name: Investigation (Audit)
         capability_id: BC-140
@@ -160,6 +170,16 @@ value_streams:
         capability_id: BC-2030
         industry_variant: HVAC & Building Automation Systems
         notes: Certifier liaison & root cause for HVAC equipment
+      - stage_order: 3
+        stage_name: Investigation (Retail Loss Prevention)
+        capability_id: BC-2340
+        industry_variant: Retail & Consumer Goods
+        notes: LP casework, ORC investigation
+      - stage_order: 3
+        stage_name: Investigation (Food Safety)
+        capability_id: BC-2380
+        industry_variant: Retail & Consumer Goods
+        notes: Lot trace and root-cause analysis
       - stage_order: 4
         stage_name: Resolution (Audit)
         capability_id: BC-140
@@ -198,6 +218,16 @@ value_streams:
         capability_id: BC-2030
         industry_variant: HVAC & Building Automation Systems
         notes: Field modification, recall, mark withdrawal
+      - stage_order: 4
+        stage_name: Resolution (Retail Loss Prevention)
+        capability_id: BC-2340
+        industry_variant: Retail & Consumer Goods
+        notes: Recovery and disciplinary follow-through
+      - stage_order: 4
+        stage_name: Resolution (Food Safety)
+        capability_id: BC-2380
+        industry_variant: Retail & Consumer Goods
+        notes: Recall execution and effectiveness verification
       - stage_order: 6
         stage_name: Lessons Learned (Aviation Safety)
         capability_id: BC-1280
@@ -244,6 +274,11 @@ value_streams:
         stage_name: Contract & Order Capture
         capability_id: BC-410
         notes: Order entry
+      - stage_order: 3
+        stage_name: Contract & Order Capture
+        capability_id: BC-2320
+        industry_variant: Retail & Consumer Goods
+        notes: POS basket capture
       - stage_order: 4
         stage_name: Order Promising & Allocation
         capability_id: BC-520
@@ -252,6 +287,11 @@ value_streams:
         stage_name: Order Promising & Allocation
         capability_id: BC-530
         notes: Stock reservation
+      - stage_order: 4
+        stage_name: Order Promising & Allocation
+        capability_id: BC-2330
+        industry_variant: Retail & Consumer Goods
+        notes: Cross-channel order routing
       - stage_order: 5
         stage_name: Production / Service Delivery
         capability_id: BC-1000
@@ -273,6 +313,16 @@ value_streams:
         capability_id: BC-1960
         industry_variant: Electrical Components & Equipment
         notes: OEM commissioning & energisation
+      - stage_order: 5
+        stage_name: Production / Service Delivery
+        capability_id: BC-2310
+        industry_variant: Retail & Consumer Goods
+        notes: In-store sale delivery
+      - stage_order: 5
+        stage_name: Production / Service Delivery
+        capability_id: BC-2330
+        industry_variant: Retail & Consumer Goods
+        notes: Omnichannel fulfilment
       - stage_order: 6
         stage_name: Outbound Logistics
         capability_id: BC-1570
@@ -282,6 +332,11 @@ value_streams:
         stage_name: Outbound Logistics
         capability_id: BC-520
         notes: Shipping
+      - stage_order: 6
+        stage_name: Outbound Logistics
+        capability_id: BC-2330
+        industry_variant: Retail & Consumer Goods
+        notes: BOPIS, kerbside, ship-from-store, last-mile slots
       - stage_order: 7
         stage_name: Customer Invoicing
         capability_id: BC-200
@@ -291,6 +346,11 @@ value_streams:
         capability_id: BC-2150
         industry_variant: Insurance
         notes: Premium invoicing
+      - stage_order: 7
+        stage_name: Customer Invoicing
+        capability_id: BC-2320
+        industry_variant: Retail & Consumer Goods
+        notes: POS receipt issuance
       - stage_order: 8
         stage_name: Cash Collection & Application
         capability_id: BC-200
@@ -304,6 +364,11 @@ value_streams:
         capability_id: BC-2150
         industry_variant: Insurance
         notes: Premium collection
+      - stage_order: 8
+        stage_name: Cash Collection & Application
+        capability_id: BC-2320
+        industry_variant: Retail & Consumer Goods
+        notes: Tender acceptance & end-of-day reconciliation
       - stage_order: 9
         stage_name: Revenue Recognition
         capability_id: BC-200
@@ -474,6 +539,11 @@ value_streams:
         capability_id: BC-2100
         industry_variant: Insurance
         notes: Insurance product design & wording
+      - stage_order: 5
+        stage_name: Design & Development
+        capability_id: BC-2300
+        industry_variant: Retail & Consumer Goods
+        notes: Private-label NPD specification
       - stage_order: 6
         stage_name: IP Protection
         capability_id: BC-840
@@ -496,6 +566,11 @@ value_streams:
         capability_id: BC-2100
         industry_variant: Insurance
         notes: Filing & channel readiness
+      - stage_order: 7
+        stage_name: Launch Readiness
+        capability_id: BC-2370
+        industry_variant: Retail & Consumer Goods
+        notes: Channel content readiness
       - stage_order: 8
         stage_name: Market Introduction
         capability_id: BC-1530
@@ -520,6 +595,11 @@ value_streams:
         capability_id: BC-2100
         industry_variant: Insurance
         notes: Regulatory rate filing & approval
+      - stage_order: 8
+        stage_name: Market Introduction
+        capability_id: BC-2360
+        industry_variant: Retail & Consumer Goods
+        notes: Trade-event launch activation
       - stage_order: 9
         stage_name: Post-Launch Performance
         capability_id: BC-820
@@ -545,6 +625,11 @@ value_streams:
         stage_name: Demand Planning
         capability_id: BC-520
         notes: Statistical forecast + consensus
+      - stage_order: 1
+        stage_name: Demand Planning
+        capability_id: BC-2300
+        industry_variant: Retail & Consumer Goods
+        notes: Cluster assortment & range demand
       - stage_order: 2
         stage_name: Supply Planning
         capability_id: BC-1000
@@ -571,6 +656,11 @@ value_streams:
         stage_name: Inventory Positioning
         capability_id: BC-530
         notes: Stock level targets; Allocation across nodes
+      - stage_order: 4
+        stage_name: Inventory Positioning
+        capability_id: BC-2300
+        industry_variant: Retail & Consumer Goods
+        notes: Allocation across store clusters
       - stage_order: 5
         stage_name: Replenishment Execution
         capability_id: BC-530
@@ -660,6 +750,11 @@ value_streams:
         stage_name: Asset Need & Justification
         capability_id: BC-230
         notes: CAPEX business case
+      - stage_order: 1
+        stage_name: Asset Need & Justification
+        capability_id: BC-2350
+        industry_variant: Retail & Consumer Goods
+        notes: Catchment, format, and network business case
       - stage_order: 2
         stage_name: Acquisition
         capability_id: BC-1110
@@ -885,6 +980,11 @@ value_streams:
         capability_id: BC-1540
         industry_variant: Pharma
         notes: GxP audit & inspection readiness
+      - stage_order: 3
+        stage_name: Fieldwork
+        capability_id: BC-2380
+        industry_variant: Retail & Consumer Goods
+        notes: Food-safety audit & inspection readiness
       - stage_order: 4
         stage_name: Findings & Reporting
         capability_id: BC-140
@@ -994,6 +1094,11 @@ value_streams:
         stage_name: Demand Generation
         capability_id: BC-400
         notes: Campaigns, content syndication; Digital marketing; Content marketing
+      - stage_order: 3
+        stage_name: Demand Generation
+        capability_id: BC-2360
+        industry_variant: Retail & Consumer Goods
+        notes: Trade-event-driven sell-through
       - stage_order: 4
         stage_name: Lead Capture & Nurture
         capability_id: BC-400
@@ -1532,6 +1637,11 @@ value_streams:
         stage_name: Crisis Response
         capability_id: BC-850
         notes: Crisis communications
+      - stage_order: 4
+        stage_name: Crisis Response
+        capability_id: BC-2380
+        industry_variant: Retail & Consumer Goods
+        notes: Major food recall response
       - stage_order: 5
         stage_name: Disaster Recovery
         capability_id: BC-160


### PR DESCRIPTION
Introduces 9 industry-specific L1s anchored on ARTS/NRF, GS1/GDSN, EPCIS,
EDI, PCI DSS, VICS CPFR, CGF, and food-safety standards (BRCGS, SQF,
FSSC 22000, IFS Food, ISO 22000):

- BC-2300 Merchandising Management
- BC-2310 Retail Store Operations Management
- BC-2320 Point of Sale Operations Management
- BC-2330 Omnichannel Order & Fulfilment Management
- BC-2340 Retail Loss Prevention Management
- BC-2350 Retail Site & Network Planning Management
- BC-2360 Trade Promotion Management
- BC-2370 Product Information Management
- BC-2380 Food Safety & Traceability Management

Adds a Retail & Consumer Goods subsection to governance model §9.8
listing the relevant reference frameworks, and maps the new L1s onto
8 existing value streams (Plan-to-Inventory, Idea-to-Market,
Order-to-Cash, Issue-to-Resolution, Acquire-to-Retire, Audit-to-Action,
Crisis-to-Recovery, Prospect-to-Customer).

Coverage gap: Trade Promotion Management's CPG-specific
plan-fund-execute-claim-measure lifecycle has no primary stream yet;
flagged for follow-up (suggested Plan-to-Lift / Trade-Plan-to-Settle).