### PR TITLE
Group L1 capabilities by industry with sticky controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,13 @@ turbo-ea-capabilities/
 ├── catalogue/              # YAML source of truth (one file per L1)
 │   ├── _index.yaml
 │   ├── _value-streams.yaml
-│   └── L1-*.yaml
+│   ├── L1-*.yaml
+│   └── i18n/               # Translation sidecars (one per locale × L1)
+│       └── <bcp47>/
+│           └── L1-*.yaml
 ├── schema/                 # JSON Schema 2020-12 for the YAML shape
+│   ├── capability.schema.json
+│   └── i18n.schema.json    # Schema for translation sidecar files
 ├── scripts/                # lint, build_api, build_pkg, cli helpers
 ├── packages/py/            # Python package (turbo_ea_capabilities)
 ├── site/                   # Astro static site for browse UI + JSON API
@@ -66,7 +71,7 @@ All editing rules — what's a capability, how to name it, when to deprecate —
 
 ## AI-assisted authoring with Claude Code
 
-Two skills under [`.claude/skills/`](.claude/skills/) help you draft governance-conformant capabilities and value-stream mappings without writing YAML by hand. Both skills enforce the rules in [`business-capability-governance-model.md`](business-capability-governance-model.md) and validate the result with `npm run lint` before suggesting a commit.
+Three skills under [`.claude/skills/`](.claude/skills/) help you draft governance-conformant capabilities, value-stream mappings, and translations without writing YAML by hand. All skills enforce the rules in [`business-capability-governance-model.md`](business-capability-governance-model.md) and validate the result with `npm run lint` before suggesting a commit.
 
 > **Names, not IDs.** You always refer to capabilities by their **name** (e.g. *"Manufacturing Operations Management"*, *"Human Capital Management"*). The skills resolve names to `BC-…` identifiers internally and only show the ID back as a confirmation. You never need to look up or type an ID.
 
@@ -163,6 +168,33 @@ The skill will:
 7. Wait for **a single approval of the whole batch** — accept "approve", "approve except <X>", or "redo with <change>".
 8. Edit `_value-streams.yaml` preserving formatting and `stage_order`; run `npm run lint`.
 
+### Scenario 5 — Translate the catalogue into another language
+
+Generate or refresh sidecar translation files under `catalogue/i18n/<locale>/`. The English source files (`catalogue/L1-*.yaml`) are never modified — translations are purely additive. Locale-neutral fields (`id`, `level`, `industry`, `references`, `deprecated`, `successor_id`, `metadata`) are never duplicated in sidecars; they are inherited from the source at build time.
+
+**Whole-Language mode** — translates every L1 in the catalogue in one go:
+
+```
+/translate-language French
+/translate-language "Brazilian Portuguese"
+/translate-language German
+```
+
+**Single-L1 mode** — translates or refreshes exactly one L1:
+
+```
+/translate-language "Human Capital Management" --language French
+```
+
+The skill will:
+
+1. Resolve the language name to a BCP-47 tag (French → `fr`, Brazilian Portuguese → `pt-BR`, Simplified Chinese → `zh-Hans`, …) and display it once for confirmation.
+2. Scan `catalogue/i18n/` for existing sidecars — defaulting to **skip-existing** strategy so prior manual edits are preserved; supports `--fill-gaps` and `--overwrite` modes.
+3. Translate only the whitelisted fields: `name`, `description`, `aliases`, `in_scope`, `out_of_scope`. All other fields stay in the English source.
+4. Maintain a consistent cross-L1 glossary so the same source term always maps to the same target-language equivalent throughout the catalogue.
+5. Write sidecar YAML to `catalogue/i18n/<locale>/L1-<slug>.yaml`, mirroring the English source filename exactly so per-L1 CODEOWNERS apply transitively.
+6. Run `npm run lint` to validate all sidecars against [`schema/i18n.schema.json`](schema/i18n.schema.json).
+
 ### After the skill runs
 
 The skills do not commit or push for you. After lint passes:
