### PR TITLE
Add Software & Technology (SaaS) capability layer (10 L1s)

### DIFF
--- a/business-capability-governance-model.md
+++ b/business-capability-governance-model.md
@@ -620,6 +620,24 @@ Where an industry reference framework exists, anchor the upper levels (L1 / L2) 
 - **BRCGS, SQF, FSSC 22000, IFS Food, ISO 22000** — food-safety management systems and certification standards.
 - **OECD Due Diligence Guidance for the Garment & Footwear Sector, WRAP, SA8000** — ethical-sourcing and labour standards relevant to consumer-goods supply chains.
 
+**Software & Technology (SaaS)**
+
+- **SOC 2 (AICPA Trust Services Criteria) and SSAE 18** — service organisation controls and attestations for service providers.
+- **ISO/IEC 27001, 27017 (cloud), 27018 (PII in public clouds), 27701 (PIMS)** — information-security and privacy management systems for cloud services.
+- **CSA STAR / Cloud Controls Matrix (CCM)** — cloud security assurance and self- or third-party assessment.
+- **FedRAMP, NIST SP 800-53, NIST SP 800-171** — US federal cloud authorisation and controlled-information protection.
+- **ENISA EUCS, BSI C5 (Germany), IRAP (Australia), MTCS (Singapore), ISMAP (Japan)** — regional cloud security and authorisation regimes.
+- **NIST SSDF (SP 800-218), OWASP ASVS / SAMM, BSIMM, SLSA, SBOM standards (SPDX, CycloneDX), CVSS / CWE / CVE / NVD** — secure software development lifecycle and software supply-chain.
+- **OpenAPI Specification, AsyncAPI, GraphQL, gRPC, JSON Schema** — API and event interface standards.
+- **OAuth 2.0 / 2.1, OpenID Connect, SAML 2.0, SCIM 2.0, FIDO2 / WebAuthn** — identity, authentication, and federation standards.
+- **Twelve-Factor App methodology, CNCF reference projects (Kubernetes, OCI, OpenTelemetry), Cloud Native Maturity Model** — cloud-native architecture and operations.
+- **DORA Four Keys metrics, SPACE framework, Accelerate / State of DevOps research** — software delivery performance measurement.
+- **ASC 606 / IFRS 15** — revenue recognition for subscription contracts.
+- **EU Digital Operational Resilience Act (Reg 2022/2554), EU NIS2 Directive (Reg 2022/2555), EU Data Act, EU AI Act** — operational resilience, cybersecurity, data, and AI obligations applicable to SaaS providers.
+- **GDPR, UK GDPR, CCPA / CPRA, LGPD, APPI** — privacy regimes routinely covered by SaaS data-processing addenda and sub-processor disclosures.
+- **HIPAA, PCI DSS** — sectoral regimes triggered when SaaS handles protected health information or payment-card data.
+- **OpenID Shared Signals (CAEP / RISC), GAIA-X** — selected ecosystem standards relevant to enterprise-grade SaaS.
+
 **Telecommunications**
 
 - **TM Forum Frameworx (eTOM, SID, TAM, ODA)** — telecom enterprise process, information, application, and Open Digital Architecture reference.

--- a/catalogue/L1-customer-success-management.yaml
+++ b/catalogue/L1-customer-success-management.yaml
@@ -1,0 +1,231 @@
+# Customer Success Management
+id: BC-4260
+name: Customer Success Management
+level: 1
+industry: Software & Technology
+description: |
+  Customer onboarding, adoption, health monitoring, retention, expansion
+  advocacy, and reference-customer cultivation distinct from reactive
+  customer service.
+children:
+  - id: BC-4260.10
+    name: "Customer Onboarding & Activation"
+    level: 2
+    industry: Software & Technology
+    description: |
+      Structured onboarding of new customers towards first value and
+      activation milestones.
+    in_scope:
+      - Onboarding plans, kickoff, and time-to-value tracking
+    out_of_scope:
+      - Tenant technical provisioning (covered by SaaS Tenant Management)
+      - Subscription provisioning (covered by Subscription Lifecycle Management)
+    children:
+      - id: BC-4260.10.10
+        name: Onboarding Plan Definition
+        level: 3
+        industry: Software & Technology
+        description: |
+          Definition of onboarding plans tailored to segment and use-case.
+        children: []
+      - id: BC-4260.10.20
+        name: Activation Milestone Tracking
+        level: 3
+        industry: Software & Technology
+        description: |
+          Tracking of activation milestones against time-to-value targets.
+        children: []
+      - id: BC-4260.10.30
+        name: Implementation Coordination
+        level: 3
+        industry: Software & Technology
+        description: |
+          Coordination of customer-side implementation activities and
+          partner engagement.
+        children: []
+  - id: BC-4260.20
+    name: Adoption Management
+    level: 2
+    industry: Software & Technology
+    description: |
+      Programmes that lift feature adoption and usage breadth across the
+      customer base.
+    children:
+      - id: BC-4260.20.10
+        name: Adoption Programme Design
+        level: 3
+        industry: Software & Technology
+        description: |
+          Design of structured adoption programmes for segments, products,
+          and personas.
+        children: []
+      - id: BC-4260.20.20
+        name: Adoption Campaign Execution
+        level: 3
+        industry: Software & Technology
+        description: |
+          Execution of adoption campaigns with in-product and outbound
+          touchpoints.
+        children: []
+      - id: BC-4260.20.30
+        name: Power-User Enablement
+        level: 3
+        industry: Software & Technology
+        description: |
+          Enablement of customer power-users and internal champions.
+        children: []
+  - id: BC-4260.30
+    name: Customer Health Management
+    level: 2
+    industry: Software & Technology
+    description: |
+      Modelling and monitoring of customer health to anticipate risk and
+      drive intervention.
+    children:
+      - id: BC-4260.30.10
+        name: Customer Health Score Modelling
+        level: 3
+        industry: Software & Technology
+        description: |
+          Modelling of customer health scores from product, support, and
+          commercial signals.
+        children: []
+      - id: BC-4260.30.20
+        name: Risk Signal Monitoring
+        level: 3
+        industry: Software & Technology
+        description: |
+          Monitoring of risk signals across the customer base.
+        children: []
+      - id: BC-4260.30.30
+        name: At-Risk Account Intervention
+        level: 3
+        industry: Software & Technology
+        description: |
+          Coordinated intervention on accounts identified as at-risk.
+        children: []
+  - id: BC-4260.40
+    name: Customer Lifecycle Engagement
+    level: 2
+    industry: Software & Technology
+    description: |
+      Recurring lifecycle touchpoints including business reviews,
+      executive sponsorship, and joint success planning.
+    children:
+      - id: BC-4260.40.10
+        name: Quarterly Business Review Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Planning and delivery of recurring business reviews with
+          customers.
+        children: []
+      - id: BC-4260.40.20
+        name: Executive Sponsor Programme
+        level: 3
+        industry: Software & Technology
+        description: |
+          Operation of executive sponsor pairings between provider and
+          customer.
+        children: []
+      - id: BC-4260.40.30
+        name: Success Plan Maintenance
+        level: 3
+        industry: Software & Technology
+        description: |
+          Maintenance of joint success plans capturing customer outcomes
+          and milestones.
+        children: []
+  - id: BC-4260.50
+    name: "Retention & Renewal Advocacy"
+    level: 2
+    industry: Software & Technology
+    description: |
+      Advocacy and intervention focused on the renewal motion, including
+      save plays and renewal forecasting input.
+    children:
+      - id: BC-4260.50.10
+        name: Renewal Risk Mitigation
+        level: 3
+        industry: Software & Technology
+        description: |
+          Mitigation of identified renewal risks before renewal date.
+        children: []
+      - id: BC-4260.50.20
+        name: Save Motion Execution
+        level: 3
+        industry: Software & Technology
+        description: |
+          Execution of save motions on accounts intending to cancel.
+        children: []
+      - id: BC-4260.50.30
+        name: Renewal Forecast Submission
+        level: 3
+        industry: Software & Technology
+        description: |
+          Submission of renewal forecasts informed by health and
+          engagement signals.
+        children: []
+  - id: BC-4260.60
+    name: "Expansion & Cross-Sell Advocacy"
+    level: 2
+    industry: Software & Technology
+    description: |
+      Identification and qualification of expansion opportunities and
+      coordination with sales for cross-sell.
+    children:
+      - id: BC-4260.60.10
+        name: Expansion Opportunity Identification
+        level: 3
+        industry: Software & Technology
+        description: |
+          Identification of expansion opportunities from usage and
+          engagement signals.
+        children: []
+      - id: BC-4260.60.20
+        name: Upsell Qualification
+        level: 3
+        industry: Software & Technology
+        description: |
+          Qualification of upsell opportunities prior to sales engagement.
+        children: []
+      - id: BC-4260.60.30
+        name: Cross-Sell Coordination
+        level: 3
+        industry: Software & Technology
+        description: |
+          Coordination with sales on cross-sell motions across the
+          customer base.
+        children: []
+  - id: BC-4260.70
+    name: "Customer Advocacy & Reference"
+    level: 2
+    industry: Software & Technology
+    description: |
+      Cultivation of references, case studies, and structured measurement
+      of customer sentiment.
+    children:
+      - id: BC-4260.70.10
+        name: Reference Programme Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Management of the customer reference programme including
+          opt-in, governance, and use.
+        children: []
+      - id: BC-4260.70.20
+        name: Case Study Development
+        level: 3
+        industry: Software & Technology
+        description: |
+          Development of customer case studies in collaboration with
+          marketing.
+        children: []
+      - id: BC-4260.70.30
+        name: Net Promoter Survey Programme
+        level: 3
+        industry: Software & Technology
+        description: |
+          Operation of NPS and equivalent customer-sentiment survey
+          programmes.
+        children: []

