### PR TITLE
Replace Cross-Industry highlight with a separator line

### DIFF
--- a/site/src/styles/catalogue.css
+++ b/site/src/styles/catalogue.css
@@ -195,11 +195,10 @@
 }
 
 .multi-select-option.is-highlight {
-  background: #dbeafe;
-}
-
-.multi-select-option.is-highlight:hover {
-  background: #bfdbfe;
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 8px;
+  margin-bottom: 4px;
+  border-radius: 4px 4px 0 0;
 }
 
 .multi-select-option input[type="checkbox"] {


### PR DESCRIPTION
Drop the tinted background in favor of a thin divider underneath the Cross-Industry row, which signals the grouping without coloring the option itself.