@@ -191,8 +223,10 @@ After `npm run build`, the following endpoints are available under `dist/api/` (
 | `GET /api/tree.json` | Nested tree (one entry per L1) |
 | `GET /api/by-l1/<slug>.json` | Single L1 nested subtree |
 | `GET /api/capability/<id>.json` | One node + its direct children |
+| `GET /api/locales.json` | List of available translation locales |
+| `GET /api/i18n/<locale>.json` | All translated strings for a locale |
 
-All responses are static, immutable per build, and cacheable by Cloudflare's edge.
+All responses are static, immutable per build, and cacheable by Cloudflare's edge. The English endpoints (`capabilities.json`, `tree.json`, etc.) are unaffected by translations — locale data is additive and ships separately under `/api/i18n/`.
 
 ## Licence
 

--- a/site/src/components/CatalogueBrowser.tsx
+++ b/site/src/components/CatalogueBrowser.tsx
@@ -468,6 +468,20 @@ export default function CatalogueBrowser({ data, valueStreams }: Props) {
   const selectionCount = selected.size;
   const detail = detailId ? byId.get(detailId) ?? null : null;
 
+  // Group root L1s by their primary industry for grid section headers.
+  const groupedRoots = new Map<string, FlatCap[]>();
+  for (const root of roots) {
+    const primaryIndustry = splitIndustry(root.industry)[0] ?? "Other";
+    const bucket = groupedRoots.get(primaryIndustry) ?? [];
+    bucket.push(root);
+    groupedRoots.set(primaryIndustry, bucket);
+  }
+  const groupIndustryKeys = Array.from(groupedRoots.keys());
+  const orderedGroupIndustries = [
+    ...groupIndustryKeys.filter((n) => n === "Cross-Industry"),
+    ...groupIndustryKeys.filter((n) => n !== "Cross-Industry").sort(),
+  ];
+
   /**
    * Stream-filter dropdown groups, narrowed to the active industry filter.
    * Cross-Industry streams always appear (they apply everywhere). When the
@@ -491,100 +505,102 @@ export default function CatalogueBrowser({ data, valueStreams }: Props) {
 
   return (
     <div class="catalogue-page">
-      <FilterBar
-        query={query}
-        onQuery={setQuery}
-        allLevels={allLevels}
-        levels={levels}
-        onLevels={setLevels}
-        allIndustries={allIndustries}
-        industries={industries}
-        onIndustries={setIndustries}
-        valueStreamNames={valueStreamNames}
-        valueStreamGroups={valueStreamGroups}
-        streams={streams}
-        onStreams={setStreams}
-        onReset={resetFilters}
-      />
+      <div class="sticky-controls">
+        <FilterBar
+          query={query}
+          onQuery={setQuery}
+          allLevels={allLevels}
+          levels={levels}
+          onLevels={setLevels}
+          allIndustries={allIndustries}
+          industries={industries}
+          onIndustries={setIndustries}
+          valueStreamNames={valueStreamNames}
+          valueStreamGroups={valueStreamGroups}
+          streams={streams}
+          onStreams={setStreams}
+          onReset={resetFilters}
+        />
 
-      <div class="action-bar">
-        <div class="action-bar-info">
-          <strong>{visible.length}</strong> match
-          {visible.length !== data.length && (
-            <>
-              {" · "}
-              <strong>{data.length}</strong> total
-            </>
-          )}
-          {selectionCount > 0 && (
-            <>
-              {" · "}
-              <strong>{selectionCount}</strong> selected
-            </>
-          )}
-        </div>
-        <div class="action-bar-buttons">
-          <div class="level-stepper" role="group" aria-label="Expand by level">
-            <button
-              type="button"
-              class="level-stepper-btn"
-              onClick={collapseOneLevel}
-              disabled={currentLevel <= 0}
-              aria-label="Collapse one level"
-              title="Collapse one level"
-            >
-              <span class="material-symbols-outlined" aria-hidden="true">remove</span>
+        <div class="action-bar">
+          <div class="action-bar-info">
+            <strong>{visible.length}</strong> match
+            {visible.length !== data.length && (
+              <>
+                {" · "}
+                <strong>{data.length}</strong> total
+              </>
+            )}
+            {selectionCount > 0 && (
+              <>
+                {" · "}
+                <strong>{selectionCount}</strong> selected
+              </>
+            )}
+          </div>
+          <div class="action-bar-buttons">
+            <div class="level-stepper" role="group" aria-label="Expand by level">
+              <button
+                type="button"
+                class="level-stepper-btn"
+                onClick={collapseOneLevel}
+                disabled={currentLevel <= 0}
+                aria-label="Collapse one level"
+                title="Collapse one level"
+              >
+                <span class="material-symbols-outlined" aria-hidden="true">remove</span>
+              </button>
+              <span class="level-stepper-label" aria-live="polite">
+                <span class="level-stepper-label-full">Level </span>
+                {currentLevel}
+                <span class="level-stepper-label-sep"> / </span>
+                {stepperMax}
+              </span>
+              <button
+                type="button"
+                class="level-stepper-btn"
+                onClick={expandOneLevel}
+                disabled={currentLevel >= stepperMax}
+                aria-label="Expand one level"
+                title="Expand one level"
+              >
+                <span class="material-symbols-outlined" aria-hidden="true">add</span>
+              </button>
+            </div>
+            <button class="btn btn-ghost" type="button" onClick={expandAll}>
+              Expand all
             </button>
-            <span class="level-stepper-label" aria-live="polite">
-              <span class="level-stepper-label-full">Level </span>
-              {currentLevel}
-              <span class="level-stepper-label-sep"> / </span>
-              {stepperMax}
-            </span>
+            <button class="btn btn-ghost" type="button" onClick={collapseAll}>
+              Collapse all
+            </button>
+            <button class="btn btn-ghost" type="button" onClick={selectAllVisible}>
+              Select visible
+            </button>
             <button
+              class="btn btn-ghost"
               type="button"
-              class="level-stepper-btn"
-              onClick={expandOneLevel}
-              disabled={currentLevel >= stepperMax}
-              aria-label="Expand one level"
-              title="Expand one level"
+              onClick={clearSelection}
+              disabled={selectionCount === 0}
             >
-              <span class="material-symbols-outlined" aria-hidden="true">add</span>
+              Clear selection
+            </button>
+            <button
+              class="btn"
+              type="button"
+              onClick={() => exportSelection("csv")}
+              disabled={selectionCount === 0}
+            >
+              Export CSV{selectionCount > 0 && ` (${selectionCount})`}
+            </button>
+            <button
+              class="btn btn-magenta"
+              type="button"
+              onClick={() => exportSelection("json")}
+              disabled={selectionCount === 0}
+            >
+              Export JSON{selectionCount > 0 && ` (${selectionCount})`}
             </button>
           </div>
-          <button class="btn btn-ghost" type="button" onClick={expandAll}>
-            Expand all
-          </button>
-          <button class="btn btn-ghost" type="button" onClick={collapseAll}>
-            Collapse all
-          </button>
-          <button class="btn btn-ghost" type="button" onClick={selectAllVisible}>
-            Select visible
-          </button>
-          <button
-            class="btn btn-ghost"
-            type="button"
-            onClick={clearSelection}
-            disabled={selectionCount === 0}
-          >
-            Clear selection
-          </button>
-          <button
-            class="btn"
-            type="button"
-            onClick={() => exportSelection("csv")}
-            disabled={selectionCount === 0}
-          >
-            Export CSV{selectionCount > 0 && ` (${selectionCount})`}
-          </button>
-          <button
-            class="btn btn-magenta"
-            type="button"
-            onClick={() => exportSelection("json")}
-            disabled={selectionCount === 0}
-          >
-            Export JSON{selectionCount > 0 && ` (${selectionCount})`}
-          </button>
         </div>
       </div>
 
@@ -594,26 +610,33 @@ export default function CatalogueBrowser({ data, valueStreams }: Props) {
           <p>Adjust your filters or search query.</p>
         </div>
       ) : (
-        <div class="l1-grid">
-          {roots.map((r) => (
-            <L1Card
-              key={r.id}
-              node={r}
-              byParent={byParent}
-              visible={visibleSet}
-              expanded={expanded}
-              selected={selected}
-              descendantsOf={descendantsOf}
-              branchLevel={l1CurrentLevels.get(r.id) ?? 0}
-              branchMax={stepperMax}
-              onToggleExpand={toggleExpand}
-              onToggleSelect={toggleSelect}
-              onOpenDetail={setDetailId}
-              onExpandBranch={expandL1Branch}
-              onCollapseBranch={collapseL1Branch}
-            />
+        <>
+          {orderedGroupIndustries.map((industry) => (
+            <section class="industry-group" key={industry}>
+              <h2 class="industry-group-title">{industry}</h2>
+              <div class="l1-grid">
+                {(groupedRoots.get(industry) ?? []).map((r) => (
+                  <L1Card
+                    key={r.id}
+                    node={r}
+                    byParent={byParent}
+                    visible={visibleSet}
+                    expanded={expanded}
+                    selected={selected}
+                    descendantsOf={descendantsOf}
+                    branchLevel={l1CurrentLevels.get(r.id) ?? 0}
+                    branchMax={stepperMax}
+                    onToggleExpand={toggleExpand}
+                    onToggleSelect={toggleSelect}
+                    onOpenDetail={setDetailId}
+                    onExpandBranch={expandL1Branch}
+                    onCollapseBranch={collapseL1Branch}
+                  />
+                ))}
+              </div>
+            </section>
           ))}
-        </div>
+        </>
       )}
 
       {detail && (

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -35,7 +35,7 @@ const generatedDate = version.generated_at.slice(0, 10);
     />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,500,0,0&icon_names=add,chevron_right,close,expand_more,remove"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,500,0,0&icon_names=add,arrow_upward,chevron_right,close,expand_more,remove"
     />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta property="og:title" content={pageTitle} />
@@ -152,5 +152,28 @@ const generatedDate = version.generated_at.slice(0, 10);
         })();
       </script>
     )}
+
+    <button
+      id="back-to-top"
+      class="back-to-top"
+      aria-label="Back to top"
+      title="Back to top"
+    >
+      <span class="material-symbols-outlined" aria-hidden="true">arrow_upward</span>
+    </button>
+
+    <script is:inline>
+      (function () {
+        var btn = document.getElementById("back-to-top");
+        if (!btn) return;
+        window.addEventListener("scroll", function () {
+          if (window.scrollY > 300) btn.classList.add("is-visible");
+          else btn.classList.remove("is-visible");
+        }, { passive: true });
+        btn.addEventListener("click", function () {
+          window.scrollTo({ top: 0, behavior: "smooth" });
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/site/src/styles/catalogue.css
+++ b/site/src/styles/catalogue.css
@@ -286,6 +286,23 @@
   pointer-events: none;
 }
 
+/* Sticky wrapper: filter bar + action bar stay pinned below the nav */
+.sticky-controls {
+  position: sticky;
+  top: var(--nav-h, 57px);
+  z-index: 90;
+  background: var(--color-light);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  /* Bleed the background edge-to-edge so scrolling cards don't show through */
+  margin-left: calc(-1 * var(--space-md));
+  margin-right: calc(-1 * var(--space-md));
+  padding-left: var(--space-md);
+  padding-right: var(--space-md);
+  padding-bottom: 12px;
+}
+
 /* Action bar (counts + bulk + export) */
 .action-bar {
   display: flex;
@@ -393,6 +410,24 @@
   max-width: none;
   padding-left: var(--space-md);
   padding-right: var(--space-md);
+}
+
+/* Industry group (wraps a heading + its L1 grid) */
+.industry-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.industry-group-title {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: var(--color-muted);
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--color-border);
+  margin: 0;
 }
 
 /* L1 grid: 4 columns at desktop, scaling down responsively. */
@@ -1218,4 +1253,57 @@
   flex-wrap: wrap;
   gap: var(--space-xs);
   margin-top: var(--space-md);
+}
+
+/* Floating back-to-top button */
+.back-to-top {
+  position: fixed;
+  bottom: 32px;
+  right: 32px;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  color: var(--color-white);
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 95;
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 0.2s ease, transform 0.2s ease, background 0.15s ease, box-shadow 0.15s ease;
+  pointer-events: none;
+  box-shadow: 0 4px 12px rgba(29, 78, 216, 0.3);
+}
+
+.back-to-top.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.back-to-top.is-visible:hover {
+  background: var(--color-secondary);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(29, 78, 216, 0.4);
+}
+
+.back-to-top:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 3px;
+}
+
+.back-to-top .material-symbols-outlined {
+  font-size: 22px;
+}
+
+@media (max-width: 640px) {
+  .back-to-top {
+    bottom: 20px;
+    right: 16px;
+    width: 40px;
+    height: 40px;
+  }
 }

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -52,6 +52,9 @@
   --space-xl: 48px;
   --space-2xl: 64px;
 