--- a/catalogue/L1-developer-platform-api-ecosystem-management.yaml
+++ b/catalogue/L1-developer-platform-api-ecosystem-management.yaml
@@ -1,0 +1,262 @@
+# Developer Platform & API Ecosystem Management
+id: BC-4270
+name: "Developer Platform & API Ecosystem Management"
+level: 1
+industry: Software & Technology
+description: |
+  Public APIs, SDKs, developer portal, developer identity, API consumption
+  governance, partner apps, software-marketplace listings, and outbound
+  webhook subscriptions for the SaaS ecosystem.
+references:
+  - https://spec.openapis.org/
+  - https://www.asyncapi.com/
+  - https://datatracker.ietf.org/doc/html/rfc6749
+children:
+  - id: BC-4270.10
+    name: Public API Lifecycle Management
+    level: 2
+    industry: Software & Technology
+    description: |
+      Specification, versioning, and deprecation of public APIs exposed to
+      external developers.
+    children:
+      - id: BC-4270.10.10
+        name: API Specification Authoring
+        level: 3
+        industry: Software & Technology
+        description: |
+          Authoring and review of public API specifications in machine-
+          readable form.
+        children: []
+      - id: BC-4270.10.20
+        name: API Versioning
+        level: 3
+        industry: Software & Technology
+        description: |
+          Versioning of public APIs with documented compatibility
+          guarantees.
+        children: []
+      - id: BC-4270.10.30
+        name: API Deprecation Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Communication and execution of API deprecations with adequate
+          notice.
+        children: []
+  - id: BC-4270.20
+    name: "SDK & Client Library Management"
+    level: 2
+    industry: Software & Technology
+    description: |
+      Generation, language coverage, and sample maintenance of SDKs and
+      client libraries that wrap public APIs.
+    children:
+      - id: BC-4270.20.10
+        name: "SDK Generation & Release"
+        level: 3
+        industry: Software & Technology
+        description: |
+          Generation and release of SDKs aligned with API versions.
+        children: []
+      - id: BC-4270.20.20
+        name: SDK Language Coverage Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Selection and stewardship of supported SDK languages and
+          runtimes.
+        children: []
+      - id: BC-4270.20.30
+        name: SDK Sample Maintenance
+        level: 3
+        industry: Software & Technology
+        description: |
+          Maintenance of SDK code samples and starter projects.
+        children: []
+  - id: BC-4270.30
+    name: Developer Portal Management
+    level: 2
+    industry: Software & Technology
+    description: |
+      Documentation, interactive references, and onboarding flows that
+      help developers integrate with the platform.
+    children:
+      - id: BC-4270.30.10
+        name: Developer Documentation Authoring
+        level: 3
+        industry: Software & Technology
+        description: |
+          Authoring of conceptual, task, and reference documentation for
+          developers.
+        children: []
+      - id: BC-4270.30.20
+        name: Interactive API Reference
+        level: 3
+        industry: Software & Technology
+        description: |
+          Operation of interactive API reference and try-it-now experiences.
+        children: []
+      - id: BC-4270.30.30
+        name: Developer Onboarding
+        level: 3
+        industry: Software & Technology
+        description: |
+          Onboarding flows that move developers from sign-up to first
+          successful API call.
+        children: []
+  - id: BC-4270.40
+    name: "Developer Identity & Credential Management"
+    level: 2
+    industry: Software & Technology
+    description: |
+      Issuance and stewardship of developer credentials, OAuth clients,
+      and federated developer identity.
+    children:
+      - id: BC-4270.40.10
+        name: API Key Issuance
+        level: 3
+        industry: Software & Technology
+        description: |
+          Issuance, rotation, and revocation of developer API keys.
+        children: []
+      - id: BC-4270.40.20
+        name: OAuth Client Registration
+        level: 3
+        industry: Software & Technology
+        description: |
+          Registration and stewardship of OAuth client applications.
+        children: []
+      - id: BC-4270.40.30
+        name: Developer Identity Federation
+        level: 3
+        industry: Software & Technology
+        description: |
+          Federation of developer identity from external identity
+          providers.
+        children: []
+  - id: BC-4270.50
+    name: API Consumption Governance
+    level: 2
+    industry: Software & Technology
+    description: |
+      Quotas, rate limits, usage analytics, and mapping of API consumption
+      to commercial plan tiers.
+    children:
+      - id: BC-4270.50.10
+        name: "API Quota & Rate Limit Management"
+        level: 3
+        industry: Software & Technology
+        description: |
+          Definition and enforcement of API quotas and rate limits per
+          consumer.
+        children: []
+      - id: BC-4270.50.20
+        name: API Usage Analytics
+        level: 3
+        industry: Software & Technology
+        description: |
+          Analytics of API consumption patterns by endpoint, consumer, and
+          plan.
+        children: []
+      - id: BC-4270.50.30
+        name: API Tier Plan Mapping
+        level: 3
+        industry: Software & Technology
+        description: |
+          Mapping of API access tiers to subscription plans and
+          entitlements.
+        children: []
+  - id: BC-4270.60
+    name: Partner App Programme Management
+    level: 2
+    industry: Software & Technology
+    description: |
+      Stewardship of third-party partner applications including listing,
+      certification, and revenue sharing.
+    children:
+      - id: BC-4270.60.10
+        name: Partner App Listing Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Listing of partner applications in the platform's app directory.
+        children: []
+      - id: BC-4270.60.20
+        name: Partner App Certification
+        level: 3
+        industry: Software & Technology
+        description: |
+          Certification of partner applications against security and
+          quality bars.
+        children: []
+      - id: BC-4270.60.30
+        name: Partner App Revenue Sharing
+        level: 3
+        industry: Software & Technology
+        description: |
+          Revenue-sharing arrangements with partner application developers.
+        children: []
+  - id: BC-4270.70
+    name: Software Marketplace Listing Management
+    level: 2
+    industry: Software & Technology
+    description: |
+      Listing and stewardship of the SaaS offering on third-party software
+      marketplaces and cloud marketplaces.
+    children:
+      - id: BC-4270.70.10
+        name: Marketplace Listing Authoring
+        level: 3
+        industry: Software & Technology
+        description: |
+          Authoring of marketplace listings including metadata, pricing,
+          and assets.
+        children: []
+      - id: BC-4270.70.20
+        name: Marketplace Listing Maintenance
+        level: 3
+        industry: Software & Technology
+        description: |
+          Ongoing maintenance of marketplace listings as the offering
+          evolves.
+        children: []
+      - id: BC-4270.70.30
+        name: Marketplace Co-Sell Coordination
+        level: 3
+        industry: Software & Technology
+        description: |
+          Coordination of co-sell motions with marketplace operators.
+        children: []
+  - id: BC-4270.80
+    name: "Webhook & Event Subscription Management"
+    level: 2
+    industry: Software & Technology
+    description: |
+      Lifecycle of outbound webhook subscriptions, event schemas, and
+      delivery reliability.
+    children:
+      - id: BC-4270.80.10
+        name: Webhook Subscription Lifecycle
+        level: 3
+        industry: Software & Technology
+        description: |
+          Lifecycle of outbound webhook subscriptions from registration to
+          retirement.
+        children: []
+      - id: BC-4270.80.20
+        name: Event Schema Catalogue
+        level: 3
+        industry: Software & Technology
+        description: |
+          Catalogue of outbound event schemas and their compatibility
+          guarantees.
+        children: []
+      - id: BC-4270.80.30
+        name: Webhook Delivery Reliability Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Retry, backoff, and dead-letter handling for outbound webhook
+          delivery.
+        children: []

--- a/catalogue/L1-product-telemetry-experimentation-management.yaml
+++ b/catalogue/L1-product-telemetry-experimentation-management.yaml
@@ -1,0 +1,196 @@
+# Product Telemetry & Experimentation Management
+id: BC-4280
+name: "Product Telemetry & Experimentation Management"
+level: 1
+industry: Software & Technology
+description: |
+  Instrumentation, governance, and analysis of product usage telemetry,
+  and the design and execution of feature experiments that shape product
+  decisions.
+children:
+  - id: BC-4280.10
+    name: Product Telemetry Instrumentation
+    level: 2
+    industry: Software & Technology
+    description: |
+      Capture of product usage events from client and server runtimes
+      against defined event schemas.
+    children:
+      - id: BC-4280.10.10
+        name: Event Schema Definition
+        level: 3
+        industry: Software & Technology
+        description: |
+          Definition of product event schemas including required and
+          optional properties.
+        children: []
+      - id: BC-4280.10.20
+        name: Client Telemetry Instrumentation
+        level: 3
+        industry: Software & Technology
+        description: |
+          Instrumentation of client runtimes to emit product events.
+        children: []
+      - id: BC-4280.10.30
+        name: Server Telemetry Instrumentation
+        level: 3
+        industry: Software & Technology
+        description: |
+          Instrumentation of server runtimes to emit product events.
+        children: []
+  - id: BC-4280.20
+    name: "Telemetry Quality & Governance"
+    level: 2
+    industry: Software & Technology
+    description: |
+      Schema governance, pipeline quality monitoring, and privacy
+      filtering of product telemetry.
+    children:
+      - id: BC-4280.20.10
+        name: Telemetry Schema Governance
+        level: 3
+        industry: Software & Technology
+        description: |
+          Governance of product event schemas across product surfaces.
+        children: []
+      - id: BC-4280.20.20
+        name: Telemetry Pipeline Quality Monitoring
+        level: 3
+        industry: Software & Technology
+        description: |
+          Monitoring of telemetry pipeline correctness, completeness, and
+          freshness.
+        children: []
+      - id: BC-4280.20.30
+        name: Telemetry Privacy Filtering
+        level: 3
+        industry: Software & Technology
+        description: |
+          Filtering, redaction, and minimisation of telemetry consistent
+          with privacy commitments.
+        children: []
+  - id: BC-4280.30
+    name: Product Usage Analytics
+    level: 2
+    industry: Software & Technology
+    description: |
+      Analytical views of product usage including funnels, retention
+      cohorts, and feature engagement.
+    children:
+      - id: BC-4280.30.10
+        name: Funnel Analytics
+        level: 3
+        industry: Software & Technology
+        description: |
+          Funnel analysis of conversion and drop-off across product
+          journeys.
+        children: []
+      - id: BC-4280.30.20
+        name: Retention Cohort Analytics
+        level: 3
+        industry: Software & Technology
+        description: |
+          Cohort-based analysis of user retention over time.
+        children: []
+      - id: BC-4280.30.30
+        name: Feature Engagement Reporting
+        level: 3
+        industry: Software & Technology
+        description: |
+          Reporting on engagement with specific features across the user
+          base.
+        children: []
+  - id: BC-4280.40
+    name: Experimentation Programme Management
+    level: 2
+    industry: Software & Technology
+    description: |
+      Methodology, design review, and adjudication of experiments that
+      drive product decisions.
+    children:
+      - id: BC-4280.40.10
+        name: Experimentation Methodology Standards
+        level: 3
+        industry: Software & Technology
+        description: |
+          Standards for valid experimentation methodology across product
+          teams.
+        children: []
+      - id: BC-4280.40.20
+        name: Experiment Design Review
+        level: 3
+        industry: Software & Technology
+        description: |
+          Review of experiment designs against methodology and ethics
+          standards.
+        children: []
+      - id: BC-4280.40.30
+        name: Experiment Result Adjudication
+        level: 3
+        industry: Software & Technology
+        description: |
+          Adjudication of experiment outcomes and consequent product
+          decisions.
+        children: []
+  - id: BC-4280.50
+    name: A/B Test Execution
+    level: 2
+    industry: Software & Technology
+    description: |
+      Configuration, targeting, and monitoring of running A/B and
+      multivariate tests.
+    children:
+      - id: BC-4280.50.10
+        name: Experiment Configuration
+        level: 3
+        industry: Software & Technology
+        description: |
+          Configuration of experiment variants and assignment rules.
+        children: []
+      - id: BC-4280.50.20
+        name: Experiment Targeting
+        level: 3
+        industry: Software & Technology
+        description: |
+          Targeting of experiment cohorts to appropriate audiences.
+        children: []
+      - id: BC-4280.50.30
+        name: Experiment Monitoring
+        level: 3
+        industry: Software & Technology
+        description: |
+          Monitoring of running experiments for guardrails and early
+          stopping.
+        children: []
+  - id: BC-4280.60
+    name: Customer Insight Synthesis
+    level: 2
+    industry: Software & Technology
+    description: |
+      Synthesis of quantitative and qualitative signals into product
+      decisions and decision memos.
+    children:
+      - id: BC-4280.60.10
+        name: Quantitative Insight Synthesis
+        level: 3
+        industry: Software & Technology
+        description: |
+          Synthesis of quantitative findings from telemetry and
+          experimentation.
+        children: []
+      - id: BC-4280.60.20
+        name: Qualitative Insight Synthesis
+        level: 3
+        industry: Software & Technology
+        description: |
+          Synthesis of qualitative research findings into product
+          insights.
+        children: []
+      - id: BC-4280.60.30
+        name: Decision Memo Authoring
+        level: 3
+        industry: Software & Technology
+        description: |
+          Authoring of decision memos that record evidence, choice, and
+          reasoning.
+        children: []

