### PR TITLE
Pin Cross-Industry to top of Industry filter with magenta highlight

### DIFF
--- a/site/src/components/CatalogueBrowser.tsx
+++ b/site/src/components/CatalogueBrowser.tsx
@@ -162,7 +162,10 @@ export default function CatalogueBrowser({ data, valueStreams }: Props) {
   const allIndustries = useMemo(() => {
     const s = new Set<string>();
     for (const c of data) for (const ind of splitIndustry(c.industry)) s.add(ind);
-    return Array.from(s).sort();
+    const sorted = Array.from(s).sort();
+    const cross = sorted.filter((i) => i === "Cross-Industry");
+    const rest = sorted.filter((i) => i !== "Cross-Industry");
+    return [...cross, ...rest];
   }, [data]);
 
   const valueStreamNames = useMemo(
@@ -697,6 +700,7 @@ function FilterBar({
           options={allIndustries}
           selected={industries}
           onChange={onIndustries}
+          highlight="Cross-Industry"
         />
       )}
 
@@ -728,9 +732,11 @@ interface MultiSelectProps {
   groups?: { label: string; options: string[] }[];
   selected: Set<string>;
   onChange: (next: Set<string>) => void;
+  /** When set, the option matching this string gets the `is-highlight` class. */
+  highlight?: string;
 }
 
-function MultiSelect({ label, options, groups, selected, onChange }: MultiSelectProps) {
+function MultiSelect({ label, options, groups, selected, onChange, highlight }: MultiSelectProps) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -794,7 +800,10 @@ function MultiSelect({ label, options, groups, selected, onChange }: MultiSelect
                 <div key={g.label} class="multi-select-group">
                   <div class="multi-select-group-label">{g.label}</div>
                   {g.options.map((opt) => (
-                    <label key={`${g.label}::${opt}`} class="multi-select-option">
+                    <label
+                      key={`${g.label}::${opt}`}
+                      class={`multi-select-option${opt === highlight ? " is-highlight" : ""}`}
+                    >
                       <input
                         type="checkbox"
                         checked={selected.has(opt)}
@@ -806,7 +815,10 @@ function MultiSelect({ label, options, groups, selected, onChange }: MultiSelect
                 </div>
               ))
             : options.map((opt) => (
-                <label key={opt} class="multi-select-option">
+                <label
+                  key={opt}
+                  class={`multi-select-option${opt === highlight ? " is-highlight" : ""}`}
+                >
                   <input
                     type="checkbox"
                     checked={selected.has(opt)}

--- a/site/src/styles/catalogue.css
+++ b/site/src/styles/catalogue.css
@@ -195,11 +195,11 @@
 }
 
 .multi-select-option.is-highlight {
-  background: #fce7f3;
+  background: #dbeafe;
 }
 
 .multi-select-option.is-highlight:hover {
-  background: #fbcfe8;
+  background: #bfdbfe;
 }
 
 .multi-select-option input[type="checkbox"] {

--- a/site/src/styles/catalogue.css
+++ b/site/src/styles/catalogue.css
@@ -194,6 +194,14 @@
   background: var(--color-pale-blue);
 }
 
+.multi-select-option.is-highlight {
+  background: #fce7f3;
+}
+
+.multi-select-option.is-highlight:hover {
+  background: #fbcfe8;
+}
+
 .multi-select-option input[type="checkbox"] {
   accent-color: var(--color-accent);
   width: 14px;


### PR DESCRIPTION
Surface the cross-industry option ahead of named industries so it's the
first thing users see in the filter list, and tint its row light magenta
so the special-case nature of the Cross-Industry tag is visually obvious.