+  /* Nav height (used by sticky bars to position below the nav) */
+  --nav-h: 57px;
+
   /* Border radius (aligned with marketing site) */
   --radius-sm: 8px;
   --radius-md: 12px;


### PR DESCRIPTION
## Summary
This PR reorganizes the catalogue browser UI to group Level 1 (L1) capabilities by their primary industry classification, adds sticky filter/action controls, and includes a floating back-to-top button for improved navigation on long pages.

## Key Changes

- **Industry grouping**: Root L1 capabilities are now grouped by their primary industry (extracted from the `industry` field). Each group displays under a styled section header with "Cross-Industry" appearing first, followed by other industries in alphabetical order.

- **Sticky controls**: The FilterBar and action bar (counts, expand/collapse, selection, export buttons) are now wrapped in a `.sticky-controls` container that remains pinned below the navigation during scrolling, improving accessibility to filters and bulk actions.

- **Back-to-top button**: Added a floating circular button in the bottom-right corner that appears after scrolling 300px down the page. Clicking smoothly scrolls to the top. The button is fully accessible with keyboard focus support and responsive sizing for mobile.

- **CSS enhancements**:
  - New `.sticky-controls` wrapper with edge-to-edge background bleed to prevent card content from showing through during scroll
  - New `.industry-group` and `.industry-group-title` styles for section headers (uppercase, muted color, bottom border)
  - New `.back-to-top` button styles with smooth transitions, hover effects, and mobile-responsive sizing
  - Added `--nav-h` CSS variable (57px) for consistent positioning of sticky elements

- **Icon addition**: Added `arrow_upward` to the Material Symbols font import for the back-to-top button.

- **Documentation updates**: Updated README.md to reflect the new translation workflow (Scenario 5) and clarify the three available Claude skills for authoring.

## Implementation Details

- Industry grouping uses `splitIndustry()` to extract the primary industry from each root node, with "Other" as a fallback.
- The sticky controls use `position: sticky` with `top: var(--nav-h)` to position below the navigation bar.
- The back-to-top button uses an inline script with passive scroll listeners for performance and is hidden by default with `opacity: 0` and `pointer-events: none`.
- All changes are backward-compatible; the grid layout and L1Card component remain unchanged.

https://claude.ai/code/session_01R85G8E3Rh3vYWp1qjaDLSr