--- a/catalogue/L1-saas-platform-operations-management.yaml
+++ b/catalogue/L1-saas-platform-operations-management.yaml
@@ -1,0 +1,219 @@
+# SaaS Platform Operations Management
+id: BC-4220
+name: SaaS Platform Operations Management
+level: 1
+industry: Software & Technology
+description: |
+  Site reliability, observability, on-call response, capacity, performance,
+  and disaster-recovery operations of the multi-tenant SaaS service.
+references:
+  - https://opentelemetry.io/
+  - https://sre.google/books/
+  - https://www.iso.org/standard/75106.html
+children:
+  - id: BC-4220.10
+    name: Service Reliability Engineering
+    level: 2
+    industry: Software & Technology
+    description: |
+      Definition and stewardship of service-level indicators, objectives,
+      and error budgets for the SaaS service.
+    in_scope:
+      - SLI / SLO / error-budget discipline for the running product
+    out_of_scope:
+      - Customer-facing SLA commitments (covered by SaaS Trust & Service Compliance Management)
+      - Internal IT service levels (covered by Information Technology Management)
+    children:
+      - id: BC-4220.10.10
+        name: Service Level Indicator Definition
+        level: 3
+        industry: Software & Technology
+        description: |
+          Definition of service-level indicators that measure the customer
+          experience of running services.
+        children: []
+      - id: BC-4220.10.20
+        name: Service Level Objective Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Setting, review, and revision of service-level objectives across
+          services.
+        children: []
+      - id: BC-4220.10.30
+        name: Error Budget Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Management of error budgets and the policy that governs their
+          consumption.
+        children: []
+  - id: BC-4220.20
+    name: Observability Management
+    level: 2
+    industry: Software & Technology
+    description: |
+      Logs, metrics, traces, and synthetic monitoring that make the running
+      service understandable in production.
+    children:
+      - id: BC-4220.20.10
+        name: Application Logging Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Stewardship of application logging conventions, pipelines, and
+          retention.
+        children: []
+      - id: BC-4220.20.20
+        name: Metrics Pipeline Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Operation of metrics ingestion, storage, and query pipelines.
+        children: []
+      - id: BC-4220.20.30
+        name: Distributed Tracing
+        level: 3
+        industry: Software & Technology
+        description: |
+          End-to-end distributed tracing across services for production
+          investigation.
+        children: []
+      - id: BC-4220.20.40
+        name: Synthetic Monitoring
+        level: 3
+        industry: Software & Technology
+        description: |
+          Synthetic probes that exercise critical user journeys from
+          outside the service.
+        children: []
+  - id: BC-4220.30
+    name: Incident Response Management
+    level: 2
+    industry: Software & Technology
+    description: |
+      On-call response, incident detection, coordination, and customer
+      communication during production incidents.
+    children:
+      - id: BC-4220.30.10
+        name: On-Call Rotation Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Definition and operation of on-call rotations across product
+          teams.
+        children: []
+      - id: BC-4220.30.20
+        name: Incident Detection
+        level: 3
+        industry: Software & Technology
+        description: |
+          Detection of production incidents from telemetry and external
+          signals.
+        children: []
+      - id: BC-4220.30.30
+        name: Incident Coordination
+        level: 3
+        industry: Software & Technology
+        description: |
+          Coordination of incident response including roles, communications,
+          and decisions during the incident.
+        children: []
+      - id: BC-4220.30.40
+        name: Customer Incident Communication
+        level: 3
+        industry: Software & Technology
+        description: |
+          Communication to affected customers during and after incidents.
+        children: []
+  - id: BC-4220.40
+    name: "Postmortem & Reliability Improvement"
+    level: 2
+    industry: Software & Technology
+    description: |
+      Postmortem authoring and tracking of reliability action items so that
+      lessons compound over time.
+    children:
+      - id: BC-4220.40.10
+        name: Postmortem Authoring
+        level: 3
+        industry: Software & Technology
+        description: |
+          Blameless postmortem authoring after incidents and significant
+          near-misses.
+        children: []
+      - id: BC-4220.40.20
+        name: Reliability Action Tracking
+        level: 3
+        industry: Software & Technology
+        description: |
+          Tracking of reliability action items to closure across teams.
+        children: []
+      - id: BC-4220.40.30
+        name: Reliability Trend Analysis
+        level: 3
+        industry: Software & Technology
+        description: |
+          Analysis of reliability trends across services and time horizons.
+        children: []
+  - id: BC-4220.50
+    name: "Capacity & Performance Management"
+    level: 2
+    industry: Software & Technology
+    description: |
+      Capacity forecasting, auto-scaling policies, and performance testing
+      of the SaaS service.
+    children:
+      - id: BC-4220.50.10
+        name: Capacity Forecasting
+        level: 3
+        industry: Software & Technology
+        description: |
+          Forecasting of capacity demand across services and regions.
+        children: []
+      - id: BC-4220.50.20
+        name: Auto-Scaling Policy Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Definition and tuning of auto-scaling policies for product
+          services.
+        children: []
+      - id: BC-4220.50.30
+        name: Performance Testing
+        level: 3
+        industry: Software & Technology
+        description: |
+          Load, stress, and soak testing of the running service.
+        children: []
+  - id: BC-4220.60
+    name: "Disaster Recovery & Resilience"
+    level: 2
+    industry: Software & Technology
+    description: |
+      Backup and restore, failover orchestration, and disaster-recovery
+      exercises for the SaaS service.
+    children:
+      - id: BC-4220.60.10
+        name: "Backup & Restore Management"
+        level: 3
+        industry: Software & Technology
+        description: |
+          Backup policy, execution, and restore validation for service
+          datastores.
+        children: []
+      - id: BC-4220.60.20
+        name: Failover Orchestration
+        level: 3
+        industry: Software & Technology
+        description: |
+          Orchestration of failover between availability zones and regions.
+        children: []
+      - id: BC-4220.60.30
+        name: Disaster Recovery Exercise Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Planning and execution of disaster-recovery exercises and
+          game-days.
+        children: []

