### PR TITLE
Remove Ko-fi support link from navigation

### DIFF
--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -86,24 +86,6 @@ const generatedDate = version.generated_at.slice(0, 10);
             </svg>
             <span>GitHub</span>
           </a>
-          <a
-            href="https://ko-fi.com/vincentmakes"
-            target="_blank"
-            rel="noopener"
-            class="kofi-button"
-            aria-label="Support on Ko-fi"
-          >
-            <svg
-              viewBox="0 0 24 24"
-              width="20"
-              height="20"
-              fill="currentColor"
-              aria-hidden="true"
-            >
-              <path d="M20 3H6a2 2 0 0 0-2 2v9a4 4 0 0 0 4 4h6a4 4 0 0 0 4-4h2a3 3 0 0 0 3-3V6a3 3 0 0 0-3-3Zm0 8h-2V5h2a1 1 0 0 1 1 1v4a1 1 0 0 1-1 1ZM4 20h16v2H4z"/>
-            </svg>
-            <span>Support on Ko-fi</span>
-          </a>
         </div>
       </div>
     </nav>


### PR DESCRIPTION
## Summary
Removed the Ko-fi donation link from the main navigation footer in the Base layout component.

## Changes
- Removed the Ko-fi support button and associated SVG icon from the navigation footer
- This includes the link to `https://ko-fi.com/vincentmakes`, the custom styling class, and the entire anchor element with its accessibility attributes

## Details
The Ko-fi button was a call-to-action link in the site's navigation that allowed users to support the project. This change removes that donation option from the primary navigation, though users may still have other ways to support the project if they exist elsewhere on the site.

https://claude.ai/code/session_01GfCizDUo9cPJ3YkKho5XzR