### PR TITLE
Make sticky controls scroll on mobile to save vertical space

### DIFF
--- a/site/src/styles/catalogue.css
+++ b/site/src/styles/catalogue.css
@@ -303,6 +303,15 @@
   padding-bottom: 12px;
 }
 
+/* On mobile, sticky bars eat too much vertical space — let them scroll away. */
+@media (max-width: 768px) {
+  .sticky-controls {
+    position: static;
+    top: auto;
+    z-index: auto;
+  }
+}
+
 /* Action bar (counts + bulk + export) */
 .action-bar {
   display: flex;


### PR DESCRIPTION
## Summary
Added a mobile-specific media query to convert sticky controls from fixed positioning to static positioning on smaller screens, allowing them to scroll away and reclaim vertical space.

## Changes
- Added `@media (max-width: 768px)` breakpoint for `.sticky-controls`
- Changed positioning from `position: sticky` to `position: static` on mobile
- Reset `top` and `z-index` properties to their default values for mobile view

## Details
On mobile devices with limited vertical space, sticky controls that remain fixed at the top of the viewport consume valuable screen real estate. This change allows the controls to scroll naturally with the page content on screens 768px or smaller, improving the mobile browsing experience while maintaining the sticky behavior on larger desktop screens.

https://claude.ai/code/session_01TG4cg3cMzJpEcpfBjSY4Kv