--- a/catalogue/L1-saas-tenant-management.yaml
+++ b/catalogue/L1-saas-tenant-management.yaml
@@ -1,0 +1,206 @@
+# SaaS Tenant Management
+id: BC-4230
+name: SaaS Tenant Management
+level: 1
+industry: Software & Technology
+description: |
+  Provisioning, configuration, isolation, region placement, identity
+  federation, and per-tenant data export of tenants in the multi-tenant
+  service.
+references:
+  - https://datatracker.ietf.org/doc/html/rfc7644
+  - https://openid.net/specs/openid-connect-core-1_0.html
+children:
+  - id: BC-4230.10
+    name: "Tenant Provisioning & Lifecycle"
+    level: 2
+    industry: Software & Technology
+    description: |
+      Creation, suspension, decommissioning, and migration of tenants in
+      the multi-tenant fleet.
+    children:
+      - id: BC-4230.10.10
+        name: Tenant Provisioning
+        level: 3
+        industry: Software & Technology
+        description: |
+          Creation of new tenants and allocation of associated resources.
+        children: []
+      - id: BC-4230.10.20
+        name: Tenant Suspension
+        level: 3
+        industry: Software & Technology
+        description: |
+          Suspension of tenants for non-payment, abuse, or contractual
+          reasons.
+        children: []
+      - id: BC-4230.10.30
+        name: Tenant Decommissioning
+        level: 3
+        industry: Software & Technology
+        description: |
+          Decommissioning of tenants including data deletion or hand-back
+          per contract.
+        children: []
+      - id: BC-4230.10.40
+        name: Tenant Migration
+        level: 3
+        industry: Software & Technology
+        description: |
+          Migration of tenants between clusters, shards, or regions.
+        children: []
+  - id: BC-4230.20
+    name: Tenant Configuration Management
+    level: 2
+    industry: Software & Technology
+    description: |
+      Per-tenant feature configuration, branding, and limits applied above
+      the shared product baseline.
+    children:
+      - id: BC-4230.20.10
+        name: Per-Tenant Feature Configuration
+        level: 3
+        industry: Software & Technology
+        description: |
+          Configuration of feature options at the tenant level.
+        children: []
+      - id: BC-4230.20.20
+        name: Tenant Branding Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Tenant-level branding such as logos, colours, and custom domains.
+        children: []
+      - id: BC-4230.20.30
+        name: Tenant Limit Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Configuration of tenant-level limits such as quotas and rate
+          ceilings.
+        children: []
+  - id: BC-4230.30
+    name: Tenant Isolation Management
+    level: 2
+    industry: Software & Technology
+    description: |
+      Mechanisms that maintain logical and physical isolation between
+      tenants across data, compute, and access paths.
+    children:
+      - id: BC-4230.30.10
+        name: Tenant Data Isolation
+        level: 3
+        industry: Software & Technology
+        description: |
+          Isolation of tenant data through partitioning, encryption, and
+          access scoping.
+        children: []
+      - id: BC-4230.30.20
+        name: Tenant Compute Isolation
+        level: 3
+        industry: Software & Technology
+        description: |
+          Isolation of tenant workloads through dedicated or constrained
+          compute boundaries.
+        children: []
+      - id: BC-4230.30.30
+        name: Cross-Tenant Access Prevention
+        level: 3
+        industry: Software & Technology
+        description: |
+          Controls and monitoring that prevent cross-tenant data and
+          identity bleed.
+        children: []
+  - id: BC-4230.40
+    name: "Data Residency & Region Placement"
+    level: 2
+    industry: Software & Technology
+    description: |
+      Assignment of tenants to regions, enforcement of data-residency
+      commitments, and management of cross-region replication policy.
+    children:
+      - id: BC-4230.40.10
+        name: Tenant Region Assignment
+        level: 3
+        industry: Software & Technology
+        description: |
+          Assignment of tenants to regions consistent with contract and
+          regulation.
+        children: []
+      - id: BC-4230.40.20
+        name: Data Residency Enforcement
+        level: 3
+        industry: Software & Technology
+        description: |
+          Enforcement of data-residency boundaries at runtime.
+        children: []
+      - id: BC-4230.40.30
+        name: Cross-Region Replication Policy
+        level: 3
+        industry: Software & Technology
+        description: |
+          Policy governing cross-region replication for resilience and
+          access.
+        children: []
+  - id: BC-4230.50
+    name: Tenant Identity Federation
+    level: 2
+    industry: Software & Technology
+    description: |
+      Federation of tenant identity providers and lifecycle of tenant user
+      accounts via single sign-on and SCIM.
+    children:
+      - id: BC-4230.50.10
+        name: Tenant SSO Configuration
+        level: 3
+        industry: Software & Technology
+        description: |
+          Configuration of single sign-on between tenant identity providers
+          and the service.
+        children: []
+      - id: BC-4230.50.20
+        name: SCIM-Based User Provisioning
+        level: 3
+        industry: Software & Technology
+        description: |
+          Lifecycle of tenant user accounts driven by SCIM or equivalent
+          provisioning protocols.
+        children: []
+      - id: BC-4230.50.30
+        name: Tenant Identity Provider Onboarding
+        level: 3
+        industry: Software & Technology
+        description: |
+          Onboarding and validation of tenant identity providers.
+        children: []
+  - id: BC-4230.60
+    name: "Tenant Backup & Export Management"
+    level: 2
+    industry: Software & Technology
+    description: |
+      Per-tenant data export, deletion, and restore capabilities exposed to
+      tenants and administrators.
+    children:
+      - id: BC-4230.60.10
+        name: Tenant Data Export
+        level: 3
+        industry: Software & Technology
+        description: |
+          Export of tenant data in machine-readable form on request or by
+          contract.
+        children: []
+      - id: BC-4230.60.20
+        name: Tenant Data Deletion
+        level: 3
+        industry: Software & Technology
+        description: |
+          Verifiable deletion of tenant data on cancellation or request.
+        children: []
+      - id: BC-4230.60.30
+        name: Tenant Backup Restoration
+        level: 3
+        industry: Software & Technology
+        description: |
+          Restoration of tenant data from backup on tenant or operator
+          request.
+        children: []

--- a/catalogue/L1-saas-trust-service-compliance-management.yaml
+++ b/catalogue/L1-saas-trust-service-compliance-management.yaml
@@ -1,0 +1,207 @@
+# SaaS Trust & Service Compliance Management
+id: BC-4290
+name: "SaaS Trust & Service Compliance Management"
+level: 1
+industry: Software & Technology
+description: |
+  Service-level attestations, customer security questionnaires, public
+  trust disclosures, sub-processor management, service-privacy
+  commitments, and customer-facing service-resilience commitments for
+  the SaaS offering.
+references:
+  - https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2
+  - https://www.iso.org/standard/27001
+  - https://cloudsecurityalliance.org/star/
+  - https://www.fedramp.gov/
+children:
+  - id: BC-4290.10
+    name: Service Attestation Management
+    level: 2
+    industry: Software & Technology
+    description: |
+      Coordination of service-level attestations such as SOC 2, ISO 27001,
+      and FedRAMP for the SaaS offering.
+    in_scope:
+      - Audit readiness for the service
+      - Auditor engagement and report production
+    out_of_scope:
+      - Enterprise-wide compliance programme (covered by Compliance Management)
+    children:
+      - id: BC-4290.10.10
+        name: Audit Readiness Coordination
+        level: 3
+        industry: Software & Technology
+        description: |
+          Coordination of audit readiness across control owners for the
+          service.
+        children: []
+      - id: BC-4290.10.20
+        name: Auditor Engagement
+        level: 3
+        industry: Software & Technology
+        description: |
+          Engagement of external auditors and management of audit
+          fieldwork.
+        children: []
+      - id: BC-4290.10.30
+        name: Attestation Renewal Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Management of attestation renewal cycles and continuous-audit
+          arrangements.
+        children: []
+  - id: BC-4290.20
+    name: Customer Security Questionnaire Management
+    level: 2
+    industry: Software & Technology
+    description: |
+      Stewardship of the questionnaire repository, response authoring, and
+      knowledge base used to answer customer vendor-risk assessments.
+    children:
+      - id: BC-4290.20.10
+        name: Questionnaire Repository Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Maintenance of the inbound questionnaire repository and routing.
+        children: []
+      - id: BC-4290.20.20
+        name: Questionnaire Response Authoring
+        level: 3
+        industry: Software & Technology
+        description: |
+          Authoring of responses to customer security questionnaires.
+        children: []
+      - id: BC-4290.20.30
+        name: Questionnaire Knowledge Base Maintenance
+        level: 3
+        industry: Software & Technology
+        description: |
+          Maintenance of a curated knowledge base of approved answers and
+          evidence.
+        children: []
+  - id: BC-4290.30
+    name: "Trust Portal & Public Disclosure"
+    level: 2
+    industry: Software & Technology
+    description: |
+      Operation of the customer trust portal, public status disclosures,
+      and document distribution workflows.
+    children:
+      - id: BC-4290.30.10
+        name: Trust Portal Content Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Curation of content published on the customer trust portal.
+        children: []
+      - id: BC-4290.30.20
+        name: Public Status Disclosure
+        level: 3
+        industry: Software & Technology
+        description: |
+          Public disclosure of incident status and historical service
+          status.
+        children: []
+      - id: BC-4290.30.30
+        name: Document Distribution Workflow
+        level: 3
+        industry: Software & Technology
+        description: |
+          Controlled distribution of audit reports and trust documents to
+          customers.
+        children: []
+  - id: BC-4290.40
+    name: Sub-Processor Management
+    level: 2
+    industry: Software & Technology
+    description: |
+      Inventory, disclosure, and change-notification of sub-processors
+      that handle customer data.
+    children:
+      - id: BC-4290.40.10
+        name: Sub-Processor Inventory
+        level: 3
+        industry: Software & Technology
+        description: |
+          Inventory of sub-processors and the categories of customer data
+          they handle.
+        children: []
+      - id: BC-4290.40.20
+        name: Sub-Processor Disclosure
+        level: 3
+        industry: Software & Technology
+        description: |
+          Customer-facing disclosure of the current sub-processor list.
+        children: []
+      - id: BC-4290.40.30
+        name: Sub-Processor Change Notification
+        level: 3
+        industry: Software & Technology
+        description: |
+          Advance notification of sub-processor additions and removals
+          per contract.
+        children: []
+  - id: BC-4290.50
+    name: Service Privacy Commitment Management
+    level: 2
+    industry: Software & Technology
+    description: |
+      Stewardship of data-processing addenda, customer data-flow
+      disclosures, and routing of data-subject requests.
+    children:
+      - id: BC-4290.50.10
+        name: Data Processing Addendum Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Maintenance and execution of data-processing addenda with
+          customers.
+        children: []
+      - id: BC-4290.50.20
+        name: Customer Data Flow Mapping
+        level: 3
+        industry: Software & Technology
+        description: |
+          Mapping of customer data flows for disclosure and assessment.
+        children: []
+      - id: BC-4290.50.30
+        name: Data Subject Request Routing
+        level: 3
+        industry: Software & Technology
+        description: |
+          Routing of data-subject requests received via customers to the
+          appropriate handlers.
+        children: []
+  - id: BC-4290.60
+    name: Service Resilience Commitment Management
+    level: 2
+    industry: Software & Technology
+    description: |
+      Customer-facing service-level commitments, uptime disclosure, and
+      service-credit administration.
+    children:
+      - id: BC-4290.60.10
+        name: Service Level Commitment Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Definition and stewardship of customer-facing service-level
+          commitments.
+        children: []
+      - id: BC-4290.60.20
+        name: Uptime Disclosure
+        level: 3
+        industry: Software & Technology
+        description: |
+          Disclosure of historical uptime against committed levels.
+        children: []
+      - id: BC-4290.60.30
+        name: Service Credit Administration
+        level: 3
+        industry: Software & Technology
+        description: |
+          Administration of service credits arising from missed
+          commitments.
+        children: []

