### PR TITLE
Reorder About in nav; add LinkedIn pill on author card

### DIFF
--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -55,9 +55,9 @@ const generatedDate = version.generated_at.slice(0, 10);
         </a>
         <div class="nav-links">
           <a href="/">Home</a>
+          <a href="/about">About</a>
           <a href="/value-streams">Value Streams</a>
           <a href="/api/tree.json">API</a>
-          <a href="/about">About</a>
           <a
             href="https://www.turbo-ea.org"
             target="_blank"

--- a/site/src/pages/about.astro
+++ b/site/src/pages/about.astro
@@ -64,6 +64,24 @@ import { version } from "../data/load.ts";
             Strategic Technology Leader and Enterprise Architect with extensive
             experience enabling business objectives with technology.
           </p>
+          <a
+            href="https://www.linkedin.com/in/vincent-verdet/"
+            target="_blank"
+            rel="noopener"
+            class="linkedin-button author-linkedin"
+            aria-label="Vincent Verdet on LinkedIn"
+          >
+            <svg
+              viewBox="0 0 24 24"
+              width="20"
+              height="20"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z"/>
+            </svg>
+            <span>Connect on LinkedIn</span>
+          </a>
         </div>
       </div>
     </div>
@@ -141,6 +159,9 @@ import { version } from "../data/load.ts";
   }
   .author-bio p {
     margin: 0;
+  }
+  .author-linkedin {
+    margin-top: 14px;
   }
   @media (max-width: 600px) {
     .author-block {

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -360,7 +360,8 @@ body {
 }
 
 .kofi-button,
-.github-button {
+.github-button,
+.linkedin-button {
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -378,7 +379,8 @@ body {
 }
 
 .kofi-button:hover,
-.github-button:hover {
+.github-button:hover,
+.linkedin-button:hover {
   color: #fff;
   transform: translateY(-1px);
 }
@@ -395,15 +397,23 @@ body {
   box-shadow: 0 4px 12px rgba(18, 110, 248, 0.35);
 }
 
+.linkedin-button { background: #0a66c2; }
+.linkedin-button:hover {
+  background: #084e96;
+  box-shadow: 0 4px 12px rgba(10, 102, 194, 0.35);
+}
+
 .kofi-button svg,
-.github-button svg {
+.github-button svg,
+.linkedin-button svg {
   display: block;
   flex-shrink: 0;
 }
 
 /* Compact pill buttons inside the top nav */
 .nav-links .kofi-button,
-.nav-links .github-button {
+.nav-links .github-button,
+.nav-links .linkedin-button {
   padding: 6px 12px;
   gap: 6px;
   font-size: 13px;
@@ -411,14 +421,16 @@ body {
 }
 
 .nav-links .kofi-button svg,
-.nav-links .github-button svg {
+.nav-links .github-button svg,
+.nav-links .linkedin-button svg {
   width: 14px;
   height: 14px;
 }
 
 /* Suppress nav underline indicator on pill buttons */
 .nav-links .kofi-button::after,
-.nav-links .github-button::after {
+.nav-links .github-button::after,
+.nav-links .linkedin-button::after {
   display: none;
 }
 


### PR DESCRIPTION
About now sits right after Home in the top nav. The author bio gets a LinkedIn pill (#0a66c2) underneath the description, sharing the same pill base styles as the Ko-fi and GitHub buttons.