### PR TITLE
Add Cloudflare Pages deployment trigger to publish workflow

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -43,3 +43,17 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/py/dist
+
+  deploy-site:
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Cloudflare Pages build
+        env:
+          DEPLOY_HOOK: ${{ secrets.CLOUDFLARE_PAGES_DEPLOY_HOOK }}
+        run: |
+          if [ -z "$DEPLOY_HOOK" ]; then
+            echo "CLOUDFLARE_PAGES_DEPLOY_HOOK secret is not set" >&2
+            exit 1
+          fi
+          curl --fail --silent --show-error -X POST "$DEPLOY_HOOK"


### PR DESCRIPTION
## Summary
This PR adds an automated deployment step to the package publishing workflow that triggers a Cloudflare Pages build after successfully publishing the Python package.

## Key Changes
- Added a new `deploy-site` job to the publish workflow that runs after the `publish` job completes
- Implemented a deployment step that triggers a Cloudflare Pages build via webhook
- Added validation to ensure the `CLOUDFLARE_PAGES_DEPLOY_HOOK` secret is configured before attempting deployment
- Uses `curl` to POST to the deployment hook with error handling (`--fail --silent --show-error` flags)

## Implementation Details
- The new job depends on the `publish` job completing successfully via the `needs` directive
- The deployment hook URL is stored as a GitHub secret for security
- The script exits with status code 1 if the required secret is not set, preventing silent failures
- Uses standard curl flags to ensure the request fails loudly if there are any issues with the deployment trigger

https://claude.ai/code/session_0184rH2CF7mjWjZwYjgTBdpq