--- a/catalogue/L1-software-product-engineering-management.yaml
+++ b/catalogue/L1-software-product-engineering-management.yaml
@@ -1,0 +1,278 @@
+# Software Product Engineering Management
+id: BC-4200
+name: Software Product Engineering Management
+level: 1
+industry: Software & Technology
+description: |
+  Discovery, specification, design, implementation, code review, and quality
+  engineering of SaaS products from idea through release-ready build.
+references:
+  - https://owasp.org/www-project-application-security-verification-standard/
+  - https://csrc.nist.gov/publications/detail/sp/800-218/final
+  - https://slsa.dev/
+  - https://spdx.dev/
+  - https://cyclonedx.org/
+children:
+  - id: BC-4200.10
+    name: "Product Discovery & Backlog Management"
+    level: 2
+    industry: Software & Technology
+    description: |
+      Opportunity research, ideation, validation, and backlog stewardship that
+      translate market and customer signals into a prioritised body of work.
+    in_scope:
+      - User and market research
+      - Backlog grooming and prioritisation
+      - Roadmap definition and refresh
+    out_of_scope:
+      - Quantitative product analytics (covered by Product Telemetry & Experimentation Management)
+      - Marketing demand generation
+    children:
+      - id: BC-4200.10.10
+        name: User Research
+        level: 3
+        industry: Software & Technology
+        description: |
+          Generative and evaluative research with users to surface needs,
+          friction, and willingness to pay.
+        children: []
+      - id: BC-4200.10.20
+        name: Backlog Refinement
+        level: 3
+        industry: Software & Technology
+        description: |
+          Continuous refinement of the product backlog including sizing,
+          decomposition, and re-prioritisation.
+        children: []
+      - id: BC-4200.10.30
+        name: Roadmap Definition
+        level: 3
+        industry: Software & Technology
+        description: |
+          Definition and periodic refresh of the product roadmap and themed
+          investment areas.
+        children: []
+      - id: BC-4200.10.40
+        name: Customer Feedback Synthesis
+        level: 3
+        industry: Software & Technology
+        description: |
+          Synthesis of inbound feedback from support, success, sales, and
+          community into actionable product signals.
+        children: []
+  - id: BC-4200.20
+    name: Product Specification Management
+    level: 2
+    industry: Software & Technology
+    description: |
+      Capture of intended behaviour, constraints, and acceptance criteria so
+      that engineering work can be executed predictably.
+    in_scope:
+      - Functional and non-functional specifications
+      - Acceptance criteria
+    out_of_scope:
+      - Visual and interaction design (covered by Software Design Management)
+    children:
+      - id: BC-4200.20.10
+        name: Functional Specification
+        level: 3
+        industry: Software & Technology
+        description: |
+          Specification of intended behaviour and user-visible outcomes for
+          features and capabilities.
+        children: []
+      - id: BC-4200.20.20
+        name: Non-Functional Specification
+        level: 3
+        industry: Software & Technology
+        description: |
+          Specification of non-functional requirements such as availability,
+          latency, throughput, and security posture.
+        children: []
+      - id: BC-4200.20.30
+        name: Acceptance Criteria Definition
+        level: 3
+        industry: Software & Technology
+        description: |
+          Definition of testable acceptance criteria that anchor "done" for
+          features and stories.
+        children: []
+  - id: BC-4200.30
+    name: Software Design Management
+    level: 2
+    industry: Software & Technology
+    description: |
+      User experience, system, and accessibility design for software products,
+      anchored in shared design systems.
+    children:
+      - id: BC-4200.30.10
+        name: User Experience Design
+        level: 3
+        industry: Software & Technology
+        description: |
+          Interaction, information architecture, and visual design of product
+          surfaces.
+        children: []
+      - id: BC-4200.30.20
+        name: System Design
+        level: 3
+        industry: Software & Technology
+        description: |
+          Architectural design of software components, services, data flows,
+          and external interfaces.
+        children: []
+      - id: BC-4200.30.30
+        name: Design System Stewardship
+        level: 3
+        industry: Software & Technology
+        description: |
+          Stewardship of the shared design system including components,
+          tokens, and usage guidance.
+        children: []
+      - id: BC-4200.30.40
+        name: Accessibility Design
+        level: 3
+        industry: Software & Technology
+        description: |
+          Design conformance to accessibility standards across product
+          surfaces.
+        children: []
+  - id: BC-4200.40
+    name: Software Construction Management
+    level: 2
+    industry: Software & Technology
+    description: |
+      Implementation practice including source control, code review, and
+      collaborative coding disciplines.
+    children:
+      - id: BC-4200.40.10
+        name: Source Code Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Stewardship of source repositories, branching policy, and code
+          ownership.
+        children: []
+      - id: BC-4200.40.20
+        name: Code Review Practice
+        level: 3
+        industry: Software & Technology
+        description: |
+          Peer review of code changes against engineering and security
+          standards.
+        children: []
+      - id: BC-4200.40.30
+        name: "Pair & Mob Programming Practice"
+        level: 3
+        industry: Software & Technology
+        description: |
+          Collaborative coding practices used to share knowledge and lift
+          quality on selected work.
+        children: []
+  - id: BC-4200.50
+    name: Software Quality Engineering
+    level: 2
+    industry: Software & Technology
+    description: |
+      Test strategy, automated test suite stewardship, and defect management
+      for software products.
+    in_scope:
+      - Automated unit, integration, end-to-end testing of the product
+      - Defect triage and resolution
+    out_of_scope:
+      - Enterprise-wide quality management system (covered by Quality Management)
+      - Performance and resilience testing of the running service (covered by SaaS Platform Operations Management)
+    children:
+      - id: BC-4200.50.10
+        name: Test Strategy Definition
+        level: 3
+        industry: Software & Technology
+        description: |
+          Definition of test strategy across unit, integration, end-to-end,
+          and exploratory layers.
+        children: []
+      - id: BC-4200.50.20
+        name: Automated Test Suite Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Stewardship of automated test suites including coverage,
+          flakiness, and runtime.
+        children: []
+      - id: BC-4200.50.30
+        name: "Defect Triage & Resolution"
+        level: 3
+        industry: Software & Technology
+        description: |
+          Triage and resolution of defects raised against the product.
+        children: []
+      - id: BC-4200.50.40
+        name: Regression Coverage Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Management of regression coverage as the product surface evolves.
+        children: []
+  - id: BC-4200.60
+    name: Open Source Stewardship
+    level: 2
+    industry: Software & Technology
+    description: |
+      Inbound use, outbound contribution, and supply-chain artefacts for
+      open-source software embedded in the product.
+    children:
+      - id: BC-4200.60.10
+        name: Inbound Open Source Compliance
+        level: 3
+        industry: Software & Technology
+        description: |
+          Compliance with inbound open-source licences and notice obligations.
+        children: []
+      - id: BC-4200.60.20
+        name: Outbound Open Source Contribution
+        level: 3
+        industry: Software & Technology
+        description: |
+          Governance of outbound contributions to and stewardship of
+          open-source projects.
+        children: []
+      - id: BC-4200.60.30
+        name: Software Bill of Materials Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Generation, distribution, and maintenance of software bills of
+          materials in standard formats.
+        children: []
+  - id: BC-4200.70
+    name: Engineering Productivity Management
+    level: 2
+    industry: Software & Technology
+    description: |
+      Internal developer platforms, tooling, and engineering performance
+      measurement that lift sustained delivery throughput.
+    children:
+      - id: BC-4200.70.10
+        name: Developer Toolchain Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Selection and stewardship of developer toolchains across the
+          engineering organisation.
+        children: []
+      - id: BC-4200.70.20
+        name: Internal Developer Platform Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Operation of internal platforms that abstract infrastructure and
+          paved-path workflows for engineers.
+        children: []
+      - id: BC-4200.70.30
+        name: Engineering Performance Metrics
+        level: 3
+        industry: Software & Technology
+        description: |
+          Measurement of engineering performance using delivery and developer
+          experience metrics.
+        children: []

--- a/catalogue/L1-software-release-deployment-management.yaml
+++ b/catalogue/L1-software-release-deployment-management.yaml
@@ -1,0 +1,238 @@
+# Software Release & Deployment Management
+id: BC-4210
+name: "Software Release & Deployment Management"
+level: 1
+industry: Software & Technology
+description: |
+  Continuous integration, environment management, release engineering,
+  feature flagging, and progressive deployment of SaaS products to
+  production.
+references:
+  - https://12factor.net/
+  - https://www.cncf.io/
+  - https://dora.dev/
+children:
+  - id: BC-4210.10
+    name: Continuous Integration Management
+    level: 2
+    industry: Software & Technology
+    description: |
+      Build pipelines, artefact production, and pipeline policy enforcement
+      that keep the integrated product continuously buildable.
+    children:
+      - id: BC-4210.10.10
+        name: Build Pipeline Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Definition and operation of automated build pipelines for product
+          components.
+        children: []
+      - id: BC-4210.10.20
+        name: Artefact Repository Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Storage, retention, and access of build artefacts and dependency
+          packages.
+        children: []
+      - id: BC-4210.10.30
+        name: Pipeline Policy Enforcement
+        level: 3
+        industry: Software & Technology
+        description: |
+          Enforcement of required quality, security, and provenance gates
+          across pipelines.
+        children: []
+  - id: BC-4210.20
+    name: Environment Management
+    level: 2
+    industry: Software & Technology
+    description: |
+      Provisioning and stewardship of non-production environments used for
+      development, integration, and pre-production validation.
+    children:
+      - id: BC-4210.20.10
+        name: Environment Provisioning
+        level: 3
+        industry: Software & Technology
+        description: |
+          Provisioning of non-production environments aligned to engineering
+          and validation needs.
+        children: []
+      - id: BC-4210.20.20
+        name: Environment Configuration
+        level: 3
+        industry: Software & Technology
+        description: |
+          Configuration of non-production environments to maintain parity
+          with production where required.
+        children: []
+      - id: BC-4210.20.30
+        name: Environment Data Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Provision, masking, and refresh of data in non-production
+          environments.
+        children: []
+  - id: BC-4210.30
+    name: Release Engineering Management
+    level: 2
+    industry: Software & Technology
+    description: |
+      Cadence, versioning, branching, and release-note discipline for
+      software releases.
+    children:
+      - id: BC-4210.30.10
+        name: Release Cadence Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Definition and stewardship of release cadence across product
+          areas.
+        children: []
+      - id: BC-4210.30.20
+        name: "Versioning & Branching"
+        level: 3
+        industry: Software & Technology
+        description: |
+          Versioning scheme and branching strategy applied to product
+          releases.
+        children: []
+      - id: BC-4210.30.30
+        name: Release Notes Authoring
+        level: 3
+        industry: Software & Technology
+        description: |
+          Authoring of customer- and operator-facing release notes for each
+          release.
+        children: []
+  - id: BC-4210.40
+    name: Deployment Orchestration
+    level: 2
+    industry: Software & Technology
+    description: |
+      Strategies for delivering software changes to production safely and
+      with controlled blast radius.
+    children:
+      - id: BC-4210.40.10
+        name: Progressive Rollout
+        level: 3
+        industry: Software & Technology
+        description: |
+          Gradual roll-out of releases to expanding cohorts of tenants or
+          users.
+        children: []
+      - id: BC-4210.40.20
+        name: Canary Deployment
+        level: 3
+        industry: Software & Technology
+        description: |
+          Deployment of releases to a small canary population with automated
+          health evaluation.
+        children: []
+      - id: BC-4210.40.30
+        name: Blue-Green Deployment
+        level: 3
+        industry: Software & Technology
+        description: |
+          Parallel-environment deployment with traffic cut-over for
+          near-zero-downtime change.
+        children: []
+      - id: BC-4210.40.40
+        name: Rollback Coordination
+        level: 3
+        industry: Software & Technology
+        description: |
+          Coordinated rollback of releases on adverse signals.
+        children: []
+  - id: BC-4210.50
+    name: Feature Flag Management
+    level: 2
+    industry: Software & Technology
+    description: |
+      Lifecycle and runtime control of feature flags used to decouple
+      deploy from release and target features to cohorts.
+    in_scope:
+      - Feature flag creation, retirement, and audit
+      - Targeting rules
+    out_of_scope:
+      - Experimentation methodology and adjudication (covered by Product Telemetry & Experimentation Management)
+    children:
+      - id: BC-4210.50.10
+        name: Feature Flag Lifecycle
+        level: 3
+        industry: Software & Technology
+        description: |
+          Lifecycle of feature flags from creation to retirement.
+        children: []
+      - id: BC-4210.50.20
+        name: Targeting Rule Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Definition of targeting rules that determine which subjects
+          receive a flag variant.
+        children: []
+      - id: BC-4210.50.30
+        name: Flag Hygiene Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Hygiene practice that retires obsolete flags and prevents
+          accumulation of dead conditional code.
+        children: []
+  - id: BC-4210.60
+    name: "Configuration & Secrets Management"
+    level: 2
+    industry: Software & Technology
+    description: |
+      Management of runtime configuration values and secrets consumed by
+      product services.
+    children:
+      - id: BC-4210.60.10
+        name: Runtime Configuration Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Storage, distribution, and audit of runtime configuration values.
+        children: []
+      - id: BC-4210.60.20
+        name: Secret Lifecycle Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Issuance, rotation, and revocation of secrets used by product
+          services.
+        children: []
+  - id: BC-4210.70
+    name: Production Change Authorisation
+    level: 2
+    industry: Software & Technology
+    description: |
+      Pre-deployment review, deployment-window governance, and authorisation
+      of human access to production.
+    children:
+      - id: BC-4210.70.10
+        name: Pre-Deployment Review
+        level: 3
+        industry: Software & Technology
+        description: |
+          Review and approval of changes prior to production deployment.
+        children: []
+      - id: BC-4210.70.20
+        name: Deployment Window Governance
+        level: 3
+        industry: Software & Technology
+        description: |
+          Governance of permissible deployment windows and freezes.
+        children: []
+      - id: BC-4210.70.30
+        name: Production Access Authorisation
+        level: 3
+        industry: Software & Technology
+        description: |
+          Authorisation, just-in-time grant, and audit of human access to
+          production systems.
+        children: []

--- a/catalogue/L1-subscription-billing-revenue-management.yaml
+++ b/catalogue/L1-subscription-billing-revenue-management.yaml
@@ -1,0 +1,253 @@
+# Subscription Billing & Revenue Management
+id: BC-4250
+name: "Subscription Billing & Revenue Management"
+level: 1
+industry: Software & Technology
+description: |
+  Usage metering, rating, invoicing, dunning, subscription revenue
+  recognition, subscription tax handling, and recurring-revenue analytics
+  for the SaaS commercial model.
+references:
+  - https://www.ifrs.org/issued-standards/list-of-standards/ifrs-15-revenue-from-contracts-with-customers/
+  - https://asc.fasb.org/topic&trid=2160963
+children:
+  - id: BC-4250.10
+    name: Usage Metering
+    level: 2
+    industry: Software & Technology
+    description: |
+      Ingestion and aggregation of usage events that feed downstream rating
+      and analytics.
+    children:
+      - id: BC-4250.10.10
+        name: Usage Event Ingestion
+        level: 3
+        industry: Software & Technology
+        description: |
+          Ingestion of usage events from product services into the
+          metering pipeline.
+        children: []
+      - id: BC-4250.10.20
+        name: Usage Aggregation
+        level: 3
+        industry: Software & Technology
+        description: |
+          Aggregation of usage events into billable quantities by tenant
+          and meter.
+        children: []
+      - id: BC-4250.10.30
+        name: Metered Quantity Reconciliation
+        level: 3
+        industry: Software & Technology
+        description: |
+          Reconciliation of metered quantities against source of truth and
+          customer-visible counters.
+        children: []
+  - id: BC-4250.20
+    name: "Rating & Charging"
+    level: 2
+    industry: Software & Technology
+    description: |
+      Application of subscription tariffs, usage tariffs, prorations, and
+      discounts to compute charges.
+    children:
+      - id: BC-4250.20.10
+        name: Subscription Rating
+        level: 3
+        industry: Software & Technology
+        description: |
+          Computation of recurring subscription charges per cycle.
+        children: []
+      - id: BC-4250.20.20
+        name: Usage Rating
+        level: 3
+        industry: Software & Technology
+        description: |
+          Computation of usage charges from rated quantities and tariffs.
+        children: []
+      - id: BC-4250.20.30
+        name: Proration Calculation
+        level: 3
+        industry: Software & Technology
+        description: |
+          Calculation of prorated charges arising from mid-cycle changes.
+        children: []
+      - id: BC-4250.20.40
+        name: Discount Application
+        level: 3
+        industry: Software & Technology
+        description: |
+          Application of negotiated discounts and credits to computed
+          charges.
+        children: []
+  - id: BC-4250.30
+    name: "Invoicing & Statement Management"
+    level: 2
+    industry: Software & Technology
+    description: |
+      Generation, delivery, and adjustment of invoices and customer
+      billing dispute handling.
+    children:
+      - id: BC-4250.30.10
+        name: Invoice Generation
+        level: 3
+        industry: Software & Technology
+        description: |
+          Generation of invoices from rated charges and contract terms.
+        children: []
+      - id: BC-4250.30.20
+        name: Invoice Delivery
+        level: 3
+        industry: Software & Technology
+        description: |
+          Delivery of invoices to customers via portal, email, and
+          partner channels.
+        children: []
+      - id: BC-4250.30.30
+        name: Invoice Adjustment
+        level: 3
+        industry: Software & Technology
+        description: |
+          Adjustment of invoices for credits, errors, and contractual
+          variances.
+        children: []
+      - id: BC-4250.30.40
+        name: Customer Billing Dispute Handling
+        level: 3
+        industry: Software & Technology
+        description: |
+          Triage and resolution of customer billing disputes.
+        children: []
+  - id: BC-4250.40
+    name: "Payment Collection & Dunning"
+    level: 2
+    industry: Software & Technology
+    description: |
+      Payment-method management, payment authorisation, dunning, and
+      involuntary churn recovery.
+    children:
+      - id: BC-4250.40.10
+        name: Payment Method Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Capture and stewardship of customer payment methods and tokens.
+        children: []
+      - id: BC-4250.40.20
+        name: Payment Authorisation
+        level: 3
+        industry: Software & Technology
+        description: |
+          Authorisation and capture of recurring payments through payment
+          processors.
+        children: []
+      - id: BC-4250.40.30
+        name: Dunning Workflow
+        level: 3
+        industry: Software & Technology
+        description: |
+          Automated dunning sequences for failed payments and ageing
+          balances.
+        children: []
+      - id: BC-4250.40.40
+        name: Involuntary Churn Recovery
+        level: 3
+        industry: Software & Technology
+        description: |
+          Recovery of subscriptions lost due to expired cards, hard
+          declines, and similar payment failures.
+        children: []
+  - id: BC-4250.50
+    name: Subscription Revenue Recognition
+    level: 2
+    industry: Software & Technology
+    description: |
+      Identification of performance obligations and management of revenue
+      schedules in line with ASC 606 / IFRS 15.
+    children:
+      - id: BC-4250.50.10
+        name: Performance Obligation Identification
+        level: 3
+        industry: Software & Technology
+        description: |
+          Identification of distinct performance obligations from
+          subscription contracts.
+        children: []
+      - id: BC-4250.50.20
+        name: Revenue Schedule Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Generation and maintenance of revenue recognition schedules
+          across contract life.
+        children: []
+      - id: BC-4250.50.30
+        name: Deferred Revenue Reconciliation
+        level: 3
+        industry: Software & Technology
+        description: |
+          Reconciliation of deferred revenue balances to billed and
+          recognised amounts.
+        children: []
+  - id: BC-4250.60
+    name: Subscription Tax Management
+    level: 2
+    industry: Software & Technology
+    description: |
+      Tax-jurisdiction determination, calculation, and exemption handling
+      across recurring and usage-based charges.
+    children:
+      - id: BC-4250.60.10
+        name: Tax Jurisdiction Determination
+        level: 3
+        industry: Software & Technology
+        description: |
+          Determination of applicable tax jurisdictions per customer and
+          charge.
+        children: []
+      - id: BC-4250.60.20
+        name: Subscription Tax Calculation
+        level: 3
+        industry: Software & Technology
+        description: |
+          Calculation of indirect tax on subscription and usage charges.
+        children: []
+      - id: BC-4250.60.30
+        name: Tax Exemption Handling
+        level: 3
+        industry: Software & Technology
+        description: |
+          Capture and application of customer tax-exemption certificates.
+        children: []
+  - id: BC-4250.70
+    name: Subscription Revenue Analytics
+    level: 2
+    industry: Software & Technology
+    description: |
+      Computation and analysis of recurring-revenue health metrics
+      including ARR, MRR, NRR, GRR, and cohort views.
+    children:
+      - id: BC-4250.70.10
+        name: "ARR & MRR Computation"
+        level: 3
+        industry: Software & Technology
+        description: |
+          Computation of annual and monthly recurring revenue from
+          subscription state.
+        children: []
+      - id: BC-4250.70.20
+        name: "Net & Gross Retention Analysis"
+        level: 3
+        industry: Software & Technology
+        description: |
+          Analysis of net and gross revenue retention across customer
+          cohorts.
+        children: []
+      - id: BC-4250.70.30
+        name: Cohort Revenue Analysis
+        level: 3
+        industry: Software & Technology
+        description: |
+          Cohort-based analysis of revenue evolution and retention
+          dynamics.
+        children: []

--- a/catalogue/L1-subscription-lifecycle-management.yaml
+++ b/catalogue/L1-subscription-lifecycle-management.yaml
@@ -1,0 +1,239 @@
+# Subscription Lifecycle Management
+id: BC-4240
+name: Subscription Lifecycle Management
+level: 1
+industry: Software & Technology
+description: |
+  Plan and entitlement design, subscription contracting, provisioning,
+  modification, renewal, cancellation, and runtime entitlement enforcement
+  across the SaaS commercial lifecycle.
+children:
+  - id: BC-4240.10
+    name: "Plan & Entitlement Design"
+    level: 2
+    industry: Software & Technology
+    description: |
+      Definition of plans, feature entitlements, and the rules governing
+      which customers are eligible for which plan.
+    in_scope:
+      - Plan catalogue and feature gating
+      - Plan eligibility rules
+    out_of_scope:
+      - Pricing strategy and price-list governance (covered by Pricing Management)
+    children:
+      - id: BC-4240.10.10
+        name: Plan Catalogue Definition
+        level: 3
+        industry: Software & Technology
+        description: |
+          Definition of the plan catalogue, including plan tiers and
+          contents.
+        children: []
+      - id: BC-4240.10.20
+        name: Feature Entitlement Definition
+        level: 3
+        industry: Software & Technology
+        description: |
+          Definition of feature entitlements attached to plans, add-ons, and
+          custom contracts.
+        children: []
+      - id: BC-4240.10.30
+        name: Plan Eligibility Rules
+        level: 3
+        industry: Software & Technology
+        description: |
+          Rules that determine which customers and use-cases are eligible
+          for each plan.
+        children: []
+  - id: BC-4240.20
+    name: Subscription Contracting
+    level: 2
+    industry: Software & Technology
+    description: |
+      Quote management, order-form generation, and capture of subscription
+      contract artefacts.
+    children:
+      - id: BC-4240.20.10
+        name: Subscription Quote Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Generation and stewardship of subscription quotes through the
+          sales motion.
+        children: []
+      - id: BC-4240.20.20
+        name: Order Form Generation
+        level: 3
+        industry: Software & Technology
+        description: |
+          Generation of order forms reflecting agreed terms for new and
+          existing customers.
+        children: []
+      - id: BC-4240.20.30
+        name: Subscription Contract Capture
+        level: 3
+        industry: Software & Technology
+        description: |
+          Capture and storage of executed subscription contract artefacts
+          and key terms.
+        children: []
+  - id: BC-4240.30
+    name: Subscription Provisioning
+    level: 2
+    industry: Software & Technology
+    description: |
+      Activation of service for new subscriptions, including trial-to-paid
+      conversion and bulk seat provisioning.
+    children:
+      - id: BC-4240.30.10
+        name: Initial Provisioning
+        level: 3
+        industry: Software & Technology
+        description: |
+          Initial provisioning of service entitlements at start of
+          subscription.
+        children: []
+      - id: BC-4240.30.20
+        name: Trial Conversion
+        level: 3
+        industry: Software & Technology
+        description: |
+          Conversion of trial accounts to paid subscriptions.
+        children: []
+      - id: BC-4240.30.30
+        name: Bulk Seat Provisioning
+        level: 3
+        industry: Software & Technology
+        description: |
+          Bulk provisioning of seats for enterprise subscriptions.
+        children: []
+  - id: BC-4240.40
+    name: Subscription Modification
+    level: 2
+    industry: Software & Technology
+    description: |
+      In-life changes to active subscriptions including upgrades,
+      downgrades, seat adjustments, and add-on activation.
+    children:
+      - id: BC-4240.40.10
+        name: Plan Upgrade Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Handling of customer-initiated and system-initiated plan upgrades.
+        children: []
+      - id: BC-4240.40.20
+        name: Plan Downgrade Management
+        level: 3
+        industry: Software & Technology
+        description: |
+          Handling of plan downgrades including effect on entitlements and
+          data.
+        children: []
+      - id: BC-4240.40.30
+        name: Seat Adjustment
+        level: 3
+        industry: Software & Technology
+        description: |
+          Adjustment of seat counts on active subscriptions.
+        children: []
+      - id: BC-4240.40.40
+        name: Add-On Activation
+        level: 3
+        industry: Software & Technology
+        description: |
+          Activation of optional add-on entitlements on active
+          subscriptions.
+        children: []
+  - id: BC-4240.50
+    name: Renewal Management
+    level: 2
+    industry: Software & Technology
+    description: |
+      Forecasting, processing, and negotiation of subscription renewals
+      whether automatic or manual.
+    children:
+      - id: BC-4240.50.10
+        name: Renewal Forecasting
+        level: 3
+        industry: Software & Technology
+        description: |
+          Forecasting of upcoming renewals and expected outcomes.
+        children: []
+      - id: BC-4240.50.20
+        name: Auto-Renewal Processing
+        level: 3
+        industry: Software & Technology
+        description: |
+          Processing of automatic subscription renewals per contract terms.
+        children: []
+      - id: BC-4240.50.30
+        name: Renewal Negotiation Support
+        level: 3
+        industry: Software & Technology
+        description: |
+          Support for renewal negotiations including data, pricing, and
+          term-change packages.
+        children: []
+  - id: BC-4240.60
+    name: "Cancellation & Termination"
+    level: 2
+    industry: Software & Technology
+    description: |
+      Voluntary cancellation, involuntary termination, and the wind-down of
+      service for departing customers.
+    children:
+      - id: BC-4240.60.10
+        name: Cancellation Processing
+        level: 3
+        industry: Software & Technology
+        description: |
+          Processing of customer-initiated cancellations.
+        children: []
+      - id: BC-4240.60.20
+        name: Involuntary Termination
+        level: 3
+        industry: Software & Technology
+        description: |
+          Termination of service for non-payment, breach, or contractual
+          end.
+        children: []
+      - id: BC-4240.60.30
+        name: Service Wind-Down Coordination
+        level: 3
+        industry: Software & Technology
+        description: |
+          Coordinated wind-down of service including data export and
+          deletion handover.
+        children: []
+  - id: BC-4240.70
+    name: Entitlement Enforcement
+    level: 2
+    industry: Software & Technology
+    description: |
+      Resolution and runtime enforcement of subscription entitlements with
+      audit trail of access decisions.
+    children:
+      - id: BC-4240.70.10
+        name: Entitlement Resolution
+        level: 3
+        industry: Software & Technology
+        description: |
+          Resolution of effective entitlements per subscription, account,
+          and user.
+        children: []
+      - id: BC-4240.70.20
+        name: Entitlement Gate Enforcement
+        level: 3
+        industry: Software & Technology
+        description: |
+          Runtime gating of features and quotas against resolved
+          entitlements.
+        children: []
+      - id: BC-4240.70.30
+        name: Entitlement Audit Trail
+        level: 3
+        industry: Software & Technology
+        description: |
+          Audit-grade record of entitlement changes and gate decisions.
+        children: []

--- a/catalogue/_index.yaml
+++ b/catalogue/_index.yaml
@@ -258,3 +258,13 @@ files:
   - L1-cruise-voyage-operations-management.yaml
   - L1-tour-itinerary-operations-management.yaml
   - L1-events-group-operations-management.yaml
+  - L1-software-product-engineering-management.yaml
+  - L1-software-release-deployment-management.yaml
+  - L1-saas-platform-operations-management.yaml
+  - L1-saas-tenant-management.yaml
+  - L1-subscription-lifecycle-management.yaml
+  - L1-subscription-billing-revenue-management.yaml
+  - L1-customer-success-management.yaml
+  - L1-developer-platform-api-ecosystem-management.yaml
+  - L1-product-telemetry-experimentation-management.yaml
+  - L1-saas-trust-service-compliance-management.yaml

--- a/catalogue/_value-streams.yaml
+++ b/catalogue/_value-streams.yaml
@@ -477,6 +477,21 @@ value_streams:
         capability_id: BC-4060
         industry_variant: Travel & Hospitality
         notes: Service-recovery actions, compensation, and follow-up
+      - stage_order: 1
+        stage_name: Issue Capture (SaaS Service)
+        capability_id: BC-4220
+        industry_variant: Software & Technology
+        notes: Production incident detection from telemetry and customer reports
+      - stage_order: 3
+        stage_name: Investigation (SaaS Service)
+        capability_id: BC-4220
+        industry_variant: Software & Technology
+        notes: Incident coordination and blameless postmortem authoring
+      - stage_order: 4
+        stage_name: Resolution (SaaS Service)
+        capability_id: BC-4220
+        industry_variant: Software & Technology
+        notes: Reliability action tracking to closure
   - name: Order-to-Cash
     industries: [Cross-Industry]
     stages:
@@ -918,6 +933,26 @@ value_streams:
         capability_id: BC-3760
         industry_variant: Media & Entertainment
         notes: Advertiser collections and make-goods
+      - stage_order: 3
+        stage_name: Contract & Order Capture
+        capability_id: BC-4240
+        notes: Subscription contracting and order forms
+      - stage_order: 5
+        stage_name: Production / Service Delivery
+        capability_id: BC-4230
+        notes: Tenant provisioning as service-delivery fulfilment
+      - stage_order: 7
+        stage_name: Customer Invoicing
+        capability_id: BC-4250
+        notes: Subscription invoicing
+      - stage_order: 8
+        stage_name: Cash Collection & Application
+        capability_id: BC-4250
+        notes: Payment collection, dunning, and involuntary churn recovery
+      - stage_order: 9
+        stage_name: Revenue Recognition
+        capability_id: BC-4250
+        notes: Subscription revenue recognition under ASC 606 / IFRS 15
   - name: Procure-to-Pay
     industries: [Cross-Industry]
     stages:
@@ -1094,6 +1129,10 @@ value_streams:
         capability_id: BC-3700
         industry_variant: Media & Entertainment
         notes: Greenlight evaluation
+      - stage_order: 2
+        stage_name: Concept & Feasibility
+        capability_id: BC-4200
+        notes: Software product discovery and feasibility
       - stage_order: 3
         stage_name: Research & Prototyping
         capability_id: BC-1500
@@ -1103,6 +1142,10 @@ value_streams:
         stage_name: Research & Prototyping
         capability_id: BC-810
         notes: Research; Experimentation & prototyping
+      - stage_order: 3
+        stage_name: Research & Prototyping
+        capability_id: BC-4200
+        notes: Software prototyping and validation
       - stage_order: 4
         stage_name: Portfolio Selection
         capability_id: BC-800
@@ -1179,6 +1222,10 @@ value_streams:
         capability_id: BC-3700
         industry_variant: Media & Entertainment
         notes: Pre-production, production, post-production
+      - stage_order: 5
+        stage_name: Design & Development
+        capability_id: BC-4200
+        notes: Software product engineering
       - stage_order: 6
         stage_name: IP Protection
         capability_id: BC-840
@@ -1226,6 +1273,14 @@ value_streams:
         capability_id: BC-3730
         industry_variant: Media & Entertainment
         notes: Schedule slot and EPG readiness
+      - stage_order: 7
+        stage_name: Launch Readiness
+        capability_id: BC-4210
+        notes: Release engineering and environment readiness
+      - stage_order: 7
+        stage_name: Launch Readiness
+        capability_id: BC-4270
+        notes: Public API and SDK release readiness
       - stage_order: 8
         stage_name: Market Introduction
         capability_id: BC-1530
@@ -1270,6 +1325,10 @@ value_streams:
         capability_id: BC-3740
         industry_variant: Media & Entertainment
         notes: First-window release
+      - stage_order: 8
+        stage_name: Market Introduction
+        capability_id: BC-4210
+        notes: Progressive production rollout
       - stage_order: 9
         stage_name: Post-Launch Performance
         capability_id: BC-820
@@ -1299,6 +1358,14 @@ value_streams:
         capability_id: BC-3770
         industry_variant: Media & Entertainment
         notes: Title performance feedback to commissioning
+      - stage_order: 9
+        stage_name: Post-Launch Performance
+        capability_id: BC-4280
+        notes: Telemetry, A/B tests, and feature engagement reporting
+      - stage_order: 9
+        stage_name: Post-Launch Performance
+        capability_id: BC-4220
+        notes: Reliability and performance of the launched service
   - name: Plan-to-Inventory
     industries: [Cross-Industry]
     stages:
@@ -1534,6 +1601,11 @@ value_streams:
         capability_id: BC-3920
         industry_variant: Utilities
         notes: Utility regulatory accounts and price-control performance reporting
+      - stage_order: 5
+        stage_name: Management Reporting
+        capability_id: BC-4250
+        industry_variant: Software & Technology
+        notes: ARR, MRR, NRR, GRR, and cohort recurring-revenue reporting
   - name: Acquire-to-Retire
     industries: [Cross-Industry]
     stages:
@@ -2087,6 +2159,16 @@ value_streams:
         capability_id: BC-3590
         industry_variant: Agriculture
         notes: Farm assurance and certification audit readiness
+      - stage_order: 3
+        stage_name: Fieldwork
+        capability_id: BC-4290
+        industry_variant: Software & Technology
+        notes: External service-attestation audits (SOC 2, ISO 27001)
+      - stage_order: 5
+        stage_name: Remediation Tracking
+        capability_id: BC-4290
+        industry_variant: Software & Technology
+        notes: Remediation of attestation findings
   - name: Threat-to-Mitigation
     industries: [Cross-Industry]
     stages:
@@ -2323,6 +2405,14 @@ value_streams:
         capability_id: BC-4050
         industry_variant: Travel & Hospitality
         notes: Loyalty enrolment and welcome programme activation
+      - stage_order: 6
+        stage_name: Customer Onboarding
+        capability_id: BC-4260
+        notes: Customer onboarding and activation
+      - stage_order: 7
+        stage_name: Retention & Advocacy
+        capability_id: BC-4260
+        notes: Retention, NPS, references, and expansion advocacy
   - name: Application-to-Funding
     industries: [Banking & Capital Markets]
     stages:
@@ -2945,6 +3035,14 @@ value_streams:
         capability_id: BC-3830
         industry_variant: Utilities
         notes: Black start and bulk-system restoration coordination
+      - stage_order: 2
+        stage_name: Resilience Testing
+        capability_id: BC-4220
+        notes: Disaster-recovery exercises and game-days for the SaaS service
+      - stage_order: 5
+        stage_name: Disaster Recovery
+        capability_id: BC-4220
+        notes: Failover orchestration and backup restoration for the SaaS service
   - name: ESG-to-Disclosure
     industries: [Cross-Industry]
     stages:
@@ -3434,6 +3532,18 @@ value_streams:
         stage_name: Handover to Fulfilment
         capability_id: BC-420
         notes: Customer lifecycle activation
+      - stage_order: 3
+        stage_name: Quote & Configuration
+        capability_id: BC-4240
+        notes: Subscription quote management
+      - stage_order: 7
+        stage_name: Contract & Order Booking
+        capability_id: BC-4240
+        notes: Order form generation and subscription contract capture
+      - stage_order: 8
+        stage_name: Handover to Fulfilment
+        capability_id: BC-4230
+        notes: Tenant provisioning handover
   - name: Lease-to-Production
     industries: [Oil & Gas]
     stages:
@@ -4334,3 +4444,58 @@ value_streams:
         stage_name: Post-Event Review
         capability_id: BC-4030
         notes: Revenue impact analysis and forecast adjustment
+  - name: Trial-to-Renewal
+    industries: [Software & Technology]
+    stages:
+      - stage_order: 1
+        stage_name: Trial Initiation
+        capability_id: BC-4240
+        notes: Trial sign-up and trial subscription provisioning
+      - stage_order: 1
+        stage_name: Trial Initiation
+        capability_id: BC-4230
+        notes: Tenant provisioning for trial accounts
+      - stage_order: 2
+        stage_name: Trial Activation
+        capability_id: BC-4260
+        notes: Onboarding and activation milestone tracking during trial
+      - stage_order: 3
+        stage_name: Conversion to Paid
+        capability_id: BC-4240
+        notes: Trial-to-paid subscription conversion
+      - stage_order: 3
+        stage_name: Conversion to Paid
+        capability_id: BC-4250
+        notes: Initial invoicing and payment authorisation on conversion
+      - stage_order: 4
+        stage_name: Adoption
+        capability_id: BC-4260
+        notes: Adoption programmes, power-user enablement
+      - stage_order: 4
+        stage_name: Adoption
+        capability_id: BC-4280
+        notes: Product telemetry and feature engagement reporting that drive adoption
+      - stage_order: 5
+        stage_name: Health & Risk Monitoring
+        capability_id: BC-4260
+        notes: Customer health scoring and at-risk account intervention
+      - stage_order: 6
+        stage_name: Renewal
+        capability_id: BC-4240
+        notes: Auto-renewal processing and renewal negotiation
+      - stage_order: 6
+        stage_name: Renewal
+        capability_id: BC-4260
+        notes: Renewal advocacy, save motions, renewal forecasting
+      - stage_order: 7
+        stage_name: Expansion
+        capability_id: BC-4260
+        notes: Expansion opportunity identification and upsell qualification
+      - stage_order: 7
+        stage_name: Expansion
+        capability_id: BC-4240
+        notes: Plan upgrade, seat adjustment, and add-on activation
+      - stage_order: 8
+        stage_name: Churn or Wind-Down
+        capability_id: BC-4240
+        notes: Cancellation processing and service wind-down coordination


### PR DESCRIPTION
Adds an industry-specific capability layer for the SaaS / Software &
Technology industry, alongside a §9.8 reference-frameworks subsection
that anchors the new L1s to the canonical SaaS standards (SOC 2, ISO
27001/27017/27018/27701, FedRAMP, NIST SSDF, OpenAPI, OAuth/OIDC, DORA
metrics, ASC 606 / IFRS 15, EU DORA / NIS2 / Data Act / AI Act, GDPR,
PCI DSS, etc.).

L1s (BC-4200 → BC-4290):
- BC-4200 Software Product Engineering Management
- BC-4210 Software Release & Deployment Management
- BC-4220 SaaS Platform Operations Management
- BC-4230 SaaS Tenant Management
- BC-4240 Subscription Lifecycle Management
- BC-4250 Subscription Billing & Revenue Management
- BC-4260 Customer Success Management
- BC-4270 Developer Platform & API Ecosystem Management
- BC-4280 Product Telemetry & Experimentation Management
- BC-4290 SaaS Trust & Service Compliance Management

Each L1 is decomposed to L2 / L3 with descriptions, in/out-of-scope
notes, and references where applicable. Designed not to duplicate the
existing Cross-Industry IT, Data, Cybersecurity, Sales, Marketing,
CRM, Customer Service, Pricing, Product Lifecycle, R&D, Innovation,
Quality, or Financial Management L1s — only the SaaS-distinctive
abilities are introduced.

Lint: 266 files, 7686 nodes, passes.

https://claude.ai/code/session_015iib5tJKVrvAjv3KKzwdnP