### PR TITLE
Add German translations for L1 business capability catalogue

### DIFF
--- a/catalogue/i18n/de/L1-academic-quality-accreditation-management.yaml
+++ b/catalogue/i18n/de/L1-academic-quality-accreditation-management.yaml
@@ -1,0 +1,150 @@
+locale: de
+source: L1-academic-quality-accreditation-management.yaml
+entries:
+  BC-4750:
+    name: Akademische Qualität und Akkreditierungsmanagement
+    description: |
+      Interne und externe Qualitätssicherung akademischer Programme und der
+      Institution, einschließlich Überprüfung, Akkreditierung, Qualitätsstandards-
+      management, Studierendenfeedback und kontinuierlicher Verbesserung.
+  BC-4750.10:
+    name: Programmüberprüfung und -validierung
+    description: |
+      Validierung neuer Programme und periodische Revalidierung gegenüber
+      institutionellen und externen akademischen Standards.
+    in_scope:
+      - Validierung neuer Programme
+      - Periodische Programmüberprüfung
+      - Programmrevalidierung
+    out_of_scope:
+      - Programmgenehmigungsstufen (abgedeckt unter Lehrplan- und Studienprogrammverwaltung)
+  BC-4750.10.10:
+    name: Validierung neuer Programme
+    description: |
+      Validierung neuer Programme gegenüber akademischen Qualitätsstandards.
+  BC-4750.10.20:
+    name: Periodische Programmüberprüfung
+    description: |
+      Periodische Qualitätsüberprüfung laufender Programme und ihrer Ergebnisse.
+  BC-4750.10.30:
+    name: Programmrevalidierung
+    description: |
+      Revalidierung von Programmen am Ende von Validierungszyklen.
+  BC-4750.20:
+    name: Institutionelle Selbstbewertung
+    description: |
+      Selbstbewertung der institutionellen Leistung gegenüber Qualitätsstandards
+      und Benchmarking mit Peer-Institutionen.
+    in_scope:
+      - Erstellung von Selbstbewertungsberichten
+      - Benchmarking von Qualitätsindikatoren
+      - Strategische Qualitätsplanung
+    out_of_scope:
+      - Externe Akkreditierungsbesuche (abgedeckt unter Externe Akkreditierung & Prüfungskoordination)
+  BC-4750.20.10:
+    name: Erstellung von Selbstbewertungsberichten
+    description: |
+      Erstellung institutioneller Selbstbewertungsberichte.
+  BC-4750.20.20:
+    name: Benchmarking von Qualitätsindikatoren
+    description: |
+      Benchmarking von Qualitätsindikatoren gegenüber Peer-Institutionen.
+  BC-4750.20.30:
+    name: Strategische Qualitätsplanung
+    description: |
+      Strategische Planung akademischer Qualitätsprioritäten und Investitionen.
+  BC-4750.30:
+    name: Externe Akkreditierung und Prüfungskoordination
+    description: |
+      Koordination mit externen Akkreditierungsgremien und Qualitätsregulatoren,
+      einschließlich Vor-Ort-Besuchen, Inspektionen und Ergebnisreaktion.
+    in_scope:
+      - Engagement mit Akkreditierungsgremien
+      - Koordination von Besuchen und Inspektionen vor Ort
+      - Reaktion auf Akkreditierungsergebnisse und Bedingungsnachverfolgung
+    out_of_scope:
+      - Gesetzliches Regulierungsberichtswesen (abgedeckt unter Bildungskonformität & Regulatorisches Berichtswesen)
+  BC-4750.30.10:
+    name: Engagement mit Akkreditierungsgremien
+    description: |
+      Engagement und Einreichungsmanagement mit Akkreditierungsgremien.
+  BC-4750.30.20:
+    name: Koordination von Vor-Ort-Besuchen und Inspektionen
+    description: |
+      Koordination von Akkreditierungsbesuchen und Inspektionslogistik.
+  BC-4750.30.30:
+    name: Reaktion auf Akkreditierungsergebnisse
+    description: |
+      Reaktion auf Akkreditierungsergebnisse, Bedingungen und Empfehlungen.
+  BC-4750.40:
+    name: Qualitätsstandard-Rahmenmanagement
+    description: |
+      Einführung, Kartierung und Pflege akademischer Qualitätsstandards und
+      institutioneller Qualitätspolitik.
+    in_scope:
+      - Einführung und Pflege von Standards (z. B. ESG, ABET, AACSB)
+      - Erstellung von Qualitätsrichtlinien
+      - Zuordnung von Qualitätsstandards in die Betriebspraxis
+    out_of_scope:
+      - Täglicher Prüfungsbetrieb (abgedeckt unter branchenübergreifendem internem Prüfungsmanagement)
+  BC-4750.40.10:
+    name: Einführung und Pflege von Standards
+    description: |
+      Einführung und Pflege externer Qualitätsstandards in der gesamten Institution.
+  BC-4750.40.20:
+    name: Erstellung von Qualitätsrichtlinien
+    description: |
+      Erstellung und Pflege institutioneller Qualitätsrichtlinien.
+  BC-4750.40.30:
+    name: Qualitätsstandard-Kartierung
+    description: |
+      Zuordnung von Qualitätsstandards in operative Prozesse und Kontrollen.
+  BC-4750.50:
+    name: Studierendenfeedback und Modulevaluierung
+    description: |
+      Erfassung, Analyse und Rückkoppelung von Studierendenfeedback auf Modul-,
+      Programm- und institutioneller Ebene.
+    in_scope:
+      - Modulevaluierungs-Umfragebetrieb
+      - Nationale und institutionsübergreifende Umfragen (z. B. NSS, NSSE)
+      - Feedbackanalyse und Rückkoppelung
+    out_of_scope:
+      - Kundenzufriedenheitsanalysen außerhalb des akademischen Kontexts (abgedeckt unter branchenübergreifendem Kundenservicemanagement)
+  BC-4750.50.10:
+    name: Modulevaluierungs-Umfragebetrieb
+    description: |
+      Betrieb von Evaluierungsumfragen auf Modulebene.
+  BC-4750.50.20:
+    name: Nationale und institutionsübergreifende Umfrageteilnahme
+    description: |
+      Teilnahme an nationalen und institutionsübergreifenden Studierendenumfragen.
+  BC-4750.50.30:
+    name: Feedbackanalyse und Rückkoppelung
+    description: |
+      Analyse von Feedback und sichtbare Rückkoppelung an Studierende.
+  BC-4750.60:
+    name: Kontinuierliche Verbesserung und Maßnahmennachverfolgung
+    description: |
+      Identifizierung, Planung und Nachverfolgung von Qualitätsverbesserungs-
+      maßnahmen aus Überprüfungen, Akkreditierungen und Feedback.
+    in_scope:
+      - Planung von Verbesserungsmaßnahmen
+      - Nachverfolgung der Maßnahmenumsetzung
+      - Lessons-Learned-Repository
+    out_of_scope:
+      - Allgemeine Prozessverbesserungsmethoden (abgedeckt unter branchenübergreifendem Qualitätsmanagement)
+  BC-4750.60.10:
+    name: Planung von Verbesserungsmaßnahmen
+    description: |
+      Planung akademischer Qualitätsverbesserungsmaßnahmen.
+  BC-4750.60.20:
+    name: Nachverfolgung der Maßnahmenumsetzung
+    description: |
+      Nachverfolgung des Umsetzungsstatus und der Wirksamkeit von Qualitätsmaßnahmen.
+  BC-4750.60.30:
+    name: Lessons-Learned-Repository
+    description: |
+      Pflege von Lessons Learned aus Qualitätsüberprüfungen und Akkreditierungszyklen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-actuarial-management.yaml
+++ b/catalogue/i18n/de/L1-actuarial-management.yaml
@@ -1,0 +1,128 @@
+locale: de
+source: L1-actuarial-management.yaml
+entries:
+  BC-2180:
+    name: Versicherungsmathematik Management
+    description: |
+      Preisfindungsmodelle, Rückstellungsberechnung, Erfahrungsstudien, Kapital- und
+      Solvabilitätsmodellierung, versicherungsmathematische IFRS-17-Berichtsunterstützung
+      und Katastrophenmodellierung.
+  BC-2180.10:
+    name: Versicherungsmathematik Preisfindung
+    description: |
+      Schadenkostenmodellierung, Tarifadäquanzanalyse, Tarifindikation und Unterstützung der Tariffiling-Dokumentation.
+  BC-2180.10.10:
+    name: Schadenkostenmodellierung
+    description: |
+      Modellierung von Schadenkosten nach Segment, Schadensart und Deckung.
+  BC-2180.10.20:
+    name: Tarifadäquanz-Analyse
+    description: |
+      Analyse der Tarifadäquanz gegenüber erwarteten Schäden und Kostenaufschlägen.
+  BC-2180.10.30:
+    name: Tarifindikations-Erstellung
+    description: |
+      Erstellung von Tarifindikatoren für Produkt- und Preisfindungskomitees.
+  BC-2180.10.40:
+    name: Tariffiling-Dokumentations-Unterstützung
+    description: |
+      Erstellung versicherungsmathematischer Memoranden und Belege zur Unterstützung von Tariff-Filings.
+  BC-2180.20:
+    name: Versicherungsmathematik Rückstellungen
+    description: |
+      Schadendreiecks-Entwicklung, IBNR-Schätzung, ULAE- und ALAE-Rückstellungen sowie Rückstellungs-Abzeichnungsdokumentation.
+  BC-2180.20.10:
+    name: Schadendreieck und -Entwicklung
+    description: |
+      Erstellung von Schadendreiecken und Auswahl von Entwicklungsfaktoren.
+  BC-2180.20.20:
+    name: IBNR-Schätzung
+    description: |
+      Schätzung eingetretener, aber noch nicht gemeldeter Rückstellungen über Portfolios.
+  BC-2180.20.30:
+    name: ULAE- und ALAE-Rückstellungen
+    description: |
+      Rückstellungen für nicht zugewiesene und zugewiesene Schadenregulierungskosten.
+  BC-2180.20.40:
+    name: Rückstellungs-Abzeichnungs-Dokumentation
+    description: |
+      Erstellung von Rückstellungskomitee-Dokumentation und versicherungsmathematischen Gutachten.
+  BC-2180.30:
+    name: Kapital- und Solvabilitätsmodellierung
+    description: |
+      Entwicklung interner Kapitalmodelle, Standardformelberechnung, Kapitalallokation und ORSA-Unterstützung.
+  BC-2180.30.10:
+    name: Internes Kapitalmodell-Entwicklung
+    description: |
+      Entwicklung und Pflege interner Kapitalmodelle für Solvabilität und Rating.
+  BC-2180.30.20:
+    name: Standardformel-Berechnung
+    description: |
+      Berechnung der Solvency-II-Standardformel und äquivalenter regulatorischer Kapitalmetriken.
+  BC-2180.30.30:
+    name: Kapitalallokation
+    description: |
+      Allokation des erforderlichen Kapitals auf Geschäftsfelder und Segmente.
+  BC-2180.30.40:
+    name: ORSA-Modellierungs-Unterstützung
+    description: |
+      Modellierungsunterstützung für Eigene Risiko- und Solvabilitätsbewertung (ORSA).
+  BC-2180.40:
+    name: Erfahrungsstudien & Annahmen-Management
+    description: |
+      Sterblichkeits-, Langlebigkeits-, Stornierungs-, Persistenz- und Morbiditätsstudien sowie Annahmen-Governance.
+  BC-2180.40.10:
+    name: Sterblichkeits- und Langlebigkeitsstudien
+    description: |
+      Sterblichkeits- und Langlebigkeitserfahrungsstudien für Lebens- und Rentenportfolios.
+  BC-2180.40.20:
+    name: Storno- und Persistenzstudien
+    description: |
+      Storno- und Persistenzerfahrungsstudien über Produktkohorten.
+  BC-2180.40.30:
+    name: Morbiditäts- und Schadenfrequenzstudien
+    description: |
+      Morbiditäts- und Schadenfrequenz-Erfahrungsstudien für Kranken- und Schutzsparten.
+  BC-2180.40.40:
+    name: Annahmen-Governance und -Abzeichnung
+    description: |
+      Governance und Abzeichnung versicherungsmathematischer Annahmen für Preisfindung, Rückstellungen und Berichterstattung.
+  BC-2180.50:
+    name: IFRS-17-Berichts-Unterstützung
+    description: |
+      Vertragsdienstmarge, Risikoausgleich, Kohortenkonstruktion und IFRS-17-Offenlegungserstellung.
+  BC-2180.50.10:
+    name: CSM- und Risikoausgleich-Berechnung
+    description: |
+      Berechnung der Vertragsdienstmarge (CSM) und des Risikoausgleichs gemäß IFRS 17.
+  BC-2180.50.20:
+    name: Kohortengruppen-Konstruktion
+    description: |
+      Konstruktion von Versicherungsvertragsgruppen und Jahreskohorten.
+  BC-2180.50.30:
+    name: IFRS-17-Offenlegungs-Erstellung
+    description: |
+      Erstellung versicherungsmathematischer Eingaben für IFRS-17-Offenlegungen und Überleitungen.
+  BC-2180.60:
+    name: Katastrophenmodellierung
+    description: |
+      CAT-Modell-Anbietermanagement, Exponierungsdaten-Aufbereitung, PML- und AAL-Berechnung sowie Modellvalidierung.
+  BC-2180.60.10:
+    name: CAT-Modell-Anbieter-Management
+    description: |
+      Auswahl und Management von CAT-Modellanbietern und Lizenzportfolios.
+  BC-2180.60.20:
+    name: Exponierungsdaten-Aufbereitung
+    description: |
+      Aufbereitung und Konditionierung von Exponierungsdaten für CAT-Modellläufe.
+  BC-2180.60.30:
+    name: PML- und AAL-Berechnung
+    description: |
+      Berechnung des wahrscheinlichen Maximalschadens (PML) und des durchschnittlichen Jahresschadens (AAL).
+  BC-2180.60.40:
+    name: CAT-Modell-Validierung und -Anpassung
+    description: |
+      Validierung und risikospezifische Anpassung von CAT-Modell-Outputs.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-advertising-sales-operations-management.yaml
+++ b/catalogue/i18n/de/L1-advertising-sales-operations-management.yaml
@@ -1,0 +1,136 @@
+locale: de
+source: L1-advertising-sales-operations-management.yaml
+entries:
+  BC-3760:
+    name: Werbevermarktung und Anzeigenoperationen
+    description: |
+      Inventar, direkte und programmatische Vermarktung,
+      Anzeigen-Trafficking und Entscheidungsfindung, Markensicherheits-
+      und Inventarqualitätskontrollen sowie Erlösberichterstattung
+      für das Werbegeschäft über lineare, digitale und
+      Connected-TV-Oberflächen.
+  BC-3760.10:
+    name: Anzeigen-Inventar-Management
+    description: |
+      Prognose, Zuteilung und Reservierung von Werbeinventar
+      über lineare und digitale Oberflächen hinweg.
+  BC-3760.10.10:
+    name: Avail-Prognose
+    description: |
+      Prognose verfügbarer Impressionen, GRPs und
+      zielgruppenspezifischer Avails über den Inventarhorizont.
+  BC-3760.10.20:
+    name: Inventar-Zuteilung
+    description: |
+      Zuteilung von Inventar zu direkten, programmatischen und
+      Haus-Pools über Oberflächen hinweg.
+  BC-3760.10.30:
+    name: Inventar-Reservierung und Holdback
+    description: |
+      Reservierung und Holdback von Inventar für committete Deals,
+      Sponsoring und Tentpole-Events.
+  BC-3760.20:
+    name: Direkt-Anzeigenverkaufs-Management
+    description: |
+      Direktverkauf von Werbeinventar über Sponsoring-, Upfront-
+      und Insertion-Order-Kanäle.
+  BC-3760.20.10:
+    name: Sponsoring-Verkauf
+    description: |
+      Sponsoring- und Integrations-Deal-Pipeline und Vertrags-
+      abschluss.
+  BC-3760.20.20:
+    name: Upfront- und Scatter-Verkauf
+    description: |
+      Upfront- und Scatter-Marktverkauf von linearem und
+      digitalem Inventar.
+  BC-3760.20.30:
+    name: Insertion-Order- und Linearer Spot-Verkauf
+    description: |
+      Insertion-Order-Erfassung und lineare Spot-Buchung gegen
+      den Avail-Plan.
+  BC-3760.30:
+    name: Programmatisches Verkaufs-Management
+    description: |
+      Konfiguration und Betrieb programmatischer Auktionen,
+      Private Marketplaces und Supply-Path-Integrationen.
+  BC-3760.30.10:
+    name: Auktions-Konfiguration
+    description: |
+      Konfiguration von Auktionsböden, Deal-IDs und Bieter-
+      Berechtigung über das Inventar hinweg.
+  BC-3760.30.20:
+    name: Private-Marketplace-Deal-Management
+    description: |
+      Erstellung und Lebenszyklus von programmatisch garantierten
+      und Private-Marketplace-Deals mit Käufern.
+  BC-3760.30.30:
+    name: Header-Bidding- und SSP-Integration
+    description: |
+      Integration von Header-Bidding-Partnern und Supply-Side-
+      Plattformen über Oberflächen hinweg.
+  BC-3760.40:
+    name: Anzeigen-Trafficking und Anzeigenoperationen
+    description: |
+      Onboarding von Creatives, Anzeigenentscheidungsfindung und
+      -Insertion sowie Spot-Scheduling über lineare und digitale
+      Werbeblockstrukturen hinweg.
+  BC-3760.40.10:
+    name: Creative-Onboarding und QC
+    description: |
+      Onboarding und QC von Werbecreatives gegen technische
+      und Richtlinienspezifikationen.
+  BC-3760.40.20:
+    name: Anzeigen-Entscheidungsfindung und Insertion
+    description: |
+      Entscheidung, welche Anzeige auszuliefern ist, und Insertion
+      in lineare Werbeblöcke, serverseitig oder clientseitig.
+  BC-3760.40.30:
+    name: Spot-Scheduling
+    description: |
+      Sendeplan-Aufbau für lineares Spot-Positioning und
+      Werbeblock-Muster-Optimierung.
+  BC-3760.50:
+    name: Markensicherheit- und Inventarqualitäts-Management
+    description: |
+      Klassifizierung von Inventar für Markensicherheit, Erkennung
+      von invalidem Traffic und Eignung-Tagging für Käufer-Targeting.
+  BC-3760.50.10:
+    name: Markensicherheits-Klassifizierung
+    description: |
+      Klassifizierung von Inhalts-Oberflächen gegen Markensicherheits-
+      und Eignungs-Frameworks.
+  BC-3760.50.20:
+    name: Invalider-Traffic-Erkennung
+    description: |
+      Erkennung und Ausschluss von invalidem Traffic über eigenes
+      und Partner-Inventar.
+  BC-3760.50.30:
+    name: Eignungs-Tagging
+    description: |
+      Tagging von Inhalts-Oberflächen mit Eignungs- und
+      kontextuellen Attributen für Käufer-Targeting.
+  BC-3760.60:
+    name: Werbeerlös-Berichterstattung
+    description: |
+      Kampagnen-Auslieferungsberichterstattung, Make-Good-
+      Abstimmung sowie Werbetreibenden-Abrechnung und -Abwicklung
+      über lineare und digitale Verkäufe hinweg.
+  BC-3760.60.10:
+    name: Kampagnen-Auslieferungs-Berichterstattung
+    description: |
+      Auslieferungs- und Pace-Berichterstattung gegen Kampagnenziele
+      über Oberflächen und Währungen hinweg.
+  BC-3760.60.20:
+    name: Make-Good und Abstimmung
+    description: |
+      Abstimmung gelieferter Impressionen mit bestellten, mit
+      Make-Good- und Gutschriftshandhabung.
+  BC-3760.60.30:
+    name: Werbetreibenden-Abrechnung und Abwicklung
+    description: |
+      Abrechnung von Werbetreibenden und Agenturen sowie
+      Abwicklung gegen Agenturrabatte und Provisionen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-aeronautical-information-management.yaml
+++ b/catalogue/i18n/de/L1-aeronautical-information-management.yaml
@@ -1,0 +1,98 @@
+locale: de
+source: L1-aeronautical-information-management.yaml
+entries:
+  BC-1230:
+    name: Luftfahrtinformationsmanagement
+    description: |
+      AIP, NOTAMs, Luftfahrtdatenbanken, Kartenerstellung und digitales AIM.
+  BC-1230.10:
+    name: Luftfahrtinformationsveröffentlichungs-Management
+    description: |
+      AIP, AIRAC-Zyklus, Änderungen und Ergänzungen.
+  BC-1230.10.10:
+    name: AIP-Erstellung
+    description: |
+      Erstellung der Luftfahrtinformationsveröffentlichung.
+  BC-1230.10.20:
+    name: AIRAC-Zyklusmanagement
+    description: |
+      Management des AIRAC-Zyklus und Wirksamkeitsdaten.
+  BC-1230.10.30:
+    name: AIP-Änderungs- und Ergänzungs-Ausgabe
+    description: |
+      Ausgabe von AIP-Änderungen und Ergänzungen.
+  BC-1230.20:
+    name: NOTAM-Management
+    description: |
+      NOTAM-Erstellung, Veröffentlichung, Verbreitung und Ablauf.
+  BC-1230.20.10:
+    name: NOTAM-Erstellung
+    description: |
+      Erstellung und Ausarbeitung von NOTAMs.
+  BC-1230.20.20:
+    name: NOTAM-Veröffentlichung und -Verbreitung
+    description: |
+      Veröffentlichung und Verbreitung über AFTN/AMHS.
+  BC-1230.20.30:
+    name: NOTAM-Lebenszyklus-Management
+    description: |
+      Lebenszyklusmanagement einschließlich Ersatz und Aufhebung.
+  BC-1230.30:
+    name: Luftfahrtdatenbank-Management
+    description: |
+      Luftfahrtdatenintegrität, Rückverfolgbarkeit, AIRAC-Konformität und Datenqualität.
+  BC-1230.30.10:
+    name: Luftfahrtdaten-Erfassung
+    description: |
+      Erfassung von Luftfahrtdaten gemäß ICAO Anhang 15.
+  BC-1230.30.20:
+    name: Luftfahrtdaten-Qualitätsmanagement
+    description: |
+      Datenqualitätskontrollen, Genauigkeit, Integrität und Auflösung.
+  BC-1230.30.30:
+    name: Luftfahrtdaten-Verteilung
+    description: |
+      Verteilung von Luftfahrtdaten an Nutzer und Werkzeuge.
+  BC-1230.30.40:
+    name: Datenrückverfolgbarkeit und Audit
+    description: |
+      Rückverfolgbarkeit der Luftfahrtdaten-Herkunft und Auditierung.
+  BC-1230.40:
+    name: Kartenerstungs- und Verfahrensdesign-Management
+    description: |
+      Luftfahrtkarten, Instrumentenflugverfahren und PBN-Verfahrensdesign.
+  BC-1230.40.10:
+    name: Luftfahrtkartenproduktion
+    description: |
+      Erstellung von Strecken-, Terminal- und Flugplatzkarten.
+  BC-1230.40.20:
+    name: Instrumentenflugverfahrens-Design
+    description: |
+      Design von SIDs, STARs und Instrumentenanflugverfahren.
+  BC-1230.40.30:
+    name: Leistungsbasiertes Navigationsverfahrens-Design
+    description: |
+      PBN-Verfahrensdesign einschließlich RNP und RNAV.
+  BC-1230.40.40:
+    name: Verfahrensvalidierung und -zulassung
+    description: |
+      Verfahrensvalidierung, Fluginspektion und behördliche Zulassung.
+  BC-1230.50:
+    name: Digitale AIM-Dienste-Management
+    description: |
+      Digitale Datenprodukte, SWIM-Dienste und maschinenlesbare Luftfahrtinformation.
+  BC-1230.50.10:
+    name: Digitales Datenprodukt-Management
+    description: |
+      Management digitaler AIM-Datenprodukte (AIXM-basiert).
+  BC-1230.50.20:
+    name: SWIM-Dienstebereitstellung
+    description: |
+      Bereitstellung von System Wide Information Management (SWIM)-Diensten.
+  BC-1230.50.30:
+    name: Maschinenlesbare AIM-Verteilung
+    description: |
+      Verteilung maschinenlesbarer Luftfahrtinformation an Abonnenten.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-aeronautical-meteorology-management.yaml
+++ b/catalogue/i18n/de/L1-aeronautical-meteorology-management.yaml
@@ -1,0 +1,74 @@
+locale: de
+source: L1-aeronautical-meteorology-management.yaml
+entries:
+  BC-1250:
+    name: Luftfahrtmeteorologie-Management
+    description: |
+      Meteorologische Beobachtung, Prognose, Briefing und Unwetterdienste.
+  BC-1250.10:
+    name: Meteorologische Beobachtungsmanagement
+    description: |
+      METAR, automatisierte Beobachtungen, Sensornetzwerke und Bodenbeobachtungen.
+  BC-1250.10.10:
+    name: Bodenwitterungsbeobachtung
+    description: |
+      Manuelle und automatisierte Bodenwitterungsbeobachtung an Flugplätzen.
+  BC-1250.10.20:
+    name: METAR- und SPECI-Erstellung
+    description: |
+      Erstellung und Verbreitung von METAR- und SPECI-Berichten.
+  BC-1250.10.30:
+    name: Meteorologisches Sensornetzwerk-Management
+    description: |
+      Betrieb automatisierter Wetterbeobachtungssysteme und Sensoren.
+  BC-1250.20:
+    name: Meteorologisches Prognosemanagement
+    description: |
+      TAFs, Gebietsvorhersagen, SIGMET, AIRMET und GAMET.
+  BC-1250.20.10:
+    name: Flugplatzvorhersage-Erstellung
+    description: |
+      Erstellung von TAFs und Trendvorhersagen für Flugplätze.
+  BC-1250.20.20:
+    name: Gebietsvorhersage-Erstellung
+    description: |
+      Erstellung von Gebiets-, GAMET- und Signifikantewetter-Vorhersagen.
+  BC-1250.20.30:
+    name: SIGMET- und AIRMET-Ausgabe
+    description: |
+      Ausgabe von SIGMET- und AIRMET-Hinweisen.
+  BC-1250.30:
+    name: Meteorologisches Briefing- und Beratungsmanagement
+    description: |
+      Vorflugbriefings, Beratungsdienste für ATS-Einheiten und Flugberatungen.
+  BC-1250.30.10:
+    name: Vorflugbriefing-Dienst
+    description: |
+      Bereitstellung von Selbstbriefing- und unterstützten Briefingdiensten.
+  BC-1250.30.20:
+    name: ATS-Einheit-Meteorologische Beratung
+    description: |
+      Bereitstellung meteorologischer Beratung für ATS-Einheiten und Aufsichten.
+  BC-1250.30.30:
+    name: Flugmeteorologische Beratung
+    description: |
+      Meteorologische Beratungsdienste für Luftraumnutzer während des Flugs.
+  BC-1250.40:
+    name: Gefahrenwetter-Management
+    description: |
+      Vulkanaschewarnungen, Unwetter und Weltraumwetterdienste.
+  BC-1250.40.10:
+    name: Vulkanasche-Beratungsdienst
+    description: |
+      Koordination mit VAACs und Verbreitung von Vulkanasche-Beratungen.
+  BC-1250.40.20:
+    name: Unwetterwarndienst
+    description: |
+      Ausgabe von Unwetterwarnungen (CB, Turbulenz, Vereisung).
+  BC-1250.40.30:
+    name: Weltraumwetter-Beratungsdienst
+    description: |
+      Weltraumwetter-Beratungen gemäß ICAO-Anforderungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-agri-environmental-stewardship-management.yaml
+++ b/catalogue/i18n/de/L1-agri-environmental-stewardship-management.yaml
@@ -1,0 +1,154 @@
+locale: de
+source: L1-agri-environmental-stewardship-management.yaml
+entries:
+  BC-3600:
+    name: Agrarumweltpflege und Umweltverantwortung
+    description: |
+      Betrieblicher Umweltschutz – Bodengesundheit,
+      Wasserpflege, Biodiversität, landwirtschaftliches
+      Treibhausgas-Management, Bodenkohleprogramme, regenerative
+      Praktiken und Teilnahme an Agrarumweltprogrammen als
+      Ergänzung zur unternehmerischen Nachhaltigkeit.
+  BC-3600.10:
+    name: Bodengesundheits-Pflege
+    description: |
+      Pflege von Bodenorganik, Zwischenfruchtanbau und
+      Erosionsschutz auf Ackerflächen.
+  BC-3600.10.10:
+    name: Bodenorganikskohlenstoff-Überwachung
+    description: |
+      Periodische Überwachung des Bodenorganikkohlenstoffs
+      über Schläge hinweg.
+  BC-3600.10.20:
+    name: Zwischenfruchtanbau-Programme
+    description: |
+      Zwischenfruchtanbau-Programme zur Erhaltung der Bodenbedeckung
+      und Bodenbiologie.
+  BC-3600.10.30:
+    name: Bodenerosionsschutz-Programme
+    description: |
+      Erosionsschutzprogramme einschließlich Kontur-, Terrassen-
+      und Pufferstreifen-Praktiken.
+  BC-3600.20:
+    name: Betrieblicher Wasserhaushalt
+    description: |
+      Wassernutzungseffizienz, Gewässerschutz und Drainage-
+      Wasserqualitätsmanagement auf Betriebsebene.
+    in_scope:
+      - Wassernutzungseffizienz-Überwachung
+      - Uferrandstreifen- und Gewässerschutz
+      - Drainagequälitäts-Management
+    out_of_scope:
+      - Unternehmens-Wasseroffenlegung (BC-740)
+      - Bewässerungsplanung (BC-3500.60.10)
+  BC-3600.20.10:
+    name: Wassernutzungseffizienz-Überwachung
+    description: |
+      Überwachung der Wassernutzungseffizienz pro Kultur und Schlag.
+  BC-3600.20.20:
+    name: Uferrandstreifen- und Gewässerschutz
+    description: |
+      Schutz von Uferrandstreifen und betrieblichen Gewässern.
+  BC-3600.20.30:
+    name: Drainagequalitäts-Management
+    description: |
+      Management von Drainage-Wasserqualität und Nährstoffverlusten.
+  BC-3600.30:
+    name: Biodiversitäts- und Biotoppflege
+    description: |
+      Betriebliches Biodiversitätsmanagement einschließlich
+      Biotopaufzeichnungen, Bestäuberpflege und
+      Feldrandpufferstreifen.
+  BC-3600.30.10:
+    name: Betriebliches Biotop-Aufzeichnung
+    description: |
+      Aufzeichnung betrieblicher Biotope und Biodiversitätsmerkmale.
+  BC-3600.30.20:
+    name: Bestäuber-Pflege
+    description: |
+      Bestäuberfreundliche Praktiken einschließlich Blühstreifen
+      und IPM-Schwellenwerte.
+  BC-3600.30.30:
+    name: Pufferstreifen-Management
+    description: |
+      Management von Feldrand- und Gewässer-Pufferstreifen.
+  BC-3600.40:
+    name: Landwirtschaftliches Treibhausgas-Management
+    description: |
+      Quantifizierung und Minderung landwirtschaftlicher Treibhausgase
+      einschließlich Entermethan, Distickstoffoxid und betrieblichem CO2.
+  BC-3600.40.10:
+    name: Entermethan-Minderungsprogramme
+    description: |
+      Minderungsprogramme für Entermethan bei Wiederkäuer-Nutzvieh.
+  BC-3600.40.20:
+    name: Distickstoffoxid-Minderungsprogramme
+    description: |
+      Distickstoffoxid-Minderung durch Stickstoffnutzungseffizienz
+      und Timing.
+  BC-3600.40.30:
+    name: Betriebliches Treibhausgas-Inventar
+    description: |
+      Betriebsebene Treibhausgas-Emissionsinventar zur Offenlegung.
+  BC-3600.50:
+    name: Bodenkohle- und CO2-Kreditprogramme
+    description: |
+      Bodenkohle-Basislinien-Messung, CO2-Kreditprojekt-Design
+      und Ausgabeaufzeichnungen nach anerkannten Methodiken.
+  BC-3600.50.10:
+    name: Bodenkohle-Basislinien-Messung
+    description: |
+      Basislinien-Bodenkohle-Messkampagnen bei Projekteintritt.
+  BC-3600.50.20:
+    name: CO2-Kredit-Projektdesign
+    description: |
+      Projektdesign nach Verra-, Gold-Standard- und gleichwertigen
+      Methodiken.
+  BC-3600.50.30:
+    name: CO2-Kredit-Ausgabeaufzeichnungen
+    description: |
+      Aufzeichnungen der Kreditausgabe, -Stilllegung und
+      Begünstigtenzuteilung.
+  BC-3600.60:
+    name: Regenerative Praxis-Management
+    description: |
+      Einführung und Aufzeichnung regenerativer Praktiken
+      einschließlich Reduzierter Bodenbearbeitung, Integration
+      und Agroforstwirtschaft.
+  BC-3600.60.10:
+    name: Direktsaat- und Reduzierter Bodenbearbeitungs-Programme
+    description: |
+      Einführung und Verfolgung von Direktsaat- und Reduzierter-
+      Bodenbearbeitungs-Programmen.
+  BC-3600.60.20:
+    name: Integrierter Pflanzenbau-Tierhaltungs-Betrieb
+    description: |
+      Integration von Pflanzenbau und Tierhaltung für
+      Nährstoffkreisläufe.
+  BC-3600.60.30:
+    name: Agroforstwirtschafts-Praxis-Aufzeichnungen
+    description: |
+      Aufzeichnungen von Agroforstwirtschaftspflanzungen und
+      Silvopastveral-Systemen.
+  BC-3600.70:
+    name: Agrarumweltprogramm-Teilnahme
+    description: |
+      Teilnahme an GAP-Öko-Regelungen, NRCS-Schutzprogrammen
+      und gleichwertigen Agrarumwelt-Zahlungsprogrammen.
+  BC-3600.70.10:
+    name: GAP-Öko-Regelung-Teilnahme
+    description: |
+      Teilnahme an EU-GAP-Öko-Regelungen und
+      Konditionalitätsanforderungen.
+  BC-3600.70.20:
+    name: Schutzprogramm-Teilnahme
+    description: |
+      Teilnahme an USDA NRCS EQIP, CSP und gleichwertigen Programmen.
+  BC-3600.70.30:
+    name: Agrarumwelt-Zahlungsabstimmung
+    description: |
+      Abstimmung von Agrarumweltzahlungen gegen
+      Programm-Verpflichtungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-agri-food-compliance-certification-management.yaml
+++ b/catalogue/i18n/de/L1-agri-food-compliance-certification-management.yaml
@@ -1,0 +1,165 @@
+locale: de
+source: L1-agri-food-compliance-certification-management.yaml
+entries:
+  BC-3590:
+    name: Agrarlebensmittel-Konformität und Zertifizierung
+    description: |
+      Branchenspezifische Konformitäts- und Zertifizierungsprogramme –
+      Landwirtschafts-Qualitätssicherung, Bio-, Tierschutz-,
+      geografische Angaben, Rückstandskonformität, Viehhaltungskenn-
+      zeichnung und vor-Hoftor-Rückverfolgbarkeitsaufzeichnungen,
+      die sich von generischem Konformitäts- und Qualitätsmanagement
+      unterscheiden.
+  BC-3590.10:
+    name: Landwirtschafts-Qualitätssicherungs-Zertifizierungs-Management
+    description: |
+      Management von Landwirtschafts-Qualitätssicherungs-Zertifizierungs-
+      programmen einschließlich GLOBALG.A.P., LEAF Marque und
+      gleichwertigen nationalen Programmen.
+    in_scope:
+      - GLOBALG.A.P. und gleichwertige Landwirtschafts-Qualitätssicherung
+      - LEAF Marque Teilnahme
+      - Auditkoordination und Korrekturmaßnahmen
+    out_of_scope:
+      - Generisches Qualitätsmanagement (BC-720)
+      - Einzelhandelseitige Lebensmittelsicherheitsprogramme (BC-2380.10)
+  BC-3590.10.10:
+    name: GLOBALG.A.P.-Zertifizierungsprogramme
+    description: |
+      Management von GLOBALG.A.P. IFA-, Aquakultur- und
+      Nutztierhaltungs-Zertifizierungen.
+  BC-3590.10.20:
+    name: LEAF Marque und gleichwertige Programme
+    description: |
+      Teilnahme an LEAF Marque und gleichwertigen nationalen
+      Qualitätssicherungsprogrammen.
+  BC-3590.10.30:
+    name: Landwirtschafts-Qualitätssicherungs-Audit-Koordination
+    description: |
+      Koordination von Landwirtschafts-Qualitätssicherungsaudits
+      und Korrekturmaßnahmenverfolgung.
+  BC-3590.20:
+    name: Bio-Zertifizierungs-Management
+    description: |
+      Management von Bio-Zertifizierungen nach USDA NOP, EU-Bio-
+      Verordnung, JAS Organic und gleichwertigen Regimes.
+  BC-3590.20.10:
+    name: Bio-Standard-Konformitätsaufzeichnungen
+    description: |
+      Aufzeichnungen der Konformität mit dem geltenden Bio-Standard.
+  BC-3590.20.20:
+    name: Bio-Inspektions-Koordination
+    description: |
+      Koordination von Bio-Zertifizierungsinspektionen und -Audits.
+  BC-3590.20.30:
+    name: Bio-Betriebsmittel-Autorisierung
+    description: |
+      Verifizierung, dass Betriebsmittel nach dem geltenden
+      Bio-Standard zugelassen sind.
+  BC-3590.30:
+    name: Tierschutz-Zertifizierungs-Management
+    description: |
+      Tierschutz-Audit-Programme, Tierschutzergebnis-Aufzeichnungen
+      und Konformität mit branchen- und qualitätssicherungs-
+      bezogenen Tierschutzstandards.
+  BC-3590.30.10:
+    name: Tierschutz-Audit-Programme
+    description: |
+      Interne und externe Tierschutz-Audit-Programme.
+  BC-3590.30.20:
+    name: Tierschutzergebnis-Aufzeichnung
+    description: |
+      Aufzeichnung von Tierschutzergebnismessungen über
+      Tierhaltungseinheiten hinweg.
+  BC-3590.30.30:
+    name: Tierschutzstandard-Konformität
+    description: |
+      Konformitätsnachweise gegen branchen- und
+      qualitätssicherungsbezogene Tierschutzstandards.
+  BC-3590.40:
+    name: Geografische Angaben und Herkunfts-Management
+    description: |
+      Aufzeichnungen und Verifizierung für geschützte
+      Ursprungsbezeichnungen, geografische Angaben und
+      Herkunftsansprüche.
+  BC-3590.40.10:
+    name: Herkunftsanspruchs-Aufzeichnungen
+    description: |
+      Aufzeichnungen zur Untermauerung von Ursprungs-, Rassen-
+      und Herkunftsansprüchen.
+  BC-3590.40.20:
+    name: Geografische Angaben-Konformität
+    description: |
+      Konformität mit g.U., g.g.A. und gleichwertigen
+      geografischen Angaben.
+  BC-3590.40.30:
+    name: Ursprungs-Verifizierung
+    description: |
+      Ursprungsverifizierung mit dokumentarischen, isotopenbasierten
+      und DNA-Methoden.
+  BC-3590.50:
+    name: Pestizidrückstände und HHR-Management
+    description: |
+      Rückstandsbeprobung, HHR-Konformität und Wartezeiten-
+      Konformität in Zielmärkten.
+  BC-3590.50.10:
+    name: Rückstandsbeprobungs-Programme
+    description: |
+      Pestizidrückstandsbeprobungsprogramme über Kulturen und Lose.
+  BC-3590.50.20:
+    name: HHR-Konformitätsüberwachung
+    description: |
+      Konformitätsüberwachung gegen HHR-Zeitpläne der Zielmärkte.
+  BC-3590.50.30:
+    name: Wartezeiten-Konformität
+    description: |
+      Konformität mit Vorernteintervallen und Milch-Wartezeiten.
+  BC-3590.60:
+    name: Viehkennzeichnung und Bewegungs-Konformität
+    description: |
+      Tierkennzeichnung, Bewegungsgenehmigungen und grenzüberschreitende
+      Gesundheitszertifizierung für Nutzvieh und Aquakulturbestände.
+    in_scope:
+      - Gesetzliche Tierkennzeichnung
+      - Bewegungsgenehmigungsaufzeichnung
+      - Grenzüberschreitende Gesundheitszertifizierung
+    out_of_scope:
+      - Generelles Konformitätsmanagement (BC-130)
+  BC-3590.60.10:
+    name: Tierkennzeichnung
+    description: |
+      Gesetzliche Tierkennzeichnung einschließlich EID und
+      Ohrmarken.
+  BC-3590.60.20:
+    name: Bewegungsgenehmigung-Aufzeichnung
+    description: |
+      Aufzeichnung gesetzlicher Bewegungsgenehmigungen und
+      betrieblicher Bewegungsregister.
+  BC-3590.60.30:
+    name: Grenzüberschreitende Gesundheitszertifizierung
+    description: |
+      Grenzüberschreitende Gesundheitszertifizierung einschließlich
+      TRACES-NT-Einreichungen.
+  BC-3590.70:
+    name: Vor-Hoftor-Rückverfolgbarkeits-Aufzeichnungen
+    description: |
+      Schlag-zu-Los-, Tier-zu-Schlachtkörper- und Input-zu-Output-
+      Rückverfolgbarkeitsaufzeichnungen als Grundlage für nachgelagerte
+      EPCIS- und Custody-Ketten-Verfolgungen.
+  BC-3590.70.10:
+    name: Schlag-zu-Los-Rückverfolgbarkeit
+    description: |
+      Rückverfolgbarkeit von Feldoperationen zu geernteten Losen.
+  BC-3590.70.20:
+    name: Tier-zu-Schlachtkörper-Rückverfolgbarkeit
+    description: |
+      Rückverfolgbarkeit von Einzeltieren zu Schlachtkörpern und
+      Teilstücken.
+  BC-3590.70.30:
+    name: Input-zu-Output-Rückverfolgungsaufzeichnung
+    description: |
+      Aufzeichnung der Verknüpfung eingesetzter Betriebsmittel
+      mit resultierenden Ausgabeslosen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-agricultural-inputs-management.yaml
+++ b/catalogue/i18n/de/L1-agricultural-inputs-management.yaml
@@ -1,0 +1,149 @@
+locale: de
+source: L1-agricultural-inputs-management.yaml
+entries:
+  BC-3550:
+    name: Landwirtschaftliche Betriebsmittel
+    description: |
+      Lebenszyklusmanagement landwirtschaftlicher Betriebsmittel –
+      Saatgut und Genetik, Düngemittel, Pflanzenschutz,
+      Tierernährung, Tierarzneimittel und Biologika – einschließlich
+      branchenspezifischer Rückverfolgbarkeit, Verantwortungsübernahme
+      und Lageranforderungen, die sich von generischer Beschaffung
+      unterscheiden.
+  BC-3550.10:
+    name: Saatgut- und Pflanzgutmaterial-Management
+    description: |
+      Beschaffung von zertifiziertem Saatgut, Saatgutbeize,
+      Abstammungs- und Merkmale-Verfolgung sowie Saatgutbestands-
+      verwaltung über den Pflanzzyklus.
+    in_scope:
+      - Zertifizierte Saatgutbeschaffung
+      - Saatgutbeizung
+      - Abstammungs- und Merkmalsverfolgung
+      - Saatgutbestand auf Betrieb und Depot
+    out_of_scope:
+      - Pflanzenzüchtungs-F&E (BC-810)
+      - Sortenempfehlung (BC-3530.40)
+  BC-3550.10.10:
+    name: Saatgutbeschaffung und -Zertifizierung
+    description: |
+      Beschaffung von zertifiziertem Saatgut nach OECD-Saatgut-
+      programmen und ISTA-Prüfung.
+  BC-3550.10.20:
+    name: Saatgutbeiz-Ausbringung
+    description: |
+      Ausbringung von Saatgutbeizmitteln und -Präparaten vor der Aussaat.
+  BC-3550.10.30:
+    name: Saatgut-Abstammungs- und Merkmale-Verfolgung
+    description: |
+      Verfolgung von Saatgutabstammung, Merkmale-Stack und
+      Stewardship-Verpflichtungen.
+  BC-3550.10.40:
+    name: Saatgutbestand-Management
+    description: |
+      Saatgutbestandsmanagement über Depots und betriebliche Lager.
+  BC-3550.20:
+    name: Düngemittel-Betriebsmittel-Management
+    description: |
+      Beschaffung, Lagerung, Handling und Applikationsaufzeichnungen
+      für feste und flüssige Düngemittel.
+  BC-3550.20.10:
+    name: Düngemittel-Beschaffung
+    description: |
+      Beschaffung von Einzel- und Mischdüngemitteln von Lieferanten
+      und Importeuren.
+  BC-3550.20.20:
+    name: Düngemittellagerung und -Handling
+    description: |
+      Betriebliche und Depot-Lagerung und -Handling von Düngemitteln
+      einschließlich Auffangwannen.
+  BC-3550.20.30:
+    name: Düngemittelausbringungs-Aufzeichnungen
+    description: |
+      Aufzeichnungen der Düngemittelausbringung nach Schlag,
+      Produkt und Aufwandmenge.
+  BC-3550.30:
+    name: Pflanzenschutz-Betriebsmittel-Management
+    description: |
+      Beschaffung, Lagerung, Applikationsaufzeichnungen und
+      Leergebinde-Verantwortung für Pflanzenschutzmittel.
+  BC-3550.30.10:
+    name: Pflanzenschutzmittel-Beschaffung
+    description: |
+      Beschaffung zugelassener Pflanzenschutzmittel über
+      lizenzierte Kanäle.
+  BC-3550.30.20:
+    name: Pestizid-Lagerung und -Handling
+    description: |
+      Pestizidlagerung, -Trennung und Bediener-Handhabungskontrollen.
+  BC-3550.30.30:
+    name: Pestizidausbringungs-Aufzeichnungen
+    description: |
+      Pestizidausbringungs-Aufzeichnungen nach Regulatoren-
+      und Qualitätssicherungsanforderungen.
+  BC-3550.30.40:
+    name: Leergebinde-Verantwortung
+    description: |
+      Dreifachspülung, Rückgabe und Recycling leerer
+      Pestizidgebinde.
+  BC-3550.40:
+    name: Tierernährungs-Betriebsmittel-Management
+    description: |
+      Beschaffung, Lagerung und Verwendungsverfolgung von
+      Futterinhaltsstoffen, Vormischungen und Futterzusatzstoffen
+      für Tierhaltungsbetriebe.
+  BC-3550.40.10:
+    name: Futterinhaltsstoff-Beschaffung
+    description: |
+      Beschaffung von Getreide, Eiweißfuttermitteln und
+      Grundfutterinhaltsstoffen.
+  BC-3550.40.20:
+    name: Vormischung und Additivmanagement
+    description: |
+      Vormischungs-, Mineral- und Futterzusatzstoff-Beschaffung
+      und -Bestandsmanagement.
+  BC-3550.40.30:
+    name: Futterbestand und Rationenverfolgung
+    description: |
+      Betrieblicher Futterbestand und Rationenverwendungsverfolgung.
+  BC-3550.50:
+    name: Tierarzneimittel-Betriebsmittel-Management
+    description: |
+      Beschaffung, Kühlketten-Lagerung und Verwendungsaufzeichnung
+      für Tierarzneimittel und Biologika auf dem Betrieb.
+  BC-3550.50.10:
+    name: Tierarzneimittel-Beschaffung
+    description: |
+      Rezeptbasierte Beschaffung von Tierarzneimitteln und Biologika.
+  BC-3550.50.20:
+    name: Kühlketten-Lagerung von Tierarzneimitteln
+    description: |
+      Betriebliche Kühlketten-Lagerung und Abweichungsmanagement
+      für Tierarzneimittel.
+  BC-3550.50.30:
+    name: Tierarzneimittel-Verwendungsaufzeichnung
+    description: |
+      Verwendungsaufzeichnung mit Charge, Dosis, Tier- und
+      Bedienerangaben.
+  BC-3550.60:
+    name: Biologische und Bodenverbesserungs-Betriebsmittel
+    description: |
+      Beschaffung biologischer Betriebsmittel, Gülle- und
+      Kompostmanagement sowie Kalk- und Bodenverbesserungsversorgung.
+  BC-3550.60.10:
+    name: Biologische Betriebsmittel-Beschaffung
+    description: |
+      Beschaffung von Biostimulanzien, Biodüngern und
+      mikrobiellen Impfmitteln.
+  BC-3550.60.20:
+    name: Gülle- und Kompost-Management
+    description: |
+      Betriebliche Güllelagerung, Kompostierung und
+      Nährstoffrückgewinnungsbetrieb.
+  BC-3550.60.30:
+    name: Kalk- und Bodenverbesserungs-Beschaffung
+    description: |
+      Beschaffung von Kalk, Gips und sonstigen Bodenverbesserern.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-agronomy-farm-advisory-management.yaml
+++ b/catalogue/i18n/de/L1-agronomy-farm-advisory-management.yaml
@@ -1,0 +1,135 @@
+locale: de
+source: L1-agronomy-farm-advisory-management.yaml
+entries:
+  BC-3530:
+    name: Agronomie und Landwirtschaftsberatung
+    description: |
+      Bodenuntersuchung, Nährstoff- und Pflanzenschutzplanung,
+      integriertes Pflanzenschutzmanagement, Sortenempfehlungen,
+      Beratungsdienstleistungen und Feldversuchs-Management, die
+      agronomische Wissenschaft in Feldentscheidungen übersetzen.
+  BC-3530.10:
+    name: Bodenuntersuchung und -Analyse
+    description: |
+      Probenahme, Laboranalyse und Interpretation von Bodentests
+      zur Ernährungs- und Verbesserungsentscheidung.
+  BC-3530.10.10:
+    name: Bodenprobnahme
+    description: |
+      Feldbodenprobnahme nach Raster-, Zonen- und
+      Mischprobenmethoden.
+  BC-3530.10.20:
+    name: Bodentestergebnis-Interpretation
+    description: |
+      Interpretation von Bodentestergebnissen gegen Kulturanforderungen.
+  BC-3530.10.30:
+    name: Bodengesundheitsindikator-Verfolgung
+    description: |
+      Langzeitverfolgung von Bodengesundheitsindikatoren über Schläge hinweg.
+  BC-3530.20:
+    name: Nährstoffmanagement-Planung
+    description: |
+      Berechnung des Kulturnährstoffbedarfs und Erstellung variableraten
+      Düngungsempfehlungen nach 4R-Nährstoffverantwortung.
+    in_scope:
+      - Nährstoffbedarfsberechnung
+      - Variabelraten-Empfehlungserstellung
+      - 4R-Konformitätsaufzeichnung
+    out_of_scope:
+      - Düngungsapplikation (BC-3500.40)
+      - Bodenkohleprogramme (BC-3600.50)
+  BC-3530.20.10:
+    name: Nährstoffbedarfs-Berechnung
+    description: |
+      Berechnung des Nährstoffbedarfs nach Kultur, Ertragszielen
+      und Schlag.
+  BC-3530.20.20:
+    name: Variabelraten-Empfehlungserstellung
+    description: |
+      Erstellung variableraten Empfehlungskarten für Dünger
+      und Kalkung.
+  BC-3530.20.30:
+    name: 4R-Konformitäts-Aufzeichnung
+    description: |
+      Aufzeichnung von richtigem Düngungsmittel, -Menge, -Zeitpunkt
+      und -Ort nach 4R-Verantwortung.
+  BC-3530.30:
+    name: Pflanzenschutz-Planung
+    description: |
+      Risikobeurteilung, Integriertes-Pflanzenschutz-Planung,
+      Spritzprogramm-Design und Resistenzmanagement-Strategie.
+  BC-3530.30.10:
+    name: Schädlings- und Krankheitsrisiko-Beurteilung
+    description: |
+      Schädlings- und Krankheitsrisikobeurteilung mit Prognosen
+      und Feldinformationen.
+  BC-3530.30.20:
+    name: Integriertes Pflanzenschutz-Planung
+    description: |
+      IPM-Planung mit kulturellen, biologischen und chemischen
+      Maßnahmen.
+  BC-3530.30.30:
+    name: Spritzprogramm-Design
+    description: |
+      Saisonales Spritzprogramm-Design mit Abwägung von Wirksamkeit,
+      Rückständen und Kosten.
+  BC-3530.30.40:
+    name: Resistenzmanagement-Planung
+    description: |
+      Pestzidresistenz-Management-Planung über Wirkmechanismen hinweg.
+  BC-3530.40:
+    name: Sorten- und Hybrid-Empfehlung
+    description: |
+      Analyse von Sortenversuchsdaten und Ausgabe lokal angepasster
+      Sorten- und Hybridempfehlungen an Landwirte.
+  BC-3530.40.10:
+    name: Sortenversuchsergebnis-Analyse
+    description: |
+      Statistische Analyse von Sortenversuchsergebnissen über
+      Standorte und Saisonen hinweg.
+  BC-3530.40.20:
+    name: Lokale Sortenempfehlung
+    description: |
+      Ausgabe von Sorten- und Hybridempfehlungen nach Zone und
+      Verwendungszweck.
+  BC-3530.50:
+    name: Agronomische Beratungsdienstleistungen
+    description: |
+      Feldberatungsbesuche, Entscheidungsunterstützungs-Empfehlungen
+      und Landwirtschaftsschulungen von Agronomiefachleuten.
+  BC-3530.50.10:
+    name: Feldberatungsbesuch-Durchführung
+    description: |
+      Betriebsberatungsbesuche und Empfehlungsübergabe.
+  BC-3530.50.20:
+    name: Entscheidungsunterstützungs-Empfehlung
+    description: |
+      Einsatz von Entscheidungsunterstützungstools für agronomische
+      Empfehlungsausgabe.
+  BC-3530.50.30:
+    name: Landwirtschaftsschulung-Durchführung
+    description: |
+      Durchführung von Landwirtschaftsschulungsveranstaltungen
+      und Feldtagen.
+  BC-3530.60:
+    name: Feldversuchs-Management
+    description: |
+      Design, Durchführung und Analyse von replizierten Feldversuchen
+      zur Agronomie-, Sorten- und Produktbewertung.
+  BC-3530.60.10:
+    name: Versuchs-Design
+    description: |
+      Statistisches Design von replizierten und Demonstrations-
+      Versuchen.
+  BC-3530.60.20:
+    name: Versuchsdurchführung und Datenerfassung
+    description: |
+      Versuchsdurchführung vor Ort und standardisierte Datenerfassung.
+  BC-3530.60.30:
+    name: Versuchsergebnis-Analyse
+    description: |
+      Statistische Analyse von Versuchsergebnissen und Berichterstattung
+      an Auftraggeber.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-air-traffic-control-operations-management.yaml
+++ b/catalogue/i18n/de/L1-air-traffic-control-operations-management.yaml
@@ -1,0 +1,122 @@
+locale: de
+source: L1-air-traffic-control-operations-management.yaml
+entries:
+  BC-1210:
+    name: Flugsicherungs-Betriebsmanagement
+    description: |
+      Echtzeit-Luftverkehrsdienstleistungen – Strecke, Anflugraum, Flugplatzkontrolle und Ozean.
+  BC-1210.10:
+    name: Streckenkontroll-Betriebsmanagement
+    description: |
+      Höhenstrecken-Flugsicherungsdienste.
+  BC-1210.10.10:
+    name: Strecken-Staffelungsbereitstellung
+    description: |
+      Bereitstellung horizontaler und vertikaler Staffelung im Streckenluftaum.
+  BC-1210.10.20:
+    name: Strecken-Konfliktdetektion und -lösung
+    description: |
+      Erkennung und Lösung von Konflikten zwischen Streckenflügen.
+  BC-1210.10.30:
+    name: Strecken-Koordination
+    description: |
+      Sektor- und zentrumsübergreifende Koordination des Streckenverkehrs.
+  BC-1210.10.40:
+    name: Flugplan-Bearbeitung
+    description: |
+      Flugplanbearbeitung, Aktivierung und Aktualisierungen.
+  BC-1210.20:
+    name: Anflugkontroll-Betriebsmanagement
+    description: |
+      Terminal-Anflug- und Abflugkontrolle.
+  BC-1210.20.10:
+    name: Ankunftssequenzierung und Metering
+    description: |
+      Ankunftssequenzierung, AMAN und Metering-Betrieb.
+  BC-1210.20.20:
+    name: Abflugmanagement
+    description: |
+      Abflugmanagement, DMAN und SID-Einhaltung.
+  BC-1210.20.30:
+    name: Anflugvektorführung und Staffelung
+    description: |
+      Vektorführung und Staffelung für den Endanflug.
+  BC-1210.20.40:
+    name: Terminalbereichs-Koordination
+    description: |
+      Koordination zwischen Anflugkontrolle und benachbarten Einheiten.
+  BC-1210.30:
+    name: Flugplatz-Tower-Betriebsmanagement
+    description: |
+      Tower-Kontrolle an Flugplätzen einschließlich Bodenbewegung.
+  BC-1210.30.10:
+    name: Bahnkontrolle
+    description: |
+      Bahnkontrolle einschließlich Start- und Landefreigaben.
+  BC-1210.30.20:
+    name: Bodenbewegungskontrolle
+    description: |
+      Bodenbewegungskontrolle von Luftfahrzeugen und Fahrzeugen.
+  BC-1210.30.30:
+    name: Freigabeerteilung
+    description: |
+      Erteilung von Abflugfreigaben und Vorabfluginformationen.
+  BC-1210.30.40:
+    name: Flugplatz-Koordination
+    description: |
+      Koordination mit Flugplatzbetrieb und Notfalldiensten.
+  BC-1210.40:
+    name: Ozeankontroll-Betriebsmanagement
+    description: |
+      Prozedurale und ozeanische Flugsicherungsdienste.
+  BC-1210.40.10:
+    name: Prozedurale Staffelungsbereitstellung
+    description: |
+      Prozedurale Staffelung in radarfreiem ozeanischen Luftraum.
+  BC-1210.40.20:
+    name: Ozeanische Freigabenerteilung
+    description: |
+      Erteilung ozeanischer Freigaben und Neufreigaben.
+  BC-1210.40.30:
+    name: CPDLC- und ADS-C-Betrieb
+    description: |
+      Datenlinkbasierter Ozeanbetrieb mit CPDLC und ADS-C.
+  BC-1210.50:
+    name: ATC-Dienst- und Schichtmanagement
+    description: |
+      Dienstaufsicht, Schichtübergaben und Positionsbesetzung.
+  BC-1210.50.10:
+    name: Dienstaufsicht
+    description: |
+      Betriebsaufsicht über Dienst und Schichtleistung.
+  BC-1210.50.20:
+    name: Schichtübergabe-Management
+    description: |
+      Strukturierte Schichtübergabe-Briefings und Dokumentation.
+  BC-1210.50.30:
+    name: Positionsbesetzungsplanung
+    description: |
+      Positionsbesetzungsplanung und Ermüdungsmanagement für Lotsen.
+  BC-1210.60:
+    name: Notfallbetriebsmanagement
+    description: |
+      Betrieb im degradierten Modus, Systemausfallreaktion und Rückfallverfahren.
+  BC-1210.60.10:
+    name: Betrieb im degradierten Modus
+    description: |
+      Betrieb im degradierten Modus mit reduzierter Systemunterstützung.
+  BC-1210.60.20:
+    name: Systemausfallreaktion
+    description: |
+      Verfahren zur Reaktion auf ATC-Systemausfälle.
+  BC-1210.60.30:
+    name: Rückfall auf Backup-Systeme
+    description: |
+      Rückfall auf Backup-ATC-Systeme und Ausweicheinrichtungen.
+  BC-1210.60.40:
+    name: Notfallplan-Pflege
+    description: |
+      Pflege und Übung betrieblicher Notfallpläne.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-air-traffic-controller-competency-management.yaml
+++ b/catalogue/i18n/de/L1-air-traffic-controller-competency-management.yaml
@@ -1,0 +1,106 @@
+locale: de
+source: L1-air-traffic-controller-competency-management.yaml
+entries:
+  BC-1290:
+    name: Lotsen-Kompetenz-Management
+    description: |
+      Grund-, Einheits- und Fortlaufende Ausbildung; Lizenzierung und Kompetenzbewertung von Lotsen.
+  BC-1290.10:
+    name: Grundausbildungs-Management
+    description: |
+      Ab-initio-Ausbildung, Grund- und Berechtigungsausbildung (oft an einer Akademie).
+  BC-1290.10.10:
+    name: Ab-initio-Ausbildungsprogramm
+    description: |
+      Ab-initio-ATCO-Ausbildung einschließlich Grundphase.
+  BC-1290.10.20:
+    name: Berechtigungsausbildung
+    description: |
+      Berechtigungsspezifische Ausbildung (ACC, APP, ADC, OCN).
+  BC-1290.10.30:
+    name: Grundausbildungsbewertung
+    description: |
+      Prüfungen und Bewertungen während der Grundausbildung.
+  BC-1290.20:
+    name: Einheitsausbildungs-Management
+    description: |
+      On-the-Job-Training an der operativen Einheit.
+  BC-1290.20.10:
+    name: Einheitsausbildungsplan-Definition
+    description: |
+      Definition von Einheitsausbildungsplänen für ATCO-Übergang.
+  BC-1290.20.20:
+    name: On-the-Job-Training-Durchführung
+    description: |
+      OJT-Durchführung mit OJT-Ausbildern.
+  BC-1290.20.30:
+    name: Einheitsausbildungsvalidierung
+    description: |
+      Validierung der Einheitszulassung nach Abschluss der Einheitsausbildung.
+  BC-1290.30:
+    name: Fortlaufende Ausbildungs-Management
+    description: |
+      Wiederholungsausbildung, Umschulung und Notfall- und Ungewöhnliche-Situationen-Training.
+  BC-1290.30.10:
+    name: Wiederholungsausbildung
+    description: |
+      Periodische Wiederholungsausbildung für lizenzierte Lotsen.
+  BC-1290.30.20:
+    name: Umschulungsausbildung
+    description: |
+      Umschulung für neue Verfahren, Systeme oder Sektoren.
+  BC-1290.30.30:
+    name: Notfall- und Ungewöhnliche-Situationen-Training
+    description: |
+      Notfall-, Abnormal- und Ungewöhnliche-Situationen-Training.
+  BC-1290.40:
+    name: Kompetenzbewertungs-Management
+    description: |
+      Periodische Kompetenzbewertungen, Linienprüfungen und Validierungen.
+  BC-1290.40.10:
+    name: Kompetenzschema-Pflege
+    description: |
+      Definition und Pflege des Kompetenzschemas.
+  BC-1290.40.20:
+    name: Kompetenzbewertungs-Durchführung
+    description: |
+      Durchführung periodischer Kompetenzbewertungen und Linienprüfungen.
+  BC-1290.40.30:
+    name: Kompetenzaufzeichnungs-Management
+    description: |
+      Management von Kompetenzbewertungsunterlagen und Gültigkeitsdaten.
+  BC-1290.50:
+    name: Lizenzierungs- und Zulassungsmanagement
+    description: |
+      ATCO-Lizenzierung, Berechtigungen, Zulassungen und Tauglichkeitsverwaltung.
+  BC-1290.50.10:
+    name: ATCO-Lizenz-Ausgabe
+    description: |
+      Ausgabe und Erneuerung von ATCO-Lizenzen und Berechtigungen.
+  BC-1290.50.20:
+    name: Zulassungs-Administration
+    description: |
+      Administration von Einheits- und Sprachzulassungen.
+  BC-1290.50.30:
+    name: Medizinische Tauglichkeits-Administration
+    description: |
+      Administration der Klasse-3-Flugmedizin für Lotsen.
+  BC-1290.60:
+    name: Simulatorbetrieb-Management
+    description: |
+      ATC-Simulatoren, Szenariodesign und Simulatorlotsen-Betrieb.
+  BC-1290.60.10:
+    name: Simulatorszenario-Design
+    description: |
+      Design von Simulatortraining-Szenarien und Übungen.
+  BC-1290.60.20:
+    name: Simulatorlotsen-Betrieb
+    description: |
+      Betrieb von Simulatorlotsen-Positionen während Übungen.
+  BC-1290.60.30:
+    name: Simulatorwartung und -konfiguration
+    description: |
+      Wartung und Konfiguration von ATC-Simulatoren.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-air-traffic-flow-management.yaml
+++ b/catalogue/i18n/de/L1-air-traffic-flow-management.yaml
@@ -1,0 +1,94 @@
+locale: de
+source: L1-air-traffic-flow-management.yaml
+entries:
+  BC-1220:
+    name: Verkehrsflusssteuerung (Luftfahrt)
+    description: |
+      Kapazitätsplanung, Verkehrsregelung, Slotallokation und Nachfrage-Kapazitäts-Ausgleich.
+  BC-1220.10:
+    name: Kapazitätsplanungsmanagement
+    description: |
+      Sektor- und Flugplatzkapazitätsbewertung und Deklaration der verfügbaren Kapazität.
+  BC-1220.10.10:
+    name: Sektorkapazitätsbewertung
+    description: |
+      Bewertung der Sektorkapazität durch Arbeitsbelastungsmessung.
+  BC-1220.10.20:
+    name: Flugplatzkapazitätsdeklaration
+    description: |
+      Deklaration der Flugplatz-Bahn- und Vorfeld-Kapazität.
+  BC-1220.10.30:
+    name: Strategische Kapazitätsplanung
+    description: |
+      Mehrjährige strategische ATC-Kapazitätsplanung.
+  BC-1220.20:
+    name: Verkehrsregelungs-Management
+    description: |
+      Verkehrsflussmaßnahmen, Regelungen und Umwegführungen.
+  BC-1220.20.10:
+    name: Flussmaßnahmen-Definition
+    description: |
+      Definition von ATFCM-Maßnahmen je Sektor und Flugplatz.
+  BC-1220.20.20:
+    name: Umwegführungs-Vorschlagsmanagement
+    description: |
+      Vorschlag und Umsetzung von Umwegführungen und Szenarien.
+  BC-1220.20.30:
+    name: Taktische Flussanpassung
+    description: |
+      Taktische Anpassung von Flussmaßnahmen in Echtzeit.
+  BC-1220.30:
+    name: Slotallokations-Management
+    description: |
+      Berechnete Startzeiten (CTOT), Slot-Management und Slot-Tausch.
+  BC-1220.30.10:
+    name: Berechnete Startzeit-Ausgabe
+    description: |
+      Berechnung und Ausgabe von CTOTs an Luftraumnutzer.
+  BC-1220.30.20:
+    name: Slot-Tausch und -Verbesserung
+    description: |
+      Slot-Tausch, Slot-Verbesserung und Zielzeitaktualisierungen.
+  BC-1220.30.30:
+    name: Abflugslot-Compliance
+    description: |
+      Überwachung der Slot-Einhaltung und Ausnahmeregelungen.
+  BC-1220.40:
+    name: Netzwerkleistungsmanagement
+    description: |
+      Netzwerkleistungsüberwachung und KPI-Berichterstattung.
+  BC-1220.40.10:
+    name: Netzwerk-KPI-Überwachung
+    description: |
+      Überwachung von Netzwerk-KPIs (Verspätung, Kapazität, Vorhersagbarkeit).
+  BC-1220.40.20:
+    name: Leistungsberichterstattung
+    description: |
+      Leistungsberichterstattung an Netzwerk- und SES-Regulatoren.
+  BC-1220.40.30:
+    name: Post-Betriebs-Analyse
+    description: |
+      Nachträgliche Analyse von Verkehrsflüssen und Engpässen.
+  BC-1220.50:
+    name: Nachfrage-Kapazitäts-Ausgleichs-Management
+    description: |
+      Vortaktischer und taktischer Nachfrage-Kapazitäts-Ausgleich.
+  BC-1220.50.10:
+    name: Strategischer Nachfrage-Kapazitäts-Ausgleich
+    description: |
+      Langfristiger Nachfrage-Kapazitäts-Ausgleich im gesamten Netzwerk.
+  BC-1220.50.20:
+    name: Vortaktischer Nachfrage-Kapazitäts-Ausgleich
+    description: |
+      Vortaktischer (D-1) Nachfrage-Kapazitäts-Ausgleich.
+  BC-1220.50.30:
+    name: Taktischer Nachfrage-Kapazitäts-Ausgleich
+    description: |
+      Echtzeit-taktischer Nachfrage-Kapazitäts-Ausgleich.
+  BC-1220.50.40:
+    name: Kollaboratives Entscheidungsmanagement
+    description: |
+      Kollaboratives Entscheidungsmanagement mit Luftraumnutzern und Flughäfen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-airline-flight-operations-management.yaml
+++ b/catalogue/i18n/de/L1-airline-flight-operations-management.yaml
@@ -1,0 +1,177 @@
+locale: de
+source: L1-airline-flight-operations-management.yaml
+entries:
+  BC-4080:
+    name: Flugbetrieb Management
+    description: |
+      Flugplanplanung, Flugzeugrouting, Crewplanung, Dispatch, Gate- und
+      Turnaround-Koordination, IROPS-Wiederherstellung sowie Flugbetriebs-
+      und Sicherheitsberichterstattung für Fluggesellschaften.
+    in_scope:
+      - Flugplanplanung, Slotkoordination und Verbindungsbanken
+      - Flugzeugrouting, Schwanzkennnummernzuweisung und MEL-Verfolgung
+      - Crew-Pairing, -Einsatzplan und FTL-Konformität
+      - Flug-Dispatch und Betriebssteuerung
+      - Gate-Zuteilung und Turnaround-Koordination
+      - Operative Störungsentscheidungen (IROPS) für Flugzeug und Besatzung
+      - Flugbetriebs- und Sicherheitsereignisberichterstattung
+    out_of_scope:
+      - Flugsicherung durch ANSPs (BC-1700)
+      - Passagier-Umbuchungsfluss auf Buchungsebene (BC-4020.70)
+      - Frachtflughandling (BC-3270)
+  BC-4080.10:
+    name: Flugplanplanung
+    description: |
+      Erstellung und Veröffentlichung des Airline-Flugplans
+      einschließlich Netzwerk, Slots und Verbindungsbanken.
+  BC-4080.10.10:
+    name: Netzwerk- und Routenplangestaltung
+    description: |
+      Gestaltung des Netzwerks und Routenplans gegen Nachfrage- und Flottenpläne.
+  BC-4080.10.20:
+    name: Slot- und Flughafenkoordination
+    description: |
+      Koordination von Flughafenslots und -beschränkungen einschließlich IATA-WSG-konformem Scheduling.
+  BC-4080.10.30:
+    name: Flugplanerstellung und Veröffentlichung
+    description: |
+      Erstellung des veröffentlichten Flugplans und SSIM-Datei-Veröffentlichung an Vertriebspartner.
+  BC-4080.10.40:
+    name: Verbindungsbank-Optimierung
+    description: |
+      Optimierung von Hub-Verbindungsbanken und Mindestumsteigezeiten.
+  BC-4080.20:
+    name: Flugzeugrouting und Schwanzkennnummernzuweisung
+    description: |
+      Erstellung von Flugzeugrotationen, Schwanzkennnummernzuweisungen,
+      Tauschoperationen, Wartungsslotkoordination und MEL-Verfolgung.
+  BC-4080.20.10:
+    name: Flottenrotationsplanung
+    description: |
+      Planung von Flottenrotationen über das Netzwerk unter Berücksichtigung von Flugstunden- und Zyklusausgleich.
+  BC-4080.20.20:
+    name: Schwanzkennnummernzuweisung und Tauschoperationen
+    description: |
+      Zuweisung konkreter Schwanzkennnummern zu Flügen und Ausführung taktischer Tausche.
+  BC-4080.20.30:
+    name: Flugzeugwartungsslotkoordination
+    description: |
+      Koordination von Wartungsslots und Überführungsflügen gegen den Flugplan.
+  BC-4080.20.40:
+    name: Minimum-Equipment-List-Verfolgung
+    description: |
+      Verfolgung von MEL-Aufschüben gegen Ablauf und operative Auswirkungen.
+  BC-4080.30:
+    name: Crewplanung und Einsatzplan
+    description: |
+      Planung von Cockpit- und Kabinenbesatzung einschließlich Pairing-Erstellung,
+      Gebotsverfahren, Qualifikationsverfolgung und FTL-Konformität.
+  BC-4080.30.10:
+    name: Crew-Pairing-Erstellung
+    description: |
+      Erstellung von Crew-Pairings über den Flugplan unter Beachtung von Rechtsregeln.
+  BC-4080.30.20:
+    name: Crew-Gebotsverfahren und Einsatzplanerstellung
+    description: |
+      Betrieb von Gebotsverfahren und Einsatzplanerstellung für Cockpit- und Kabinenbesatzung.
+  BC-4080.30.30:
+    name: Crew-Qualifikations- und Aktualitätsverfolgung
+    description: |
+      Verfolgung von Qualifikation, Aktualität und Berechtigung für Besatzungsmitglieder.
+  BC-4080.30.40:
+    name: Flug- und Dienstzeiten-Konformität
+    description: |
+      Konformität mit FTL- und Dienstzeitregeln bei Planung und Ausführung.
+  BC-4080.40:
+    name: Flug-Dispatch und Betriebssteuerung
+    description: |
+      Generierung operativer Flugpläne, Kraftstoffentscheidungen, Wetter-
+      und NOTAM-Briefing sowie Betriebssteuerungs-Entscheidungsprozess.
+  BC-4080.40.10:
+    name: Flugplangenerierung
+    description: |
+      Generierung operativer Flugpläne einschließlich Route, Flugfläche und Flugzeit.
+  BC-4080.40.20:
+    name: Operative Kraftstoffberechnung
+    description: |
+      Berechnung des operativen Kraftstoffs einschließlich Reserve, Kontingenz und Ermessensbetankung.
+  BC-4080.40.30:
+    name: Wetter- und NOTAM-Briefing
+    description: |
+      Zusammenstellung und Weitergabe von Wetter- und NOTAM-Briefings an Crew und Dispatch.
+  BC-4080.40.40:
+    name: Operations-Control-Centre-Entscheidungsfindung
+    description: |
+      OCC-Entscheidungsfindung bei Verzögerungen, Umweglandungen und Wiederherstellungsoptionen.
+  BC-4080.50:
+    name: Gate- und Turnaround-Betrieb
+    description: |
+      Gate-Planung und Live-Turnaround-Koordination an Flughäfen
+      einschließlich Pushback- und Verspätungsmanagement auf dem Vorfeld.
+  BC-4080.50.10:
+    name: Gate-Zuteilung und Sequenzierung
+    description: |
+      Zuteilung von Gates und Stand-Sequenzierung im Tageslaufbetrieb.
+  BC-4080.50.20:
+    name: Turnaround-Koordination
+    description: |
+      Live-Koordination der Turnaround-Aktivitäten einschließlich Catering, Betankung und Boarding.
+  BC-4080.50.30:
+    name: Pushback- und Block-out-Betrieb
+    description: |
+      Pushback-, Block-out- und Rollout-Koordination am Stand.
+  BC-4080.50.40:
+    name: Vorfeld-Verspätungsmanagement
+    description: |
+      Management von Vorfeld-Verspätungen gemäß regulatorischen Zeitlimiten und Fahrgastversorgungspflichten.
+  BC-4080.60:
+    name: Flugstörungs- und IROPS-Management
+    description: |
+      Operative Entscheidungen bei Störungsereignissen einschließlich
+      Umweglandungen, Massenstornierungen und Crew-Wiederherstellung.
+    in_scope:
+      - Umweglandungs- und Stornierungsentscheidungen
+      - Crew-Störungswiederherstellung und Bereitschaftszuweisung
+      - Koordinationsübergabe an Passagier-Umbuchung (BC-4020.70)
+    out_of_scope:
+      - Passagierseitige Umbuchung und Entschädigungsfeststellung (BC-4020.70)
+  BC-4080.60.10:
+    name: Umweglandungs-Entscheidungsbetrieb
+    description: |
+      Betrieb zur Entscheidung und Durchführung von En-Route- und Vor-Abflug-Umweglandungen.
+  BC-4080.60.20:
+    name: Massenrückstellungs-Wiederherstellungsbetrieb
+    description: |
+      Wiederherstellungsbetrieb bei Massenstornierungen für Flugzeug, Crew und Slot.
+  BC-4080.60.30:
+    name: Crew-Störungswiederherstellung
+    description: |
+      Wiederherstellung von Crew-Einsatzplänen bei Störungen einschließlich Bereitschaftszuweisung.
+  BC-4080.60.40:
+    name: Passagier-Umbuchungskoordination
+    description: |
+      Koordination mit Passagier-Umbuchungsteams zu Wiederherstellungsoptionen und Priorisierung.
+  BC-4080.70:
+    name: Flugbetriebs- und Sicherheitsberichterstattung
+    description: |
+      Berichterstattung über Flugbetriebsleistung, Pünktlichkeits-KPIs,
+      Luftsicherheitsberichte und operative Sicherheitsdaten.
+  BC-4080.70.10:
+    name: Pünktlichkeitsberichterstattung
+    description: |
+      Berichterstattung über Pünktlichkeit und Verspätungscodes über das Netzwerk.
+  BC-4080.70.20:
+    name: Luftsicherheitsberichtserfassung
+    description: |
+      Erfassung und Priorisierung von Luftsicherheitsberichten von Crew und Betriebspersonal.
+  BC-4080.70.30:
+    name: Operative Sicherheitsuntersuchungsunterstützung
+    description: |
+      Unterstützung operativer Sicherheitsuntersuchungen einschließlich Datenerhebung und Nachverfolgung.
+  BC-4080.70.40:
+    name: Flugdatenanalyse-Feeds
+    description: |
+      Feeds von Flugdatenanalysen an Sicherheits- und Betriebsanalyseprogramme.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-airspace-management.yaml
+++ b/catalogue/i18n/de/L1-airspace-management.yaml
@@ -1,0 +1,82 @@
+locale: de
+source: L1-airspace-management.yaml
+entries:
+  BC-1200:
+    name: Luftraummanagement
+    description: |
+      Luftraumdesign, Sektorisierung, Sperrbereiche und Zivil-Militär-Koordination.
+  BC-1200.10:
+    name: Luftraumdesign-Management
+    description: |
+      Luftraumstruktur, Klassen, Streckennetzdesign und Sektorgrenzen.
+  BC-1200.10.10:
+    name: Luftraumstruktur-Design
+    description: |
+      Definition von FIR, UIR, Kontrollbereichen und Luftraumklassen gemäß ICAO Anhang 11.
+  BC-1200.10.20:
+    name: ATS-Streckennetz-Design
+    description: |
+      Design konventioneller und PBN-basierter ATS-Streckennetze.
+  BC-1200.10.30:
+    name: Sektorgrenz-Design
+    description: |
+      Definition von Sektorgrenzen und elementaren Sektoren.
+  BC-1200.10.40:
+    name: Freier Routenluftraum-Design
+    description: |
+      Design und Implementierung von freiem Routenluftraum.
+  BC-1200.20:
+    name: Luftraumsektorisierungs-Management
+    description: |
+      Sektordefinitionen, Öffnungsschemata und Lotsenarbeitsbelastungsausrichtung.
+  BC-1200.20.10:
+    name: Sektor-Konfigurations-Management
+    description: |
+      Definition und Pflege von Sektorkonfigurationen.
+  BC-1200.20.20:
+    name: Sektoröffnungsschema-Planung
+    description: |
+      Planung von Sektoröffnungsschemata nach Verkehrsprognose.
+  BC-1200.20.30:
+    name: Arbeitsbelastungsbasierte Sektorisierung
+    description: |
+      Sektorisierung ausgerichtet auf die Lotsenarbeitsbelastungsbewertung.
+  BC-1200.30:
+    name: Luftraumbeschränkungs-Management
+    description: |
+      Gefahrengebiete, Sperrbereiche, verbotene Gebiete und Militärzonen.
+  BC-1200.30.10:
+    name: Sperrgebiet-Definition
+    description: |
+      Definition von Sperr-, Beschränkungs- und Gefahrengebieten.
+  BC-1200.30.20:
+    name: Temporäre Reservierungsgebiets-Management
+    description: |
+      Management temporärer reservierter und abgesonderter Gebiete.
+  BC-1200.30.30:
+    name: Aktivierungs- und Freigabe-Koordination
+    description: |
+      Aktivierung, Freigabe und Benachrichtigung für gesperrten Luftraum.
+  BC-1200.40:
+    name: Luftraumkoordinations-Management
+    description: |
+      Zivil-Militär-Koordination, grenzüberschreitende Luftraumkoordination und FAB-Zusammenarbeit.
+  BC-1200.40.10:
+    name: Zivil-Militär-Luftraumkoordination
+    description: |
+      Zivil-Militär-Koordination und flexible Nutzung des Luftraums.
+  BC-1200.40.20:
+    name: Grenzüberschreitende Luftraumkoordination
+    description: |
+      Koordination der Luftraumnutzung über FIR-Grenzen hinweg.
+  BC-1200.40.30:
+    name: Funktionaler Luftraumblock-Zusammenarbeit
+    description: |
+      Zusammenarbeit in funktionalen Luftraumblöcken (FAB).
+  BC-1200.40.40:
+    name: Luftraumnutzer-Konsultation
+    description: |
+      Konsultation mit Luftraumnutzern zu Designänderungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-aquaculture-operations-management.yaml
+++ b/catalogue/i18n/de/L1-aquaculture-operations-management.yaml
@@ -1,0 +1,154 @@
+locale: de
+source: L1-aquaculture-operations-management.yaml
+entries:
+  BC-3520:
+    name: Aquakultur-Betrieb
+    description: |
+      Produktion von Zuchtaquatikarten – Brüterei und Besatz,
+      Fütterung, Wasserqualität, Tiergesundheit, Netz- und
+      Teichbetrieb, Ernte und Umweltkonformität für Fisch,
+      Schalentiere und Wasserpflanzen.
+  BC-3520.10:
+    name: Besatzmaterial-Beschaffung und Besatzbetrieb
+    description: |
+      Elterntier-Beschaffung, Brütereibetrieb und Jungfischbesatz
+      in Aufzuchtsysteme.
+  BC-3520.10.10:
+    name: Elterntier-Beschaffung
+    description: |
+      Beschaffung und Quarantäne von Elterntieren für die
+      Brütereiproduktion.
+  BC-3520.10.20:
+    name: Brütereibetrieb
+    description: |
+      Eiinkubation, Larvenaufzucht und Jungfischproduktion
+      in Brütereien.
+  BC-3520.10.30:
+    name: Jungfisch-Besatzbetrieb
+    description: |
+      Besatz von Jungfischen in Aufzuchtgehege, -teiche und -tanks.
+  BC-3520.20:
+    name: Aquakultur-Fütterungsbetrieb
+    description: |
+      Futterplanung, -Verteilung und Futterverwertungsüberwachung
+      für Zuchtaquatikarten.
+  BC-3520.20.10:
+    name: Futterrationen-Planung
+    description: |
+      Futterrationenplanung nach Art, Entwicklungsstadium und
+      Wassertemperatur.
+  BC-3520.20.20:
+    name: Futterverteilungs-Betrieb
+    description: |
+      Manuelle, mechanische und automatisierte Futterverteilung
+      zu Gehegen und Teichen.
+  BC-3520.20.30:
+    name: Futterverwertungs-Überwachung
+    description: |
+      Futterverwertungsquoten-Überwachung gegen Futterpläne.
+  BC-3520.30:
+    name: Wasserqualitäts-Management
+    description: |
+      Kontinuierliche Wasserqualitätsüberwachung, Belüftung und
+      Behandlung in Durchfluss- und Kreislaufwassersystemen.
+    in_scope:
+      - Sauerstoff- und Temperaturüberwachung
+      - Belüftungs- und Sauerstoffversorgungsbetrieb
+      - Wasseraufbereitung und Kreislaufführung
+  BC-3520.30.10:
+    name: Wasserqualitäts-Überwachung
+    description: |
+      Echtzeitüberwachung von Sauerstoff, Temperatur, Salinität und pH.
+  BC-3520.30.20:
+    name: Belüftungs- und Sauerstoffversorgungsbetrieb
+    description: |
+      Betrieb von Belüftungs- und Sauerstoffinjektionssystemen.
+  BC-3520.30.30:
+    name: Wasseraufbereitung und Kreislaufführung
+    description: |
+      Mechanische, biologische und UV-Wasseraufbereitung in
+      Kreislaufsystemen.
+  BC-3520.40:
+    name: Aquatische Tiergesundheits-Management
+    description: |
+      Krankheitsüberwachung, Behandlung, Biosicherheit und
+      Sterblichkeitserfassung für Zuchtaquatikarten.
+  BC-3520.40.10:
+    name: Aquatische Krankheits-Surveillance
+    description: |
+      Überwachung von Pathogenen, Parasiten und anzeigepflichtigen
+      aquatischen Krankheiten.
+  BC-3520.40.20:
+    name: Aquakultur-Behandlungsbetrieb
+    description: |
+      Im-Wasser- und Badbehandlungsbetrieb einschließlich
+      Seelausbekämpfung.
+  BC-3520.40.30:
+    name: Aquakultur-Biosicherheitsbetrieb
+    description: |
+      Standort-Biosicherheit, Gerätedesinfektion und
+      Bewegungskontrollen.
+  BC-3520.40.40:
+    name: Sterblichkeits-Aufzeichnung
+    description: |
+      Tägliche Sterblichkeitserfassung, Klassifizierung und
+      Entsorgungsmanagement.
+  BC-3520.50:
+    name: Netz- und Teich-Betrieb
+    description: |
+      Täglicher Betrieb und Integrität von Aufzuchtgehegen, Käfigen
+      und Teichen einschließlich Raubtierschutz und Antifouling.
+  BC-3520.50.10:
+    name: Netz- und Käfig-Inspektion
+    description: |
+      Routineinspektion von Netzen, Käfigen und Verankerungen
+      auf Integrität.
+  BC-3520.50.20:
+    name: Raubtier- und Fluchtprävention
+    description: |
+      Raubtierabwehr- und Fluchtpräventionsbetrieb.
+  BC-3520.50.30:
+    name: Antifouling-Betrieb
+    description: |
+      Netzreinigung und Antifouling-Betrieb an untergetauchter
+      Infrastruktur.
+  BC-3520.60:
+    name: Aquakultur-Ernte-Betrieb
+    description: |
+      Vor-Ernte-Probenahme, Erntedurchführung und Lebendhaltung
+      für Verarbeitung oder Lebendmarkt-Versand.
+  BC-3520.60.10:
+    name: Vor-Ernte-Probenahme
+    description: |
+      Vor-Ernte-Größen-, Qualitäts- und Rückstandsprobenahme.
+  BC-3520.60.20:
+    name: Ernte-Durchführung
+    description: |
+      Zusammentreiben, Pumpen, Betäuben und Erntedurchführung.
+  BC-3520.60.30:
+    name: Lebendhaltung und Transfer
+    description: |
+      Lebendhaltung und Brunnenschiff- oder Tankertransfer
+      zu Verarbeiter oder Markt.
+  BC-3520.70:
+    name: Aquakultur-Umweltkonformität
+    description: |
+      Standortbezogene Umweltüberwachung und Berichterstattung
+      gemäß Aquakulturerlizenzen und Zertifizierungsprogrammen.
+  BC-3520.70.10:
+    name: Standort-Umweltüberwachung
+    description: |
+      Standortbezogene Umweltüberwachung gegen Lizenzbedingungen.
+  BC-3520.70.20:
+    name: Ablaufberichterstattung
+    description: |
+      Berichterstattung von Nährstoff- und Ablaufeinleitungen
+      an Regulatoren.
+  BC-3520.70.30:
+    name: Benthos-Impact-Beurteilung
+    description: |
+      Benthos-Impact-Untersuchungen und Sanierungsverfolgung
+      unter Käfigstandorten.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-assessment-examinations-management.yaml
+++ b/catalogue/i18n/de/L1-assessment-examinations-management.yaml
@@ -1,0 +1,152 @@
+locale: de
+source: L1-assessment-examinations-management.yaml
+entries:
+  BC-4740:
+    name: Prüfungs- und Bewertungswesen
+    description: |
+      Konzeption, Durchführung, Bewertung, Moderation und Abschluss von
+      Prüfungen und Leistungsnachweisen, die das Lernen der Studierenden belegen,
+      einschließlich Überwachung der akademischen Integrität.
+  BC-4740.10:
+    name: Prüfungskonzeption und Aufgabenbank
+    description: |
+      Konzeption von Prüfungsinstrumenten und Pflege kalibrierter Aufgabenbanken,
+      die konsistente und zuverlässige Prüfungen unterstützen.
+    in_scope:
+      - Definition von Prüfungsblaupausen
+      - Aufgabenerstellung und -kalibrierung
+      - Pflege der Aufgabenbank
+    out_of_scope:
+      - Lehrplangestaltung auf Kursebene (abgedeckt unter Lehrplan- und Studienprogrammverwaltung)
+  BC-4740.10.10:
+    name: Definition von Prüfungsblaupausen
+    description: |
+      Definition von Prüfungsblaupausen und Gewichtung gegenüber Lernergebnissen.
+  BC-4740.10.20:
+    name: Aufgabenerstellung und -kalibrierung
+    description: |
+      Erstellung und statistische Kalibrierung von Prüfungsaufgaben.
+  BC-4740.10.30:
+    name: Pflege der Aufgabenbank
+    description: |
+      Pflege sicherer Aufgabenbanken über Versionen und Expositionszyklen hinweg.
+  BC-4740.20:
+    name: Prüfungsbetrieb
+    description: |
+      Operativer Ablauf von Präsenz- und Online-Prüfungen, einschließlich Planung,
+      Aufsicht und Fernprüfungsdiensten.
+    in_scope:
+      - Prüfungsplanung
+      - Prüfungsräumlichkeiten und Aufsicht
+      - Online- und Fernprüfung
+    out_of_scope:
+      - Tägliche Unterrichtsbewertung (abgedeckt unter Lehr- und Lernbetriebsmanagement)
+  BC-4740.20.10:
+    name: Prüfungsplanung
+    description: |
+      Planung von Prüfungen für Kohorten, Räumlichkeiten und Modalitäten.
+  BC-4740.20.20:
+    name: Prüfungsräumlichkeiten und Aufsicht
+    description: |
+      Raumgestaltung und Aufsicht bei Präsenzprüfungen.
+  BC-4740.20.30:
+    name: Online- und Fernprüfung
+    description: |
+      Betrieb von Online- und Fernprüfungsüberwachung für Online-Prüfungen.
+  BC-4740.30:
+    name: Bewertungs- und Benotungsbetrieb
+    description: |
+      Bewertung studentischer Arbeit und Notenberechnung, einschließlich
+      Doppel- und anonymer Bewertung sowie Notenaggregatregeln.
+    in_scope:
+      - Anwendung von Bewertungsschemata
+      - Doppel- und anonyme Bewertung
+      - Notenaggregation und -berechnung
+    out_of_scope:
+      - Maßgebliche Notenerfassung (abgedeckt unter Studierendeneinschreibung & Immatrikulationsregisterverwaltung)
+  BC-4740.30.10:
+    name: Anwendung von Bewertungsschemata
+    description: |
+      Anwendung von Bewertungsschemata und Rubriken auf studentische Arbeiten.
+  BC-4740.30.20:
+    name: Doppel- und anonyme Bewertung
+    description: |
+      Betrieb von Doppelbewertungs- und anonymen Bewertungsworkflows.
+  BC-4740.30.30:
+    name: Notenaggregation und -berechnung
+    description: |
+      Aggregation und Berechnung von Teilnoten zu Endnoten.
+  BC-4740.40:
+    name: Moderation und Prüfungsausschüsse
+    description: |
+      Interne Moderation, Einbindung externer Prüfender und Entscheidungsfindung
+      durch Prüfungsausschüsse zu Abschlüssen und Studienfortschritt.
+    in_scope:
+      - Interne Moderation
+      - Koordination externer Prüfender
+      - Entscheidungsfindung des Prüfungsausschusses
+    out_of_scope:
+      - Überprüfung auf Programmebene (abgedeckt unter Akademische Qualität & Akkreditierungsmanagement)
+  BC-4740.40.10:
+    name: Interne Moderation
+    description: |
+      Interne Moderation von Bewertungsentscheidungen über Prüfende und Kohorten.
+  BC-4740.40.20:
+    name: Koordination externer Prüfender
+    description: |
+      Koordination externer Prüfender und ihrer Berichtszyklen.
+  BC-4740.40.30:
+    name: Entscheidungsfindung des Prüfungsausschusses
+    description: |
+      Entscheidungsfindung durch Prüfungsausschüsse zu Ergebnissen, Studienfortschritt
+      und Abschlüssen.
+  BC-4740.50:
+    name: Abschluss- und Qualifikationsausstellung
+    description: |
+      Veröffentlichung von Ergebnissen und Ausstellung von Abschlüssen und
+      Qualifikationen, einschließlich Bearbeitung von Ergebniseinsprüchen.
+    in_scope:
+      - Ergebnisveröffentlichung
+      - Ausstellung von Zertifikaten und Diplomen
+      - Bearbeitung von Ergebniseinsprüchen
+    out_of_scope:
+      - Verifizierbare digitale Zeugnisse (abgedeckt unter Studierendeneinschreibung & Immatrikulationsregisterverwaltung)
+  BC-4740.50.10:
+    name: Ergebnisveröffentlichung
+    description: |
+      Veröffentlichung vorläufiger und ratifizierter Ergebnisse an Studierende.
+  BC-4740.50.20:
+    name: Zertifikats- und Diplomausstellung
+    description: |
+      Ausstellung von Zertifikaten und Diplomen als Nachweis von Abschlüssen.
+  BC-4740.50.30:
+    name: Bearbeitung von Ergebniseinsprüchen
+    description: |
+      Bearbeitung von Studierendeneinsprüchen gegen Bewertungsergebnisse.
+  BC-4740.60:
+    name: Akademisches Integritätsmanagement
+    description: |
+      Aufdeckung, Untersuchung und Behebung akademischen Fehlverhaltens,
+      einschließlich Plagiarismus und Auftragsarbeiten.
+    in_scope:
+      - Plagiatsaufdeckung
+      - Fehlverhaltensuntersuchung
+      - Sanktionierung und Wiedergutmachung
+    out_of_scope:
+      - Forschungsfehlverhalten (abgedeckt unter Forschungs- und Stipendienwesen)
+  BC-4740.60.10:
+    name: Plagiatsaufdeckung
+    description: |
+      Aufdeckung von Plagiarismus und Auftragsarbeiten in eingereichten Arbeiten.
+  BC-4740.60.20:
+    name: Fehlverhaltensuntersuchung
+    description: |
+      Untersuchung vermuteter akademischer Fehlverhaltensfälle.
+  BC-4740.60.30:
+    name: Sanktionierung und Wiedergutmachung
+    description: |
+      Verhängung von Sanktionen und Wiedergutmachungsmaßnahmen bei bestätigtem
+      Fehlverhalten.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-audience-measurement-insights-management.yaml
+++ b/catalogue/i18n/de/L1-audience-measurement-insights-management.yaml
@@ -1,0 +1,114 @@
+locale: de
+source: L1-audience-measurement-insights-management.yaml
+entries:
+  BC-3770:
+    name: Publikumsmessung und Zuschaueranalyse
+    description: |
+      Erfassung von Einschaltquoten-Telemetrie, Panel- und
+      Census-Messung, Content-Leistungsanalyse, Empfehlungs-
+      Modellierung und Publikumsforschung über lineare, On-Demand-
+      und Live-Inhaltsdienste hinweg.
+  BC-3770.10:
+    name: Zuschauerdaten-Erfassung
+    description: |
+      Erfassung von linearem Tuning, OTT-Wiedergabe-Telemetrie
+      und Set-Top-Box-Census-Signalen in die Analytics-Plattform.
+  BC-3770.10.10:
+    name: Lineare Tuning-Daten-Erfassung
+    description: |
+      Erfassung linearer Tuning-Daten von Operator-Rückkanälen
+      und Partnerquellen.
+  BC-3770.10.20:
+    name: OTT-Wiedergabe-Telemetrie-Erfassung
+    description: |
+      Erfassung von OTT-Wiedergabe-Telemetrie von Clients und
+      Origin-Diensten für Analytics.
+  BC-3770.10.30:
+    name: Set-Top-Box-Census-Erfassung
+    description: |
+      Census-Erfassung von Set-Top-Box-Sehereignissen mit
+      angewendeten Datenschutzkontrollen.
+  BC-3770.20:
+    name: Publikumspanel- und Census-Messung
+    description: |
+      Panel-Kalibrierung, Erstellung von Währungsmessungen und
+      plattformübergreifende Publikumsdeduplizierung.
+  BC-3770.20.10:
+    name: Panel-Kalibrierung
+    description: |
+      Kalibrierung der panelbasierten Messung gegen
+      Census-Signale und demographische Rahmen.
+  BC-3770.20.20:
+    name: Währungsmessungs-Erstellung
+    description: |
+      Erstellung von Währungsklasse-Publikumsmessungskennzahlen
+      für Handel und Berichterstattung.
+  BC-3770.20.30:
+    name: Plattformübergreifende Publikums-Deduplizierung
+    description: |
+      Deduplizierung von Publikum über lineare, OTT- und digitale
+      Oberflächen zu einer einheitlichen plattformübergreifenden Sicht.
+  BC-3770.30:
+    name: Content-Leistungs-Analytics
+    description: |
+      Analytics zur Content-Leistung nach Titel, Kohorte und über
+      die Zeit zur Information von Beauftragung und Akquisition.
+  BC-3770.30.10:
+    name: Titel-Leistungs-Berichterstattung
+    description: |
+      Titelbasierte Leistungsberichterstattung zu Reichweite,
+      Vollständigkeit und Beitrag.
+  BC-3770.30.20:
+    name: Engagement-Funnel-Analytics
+    description: |
+      Funnel-Analytics über Entdeckung, Start, Vollständigkeit
+      und Folgeseher-Verhalten.
+  BC-3770.30.30:
+    name: Kohorten- und Lifetime-Value-Analytics
+    description: |
+      Kohorten-Retention- und Lifetime-Value-Analytics für
+      Direct-to-Consumer-Abonnenten.
+  BC-3770.40:
+    name: Content-Empfehlungs-Modellierung
+    description: |
+      Training, Testing und personalisierte Komposition von
+      Content-Empfehlungen für Zuschauer-Oberflächen.
+  BC-3770.40.10:
+    name: Empfehlungs-Modell-Training
+    description: |
+      Training und Lebenszyklus von Empfehlungsmodellen gegen
+      Sehe- und Metadaten-Signale.
+  BC-3770.40.20:
+    name: Empfehlungs-A/B-Test-Management
+    description: |
+      A/B-Testing und Multi-Armed-Bandits für Empfehlungsrichtlinien
+      und Oberflächenentscheidungen.
+  BC-3770.40.30:
+    name: Personalisierte Slate-Komposition
+    description: |
+      Komposition personalisierter Home-, Reihen- und Regal-Slates
+      für Zuschauer-Oberflächen.
+  BC-3770.50:
+    name: Publikumseinblicke und Forschungs-Management
+    description: |
+      Benutzerdefinierte quantitative und qualitative Publikums-
+      forschung sowie Synthese und Verteilung von Erkenntnissen
+      an das Unternehmen.
+  BC-3770.50.10:
+    name: Benutzerdefinierte Publikumsforschungs-Studien
+    description: |
+      Design und Durchführung benutzerdefinierter Publikumsstudien
+      einschließlich Segmentierungs- und Tracker-Arbeit.
+  BC-3770.50.20:
+    name: Qualitative Forschungs-Management
+    description: |
+      Qualitative Forschung mit Zuschauern einschließlich
+      Fokusgruppen und Tiefeninterviews.
+  BC-3770.50.30:
+    name: Erkenntnis-Synthese und Distribution
+    description: |
+      Synthese von Mess- und Forschungsoutputs in Erkenntnisse
+      und deren Verteilung an das Unternehmen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-audience-viewer-management.yaml
+++ b/catalogue/i18n/de/L1-audience-viewer-management.yaml
@@ -1,0 +1,116 @@
+locale: de
+source: L1-audience-viewer-management.yaml
+entries:
+  BC-3750:
+    name: Zuschauer- und Publikums-Management
+    description: |
+      Zuschauer-Identität, Abonnements und Berechtigungen,
+      Geräteübergreifende Authentifizierung, Engagement und
+      Bindung sowie Kindersicherung für Direct-to-Consumer-
+      Inhaltsdienste über OTT-, IPTV- und Pay-TV-Plattformen.
+  BC-3750.10:
+    name: Zuschauer-Identitätsmanagement
+    description: |
+      Bereitstellung und Pflege von Zuschauer-Konten, Haushalts-
+      konstrukten und föderierter Identität über Dienste hinweg.
+  BC-3750.10.10:
+    name: Zuschauer-Konto-Bereitstellung
+    description: |
+      Erstellung und Lebenszyklus von Zuschauer-Konten einschließlich
+      Konto-Merge- und Split-Operationen.
+  BC-3750.10.20:
+    name: Haushalts- und Profil-Management
+    description: |
+      Management von Haushaltskonstrukten und Zuschauer-Profilen
+      innerhalb gemeinsamer Konten.
+  BC-3750.10.30:
+    name: Identitäts-Föderierung
+    description: |
+      Föderierung der Zuschauer-Identität mit Operator-, Händler-
+      und Drittanbieter-Identitätsanbietern.
+  BC-3750.20:
+    name: Abonnements- und Berechtigungs-Management
+    description: |
+      Lebenszyklus von Zuschauer-Abonnements und den
+      Berechtigungsaufzeichnungen, die den Zugang zu
+      Inhaltsdiensten und -Stufen regeln.
+  BC-3750.20.10:
+    name: Abonnementplan-Registrierung
+    description: |
+      Registrierung von Zuschauern in Abonnements-, transaktionalen
+      und werbefinanzierten Plänen.
+  BC-3750.20.20:
+    name: Berechtigungs-Erteilung und Entzug
+    description: |
+      Erteilung und Entzug von Inhaltsberechtigungen durch
+      Abonnements, Käufe und Partnerpakete.
+  BC-3750.20.30:
+    name: Gleichzeitige Stream-Berechtigung
+    description: |
+      Berechtigungsgesteuerte Kontrolle gleichzeitiger Streams
+      und Geräteanzahl pro Konto.
+  BC-3750.30:
+    name: Geräteübergreifende Authentifizierung
+    description: |
+      Authentifizierung von Zuschauern über den Gerätebestand
+      einschließlich TV-Everywhere-Abläufe mit Operator-
+      Identitätsanbietern.
+  BC-3750.30.10:
+    name: Geräteregistrierung
+    description: |
+      Registrierung und Deregistrierung von Geräten gegen
+      Zuschauer-Konten.
+  BC-3750.30.20:
+    name: Authentifizierte Sitzungs-Management
+    description: |
+      Management authentifizierter Wiedergabesitzungen und
+      Token-Lebenszyklus über Geräte hinweg.
+  BC-3750.30.30:
+    name: TV-Everywhere-Authentifizierung
+    description: |
+      Authentifizierung von Pay-TV-Abonnenten gegen
+      Operator-Identitätsanbieter für Over-the-Top-Berechtigungen.
+  BC-3750.40:
+    name: Zuschauer-Engagement- und Bindungsmanagement
+    description: |
+      Modellierung, Journey-Design und Intervention zum Wachstum
+      von Inhaltsbindung und Reduzierung von Churn bei
+      Direct-to-Consumer-Diensten.
+  BC-3750.40.10:
+    name: Sehgewohnheits-Modellierung
+    description: |
+      Modellierung von Sehgewohnheiten, Wiedergabestatus und
+      Inhaltsaffinität für Engagement-Entscheidungen.
+  BC-3750.40.20:
+    name: Rückgewinnung- und Bindungsprogramm-Management
+    description: |
+      Design und Durchführung von Save-, Win-Back- und
+      Bindungsprogrammen für gefährdete und abgewanderte Zuschauer.
+  BC-3750.40.30:
+    name: Onboarding- und Aktivierungs-Journey-Management
+    description: |
+      Journeys für das Onboarding neuer Zuschauer und den Antrieb
+      der ersten bedeutungsvollen Wiedergabe-Aktivierung.
+  BC-3750.50:
+    name: Kindersicherung- und Profilbeschränkungs-Management
+    description: |
+      Konfiguration und Durchsetzung von Profil-Inhaltsbeschränkungen,
+      PIN-Sperren und Sehdauerlimits.
+  BC-3750.50.10:
+    name: Profilbasierte Inhaltsbeschränkung
+    description: |
+      Pro-Profil-Beschränkung von Inhalten nach Altersfreigabe,
+      Kategorie und benutzerdefinierten Sperrlisten.
+  BC-3750.50.20:
+    name: PIN- und Sperr-Management
+    description: |
+      PIN-, Profil-Sperr- und Kauf-Sperr-Management über
+      Geräte und Oberflächen hinweg.
+  BC-3750.50.30:
+    name: Sehdauerlimit-Konfiguration
+    description: |
+      Konfiguration von Sehdauerlimits, Tageszeit-Beschränkungen
+      und Bildschirmzeit-Kontrollen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-autonomous-driving-operations-management.yaml
+++ b/catalogue/i18n/de/L1-autonomous-driving-operations-management.yaml
@@ -1,0 +1,167 @@
+locale: de
+source: L1-autonomous-driving-operations-management.yaml
+entries:
+  BC-3470:
+    name: Autonomer Fahrbetrieb
+    description: |
+      Operativer Betrieb von automatisierten Fahrflotten –
+      Betriebsbereichs-Governance, Szenariobibliotheken,
+      ADS-Sicherheitsnachweis, Simulations- und Straßenvalidierung,
+      Teleoperation und Regulierungsengagement für Genehmigungen
+      und Vorfallmeldungen – verankert in ISO 21448, SAE J3016
+      und UN R157.
+  BC-3470.10:
+    name: Betriebsbereichs-Governance
+    description: |
+      Definition, Konformitätsüberwachung und Lebenszyklusmanagement
+      des Betriebsbereichs (ODD) für jede automatisierte Fahrfunktion.
+  BC-3470.10.10:
+    name: ODD-Definitions-Management
+    description: |
+      Definition des Betriebsbereichs einschließlich geografischer,
+      umgebungsbezogener und verhaltensbezogener Grenzen.
+  BC-3470.10.20:
+    name: ODD-Konformitätsüberwachung
+    description: |
+      Überwachung der In-Service-ODD-Konformität und Erkennung von
+      Betrieb außerhalb des definierten Bereichs.
+  BC-3470.10.30:
+    name: ODD-Grenz-Update-Management
+    description: |
+      Management von ODD-Erweiterungen und -Einschränkungen über
+      den Lebenszyklus einschließlich Genehmigung und Deployment.
+  BC-3470.20:
+    name: Fahrszenarien- und Testkatalog-Management
+    description: |
+      Kuratierung der Fahrszenarien-Bibliothek und des Testkatalogs
+      für Design, Simulation und Validierung automatisierter
+      Fahrsysteme.
+  BC-3470.20.10:
+    name: Szenariobibliotheks-Kuratierung
+    description: |
+      Kuratierung strukturierter Szenarien-Bibliotheken für ADS-Design
+      und -Validierung.
+  BC-3470.20.20:
+    name: Grenzfall-Erfassung und -Triage
+    description: |
+      Erfassung, Triage und Priorisierung von Grenzfällen aus
+      Simulation, Testflotten und Serienfahrzeugen.
+  BC-3470.20.30:
+    name: Szenarioabdeckungs-Berichterstattung
+    description: |
+      Berichterstattung zur Szenarioabdeckung und verbleibenden
+      Lücken gegenüber ODD-Anforderungen.
+  BC-3470.30:
+    name: Autonomer Flottenbetrieb
+    description: |
+      Täglicher Betrieb von Test-, Pilot- und kommerziellen
+      automatisierten Fahrflotten einschließlich Disposition,
+      Gesundheitszustand und Umrüstung.
+    in_scope:
+      - Disposition und Routenplanung autonomer Fahrzeuge
+      - Flottengesundheitsüberwachung und Grundwahrheits-Telemetrie
+      - Koordination von Laden, Reinigung und Umrüstung
+    out_of_scope:
+      - Fahrgastbuchung und -Preisgestaltung für Mobilitätsdienste (BC-3490)
+      - Fahrzeug-Engineering und Softwareentwicklung (BC-3400)
+  BC-3470.30.10:
+    name: Autonome Fahrzeug-Dispositionsbetrieb
+    description: |
+      Disposition und Routenplanung autonomer Fahrzeuge für Test-,
+      Pilot- und kommerzielle Einsätze.
+  BC-3470.30.20:
+    name: Autonome Flottengesundheitsüberwachung
+    description: |
+      Echtzeitüberwachung autonomer Flotten einschließlich
+      Sensorkalibrierung und Softwarestatus.
+  BC-3470.30.30:
+    name: Lade- und Reinigungskoordination für autonome Fahrzeuge
+    description: |
+      Koordination von Lade-, Reinigungs- und Umrüstungsaktivitäten
+      für autonome Flotten an Depots.
+  BC-3470.40:
+    name: Fernbetrieb und Teleassistenz
+    description: |
+      Betrieb von Teleassistenz-Zentren mit Fernunterstützung und
+      genehmigten Eingriffen für automatisierte Fahrflotten.
+  BC-3470.40.10:
+    name: Teleassistenz-Zentrum-Betrieb
+    description: |
+      Betrieb von Remote-Teleassistenz-Zentren einschließlich
+      Schichtmanagement und Eskalationswegen.
+  BC-3470.40.20:
+    name: Ferneingriff-Entscheidungsmanagement
+    description: |
+      Entscheidungsrahmen und Autorisierung für Ferneingriffe von
+      beratend bis zur direkten Fahrzeugsteuerung.
+  BC-3470.40.30:
+    name: Teleoperator-Personalmanagement
+    description: |
+      Rekrutierung, Schulung, Zertifizierung und Leistungsmanagement
+      des Teleoperator-Personals.
+  BC-3470.50:
+    name: Sicherheitsnachweis- und Assurance-Management
+    description: |
+      Pflege des operativen ADS-Sicherheitsnachweises und der
+      Indikatoren zur Überwachung seiner anhaltenden Gültigkeit.
+  BC-3470.50.10:
+    name: Sicherheitsnachweis-Erstellung
+    description: |
+      Erstellung des strukturierten ADS-Sicherheitsnachweises
+      einschließlich Behauptungen, Argumenten und Nachweisen.
+  BC-3470.50.20:
+    name: Sicherheitsargument-Pflege
+    description: |
+      Pflege von Sicherheitsargumenten bei Weiterentwicklung des
+      Systems, ODD und Betriebskontexts.
+  BC-3470.50.30:
+    name: Sicherheitsleistungsindikator-Verfolgung
+    description: |
+      Definition und Verfolgung führender und nachlaufender
+      Sicherheitsleistungsindikatoren für die eingesetzte Flotte.
+  BC-3470.60:
+    name: Autonomer Fahrt-Validierungsbetrieb
+    description: |
+      Operativer Betrieb der Validierungskampagnen – Simulation,
+      Versuchsgelände und öffentliche Straße – zur Bereitstellung
+      von Belegen für den Sicherheitsnachweis.
+  BC-3470.60.10:
+    name: Simulationsbasierter Validierungsbetrieb
+    description: |
+      Betrieb großangelegter Simulationsfarmen und
+      Szenario-Regression für ADS-Validierung.
+  BC-3470.60.20:
+    name: Geschlossener-Kurs-Validierungsbetrieb
+    description: |
+      Betrieb von geschlossenen Kursprüfprogrammen und
+      Versuchsgelände-Kampagnen für ADS-Validierung.
+  BC-3470.60.30:
+    name: Öffentlicher-Straßen-Erprobungsbetrieb
+    description: |
+      Betrieb überwachter Erprobungen auf öffentlichen Straßen
+      einschließlich Sicherheitsfahrer-Disziplin und
+      Vorfall-Management.
+  BC-3470.70:
+    name: ADS-Regulierungsengagement
+    description: |
+      Engagement mit Regulatoren und der Öffentlichkeit zu
+      automatisierten Fahrfreigaben, Vorfallmeldungen und
+      Vertrauensaufbau.
+  BC-3470.70.10:
+    name: ADS-Genehmigungen und Autorisierungs-Management
+    description: |
+      Management von Genehmigungen, Ausnahmen und Autorisierungen
+      für den ADS-Einsatz in den jeweiligen Rechtsgebieten.
+  BC-3470.70.20:
+    name: Vorfallmeldung an Regulatoren
+    description: |
+      Meldung von ADS-Vorfällen und Deaktivierungen an Regulatoren
+      sowie Koordination bei Untersuchungen.
+  BC-3470.70.30:
+    name: Öffentlichkeits- und Stakeholder-Engagement
+    description: |
+      Engagement mit Städten, Gemeinschaften und Stakeholdern
+      zum ADS-Einsatz, zur Sicherheit und zu Vorteilen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-aviation-safety-management.yaml
+++ b/catalogue/i18n/de/L1-aviation-safety-management.yaml
@@ -1,0 +1,114 @@
+locale: de
+source: L1-aviation-safety-management.yaml
+entries:
+  BC-1280:
+    name: Flugsicherheitsmanagement
+    description: |
+      Sicherheitsmanagementsystem, Risikobewertung, gerechte Sicherheitskultur und Vorfall-Untersuchung.
+  BC-1280.10:
+    name: Sicherheitsmanagementsystem-Management
+    description: |
+      SMS-Rahmenwerk, Sicherheitspolitik, Sicherheitsziele und Sicherheitssteuerung.
+  BC-1280.10.10:
+    name: Sicherheitspolitik und -ziele
+    description: |
+      Definition von Sicherheitspolitik und Sicherheitszielen.
+  BC-1280.10.20:
+    name: SMS-Rahmenwerk-Management
+    description: |
+      Pflege des SMS-Rahmenwerks gemäß ICAO Anhang 19.
+  BC-1280.10.30:
+    name: Sicherheitssteuerung und Rechenschaftspflicht
+    description: |
+      Sicherheitsüberprüfungsgremien und Regelungen für verantwortliche Manager.
+  BC-1280.10.40:
+    name: Sicherheitsressourcenmanagement
+    description: |
+      Zuteilung von Ressourcen für die Sicherheitsfunktion.
+  BC-1280.20:
+    name: Sicherheitsrisikobewertungs-Management
+    description: |
+      Gefahrenidentifikation, Risikobewertung und Risikominderung.
+  BC-1280.20.10:
+    name: Gefahrenidentifikation
+    description: |
+      Proaktive und reaktive Gefahrenidentifikation.
+  BC-1280.20.20:
+    name: Sicherheitsrisikobewertung
+    description: |
+      Bewertung von Wahrscheinlichkeit und Schwere von Sicherheitsrisiken.
+  BC-1280.20.30:
+    name: Sicherheitsrisikominderung
+    description: |
+      Definition und Verfolgung von Sicherheitsrisikominderungsmaßnahmen.
+  BC-1280.20.40:
+    name: Änderungssicherheitsbewertung
+    description: |
+      Sicherheitsbewertung betrieblicher und technischer Änderungen.
+  BC-1280.30:
+    name: Gerechte Sicherheitskultur- und Meldesystem-Management
+    description: |
+      Vertrauliche Meldungen, gerechte Sicherheitskultur und freiwillige Vorfall-Meldungen.
+  BC-1280.30.10:
+    name: Gerechte Sicherheitskultur-Programm
+    description: |
+      Programm zur gerechten Sicherheitskultur und Schutz von Meldern.
+  BC-1280.30.20:
+    name: Freiwillige Vorfall-Meldung
+    description: |
+      Freiwillige und vertrauliche Vorfall-Meldekanäle.
+  BC-1280.30.30:
+    name: Pflichtgemäße Vorfall-Meldung
+    description: |
+      Pflichtgemäße Vorfall-Meldung an Regulatoren.
+  BC-1280.40:
+    name: Vorfall-Untersuchungsmanagement
+    description: |
+      Interne Untersuchungen, Ursachenanalyse und Lessons Learned.
+  BC-1280.40.10:
+    name: Interne Vorfall-Untersuchung
+    description: |
+      Interne Untersuchung von Sicherheitsvorfällen.
+  BC-1280.40.20:
+    name: Ursachenanalyse
+    description: |
+      Ursachenanalyse von Vorfällen und mitwirkenden Faktoren.
+  BC-1280.40.30:
+    name: Untersuchungs-Lessons Learned
+    description: |
+      Erfassung und Verbreitung sicherheitsbezogener Lektionen.
+  BC-1280.50:
+    name: Sicherheitsleistungsüberwachungs-Management
+    description: |
+      SPIs, SPTs, Sicherheitsleistungs-Dashboards und Regulatorenberichterstattung.
+  BC-1280.50.10:
+    name: Sicherheitsleistungsindikator-Management
+    description: |
+      Definition und Verfolgung von SPIs und SPTs.
+  BC-1280.50.20:
+    name: Sicherheitstrend-Analyse
+    description: |
+      Trendanalyse von Vorfällen und SPI-Leistung.
+  BC-1280.50.30:
+    name: Sicherheitsberichterstattung an den Regulator
+    description: |
+      Periodische Sicherheitsleistungsberichterstattung an die Zivilluftfahrtbehörde.
+  BC-1280.60:
+    name: Sicherheitsförderungs-Management
+    description: |
+      Sicherheitskultur-Programme, Schulungen, Sensibilisierung und Kommunikation.
+  BC-1280.60.10:
+    name: Sicherheitskultur-Programm
+    description: |
+      Sicherheitskultur-Erhebungen und Verbesserungsprogramme.
+  BC-1280.60.20:
+    name: Sicherheitsschulungs-Durchführung
+    description: |
+      Durchführung von Sicherheitsschulungen und wiederkehrendem SMS-Training.
+  BC-1280.60.30:
+    name: Sicherheitskommunikation
+    description: |
+      Sicherheitskommunikation, Bulletins und Sensibilisierungskampagnen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-banking-customer-management.yaml
+++ b/catalogue/i18n/de/L1-banking-customer-management.yaml
@@ -1,0 +1,118 @@
+locale: de
+source: L1-banking-customer-management.yaml
+entries:
+  BC-1300:
+    name: Bankkunden-Management
+    description: |
+      Onboarding, KYC/CDD, Betreuung und Kanalzugang für Bankkunden.
+  BC-1300.10:
+    name: Kunden-Onboarding-Management
+    description: |
+      Kontoeröffnung, Identitätsverifizierung und Kontoaktivierung.
+  BC-1300.10.10:
+    name: Antragserfassung
+    description: |
+      Erfassung von Neukunden- und Kontoantragsdata.
+  BC-1300.10.20:
+    name: Identitätsverifizierung
+    description: |
+      Identitätsverifizierung einschließlich Dokument- und biometrischer Prüfungen.
+  BC-1300.10.30:
+    name: Kontoeinrichtung und -aktivierung
+    description: |
+      Einrichtung von Konten, Produkten und Kanalzugangsaktivierung.
+  BC-1300.10.40:
+    name: Onboarding-Statuskommunikation
+    description: |
+      Kundenkommunikation über den Onboarding-Status und nächste Schritte.
+  BC-1300.20:
+    name: KYC- und Kundensorgfaltspflicht-Management
+    description: |
+      KYC, CDD, EDD, regelmäßige Überprüfung und PEP-Screening.
+  BC-1300.20.10:
+    name: Kunden-Risikobewertung
+    description: |
+      Risikobewertung von Kunden auf Basis von AML-Risikofaktoren.
+  BC-1300.20.20:
+    name: KYC-Dokumentenerhebung
+    description: |
+      Erhebung und Validierung von KYC-Dokumentation.
+  BC-1300.20.30:
+    name: Sanktions- und PEP-Screening
+    description: |
+      Sanktions-, PEP- und Negativpresse-Screening.
+  BC-1300.20.40:
+    name: Erweiterte Due Diligence
+    description: |
+      EDD für Hochrisikokunden und komplexe Strukturen.
+  BC-1300.20.50:
+    name: Regelmäßige KYC-Überprüfung
+    description: |
+      Regelmäßige Überprüfung und Aktualisierung von Kunden-KYC-Informationen.
+  BC-1300.30:
+    name: Kundenbetreuungs-Management
+    description: |
+      Tägliche Serviceanfragen und Kontopflege.
+  BC-1300.30.10:
+    name: Kontopflege
+    description: |
+      Kontopflege einschließlich Limits, Bevollmächtigte und Adressen.
+  BC-1300.30.20:
+    name: Serviceanfragenbearbeitung
+    description: |
+      Bearbeitung von Kundenserviceanfragen und -aufträgen.
+  BC-1300.30.30:
+    name: Kontoauszugs- und Dokumentenbereitstellung
+    description: |
+      Bereitstellung von Auszügen, Bescheinigungen und Kundendokumenten.
+  BC-1300.30.40:
+    name: Kundenabschluss-Management
+    description: |
+      Kunden-Offboarding und Beendigung von Kundenbeziehungen.
+  BC-1300.40:
+    name: Kunden-Informations-Management
+    description: |
+      Kundendaten, Einwilligungen, Präferenzen und Golden Record.
+  BC-1300.40.10:
+    name: Kundenprofil-Pflege
+    description: |
+      Pflege von Kundenprofil und demografischen Daten.
+  BC-1300.40.20:
+    name: Wirtschaftlich-Berechtigten-Management
+    description: |
+      Erfassung und Pflege von Informationen zu wirtschaftlich Berechtigten.
+  BC-1300.40.30:
+    name: Kunden-Einwilligungs-Management
+    description: |
+      Erfassung und Durchsetzung von Marketing- und Datenweitergabeeinwilligungen.
+  BC-1300.40.40:
+    name: Kunden-Golden-Record-Management
+    description: |
+      Pflege des Kunden-Golden-Record systemübergreifend.
+  BC-1300.50:
+    name: Bankkanal-Management
+    description: |
+      Filial-, ATM-, Online-, Mobil- und Telefonkanal-Betrieb.
+  BC-1300.50.10:
+    name: Filialkanal-Betrieb
+    description: |
+      Betrieb des physischen Filialkanals und Kassendienstleistungen.
+  BC-1300.50.20:
+    name: ATM- und SB-Betrieb
+    description: |
+      Betrieb von ATM-, Kiosk- und Selbstbedienungsgeräten.
+  BC-1300.50.30:
+    name: Digitalkanal-Betrieb
+    description: |
+      Betrieb von Online- und Mobile-Banking-Kanälen.
+  BC-1300.50.40:
+    name: Telefonkanal-Betrieb
+    description: |
+      Betrieb von Telefon-Banking-Kanälen und Sprachauthentifizierung.
+  BC-1300.50.50:
+    name: Open-Banking- und API-Kanal-Betrieb
+    description: |
+      Betrieb von Open-Banking-APIs und Drittanbieterzugang.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-banking-product-management.yaml
+++ b/catalogue/i18n/de/L1-banking-product-management.yaml
@@ -1,0 +1,98 @@
+locale: de
+source: L1-banking-product-management.yaml
+entries:
+  BC-1310:
+    name: Bankprodukt-Management
+    description: |
+      Bankprodukt-Fabrik – Katalog, Parameter, Preisgestaltung und Lebenszyklus.
+  BC-1310.10:
+    name: Produktkatalog-Management
+    description: |
+      Bankprodukt-Katalog und Produkt-Stammdaten.
+  BC-1310.10.10:
+    name: Produkt-Stammdaten-Management
+    description: |
+      Pflege von Produkt-Stammdaten und Produkthierarchien.
+  BC-1310.10.20:
+    name: Produktkatalog-Publikation
+    description: |
+      Veröffentlichung des Produktkatalogs über Kanäle und Partner.
+  BC-1310.10.30:
+    name: Produktoffenlegungs-Management
+    description: |
+      Erstellung und Pflege von Produktoffenlegungsdokumenten.
+  BC-1310.20:
+    name: Produktparameter- und Konfigurationsmanagement
+    description: |
+      Zinssätze, Gebühren, Limits, Eignungsregeln und Produktparameter.
+  BC-1310.20.10:
+    name: Produktzins-Konfiguration
+    description: |
+      Konfiguration von Zinssätzen und Zinskarten.
+  BC-1310.20.20:
+    name: Produktgebühren-Konfiguration
+    description: |
+      Konfiguration von Produktgebühren und -befreiungen.
+  BC-1310.20.30:
+    name: Produktlimit-Konfiguration
+    description: |
+      Konfiguration von Transaktions- und Produktlimits.
+  BC-1310.20.40:
+    name: Produkteignungsregel-Konfiguration
+    description: |
+      Konfiguration von Eignungs- und Qualifikationsregeln.
+  BC-1310.30:
+    name: Bankprodukt-Preismanagement
+    description: |
+      Produktpreisgestaltung, Aktionen und kundenspezifische Preisgestaltung.
+  BC-1310.30.10:
+    name: Standard-Produktpreisgestaltung
+    description: |
+      Standardpreisgestaltung für Bankprodukte und -dienstleistungen.
+  BC-1310.30.20:
+    name: Aktionspreisgestaltung
+    description: |
+      Aktionspreiskampagnen und zeitlich begrenzte Angebote.
+  BC-1310.30.30:
+    name: Kunden- und Beziehungspreisgestaltung
+    description: |
+      Kunden- und beziehungsbasierte Preisgestaltung.
+  BC-1310.40:
+    name: Produktbündelungs-Management
+    description: |
+      Pakete, Bündel und Beziehungspreisgestaltung.
+  BC-1310.40.10:
+    name: Bündeldefinition
+    description: |
+      Definition von Produktbündeln, Paketen und Regeln.
+  BC-1310.40.20:
+    name: Bündeleignungs-Management
+    description: |
+      Eignungsregeln und Qualifikationskriterien für Bündel.
+  BC-1310.40.30:
+    name: Bündel-Leistungsverfolgung
+    description: |
+      Verfolgung von Bündelnutzung und -wirtschaftlichkeit.
+  BC-1310.50:
+    name: Bankprodukt-Lebenszyklusmanagement
+    description: |
+      Neuprodukteinführung, Rückzug und Auslaufen.
+  BC-1310.50.10:
+    name: Neuprodukt-Genehmigung
+    description: |
+      Neuprodukt-Genehmigungsprozess und Produktausschuss-Governance.
+  BC-1310.50.20:
+    name: Produkteinführungs-Durchführung
+    description: |
+      Produkteinführungsdurchführung und Kanalbereitschaft.
+  BC-1310.50.30:
+    name: Produkt-Leistungsüberprüfung
+    description: |
+      Regelmäßige Produkt-Leistungs- und Preis-Leistungs-Überprüfungen.
+  BC-1310.50.40:
+    name: Produktrückzug und -migration
+    description: |
+      Produktrückzug und Kundenmigration zu Nachfolgeprodukten.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-banking-risk-management.yaml
+++ b/catalogue/i18n/de/L1-banking-risk-management.yaml
@@ -1,0 +1,126 @@
+locale: de
+source: L1-banking-risk-management.yaml
+entries:
+  BC-1410:
+    name: Bankenrisiko-Management
+    description: |
+      Bankspezifische Risikoarten – Kredit-, Markt-, Liquiditäts-, Modell- und Kontrahentenausfallrisiko.
+  BC-1410.10:
+    name: Bankkredit-Risikomanagement
+    description: |
+      Kreditrisikorahmenwerk, RWA und Stresstesting.
+  BC-1410.10.10:
+    name: Kreditrisikorahmenwerk
+    description: |
+      Definition des Kreditrisikorahmenwerks und der Kreditrichtlinien.
+  BC-1410.10.20:
+    name: RWA-Berechnung und -Meldung
+    description: |
+      Standardansatz- und IRB-RWA-Berechnung und -Berichterstattung.
+  BC-1410.10.30:
+    name: Kreditstresstesting
+    description: |
+      Kreditrisiko-Stresstesting und Szenarioanalyse.
+  BC-1410.10.40:
+    name: Konzentrationsrisiko-Management
+    description: |
+      Einzelschuldner-, Branchen- und Länder-Konzentrationsrisikomanagement.
+  BC-1410.20:
+    name: Marktrisiko-Management
+    description: |
+      VaR, Sensitivitäten, Marktrisikolimits und FRTB.
+  BC-1410.20.10:
+    name: Marktrisiko-Messung
+    description: |
+      VaR-, ES- und Sensitivitätsmessung des Handelsbuchs.
+  BC-1410.20.20:
+    name: Marktrisikslimit-Management
+    description: |
+      Definition und Überwachung von Marktrisikolimits.
+  BC-1410.20.30:
+    name: Marktrisiko-Stresstesting
+    description: |
+      Marktrisiko-Stress- und Szenariotesting.
+  BC-1410.20.40:
+    name: FRTB-Implementierungsmanagement
+    description: |
+      Implementierung und Betrieb von FRTB-SA und IMA.
+  BC-1410.30:
+    name: Bankoperationelles-Risikomanagement
+    description: |
+      OpRisk-Rahmenwerk, RCSA und Verlustdaten.
+  BC-1410.30.10:
+    name: Operationelles-Risikorahmenwerk
+    description: |
+      Operationelles Risikorahmenwerk, Taxonomie und Richtlinien.
+  BC-1410.30.20:
+    name: Risiko- und Kontroll-Selbstbewertung
+    description: |
+      RCSA-Durchführung und Risikoprofil-Aktualisierungen.
+  BC-1410.30.30:
+    name: Operationelles-Risikoverlust-Erfassung
+    description: |
+      Erfassung und Klassifizierung operationeller Risikoereignisse.
+  BC-1410.30.40:
+    name: Operationelle-Risikoindikatoren-Management
+    description: |
+      KRI-Definition, -Schwellenwerte und -Überwachung.
+  BC-1410.40:
+    name: Liquiditätsrisiko-Management
+    description: |
+      Liquiditätsrisikorahmenwerk, Stresstesting und Notfallfinanzierungsplanung.
+  BC-1410.40.10:
+    name: Liquiditätsrisikorahmenwerk
+    description: |
+      Liquiditätsrisikorahmenwerk, -appetit und -richtlinien.
+  BC-1410.40.20:
+    name: Liquiditäts-Stresstesting
+    description: |
+      Liquiditätsspezifische Stress- und Reverse-Stresstests.
+  BC-1410.40.30:
+    name: Notfallfinanzierungsplan-Management
+    description: |
+      Notfallfinanzierungsplan-Pflege und -Testing.
+  BC-1410.50:
+    name: Modellrisiko-Management
+    description: |
+      Modellvalidierung, Modellgovernance und Modellinventar.
+  BC-1410.50.10:
+    name: Modellinventar-Management
+    description: |
+      Pflege des unternehmensweiten Modellinventars.
+  BC-1410.50.20:
+    name: Modellrisiko-Einstufung
+    description: |
+      Risikobasierte Einstufung von Modellen zur Governance-Priorisierung.
+  BC-1410.50.30:
+    name: Unabhängige-Modellvalidierung
+    description: |
+      Unabhängige Validierung von Modellen gemäß SR 11-7 / TRIM.
+  BC-1410.50.40:
+    name: Modell-Leistungsüberwachung
+    description: |
+      Laufende Leistungsüberwachung und Rekalibrierung von Modellen.
+  BC-1410.60:
+    name: Kontrahentenausfallrisiko-Management
+    description: |
+      CCR, CVA und Derivate-Kontrahentenexposure.
+  BC-1410.60.10:
+    name: Kontrahentenexposure-Messung
+    description: |
+      Messung des Kontrahentenexposures (PFE, EEPE).
+  BC-1410.60.20:
+    name: CVA- und XVA-Management
+    description: |
+      CVA-, DVA-, FVA- und sonstiges XVA-Management.
+  BC-1410.60.30:
+    name: Kontrahentenlimit-Management
+    description: |
+      Festlegung und Überwachung von Kontrahentenlimits.
+  BC-1410.60.40:
+    name: Wrong-Way-Risk-Management
+    description: |
+      Identifikation und Management von spezifischem und allgemeinem Wrong-Way-Risk.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-border-immigration-management.yaml
+++ b/catalogue/i18n/de/L1-border-immigration-management.yaml
@@ -1,0 +1,140 @@
+locale: de
+source: L1-border-immigration-management.yaml
+entries:
+  BC-3300:
+    name: Grenz- und Einwanderungsverwaltung
+    description: |
+      Personenbezogene Grenzkontrolle, Visa- und Reisegenehmigungen, Asyl-
+      und Flüchtlingsstatusbestimmung, Aufenthaltsstatus- und
+      Wohnsitzverwaltung, Einbürgerung und Abschiebungsoperationen.
+  BC-3300.10:
+    name: Visa- und Reisegenehmigungsverwaltung
+    description: |
+      Antragsbearbeitung, Entscheidungsfindung und Ausstellung von Visa
+      und Reisegenehmigungen einschließlich ETA-artiger Vorabgenehmigungen.
+    in_scope:
+      - Visaantragsbearbeitung und Entscheidungsfindung
+      - Elektronische Reisegenehmigung
+      - Visa-Betrugsprüfung
+    out_of_scope:
+      - Zollabfertigung und Handelscompliance (durch Zoll- und Handels-Compliance-Management abgedeckt)
+  BC-3300.10.10:
+    name: Visaantrags-Bearbeitung
+    description: |
+      Eingang, Validierung und Bearbeitung von Visaanträgen über alle Kategorien.
+  BC-3300.10.20:
+    name: Visa-Entscheidungsfindung
+    description: |
+      Entscheidungsfindung über Visaanträge einschließlich Ablehnung und Auflagen.
+  BC-3300.10.30:
+    name: Elektronische Reisegenehmigung
+    description: |
+      Ausstellung und Widerruf von ETA-artigen Vorabgenehmigungen für die Einreise.
+  BC-3300.10.40:
+    name: Visa-Betrugsprüfung
+    description: |
+      Prüfung von Anträgen auf Betrug, Urkundenfälschung und Identitätsdokument-Anomalien.
+  BC-3300.20:
+    name: Grenzinspektion und Einreisekontrolle
+    description: |
+      Inspektion und Einreisekontrolle von Reisenden an Grenzübergangsstellen
+      einschließlich Erst- und Zweitbefragung.
+  BC-3300.20.10:
+    name: Vorab-Passagierdaten-Verarbeitung
+    description: |
+      Verarbeitung von API- und PNR-Daten vor der Ankunft von Reisenden.
+  BC-3300.20.20:
+    name: Erstbefragung
+    description: |
+      Erstlinien-Inspektion an Grenzübergangsstellen einschließlich biometrischer Verifikation.
+  BC-3300.20.30:
+    name: Zweitbefragung
+    description: |
+      Zweitbefragung von Reisenden, die einer weiteren Prüfung bedürfen.
+  BC-3300.20.40:
+    name: Einreise- und Zurückweisungsentscheidung
+    description: |
+      Entscheidungsfindung über Einreise, Zurückweisung und Einreisebedingungen.
+  BC-3300.30:
+    name: Asyl- und Flüchtlingsstatusbestimmung
+    description: |
+      Eingang, Prüfung und Entscheidung über Asylanträge nach der
+      Genfer Flüchtlingskonvention von 1951 und nationalen Schutzregimen.
+  BC-3300.30.10:
+    name: Asylantrag-Aufnahme
+    description: |
+      Aufnahme und Registrierung von Asylanträgen an der Grenze und im Inland.
+  BC-3300.30.20:
+    name: Flüchtlingsstatus-Bestimmung
+    description: |
+      Adjudizierung des Flüchtlingsstatus nach der Konvention von 1951 und ergänzendem Schutz.
+  BC-3300.30.30:
+    name: Asylbewerber-Aufnahme und Unterstützungskoordination
+    description: |
+      Koordination von Aufnahme, Unterkunft und Grundversorgung für Asylbewerber.
+  BC-3300.30.40:
+    name: Umsiedlungs- und Humanitäre Aufnahmeprogramme
+    description: |
+      Betrieb von Umsiedlungs- und humanitären Aufnahmeprogrammen.
+  BC-3300.40:
+    name: Aufenthaltsstatus- und Wohnsitzverwaltung
+    description: |
+      Verwaltung des Aufenthaltsstatus im Inland einschließlich Aufenthaltserlaubnissen,
+      Arbeitserlaubnissen und Familienzusammenführungsfällen.
+  BC-3300.40.10:
+    name: Aufenthaltserlaubnis-Verwaltung
+    description: |
+      Ausstellung und Erneuerung von Aufenthaltserlaubnissen und biometrischen Aufenthaltstiteln.
+  BC-3300.40.20:
+    name: Arbeitserlaubnis-Verwaltung
+    description: |
+      Verwaltung von Arbeitserlaubnissen, Sponsoring-Lizenzen und Arbeitsmarktprüfungen.
+  BC-3300.40.30:
+    name: Familienzusammenführungs-Bearbeitung
+    description: |
+      Bearbeitung von Familienzusammenführungs- und Familienangehörigen-Anträgen.
+  BC-3300.40.40:
+    name: Statuscompliance-Monitoring
+    description: |
+      Monitoring der Compliance mit Auflagenbestimmungen und Statusänderungen.
+  BC-3300.50:
+    name: Einbürgerungs- und Staatsangehörigkeitsverwaltung
+    description: |
+      Adjudizierung von Einbürgerungsanträgen, Staatsangehörigkeit durch Abstammung
+      oder Eintragung sowie Staatsangehörigkeitsentzugs-Fällen.
+  BC-3300.50.10:
+    name: Einbürgerungsantrags-Bearbeitung
+    description: |
+      Bearbeitung von Einbürgerungsanträgen und Unbescholtenheitsbewertungen.
+  BC-3300.50.20:
+    name: Staatsangehörigkeit durch Abstammung und Eintragung
+    description: |
+      Feststellung der Staatsangehörigkeit durch Abstammung, Eintragung und Adoption.
+  BC-3300.50.30:
+    name: Einbürgerungszeremonie und Eidverwaltung
+    description: |
+      Durchführung von Einbürgerungsfeiern und Eidesablegungen zur Staatstreue.
+  BC-3300.50.40:
+    name: Staatsangehörigkeitsentzug-Bearbeitung
+    description: |
+      Adjudizierung von Staatsangehörigkeitsentzugs-, Verzichts- und Widerrufsfällen.
+  BC-3300.60:
+    name: Abschiebungs- und Abschiebehaft-Verwaltung
+    description: |
+      Abschiebehaft-, Abschiebungs- und freiwillige Rückkehr-Operationen für
+      Personen ohne Aufenthaltsstatus.
+  BC-3300.60.10:
+    name: Einwanderungs-Abschiebehaft-Betrieb
+    description: |
+      Betrieb von Abschiebehafteinrichtungen und Wohlfahrtsstandards.
+  BC-3300.60.20:
+    name: Abschiebungsbescheid-Vollstreckung
+    description: |
+      Vollstreckung von Abschiebungs- und Ausweisungsbescheiden einschließlich begleiteter Abschiebungen.
+  BC-3300.60.30:
+    name: Freiwillige Rückkehr-Programmoperationen
+    description: |
+      Koordination von unterstützten Freiwilligenrückkehr- und Reintegrationsprogrammen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-building-automation-system-engineering-management.yaml
+++ b/catalogue/i18n/de/L1-building-automation-system-engineering-management.yaml
@@ -1,0 +1,182 @@
+locale: de
+source: L1-building-automation-system-engineering-management.yaml
+entries:
+  BC-2010:
+    name: Gebäudeautomationssystem (GAS) Engineering Management
+    description: |
+      Produktentwicklung von GAS-Reglern, Feldgeräten, Supervisor-Software,
+      wiederverwendbaren Regelablaufbibliotheken, Kommunikationsprotokoll-Stacks, semantischen
+      Datenmodellen und GAS-Cybersicherheit — verankert in ISO 16484 / ASHRAE 135 (BACnet)
+      und ASHRAE Guideline 36.
+  BC-2010.10:
+    name: GAS-Regler-Produktentwicklung
+    description: |
+      Engineering anwendungsspezifischer Gebäuderegler-Produkte — Zonenregler, LG-Regler, Anlagenregler,
+      programmierbare Regler und Edge-Gateways.
+  BC-2010.10.10:
+    name: Zonenregler-Engineering
+    description: |
+      Engineering von Zonenreglern für VAV-, Gebläsekonvektor- und unitäre Steuerung.
+  BC-2010.10.20:
+    name: Lüftungsgeräte-Regler-Engineering
+    description: |
+      Engineering von Lüftungsgeräte-Reglern mit eingebauter Regelabfolgeunterstützung.
+  BC-2010.10.30:
+    name: Anlagen-Regler-Engineering
+    description: |
+      Engineering von Anlagenreglern für Kältemaschinen- und Heizkessel-Anlagen.
+  BC-2010.10.40:
+    name: Programmierbarer Regler-Engineering
+    description: |
+      Engineering frei programmierbarer GAS-Regler.
+  BC-2010.10.50:
+    name: Edge-Gateway-Engineering
+    description: |
+      Engineering von Edge-Gateways zur Übersetzung zwischen GAS- und IoT-/Cloud-Plattformen.
+  BC-2010.20:
+    name: GAS-Feldgeräte-Engineering
+    description: |
+      Engineering von Sensoren, Ventilen, Klappen und drahtlosen Feldgeräten für GAS.
+  BC-2010.20.10:
+    name: Sensor-Produktentwicklung
+    description: |
+      Engineering von Temperatur-, Feuchtigkeits-, Druck-, CO2- und IAQ-Sensoren als GAS-Geräte.
+  BC-2010.20.20:
+    name: Ventil- & Stellantrieb-Engineering
+    description: |
+      Engineering von Regelventilen und Ventilantrieben für Hydrauliksysteme.
+  BC-2010.20.30:
+    name: Klappenantrieb-Engineering
+    description: |
+      Engineering von Klappenantrieben für luftseitige GAS-Steuerung.
+  BC-2010.20.40:
+    name: Drahtlose Feldgeräte-Engineering
+    description: |
+      Engineering drahtloser Sensoren und Aktoren für Nachrüst- und IoT-Anwendungen.
+  BC-2010.30:
+    name: GAS-Supervisor-Software-Engineering
+    description: |
+      Engineering von Supervisor-Servern, Bedienerschnittstellen, Alarmmaschinen und Historisierern.
+  BC-2010.30.10:
+    name: Supervisor-Server-Engineering
+    description: |
+      Engineering von Head-End-Supervisor-Servern zur Verwaltung von Reglernetzwerken.
+  BC-2010.30.20:
+    name: Bediener-Schnittstellen-Engineering
+    description: |
+      Engineering grafischer Bedienerschnittstellen und Dashboards.
+  BC-2010.30.30:
+    name: Alarm- & Ereignis-Maschinen-Engineering
+    description: |
+      Engineering von Alarmverarbeitungs-, Priorisierungs- und Benachrichtigungsmaschinen.
+  BC-2010.30.40:
+    name: Trend- & Historisierer-Engineering
+    description: |
+      Engineering von Trendprotokollierungs- und Zeitreihen-Historisierer-Subsystemen.
+  BC-2010.40:
+    name: Regelablauf-Bibliotheks-Engineering
+    description: |
+      Engineering wiederverwendbarer, herstellerunabhängiger Regelablaufbibliotheken für HLK-Subsysteme.
+  BC-2010.40.10:
+    name: VAV-Sequenz-Bibliothek
+    description: |
+      Wiederverwendbare Sequenzen für Variabel-Volumenstrom-Zonensteuerung.
+  BC-2010.40.20:
+    name: Lüftungsgeräte-Sequenz-Bibliothek
+    description: |
+      Wiederverwendbare Sequenzen für Lüftungsgeräte-Steuerung.
+  BC-2010.40.30:
+    name: Zentralanlage-Sequenz-Bibliothek
+    description: |
+      Wiederverwendbare Sequenzen für Kältemaschinen- und Heizkessel-Anlagensteuerung.
+  BC-2010.40.40:
+    name: Erweiterte Steuerungssequenz-Bibliothek
+    description: |
+      Wiederverwendbare Sequenzen für modellprädiktive und optimierungsbasierte Steuerung.
+  BC-2010.50:
+    name: GAS-Kommunikationsprotokoll-Engineering
+    description: |
+      Engineering von Gebäudeautomations-Kommunikationsprotokoll-Stacks und Treibern.
+  BC-2010.50.10:
+    name: BACnet-Stack-Engineering
+    description: |
+      Engineering von BACnet/IP- und BACnet/MSTP-Protokoll-Stacks.
+  BC-2010.50.20:
+    name: KNX & LonWorks-Stack-Engineering
+    description: |
+      Engineering von KNX- und LonWorks-Protokoll-Stacks.
+  BC-2010.50.30:
+    name: Modbus & DALI-Treiber-Engineering
+    description: |
+      Engineering von Modbus- und DALI-Treibern für HLK- und Beleuchtungsintegration.
+  BC-2010.50.40:
+    name: OPC-UA-Server-Engineering
+    description: |
+      Engineering von OPC-UA-Servern für industriegradige GAS-Interoperabilität.
+  BC-2010.50.50:
+    name: MQTT & IoT-Messaging-Engineering
+    description: |
+      Engineering von MQTT- und IoT-Messaging-Schnittstellen für Cloud-Konnektivität.
+  BC-2010.60:
+    name: Gebäude-Semantisches Datenmodell-Engineering
+    description: |
+      Engineering semantischer Modelle, Ontologien und Namenskonventionen für maschineninterpretierfähige GAS-Daten.
+  BC-2010.60.10:
+    name: Brick-Schema-Modellierung
+    description: |
+      Engineering von Brick-Schema-Modellen zur Beschreibung von Gebäudetopologie und Ausrüstung.
+  BC-2010.60.20:
+    name: Haystack-Tag-Bibliotheks-Engineering
+    description: |
+      Engineering von Haystack-Tag-Bibliotheken und Tagging-Konventionen.
+  BC-2010.60.30:
+    name: Punkte- & Namenskonventions-Bibliothek
+    description: |
+      Pflege von Punktnamen- und Tag-Namenskonventions-Bibliotheken.
+  BC-2010.60.40:
+    name: Asset-Ontologie-Engineering
+    description: |
+      Engineering von Asset-Ontologien, die GAS-Daten mit Ausrüstung und Standorten verknüpfen.
+  BC-2010.70:
+    name: GAS-Cybersicherheits-Engineering
+    description: |
+      Secure-by-Design-Engineering von GAS-Produkten, -Netzwerken und Identitätskontrollen.
+  BC-2010.70.10:
+    name: Sichere Regler-Architektur
+    description: |
+      Secure Boot, sichere Updates und gehärtete Regler-Architektur.
+  BC-2010.70.20:
+    name: GAS-Netzwerk-Segmentierungs-Design
+    description: |
+      Segmentierungsmuster und Zonierung von GAS-Netzwerken.
+  BC-2010.70.30:
+    name: Authentifizierungs- & Identitäts-Engineering
+    description: |
+      Engineering von Geräte-, Benutzer- und Dienstidentität für GAS.
+  BC-2010.70.40:
+    name: GAS-Schwachstellenmanagement-Engineering
+    description: |
+      Engineering von Produkt-Schwachstellen-Triage, -Patching und -Offenlegung für GAS-Produkte.
+  BC-2010.80:
+    name: GAS-Produkt-Verifizierung & Konformität
+    description: |
+      Verifizierung von GAS-Produkten hinsichtlich Protokollkonformität, Interoperabilität und Listing-Bereitschaft.
+  BC-2010.80.10:
+    name: Protokollkonformitäts-Testung
+    description: |
+      Tests von Produkten gegen BACnet-, LonMark-, KNX- und andere Protokollkonformitäts-Suiten.
+  BC-2010.80.20:
+    name: Interoperabilitätslabor-Testung
+    description: |
+      Mehrherstellerfähige Interoperabilitätstests in dedizierten Labors.
+  BC-2010.80.30:
+    name: Protokoll-Regressionstestung
+    description: |
+      Regressionstests von Protokoll-Stacks über Firmware-Revisionen hinweg.
+  BC-2010.80.40:
+    name: Konformitätsdokumentation
+    description: |
+      Erstellung von PICS-, BIBB- und gleichwertigen Konformitätsdokumentationen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-building-performance-management.yaml
+++ b/catalogue/i18n/de/L1-building-performance-management.yaml
@@ -1,0 +1,173 @@
+locale: de
+source: L1-building-performance-management.yaml
+entries:
+  BC-2070:
+    name: Gebäudeleistung Management
+    description: |
+      Kontinuierliche, datengesteuerte Optimierung der Gebäudeleistung — Energiemessung und
+      -verifizierung (IPMVP/ASHRAE Guideline 14), Fehlerkennung und Diagnostik, Energie- und
+      IAQ-Analytik, Laststeuerung und Netzinteraktion, CO2- und Nachhaltigkeitsverfolgung
+      sowie periodische Leistungsberichterstattung an Gebäudeeigentümer.
+  BC-2070.10:
+    name: Energie-Messung & Verifizierung
+    description: |
+      Baseline-Modellierung, Einsparberechnung und Anpassung der Energieleistung gemäß IPMVP/ASHRAE Guideline 14.
+  BC-2070.10.10:
+    name: Baseline-Modellierung
+    description: |
+      Modellierung von Energie-Baselines, gegen die Einsparungen gemessen werden.
+  BC-2070.10.20:
+    name: Mess- & Verifizierungsplan-Erstellung
+    description: |
+      Erstellung von Mess- und Verifizierungsplänen entsprechend anerkannter Protokolle.
+  BC-2070.10.30:
+    name: Einsparberechnung
+    description: |
+      Berechnung von Energieeinsparungen gegen die Baseline.
+  BC-2070.10.40:
+    name: Anpassung & Normalisierung
+    description: |
+      Anpassung und Normalisierung von M&V-Ergebnissen für Witterung und Belegung.
+  BC-2070.20:
+    name: Fehlerkennung & Diagnostik-Betrieb
+    description: |
+      Betrieb von FDD-Regelbibliotheken und laufende Triage erkannter Fehler.
+  BC-2070.20.10:
+    name: FDD-Regelbibliotheks-Management
+    description: |
+      Pflege von Fehlerkennung- und Diagnostik-Regelbibliotheken.
+  BC-2070.20.20:
+    name: Fehler-Triage & Priorisierung
+    description: |
+      Triage und Priorisierung erkannter Fehler nach Auswirkung.
+  BC-2070.20.30:
+    name: Grundursachen-Diagnose-Analyse
+    description: |
+      Diagnoseanalyse zur Identifikation von Grundursachen hinter erkannten Fehlern.
+  BC-2070.20.40:
+    name: FDD-Falsch-Positiv-Abstimmung
+    description: |
+      Abstimmung von FDD-Regeln zur Reduzierung von Falsch-Positiv-Alarmraten.
+  BC-2070.30:
+    name: Energieleistungs-Analytik
+    description: |
+      Analytik des Energieverbrauchs über das Gebäudeportfolio.
+  BC-2070.30.10:
+    name: Benchmarking & Peer-Vergleich
+    description: |
+      Benchmarking der Gebäudeenergieeffizienz gegen Vergleichsgebäude.
+  BC-2070.30.20:
+    name: Energieverbrauchs-Zurechnung
+    description: |
+      Zurechnung des Energieverbrauchs auf Systeme, Zonen und Lasten.
+  BC-2070.30.30:
+    name: Energie-Anomalie-Erkennung
+    description: |
+      Erkennung von Anomalien in Energieverbrauchsmustern.
+  BC-2070.30.40:
+    name: Prognose & Zielsetzung
+    description: |
+      Prognose des künftigen Energieverbrauchs und Zielsetzung gegen Verbesserungsziele.
+  BC-2070.40:
+    name: Innenraumklima-Analytik
+    description: |
+      Analytik von Innenraumklimaergebnissen, einschließlich Komfort-, Luft-, Akustik- und Beleuchtungsmetriken.
+  BC-2070.40.10:
+    name: Thermischer Komfort-Analytik
+    description: |
+      Analytik des thermischen Komforts gegen ASHRAE 55 und gleichwertige Kriterien.
+  BC-2070.40.20:
+    name: Luftqualitäts-Analytik
+    description: |
+      Analytik der Raumluftqualität gegen ASHRAE 62.1 und gleichwertige Kriterien.
+  BC-2070.40.30:
+    name: Akustik- & Beleuchtungs-Analytik
+    description: |
+      Analytik akustischer und Beleuchtungsleistung für Nutzerergebnisse.
+  BC-2070.40.40:
+    name: Nutzer-Feedback-Korrelation
+    description: |
+      Korrelation von Nutzerfeedback mit gemessenen Umweltdaten.
+  BC-2070.50:
+    name: Laststeuerungs- & Netzinteraktions-Management
+    description: |
+      Betrieb netzinteraktiven Gebäudeverhaltens und Teilnahme an Laststeuerungsprogrammen.
+  BC-2070.50.10:
+    name: Laststeuerungsprogramm-Einschreibung
+    description: |
+      Einschreibung von Gebäuden in Laststeuerungsprogramme.
+  BC-2070.50.20:
+    name: Lastabregelungs-Durchführung
+    description: |
+      Durchführung von Lastabregelungs-Ereignissen gegen vertragliche Verpflichtungen.
+  BC-2070.50.30:
+    name: Netzinteraktiver Gebäudebetrieb
+    description: |
+      Betrieb netzinteraktiver Effizienzgebäude.
+  BC-2070.50.40:
+    name: Tarif- & Preisreaktion
+    description: |
+      Reaktion des Gebäudebetriebs auf Zeitvariable- und Dynamiktarife.
+  BC-2070.60:
+    name: CO2- & Nachhaltigkeits-Leistungs-Tracking
+    description: |
+      Gebäudebezogene Betriebskohlenstoff-Buchführung und Nachhaltigkeitsergebnis-Tracking.
+  BC-2070.60.10:
+    name: Betriebskohlenstoff-Buchführung
+    description: |
+      Buchführung der Betriebskohlenstoffemissionen auf Gebäudeebene.
+  BC-2070.60.20:
+    name: Erneuerbare Energie-Zuteilung
+    description: |
+      Zuteilung von vor-Ort- und vertraglich gesicherter erneuerbarer Energie an Gebäude.
+  BC-2070.60.30:
+    name: ESG-Gebäudeebenen-Metriken
+    description: |
+      Berechnung von ESG-Metriken auf Gebäudeebene für Portfolio-Berichterstattung.
+  BC-2070.60.40:
+    name: Nachhaltigkeitszertifizierungs-Leistungs-Tracking
+    description: |
+      Verfolgung der Leistung gegen Grünes-Gebäude-Zertifizierungskriterien.
+  BC-2070.70:
+    name: Leistungsverbesserungs-Empfehlungs-Management
+    description: |
+      Identifikation und Verwaltung von Leistungsverbesserungsmöglichkeiten und Einsparpotenzial.
+  BC-2070.70.10:
+    name: Chancen-Identifikation
+    description: |
+      Identifikation von Leistungsverbesserungsmöglichkeiten aus Analytik.
+  BC-2070.70.20:
+    name: Einspar-Business-Case
+    description: |
+      Entwicklung von Business-Cases zur Unterstützung empfohlener Verbesserungen.
+  BC-2070.70.30:
+    name: Empfehlungs-Priorisierung
+    description: |
+      Priorisierung von Empfehlungen über das Portfolio.
+  BC-2070.70.40:
+    name: Implementierungs-Tracking
+    description: |
+      Verfolgung der Implementierung akzeptierter Empfehlungen.
+  BC-2070.80:
+    name: Leistungs-Berichterstattung & Dashboard-Betrieb
+    description: |
+      Eigentümer-Dashboards, periodische Berichte und regulatorische Leistungsberichterstattung.
+  BC-2070.80.10:
+    name: Eigentümer-Dashboard-Betrieb
+    description: |
+      Betrieb eigentümerorientierter Leistungs-Dashboards.
+  BC-2070.80.20:
+    name: Periodische Leistungs-Berichterstattung
+    description: |
+      Erstellung periodischer Leistungsberichte für Kunden.
+  BC-2070.80.30:
+    name: Regulatorische Leistungs-Berichterstattung
+    description: |
+      Berichterstattung der Gebäudeleistung an regulatorische Programme (z.B. obligatorisches Benchmarking).
+  BC-2070.80.40:
+    name: Stakeholder-Leistungs-Briefings
+    description: |
+      Briefings für Nutzer, Investoren und Stakeholder zur Gebäudeleistung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-building-systems-commissioning-management.yaml
+++ b/catalogue/i18n/de/L1-building-systems-commissioning-management.yaml
@@ -1,0 +1,172 @@
+locale: de
+source: L1-building-systems-commissioning-management.yaml
+entries:
+  BC-2050:
+    name: Inbetriebnahme von Gebäudesystemen Management
+    description: |
+      Inbetriebnahme von HLK- und GAS-Systemen als lieferbare Dienstleistung — Erstinbetriebnahme,
+      Retrocommissioning, Recommissioning und überwachungsbasiertes Commissioning. Verankert in
+      ASHRAE Guideline 0/Guideline 1.1 für den gesamten Gebäude-Commissioning-Prozess.
+  BC-2050.10:
+    name: Commissioning-Planung & Umfangsdefinition
+    description: |
+      Aufstellung des Commissioning-Programms, Umfangs und der Abnahmebasis für das Projekt.
+  BC-2050.10.10:
+    name: Eigentümer-Projektanforderungen-Überprüfung
+    description: |
+      Überprüfung der Eigentümer-Projektanforderungen als Commissioning-Baseline.
+  BC-2050.10.20:
+    name: Designbasis-Überprüfung
+    description: |
+      Überprüfung der Designbasis gegen die Eigentümer-Projektanforderungen.
+  BC-2050.10.30:
+    name: Commissioning-Plan-Erstellung
+    description: |
+      Erstellung des Commissioning-Plans mit Definition von Umfang, Rollen und Abnahme.
+  BC-2050.10.40:
+    name: Commissioning-Risikoregister
+    description: |
+      Pflege des Commissioning-Risikoregisters durch die Lieferung.
+  BC-2050.20:
+    name: Vorfunktionale Inspektions-Management
+    description: |
+      Verifizierung der Installationsvollständigkeit und Anlaufbereitschaft vor Funktionstests.
+  BC-2050.20.10:
+    name: Installationsverifizierungs-Checklisten
+    description: |
+      Durchführung von Installationsverifizierungs-Checklisten.
+  BC-2050.20.20:
+    name: Anlauf-Inspektion
+    description: |
+      Inspektion des Geräteanlaufs gegen Herstelleranforderungen.
+  BC-2050.20.30:
+    name: Vorfunktionale Probleme-Protokollierung
+    description: |
+      Protokollierung vorfunktionaler Probleme im Commissioning-Problemprotokoll.
+  BC-2050.20.40:
+    name: Vorfunktionale Abzeichnung
+    description: |
+      Abzeichnung, dass vorfunktionale Bereitschaft erreicht wurde.
+  BC-2050.30:
+    name: Funktionale Leistungstestung
+    description: |
+      Funktionale Leistungstests von HLK- und GAS-Subsystemen gegen dokumentierte Kriterien.
+  BC-2050.30.10:
+    name: Testskript-Erstellung
+    description: |
+      Erstellung von Funktionstestskripten gegen Designkonzept.
+  BC-2050.30.20:
+    name: Test-Durchführung & Zeugenschaft
+    description: |
+      Durchführung und Zeugenschaft funktionaler Tests an HLK- und GAS-Systemen.
+  BC-2050.30.30:
+    name: Test-Problem-Lösung
+    description: |
+      Lösung von während der Funktionstestung identifizierten Problemen.
+  BC-2050.30.40:
+    name: Testergebnis-Genehmigung
+    description: |
+      Genehmigung von Testergebnissen und Abschluss von Testfällen.
+  BC-2050.40:
+    name: Regelablauf-Verifizierung
+    description: |
+      Verifizierung programmierter Regelsequenzen gegen die entworfenen Regelabläufe.
+  BC-2050.40.10:
+    name: Regellogik-Durchgang
+    description: |
+      Durchgang der Regellogik gegen erstellte Sequenzen.
+  BC-2050.40.20:
+    name: Sollwert- & Betriebsmodus-Verifizierung
+    description: |
+      Verifizierung von Sollwerten und Betriebsmodi über Zeitpläne.
+  BC-2050.40.30:
+    name: Übersteuerungs- & Ausfallmodus-Testung
+    description: |
+      Testung von Übersteuerungspfaden und Ausfallmodusverhalten.
+  BC-2050.40.40:
+    name: Trendbasierte Verifizierung
+    description: |
+      Verwendung von Trenddaten zur Verifizierung der Sequenzleistung über Zeit.
+  BC-2050.50:
+    name: Integrierte Systemtestung
+    description: |
+      Tests integrierter systemübergreifender Verhaltensweisen mit HLK-, Brandschutz- und Elektrosystemen.
+  BC-2050.50.10:
+    name: Brand- & Lebenssicherheits-Integrations-Test
+    description: |
+      Integrationstests für HLK-Wechselwirkungen mit Brand- und Lebenssicherheitssystemen.
+  BC-2050.50.20:
+    name: Rauchschutz- & Druckbeaufschlagungs-Test
+    description: |
+      Tests von Rauchschutz- und Druckbeaufschlagungssequenzen.
+  BC-2050.50.30:
+    name: Stromausfall- & Lastabwurf-Test
+    description: |
+      Tests des HLK-Verhaltens bei Stromausfall und Lastabwurf-Ereignissen.
+  BC-2050.50.40:
+    name: Gebäudenetzwerk-Integrations-Test
+    description: |
+      Integrationstests über GAS- und benachbarte Gebäude-IT-Netzwerke.
+  BC-2050.60:
+    name: Retrocommissioning & Recommissioning
+    description: |
+      Commissioning-Dienstleistung für bestehende Gebäude und als periodische Recommissioning-Zyklen.
+  BC-2050.60.10:
+    name: Bestandsgebäude-Untersuchung
+    description: |
+      Untersuchung der Bestandsgebäudeleistung gegen aktuelles Konzept.
+  BC-2050.60.20:
+    name: Leistungslücken-Analyse
+    description: |
+      Analyse von Leistungslücken und Grundursachen in bestehenden Gebäuden.
+  BC-2050.60.30:
+    name: Retrocommissioning-Maßnahmen-Implementierung
+    description: |
+      Implementierung von Retrocommissioning-Maßnahmen über bestehende Systeme.
+  BC-2050.60.40:
+    name: Recommissioning-Zyklus-Durchführung
+    description: |
+      Durchführung periodischer Recommissioning-Zyklen für nachhaltige Leistung.
+  BC-2050.70:
+    name: Überwachungsbasiertes Commissioning
+    description: |
+      Kontinuierliches, datengesteuertes Commissioning mittels Instrumentierung und Telemetrie.
+  BC-2050.70.10:
+    name: Überwachungsplan & Instrumentierung
+    description: |
+      Erstellung von Überwachungsplänen und Auswahl unterstützender Instrumentierung.
+  BC-2050.70.20:
+    name: Kontinuierliches Leistungs-Trending
+    description: |
+      Kontinuierliches Trending der Gebäudeleistung für Commissioning-Erkenntnisse.
+  BC-2050.70.30:
+    name: Anomalie-Untersuchung
+    description: |
+      Untersuchung erkannter Anomalien aus kontinuierlichen Trends.
+  BC-2050.70.40:
+    name: Persistenz-Verifizierung
+    description: |
+      Verifizierung, dass kommissionierte Leistung im Zeitverlauf anhält.
+  BC-2050.80:
+    name: Commissioning-Dokumentation & Abschluss
+    description: |
+      Erstellung von Commissioning-Lieferungen und formaler Abschluss des Commissioning-Umfangs.
+  BC-2050.80.10:
+    name: Commissioning-Bericht-Erstellung
+    description: |
+      Erstellung des abschließenden Commissioning-Berichts.
+  BC-2050.80.20:
+    name: System-Handbuch-Zusammenstellung
+    description: |
+      Zusammenstellung des System-Handbuchs für den Eigentümerbetrieb.
+  BC-2050.80.30:
+    name: Eigentümer-Schulungs-Lieferung
+    description: |
+      Lieferung von Eigentümerschulungen zu kommissionierten Systemen.
+  BC-2050.80.40:
+    name: Endabnahme-Abzeichnung
+    description: |
+      Abschließende Commissioning-Abzeichnung und Übergabe an den Betrieb.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-business-continuity-management.yaml
+++ b/catalogue/i18n/de/L1-business-continuity-management.yaml
@@ -1,0 +1,90 @@
+locale: de
+source: L1-business-continuity-management.yaml
+entries:
+  BC-160:
+    name: Betriebskontinuitätsmanagement
+    description: |
+      Resilienzplanung, Notfallwiederherstellung und Krisenreaktion.
+  BC-160.10:
+    name: Betriebskontinuitätsplanung
+    description: |
+      Business-Impact-Analyse, Planentwicklung und Kontinuitätsstrategien.
+  BC-160.10.10:
+    name: Business-Impact-Analyse
+    description: |
+      Identifikation kritischer Prozesse, RTO, RPO und Abhängigkeiten.
+  BC-160.10.20:
+    name: Kontinuitätsstrategie-Definition
+    description: |
+      Auswahl von Kontinuitätsstrategien und Wiederherstellungsoptionen.
+  BC-160.10.30:
+    name: Kontinuitätsplanentwicklung
+    description: |
+      Dokumentation von Betriebskontinuitätsplänen gemäß ISO 22301.
+  BC-160.10.40:
+    name: Planpflege und -aktualität
+    description: |
+      Periodische Überprüfung und Aktualisierung der Kontinuitätspläne.
+  BC-160.20:
+    name: Notfallwiederherstellungsmanagement
+    description: |
+      IT- und operative Notfallwiederherstellung.
+  BC-160.20.10:
+    name: IT-Dienstwiederherstellungsplanung
+    description: |
+      Wiederherstellungspläne für kritische IT-Dienste und Infrastruktur.
+  BC-160.20.20:
+    name: Datensicherungs- und Wiederherstellungsmanagement
+    description: |
+      Datensicherungsstrategien, Unveränderlichkeit und Wiederherstellungsvalidierung.
+  BC-160.20.30:
+    name: Failover- und Standortwiederherstellungsbetrieb
+    description: |
+      Failover, Aktivierung des Ausweichstandorts und operationelle Wiederherstellung.
+  BC-160.20.40:
+    name: Operative Wiederherstellungskoordination
+    description: |
+      Koordination des Geschäftsbetriebs bei aktivierter Wiederherstellung.
+  BC-160.30:
+    name: Krisenmanagement
+    description: |
+      Krisenreaktion, Führungsstruktur und Eskalation.
+  BC-160.30.10:
+    name: Krisenführungsstruktur
+    description: |
+      Krisenmanagementteam, Rollen und Führungs- und Kontrollstruktur.
+  BC-160.30.20:
+    name: Krisenkommunikation
+    description: |
+      Interne und externe Krisenkommunikation und Stakeholdermanagement.
+  BC-160.30.30:
+    name: Vorfallseskalation und -aktivierung
+    description: |
+      Schweregradungseinstufung, Eskalationspfade und Planaktivierung.
+  BC-160.30.40:
+    name: Krisenüberprüfung nach Ereignis
+    description: |
+      Lessons Learned und Verbesserungsmaßnahmen nach Krisen.
+  BC-160.40:
+    name: Resilienzprüfungen und Übungen
+    description: |
+      Übungen, Drills und Planvalidierung.
+  BC-160.40.10:
+    name: Tabletop- und Simulationsübungen
+    description: |
+      Tabletop-, Walkthrough- und simulationsbasierte Übungen.
+  BC-160.40.20:
+    name: Live-Failover-Tests
+    description: |
+      Live-Failover- und Wiederherstellungstests gegenüber RTO- und RPO-Zielen.
+  BC-160.40.30:
+    name: Übungsprogrammmanagement
+    description: |
+      Jährlicher Übungskalender, Umfang und Stakeholderabdeckung.
+  BC-160.40.40:
+    name: Testergebnisse und Verbesserungsverfolgung
+    description: |
+      Erfassung von Übungsergebnissen und Nachverfolgung von Verbesserungsmaßnahmen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-capital-markets-operations-management.yaml
+++ b/catalogue/i18n/de/L1-capital-markets-operations-management.yaml
@@ -1,0 +1,154 @@
+locale: de
+source: L1-capital-markets-operations-management.yaml
+entries:
+  BC-1380:
+    name: Kapitalmarktabwicklungs-Management
+    description: |
+      Handelsbestätigung, Clearing, Abwicklung, Verwahrung, Sicherheiten, Kapitalmaßnahmen und Abstimmung.
+  BC-1380.10:
+    name: Handelsbestätigungs-Management
+    description: |
+      Handelserfassung, -buchung, -bestätigung und Reklamation.
+  BC-1380.10.10:
+    name: Handelserfassung und -buchung
+    description: |
+      Erfassung und Buchung von Transaktionen in Front- und Middle-Office-Systemen.
+  BC-1380.10.20:
+    name: Handelsbestätigungs-Abgleich
+    description: |
+      Abgleich und Bestätigung von Handelsbestätigungen.
+  BC-1380.10.30:
+    name: Handelsreklamations-Bearbeitung
+    description: |
+      Bearbeitung von Reklamationen und nicht abgeglichenen Geschäften.
+  BC-1380.20:
+    name: Clearing-Management
+    description: |
+      Zentrales Clearing, CCP und Clearing-Mitgliedschaft.
+  BC-1380.20.10:
+    name: CCP-Handelseinreichung
+    description: |
+      Einreichung geclearter Geschäfte bei zentralen Gegenparteien.
+  BC-1380.20.20:
+    name: Clearing-Margenanforderungs-Management
+    description: |
+      Ersteinschuss- und Nachschussmanagement mit CCPs.
+  BC-1380.20.30:
+    name: Clearing-Mitglieds-Betrieb
+    description: |
+      Betrieb von Direkt- und Kunden-Clearing-Mitgliedschaftsdienstleistungen.
+  BC-1380.30:
+    name: Abwicklungs-Management
+    description: |
+      DvP-Abwicklung, T+1/T+2-Zyklen und Fehlerverwaltung.
+  BC-1380.30.10:
+    name: Abwicklungsanweisungs-Erstellung
+    description: |
+      Erstellung von Abwicklungsanweisungen für Geschäfte.
+  BC-1380.30.20:
+    name: Wertpapierabwicklungs-Betrieb
+    description: |
+      DvP-Abwicklungsbetrieb über CSDs und ICSDs.
+  BC-1380.30.30:
+    name: Abwicklungsfehler-Management
+    description: |
+      Identifikation und Lösung von Abwicklungsfehlern (CSDR).
+  BC-1380.40:
+    name: Verwahrungs-Management
+    description: |
+      Wertpapierverwahrung und Sub-Custody-Netzwerke.
+  BC-1380.40.10:
+    name: Wertpapierverwahrung
+    description: |
+      Verwahrung von Wertpapieren für Kunden und Eigenbestände.
+  BC-1380.40.20:
+    name: Sub-Custody-Netzwerk-Management
+    description: |
+      Sub-Custody-Netzwerk- und Depotbanken-Management.
+  BC-1380.40.30:
+    name: Verwahrungs-Steuerdienstleistungen
+    description: |
+      Verwahrungs-bezogene Steuererstattung und Quellensteuerdienstleistungen.
+  BC-1380.50:
+    name: Sicherheiten-Management
+    description: |
+      Sicherheiten, Margenverwaltung und Optimierung.
+  BC-1380.50.10:
+    name: Margenanforderungs-Management
+    description: |
+      Stellung und Beantwortung von Margenanforderungen im bilateralen und CCP-Regime.
+  BC-1380.50.20:
+    name: Sicherheitenbewegung-Betrieb
+    description: |
+      Betriebliche Sicherheitenbewegung zwischen Gegenparteien.
+  BC-1380.50.30:
+    name: Sicherheiten-Optimierung
+    description: |
+      Optimierung der Sicherheitennutzung und -substituierung.
+  BC-1380.50.40:
+    name: Sicherheiteneignungs-Management
+    description: |
+      Sicherheiteneignungsregeln und Abschlagsanwendung.
+  BC-1380.60:
+    name: Kapitalmaßnahmen-Management
+    description: |
+      Pflicht- und freiwillige Kapitalmaßnahmenverarbeitung.
+  BC-1380.60.10:
+    name: Kapitalmaßnahmen-Benachrichtigung
+    description: |
+      Erfassung und Kundenbenachrichtigung über Kapitalmaßnahmen.
+  BC-1380.60.20:
+    name: Pflichtkapitalmaßnahmen-Verarbeitung
+    description: |
+      Verarbeitung von Dividenden, Zinsen und Pflichtmaßnahmen.
+  BC-1380.60.30:
+    name: Freiwillige-Kapitalmaßnahmen-Verarbeitung
+    description: |
+      Verarbeitung freiwilliger Maßnahmen einschließlich Wahlangeboten.
+  BC-1380.60.40:
+    name: Stimmrechtsbevollmächtigungs-Betrieb
+    description: |
+      Stimmrechtsbeauftragung und -einreichung.
+  BC-1380.70:
+    name: Abstimmungs-Management
+    description: |
+      Nostro/Vostro-, Positions- und Kassenabstimmung.
+  BC-1380.70.10:
+    name: Kassenabstimmung
+    description: |
+      Abstimmung von Kassenkonten einschließlich Nostro/Vostro.
+  BC-1380.70.20:
+    name: Wertpapierpositions-Abstimmung
+    description: |
+      Abstimmung von Wertpapierpositionen über Systeme und Depotbanken.
+  BC-1380.70.30:
+    name: Handels- und Front-Back-Abstimmung
+    description: |
+      Front-to-Back-Handelsabstimmung über Systeme.
+  BC-1380.70.40:
+    name: Abstimmungsdifferenzen-Untersuchung
+    description: |
+      Untersuchung und Lösung von Abstimmungsdifferenzen.
+  BC-1380.80:
+    name: Wertpapierleihe-Management
+    description: |
+      Wertpapierleihe, -entleihe und Sicherheitenverwaltung.
+  BC-1380.80.10:
+    name: Wertpapierleihe-Origination
+    description: |
+      Origination von Wertpapierleih- und -entleihgeschäften.
+  BC-1380.80.20:
+    name: Wertpapierleihe-Sicherheitenbetrieb
+    description: |
+      Sicherheitenbetrieb zur Unterstützung der Wertpapierleihe.
+  BC-1380.80.30:
+    name: Wertpapierleihe-Gebühren- und Rabattberechnung
+    description: |
+      Berechnung und Abwicklung von Gebühren und Rabatten.
+  BC-1380.80.40:
+    name: Wertpapierleihe-Rückforderungsmanagement
+    description: |
+      Rückforderung verliehener Wertpapiere und Substitutionsvorgänge.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-capital-markets-trading-management.yaml
+++ b/catalogue/i18n/de/L1-capital-markets-trading-management.yaml
@@ -1,0 +1,114 @@
+locale: de
+source: L1-capital-markets-trading-management.yaml
+entries:
+  BC-1370:
+    name: Kapitalmarkthandel-Management
+    description: |
+      Front-Office-Handel, Market-Making, Positionsmanagement und Sales & Trading.
+  BC-1370.10:
+    name: Market-Making-Management
+    description: |
+      Market-Making über alle Anlageklassen.
+  BC-1370.10.10:
+    name: Kursstellung
+    description: |
+      Stellung von Geld-/Briefkursen in allen Märkten.
+  BC-1370.10.20:
+    name: Market-Maker-Inventarmanagement
+    description: |
+      Verwaltung von Market-Maker-Inventar und Risikopositionen.
+  BC-1370.10.30:
+    name: Market-Maker-Preisstellungsmaschine
+    description: |
+      Betrieb und Parametersteuerung der Preisstellungsmaschine.
+  BC-1370.20:
+    name: Handelspositions-Management
+    description: |
+      Handelspositionen und G&V-Zurechnung.
+  BC-1370.20.10:
+    name: Echtzeit-Positionsführung
+    description: |
+      Echtzeit-Verfolgung von Handelsbuchpositionen.
+  BC-1370.20.20:
+    name: Handels-G&V-Berechnung
+    description: |
+      Berechnung des Handels-G&V über alle Desks.
+  BC-1370.20.30:
+    name: G&V-Zurechnungsanalyse
+    description: |
+      G&V-Zurechnung nach Risikofaktor, Zeit und Händler.
+  BC-1370.30:
+    name: Handelsauftrags-Management
+    description: |
+      Auftragserfassung, Ausführung, Smart-Order-Routing und Best Execution.
+  BC-1370.30.10:
+    name: Handelsauftragserfassung
+    description: |
+      Erfassung und Validierung von Kunden- und Eigenhandelsaufträgen.
+  BC-1370.30.20:
+    name: Smart-Order-Routing
+    description: |
+      Intelligentes Auftrags-Routing über Handelsplätze für Best Execution.
+  BC-1370.30.30:
+    name: Ausführungsqualitäts-Überwachung
+    description: |
+      Überwachung der Ausführungsqualität und Best-Execution-Analytik.
+  BC-1370.30.40:
+    name: Auftrags-Lebenszyklusmanagement
+    description: |
+      Auftrags-Lebenszyklus einschließlich Änderungen und Stornierungen.
+  BC-1370.40:
+    name: Algorithmushandels-Management
+    description: |
+      Algo-Strategien, Backtesting und Compliance.
+  BC-1370.40.10:
+    name: Algorithmische-Strategie-Entwicklung
+    description: |
+      Entwicklung und Zertifizierung algorithmischer Handelsstrategien.
+  BC-1370.40.20:
+    name: Algorithmisches-Backtesting
+    description: |
+      Backtesting und Simulation von Handelsalgorithmen.
+  BC-1370.40.30:
+    name: Algorithmischer-Handels-Kontrollen
+    description: |
+      Vor-Handels- und Laufzeitkontrollen des algorithmischen Handels.
+  BC-1370.50:
+    name: Sales-und-Trading-Management
+    description: |
+      Kunden-Sales-Desks sowie Telefon- und elektronischer Handel.
+  BC-1370.50.10:
+    name: Kunden-Sales-Desk-Betrieb
+    description: |
+      Betrieb von Telefon-Sales-Desks für institutionelle Kunden.
+  BC-1370.50.20:
+    name: Elektronischer-Handels-Betrieb
+    description: |
+      Betrieb elektronischer Handelsplattformen und Konnektivität.
+  BC-1370.50.30:
+    name: Vor-Handels-Research und -Preisgestaltung
+    description: |
+      Vor-Handels-Research, indikative Preisstellung und Strukturierungsunterstützung.
+  BC-1370.60:
+    name: Handels-Compliance- und Überwachungs-Management
+    description: |
+      Handelsüberwachung, Marktmissbrauchserkennung und MiFID II.
+  BC-1370.60.10:
+    name: Handelsüberwachung
+    description: |
+      Handelsüberwachung und Erkennung verdächtiger Handelsmuster.
+  BC-1370.60.20:
+    name: Marktmissbrauchserkennung
+    description: |
+      Erkennung von Marktmissbrauch einschließlich Insiderhandel und Marktmanipulation.
+  BC-1370.60.30:
+    name: Kommunikationsüberwachung
+    description: |
+      Überwachung der Händlerkommunikation und Sprachaufzeichnungen.
+  BC-1370.60.40:
+    name: Regulatorische-Handelsmeldung
+    description: |
+      Regulatorische Handels- und Transaktionsmeldung (MiFIR, EMIR, SFTR).
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-care-coordination-management.yaml
+++ b/catalogue/i18n/de/L1-care-coordination-management.yaml
@@ -1,0 +1,138 @@
+locale: de
+source: L1-care-coordination-management.yaml
+entries:
+  BC-2820:
+    name: Versorgungskoordination-Management
+    description: |
+      Koordination der Versorgung über Anbieter, Einrichtungen und Zeit hinweg
+      einschließlich Überweisungen, Fallmanagement, Versorgungsübergängen, Entlassungsplanung,
+      Nutzungsmanagement und Soziale-Determinanten-Vernetzung.
+  BC-2820.10:
+    name: Überweisungs-Management
+    description: |
+      End-to-End-Management von Patientenüberweisungen von der Auftragserfassung
+      über die Facharztzuordnung, Verfolgung bis zum Abschluss.
+  BC-2820.10.10:
+    name: Überweisungsauftrags-Erfassung
+    description: |
+      Erfassung von Überweisungsaufträgen von überweisenden Anbietern mit erforderlichem klinischen Kontext.
+  BC-2820.10.20:
+    name: Facharzt-Zuordnung
+    description: |
+      Zuordnung von Überweisungen an Fachärzte basierend auf klinischem Bedarf, Netzwerk und Verfügbarkeit.
+  BC-2820.10.30:
+    name: Überweisungs-Verfolgung
+    description: |
+      Verfolgung von Überweisungsstatus, Terminplanung und Abschluss im Netzwerk.
+  BC-2820.10.40:
+    name: Überweisungs-Abschluss
+    description: |
+      Abschluss von Überweisungen mit Rückbericht des Konsiliarius an den überweisenden Arzt.
+  BC-2820.20:
+    name: Fall- und Versorgungsmanagement
+    description: |
+      Identifikation, Planung und Durchführung von Fallmanagement-Interventionen
+      für Hochrisiko- und komplexe Patienten.
+  BC-2820.20.10:
+    name: Fall-Stratifizierung
+    description: |
+      Stratifizierung von Patienten in Fallmanagement-Stufen basierend auf klinischem und sozialem Risiko.
+  BC-2820.20.20:
+    name: Versorgungsplan-Entwicklung
+    description: |
+      Entwicklung individualisierter Versorgungspläne mit patientenzentrierten Zielen.
+  BC-2820.20.30:
+    name: Versorgungsplan-Durchführung
+    description: |
+      Durchführung und laufende Neubewertung von Versorgungsplan-Interventionen.
+  BC-2820.20.40:
+    name: Versorgungsmanager-Zuweisung
+    description: |
+      Zuweisung und Falllastverwaltung von Versorgungsmanagern und -lotsen.
+  BC-2820.30:
+    name: Entlassungsplanung
+    description: |
+      Planung der sicheren Entlassung aus der stationären Versorgung einschließlich
+      Bedarfsbeurteilung, Nachsorgeplacierung und Patientenaufklärung.
+  BC-2820.30.10:
+    name: Entlassungsbedarfs-Beurteilung
+    description: |
+      Multidisziplinäre Beurteilung des post-stationären klinischen und sozialen Bedarfs.
+  BC-2820.30.20:
+    name: Entlassungsplan-Entwicklung
+    description: |
+      Entwicklung von Entlassungsplänen einschließlich Dienste, Ausrüstung und Nachsorge.
+  BC-2820.30.30:
+    name: Nachsorge-Placierung
+    description: |
+      Placierung von Patienten in qualifizierte Pflege-, Rehabilitations- und Hausversorgungsdienste.
+  BC-2820.30.40:
+    name: Entlassungs-Aufklärung
+    description: |
+      Patienten- und Angehörigenaufklärung über Entlassungsanweisungen, Medikamente und Warnsignale.
+  BC-2820.40:
+    name: Versorgungsübergänge
+    description: |
+      Koordination von Patientenübergängen zwischen Anbietern und Einrichtungen
+      zur Sicherstellung von Kontinuität, Sicherheit und Ergebnisverantwortung.
+  BC-2820.40.10:
+    name: Versorgungsübergabe-Kommunikation
+    description: |
+      Strukturierte Übergabe-Kommunikation zwischen Anbietern und Versorgungsteams bei Übergängen.
+  BC-2820.40.20:
+    name: Übergangs-Medikamentenabgleich
+    description: |
+      Medikamentenabgleich bei Versorgungsübergängen.
+  BC-2820.40.30:
+    name: Nachsorge-Terminplanung
+    description: |
+      Planung von Post-Entlassungs- und Post-Besuchs-Nachsorgetteminen.
+  BC-2820.40.40:
+    name: Übergangs-Ergebnis-Verfolgung
+    description: |
+      Verfolgung von Wiederaufnahme-, Komplikations- und Ergebnismetriken bei Übergängen.
+  BC-2820.50:
+    name: Nutzungs-Management
+    description: |
+      Überprüfung und Überwachung von Aufnahmen, Weiterbehandlungen und Verweildauer
+      gegen medizinische Notwendigkeit und Nutzungskriterien.
+  BC-2820.50.10:
+    name: Aufnahme-Überprüfung
+    description: |
+      Überprüfung der medizinischen Notwendigkeit der Aufnahme und stationärer versus Beobachtungsstatus.
+  BC-2820.50.20:
+    name: Weiterbehandlungs-Überprüfung
+    description: |
+      Regelmäßige Überprüfung des weiteren stationären Aufenthalts gegen Kriterien.
+  BC-2820.50.30:
+    name: Verweildauer-Optimierung
+    description: |
+      Optimierung der Verweildauer durch Barrieridentifikation und -lösung.
+  BC-2820.50.40:
+    name: Vermeidbare-Tage-Verfolgung
+    description: |
+      Erfassung und Analyse vermeidbarer stationärer Tage und Ursachen.
+  BC-2820.60:
+    name: Soziale Determinanten und Gemeinschafts-Vernetzung
+    description: |
+      Identifikation sozialer Gesundheitsdeterminanten und Vernetzung mit
+      Gemeinschaftsressourcen zur Unterstützung klinischer Ergebnisse.
+  BC-2820.60.10:
+    name: Soziale-Bedarfs-Screening
+    description: |
+      Screening auf Wohn-, Ernährungs-, Transport- und andere soziale Bedarfe.
+  BC-2820.60.20:
+    name: Gemeinschafts-Ressourcen-Überweisung
+    description: |
+      Überweisung an Gemeinschaftsressourcen zur Deckung identifizierter sozialer Bedarfe.
+  BC-2820.60.30:
+    name: Soziale-Determinanten-Dokumentation
+    description: |
+      Strukturierte Dokumentation sozialer Determinanten in der Krankenakte.
+  BC-2820.60.40:
+    name: Geschlossene-Schleife-Überweisungs-Verfolgung
+    description: |
+      Geschlossene-Schleife-Verfolgung von Gemeinschaftsüberweisungen bis zum Ergebnis und Abschluss.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-cargo-documentation-management.yaml
+++ b/catalogue/i18n/de/L1-cargo-documentation-management.yaml
@@ -1,0 +1,100 @@
+locale: de
+source: L1-cargo-documentation-management.yaml
+entries:
+  BC-2500:
+    name: Frachtdokumentation-Management
+    description: |
+      Ausstellung, Austausch und Lebenszyklusverwaltung von Frachtdokumenten einschließlich
+      Konnossements, Luftfrachtbriefen, Straßen- und Schienen-Frachtbriefen, Manifesten
+      und deren elektronischen Äquivalenten.
+  BC-2500.10:
+    name: Konnossement-Management
+    description: |
+      Ausstellung, Übergabe und Verwaltung von See- und Binnenwasserstraßen-Konnossements
+      in begebbarer und nicht-begebbarer Form.
+    in_scope:
+      - Master- und Haus-Konnossements
+      - Begebbare, direkte und Seeway-Bill-Varianten
+    out_of_scope:
+      - Akkreditivbearbeitung im Handelsfinanzierungsbereich (BC-1360)
+  BC-2500.10.10:
+    name: Konnossement-Ausstellung
+    description: |
+      Ausstellung von Master- und Haus-Konnossements.
+  BC-2500.10.20:
+    name: Konnossement-Übergabe und Freigabe
+    description: |
+      Telex-Freigabe, Übergabe und Frachtfreigabe gegen Konnossements.
+  BC-2500.10.30:
+    name: Begebbare und direkte Konnossement-Varianten
+    description: |
+      Ausstellung von begebbaren, direkten und Seeway-Bill-Varianten.
+  BC-2500.20:
+    name: Luftfrachtbrief-Management
+    description: |
+      Ausstellung und Verwaltung von Master- und Haus-Luftfrachtbriefen einschließlich e-AWB.
+  BC-2500.20.10:
+    name: Master-Luftfrachtbrief-Ausstellung
+    description: |
+      Ausstellung von Master-Luftfrachtbriefen durch Luftfrachtgesellschaften.
+  BC-2500.20.20:
+    name: Haus-Luftfrachtbrief-Ausstellung
+    description: |
+      Ausstellung von Haus-Luftfrachtbriefen durch Spediteure und Konsolidatoren.
+  BC-2500.20.30:
+    name: e-AWB-Konvertierung und Pflege
+    description: |
+      Konvertierung von Papier-AWBs auf e-AWB und Lebenszyklusverwaltung.
+  BC-2500.30:
+    name: Straßen- und Schienen-Frachtbrief-Management
+    description: |
+      Ausstellung und Verwaltung von Straßen- und Schienen-Frachtbriefen gemäß
+      CMR- und CIM/SMGS-Regelungen.
+  BC-2500.30.10:
+    name: CMR-Frachtbrief-Ausstellung
+    description: |
+      Ausstellung von CMR-Frachtbriefen für den internationalen Straßengüterverkehr.
+  BC-2500.30.20:
+    name: CIM- und SMGS-Frachtbrief-Ausstellung
+    description: |
+      Ausstellung von CIM- und SMGS-Frachtbriefen für den internationalen Schienengüterverkehr.
+  BC-2500.30.30:
+    name: Nationaler Inlandsfrachtbrief-Ausstellung
+    description: |
+      Ausstellung nationaler Inlandsfrachtbriefe und Lieferscheine.
+  BC-2500.40:
+    name: Manifest- und Frachterklärungs-Management
+    description: |
+      Einreichung von Frachtmanifesten und Vorankunfts-Frachterklärungen bei Zoll,
+      Terminals und Partnercarriern.
+  BC-2500.40.10:
+    name: Eingangsmanifest-Einreichung
+    description: |
+      Einreichung von Eingangsmanifesten bei Terminals und Zoll.
+  BC-2500.40.20:
+    name: Ausgangsmanifest-Einreichung
+    description: |
+      Einreichung von Ausgangsmanifesten bei Terminals und Zoll.
+  BC-2500.40.30:
+    name: Vorankunfts-Frachtmeldung
+    description: |
+      Vorankunftsmeldung unter Regelungen wie ICS2 und CBP ACE.
+  BC-2500.50:
+    name: Elektronische Dokumentenverwaltung
+    description: |
+      Betrieb elektronischer Transportdokumentplattformen einschließlich eBL und ONE-Record-Austausch.
+  BC-2500.50.10:
+    name: Elektronisches Konnossement-Betrieb
+    description: |
+      Betrieb von Plattformen für elektronische Konnossements.
+  BC-2500.50.20:
+    name: e-AWB- und ONE-Record-Betrieb
+    description: |
+      Betrieb von e-AWB- und ONE-Record-Datenaustauschen.
+  BC-2500.50.30:
+    name: Dokumentenaustausch und Verifikation
+    description: |
+      Zwischenparteilicher Dokumentenaustausch und Verifikation elektronischer Signaturen und Siegel.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-change-management.yaml
+++ b/catalogue/i18n/de/L1-change-management.yaml
@@ -1,0 +1,90 @@
+locale: de
+source: L1-change-management.yaml
+entries:
+  BC-910:
+    name: Veränderungsmanagement
+    description: |
+      Planung und Umsetzung organisatorischer Veränderungen.
+  BC-910.10:
+    name: Veränderungsstrategiemanagement
+    description: |
+      Veränderungsvision, Narrativ und Strategie.
+  BC-910.10.10:
+    name: Veränderungsvision und -narrativ
+    description: |
+      Formulierung der Veränderungsvision, des Veränderungsbedarfs und des Narrativs.
+  BC-910.10.20:
+    name: Veränderungsfolgenabschätzung
+    description: |
+      Identifikation und Bewertung von Veränderungsauswirkungen auf Mitarbeiter und Prozesse.
+  BC-910.10.30:
+    name: Veränderungsbereitschaftsanalyse
+    description: |
+      Bewertung der organisatorischen Bereitschaft für Veränderungen.
+  BC-910.10.40:
+    name: Veränderungsplan-Entwicklung
+    description: |
+      Entwicklung integrierter Veränderungsmanagementpläne.
+  BC-910.20:
+    name: Stakeholder-Engagement-Management im Wandel
+    description: |
+      Stakeholder-Identifikation, -Engagement und -Ausrichtung.
+  BC-910.20.10:
+    name: Stakeholder-Identifikation und -Mapping
+    description: |
+      Identifikation und Mapping betroffener Stakeholder.
+  BC-910.20.20:
+    name: Sponsor-Engagement
+    description: |
+      Definition der Sponsorenkoalition und Engagement.
+  BC-910.20.30:
+    name: Veränderungsnetzwerk-Management
+    description: |
+      Change-Agent- und Change-Champion-Netzwerke.
+  BC-910.20.40:
+    name: Widerstandsmanagement
+    description: |
+      Identifikation und Management von Widerstand gegen Veränderungen.
+  BC-910.30:
+    name: Veränderungskommunikations- und Schulungsmanagement
+    description: |
+      Kommunikation und Schulung als Teil des Wandels.
+  BC-910.30.10:
+    name: Veränderungskommunikationsplanung
+    description: |
+      Kommunikationspläne nach Zielgruppe und Kanal für Veränderungsinitiativen.
+  BC-910.30.20:
+    name: Veränderungskommunikations-Durchführung
+    description: |
+      Durchführung von Kommunikationskampagnen und -materialien.
+  BC-910.30.30:
+    name: Veränderungsschulungsdesign
+    description: |
+      Gestaltung von Veränderungsschulungen und Kompetenzaufbau.
+  BC-910.30.40:
+    name: Veränderungsschulungs-Durchführung
+    description: |
+      Durchführung von Schulungen bei der Veränderungsumsetzung.
+  BC-910.40:
+    name: Veränderungsadoptions- und Verstärkungs-Management
+    description: |
+      Adoptionsverfolgung, Verstärkung und Verstetigung.
+  BC-910.40.10:
+    name: Adoptionsmessung
+    description: |
+      Messung von Adoption, Nutzung und Verhaltensveränderung.
+  BC-910.40.20:
+    name: Verstärkung und Verstetigung
+    description: |
+      Verstärkungsmechanismen und Verstetigung neuer Verhaltensweisen.
+  BC-910.40.30:
+    name: Change-Hypercare-Management
+    description: |
+      Hypercare-Unterstützung nach der Implementierung.
+  BC-910.40.40:
+    name: Lessons Learned aus Veränderungen
+    description: |
+      Erfassung und Verbreitung von Lessons Learned aus Veränderungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-chemical-bulk-logistics-management.yaml
+++ b/catalogue/i18n/de/L1-chemical-bulk-logistics-management.yaml
@@ -1,0 +1,170 @@
+locale: de
+source: L1-chemical-bulk-logistics-management.yaml
+entries:
+  BC-4680:
+    name: Chemikalien-Bulk-Logistik
+    description: |
+      Schüttgut-Chemikalienumschlag über Tanklager-, Straßen-, Schienen-,
+      Marine-, Pipeline- und Lagerhaltungsmodalitäten — einschließlich
+      Gefahrgut-konformer Operationen, Lohnherstellung und
+      Schüttgut-Eigentumsübergangsmessung. Distinct von den
+      branchenübergreifenden Supply-Chain- (BC-520) und Transport-L1s.
+  BC-4680.10:
+    name: Bulk-Lagerung und Tanklager-Betrieb
+    description: |
+      Betrieb von Bulk-Lagertanks und Tanklagern einschließlich
+      Zuteilung, Reinigung und Verlustsabgleich.
+  BC-4680.10.10:
+    name: Tanklager-Bestandsmanagement
+    description: |
+      Bestandsmanagement über atmosphärische und druckbelastete
+      Tanklager hinweg.
+  BC-4680.10.20:
+    name: Tankzuteilung und -weiterleitung
+    description: |
+      Zuteilung von Tanks zu Produkten und Weiterleitung ein- und
+      ausgehender Ströme.
+  BC-4680.10.30:
+    name: Tankreinigungs-Koordination
+    description: |
+      Koordination der Tankreinigung zwischen Produktwechseln.
+  BC-4680.10.40:
+    name: Tanklager-Verlustabgleich
+    description: |
+      Abgleich physischer Verluste über Tanklager-Inventare hinweg.
+  BC-4680.20:
+    name: Tank-LKW- und ISO-Tank-Logistik
+    description: |
+      Betrieb von Tank-LKW- und ISO-Tank-Flotten einschließlich
+      Verladebereich-Operationen und Containerwäsche.
+  BC-4680.20.10:
+    name: Tank-LKW-Planung
+    description: |
+      Planung von Tank-LKW-Bewegungen und Andockzuteilung.
+  BC-4680.20.20:
+    name: ISO-Tank-Flotten-Management
+    description: |
+      Management von ISO-Tank-Flotten einschließlich Positionierung
+      und Wiederverwendung.
+  BC-4680.20.30:
+    name: Verladebereich-Betrieb
+    description: |
+      Betrieb von Verladebereichen für Straßen- und
+      ISO-Tank-Versand.
+  BC-4680.20.40:
+    name: Container-Reinigungs-Koordination
+    description: |
+      Koordination genehmigter Containerreinigung zwischen
+      Ladungen.
+  BC-4680.30:
+    name: Eisenbahntankwagen-Logistik
+    description: |
+      Zuteilung, Beladung, Entladung und Wartungskoordination
+      von Eisenbahntankwagen.
+  BC-4680.30.10:
+    name: Eisenbahntankwagen-Zuteilung
+    description: |
+      Zuteilung von Eisenbahntankwagen zu Produkten und Routen.
+  BC-4680.30.20:
+    name: Eisenbahn-Beladungs- und Entladungsbetrieb
+    description: |
+      Betrieb von Eisenbahn-Beladungs- und Entladungsanlagen.
+  BC-4680.30.30:
+    name: Eisenbahntankwagen-Wartungskoordination
+    description: |
+      Koordination flottenweiter Eisenbahntankwagen-Wartung
+      und -Qualifikation.
+  BC-4680.40:
+    name: Marine-Schüttgut-Chemikalienlogistik
+    description: |
+      Marinelogistik für Stückgut- und Chemikalientanker einschließlich
+      Befrachtung, Beladung und Stauung.
+  BC-4680.40.10:
+    name: Chemikalientanker-Befrachtungskoordination
+    description: |
+      Koordination der Befrachtung von Chemikalien- und
+      Stückguttankern.
+  BC-4680.40.20:
+    name: Marine-Beladungs- und Löschbetrieb
+    description: |
+      Betrieb mariner Beladungs- und Löscheinrichtungen.
+  BC-4680.40.30:
+    name: Stückguttanker-Stauplanung
+    description: |
+      Stauplanung für kompatible Stückgutladungen auf
+      Chemikalientankern.
+  BC-4680.50:
+    name: Pipeline-Bewegungskoordination
+    description: |
+      Nominierung, Sequenzierung und Eigentumsübergangskoordination
+      für Pipeline-Bewegungen von Schüttgut-Chemikalien.
+  BC-4680.50.10:
+    name: Pipeline-Nominierungs-Management
+    description: |
+      Nominierung von Pipeline-Bewegungen mit Betreibern und
+      Gegenparteien.
+  BC-4680.50.20:
+    name: Batch-Sequenzierung in Pipelines
+    description: |
+      Sequenzierung von Chargen mit Schnittstellenmanagement.
+  BC-4680.50.30:
+    name: Pipeline-Eigentumsübergangs-Koordination
+    description: |
+      Koordination des Eigentumsübergangs an Pipeline-Einspeis-
+      und Lieferpunkten.
+  BC-4680.60:
+    name: Gefahrstoff-Lagerhaltungsbetrieb
+    description: |
+      Annahme, Segregierung und Lagerung gefährlicher verpackter
+      Chemikalien in konformen Lagerhäusern.
+  BC-4680.60.10:
+    name: Gefahrstoff-Lager-Annahme und -Einlagerung
+    description: |
+      Annahme und Einlagerung gefährlicher verpackter Chemikalien.
+  BC-4680.60.20:
+    name: Segregierungs-Konformitätsmanagement
+    description: |
+      Konformitätsmanagement für Chemikaliensegregierung in der
+      Lagerhaltung.
+  BC-4680.60.30:
+    name: Fass- und IBC-Lagerbetrieb
+    description: |
+      Lagerbetrieb für Fässer und Intermediate Bulk Container.
+  BC-4680.70:
+    name: Lohnherstellungs- und Drittfertigungs-Koordination
+    description: |
+      Koordination der Lohnfertigung über Drittanbieter-Assets
+      hinweg einschließlich Abgleich gelohnter Materialien.
+  BC-4680.70.10:
+    name: Lohnhersteller-Auswahl und -Qualifizierung
+    description: |
+      Auswahl und Qualifizierung von Lohnfertigungs-Partnern.
+  BC-4680.70.20:
+    name: Lohnfertigungs-Planung
+    description: |
+      Planung von Lohnkampagnen über Drittanbieter-Assets hinweg.
+  BC-4680.70.30:
+    name: Lohnmaterial-Abgleich
+    description: |
+      Abgleich von Materialein- und -ausgängen der Lohnfertigung.
+  BC-4680.80:
+    name: Schüttgut-Eigentumsübergangs-Messung
+    description: |
+      Volumen-, Massen- und Probenmessung an Eigentumsübergangs-
+      Schnittstellen.
+  BC-4680.80.10:
+    name: Volumen- und Massenmessung
+    description: |
+      Kalibrierte Volumen- und Massenmessung an Eigentumsübergangs-
+      punkten.
+  BC-4680.80.20:
+    name: Probenahme-Koordination
+    description: |
+      Koordination repräsentativer Probenahme beim Eigentumsübergang.
+  BC-4680.80.30:
+    name: Eigentumsübergangs-Dokumentation
+    description: |
+      Ausstellung und Aufbewahrung von Eigentumsübergangs-Dokumenten.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-chemical-commercial-trading-management.yaml
+++ b/catalogue/i18n/de/L1-chemical-commercial-trading-management.yaml
@@ -1,0 +1,157 @@
+locale: de
+source: L1-chemical-commercial-trading-management.yaml
+entries:
+  BC-4690:
+    name: Chemikalien-Handel und -Vertrieb
+    description: |
+      Bulk- und Spezialchemikalienhandel, Angebots- und Nachfrage-
+      ausgleichsmanagement, Rohstoffbeschaffung, Absicherung,
+      Langzeit-Abnahmeverträge und Preisindexreferenzierung. Distinct
+      vom branchenübergreifenden Vertrieb (BC-410) und Preisgestaltung
+      (BC-440).
+  BC-4690.10:
+    name: Bulk-Chemikalienhandel
+    description: |
+      Spot- und Terminhandel mit Bulk-Standardchemikalien auf
+      physischen Märkten.
+  BC-4690.10.10:
+    name: Spot-Frachthandel
+    description: |
+      Handel mit Spot-Frachten zu aktuellen Marktpreisen.
+  BC-4690.10.20:
+    name: Terminvertrags-Handel
+    description: |
+      Verhandlung und Abschluss von Terminvertragsgeschäften.
+  BC-4690.10.30:
+    name: Notfracht-Verkauf
+    description: |
+      Veräußerung von Not- und Überschussfrachten über
+      Handelskanäle.
+  BC-4690.20:
+    name: Spezialchemikalien-Vertriebsmanagement
+    description: |
+      Account-Management, Distribution und Lösungsverkauf
+      differenzierter Spezialchemikalien.
+  BC-4690.20.10:
+    name: Spezialchemikalien-Account-Management
+    description: |
+      Management strategischer Spezialchemikalien-Accounts.
+  BC-4690.20.20:
+    name: Distributions-Kanal-Management
+    description: |
+      Management indirekter Distributionskanäle.
+  BC-4690.20.30:
+    name: Anwendungs-Pull-Through-Verkauf
+    description: |
+      Pull-Through-Verkauf bei nachgelagerten Formulierer- und
+      Verarbeiter-Accounts.
+  BC-4690.20.40:
+    name: Lösungsverkaufs-Koordination
+    description: |
+      Koordination des Mehrprodukt-Lösungsverkaufs für komplexe
+      Anwendungen.
+  BC-4690.30:
+    name: Rohstoff- und Petrochemikalien-Beschaffung
+    description: |
+      Beschaffung von Kohlenwasserstoff-, aromatischen, Bio- und
+      anorganischen Rohstoffen für Chemikalienbetriebe.
+  BC-4690.30.10:
+    name: Naphtha- und Olefin-Rohstoffbeschaffung
+    description: |
+      Beschaffung von Naphtha-, Ethan- und Olefin-Rohstoffen
+      für Cracker.
+  BC-4690.30.20:
+    name: Aromatische Rohstoffbeschaffung
+    description: |
+      Beschaffung von Benzol-, Toluol- und Xylol-Rohstoffen.
+  BC-4690.30.30:
+    name: Bio-Rohstoffbeschaffung
+    description: |
+      Beschaffung bio-basierter Rohstoffe unter Massenbilanz-
+      Schemata.
+  BC-4690.30.40:
+    name: Anorganische Rohstoffbeschaffung
+    description: |
+      Beschaffung anorganischer Salze, Mineralien und Erze für
+      die Chemikalienverarbeitung.
+  BC-4690.40:
+    name: Chemikalien-Absicherung und Risikomanagement
+    description: |
+      Absicherung von Rohstoffpreis-, Währungs- und Margen-
+      Exponierung über das Chemikalienbuch hinweg.
+  BC-4690.40.10:
+    name: Rohstoffpreis-Absicherung
+    description: |
+      Absicherung der Rohstoffpreisexponierung auf
+      Rohstoffmärkten.
+  BC-4690.40.20:
+    name: Währungsexponierung-Absicherung
+    description: |
+      Absicherung der Devisenexponierung aus
+      Chemikalienverträgen.
+  BC-4690.40.30:
+    name: Margen-Absicherungsstrategie
+    description: |
+      Definition und Durchführung von Cracker- und
+      Chemikalienmargen-Absicherungsstrategien.
+  BC-4690.50:
+    name: Angebots- und Nachfrageausgleich-Management
+    description: |
+      Zusammenstellung und Abgleich von Angebot, Nachfrage und
+      Ausgleich über das Chemikalienproduktspektrum hinweg.
+  BC-4690.50.10:
+    name: Nachfrageprognose-Zusammenstellung
+    description: |
+      Zusammenstellung kurz- und mittelfristiger
+      Nachfrageprognosen.
+  BC-4690.50.20:
+    name: Angebotskapazitäts-Zusammenstellung
+    description: |
+      Zusammenstellung der Angebotskapazität über eigene und
+      gelohnte Assets hinweg.
+  BC-4690.50.30:
+    name: Ausgleichs-Abgleich
+    description: |
+      Abgleich von Angebots- und Nachfrageausgleichen sowie
+      Engpassidentifikation.
+  BC-4690.60:
+    name: Langzeit-Abnahmevertrag-Management
+    description: |
+      Verhandlung, Entwurf und Leistungsmanagement langfristiger
+      Abnahme- und Liefervereinbarungen.
+  BC-4690.60.10:
+    name: Abnahme-Termsheet-Verhandlung
+    description: |
+      Verhandlung langfristiger Abnahme-Termsheets.
+  BC-4690.60.20:
+    name: Langzeitvertrag-Erstellung
+    description: |
+      Erstellung definitiver langfristiger Liefer- und
+      Abnahmeverträge.
+  BC-4690.60.30:
+    name: Abnahmeleistungs-Überwachung
+    description: |
+      Überwachung der Abnahmeleistung gegenüber
+      Vertragsverpflichtungen.
+  BC-4690.70:
+    name: Preisindex- und Referenz-Management
+    description: |
+      Management von Abonnements und Referenzpreisindizes
+      für die Chemikalienpreisgestaltung.
+  BC-4690.70.10:
+    name: Preisindex-Abonnement-Management
+    description: |
+      Management von Abonnements bei ICIS, Argus, Platts und
+      ähnlichen Indizes.
+  BC-4690.70.20:
+    name: Referenzpreiskurven-Pflege
+    description: |
+      Pflege interner Referenzpreiskurven für Chemikalien.
+  BC-4690.70.30:
+    name: Indexgebundene Preisberechnung
+    description: |
+      Berechnung indexgebundener Kundenpreise und
+      Vertragsabrechnungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-chemical-manufacturing-operations-management.yaml
+++ b/catalogue/i18n/de/L1-chemical-manufacturing-operations-management.yaml
@@ -1,0 +1,198 @@
+locale: de
+source: L1-chemical-manufacturing-operations-management.yaml
+entries:
+  BC-4620:
+    name: Chemische Herstellung und Produktion
+    description: |
+      Täglicher Betrieb von Reaktions-, Trenn-, Polymerisierungs-
+      und anorganischen Prozessanlagen — einschließlich
+      Katalysatorüberwachung, Produktionsplanung und
+      Revisionskoordination.
+  BC-4620.10:
+    name: Reaktionseinheiten-Betrieb
+    description: |
+      Betrieb kontinuierlicher, batch-, katalytischer und
+      elektrochemischer Reaktorsysteme.
+  BC-4620.10.10:
+    name: Kontinuierlicher Reaktorbetrieb
+    description: |
+      Betrieb kontinuierlicher Rühr- und Pfropfenstrom-Reaktoren.
+  BC-4620.10.20:
+    name: Batch-Reaktorbetrieb
+    description: |
+      Betrieb von Batch- und Semi-Batch-Reaktoren gemäß
+      genehmigten Rezepten.
+  BC-4620.10.30:
+    name: Katalytischer Reaktorbetrieb
+    description: |
+      Betrieb von Festbett- und Wirbelschicht-Katalysatorreaktoren.
+  BC-4620.10.40:
+    name: Photochemischer und elektrochemischer Reaktorbetrieb
+    description: |
+      Betrieb photochemischer, elektrochemischer und
+      Plasma-Reaktoren.
+  BC-4620.20:
+    name: Trenneinheiten-Betrieb
+    description: |
+      Betrieb von Destillations-, Kristallisations-, Filtrations-,
+      Trocknungs- und Membrantrennungseinheiten.
+  BC-4620.20.10:
+    name: Destillationsbetrieb
+    description: |
+      Betrieb von Boden- und Füllkörper-Destillationskolonnen.
+  BC-4620.20.20:
+    name: Kristallisationsbetrieb
+    description: |
+      Betrieb von Kühl-, Verdampfungs- und reaktiven
+      Kristallisatoren.
+  BC-4620.20.30:
+    name: Filtrations- und Fest-Flüssig-Trennung
+    description: |
+      Betrieb von Zentrifugen, Filterpressen und
+      Drehvakuumfiltern.
+  BC-4620.20.40:
+    name: Trocknungsbetrieb
+    description: |
+      Betrieb von Wirbelschicht-, Sprüh- und Kontakt-Trocknern.
+  BC-4620.20.50:
+    name: Membrantrennungsbetrieb
+    description: |
+      Betrieb von Umkehrosmose-, Ultrafiltrations- und
+      Pervaporations-Membranen.
+  BC-4620.30:
+    name: Polymerisierungsbetrieb
+    description: |
+      Betrieb von Massen-, Lösungs-, Suspensions- und
+      Emulsionspolymerisierung sowie nachgelagerter
+      Polymer-Compoundierung.
+  BC-4620.30.10:
+    name: Massenpolymerisierungsbetrieb
+    description: |
+      Betrieb von Massen- und Massepolymerisierungs-Reaktoren.
+  BC-4620.30.20:
+    name: Lösungspolymerisierungsbetrieb
+    description: |
+      Betrieb von Lösungspolymerisierungsprozessen.
+  BC-4620.30.30:
+    name: Suspensions- und Emulsionspolymerisierung
+    description: |
+      Betrieb von Suspensions- und Emulsionspolymerisierungs-
+      Reaktoren.
+  BC-4620.30.40:
+    name: Polymer-Compounding-Betrieb
+    description: |
+      Compoundierung von Polymeren mit Additiven über
+      Schmelzmischung.
+  BC-4620.40:
+    name: Anorganischer und elektrochemischer Betrieb
+    description: |
+      Betrieb von Chlor-Alkali-, Elektrolyse-, Calcinierung-
+      und anderen anorganischen Syntheseprozessen.
+  BC-4620.40.10:
+    name: Chlor-Alkali-Zellen-Betrieb
+    description: |
+      Betrieb quecksilberfreier Membran- und Diaphragma-
+      Chlor-Alkali-Zellen.
+  BC-4620.40.20:
+    name: Elektrolysebetrieb
+    description: |
+      Betrieb von Metall- und Gas-Elektrolyse-Zellen.
+  BC-4620.40.30:
+    name: Calcinierungs- und Röstbetrieb
+    description: |
+      Betrieb von Drehrohröfen, Wirbelschicht-Röstern und
+      Calcinatoren.
+  BC-4620.40.40:
+    name: Anorganischer Synthesebetrieb
+    description: |
+      Betrieb anorganischer Syntheseeinheiten einschließlich
+      Fällung und Aufschluss.
+  BC-4620.50:
+    name: Katalysator- und Prozesschemikalien-Lebenszyklusmanagement
+    description: |
+      Auswahl, Überwachung, Regeneration und Inventar von
+      Prozesskatalysatoren und Chemikalien.
+  BC-4620.50.10:
+    name: Katalysatorauswahl und -beladung
+    description: |
+      Auswahl und Beladung von Festbett- und
+      Wirbelschicht-Katalysatoren.
+  BC-4620.50.20:
+    name: Katalysatorleistungs-Überwachung
+    description: |
+      Betriebsüberwachung von Katalysatoraktivität und
+      Selektivität.
+  BC-4620.50.30:
+    name: Katalysatorregeneration-Koordination
+    description: |
+      Koordination von In-situ- und Ex-situ-Katalysator-
+      Regenerationskampagnen.
+  BC-4620.50.40:
+    name: Prozesschemikalien-Inventarmanagement
+    description: |
+      Inventar- und Verbrauchsmanagement von Lösungsmitteln,
+      Additiven und Prozesschemikalien.
+  BC-4620.60:
+    name: Prozessleitung und Betriebsdurchführung
+    description: |
+      Tägliche Betriebsdurchführung aus dem Feld und Leitstand
+      einschließlich Hüllenüberwachung.
+  BC-4620.60.10:
+    name: Operatorrundendurchführung
+    description: |
+      Durchführung strukturierter Operatorrunden und
+      Feldprüfungen.
+  BC-4620.60.20:
+    name: DCS-Konsolenbetrieb
+    description: |
+      Konsolenbetrieb einschließlich Alarmreaktion und
+      Aufsichtssteuerung.
+  BC-4620.60.30:
+    name: Schichtwechsel-Management
+    description: |
+      Strukturierter Schichtwechsel und Betriebslog-Review.
+  BC-4620.60.40:
+    name: Betriebsbereich-Überwachung
+    description: |
+      Echtzeit-Überwachung sicherer und qualitätsbezogener
+      Betriebsbereiche.
+  BC-4620.70:
+    name: Anlagen-Revisions-Koordination
+    description: |
+      Umfangs-, Termin- und Durchführungskoordination für
+      chemische Anlagenrevisionen und Hauptstillstände.
+  BC-4620.70.10:
+    name: Revisionsumfang-Management
+    description: |
+      Definition und Einfrieren des Revisionsumfangs
+      einschließlich Herausforderungsverfahren.
+  BC-4620.70.20:
+    name: Revisionstermin-Management
+    description: |
+      Detaillierte Revisionsplanung und Fortschrittskontrolle.
+  BC-4620.70.30:
+    name: Stillstands- und Wiederanfahrkoordination
+    description: |
+      Sequenzierte Einheitenstillstände, Dekontamination und
+      Wiederanfahrkoordination.
+  BC-4620.80:
+    name: Chemische Produktionsplanung
+    description: |
+      Kampagnenbasierte und kontinuierliche Produktionsplanung
+      sowie Umstellungsplanung.
+  BC-4620.80.10:
+    name: Kampagnenplanung
+    description: |
+      Planung von Mehrprodukt-Kampagnen auf gemeinsamen Anlagen.
+  BC-4620.80.20:
+    name: Produktionssequenzierung
+    description: |
+      Sequenzierung von Produkten zur Minimierung von
+      Übergängen und Ausbeuteverlusten.
+  BC-4620.80.30:
+    name: Umstellungsplanung
+    description: |
+      Planung und Koordination von Grad- und Produktumstellungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-chemical-process-engineering-management.yaml
+++ b/catalogue/i18n/de/L1-chemical-process-engineering-management.yaml
@@ -1,0 +1,180 @@
+locale: de
+source: L1-chemical-process-engineering-management.yaml
+entries:
+  BC-4610:
+    name: Chemische Verfahrenstechnik
+    description: |
+      Prozessdesign, Massen- und Energiebilanzberechnung, Simulation,
+      Ausrüstungsspezifikation und Front-End-Engineering für chemische
+      Anlagen und Revamps. Distinct vom branchenübergreifenden
+      Engineering-Disziplinmanagement (BC-1100).
+  BC-4610.10:
+    name: Prozessfließschema-Design
+    description: |
+      Entwicklung von Blockfließbildern, Prozessfließschemata und
+      Rohrleitungs- und Instrumentenplänen für chemische Prozesse.
+  BC-4610.10.10:
+    name: Blockfließbild-Entwicklung
+    description: |
+      Erstellung von Blockfließbildern für frühe Prozessdefinition.
+  BC-4610.10.20:
+    name: Prozessfließschema-Entwicklung
+    description: |
+      Erstellung von Prozessfließschemata mit Stromentnahmebedingungen
+      und Eigenschaften.
+  BC-4610.10.30:
+    name: Rohrleitungs- und Instrumentenplan-Entwicklung
+    description: |
+      Erstellung und Revision von R&Is für chemische Prozesseinheiten.
+  BC-4610.10.40:
+    name: Hilfsstoff-Fließschema-Entwicklung
+    description: |
+      Erstellung von Hilfsstoff-Fließschemata für Dampf,
+      Kühlwasser und Inertgas.
+  BC-4610.20:
+    name: Reaktor- und Trennapparateauslegung
+    description: |
+      Auslegung von Reaktoren und Trennapparaten auf Basis von
+      Kinetik, Thermodynamik und Grundoperationsprinzipien.
+  BC-4610.20.10:
+    name: Reaktorauslegung
+    description: |
+      Auslegung und Konfiguration von CSTR-, PFR- und
+      Festbett-Reaktoren.
+  BC-4610.20.20:
+    name: Destillationskolonnen-Auslegung
+    description: |
+      Auslegung von Boden- und Füllkörper-Destillationskolonnen
+      einschließlich Einbauten.
+  BC-4610.20.30:
+    name: Wärmetauscher-Netzwerk-Auslegung
+    description: |
+      Pinch- und Tauscher-Netzwerk-Auslegung für
+      Energieintegration.
+  BC-4610.20.40:
+    name: Kristallisator- und Filter-Auslegung
+    description: |
+      Auslegung von Kristallisatoren, Zentrifugen und
+      Filterausrüstung.
+  BC-4610.30:
+    name: Massen- und Energiebilanz-Engineering
+    description: |
+      Abschluss von Gesamtanlagen- und Einheitenebene-Massen- und
+      Energiebilanzen sowie Hilfsstoffbedarfsschätzung.
+  BC-4610.30.10:
+    name: Massenbilanz-Berechnung
+    description: |
+      Berechnung und Abgleich von Anlagen- und Einheitenbilanzen.
+  BC-4610.30.20:
+    name: Energiebilanz-Berechnung
+    description: |
+      Berechnung von Energiebilanzen über Reaktoren, Tauscher
+      und Hilfssysteme hinweg.
+  BC-4610.30.30:
+    name: Hilfsstoffbedarfs-Schätzung
+    description: |
+      Schätzung von Dampf-, Strom-, Kühlwasser- und
+      Inertgasbedarf.
+  BC-4610.40:
+    name: Prozesssimulations-Management
+    description: |
+      Aufbau und Pflege von Stationär- und dynamischen
+      Prozesssimulationen für Design und Betrieb.
+  BC-4610.40.10:
+    name: Stationäre Prozesssimulation
+    description: |
+      Aufbau und Ausführung stationärer Simulatoren für
+      Design und Analyse.
+  BC-4610.40.20:
+    name: Dynamische Prozesssimulation
+    description: |
+      Aufbau und Ausführung dynamischer Simulatoren für
+      Steuerungs- und Sicherheitsstudien.
+  BC-4610.40.30:
+    name: Simulationsmodell-Validierung
+    description: |
+      Validierung von Simulationsmodellen gegenüber Anlagen-
+      oder Pilotdaten.
+  BC-4610.50:
+    name: Ausrüstungsspezifikations-Management
+    description: |
+      Erstellung und Lebenszyklusmanagement von Ausrüstungs-
+      Datenblättern und Lieferantenzeichnungen.
+  BC-4610.50.10:
+    name: Ausrüstungs-Datenblatt-Erstellung
+    description: |
+      Erstellung mechanischer, elektrischer und
+      Instrumenten-Datenblätter.
+  BC-4610.50.20:
+    name: Ausrüstungsspezifikations-Pflege
+    description: |
+      Konfigurationsmanagement genehmigter
+      Ausrüstungsspezifikationen.
+  BC-4610.50.30:
+    name: Lieferantenzeichnungs-Review
+    description: |
+      Review von Lieferantenzeichnungen gegenüber Datenblättern
+      und Prozessanforderungen.
+  BC-4610.60:
+    name: Anlagenlayout und Grundrissplanung
+    description: |
+      Definition von Grundrissen, Ausrüstungsabständen und
+      Gefahrenbereichsklassifikation für chemische Anlagen.
+  BC-4610.60.10:
+    name: Grundrissplanung
+    description: |
+      Entwicklung von Einheiten- und Standort-Gesamtgrundrissen.
+  BC-4610.60.20:
+    name: Ausrüstungsabstands-Bestimmung
+    description: |
+      Bestimmung von Ausrüstungsabständen gemäß Prozesssicherheit
+      und Konstruierbarkeit.
+  BC-4610.60.30:
+    name: Gefahrenbereichsklassifikation
+    description: |
+      Klassifikation von Gefahrenbereichen zur
+      Zündquellenkontrolle.
+  BC-4610.70:
+    name: Prozessleitsystem-Philosophie-Entwicklung
+    description: |
+      Definition von Prozessleitsystemstrategien, erweiterter
+      Regelung und Betriebsverfahrensbasis für neue und
+      modifizierte Anlagen.
+  BC-4610.70.10:
+    name: Regelkreis-Definition
+    description: |
+      Definition regulatorischer Regelkreise und
+      Abstimmungsabsicht.
+  BC-4610.70.20:
+    name: Erweitertes Prozessleitsystem-Strategie
+    description: |
+      Definition modellprädiktiver und erweiterter
+      Regelungsstrategien.
+  BC-4610.70.30:
+    name: Betriebsverfahrensbasis-Entwicklung
+    description: |
+      Entwicklung der Betriebsverfahrensbasis für neue
+      und modifizierte Anlagen.
+  BC-4610.80:
+    name: Front-End-Engineering-Design-Koordination
+    description: |
+      Koordination konzeptioneller, grundlegender und
+      Front-End-Engineering-Design-Pakete für chemische Projekte.
+  BC-4610.80.10:
+    name: Konzeptionelle Engineering-Koordination
+    description: |
+      Koordination konzeptioneller Ingenieursstudien und
+      Optionsscreening.
+  BC-4610.80.20:
+    name: Grundlegendes Ingenieurpaket-Produktion
+    description: |
+      Produktion grundlegender Ingenieurpakete für die
+      Detailplanung.
+  BC-4610.80.30:
+    name: FEED-Verifikation
+    description: |
+      Verifikation von FEED-Lieferergebnissen gegenüber
+      Prozess- und Projektanforderungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-chemical-process-safety-management.yaml
+++ b/catalogue/i18n/de/L1-chemical-process-safety-management.yaml
@@ -1,0 +1,215 @@
+locale: de
+source: L1-chemical-process-safety-management.yaml
+entries:
+  BC-4640:
+    name: Chemische Anlagensicherheit
+    description: |
+      Verhütung von Schwerstunfallgefahren in reaktiven, brennbaren
+      und toxischen chemischen Prozessen — Prozessgefahrenanalyse,
+      mechanische Integrität, Sicherheitsinstrumentierungssysteme,
+      reaktive und brennbare Gefahren, Leistungsberichterstattung
+      und Notfallreaktion. Distinct vom branchenübergreifenden
+      HSE-Management (BC-730).
+  BC-4640.10:
+    name: Prozessgefahrenanalyse
+    description: |
+      Strukturierte Identifikation und Analyse von
+      Schwerstunfallgefahren über den Anlagenlebenszyklus hinweg.
+    in_scope:
+      - HAZID, HAZOP, LOPA und Bow-Tie-Analyse
+      - Quantitative Risikobewertung
+    out_of_scope:
+      - Persönliche Sicherheitsrisikobewertung (BC-730)
+  BC-4640.10.10:
+    name: HAZOP-Studien
+    description: |
+      Gefährdungs- und Betreibbarkeitsstudien an neuen und
+      modifizierten Anlagen.
+  BC-4640.10.20:
+    name: HAZID-Studien
+    description: |
+      Gefährdungsidentifikationsstudien in frühen Konzept-
+      und Designphasen.
+  BC-4640.10.30:
+    name: LOPA-Studien
+    description: |
+      Schutzschichtenanalyse zur Definition von
+      Sicherheitsintegritätsniveaus.
+  BC-4640.10.40:
+    name: Bow-Tie-Analyse
+    description: |
+      Bow-Tie-Analyse zur Kartierung von Schutzbarrieren
+      gegenüber Schwerstunfallszenarien.
+  BC-4640.10.50:
+    name: Quantitative Risikobewertung
+    description: |
+      Quantitative Risikobewertung von Schwerstunfallgefahren-
+      szenarien.
+  BC-4640.20:
+    name: Mechanische Integritätsmanagement
+    description: |
+      Inspektions- und Integritätsmanagement druckhaltender
+      Ausrüstung und Sicherheitsventile.
+  BC-4640.20.10:
+    name: Druckbehälterinspektion
+    description: |
+      Risikobasierte Inspektion von Druckbehältern gemäß API 510.
+  BC-4640.20.20:
+    name: Prozessrohrleitung-Integritätsinspektion
+    description: |
+      Inspektion von Prozessrohrleitungen gemäß API 570 und
+      ASME B31.3.
+  BC-4640.20.30:
+    name: Lagertankinspektion
+    description: |
+      Atmosphärische und druckbelastete Lagertankinspektion
+      gemäß API 653.
+  BC-4640.20.40:
+    name: Sicherheitsdruckventil-Management
+    description: |
+      Auslegung, Prüfung und Lebenszyklusmanagement von
+      Sicherheitsventilen und Berstscheiben.
+  BC-4640.20.50:
+    name: Atmosphärische Entlüftungs- und Fackel-Integrität
+    description: |
+      Integritätssicherung atmosphärischer Entlüftungen,
+      Wäscher und Fackeln.
+  BC-4640.30:
+    name: Sicherheitsinstrumentierungssystem-Management
+    description: |
+      Funktionale Sicherheitslebenszyklus-Management von
+      Sicherheitsinstrumentierungssystemen gemäß IEC 61511.
+  BC-4640.30.10:
+    name: SIL-Bestimmung
+    description: |
+      Bestimmung von Sicherheitsintegritätsniveaus für
+      Schutzfunktionen.
+  BC-4640.30.20:
+    name: Sicherheitsfunktions-Verifikation
+    description: |
+      Verifikation, dass entworfene SIFs das erforderliche SIL
+      erfüllen.
+  BC-4640.30.30:
+    name: SIS-Nachweisprüfung
+    description: |
+      Periodische Nachweisprüfung von
+      Sicherheitsinstrumentierungssystemen.
+  BC-4640.30.40:
+    name: Funktionale Sicherheitsbewertung
+    description: |
+      Funktionale Sicherheitsbewertungen an den
+      Lebenszyklusprüfpunkten.
+  BC-4640.40:
+    name: Reaktive und brennbare Gefährdungsmanagement
+    description: |
+      Identifikation und Kontrolle reaktiver Chemie-, Durchgeh-,
+      brennbarer Staub- und Zündgefahren.
+  BC-4640.40.10:
+    name: Reaktive Chemie-Risikobewertung
+    description: |
+      Bewertung reaktiver Chemierisiken einschließlich
+      Inkompatibilitäten.
+  BC-4640.40.20:
+    name: Durchgehreaktion-Verhütung
+    description: |
+      Verhütung und Minderung durchgehender exothermer
+      Reaktionen.
+  BC-4640.40.30:
+    name: Brennbarer Staub-Gefährdungskontrolle
+    description: |
+      Kontrolle brennbarer Staubgefahren gemäß NFPA 654.
+  BC-4640.40.40:
+    name: Statische Elektrizität und Zündquellenkontrolle
+    description: |
+      Kontrolle elektrostatischer und anderer Zündquellen
+      in Prozessbereichen.
+  BC-4640.50:
+    name: Prozesssicherheits-Änderungsmanagement
+    description: |
+      Prozesssicherheits-Governance über Anlagen-, Verfahrens-
+      und Personaländerungen einschließlich Vor-Inbetriebnahme-
+      Sicherheitsüberprüfung.
+  BC-4640.50.10:
+    name: PSM-Änderungsanforderungs-Review
+    description: |
+      Review PSM-beeinflussender Änderungsanforderungen gegen
+      Gefährdungsstandards.
+  BC-4640.50.20:
+    name: Vor-Inbetriebnahme-Sicherheitsüberprüfung
+    description: |
+      Vor-Inbetriebnahme-Sicherheitsüberprüfungen für neue und
+      modifizierte Anlagen.
+  BC-4640.50.30:
+    name: Temporäre Änderungs-Management
+    description: |
+      Management temporärer Prozessänderungen innerhalb ihres
+      genehmigten Zeitfensters.
+  BC-4640.60:
+    name: Prozesssicherheitsleistungs-Management
+    description: |
+      Verfolgung und Berichterstattung führender und
+      nacheilender Prozesssicherheitsindikatoren gemäß CCPS RBPS
+      und gleichwertigen Frameworks.
+  BC-4640.60.10:
+    name: Tier-1- und Tier-2-Prozesssicherheitsereignis-Berichterstattung
+    description: |
+      Erfassung und Berichterstattung von Tier-1- und Tier-2-
+      Prozesssicherheitsereignissen.
+  BC-4640.60.20:
+    name: Frühindikator-Überwachung
+    description: |
+      Überwachung von Tier-3- und Tier-4-führenden
+      Prozesssicherheitsindikatoren.
+  BC-4640.60.30:
+    name: Prozesssicherheits-KPI-Berichterstattung
+    description: |
+      Externe und interne Berichterstattung über
+      Prozesssicherheits-KPI-Leistung.
+  BC-4640.70:
+    name: Notfallvorsorge und -reaktion
+    description: |
+      Notfallreaktionsplanung, Übungskoordination und
+      Toxisch-Freisetzungs-Reaktionskoordination für
+      Schwerstunfallszenarien.
+  BC-4640.70.10:
+    name: Notfallreaktionsplanung
+    description: |
+      Pflege von Installations- und betrieblichen
+      Notfallreaktionsplänen.
+  BC-4640.70.20:
+    name: Übungs- und Manöver-Koordination
+    description: |
+      Koordination von Notfallübungen und
+      Schwerstunfall-Manövern.
+  BC-4640.70.30:
+    name: Toxisch-Freisetzungs-Reaktionskoordination
+    description: |
+      Koordination toxischer und brennbarer
+      Freisetzungsreaktionsbetriebe.
+  BC-4640.70.40:
+    name: Gegenseitigkeitshilfe-Koordination
+    description: |
+      Koordination gegenseitiger Hilfe mit industriellen
+      Reaktionskooperativen.
+  BC-4640.80:
+    name: Prozesssicherheits-Betriebsverfahren
+    description: |
+      Erstellung, Review und Betriebsbereichsdefinition für
+      prozesssicherheitskritische Verfahren.
+  BC-4640.80.10:
+    name: Sicherheitskritische Verfahren-Erstellung
+    description: |
+      Erstellung prozesssicherheitskritischer
+      Betriebsverfahren.
+  BC-4640.80.20:
+    name: Betriebsbereichs-Definition
+    description: |
+      Definition sicherer Betriebsbereiche für Prozesseinheiten.
+  BC-4640.80.30:
+    name: Periodische Verfahrensüberprüfung
+    description: |
+      Periodische Überprüfung und Aktualisierung von
+      Prozesssicherheitsverfahren.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-chemical-product-stewardship-management.yaml
+++ b/catalogue/i18n/de/L1-chemical-product-stewardship-management.yaml
@@ -1,0 +1,136 @@
+locale: de
+source: L1-chemical-product-stewardship-management.yaml
+entries:
+  BC-4650:
+    name: Chemikalien-Produktverantwortung
+    description: |
+      Gefahreneinstufung und -kennzeichnung, Sicherheitsdatenblatt-
+      Erstellung, Expositionsszenarien, Programme für besonders
+      besorgniserregende Stoffe und Gefahrenkommunikation gegenüber
+      Kunden über den gesamten Produktlebenszyklus.
+  BC-4650.10:
+    name: Gefahreneinstufung und -kennzeichnung
+    description: |
+      GHS-Einstufung von Stoffen und Gemischen sowie Gestaltung
+      konformer Kennzeichnungen.
+  BC-4650.10.10:
+    name: GHS-Stoffeinstufung
+    description: |
+      Einstufung von Stoffen nach dem UN-GHS-Gefahrenschema.
+  BC-4650.10.20:
+    name: Gemischeinstufung
+    description: |
+      Einstufung von Gemischen mittels Übertragungsprinzipien
+      und Prüfdaten.
+  BC-4650.10.30:
+    name: Gefahrenpiktogramm- und Etikettengestaltung
+    description: |
+      Gestaltung GHS-konformer Piktogramme, Signalwörter und
+      Etikettenvorlagen.
+  BC-4650.10.40:
+    name: Mehrsprachige Etiketten-Lokalisierung
+    description: |
+      Übersetzung und Lokalisierung von Etiketten für
+      Zielmärkte.
+  BC-4650.20:
+    name: Sicherheitsdatenblatt-Management
+    description: |
+      Erstellung, Review und Verteilung von Sicherheitsdatenblättern
+      einschließlich erweiterter SDB für nachgeschaltete Anwender.
+  BC-4650.20.10:
+    name: SDB-Erstellung
+    description: |
+      Erstellung von Sicherheitsdatenblättern im 16-Abschnitte-Format.
+  BC-4650.20.20:
+    name: SDB-Review und -Aktualisierung
+    description: |
+      Review und Aktualisierung von SDB gegenüber neuen Daten
+      und regulatorischen Änderungen.
+  BC-4650.20.30:
+    name: SDB-Verteilungsmanagement
+    description: |
+      Verteilung von SDB an Kunden und Lieferkettenpartner.
+  BC-4650.20.40:
+    name: Erweitertes SDB-Management
+    description: |
+      Management erweiterter SDB-Anhänge mit Expositionsszenarien.
+  BC-4650.30:
+    name: Expositionsszenario-Management
+    description: |
+      Entwicklung und Pflege von Arbeitnehmer-, Verbraucher- und
+      Umwelt-Expositionsszenarien für registrierte Stoffe.
+  BC-4650.30.10:
+    name: Arbeitnehmer-Expositionsszenario-Entwicklung
+    description: |
+      Entwicklung von Arbeitnehmer-Expositionsszenarien unter
+      typischen Verwendungsbedingungen.
+  BC-4650.30.20:
+    name: Verbraucher-Expositionsszenario-Entwicklung
+    description: |
+      Entwicklung von Verbraucher-Expositionsszenarien für
+      Endproduktverwendungen.
+  BC-4650.30.30:
+    name: Umweltfreisetzungsszenario-Entwicklung
+    description: |
+      Entwicklung von Umweltfreisetzungsszenarien über den
+      Lebenszyklus hinweg.
+  BC-4650.40:
+    name: SVHC-Stoffmanagement
+    description: |
+      Identifikation, Substitution und Restriktionsverfolgung
+      besonders besorgniserregender Stoffe im Produktportfolio.
+  BC-4650.40.10:
+    name: SVHC-Bestandsverwaltung
+    description: |
+      Pflege des Inventars zu SVHC-Präsenz im Portfolio.
+  BC-4650.40.20:
+    name: Stoffsubstitutions-Programm-Management
+    description: |
+      Programmmanagement für Substitutionsinitiativen mit
+      sichereren Stoffen.
+  BC-4650.40.30:
+    name: Beschränkungsstofflisten-Pflege
+    description: |
+      Pflege interner und kundenseitig vorgeschriebener
+      Beschränkungsstofflisten.
+  BC-4650.50:
+    name: Kunden-Gefahrenkommunikation
+    description: |
+      Ausgehende Kommunikation von Gefahreninformationen an Kunden
+      und nachgeschaltete Anwender.
+  BC-4650.50.10:
+    name: Kunden-Stewardship-Benachrichtigung
+    description: |
+      Benachrichtigung von Kunden über stewardship-relevante
+      Änderungen.
+  BC-4650.50.20:
+    name: Gefahrenschulungsmaterial-Produktion
+    description: |
+      Produktion von Schulungsmaterialien zur sicheren Handhabung
+      und Verwendung.
+  BC-4650.50.30:
+    name: Nachgeschaltete-Anwender-Anfragenbearbeitung
+    description: |
+      Bearbeitung von Stewardship-Anfragen nachgeschalteter Anwender.
+  BC-4650.60:
+    name: Produkt-Lebenszyklusverantwortung
+    description: |
+      Lebenszyklusverantwortung für Chemikalienprodukte einschließlich
+      Lebensende-, Recyclingfähigkeits- und Wiederverwendungsaspekten.
+  BC-4650.60.10:
+    name: Produktgefahrenprofil-Pflege
+    description: |
+      Pflege konsolidierter Gefahrenprofile je Produkt.
+  BC-4650.60.20:
+    name: Lebensende-Stewardship-Koordination
+    description: |
+      Koordination von Rücknahme- und Lebensende-
+      Stewardship-Vereinbarungen.
+  BC-4650.60.30:
+    name: Recyclingfähigkeits- und Wiederverwendungsbewertung
+    description: |
+      Bewertung von Recyclingfähigkeit und Wiederverwendungspotenzial
+      chemischer Produkte.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-chemical-quality-management.yaml
+++ b/catalogue/i18n/de/L1-chemical-quality-management.yaml
@@ -1,0 +1,156 @@
+locale: de
+source: L1-chemical-quality-management.yaml
+entries:
+  BC-4670:
+    name: Chemisches Qualitätsmanagement
+    description: |
+      Chemikalienspezifische Spezifikationsfestlegung, analytischer
+      Laborbetrieb, Chargenfreigabe, Beschwerde- und
+      Analysenzertifikat-Streitbearbeitung, Referenzstandards und
+      sektorspezifische GMP-Konformität. Distinct vom
+      branchenübergreifenden Qualitätsmanagement (BC-720), das
+      das unternehmerische QMS abdeckt.
+  BC-4670.10:
+    name: Chemikalienspezifikations-Management
+    description: |
+      Festlegung und Lebenszyklusmanagement von Rohstoff-,
+      Zwischen- und Fertigproduktspezifikationen.
+  BC-4670.10.10:
+    name: Rohstoffspezifikations-Festlegung
+    description: |
+      Festlegung und Revision eingehender Rohstoffspezifikationen.
+  BC-4670.10.20:
+    name: Zwischenproduktspezifikations-Festlegung
+    description: |
+      Festlegung von Zwischenproduktspezifikationen entlang der
+      Produktionskette.
+  BC-4670.10.30:
+    name: Fertigproduktspezifikations-Festlegung
+    description: |
+      Festlegung von Fertigproduktspezifikationen und
+      Freigabekriterien.
+  BC-4670.10.40:
+    name: Spezifikations-Lebenszyklusmanagement
+    description: |
+      Lebenszyklusmanagement genehmigter Spezifikationen
+      und Änderungen.
+  BC-4670.20:
+    name: Analytischer Laborbetrieb
+    description: |
+      Betrieb von QK-Laboratorien mit Nasschemieverfahren,
+      Chromatographie, Spektroskopie und Physikalprüfungen.
+  BC-4670.20.10:
+    name: Nasschemie-Laborbetrieb
+    description: |
+      Betrieb nasschemischer Analyseworkflows.
+  BC-4670.20.20:
+    name: Chromatographie-Betrieb
+    description: |
+      Betrieb von HPLC-, GC- und Ionenchromatographie-Plattformen.
+  BC-4670.20.30:
+    name: Spektroskopie-Betrieb
+    description: |
+      Betrieb von FTIR-, NMR-, ICP- und Massenspektrometrie-
+      Plattformen.
+  BC-4670.20.40:
+    name: Physikalische Eigenschaftsprüfung
+    description: |
+      Prüfung physikalischer Eigenschaften wie Viskosität, Dichte
+      und Partikelgröße.
+  BC-4670.30:
+    name: Chargenfreigabe-Management
+    description: |
+      Dispositionsentscheidungen, Analysenzertifikat-Ausstellung und
+      Außer-Spezifikation-Bearbeitung für Chemikalienchargen.
+  BC-4670.30.10:
+    name: Chargen-Dispositionsentscheidung
+    description: |
+      Dispositionsentscheidung für hergestellte Chargen gegen
+      Spezifikation.
+  BC-4670.30.20:
+    name: Analysenzertifikat-Ausstellung
+    description: |
+      Ausstellung von Analysenzertifikaten an Kunden.
+  BC-4670.30.30:
+    name: Außer-Spezifikation-Untersuchung
+    description: |
+      Untersuchung außerhalb der Spezifikation liegender
+      Analysenergebnisse.
+  BC-4670.40:
+    name: Kunden-Beschwerde- und COA-Streit-Management
+    description: |
+      Erfassung und Beilegung von Kundenbeschwerden und
+      Analysenzertifikat-Streitigkeiten.
+  BC-4670.40.10:
+    name: Kundenbeschwerde-Erfassung
+    description: |
+      Erfassung und Triage von Kundenbeschwerden zu
+      Chemikalienprodukten.
+  BC-4670.40.20:
+    name: COA-Streit-Untersuchung
+    description: |
+      Untersuchung von Streitigkeiten über Analysenzertifikatswerte.
+  BC-4670.40.30:
+    name: Kunden-Proben-Nachprüfung
+    description: |
+      Nachprüfung von zurückbehaltenen und kundenbereitgestellten
+      Proben.
+  BC-4670.50:
+    name: Referenzmaterial- und Standards-Management
+    description: |
+      Beschaffung, Qualifizierung und Stabilitätsüberwachung von
+      Referenzstandards und -materialien.
+  BC-4670.50.10:
+    name: Referenzstandard-Beschaffung
+    description: |
+      Beschaffung zertifizierter Referenzmaterialien von
+      akkreditierten Anbietern.
+  BC-4670.50.20:
+    name: Interne Referenzstandard-Qualifizierung
+    description: |
+      Qualifizierung interner Arbeitsreferenzstandards.
+  BC-4670.50.30:
+    name: Referenzstandard-Stabilitätsüberwachung
+    description: |
+      Stabilitätsüberwachung in Gebrauch befindlicher
+      Referenzstandards.
+  BC-4670.60:
+    name: Methodenentwicklung und -validierung
+    description: |
+      Entwicklung, Validierung und Transfer analytischer Methoden
+      zwischen Laboratorien.
+  BC-4670.60.10:
+    name: Analytische Methodenentwicklung
+    description: |
+      Entwicklung neuer analytischer Methoden zur Unterstützung
+      von Spezifikationen.
+  BC-4670.60.20:
+    name: Methodenvalidierung
+    description: |
+      Validierung analytischer Methoden auf Richtigkeit, Präzision
+      und Robustheit.
+  BC-4670.60.30:
+    name: Methodentransfer
+    description: |
+      Transfer validierter Methoden zwischen Laboratorien.
+  BC-4670.70:
+    name: Sektorspezifische GMP-Konformität
+    description: |
+      Konformität mit sektorspezifischen GMP-Regimen für Chemikalien,
+      die in regulierte nachgelagerte Märkte geliefert werden.
+  BC-4670.70.10:
+    name: EFfCI-GMP-Konformität
+    description: |
+      Konformität mit EFfCI-GMP für kosmetische Inhaltsstoffe.
+  BC-4670.70.20:
+    name: IPEC-GMP-Konformität
+    description: |
+      Konformität mit IPEC-GMP für pharmazeutische Hilfsstoffe.
+  BC-4670.70.30:
+    name: Lebensmittelkontakt-Konformität
+    description: |
+      Konformität mit Lebensmittelkontaktvorschriften für Chemikalien
+      in Lebensmittelverpackungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-chemical-regulatory-compliance-management.yaml
+++ b/catalogue/i18n/de/L1-chemical-regulatory-compliance-management.yaml
@@ -1,0 +1,161 @@
+locale: de
+source: L1-chemical-regulatory-compliance-management.yaml
+entries:
+  BC-4660:
+    name: Chemikalien-Regulierungskonformität
+    description: |
+      Stoffregistrierung, Dossiers, Zulassungen, Beschränkungen,
+      Inventarlistungen und Import-/Exportkontrollen unter REACH,
+      TSCA, K-REACH, CWK und gleichwertigen Regimen. Distinct vom
+      branchenübergreifenden Compliance-Management (BC-130), das
+      die unternehmenspolitische Konformität abdeckt.
+  BC-4660.10:
+    name: Stoffregistrierungs-Management
+    description: |
+      Registrierung von Stoffen unter den wichtigsten globalen
+      chemischen Inventarregimen.
+  BC-4660.10.10:
+    name: REACH-Registrierungs-Management
+    description: |
+      Management von REACH-Registrierungen einschließlich
+      SIEF und gemeinsamer Einreichung.
+  BC-4660.10.20:
+    name: TSCA-PMN- und Inventarnotifizierung
+    description: |
+      Voranmelde- und TSCA-Inventarnotifizierung vor der Herstellung.
+  BC-4660.10.30:
+    name: K-REACH- und Asien-Pazifik-Notifizierung
+    description: |
+      Notifizierung unter K-REACH, China, Japan und anderen
+      Asien-Pazifik-Regimen.
+  BC-4660.10.40:
+    name: Polymer-Notifizierungs-Management
+    description: |
+      Notifizierungs- und Ausnahme-Management für Polymerstoffe.
+  BC-4660.20:
+    name: Zulassungs- und Beschränkungs-Management
+    description: |
+      Konformität mit Zulassungs-, Beschränkungs- und aufkommenden
+      Stoffkontrollen.
+  BC-4660.20.10:
+    name: REACH-Zulassungsantragstellung
+    description: |
+      Erstellung und Einreichung von REACH-Anhang-XIV-
+      Zulassungsanträgen.
+  BC-4660.20.20:
+    name: REACH-Beschränkungs-Konformität
+    description: |
+      Konformität mit REACH-Anhang-XVII-Beschränkungseinträgen.
+  BC-4660.20.30:
+    name: SVHC-Kandidatenlisten-Verfolgung
+    description: |
+      Verfolgung von SVHC-Kandidatenlisten-Aktualisierungen und
+      Folgenabschätzung.
+  BC-4660.20.40:
+    name: PFAS- und Aufkommende-Beschränkungen-Management
+    description: |
+      Management von PFAS-, Mikroplastik- und anderen aufkommenden
+      Beschränkungen.
+  BC-4660.30:
+    name: Regulatorisches Dossier-Management
+    description: |
+      Erstellung und Pflege regulatorischer Dossiers in IUCLID
+      und gleichwertigen Formaten.
+  BC-4660.30.10:
+    name: IUCLID-Dossier-Management
+    description: |
+      Erstellung und Pflege von IUCLID-6-Dossiers.
+  BC-4660.30.20:
+    name: Chemikalien-Sicherheitsbericht-Erstellung
+    description: |
+      Erstellung von Chemikalien-Sicherheitsberichten gemäß
+      REACH-Anhang I.
+  BC-4660.30.30:
+    name: Stoffidentitätsprofil-Pflege
+    description: |
+      Pflege von Stoffidentitätsprofilen und analytischen Belegen.
+  BC-4660.40:
+    name: Inventarlistungs-Management
+    description: |
+      Management der Stoffpräsenz in EINECS-, EG- und nationalen
+      Chemikalieninventaren.
+  BC-4660.40.10:
+    name: EINECS- und EG-Nummern-Management
+    description: |
+      Management von EINECS- und EG-Nummernzuweisungen und
+      -aktualisierungen.
+  BC-4660.40.20:
+    name: Neustoff-Inventarnotifizierung
+    description: |
+      Notifizierung neuer Stoffe bei nationalen Inventaren.
+  BC-4660.40.30:
+    name: Länderinventar-Abgleich
+    description: |
+      Abgleich des Portfolios gegenüber nationalen Chemikalieninventaren.
+  BC-4660.50:
+    name: Chemikalien-Import-Export-Kontrolle
+    description: |
+      Konformität mit internationalen chemischen Handelskontrolle
+      einschließlich CWK, Drogenvorläufer, Dual-Use und PIC.
+  BC-4660.50.10:
+    name: CWK-Zeitplan-Konformität
+    description: |
+      Konformität mit OPCW-Zeitplan-1-, -2- und -3-Deklaration
+      und Lizenzierung.
+  BC-4660.50.20:
+    name: Drogenvorläufer-Kontrolle
+    description: |
+      Konformität mit INCB- und nationalen
+      Drogenvorläufer-Kontrollregimen.
+  BC-4660.50.30:
+    name: Dual-Use-Exportlizenzierung
+    description: |
+      Lizenzierung und Endverwendungs-Konformität für
+      Dual-Use-Chemikalienexporte.
+  BC-4660.50.40:
+    name: Vorabinformierte-Zustimmungs-Konformität
+    description: |
+      Konformität mit dem Rotterdam-Konvention-
+      Vorabinformierungsregime.
+  BC-4660.60:
+    name: Regulatorische Überwachung und Intelligenz
+    description: |
+      Überwachung und Folgenabschätzung sich entwickelnder
+      Chemikalienvorschriften in verschiedenen Märkten.
+  BC-4660.60.10:
+    name: Regulatorisches Horizon-Scanning
+    description: |
+      Horizon-Scanning ausstehender und aufkommender
+      Chemikalienvorschriften.
+  BC-4660.60.20:
+    name: Regulatorische Änderungs-Folgenabschätzung
+    description: |
+      Folgenabschätzung regulatorischer Änderungen für Portfolio
+      und Betrieb.
+  BC-4660.60.30:
+    name: Branchenverbands-Liaison
+    description: |
+      Liaison mit Cefic, ACC und gleichwertigen Branchenverbänden.
+  BC-4660.70:
+    name: Behörden-Engagement und -Einreichung
+    description: |
+      Engagement mit Regulierungsbehörden einschließlich Einreichungen,
+      Anfragen und Inspektionen.
+  BC-4660.70.10:
+    name: Behörden-Einreichungs-Vorbereitung
+    description: |
+      Vorbereitung von Einreichungen an ECHA, EPA und gleichwertige
+      Behörden.
+  BC-4660.70.20:
+    name: Behörden-Anfragen-Beantwortung
+    description: |
+      Beantwortung behördlicher Anfragen zu Dossiers und
+      Registrierungen.
+  BC-4660.70.30:
+    name: Inspektionsbereitschaft
+    description: |
+      Pflege der Bereitschaft für Regulierungsinspektionen
+      und Audits.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-chemical-research-process-development-management.yaml
+++ b/catalogue/i18n/de/L1-chemical-research-process-development-management.yaml
@@ -1,0 +1,171 @@
+locale: de
+source: L1-chemical-research-process-development-management.yaml
+entries:
+  BC-4600:
+    name: Chemische Forschung und Verfahrensentwicklung
+    description: |
+      Entdeckung neuer Moleküle und Synthesewege, Labormaßstab-
+      Verfahrensentwicklung, Pilotanlagenbetrieb und Hochskalierung
+      zur kommerziellen Produktion chemischer Produkte.
+  BC-4600.10:
+    name: Molekül- und Syntheseweg-Entdeckung
+    description: |
+      Identifikation von Zielmolekülen und Auswahl realisierter
+      Synthesewege für neue und bestehende chemische Produkte.
+  BC-4600.10.10:
+    name: Zielmolekül-Identifikation
+    description: |
+      Identifikation von Kandidatenmolekülen gegenüber
+      Anwendungszielen.
+  BC-4600.10.20:
+    name: Retrosynthetische Analyse
+    description: |
+      Computergestützte und Experten-retrosynthetische Analyse
+      von Synthesewegen.
+  BC-4600.10.30:
+    name: Katalysator- und Reagenzienscreening
+    description: |
+      Hochdurchsatz- und gezieltes Screening von Katalysatoren
+      und Reagenzien.
+  BC-4600.10.40:
+    name: Wegauswahlbewertung
+    description: |
+      Multikriterielle Bewertung von Kandidatenwegen nach
+      Ausbeute, Kosten, Sicherheit und Nachhaltigkeit.
+  BC-4600.20:
+    name: Reaktionskinetik- und Thermodynamikforschung
+    description: |
+      Erzeugung kinetischer und thermodynamischer Daten zur
+      Modellierung und Planung chemischer Prozesse.
+  BC-4600.20.10:
+    name: Reaktionskinetik-Messung
+    description: |
+      Messung von Reaktionsraten und Ratenkonstanten unter
+      kontrollierten Bedingungen.
+  BC-4600.20.20:
+    name: Thermodynamische Eigenschaftsmessung
+    description: |
+      Bestimmung von Enthalpie, Entropie und Wärmekapazität
+      für Reaktanten und Produkte.
+  BC-4600.20.30:
+    name: Phasengleichgewichtsstudien
+    description: |
+      Dampf-Flüssigkeit-, Flüssigkeit-Flüssigkeit- und
+      Feststoff-Flüssigkeit-Gleichgewichtsexperimente.
+  BC-4600.20.40:
+    name: Kinetisches Modellentwicklung
+    description: |
+      Anpassung und Validierung kinetischer Modelle gegenüber
+      gemessenen Daten.
+  BC-4600.30:
+    name: Verfahrensentwicklung und -optimierung
+    description: |
+      Labormaßstab-Entwicklung und Optimierung chemischer
+      Prozess-Betriebsfenster vor Pilotversuchen.
+  BC-4600.30.10:
+    name: Labormaßstab-Versuchsplanung
+    description: |
+      Versuchsplanung im Labormaßstab zur Charakterisierung
+      des Prozessverhaltens.
+  BC-4600.30.20:
+    name: Prozessparameter-Optimierung
+    description: |
+      Optimierung von Temperatur, Druck, Verweilzeit und
+      Stöchiometrie.
+  BC-4600.30.30:
+    name: Ausbeute- und Selektivitätsverbesserung
+    description: |
+      Verbesserung von Ausbeute und Selektivität durch
+      reaktionstechnische Maßnahmen.
+  BC-4600.30.40:
+    name: Lösungsmittelsystem-Auswahl
+    description: |
+      Auswahl und Optimierung von Lösungsmittelsystemen
+      unter Abwägung von Leistung und HSE.
+  BC-4600.40:
+    name: Pilotanlagen-Betriebsmanagement
+    description: |
+      Planung, Durchführung und Analyse von Pilotmaßstab-
+      Kampagnen zur Risikoreduzierung der kommerziellen
+      Hochskalierung.
+  BC-4600.40.10:
+    name: Pilotkampagnen-Planung
+    description: |
+      Planung von Pilotanlagen-Kampagnen einschließlich
+      Zielen und Materialbilanzen.
+  BC-4600.40.20:
+    name: Pilotanlagen-Durchführung
+    description: |
+      Durchführung von Pilotläufen unter repräsentativen
+      Prozessbedingungen.
+  BC-4600.40.30:
+    name: Pilotdaten-Analyse
+    description: |
+      Analyse von Pilotdaten zur Verfeinerung kinetischer
+      und Ausbeute-Modelle.
+  BC-4600.40.40:
+    name: Pilotanlagen-Asset-Management
+    description: |
+      Lebenszyklusmanagement von Pilotanlagenausrüstung
+      und Instrumentierung.
+  BC-4600.50:
+    name: Prozesshochskalierungs-Management
+    description: |
+      Übertragung von Pilotmaßstab-Prozessen in validierte
+      kommerzielle Prozessdefinitionen.
+  BC-4600.50.10:
+    name: Hochskalierungs-Modellierung
+    description: |
+      Verwendung von Dimensionsanalyse und CFD zur Modellierung
+      von Hochskalierungseffekten.
+  BC-4600.50.20:
+    name: Demonstrationsmaßstab-Validierung
+    description: |
+      Betrieb von Demonstrationsmaßstab-Anlagen zur Validierung
+      von Hochskalierungsannahmen.
+  BC-4600.50.30:
+    name: Kommerzielle Prozess-Definition
+    description: |
+      Finalisierung der kommerziellen Prozessbasis für FEED.
+  BC-4600.60:
+    name: Prozesssicherheits-Gefährdungsscreening
+    description: |
+      Frühphasiges Screening reaktiver, thermischer und
+      Staubgefahren während Forschung und Entwicklung.
+  BC-4600.60.10:
+    name: Reaktive Chemie-Screening
+    description: |
+      Screening reaktiver Chemiegefahren mittels DSC, ARC und
+      Calvet-Kalorimetrie.
+  BC-4600.60.20:
+    name: Thermische Stabilitätsprüfung
+    description: |
+      Bestimmung thermischer Zersetzungseinsätze und
+      Durchgangspotenzials.
+  BC-4600.60.30:
+    name: Staubgefahren-Charakterisierung
+    description: |
+      Charakterisierung brennbarer Staubgefahren einschließlich
+      Kst und MIE.
+  BC-4600.70:
+    name: F&E-Wissens- und Datenmanagement
+    description: |
+      Erfassung und Verwaltung von F&E-Wissen, Experimentaufzeichnungen
+      und Prozessdatenassets.
+  BC-4600.70.10:
+    name: Elektronisches Labornotizbuch-Management
+    description: |
+      Betrieb elektronischer Labornotizbücher für chemische F&E.
+  BC-4600.70.20:
+    name: Prozesswissens-Repository-Management
+    description: |
+      Kuration von Prozesswissen über Entdeckung, Entwicklung
+      und Hochskalierung hinweg.
+  BC-4600.70.30:
+    name: F&E-Datenkuration
+    description: |
+      Kuration, Aufbewahrung und Wiederverwendung strukturierter
+      F&E-Experimentdaten.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-citizen-constituent-service-management.yaml
+++ b/catalogue/i18n/de/L1-citizen-constituent-service-management.yaml
@@ -1,0 +1,133 @@
+locale: de
+source: L1-citizen-constituent-service-management.yaml
+entries:
+  BC-3220:
+    name: Bürger- und Behördendienstleistungen
+    description: |
+      Mehrkanalige Erbringung staatlicher Dienstleistungen für Bürger, Einwohner und
+      Wahlkreisangehörige, einschließlich Identitätsauthentifizierung, Fallmanagement,
+      Anfragen, Widersprüche und Bürgerbeteiligung.
+  BC-3220.10:
+    name: Dienstleistungskanal-Betrieb
+    description: |
+      Betrieb von persönlichen, telefonischen, postalischen, digitalen und mobilen Kanälen,
+      über die Bürger staatliche Dienstleistungen in Anspruch nehmen.
+    in_scope:
+      - One-Stop-Shop- und Walk-in-Dienstleistungszentren
+      - Kontaktzentrum- und Telefonie-Kanäle
+      - Digitale Portale und Mobile-Apps
+      - Postalische und formularbasierte Kanäle
+    out_of_scope:
+      - Bürger-Identitätsverifikation (durch Bürgeridentität und Authentifizierung abgedeckt)
+  BC-3220.10.10:
+    name: One-Stop-Shop-Betrieb
+    description: |
+      Betrieb persönlicher Dienstleistungszentren und One-Stop-Schalter über Behörden.
+  BC-3220.10.20:
+    name: Kontaktzentrum-Betrieb
+    description: |
+      Betrieb behördenübergreifender Telefon- und Chat-Kontaktzentren.
+  BC-3220.10.30:
+    name: Digitales Dienstleistungsportal-Betrieb
+    description: |
+      Betrieb bürgerseitiger digitaler Portale und mobiler Dienstleistungs-Apps.
+  BC-3220.10.40:
+    name: Dienstleistungszugänglichkeits-Sicherung
+    description: |
+      WCAG- und Section-508-Zugänglichkeitssicherung über Dienstleistungskanäle und Unterstützungstechnologie.
+  BC-3220.20:
+    name: Bürgeridentität und Authentifizierung
+    description: |
+      Etablierung und Verifikation digitaler Bürgeridentitäten, Anmeldedaten
+      und Sicherheitsniveaus für den staatlichen Dienstleistungszugang.
+  BC-3220.20.10:
+    name: Identitätsprüfung
+    description: |
+      Identitätsprüfung nach NIST 800-63 IAL- oder eIDAS-Sicherheitsniveaus.
+  BC-3220.20.20:
+    name: Anmeldedaten-Ausstellung
+    description: |
+      Ausstellung von Authentifikatoren und Anmeldedaten für staatlichen Zugang.
+  BC-3220.20.30:
+    name: Authentifizierungs-Betrieb
+    description: |
+      Tägliche Authentifizierung von Bürgern gegenüber staatlichen Diensten.
+  BC-3220.20.40:
+    name: Föderierung und grenzüberschreitendes Vertrauen
+    description: |
+      Identitätsföderierung über Behörden und grenzüberschreitendes Vertrauen nach eIDAS oder Äquivalent.
+  BC-3220.30:
+    name: Bürger-Fallmanagement
+    description: |
+      End-to-End-Falllebenszyklus-Management von Bürgerinteraktionen über
+      Behörden und Programme hinweg.
+  BC-3220.30.10:
+    name: Falleingang und Triage
+    description: |
+      Eingang, Klassifikation und Triage von Bürgerfällen.
+  BC-3220.30.20:
+    name: Fall-Weiterleitung und Zuweisung
+    description: |
+      Weiterleitung von Fällen an Sachbearbeiter und Behörden nach Zuständigkeit und Regeln.
+  BC-3220.30.30:
+    name: Fallfortschritt und -lösung
+    description: |
+      Fortschritt von Fällen durch Dienstleistungs-Workflows bis zur Lösung.
+  BC-3220.30.40:
+    name: Fallabschluss und Qualitätsprüfung
+    description: |
+      Abschluss, Qualitätsprüfung und Nachbearbeitung abgeschlossener Fälle.
+  BC-3220.40:
+    name: Dienstleistungsanfragen und Auskunftsbearbeitung
+    description: |
+      Bearbeitung von Anfragen, Ersuchen, Beschwerden und Informationsfreiheits-
+      Einreichungen über alle Kanäle.
+  BC-3220.40.10:
+    name: Allgemeine Auskunftsbearbeitung
+    description: |
+      Bearbeitung allgemeiner Anfragen und Informationsersuchen.
+  BC-3220.40.20:
+    name: Beschwerdebearbeitung
+    description: |
+      Eingang, Untersuchung und Lösung von Bürgerbeschwerden.
+  BC-3220.40.30:
+    name: Informationsfreiheits-Anfragen
+    description: |
+      Bearbeitung von Informationsfreiheits- und Akteneinsichtsersuchen.
+  BC-3220.50:
+    name: Widerspruchs- und Ombudsmann-Management
+    description: |
+      Unabhängige Verwaltungsüberprüfung von Behördenentscheidungen einschließlich Widersprüchen,
+      Verwaltungsgerichten und Ombudsmann-Untersuchungen.
+  BC-3220.50.10:
+    name: Verwaltungswiderspruchs-Eingang
+    description: |
+      Eingang und Validierung von Verwaltungswidersprüchen gegen Behördenentscheidungen.
+  BC-3220.50.20:
+    name: Widerspruchsanhörung und -entscheidung
+    description: |
+      Anhörung von Widersprüchen und Entscheidungsfindung durch Überprüfungsbehörden.
+  BC-3220.50.30:
+    name: Ombudsmann-Untersuchung
+    description: |
+      Unabhängige Ombudsmann-Untersuchung von Missverwaltungsbeschwerden.
+  BC-3220.60:
+    name: Bürgerbeteiligung und Partizipation
+    description: |
+      Wechselseitiger Austausch mit Bürgern durch Partizipationsplattformen,
+      Petitionen und Feedback-Kanäle.
+  BC-3220.60.10:
+    name: Petitions- und Bürgerinitiative-Bearbeitung
+    description: |
+      Eingang, Validierung und Reaktion auf Petitionen und bürgerinitiierte Vorschläge.
+  BC-3220.60.20:
+    name: Partizipationsplattform-Betrieb
+    description: |
+      Betrieb von partizipativen Haushalts-, Beratungs- und Co-Creation-Plattformen.
+  BC-3220.60.30:
+    name: Bürgerzufriedenheitsmessung
+    description: |
+      Messung von Bürgerzufriedenheit, Vertrauen und Serviceerfahrung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-civil-records-identity-registration-management.yaml
+++ b/catalogue/i18n/de/L1-civil-records-identity-registration-management.yaml
@@ -1,0 +1,133 @@
+locale: de
+source: L1-civil-records-identity-registration-management.yaml
+entries:
+  BC-3290:
+    name: Personenstandsregister und Identitätsverwaltung
+    description: |
+      Autoritative Registrierung und Pflege von Personenstands- und
+      Rechtsregistern einschließlich Vitalregistrierung, nationaler
+      Identität, Unternehmens- und Grundbuchregistern sowie
+      Authentifizierungs-, Offenlegungs- und Datenschutzkontrollen.
+  BC-3290.10:
+    name: Vitalregistrierung
+    description: |
+      Registrierung von Vitalereignissen einschließlich Geburten, Sterbefällen,
+      Eheschließungen, eingetragenen Lebenspartnerschaften und Scheidungen.
+    in_scope:
+      - Geburts-, Sterbefall-, Ehe- und Scheidungsregistrierung
+      - Beurkundung von Vitalereignissen
+      - Extraktion von Vitalstatistiken
+    out_of_scope:
+      - Ausstellung nationaler Identifikationsnummern (durch Nationale Identitätsregistrierung abgedeckt)
+  BC-3290.10.10:
+    name: Geburtsregistrierung
+    description: |
+      Registrierung von Geburten und Ausstellung von Geburtsurkunden.
+  BC-3290.10.20:
+    name: Sterbefall-Registrierung
+    description: |
+      Registrierung von Sterbefällen und Ausstellung von Sterbeurkunden.
+  BC-3290.10.30:
+    name: Ehe- und Partnerschaftsregistrierung
+    description: |
+      Registrierung von Eheschließungen und eingetragenen Lebenspartnerschaften sowie Urkundenausstellung.
+  BC-3290.10.40:
+    name: Scheidungs- und Nichtigkeitsregistrierung
+    description: |
+      Registrierung von Scheidungen, Eheauflösungen und Nichtigkeitsbeschlüssen.
+  BC-3290.20:
+    name: Nationale Identitätsregistrierung
+    description: |
+      Einrichtung, Pflege und Authentifizierung grundlegender nationaler
+      Identitätsnachweise und Anmeldedaten.
+  BC-3290.20.10:
+    name: Identitätseinschreibung
+    description: |
+      Einschreibung von Bürgern und Einwohnern in das nationale Identitätssystem.
+  BC-3290.20.20:
+    name: Biometrische Erfassung und Deduplizierung
+    description: |
+      Erfassung, Deduplizierung und Abgleich biometrischer Identifikatoren.
+  BC-3290.20.30:
+    name: Identitätsdokument-Ausstellung
+    description: |
+      Produktion und Ausstellung nationaler Personalausweise und digitaler Anmeldedaten.
+  BC-3290.20.40:
+    name: Identitäts-Aktualisierung und Lebenszyklus
+    description: |
+      Aktualisierung von Identitätsmerkmalen, Lebenszyklusereignissen und Neuausstellung von Anmeldedaten.
+  BC-3290.30:
+    name: Unternehmens- und Rechtsträger-Registrierung
+    description: |
+      Registrierung von Unternehmen, Personengesellschaften, gemeinnützigen Organisationen
+      und anderen Rechtsträgern sowie Pflege autoritativer Rechtsträger-Nachweise.
+  BC-3290.30.10:
+    name: Rechtsträger-Registrierung
+    description: |
+      Registrierung von Unternehmen, Personengesellschaften, gemeinnützigen Organisationen und anderen Rechtsträgern.
+  BC-3290.30.20:
+    name: Jahresabschluss-Bearbeitung
+    description: |
+      Eingang und Bearbeitung von Jahresberichten, Jahresabschlüssen und Geschäftsführer-Einreichungen.
+  BC-3290.30.30:
+    name: Wirtschaftlich Berechtigte Registerführung
+    description: |
+      Führung des Registers wirtschaftlich Berechtigter und Offenlegung von Kontrollstrukturen.
+  BC-3290.30.40:
+    name: Rechtsträger-Auflösung und Löschung
+    description: |
+      Löschung, Auflösung und Wiedereintragung von Rechtsträgern.
+  BC-3290.40:
+    name: Grundbuch- und Kataserverwaltung
+    description: |
+      Eintragung von Grundstückstiteln, Dienstbarkeiten, Belastungen und Katasterparzellen
+      sowie Pflege autoritativer Grundstücksnachweise.
+  BC-3290.40.10:
+    name: Titelregistrierung
+    description: |
+      Eintragung von Grundstückstiteln, Eigentumsübertragungen und dinglichen Rechten.
+  BC-3290.40.20:
+    name: Belastungs- und Hypothekeneintragung
+    description: |
+      Eintragung von Hypotheken, Dienstbarkeiten und sonstigen Grundstücksbelastungen.
+  BC-3290.40.30:
+    name: Katasterpflege
+    description: |
+      Pflege von Katasterparzellengrenzen und Vermessungsunterlagen.
+  BC-3290.50:
+    name: Urkundenbeglaubigung und Apostille
+    description: |
+      Beglaubigung öffentlicher Urkunden für den Inlands- und Auslandsgebrauch
+      einschließlich Apostille-Diensten nach dem Haager Übereinkommen.
+  BC-3290.50.10:
+    name: Dokument-Beglaubigung
+    description: |
+      Beglaubigung öffentlicher Urkunden für rechtliche und administrative Zwecke.
+  BC-3290.50.20:
+    name: Apostille-Ausstellung
+    description: |
+      Ausstellung von Apostille-Beglaubigungen nach dem Haager Übereinkommen von 1961.
+  BC-3290.50.30:
+    name: Notarielle Dienstleistungskoordination
+    description: |
+      Koordination notarieller Dienstleistungen, soweit durch Behörden erbracht.
+  BC-3290.60:
+    name: Registeroffenlegung und Datenschutz
+    description: |
+      Kontrollierte Offenlegung, Schwärzung und Datenschutzverwaltung von
+      Personenstands- und Rechtsregistern.
+  BC-3290.60.10:
+    name: Öffentliche Suchdienste
+    description: |
+      Bereitstellung öffentlicher Such- und Urkundendienste zu Personenstandsregistern.
+  BC-3290.60.20:
+    name: Beschränkte Offenlegungsbearbeitung
+    description: |
+      Bearbeitung beschränkter Offenlegungen einschließlich Adoption, Zeugenschutz und Sicherheitsvermerken.
+  BC-3290.60.30:
+    name: Datenschutz und Schwärzung
+    description: |
+      Anwendung von Datenschutzkontrollen und Schwärzungen auf Personenstandsregister vor der Offenlegung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-classified-information-security-management.yaml
+++ b/catalogue/i18n/de/L1-classified-information-security-management.yaml
@@ -1,0 +1,114 @@
+locale: de
+source: L1-classified-information-security-management.yaml
+entries:
+  BC-1810:
+    name: Verschlusssachen-Sicherheit Management
+    description: |
+      Personalsicherheitsüberprüfungen, Klassifizierung, Industriesicherheit, COMSEC, Insider-Bedrohung.
+  BC-1810.10:
+    name: Personalsicherheits-Überprüfungsmanagement
+    description: |
+      Überprüfungsanträge, periodische Neuuntersuchungen, Sicherheitsentlassung.
+  BC-1810.10.10:
+    name: Überprüfungsantragsbearbeitung
+    description: |
+      Sponsoring und Bearbeitung von Personalsicherheitsüberprüfungsanträgen.
+  BC-1810.10.20:
+    name: Periodische Neuuntersuchung
+    description: |
+      Periodische Neuuntersuchung und kontinuierliche Bewertung von überprüftem Personal.
+  BC-1810.10.30:
+    name: Einweisung und Entlassung von überprüftem Personal
+    description: |
+      Sicherheitseinweisung, NDA-Abschluss und Sicherheitsentlassung.
+  BC-1810.20:
+    name: Informationsklassifizierungs-Management
+    description: |
+      Klassifizierung, Deklassifizierung und Handhabungskennzeichnungen.
+  BC-1810.20.10:
+    name: Ursprüngliche Klassifizierungsentscheidungen
+    description: |
+      Entscheidungen der ursprünglichen Klassifizierungsbehörde.
+  BC-1810.20.20:
+    name: Derivative Klassifizierung
+    description: |
+      Derivative Klassifizierung neuer Dokumente aus bestehendem Material.
+  BC-1810.20.30:
+    name: Deklassifizierungsüberprüfung
+    description: |
+      Systematische und obligatorische Deklassifizierungsüberprüfung.
+  BC-1810.20.40:
+    name: Handhabungskennzeichnungen und -markierung
+    description: |
+      Anwendung von Handhabungskennzeichnungen, Verbreitungskontrolle und Markierung.
+  BC-1810.30:
+    name: Verteidigungsphysische Sicherheitsmanagement
+    description: |
+      Überprüfte Einrichtungen, SCIFs, Sicherheitsbereiche.
+  BC-1810.30.10:
+    name: Akkreditierung überprüfter Einrichtungen
+    description: |
+      Akkreditierung und Pflege überprüfter Einrichtungen.
+  BC-1810.30.20:
+    name: SCIF-Betrieb
+    description: |
+      Betrieb von Sensitive Compartmented Information Facilities.
+  BC-1810.30.30:
+    name: Zugangskontrolle für Sicherheitsbereiche
+    description: |
+      Zugangskontrolle und Besuchermanagement für Sicherheitsbereiche.
+  BC-1810.40:
+    name: Industriesicherheits-Management
+    description: |
+      NISPOM/Äquivalente, FOCI, Lieferkettensicherheit.
+  BC-1810.40.10:
+    name: NISPOM-Compliance-Management
+    description: |
+      Compliance mit NISPOM/32 CFR 117 oder gleichwertigen nationalen Vorschriften.
+  BC-1810.40.20:
+    name: Ausländische Eigentümerschaft, Kontrolle und Einfluss Management
+    description: |
+      FOCI-Bewertung und Abhilfemaßnahmen.
+  BC-1810.40.30:
+    name: Lieferkettensicherheitsüberprüfung
+    description: |
+      Überprüfung überprüfter Lieferkettenpartner und CMMC-Ausrichtung.
+  BC-1810.40.40:
+    name: Verwaltung klassifizierter Vertragsicherheit
+    description: |
+      Verwaltung der Sicherheitsanforderungen für klassifizierte Verträge gemäß DD Form 254.
+  BC-1810.50:
+    name: COMSEC-Management
+    description: |
+      Kommunikationssicherheit, kryptografisches Schlüsselmanagement.
+  BC-1810.50.10:
+    name: COMSEC-Kontenverwaltung
+    description: |
+      Betrieb von COMSEC-Konten und Verwahrerpflichten.
+  BC-1810.50.20:
+    name: Kryptografisches Schlüsselmanagement
+    description: |
+      Verwaltung kryptografischer Schlüssel einschließlich EKMS/KMI.
+  BC-1810.50.30:
+    name: COMSEC-Geräteüberwachung
+    description: |
+      Überwachung und Rechenschaftspflicht für COMSEC-Geräte.
+  BC-1810.60:
+    name: Insider-Bedrohungs-Management
+    description: |
+      Insider-Bedrohungsprogramme, Überwachung, Reaktion.
+  BC-1810.60.10:
+    name: Insider-Bedrohungsprogramm-Betrieb
+    description: |
+      Betrieb des Insider-Bedrohungsprogramms gemäß E.O. 13587.
+  BC-1810.60.20:
+    name: Benutzeraktivitätsüberwachung
+    description: |
+      Überwachung der Benutzeraktivitäten auf klassifizierten Informationssystemen.
+  BC-1810.60.30:
+    name: Insider-Bedrohungs-Untersuchung
+    description: |
+      Untersuchung von Insider-Bedrohungsindikatoren und -vorfällen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-client-engagement-management.yaml
+++ b/catalogue/i18n/de/L1-client-engagement-management.yaml
@@ -1,0 +1,219 @@
+locale: de
+source: L1-client-engagement-management.yaml
+entries:
+  BC-4300:
+    name: Mandatsbetreuung
+    description: |
+      Lebenszyklus der Mandanten- und Auftragsannahme, Umfangsdefinition,
+      Mobilisierung, Änderungssteuerung, Abschluss und laufende
+      Mandantenbetreuung über Rechtsmandate, Beratungsaufträge sowie
+      Prüfungs- und Bestätigungsaufträge hinweg.
+  BC-4300.10:
+    name: Mandanten-Annahmemanagement
+    description: |
+      Aufnahme neuer Mandantenbeziehungen einschließlich KYC-,
+      AML-Screening, Sanktions- und PEP-Prüfungen sowie Verification
+      des wirtschaftlichen Eigentums vor Annahme eines Auftrags.
+    in_scope:
+      - KYC- und AML-Freigabe für neue Mandanten
+      - Sanktions- und PEP-Screening für Interessenten
+      - Prüfung des wirtschaftlichen Eigentums und der Mittelherkunft
+      - Periodische Aktualisierung der KYC-Unterlagen
+    out_of_scope:
+      - Unabhängigkeits- und Interessenkonfliktprüfung (BC-4350)
+      - Auftragsspezifische Risikoakzeptanz (BC-4300.20)
+  BC-4300.10.10:
+    name: Mandanten-KYC-Erfassung
+    description: |
+      Erfassung von Identifikations-, Eigentums- und
+      Mittelherkunftsinformationen für potenzielle und bestehende
+      Mandanten.
+  BC-4300.10.20:
+    name: Mandanten-Sanktions- und PEP-Screening
+    description: |
+      Screening von Mandanten und wirtschaftlichen Eigentümern gegen
+      Sanktionslisten, PEP- und Negativmedienlisten.
+  BC-4300.10.30:
+    name: Mandanten-Risikoeinstufung
+    description: |
+      Risikoeinstufung der Mandantenbeziehung zur Steuerung der
+      Sorgfaltspflichtiefe und des Überprüfungsturnus.
+  BC-4300.10.40:
+    name: Periodische Mandanten-KYC-Aktualisierung
+    description: |
+      Aktualisierung von Mandanten-KYC, Eigentumsverhältnissen
+      und Risikoeinstufungen in einem definierten Zyklus.
+  BC-4300.20:
+    name: Auftragsannahmemanagement
+    description: |
+      Entscheidungsprozess zur Annahme oder Ablehnung eines bestimmten
+      Auftrags unter Berücksichtigung von Unabhängigkeits- und
+      Konfliktfreigabe, Kapazitätsprüfung, Honorarmachbarkeit und
+      auftragsspezifischer Risikobewertung.
+    in_scope:
+      - Auftragsspezifische Risikobewertung
+      - Kapazitäts- und Fähigkeitsprüfung
+      - Go/No-Go-Entscheidung für den Auftrag
+    out_of_scope:
+      - Materielle Unabhängigkeits- und Konfliktprüfungen (BC-4350)
+      - Akquise- und Angebotsstätigkeit (BC-4360)
+  BC-4300.20.10:
+    name: Auftragsrisikobewertung
+    description: |
+      Bewertung auftragsspezifischer Risiken einschließlich
+      Sachkomplexität, Mandantenintegrität und Honorareintreibbarkeit.
+  BC-4300.20.20:
+    name: Kapazitäts- und Fähigkeitsprüfung
+    description: |
+      Bestätigung, dass die Kanzlei über die fachliche Kompetenz und
+      die Ressourcenkapazität zur Auftragsdurchführung verfügt.
+  BC-4300.20.30:
+    name: Auftrags-Go-No-Go-Entscheidung
+    description: |
+      Go/No-Go-Entscheidung auf Partnerebene unter Integration von
+      Risiko-, Konflikt-, Unabhängigkeits-, Kapazitäts- und
+      kommerziellen Inputs.
+  BC-4300.30:
+    name: Auftragsumfang und Vertragsbedingungen
+    description: |
+      Definition von Auftragsumfang, Leistungen, Annahmen, Honorar-
+      bedingungen sowie Auftragsschreiben oder Rahmenvertrag.
+    in_scope:
+      - Definition des Leistungsumfangs
+      - Honorarstruktur und Bedingungsentwurf
+      - Ausstellung des Auftragsschreibens oder Rahmenvertrags
+    out_of_scope:
+      - Preisstrategie auf Kanzleibene (BC-4360.50)
+      - Angebotsseitige Proposal-Erstellung (BC-4360.30)
+  BC-4300.30.10:
+    name: Auftragsumfangsdefinition
+    description: |
+      Definition von Leistungen, Ergebnissen, Annahmen, Ausschlüssen
+      und Abhängigkeiten des Auftrags.
+  BC-4300.30.20:
+    name: Auftragsschreibenentwurf
+    description: |
+      Entwurf von Auftragsschreiben und Rahmenverträgen gemäß
+      Kanzleivorlagen und geltenden Berufsstandards.
+  BC-4300.30.30:
+    name: Auftragsbedingungenverhandlung
+    description: |
+      Verhandlung der Auftragsbedingungen mit dem Mandanten
+      einschließlich Haftungsgrenzen, Rechtsordnung und
+      Streitbeilegungsklauseln.
+  BC-4300.30.40:
+    name: Auftragsschreiben-Unterzeichnung
+    description: |
+      Unterzeichnung, Gegenzeichnung und Aufbewahrung unterzeichneter
+      Auftragsschreiben als Voraussetzung für die Auftragsmobilisierung.
+  BC-4300.40:
+    name: Auftragsmobilisierungsmanagement
+    description: |
+      Operativer Start eines angenommenen Auftrags einschließlich
+      Teambildung, Kickoff, sicherem Datenzugang und Einrichtung
+      der Auftragsinfrastruktur.
+  BC-4300.40.10:
+    name: Auftragsteambildung
+    description: |
+      Identifikation und Bestätigung der Partner-, Manager- und
+      Mitarbeiterrollen im Auftragsteam.
+  BC-4300.40.20:
+    name: Auftrags-Kickoff-Management
+    description: |
+      Interne und mandantenseitige Kickoff-Meetings, Briefingmaterialien
+      und Bestätigung von Zielen und Arbeitsweisen.
+  BC-4300.40.30:
+    name: Auftragsdatenzugangseinrichtung
+    description: |
+      Bereitstellung von sicheren Datenräumen, Mandantenportalen und
+      auftragsspezifischen Zugangsdaten.
+  BC-4300.40.40:
+    name: Auftragsinfrastruktureinrichtung
+    description: |
+      Einrichtung von Auftragscodes, Abrechnungsstrukturen und
+      Mandatsnummern in den Kanzleisystemen.
+  BC-4300.50:
+    name: Auftragsänderungsmanagement
+    description: |
+      Steuerung von Änderungen des Auftragsumfangs, der Honorare,
+      Zeitpläne oder Teamzusammensetzung nach Unterzeichnung des
+      Auftragsschreibens.
+  BC-4300.50.10:
+    name: Umfangsänderungsantrag-Bearbeitung
+    description: |
+      Erfassung, Bewertung und Behandlung von Umfangsänderungsanträgen
+      des Mandanten oder des Auftragsteams.
+  BC-4300.50.20:
+    name: Honoraranpassungsgenehmigung
+    description: |
+      Genehmigungsworkflow für Honoraranpassungen, zusätzliche
+      Retainer und Genehmigungen für außerhalb des Umfangs liegende
+      Arbeiten.
+  BC-4300.50.30:
+    name: Auftragsschreibenänderung
+    description: |
+      Ausstellung und Ausführung von Nachträgen und Seitenbriefen,
+      die genehmigte Auftragsänderungen widerspiegeln.
+  BC-4300.60:
+    name: Auftragsabschlussmanagement
+    description: |
+      Abschluss abgeschlossener Aufträge einschließlich Leistungs-
+      übergabe, Arbeitsaktenaufbewahrung, Abschlussrechnungsauslösung
+      und Nachbesprechung.
+  BC-4300.60.10:
+    name: Leistungsübergabemanagement
+    description: |
+      Endgültige Übergabe von Berichten, Gutachten und Arbeitsprodukten
+      an den Mandanten mit entsprechenden Übersendungsschreiben.
+  BC-4300.60.20:
+    name: Auftragsakte-Aufbewahrungseinrichtung
+    description: |
+      Schließung der Auftragsakte und Konfiguration von Aufbewahrungs-,
+      Abfrage- und Vernichtungsrichtlinien.
+  BC-4300.60.30:
+    name: Auftragsnachbesprechung und Lessons Learned
+    description: |
+      Nachbesprechung nach Auftragsabschluss mit dem Auftragsteam
+      zur Erfassung von Lessons Learned und Verbesserungsmaßnahmen.
+  BC-4300.60.40:
+    name: Mandantenabschlusskommunikation
+    description: |
+      Abschlusskommunikation an den Mandanten einschließlich
+      Abschlussbericht, Zufriedenheitsumfrage und Folgeterminplanung.
+  BC-4300.70:
+    name: Mandantenbeziehungsstewardship
+    description: |
+      Laufende Betreuung strategischer Mandantenbeziehungen
+      einschließlich Partner-Verantwortlichkeit, Mandanten-
+      Accountplanung und kanzleiübergreifender Koordination.
+    in_scope:
+      - Zuweisung des Beziehungspartners
+      - Mandantenaccountplanung über mehrere Aufträge
+      - Mandantenzufriedenheitsverfolgung
+    out_of_scope:
+      - Akquise- und Angebotstätigkeit (BC-4360)
+      - Generisches CRM (BC-3060)
+  BC-4300.70.10:
+    name: Beziehungspartnerzuweisung
+    description: |
+      Zuweisung und Rotation des Leitenden Beziehungspartners für
+      jeden strategischen Mandanten.
+  BC-4300.70.20:
+    name: Mandantenaccountplanung
+    description: |
+      Accountbezogene Planung über das Portfolio der Aufträge mit
+      einem einzelnen Mandanten einschließlich Wallet-Share- und
+      Beziehungszielen.
+  BC-4300.70.30:
+    name: Mandantenzufriedenheitsverfolgung
+    description: |
+      Erfassung von Mandantenfeedback, NPS oder gleichwertigen
+      Kennzahlen und Eskalation von Unzufriedenheitssignalen.
+  BC-4300.70.40:
+    name: Bereichsübergreifende Mandantenkoordination
+    description: |
+      Koordination über Fachbereiche und Standorte hinweg für
+      gemeinsame Mandanten.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-clinical-care-delivery-management.yaml
+++ b/catalogue/i18n/de/L1-clinical-care-delivery-management.yaml
@@ -1,0 +1,179 @@
+locale: de
+source: L1-clinical-care-delivery-management.yaml
+entries:
+  BC-2810:
+    name: Klinische Versorgung-Management
+    description: |
+      Erbringung direkter klinischer Versorgung in stationären, ambulanten, Notfall-,
+      chirurgischen, Mutter-, Verhaltensgesundheits-, Rehabilitations- und Hausversorgungsumgebungen.
+  BC-2810.10:
+    name: Stationäre Versorgungserbringung
+    description: |
+      Erbringung akuter, intermediärer und intensivstationärer Versorgung einschließlich
+      Beurteilung, Visiten, Bettversorgung und Intensivbetrieb.
+  BC-2810.10.10:
+    name: Aufnahmebeurteilung
+    description: |
+      Anamnese, körperliche Untersuchung, Pflegebeurteilung und Risikoscreen bei Aufnahme.
+  BC-2810.10.20:
+    name: Klinische Visiten
+    description: |
+      Multidisziplinäre klinische Visiten und Versorgungsplanung am Krankenbett.
+  BC-2810.10.30:
+    name: Bettversorgung
+    description: |
+      Direkte Pflege- und klinische Bettversorgung einschließlich Unterstützung bei Alltagsaktivitäten.
+  BC-2810.10.40:
+    name: Intensivbetrieb
+    description: |
+      Intensivbetrieb einschließlich Beatmungs-, hämodynamischer und kontinuierlicher Überwachungsversorgung.
+  BC-2810.20:
+    name: Ambulante Versorgungserbringung
+    description: |
+      Erbringung ambulanter, Telehealth- und tagesklinischer Verfahrens- und Behandlungsdienste
+      in Praxis- und Tagesklinikumgebungen.
+  BC-2810.20.10:
+    name: Ambulanter Besuchs-Durchführung
+    description: |
+      Durchführung von Praxis- und Klinikbesuchen einschließlich Primärversorgung und Fachkonsultationen.
+  BC-2810.20.20:
+    name: Ambulante Eingriffs-Erbringung
+    description: |
+      Erbringung von Tages- und ambulanten Eingriffen einschließlich kleiner Operationen und Infusionen.
+  BC-2810.20.30:
+    name: Telehealth-Begegnungs-Erbringung
+    description: |
+      Erbringung synchroner und asynchroner Telehealth-Begegnungen.
+  BC-2810.20.40:
+    name: Ambulante Behandlungs-Verabreichung
+    description: |
+      Verabreichung ambulanter Behandlungen wie Chemotherapie, Dialyse und Infusionen.
+  BC-2810.30:
+    name: Notfallversorgung-Erbringung
+    description: |
+      Erbringung von Notaufnahme-Triage, Stabilisierung, Traumareaktion
+      und Dispositionsentscheidungen für ungeplante Versorgung.
+  BC-2810.30.10:
+    name: Notaufnahme-Triage
+    description: |
+      Triage und Schweregrad-Einstufung für in der Notaufnahme vorstellende Patienten.
+  BC-2810.30.20:
+    name: Notfall-Stabilisierung
+    description: |
+      Erstbeurteilung, Reanimation und Stabilisierung akut kranker oder verletzter Patienten.
+  BC-2810.30.30:
+    name: Traumareaktion
+    description: |
+      Traumaaktivierung, Teamreaktion und Schadenskontrollversorgung bei schweren Traumafällen.
+  BC-2810.30.40:
+    name: Notaufnahme-Disposition
+    description: |
+      Dispositionsentscheidungen einschließlich Aufnahme, Verlegung, Beobachtung und Entlassung aus der Notaufnahme.
+  BC-2810.40:
+    name: Chirurgische und Verfahrensversorgung-Erbringung
+    description: |
+      Prä-, intra- und postoperative Versorgung für chirurgische und interventionelle
+      Eingriffe in Operationssälen und Verfahrenseinheiten.
+  BC-2810.40.10:
+    name: Präoperative Versorgung
+    description: |
+      Präoperative Beurteilung, Optimierung und Vorhaltebereich-Versorgung.
+  BC-2810.40.20:
+    name: Intraoperative Verwaltung
+    description: |
+      Intraoperative chirurgische, Anästhesie- und Zirkulationsteam-Versorgung.
+  BC-2810.40.30:
+    name: Postanästhesie-Versorgung
+    description: |
+      Aufwachraum-Erholung und Entlassungsbereitschaftsbeurteilung nach der Anästhesie.
+  BC-2810.40.40:
+    name: Endoskopie und Interventionseingriffe
+    description: |
+      Erbringung endoskopischer, interventioneller Radiologie- und Kardiologieeingriffe.
+  BC-2810.50:
+    name: Mutter- und Neugeborenenversorgung-Erbringung
+    description: |
+      Antepartale, intrapartale, postpartale und Neugeborenenversorgung über
+      Entbindungs- und Neonataldienste.
+  BC-2810.50.10:
+    name: Antepartale Versorgung
+    description: |
+      Pränatale Beurteilung, Screening und antepartale Aufnahmen.
+  BC-2810.50.20:
+    name: Intrapartale Versorgung
+    description: |
+      Geburtsmanagement einschließlich Kaiserschnitt und operativer Entbindung.
+  BC-2810.50.30:
+    name: Postpartale Versorgung
+    description: |
+      Postpartale mütterliche Erholung, Stillberatung und postpartale Aufklärung.
+  BC-2810.50.40:
+    name: Neugeborenenversorgung
+    description: |
+      Gesundes Neugeborenen-Pflegedienst, Screening und neonatale Intensivversorgung.
+  BC-2810.60:
+    name: Verhaltensgesundheits-Versorgung-Erbringung
+    description: |
+      Verhaltensgesundheitsversorgung über psychiatrische Beurteilung, stationäre
+      Verhaltenseinheiten, ambulante Therapie und Suchtbehandlung.
+  BC-2810.60.10:
+    name: Psychiatrische Beurteilung
+    description: |
+      Psychiatrische und psychologische Beurteilung und Krisenintervention.
+  BC-2810.60.20:
+    name: Stationäre Verhaltensversorgung
+    description: |
+      Stationäre psychiatrische Versorgung einschließlich Milieutherapie und pharmakologischer Behandlung.
+  BC-2810.60.30:
+    name: Ambulante Verhaltenstherapie
+    description: |
+      Ambulante Psychotherapie, Gruppentherapie und Tagesklinik-Programme.
+  BC-2810.60.40:
+    name: Suchtversorgung
+    description: |
+      Entgiftung, medikamentös unterstützte Behandlung und Suchtrehabilitationsdienste.
+  BC-2810.70:
+    name: Rehabilitations- und Therapiedienste
+    description: |
+      Physikalische, Ergo-, Sprach-Sprach-Therapie und Herz-Lungen-Rehabilitationsdienste
+      in stationären und ambulanten Umgebungen.
+  BC-2810.70.10:
+    name: Physiotherapie
+    description: |
+      Physiotherapeutische Beurteilung und Behandlung in stationären und ambulanten Umgebungen.
+  BC-2810.70.20:
+    name: Ergotherapie
+    description: |
+      Ergotherapeutische Beurteilung und Behandlung mit Fokus auf funktionelle Selbständigkeit.
+  BC-2810.70.30:
+    name: Sprach-Sprach-Therapie
+    description: |
+      Sprach-, Kommunikations- und Schlucktherapiedienste.
+  BC-2810.70.40:
+    name: Herz- und Lungenrehabilitation
+    description: |
+      Herz- und Lungenrehabilitationsprogramm-Erbringung.
+  BC-2810.80:
+    name: Haus- und Gemeinschaftsversorgung-Erbringung
+    description: |
+      Versorgung im häuslichen oder gemeinschaftlichen Umfeld des Patienten einschließlich
+      Hausbesuche, Hospiz und Fernüberwachung.
+  BC-2810.80.10:
+    name: Hausbesuche durch Fachkräfte
+    description: |
+      Qualifizierte Hausbesuche einschließlich Pflege- und Therapiedienste im Zuhause.
+  BC-2810.80.20:
+    name: Hospiz- und Palliativversorgung zu Hause
+    description: |
+      End-of-Life- und Palliativversorgung im Zuhause.
+  BC-2810.80.30:
+    name: Gemeinschaftliche Gesundheitsbesuche
+    description: |
+      Gemeinschaftliche Gesundheitsbesuche und Outreach-Programme.
+  BC-2810.80.40:
+    name: Fernüberwachungs-Versorgung
+    description: |
+      Fernpatientenüberwachungsdienste für chronisch kranke und post-akute Populationen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-clinical-documentation-management.yaml
+++ b/catalogue/i18n/de/L1-clinical-documentation-management.yaml
@@ -1,0 +1,138 @@
+locale: de
+source: L1-clinical-documentation-management.yaml
+entries:
+  BC-2830:
+    name: Klinische Dokumentation-Management
+    description: |
+      Klinische Dokumentation, computergestützte Auftragserteilung, Befundprüfung,
+      Entscheidungsunterstützung, Dokumentationsverbesserung und EHR-vermittelte Workflows
+      als Grundlage der aktiven Patientenversorgungsakte.
+  BC-2830.10:
+    name: Klinische Notizen-Dokumentation
+    description: |
+      Erstellung klinischer Notizen über Begegnungstypen mit narrativen, strukturierten,
+      Sprach- und Ambient-Erfassungsmodalitäten.
+  BC-2830.10.10:
+    name: Verlaufsnotiz-Erstellung
+    description: |
+      Erstellung stationärer und ambulanter Verlaufsnotizen.
+  BC-2830.10.20:
+    name: Eingriffsnotiz-Erstellung
+    description: |
+      Erstellung von Operations- und Eingriffsberichten.
+  BC-2830.10.30:
+    name: Entlassungsbrief-Erstellung
+    description: |
+      Erstellung von Entlassungsbriefen und Verlegungsberichten.
+  BC-2830.10.40:
+    name: Sprach- und Ambient-Dokumentation
+    description: |
+      Sprachdiktat und Ambient-Erfassungs-Dokumentations-Workflows.
+  BC-2830.20:
+    name: Computergestützte Auftragserteilung
+    description: |
+      Ärztliche Auftragserteilung für Medikamente, Diagnostik und Eingriffe
+      einschließlich Auftragssets und klinischer Protokolle.
+  BC-2830.20.10:
+    name: Medikationsauftrag-Eingabe
+    description: |
+      Ärztliche Eingabe von Medikationsaufträgen mit Dosis, Applikationsweg und Häufigkeit.
+  BC-2830.20.20:
+    name: Diagnostik-Auftrags-Eingabe
+    description: |
+      Ärztliche Eingabe von Labor-, Bildgebungs- und anderen Diagnostikaufträgen.
+  BC-2830.20.30:
+    name: Eingriffs-Auftrags-Eingabe
+    description: |
+      Ärztliche Eingabe von Eingriffs- und Konsiliationsaufträgen.
+  BC-2830.20.40:
+    name: Auftragsset- und Protokoll-Nutzung
+    description: |
+      Nutzung standardisierter Auftragssets, Power-Plans und klinischer Protokolle.
+  BC-2830.30:
+    name: Befundprüfung und Bestätigung
+    description: |
+      Routing, Prüfung und Bestätigung diagnostischer Befunde und
+      Management der Kritischer-Wert-Benachrichtigung.
+  BC-2830.30.10:
+    name: Befund-Benachrichtigung und Routing
+    description: |
+      Routing von Befunden an anfordernde und vertretende Ärzte.
+  BC-2830.30.20:
+    name: Befund-Bestätigung
+    description: |
+      Ärztliche Bestätigung und Kenntnisnahme eingegangener Befunde.
+  BC-2830.30.30:
+    name: Kritische Befund-Kommunikation
+    description: |
+      Zeitgebundene Kommunikation kritischer und Panikwert-Befunde.
+  BC-2830.30.40:
+    name: Befund-Trend-Überprüfung
+    description: |
+      Überprüfung von Befundtrends und longitudinalen Daten in der Patientenakte.
+  BC-2830.40:
+    name: Klinische Entscheidungsunterstützung
+    description: |
+      Echtzeit-klinische Entscheidungsunterstützung einschließlich Warnungen, Pfade,
+      Risikoscore-Anzeige und Best-Practice-Empfehlungen.
+  BC-2830.40.10:
+    name: Medikamenten-Wechselwirkungs-Warnung
+    description: |
+      Arzneimittel-Arzneimittel-, Arzneimittel-Allergie- und Arzneimittel-Krankheits-Wechselwirkungswarnung.
+  BC-2830.40.20:
+    name: Klinischer Pfad-Leitfaden
+    description: |
+      Pfad- und leitlinienbasierte Entscheidungsunterstützung am Behandlungsort.
+  BC-2830.40.30:
+    name: Risikoscore-Anzeige
+    description: |
+      Anzeige klinischer Risikoscores wie Verschlechterungs- und Sepsisprädikatoren.
+  BC-2830.40.40:
+    name: Best-Practice-Empfehlungs-Management
+    description: |
+      Erstellung, Abstimmung und Governance von Best-Practice-Empfehlungen.
+  BC-2830.50:
+    name: Klinische Dokumentationsverbesserung
+    description: |
+      Gleichzeitige und retrospektive Überprüfung, Abfrage und Aufklärungsprogramme
+      zur Verbesserung der Dokumentationsvollständigkeit und -spezifität.
+  BC-2830.50.10:
+    name: Gleichzeitige Dokumentationsüberprüfung
+    description: |
+      Gleichzeitige Überprüfung stationärer Dokumentation auf klinische Genauigkeit und Spezifität.
+  BC-2830.50.20:
+    name: Arzt-Anfrage-Management
+    description: |
+      Erstellung und Verfolgung konformer klinischer Dokumentationsanfragen.
+  BC-2830.50.30:
+    name: Dokumentationsqualitäts-Audit
+    description: |
+      Audit der klinischen Dokumentationsqualität und Fallmix-Index-Auswirkung.
+  BC-2830.50.40:
+    name: Arzt-Dokumentations-Aufklärung
+    description: |
+      Arztaufklärung zu Dokumentationsstandards und Verbesserungsmöglichkeiten.
+  BC-2830.60:
+    name: EHR-Workflow-Management
+    description: |
+      Klinikerseitige elektronische Krankenakte-Workflows einschließlich Posteingang,
+      Aufgaben, Begegnungsabschluss und Übergabemanagement.
+  BC-2830.60.10:
+    name: Posteingang- und Aufgaben-Management
+    description: |
+      Verwaltung von Kliniker-Posteingang-Nachrichten, Aufgaben und To-Do-Warteschlangen.
+  BC-2830.60.20:
+    name: Begegnungsabschluss
+    description: |
+      Begegnungsabschluss einschließlich Codierung, Abrechnung und Dokumentationsabschluss.
+  BC-2830.60.30:
+    name: Vertretungs-Dokumentation
+    description: |
+      Vertretungs- und Rufbereitschafts-Dokumentations-Workflows.
+  BC-2830.60.40:
+    name: Patientenlisten- und Übergabe-Management
+    description: |
+      Verwaltung von Patientenlisten und strukturierter Übergabedokumentation zwischen Schichten.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-clinical-quality-safety-management.yaml
+++ b/catalogue/i18n/de/L1-clinical-quality-safety-management.yaml
@@ -1,0 +1,138 @@
+locale: de
+source: L1-clinical-quality-safety-management.yaml
+entries:
+  BC-2840:
+    name: Klinische Qualität und Patientensicherheit
+    description: |
+      Management von Patientensicherheitsereignissen, Infektionsprävention und -kontrolle,
+      Messung klinischer Ergebnisse, Akkreditierungsbereitschaft, klinisches Risiko und
+      Haftung sowie Qualitätsverbesserungsprogramme spezifisch für die klinische Versorgung.
+  BC-2840.10:
+    name: Management von Patientensicherheitsereignissen
+    description: |
+      Erfassung, Untersuchung und Management von Patientensicherheitsereignissen
+      einschließlich Sentinel-Ereignissen und Beinahe-Fehlern.
+  BC-2840.10.10:
+    name: Ereignismeldung und -erfassung
+    description: |
+      Mehrkanalige Meldung und Erfassung von Patientensicherheitsereignissen und Beinahe-Fehlern.
+  BC-2840.10.20:
+    name: Ursachenanalyse
+    description: |
+      Ursachen- und Scheinursachenanalyse von Patientensicherheitsereignissen.
+  BC-2840.10.30:
+    name: Sentinel-Ereignis-Management
+    description: |
+      Identifikation, Reaktion und Meldung von Sentinel-Ereignissen und Never Events.
+  BC-2840.10.40:
+    name: Just-Culture-Untersuchung
+    description: |
+      Überprüfung menschlicher Faktoren und Verantwortlichkeit bei Sicherheitsereignissen nach dem Just-Culture-Prinzip.
+  BC-2840.20:
+    name: Infektionsprävention und -kontrolle
+    description: |
+      Überwachung, Prävention und Kontrolle nosokomialer Infektionen
+      einschließlich Ausbruchsreaktion und Antibiotika-Stewardship.
+  BC-2840.20.10:
+    name: Überwachung nosokomialer Infektionen
+    description: |
+      Surveillance und Meldung von im Gesundheitswesen erworbenen Infektionen.
+  BC-2840.20.20:
+    name: Ausbruchsuntersuchung
+    description: |
+      Untersuchung und Eindämmung von Infektionsclustern und Ausbrüchen.
+  BC-2840.20.30:
+    name: Sterilisationsüberwachung
+    description: |
+      Überwachung des Sterilisationsbereichs und Sicherstellung der Compliance.
+  BC-2840.20.40:
+    name: Antibiotika-Stewardship
+    description: |
+      Betrieb von Antibiotika-Stewardship-Programmen und Verschreibungsüberwachung.
+  BC-2840.30:
+    name: Messung klinischer Ergebnisse
+    description: |
+      Messung und Berichterstattung klinischer Ergebnisse gegenüber Kernkennzahlen,
+      Registermeldungen und patientenberichteten Ergebnissen.
+  BC-2840.30.10:
+    name: Berichterstattung von Kernkennzahlen
+    description: |
+      Erfassung und Einreichung regulatorischer Qualitätskernkennzahlen.
+  BC-2840.30.20:
+    name: Mortalitäts- und Wiederaufnahme-Tracking
+    description: |
+      Erfassung von Mortalität, Wiederaufnahmeraten und risikobereinigten Ergebnissen.
+  BC-2840.30.30:
+    name: Fachspezifische Ergebnisregistermeldung
+    description: |
+      Meldung an Fachregister wie Herz-, Chirurgie- und Schlaganfallregister.
+  BC-2840.30.40:
+    name: Erfassung patientenberichteter Ergebnisse
+    description: |
+      Erfassung und Analyse patientenberichteter Ergebnisse und Erfahrungskennzahlen.
+  BC-2840.40:
+    name: Akkreditierungs- und Prüfungsbereitschaft
+    description: |
+      Akkreditierungsbereitschaft für klinische, regulatorische und fachspezifische
+      Prüfungsprogramme.
+  BC-2840.40.10:
+    name: Simulierte Prüfungsprogramme
+    description: |
+      Betrieb von Simulationsprüfungen und kontinuierlichen Bereitschaftsprogrammen.
+  BC-2840.40.20:
+    name: Tracer-Methodik
+    description: |
+      Patienten- und System-Tracer-Methodik zur Akkreditierungsbereitschaft.
+  BC-2840.40.30:
+    name: Compliance-Nachverfolgung nach Standards
+    description: |
+      Nachverfolgung der Compliance gegenüber Akkreditierungs- und Regulierungsstandards.
+  BC-2840.40.40:
+    name: Koordination von Prüfungsreaktionen
+    description: |
+      Koordination von Akkreditierungsprüfungen, Befunden und Korrekturmaßnahmenplänen.
+  BC-2840.50:
+    name: Klinisches Risiko- und Haftungsmanagement
+    description: |
+      Identifikation, Minderung und Abwehr klinischer Risiken und Haftungsansprüche
+      spezifisch für die medizinische Versorgung.
+  BC-2840.50.10:
+    name: Klinische Risikobewertung
+    description: |
+      Identifikation und Bewertung klinischer Risiken über Leistungen und Prozesse hinweg.
+  BC-2840.50.20:
+    name: Unterstützung bei der Schadensabwehr
+    description: |
+      Unterstützung bei der Untersuchung und Abwehr von Arzthaftungsansprüchen.
+  BC-2840.50.30:
+    name: Offenlegungs- und Entschuldigungsprozess
+    description: |
+      Betrieb von Offenlegungs- und Entschuldigungsprogrammen bei unerwünschten Ereignissen.
+  BC-2840.50.40:
+    name: Klinische Risikoplanung
+    description: |
+      Planung und Umsetzung klinischer Risikominderungsmaßnahmen.
+  BC-2840.60:
+    name: Qualitätsverbesserungsprogramme
+    description: |
+      Methodik zur Leistungsverbesserung, Bündelimplementierung und
+      Hochzuverlässigkeitsinitiativen.
+  BC-2840.60.10:
+    name: PDCA-Zyklus-Management
+    description: |
+      Plan-Do-Check-Act-Zyklusmanagement zur klinischen Verbesserung.
+  BC-2840.60.20:
+    name: Bündel- und Protokollimplementierung
+    description: |
+      Implementierung evidenzbasierter Bündel und klinischer Protokolle.
+  BC-2840.60.30:
+    name: Projekttracking zur Leistungsverbesserung
+    description: |
+      Nachverfolgung von Leistungsverbesserungsprojekten und deren Ergebnissen.
+  BC-2840.60.40:
+    name: Hochzuverlässigkeitsinitiativen
+    description: |
+      Grundsätze und Initiativenmanagement hochzuverlässiger Organisationen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-clinical-trials-management.yaml
+++ b/catalogue/i18n/de/L1-clinical-trials-management.yaml
@@ -1,0 +1,142 @@
+locale: de
+source: L1-clinical-trials-management.yaml
+entries:
+  BC-1520:
+    name: Klinische-Studien-Management
+    description: |
+      Planung, Durchführung und Überwachung klinischer Studien.
+  BC-1520.10:
+    name: Klinische-Studiendesign-Management
+    description: |
+      Protokolldesign, statistische Methodik und Endpunkte.
+  BC-1520.10.10:
+    name: Klinisches-Protokoll-Authoring
+    description: |
+      Erstellung klinischer Studienprotokolle.
+  BC-1520.10.20:
+    name: Statistischer-Analyseplan-Definition
+    description: |
+      Statistische Methodik und Analyseplan-Definition.
+  BC-1520.10.30:
+    name: Endpunkt- und Ergebnis-Definition
+    description: |
+      Definition primärer, sekundärer und explorativer Endpunkte.
+  BC-1520.10.40:
+    name: Adaptives-Design-Management
+    description: |
+      Design adaptiver und Plattformstudien.
+  BC-1520.20:
+    name: Klinisches-Studienzentrum-Management
+    description: |
+      Zentrenauswahl, -aktivierung und -überwachung.
+  BC-1520.20.10:
+    name: Zentrenidentifikation und -machbarkeit
+    description: |
+      Identifikation und Machbarkeitsbewertung von Prüfzentren.
+  BC-1520.20.20:
+    name: Zentrenaktivierung
+    description: |
+      Zentrenaktivierung einschließlich Ethik-, Regulierungs- und Vertragsverfahren.
+  BC-1520.20.30:
+    name: Prüfer- und Zentrentraining
+    description: |
+      Durchführung von Prüfer- und Zentrentraining.
+  BC-1520.20.40:
+    name: Zentren-Leistungsmanagement
+    description: |
+      Zentren-Leistungsverfolgung und Korrekturmaßnahmen.
+  BC-1520.30:
+    name: Klinische-Studien-Probandenmanagement
+    description: |
+      Rekrutierung, Screening, Bindung und informierte Einwilligung.
+  BC-1520.30.10:
+    name: Probanden-Rekrutierung
+    description: |
+      Probandenrekrutierung einschließlich digitaler Rekrutierungskanäle.
+  BC-1520.30.20:
+    name: Informierte-Einwilligungs-Management
+    description: |
+      Erfassung der informierten Einwilligung und elektronische Einwilligung.
+  BC-1520.30.30:
+    name: Probanden-Screening und -Einschluss
+    description: |
+      Screening und Einschluss gemäß Ein-/Ausschlusskriterien.
+  BC-1520.30.40:
+    name: Probanden-Bindung
+    description: |
+      Bindungsstrategien und Patientenengagement.
+  BC-1520.40:
+    name: Klinisches-Daten-Management
+    description: |
+      EDC, Datenerfassung, Abfragemanagement und Datenbankschluss.
+  BC-1520.40.10:
+    name: EDC- und CRF-Management
+    description: |
+      Elektronisches Datenerfassungssystem und CRF-Design.
+  BC-1520.40.20:
+    name: Klinische-Datenabfrage-Management
+    description: |
+      Abfragenerstellung, -lösung und Datenbereinigung.
+  BC-1520.40.30:
+    name: Klinische-Datenstandardisierung
+    description: |
+      CDISC-SDTM/ADaM-Datenstandardisierung.
+  BC-1520.40.40:
+    name: Datenbankschluss und -archivierung
+    description: |
+      Datenbankschluss, -archivierung und Einreichungspaket-Vorbereitung.
+  BC-1520.50:
+    name: Klinische-Studienüberwachungs-Management
+    description: |
+      Vor-Ort-Monitoring, risikobasiertes Monitoring und Audits.
+  BC-1520.50.10:
+    name: Vor-Ort-Monitoring
+    description: |
+      Quelldatenverifizierung und Monitoring-Besuche vor Ort.
+  BC-1520.50.20:
+    name: Zentralisiertes und risikobasiertes Monitoring
+    description: |
+      Zentralisierte und risikobasierte Monitoring-Programme.
+  BC-1520.50.30:
+    name: Klinische-Qualitätsaudits
+    description: |
+      GCP-Audits von Studien, Zentren und Dienstleistern.
+  BC-1520.60:
+    name: Klinische-Studienversorgung-Management
+    description: |
+      IMP-Versorgung, Verteilung, Randomisierung und Arzneimittelverantwortung.
+  BC-1520.60.10:
+    name: IMP-Produktion und -Verpackung
+    description: |
+      Produktion und Verpackung von Prüfpräparaten.
+  BC-1520.60.20:
+    name: IMP-Vertrieb und -Depotbetrieb
+    description: |
+      IMP-Depot und globaler Vertriebsbetrieb.
+  BC-1520.60.30:
+    name: Randomisierung und IRT-Betrieb
+    description: |
+      IRT/IWRS-Randomisierung und Prüfpräparatversorgungsmanagement.
+  BC-1520.60.40:
+    name: IMP-Verantwortung und -Abstimmung
+    description: |
+      IMP-Verantwortung, Rückgabe und Vernichtung.
+  BC-1520.70:
+    name: Klinisches-Outsourcing- und CRO-Management
+    description: |
+      CRO-Auswahl, -Vertragsgestaltung und -Überwachung.
+  BC-1520.70.10:
+    name: CRO-Auswahl und -Vertragsgestaltung
+    description: |
+      CRO-Auswahl, Leistungsumfang und Vertragsgestaltung.
+  BC-1520.70.20:
+    name: CRO-Leistungsüberwachung
+    description: |
+      Sponsor-Überwachung der CRO-Leistung und KPIs.
+  BC-1520.70.30:
+    name: Lieferanten-Qualitätsüberwachung
+    description: |
+      Qualitätsüberwachung klinischer Lieferanten und Labore.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-commissioning-handover-management.yaml
+++ b/catalogue/i18n/de/L1-commissioning-handover-management.yaml
@@ -1,0 +1,102 @@
+locale: de
+source: L1-commissioning-handover-management.yaml
+entries:
+  BC-1160:
+    name: Inbetriebnahme- und Übergabemanagement
+    description: |
+      Vorinbetriebnahme, Inbetriebnahme, Leistungsprüfung und Übergabe.
+  BC-1160.10:
+    name: Vorinbetriebnahme-Management
+    description: |
+      Mechanische Fertigstellung, Spülung, Dichtheitsprüfung und Einschaltung.
+  BC-1160.10.10:
+    name: Mechanische Fertigstellungsverifikation
+    description: |
+      Verifikation der mechanischen Fertigstellung anhand von Mängellisten.
+  BC-1160.10.20:
+    name: Spül- und Reinigungsarbeiten
+    description: |
+      Rohrleitungsspülung, Reinigung und chemische Konditionierung.
+  BC-1160.10.30:
+    name: Druck- und Dichtheitsprüfung
+    description: |
+      Druckprüfung, pneumatische Prüfung und Dichtheitsprüfung.
+  BC-1160.10.40:
+    name: Anlageneinschaltung
+    description: |
+      Ersteinschaltung und Funktionsüberprüfungen von Anlagen.
+  BC-1160.20:
+    name: Inbetriebnahme-Ausführungsmanagement
+    description: |
+      Systemweise Inbetriebnahme, Funktionstests und integrierte Tests.
+  BC-1160.20.10:
+    name: Systemweite Inbetriebnahmeplanung
+    description: |
+      Inbetriebnahmepläne je System und Teilsystem.
+  BC-1160.20.20:
+    name: Systemfunktionstest
+    description: |
+      Funktionstests einzelner Systeme.
+  BC-1160.20.30:
+    name: Integrierter Systemtest
+    description: |
+      Integrierter Test über mehrere Systeme hinweg.
+  BC-1160.20.40:
+    name: Inbetriebnahmedokumentation
+    description: |
+      Inbetriebnahmeunterlagen, Dossiers und Zertifikate.
+  BC-1160.30:
+    name: Leistungsprüfungs-Management
+    description: |
+      Leistungsprüfläufe und Validierung der Abnahmekriterien.
+  BC-1160.30.10:
+    name: Leistungsprüfungsplanung
+    description: |
+      Leistungsprüfprotokolle und Abnahmekriterien.
+  BC-1160.30.20:
+    name: Leistungsprüfungs-Durchführung
+    description: |
+      Durchführung von Leistungsprüfläufen und Datenerfassung.
+  BC-1160.30.30:
+    name: Leistungsprüfungs-Auswertung
+    description: |
+      Auswertung der Prüfergebnisse und Validierung gegenüber Garantien.
+  BC-1160.40:
+    name: Übergabe- und Abnahmemanagement
+    description: |
+      Endabnahme, Zertifikate, Mängellistenabschluss und Übergabe an den Betreiber.
+  BC-1160.40.10:
+    name: Mängellistenabschluss
+    description: |
+      Verfolgung und Abschluss von Mängellistenpunkten vor der Abnahme.
+  BC-1160.40.20:
+    name: Abnahmezertifizierung
+    description: |
+      Ausstellung von vorläufigen und finalen Abnahmezertifikaten.
+  BC-1160.40.30:
+    name: Betreibertraining und Übergabe
+    description: |
+      Schulung des Betriebsteams und Übergabe der Anlage.
+  BC-1160.40.40:
+    name: Eigentumsübergabe
+    description: |
+      Formale Eigentumsübergabe von Anlage und Assets an den Auftraggeber.
+  BC-1160.50:
+    name: Post-Übergabe-Unterstützungs-Management
+    description: |
+      Mängelgewährleistungszeitraum, Gewährleistungszeit und technische Restunterstützung.
+  BC-1160.50.10:
+    name: Mängelgewährleistungsmanagement
+    description: |
+      Management des Mängelgewährleistungszeitraums und Mängelbeseitigung.
+  BC-1160.50.20:
+    name: Gewährleistungsunterstützung
+    description: |
+      Koordination der Gewährleistungsunterstützung und Lieferanten-Gewährleistungsforderungen.
+  BC-1160.50.30:
+    name: Technische Restunterstützung
+    description: |
+      Technische Unterstützung des Betriebs während der anfänglichen Betriebsphase.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-commodity-origination-merchandising-management.yaml
+++ b/catalogue/i18n/de/L1-commodity-origination-merchandising-management.yaml
@@ -1,0 +1,148 @@
+locale: de
+source: L1-commodity-origination-merchandising-management.yaml
+entries:
+  BC-3570:
+    name: Rohwarenhandel und Warenvermarktung
+    description: |
+      Originierungsprogramme mit Landwirten, Rohwarenkontraktierung,
+      Brückenwaage und Beprobung, physische Lagerpositionen,
+      Kassa- und Basis-Handel, Absicherung und Abwicklung für
+      Getreide, Ölsaaten, Softs, Nutzvieh und Molkerei-Rohwaren.
+  BC-3570.10:
+    name: Originierungsprogramm-Management
+    description: |
+      Landwirtschaftskontraktierung, Erzeuger-Beziehungsmanagement
+      und Originierungsprognose für das Versorgungsbuch.
+  BC-3570.10.10:
+    name: Landwirtschaftskontraktierungs-Programme
+    description: |
+      Design und Durchführung regionaler Landwirtschafts-
+      kontraktierungsprogramme.
+  BC-3570.10.20:
+    name: Erzeuger-Beziehungsmanagement
+    description: |
+      Erzeuger-Beziehungsmanagement getrennt von allgemeinem CRM.
+  BC-3570.10.30:
+    name: Originierungsprognose
+    description: |
+      Prognose erwarteter Originierungsvolumina nach Region und Kultur.
+  BC-3570.20:
+    name: Rohwarenkontrakt-Management
+    description: |
+      Ausgabe und Leistungsverfolgung von Termin-, Produktions-
+      und Deferred-Pricing-Rohwarenkontrakten.
+    in_scope:
+      - Terminkontrakte mit Landwirten und Gegenparteien
+      - Produktionskontrakte mit Qualitätsspezifikationen
+      - Kontraktleistungsverfolgung
+    out_of_scope:
+      - Generelles rechtliches Vertragsmanagement (BC-150)
+  BC-3570.20.10:
+    name: Terminkontrakt-Ausgabe
+    description: |
+      Ausgabe von Festpreis- und Basis-Terminkontrakten.
+  BC-3570.20.20:
+    name: Produktionskontrakt-Management
+    description: |
+      Management von Produktionskontrakten mit Qualitäts- und
+      Lieferspezifikationen.
+  BC-3570.20.30:
+    name: Kontraktleistungs-Verfolgung
+    description: |
+      Verfolgung gelieferter Tonnen gegen Kontraktleistung.
+  BC-3570.30:
+    name: Eingangsbrückenwaage und -Beprobung
+    description: |
+      Brückenwaagenbetrieb, Qualitätsbeprobung und -Klassifizierung
+      sowie Annahmeverrechnungsberechnung am Annahmeort.
+  BC-3570.30.10:
+    name: Brückenwaagen-Betrieb
+    description: |
+      Ein- und Ausgangsbrückenwaagenbetrieb und Ticketausstellung.
+  BC-3570.30.20:
+    name: Qualitätsbeprobung und -Klassifizierung
+    description: |
+      Annahmebeprobung und -Klassifizierung gegen Handels-
+      spezifikationen.
+  BC-3570.30.30:
+    name: Annahmeverrechnungs-Berechnung
+    description: |
+      Berechnung von Qualitätsabschlägen und -Zuschlägen bei
+      der Annahme.
+  BC-3570.40:
+    name: Rohwarenbestand-Positions-Management
+    description: |
+      Verfolgung physischer Rohwarenpositionen, Mischentscheidungen
+      und In-Transit-Positionen über das Netzwerk.
+  BC-3570.40.10:
+    name: Physische Positions-Verfolgung
+    description: |
+      Verfolgung von Long- und Short-Positionen nach Standort und Klasse.
+  BC-3570.40.20:
+    name: Qualitätsmisch-Entscheidungen
+    description: |
+      Mischentscheidungen zur Erfüllung vertraglicher
+      Qualitätsspezifikationen.
+  BC-3570.40.30:
+    name: In-Transit-Positions-Verfolgung
+    description: |
+      Verfolgung von Schiff-, Bahn- und Lastwagen-In-Transit-Positionen.
+  BC-3570.50:
+    name: Rohwarenhandels-Betrieb
+    description: |
+      Kassa- und Basis-Handel, Spot-Verkaufsdurchführung und
+      Cross-Commodity-Spread-Management in physischen Rohwarenbüchern.
+  BC-3570.50.10:
+    name: Kassa- und Basis-Handel
+    description: |
+      Handel von Kassa- und Basis-Positionen in physischen Rohwaren.
+  BC-3570.50.20:
+    name: Spot-Verkaufs-Durchführung
+    description: |
+      Durchführung von Spot-Verkäufen an Verarbeiter und Exporteure.
+  BC-3570.50.30:
+    name: Cross-Commodity-Spread-Management
+    description: |
+      Management von Cross-Commodity-Spreads wie Crush- und
+      Crack-Margen.
+  BC-3570.60:
+    name: Absicherung und Risikopositions-Management
+    description: |
+      Durchführung und Abstimmung von Futures- und Options-
+      Absicherungen gegen physische Rohwarenpositionen.
+  BC-3570.60.10:
+    name: Futures-Absicherungs-Durchführung
+    description: |
+      Durchführung von Futures-Absicherungen an regulierten Börsen.
+  BC-3570.60.20:
+    name: Options-Absicherungs-Durchführung
+    description: |
+      Durchführung von Options-Absicherungen zur Steuerung des
+      Preisschwanzrisikos.
+  BC-3570.60.30:
+    name: Absicherungspositions-Abstimmung
+    description: |
+      Abstimmung von Absicherungspositionen gegen zugrundeliegende
+      physische Exposures.
+  BC-3570.70:
+    name: Rohwarenabwicklung und -Preisstellung
+    description: |
+      Endpreisstellung, Abrechnungsnachweis-Ausgabe und Klärung
+      von Qualitätsansprüchen mit Gegenparteien.
+  BC-3570.70.10:
+    name: Endpreisstellung und Abschlagsberechnung
+    description: |
+      Endpreisstellung einschließlich Qualitätsabschlag- und
+      -Zuschlaganwendung.
+  BC-3570.70.20:
+    name: Abrechnungsnachweis-Ausgabe
+    description: |
+      Ausgabe von Abrechnungsnachweisen an Landwirte und Gegenparteien.
+  BC-3570.70.30:
+    name: Qualitätsanspruchs-Klärung
+    description: |
+      Klärung von Qualitätsansprüchen mit Landwirten, Käufern
+      und Schiedsorganen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-communication-navigation-surveillance-operations-management.yaml
+++ b/catalogue/i18n/de/L1-communication-navigation-surveillance-operations-management.yaml
@@ -1,0 +1,122 @@
+locale: de
+source: L1-communication-navigation-surveillance-operations-management.yaml
+entries:
+  BC-1240:
+    name: Kommunikation, Navigation und Überwachung (KNÜ) Betriebsmanagement
+    description: |
+      KNÜ-Infrastruktur – Sprach- und Datenkommunikation, Navigationseinrichtungen, Radar/ADS-B/Multilaterations.
+  BC-1240.10:
+    name: Sprachkommunikationssysteme-Management
+    description: |
+      Luft-Boden-Sprache, Controller-Piloten-Sprachsysteme und Boden-Boden-Sprache.
+  BC-1240.10.10:
+    name: Luft-Boden-Sprach-Betrieb
+    description: |
+      Betrieb der Luft-Boden-Sprachfunkkommunikation.
+  BC-1240.10.20:
+    name: Boden-Boden-Sprach-Betrieb
+    description: |
+      Betrieb von Zentren- und Sektorverbindungen.
+  BC-1240.10.30:
+    name: Sprachaufzeichnung und -wiedergabe
+    description: |
+      Aufzeichnung und Wiedergabe betrieblicher Sprache für Sicherheit und Auditierung.
+  BC-1240.20:
+    name: Datenlinkkommunkations-Management
+    description: |
+      CPDLC, ADS-C, FANS und ATN-Datenlinks.
+  BC-1240.20.10:
+    name: CPDLC-Betrieb
+    description: |
+      Betrieb der Controller-Piloten-Datenlinkommunikation.
+  BC-1240.20.20:
+    name: ADS-C-Betrieb
+    description: |
+      Betrieb des automatischen abhängigen Überwachungsvertrags.
+  BC-1240.20.30:
+    name: ATN- und FANS-Netzwerkbetrieb
+    description: |
+      ATN- und FANS-Datenlinknetzbetrieb.
+  BC-1240.30:
+    name: Navigationseinrichtungs-Management
+    description: |
+      VOR, DME, ILS und GNSS-basierte Navigationsdienste.
+  BC-1240.30.10:
+    name: VOR- und DME-Betrieb
+    description: |
+      Betrieb und Wartung von VOR- und DME-Beacons.
+  BC-1240.30.20:
+    name: ILS-Betrieb
+    description: |
+      Betrieb und Wartung von ILS-Anflugsystemen.
+  BC-1240.30.30:
+    name: GNSS-basierter Navigationsdienst
+    description: |
+      GNSS-, SBAS- und GBAS-Navigationsdienstbereitstellung.
+  BC-1240.30.40:
+    name: Flugvermessung
+    description: |
+      Periodische Flugvermessung von Navigationseinrichtungen.
+  BC-1240.40:
+    name: Überwachungssysteme-Management
+    description: |
+      Primärradar, Sekundärradar, ADS-B und Multilateration.
+  BC-1240.40.10:
+    name: Primär-Überwachungsradar-Betrieb
+    description: |
+      Betrieb primärer Überwachungsradarsysteme.
+  BC-1240.40.20:
+    name: Sekundär-Überwachungsradar-Betrieb
+    description: |
+      Betrieb von SSR Mode S und konventionellen Mode-A/C-Systemen.
+  BC-1240.40.30:
+    name: ADS-B-Überwachungs-Betrieb
+    description: |
+      Betrieb von ADS-B-Bodenstationen und -Verarbeitung.
+  BC-1240.40.40:
+    name: Multilaterations-Betrieb
+    description: |
+      Betrieb von WAM/MLAT-Überwachung.
+  BC-1240.40.50:
+    name: Überwachungsdaten-Fusion
+    description: |
+      Fusion von Überwachungsquellen für ATC-Displays.
+  BC-1240.50:
+    name: KNÜ-Infrastruktur-Instandhaltungsmanagement
+    description: |
+      Feldinstandhaltung von KNÜ-Ausrüstung, Kalibrierung und Flugvermessung.
+  BC-1240.50.10:
+    name: KNÜ-Präventive Instandhaltung
+    description: |
+      Planmäßige präventive Instandhaltung von KNÜ-Ausrüstung.
+  BC-1240.50.20:
+    name: KNÜ-Korrektive Instandhaltung
+    description: |
+      Korrektive Instandhaltung und Störungsreaktion bei KNÜ-Ausrüstung.
+  BC-1240.50.30:
+    name: KNÜ-Ausrüstungskalibrierung
+    description: |
+      Kalibrierung und Justierung von KNÜ-Ausrüstung.
+  BC-1240.50.40:
+    name: KNÜ-Ersatzteil-Management
+    description: |
+      Bestand und Versorgung mit KNÜ-Ersatzteilen und Verbrauchsmaterialien.
+  BC-1240.60:
+    name: Frequenzspektrum- und -Management
+    description: |
+      Luftfahrtfrequenzzuweisung, Koordination und Störungsmanagement.
+  BC-1240.60.10:
+    name: Frequenzzuweisung
+    description: |
+      Zuweisung von Luftfahrtfrequenzen an Dienste.
+  BC-1240.60.20:
+    name: Frequenzkoordination
+    description: |
+      Grenzüberschreitende und diensteübergreifende Frequenzkoordination.
+  BC-1240.60.30:
+    name: Störungserkennung und -lösung
+    description: |
+      Erkennung und Lösung von Frequenzstörungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-compliance-management.yaml
+++ b/catalogue/i18n/de/L1-compliance-management.yaml
@@ -1,0 +1,118 @@
+locale: de
+source: L1-compliance-management.yaml
+entries:
+  BC-130:
+    name: Compliance-Management
+    description: |
+      Sicherstellung der Einhaltung von Gesetzen, Vorschriften und internen Richtlinien.
+  BC-130.10:
+    name: Regulatorisches Compliance-Management
+    description: |
+      Einhaltung branchenspezifischer Vorschriften.
+  BC-130.10.10:
+    name: Regulatorisches Inventarmanagement
+    description: |
+      Erfassung anwendbarer Vorschriften und Pflichten über alle Jurisdiktionen.
+  BC-130.10.20:
+    name: Regulatorisches Änderungsmonitoring
+    description: |
+      Frühwarnscan regulatorischer Entwicklungen und Folgenabschätzung.
+  BC-130.10.30:
+    name: Compliance-Risikobewertung
+    description: |
+      Bewertung des Compliance-Risikos nach Geschäftsbereich, Geografie und Produkt.
+  BC-130.10.40:
+    name: Compliance-Überwachung und -Prüfung
+    description: |
+      Compliance-Überwachungsplan, Kontrollprüfung und Berichterstattung.
+  BC-130.10.50:
+    name: Behördenkommunikationsmanagement
+    description: |
+      Behördenmeldungen, Prüfungen und Nachverfolgung von Abhilfemaßnahmen.
+  BC-130.20:
+    name: Richtlinienmanagement
+    description: |
+      Richtlinienlebenszyklus – Entwurf, Genehmigung, Bestätigung und Rücknahme.
+  BC-130.20.10:
+    name: Richtlinienentwicklung
+    description: |
+      Entwurf und Überarbeitung von Unternehmensrichtlinien und -standards.
+  BC-130.20.20:
+    name: Richtliniengenehmigung und -veröffentlichung
+    description: |
+      Steuerungsgenehmigung und kontrollierte Veröffentlichung von Richtlinien.
+  BC-130.20.30:
+    name: Richtlinienbestätigung
+    description: |
+      Kenntnisnahme und Bestätigung durch Mitarbeitende und Dritte.
+  BC-130.20.40:
+    name: Richtlinienausnahmemanagement
+    description: |
+      Erfassung und Genehmigung von Richtlinienausnahmen und -befreiungen.
+  BC-130.30:
+    name: Ethik- und Verhaltensmanagement
+    description: |
+      Verhaltenskodex, Ethik und Hinweisgeberprogramme.
+  BC-130.30.10:
+    name: Verhaltenskodexadministration
+    description: |
+      Pflege und Einführung des unternehmensweiten Verhaltenskodex.
+  BC-130.30.20:
+    name: Interessenkonfliktmanagement
+    description: |
+      Offenlegung und Handhabung persönlicher und organisatorischer Interessenkonflikte.
+  BC-130.30.30:
+    name: Hinweisgebermanagement
+    description: |
+      Meldungskanäle, Aufnahme, Triage und Schutz für Hinweisgebende.
+  BC-130.30.40:
+    name: Verhaltensuntersuchungen
+    description: |
+      Untersuchung von Fehlverhalten und Verwaltung disziplinarischer Fälle.
+  BC-130.40:
+    name: Anti-Korruptions-Management
+    description: |
+      ABC-Programme, Drittpartei-Due-Diligence, Geschenke und Bewirtung.
+  BC-130.40.10:
+    name: ABC-Programm-Steuerung
+    description: |
+      Design des Anti-Bestechungs- und Korruptionsprogramms gemäß FCPA und UKBA.
+  BC-130.40.20:
+    name: Integritäts-Due-Diligence Dritter
+    description: |
+      Integritäts-Due-Diligence und laufende Überwachung von Vermittlern.
+  BC-130.40.30:
+    name: Geschenke-, Bewirtungs- und Sponsoringmanagement
+    description: |
+      Vorabgenehmigung und Register für Geschenke, Bewirtung und Sponsoring.
+  BC-130.40.40:
+    name: ABC-Training und -Sensibilisierung
+    description: |
+      Zielgerichtetes Training und Kommunikation zu Anti-Bestechungsanforderungen.
+  BC-130.50:
+    name: Datenschutz- und Datenschutzmanagement
+    description: |
+      DSGVO-/äquivalente Compliance, Betroffenenrechte und Privacy by Design.
+  BC-130.50.10:
+    name: Datenschutzprogrammsteuerung
+    description: |
+      Datenschutzrahmen, DSB-Funktion und Rechenschaftsarrangements.
+  BC-130.50.20:
+    name: Verarbeitungsverzeichnismanagement
+    description: |
+      Pflege des Verzeichnisses von Verarbeitungstätigkeiten und Datenflüssen.
+  BC-130.50.30:
+    name: Datenschutz-Folgenabschätzung
+    description: |
+      DSFAs und Privacy-by-Design-Überprüfungen neuer Verarbeitungstätigkeiten.
+  BC-130.50.40:
+    name: Betroffenenrechtebearbeitung
+    description: |
+      Aufnahme und Erfüllung von Auskunfts-, Berichtigungs- und Löschanträgen.
+  BC-130.50.50:
+    name: Datenschutzverletzungsmanagement
+    description: |
+      Erkennung, Meldung und Behebung von Datenschutzverletzungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-connected-product-firmware-management.yaml
+++ b/catalogue/i18n/de/L1-connected-product-firmware-management.yaml
@@ -1,0 +1,147 @@
+locale: de
+source: L1-connected-product-firmware-management.yaml
+entries:
+  BC-1950:
+    name: Vernetztes Produkt & Firmware Management
+    description: |
+      Betrieblicher Lebenszyklus vernetzter elektrischer Produkte im Feld — Geräteidentität,
+      Firmware-Build und -Release, OTA-Updates, Telemetrie, Produktcybersicherheit, IIoT-Plattformbetrieb.
+  BC-1950.10:
+    name: Geräteidentitäts- & Provisionierungs-Management
+    description: |
+      Ausgabe und Lebenszyklus von Geräteidentitäten und kryptografischen Zugangsdaten.
+  BC-1950.10.10:
+    name: Geräteidentitätsausgabe
+    description: |
+      Ausgabe eindeutiger Geräteidentitäten bei der Herstellung.
+  BC-1950.10.20:
+    name: Kryptografische Schlüsselprovisionierung
+    description: |
+      Provisionierung kryptografischer Schlüssel auf Geräten.
+  BC-1950.10.30:
+    name: Geräte-Onboarding auf Plattform
+    description: |
+      Onboarding von Geräten auf der vernetzten Produktplattform.
+  BC-1950.10.40:
+    name: Geräte-Dekommissionierung
+    description: |
+      Dekommissionierung und Zugangsdatenwiderruf für ausgemusterte Geräte.
+  BC-1950.20:
+    name: Firmware-Build- & Release-Management
+    description: |
+      Build-Pipelines, Release-Genehmigung, Signierung und Versionsinventar für Produktions-Firmware.
+  BC-1950.20.10:
+    name: Firmware-Build-Pipeline-Management
+    description: |
+      Betrieb von Firmware-Build- und Continuous-Integration-Pipelines.
+  BC-1950.20.20:
+    name: Firmware-Release-Genehmigung
+    description: |
+      Stage-Gate-Genehmigung von Firmware-Releases zur Bereitstellung.
+  BC-1950.20.30:
+    name: Firmware-Signierung & Integritäts-Management
+    description: |
+      Code-Signierung und Integritätsschutz von Firmware-Artefakten.
+  BC-1950.20.40:
+    name: Firmware-Versionsinventar
+    description: |
+      Inventar der bereitgestellten Firmware-Versionen über die installierte Basis.
+  BC-1950.30:
+    name: Over-the-Air-Update-Management
+    description: |
+      Planung, Durchführung und Rollback von Over-the-Air-Firmware-Updates.
+  BC-1950.30.10:
+    name: OTA-Kampagnen-Planung
+    description: |
+      Planung von OTA-Kampagnen und Rollout-Kohorten.
+  BC-1950.30.20:
+    name: OTA-Rollout-Durchführung
+    description: |
+      Durchführung von OTA-Rollouts und Fortschrittsverfolgung.
+  BC-1950.30.30:
+    name: OTA-Rollback-Management
+    description: |
+      Rollback fehlgeschlagener OTA-Updates auf bekannt-gute Versionen.
+  BC-1950.30.40:
+    name: OTA-Kompatibilitätsverifizierung
+    description: |
+      Verifizierung der Firmware-Kompatibilität vor OTA-Release.
+  BC-1950.40:
+    name: Gerätetelemetrie- & Konnektivitäts-Management
+    description: |
+      Telemetrieaufnahme, Konnektivitätsstatus, Routing und Carrier-/SIM-Management.
+  BC-1950.40.10:
+    name: Telemetrie-Aufnahme-Betrieb
+    description: |
+      Aufnahme von Gerätetelemetrie in Plattformspeicher.
+  BC-1950.40.20:
+    name: Konnektivitätsstatus-Überwachung
+    description: |
+      Überwachung des Gerätekonnektivitätsstatus und der Erreichbarkeit.
+  BC-1950.40.30:
+    name: Telemetriedaten-Routing
+    description: |
+      Routing von Telemetrie an nachgelagerte Verbraucher und Analytik.
+  BC-1950.40.40:
+    name: Netzwerk-Carrier- & SIM-Management
+    description: |
+      Verwaltung von Mobilfunk-Carrier-Beziehungen und SIM-Inventar.
+  BC-1950.50:
+    name: Vernetztes Produkt Cybersicherheits-Management
+    description: |
+      Produktseitige Cybersicherheit für Bedrohungen, Schwachstellen, Secure Boot und Konformität.
+  BC-1950.50.10:
+    name: Produkt-Bedrohungsmodellierung
+    description: |
+      Bedrohungsmodellierung für vernetzte Produktdesigns.
+  BC-1950.50.20:
+    name: Schwachstellenoffenlegung & -reaktion
+    description: |
+      Koordinierte Offenlegung und Reaktion auf Produktschwachstellen.
+  BC-1950.50.30:
+    name: Secure Boot & Attestierung
+    description: |
+      Secure-Boot- und Attestierungsmechanismen auf Geräten.
+  BC-1950.50.40:
+    name: Produkt-Cybersicherheits-Konformität
+    description: |
+      Konformität vernetzter Produkte mit IEC 62443 und gleichwertigen Regimen.
+  BC-1950.60:
+    name: Vernetztes Produkt Plattform-Betrieb
+    description: |
+      Betrieb der IIoT-Plattform, die vernetzten Produkten zugrunde liegt.
+  BC-1950.60.10:
+    name: IIoT-Plattform-Mandanten-Management
+    description: |
+      Mandanten-Onboarding und -Isolation auf der IIoT-Plattform.
+  BC-1950.60.20:
+    name: Plattform-Kapazität & -Leistung
+    description: |
+      Kapazitätsplanung und Leistungsmanagement der Plattform.
+  BC-1950.60.30:
+    name: Plattform-Integrationsdienste
+    description: |
+      Integration der Plattform mit Unternehmens- und Kundensystemen.
+  BC-1950.60.40:
+    name: Plattform-API-Lebenszyklus
+    description: |
+      Lebenszyklus plattformseitig exponierter APIs und SDKs.
+  BC-1950.70:
+    name: Edge- & Gateway-Betriebsmanagement
+    description: |
+      Betrieb von Edge-Anwendungen und Gateway-Geräten im Feld.
+  BC-1950.70.10:
+    name: Edge-Anwendungs-Bereitstellung
+    description: |
+      Bereitstellung von Edge-Anwendungen auf Gateways und Steuerungen.
+  BC-1950.70.20:
+    name: Gateway-Konfigurations-Management
+    description: |
+      Konfigurationsmanagement von Feld-Gateway-Geräten.
+  BC-1950.70.30:
+    name: Edge-Zustandsüberwachung
+    description: |
+      Zustandsüberwachung von Edge-Geräten und -Anwendungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-construction-management.yaml
+++ b/catalogue/i18n/de/L1-construction-management.yaml
@@ -1,0 +1,134 @@
+locale: de
+source: L1-construction-management.yaml
+entries:
+  BC-1150:
+    name: Baumanagement
+    description: |
+      Bauaufsicht und -ausführung (für EPC-Unternehmen).
+  BC-1150.10:
+    name: Bauplanungsmanagement
+    description: |
+      Bausequenzierung, Methoden und Hauptterminpläne.
+  BC-1150.10.10:
+    name: Baumethoden-Statement
+    description: |
+      Definition von Baumethoden und -sequenzierung.
+  BC-1150.10.20:
+    name: Bau-Hauptterminplan
+    description: |
+      Bau-Hauptterminplan und Vorschau-Pläne.
+  BC-1150.10.30:
+    name: Bau-Ressourcenplanung
+    description: |
+      Personal-, Anlagen- und Materialplanung für den Bau.
+  BC-1150.10.40:
+    name: Bau-Ausführungsplan
+    description: |
+      Projektausführungsplan zur Baustrategie.
+  BC-1150.20:
+    name: Baustellenmobilisierungs- und Einrichtungsmanagement
+    description: |
+      Baustelleneinrichtung, Provisorien und Baustellenlogistik.
+  BC-1150.20.10:
+    name: Baustelleneinrichtung
+    description: |
+      Aufbau von Provisorien, Büros und Sanitäreinrichtungen.
+  BC-1150.20.20:
+    name: Baustellenlogistikplanung
+    description: |
+      Planung von Baustellenzufahrt, Lagerflächen und Materialhandhabung.
+  BC-1150.20.30:
+    name: Bauanlagen-Mobilisierung
+    description: |
+      Mobilisierung von Kränen, Gerät und Baumaschinen.
+  BC-1150.30:
+    name: Bauaufsichts-Management
+    description: |
+      Baustellenaufsicht, Arbeitsfront-Management und täglicher Baustellenbetrieb.
+  BC-1150.30.10:
+    name: Täglicher Baustellenbetrieb
+    description: |
+      Tägliche Baustellenkoordination, Besprechungen und Ausführung.
+  BC-1150.30.20:
+    name: Arbeitsfront-Management
+    description: |
+      Definition und Fortschritt von Bau-Arbeitsfronten.
+  BC-1150.30.30:
+    name: Genehmigungs- und Methodenkonformität
+    description: |
+      Einhaltung von Genehmigungen und zugelassenen Methodenbeschreibungen.
+  BC-1150.40:
+    name: Nachunternehmer-Management
+    description: |
+      Nachunternehmerauswahl, -aufsicht, -leistung und Zahlungszertifizierung.
+  BC-1150.40.10:
+    name: Nachunternehmerauswahl
+    description: |
+      Präqualifikation und Auswahl von Baunachunternehmern.
+  BC-1150.40.20:
+    name: Nachunternehmeraufsicht
+    description: |
+      Baustellenaufsicht über Nachunternehmerleistung und -konformität.
+  BC-1150.40.30:
+    name: Zahlungszertifizierung
+    description: |
+      Aufmessung und Zertifizierung von Nachunternehmerzahlungen.
+  BC-1150.40.40:
+    name: Nachunternehmer-Nachtragsverwaltung
+    description: |
+      Management von Nachunternehmer-Nachträgen und Forderungen.
+  BC-1150.50:
+    name: Bauqualitätsmanagement
+    description: |
+      QS/QK auf der Baustelle, Inspektionen und Halte- sowie Überwachungspunkte.
+  BC-1150.50.10:
+    name: Baustelleninspektions-Prüfpläne
+    description: |
+      ITP-Definition, Halte- und Überwachungspunkte und Inspektionspläne.
+  BC-1150.50.20:
+    name: Baustellenqualitätsinspektion
+    description: |
+      Durchführung von Baustellenqualitätsinspektionen und -tests.
+  BC-1150.50.30:
+    name: Nichtkonformitäts- und Mängellisten-Management
+    description: |
+      Nichtkonformitätsberichte und Mängellistenabschluss auf der Baustelle.
+  BC-1150.60:
+    name: Baufortschritts-Management
+    description: |
+      Fortschrittsmessung, Earned Value und Abweichungsanalyse.
+  BC-1150.60.10:
+    name: Baufortschritts-Messung
+    description: |
+      Mengenbasierte Fortschrittsmessung auf der Baustelle.
+  BC-1150.60.20:
+    name: Earned-Value-Berichterstattung
+    description: |
+      Earned-Value-Analyse und Projektleistungsberichterstattung.
+  BC-1150.60.30:
+    name: Termin- und Kostenabweichungsanalyse
+    description: |
+      Abweichungsanalyse und Korrekturmaßnahmen.
+  BC-1150.70:
+    name: Baustellen-HSE-Management
+    description: |
+      Baustellensicherheit, Arbeitserlaubnisschein, Gefahrenmanagement und Notfallreaktion.
+  BC-1150.70.10:
+    name: Baustellen-HSE-Planung
+    description: |
+      Baustellen-HSE-Pläne und Risikobewertungen.
+  BC-1150.70.20:
+    name: Baustellenarbeitserlaubnisschein
+    description: |
+      Baustellenarbeitserlaubnisschein und Heißarbeiten-Erlaubnis.
+  BC-1150.70.30:
+    name: Baustellensicherheitsinspektionen und -audits
+    description: |
+      Sicherheitsinspektionen, Audits und Verhaltensbeobachtungen.
+  BC-1150.70.40:
+    name: Baustellennotfallreaktion
+    description: |
+      Baustellennotfallreaktionspläne, Übungen und Vorfallsmanagement.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-content-compliance-standards-management.yaml
+++ b/catalogue/i18n/de/L1-content-compliance-standards-management.yaml
@@ -1,0 +1,136 @@
+locale: de
+source: L1-content-compliance-standards-management.yaml
+entries:
+  BC-3780:
+    name: Inhaltskonformität und Medienstandards
+    description: |
+      Inhaltsklassifizierung und -Bewertung, Redaktionsstandards,
+      Regulierungskonformität für Broadcast und Online-Inhalte,
+      Moderation nutzergenerierter Inhalte, Barrierefreiheits-
+      Konformität sowie Takedown- und Notice-Behandlung über
+      das Inhaltsportfolio.
+  BC-3780.10:
+    name: Inhaltsklassifizierungs- und Bewertungs-Management
+    description: |
+      Einreichung, Anwendung und Selbstklassifizierung von Alters-
+      und Inhaltsbewertungen über Territorien und Plattformen.
+  BC-3780.10.10:
+    name: Vor-Release-Klassifizierungs-Einreichung
+    description: |
+      Einreichung von Titeln bei Klassifizierungsstellen für
+      territoriale Altersfreigaben vor der Veröffentlichung.
+  BC-3780.10.20:
+    name: Bewertungsanzeige-Konformität
+    description: |
+      Anzeige von Altersfreigaben, Inhaltsdeskriptoren und
+      Warnhinweisen auf verbraucherorientierten Oberflächen.
+  BC-3780.10.30:
+    name: Selbstklassifizierungs-Management
+    description: |
+      Betrieb von Selbstklassifizierungsregimes und Einhaltung
+      von Plattform-Altersfreigabe-Tools.
+  BC-3780.20:
+    name: Redaktionsstandards-Management
+    description: |
+      Erstellung von Redaktionsrichtlinien, Vor-Ausstrahlung-
+      Konformitätsprüfung und Behandlung redaktioneller Beschwerden.
+  BC-3780.20.10:
+    name: Redaktionsrichtlinien-Management
+    description: |
+      Erstellung und Lebenszyklus von Redaktionsrichtlinien,
+      Unparteilichkeits- und Genauigkeitsstandards.
+  BC-3780.20.20:
+    name: Vor-Ausstrahlung-Konformitätsprüfung
+    description: |
+      Vor-Ausstrahlung-Prüfung von Programmen und Werbeblöcken
+      gegen redaktionelle und regulatorische Standards.
+  BC-3780.20.30:
+    name: Redaktionelle Beschwerde-Bearbeitung
+    description: |
+      Triage, Untersuchung und Antwort auf redaktionelle Beschwerden
+      von Zuschauern und Regulatoren.
+  BC-3780.30:
+    name: Broadcast-Regulierungskonformität
+    description: |
+      Konformität mit Broadcast- und audiovisuelle Regulierung
+      einschließlich Scheduling-Regeln, Inhaltskontingenten und
+      Werbecodes.
+  BC-3780.30.10:
+    name: Watershed- und Scheduling-Konformität
+    description: |
+      Konformität mit Watershed- und Zeitfenster-Regeln für
+      das Scheduling von Erwachseneninhalten.
+  BC-3780.30.20:
+    name: Kontingenten- und Lokale-Inhalts-Konformität
+    description: |
+      Konformität mit Inhaltskontingenten einschließlich europäischer
+      Werke, unabhängiger Produktion und Landessprachen-Verpflichtungen.
+  BC-3780.30.30:
+    name: Werbecode-Konformität
+    description: |
+      Konformität von Werbung und Sponsoring mit geltenden Codes
+      und Kategoriebeschränkungen.
+  BC-3780.40:
+    name: Nutzergenerierter-Inhalts-Moderation
+    description: |
+      Moderation nutzergenerierter Inhalte durch automatisierte
+      Triage, menschliche Überprüfung und Trusted-Flagger-Workflows.
+  BC-3780.40.10:
+    name: Automatisierte Inhalts-Triage
+    description: |
+      Automatisierte Triage und Klassifizierung nutzergenerierter
+      Inhalte auf Sicherheits- und Richtlinienprobleme.
+  BC-3780.40.20:
+    name: Menschliche Überprüfungswarteschlangen-Management
+    description: |
+      Betrieb menschlicher Überprüfungswarteschlangen einschließlich
+      Qualitätssicherung und Reviewer-Wohlbefindenkontrollen.
+  BC-3780.40.30:
+    name: Trusted-Flagger-Management
+    description: |
+      Management von Trusted-Flagger-Beziehungen und priorisierten
+      Überprüfungskanälen unter Online-Inhalts-Regulierung.
+  BC-3780.50:
+    name: Barrierefreiheits-Konformitäts-Management
+    description: |
+      Konformität mit Barrierefreiheitsverpflichtungen über
+      Untertitelung, Audiodeskription und Gebärdensprachen-
+      Bereitstellung.
+  BC-3780.50.10:
+    name: Closed-Captioning-Konformität
+    description: |
+      Konformität mit Closed-Captioning-Verpflichtungen einschließlich
+      Abdeckung, Qualität und Präsentationsstandards.
+  BC-3780.50.20:
+    name: Audiodeskription-Konformität
+    description: |
+      Konformität mit Audiodeskription-Abdeckungs- und
+      Qualitätsverpflichtungen.
+  BC-3780.50.30:
+    name: Gebärdensprachen-Bereitstellungs-Konformität
+    description: |
+      Konformität mit Gebärdensprachdolmetscher- und
+      eingeblendeten Gebärdensprach-Verpflichtungen.
+  BC-3780.60:
+    name: Takedown- und Notice-Management
+    description: |
+      Bearbeitung von Urheberrechts- und Online-Inhalts-Notices
+      einschließlich Counter-Notice- und Berufungsverfahren.
+  BC-3780.60.10:
+    name: Urheberrechts-Notice-Bearbeitung
+    description: |
+      Bearbeitung von Urheberrechts-Takedown-Notices und
+      Mehrfachverstoß-Richtlinien-Durchsetzung.
+  BC-3780.60.20:
+    name: Online-Inhalts-Notice-Bearbeitung
+    description: |
+      Bearbeitung von Meldungen illegaler Inhalte und Anordnungen
+      nach Online-Inhalts-Regulierung.
+  BC-3780.60.30:
+    name: Counter-Notice- und Berufungs-Management
+    description: |
+      Management von Counter-Notices und außergerichtlichen
+      Berufungsmechanismen für Inhaltsentfernungsentscheidungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-content-distribution-delivery-management.yaml
+++ b/catalogue/i18n/de/L1-content-distribution-delivery-management.yaml
@@ -1,0 +1,135 @@
+locale: de
+source: L1-content-distribution-delivery-management.yaml
+entries:
+  BC-3740:
+    name: Inhaltsverteilung und Content-Auslieferung
+    description: |
+      Linearer Broadcast, OTT- und Streaming-Auslieferung,
+      Content-Delivery-Netzwerk-Betrieb, IPTV und Multicast,
+      Inhaltsschutz sowie Syndikation und Affiliate-Distribution
+      von Inhalten auf verbraucherorientierte Oberflächen und Partner.
+  BC-3740.10:
+    name: Lineare Broadcast-Distribution
+    description: |
+      Betrieb linearer Broadcast-Distribution über digitale
+      terrestrische, Satelliten- und Kabelübertragungswege.
+  BC-3740.10.10:
+    name: Terrestrischer Broadcast-Betrieb
+    description: |
+      Betrieb digitaler terrestrischer Übertragungsketten und
+      Multiplex-Übertragung.
+  BC-3740.10.20:
+    name: Satelliten-Uplink-Betrieb
+    description: |
+      Betrieb von Satelliten-Uplink-Ketten für Direktempfang
+      und Beitragsdistribution.
+  BC-3740.10.30:
+    name: Kabel-Headend-Betrieb
+    description: |
+      Betrieb von Kabelübertragung und Headend-Integration
+      mit Operatorplattformen.
+  BC-3740.20:
+    name: OTT- und Streaming-Auslieferung
+    description: |
+      Betrieb von Streaming-Origin, -Packaging und Live-Streaming
+      für Direct-to-Consumer- und Partner-OTT-Dienste.
+  BC-3740.20.10:
+    name: Origin-Service-Betrieb
+    description: |
+      Betrieb von Streaming-Origin-Diensten zur Auslieferung
+      von On-Demand- und Live-Inhalten an Auslieferungsoberflächen.
+  BC-3740.20.20:
+    name: Adaptives Streaming-Packaging
+    description: |
+      Just-in-Time- und vor-gepacktes adaptives Streaming für
+      HLS, MPEG-DASH und CMAF.
+  BC-3740.20.30:
+    name: Live-Streaming-Betrieb
+    description: |
+      Betrieb von Live-Streaming-Pipelines für Events, Kanäle
+      und Fast-Dienste.
+  BC-3740.30:
+    name: Content-Delivery-Netzwerk-Betrieb
+    description: |
+      Kapazitäts-, Caching- und Kosten-Leistungsmanagement
+      von Content-Delivery-Netzwerken für die Inhaltsverteilung.
+  BC-3740.30.10:
+    name: CDN-Kapazitätsplanung
+    description: |
+      Prognose und Bereitstellung von CDN-Kapazität über Regionen,
+      Peering und Spitzenereignisse hinweg.
+  BC-3740.30.20:
+    name: Edge-Cache-Management
+    description: |
+      Management von Edge-Cache-Footprint, Befüllungsverhalten
+      und Offloading zu Partner-Caches.
+  BC-3740.30.30:
+    name: CDN-Kosten- und Leistungsoptimierung
+    description: |
+      Multi-CDN-Steuerung und Kosten-Leistungsoptimierung
+      über Auslieferungspartner hinweg.
+  BC-3740.40:
+    name: IPTV- und Multicast-Auslieferungs-Management
+    description: |
+      Betrieb von Telco-Grade IPTV-Headends, Multicast-Streams
+      und Set-Top-Box-Dienstaktivierung.
+  BC-3740.40.10:
+    name: IPTV-Headend-Betrieb
+    description: |
+      Betrieb von IPTV-Headends einschließlich Signalakquisition,
+      Encodierung und Conditional-Access-Integration.
+  BC-3740.40.20:
+    name: Multicast-Stream-Management
+    description: |
+      Management der Multicast-Stream-Bereitstellung über IP-
+      und 3GPP-Broadcast-Träger.
+  BC-3740.40.30:
+    name: Set-Top-Box-Dienstaktivierung
+    description: |
+      Aktivierung von Set-Top-Boxen und verwalteten Geräten
+      auf dem IPTV-Dienst einschließlich Kanal-Lineup-Bereitstellung.
+  BC-3740.50:
+    name: Inhaltsschutz- und DRM-Management
+    description: |
+      Betrieb von Inhaltsschutzsystemen einschließlich Schlüssel-
+      und Lizenzverwaltung, Wasserzeichen und
+      gleichzeitigen Stream-Kontrolle.
+  BC-3740.50.10:
+    name: Lizenz- und Schlüssel-Management
+    description: |
+      Ausgabe und Management von DRM-Lizenzen und Content-Keys
+      über Geräte und Plattformen.
+  BC-3740.50.20:
+    name: Wasserzeichen und Forensische Nachverfolgung
+    description: |
+      Anwendung von Sitzungs- und forensischen Wasserzeichen für
+      Piraterie-Erkennung und Quellenverfolgung.
+  BC-3740.50.30:
+    name: Gleichzeitige Stream-Kontrolle
+    description: |
+      Durchsetzung von gleichzeitigen Stream-Limits und
+      Konten-Sharing-Richtlinien über Zuschauer und Geräte.
+  BC-3740.60:
+    name: Syndikation- und Affiliate-Distribution
+    description: |
+      Distribution von Programmen und Feeds an syndizierte
+      Affiliates und Drittplattformen mit Auslieferungs-Accounting.
+  BC-3740.60.10:
+    name: Syndikationsauftrags-Management
+    description: |
+      Erfassung und Erfüllung von Syndikationsaufträgen gegen
+      gehaltene Rechte und Auslieferungsslots.
+  BC-3740.60.20:
+    name: Affiliate-Feed-Distribution
+    description: |
+      Distribution von Netzwerk- und Kanalfeeds an
+      Broadcast-Affiliates mit Lokalisierungs-Übergaben.
+  BC-3740.60.30:
+    name: Programm-Auslieferungs-Verfolgung
+    description: |
+      Verfolgung von Programm-Auslieferungen an Plattformen und
+      Partner einschließlich Auslieferungsnachweis und
+      Ausnahmebehandlung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-content-origination-production-management.yaml
+++ b/catalogue/i18n/de/L1-content-origination-production-management.yaml
@@ -1,0 +1,156 @@
+locale: de
+source: L1-content-origination-production-management.yaml
+entries:
+  BC-3700:
+    name: Inhaltsproduktion und Content-Produktion
+    description: |
+      Grünlicht-Entscheidung, Vorproduktion, Hauptdreharbeiten oder
+      Studioproduktion, Live- und Nachrichtenproduktion,
+      Nachbearbeitung und Lokalisierung von audiovisuellem, Audio-
+      und Redaktionsinhalt vom Konzept bis zum auslieferungsfertigen Master.
+  BC-3700.10:
+    name: Inhaltsbeauftragung und Grünlicht
+    description: |
+      Bewertung von Konzepten und Pitches, Slatekomposition und
+      Freigabebeschluss für neue Produktionen oder Akquisitionen.
+  BC-3700.10.10:
+    name: Konzept- und Pitch-Bewertung
+    description: |
+      Strukturierte Bewertung eingehender Pitches, Treatments
+      und Bibeln gegen redaktionelle und kommerzielle Kriterien.
+  BC-3700.10.20:
+    name: Slate- und Portfolio-Planung
+    description: |
+      Komposition des Produktions-Slates über Genres, Budgets,
+      Zielgruppen und Ausstrahlungsfenster hinweg.
+  BC-3700.10.30:
+    name: Grünlicht-Entscheidung
+    description: |
+      Freigabe und Aufzeichnung der Grünlicht-Entscheidung
+      einschließlich Budget, Zeitplan und kreativem Rahmen.
+  BC-3700.10.40:
+    name: Beauftragungsbrief-Management
+    description: |
+      Erstellung und Lebenszyklus von Beauftragungsbriefen
+      für interne Produktionseinheiten und externe Produzenten.
+  BC-3700.20:
+    name: Vorproduktions-Management
+    description: |
+      Skriptentwicklung, Produktionsbudgetierung, Terminplanung
+      sowie Location- und Set-Planung bis zur Drehbereitschaft.
+  BC-3700.20.10:
+    name: Skript- und Storyboard-Entwicklung
+    description: |
+      Iterative Entwicklung von Skripten, Storyboards und
+      Einstellungslisten für Scripted- und Unscripted-Produktionen.
+  BC-3700.20.20:
+    name: Produktionsbudget-Planung
+    description: |
+      Detailliertes Bottom-up-Produktionsbudget nach Abteilung
+      und Phase mit Kontingenz- und Fertigstellungsgarantie-Überlegungen.
+  BC-3700.20.30:
+    name: Produktionsterminplanung
+    description: |
+      Stripboard- und Drehplan-Erstellung, Talent- und
+      Crew-Verfügbarkeitsfenster und Einheitenteilung.
+  BC-3700.20.40:
+    name: Location- und Set-Planung
+    description: |
+      Location-Scouting, Genehmigungen sowie Set-Design- und
+      Bauplanung an Studios und Außenlocations.
+  BC-3700.30:
+    name: Produktions-Betriebsmanagement
+    description: |
+      Durchführung von Hauptdreharbeiten oder Studioproduktion
+      einschließlich Crew-, Ausrüstungs- und On-Set-Workflow-Logistik.
+  BC-3700.30.10:
+    name: Studioproduktions-Betrieb
+    description: |
+      Studioseitige Produktion für Entertainment-, Scripted- und
+      Unscripted-Formate einschließlich Multi-Kamera-Setups.
+  BC-3700.30.20:
+    name: Location-Produktions-Betrieb
+    description: |
+      Produktionsdurchführung an praktischen und Remote-Locations
+      einschließlich Einheitsmanagement und On-Set-Sicherheit.
+  BC-3700.30.30:
+    name: Produktionslogistik und Crew-Betrieb
+    description: |
+      Logistik von Crew-Call-Sheets, Transport, Catering und
+      Ausrüstungsbewegungen über die Produktion hinweg.
+  BC-3700.40:
+    name: Live-Event- und Nachrichtenproduktions-Management
+    description: |
+      Echtzeitproduktion von Live-Events, Sport und
+      Nachrichtensendungen einschließlich Multi-Kamera-Regie
+      und Live-Grafiken.
+  BC-3700.40.10:
+    name: Live-Event-Produktion
+    description: |
+      Produktion von Live-Entertainment- und Sonderveranstaltungen
+      mit Echtzeit-Bildmischung und Audiomischung.
+  BC-3700.40.20:
+    name: Nachrichtensendungs-Produktion
+    description: |
+      Nachrichtenraum-Produktion von Sendungen und Rolling-News-
+      Output einschließlich Rundown-Management und Live-Insert-Koordination.
+  BC-3700.40.30:
+    name: Sportberichterstattungs-Produktion
+    description: |
+      Multi-Kamera-Produktion von Live-Sport einschließlich
+      Außenübertragungen und Host-Broadcast-Betrieb.
+  BC-3700.40.40:
+    name: Echtzeit-Grafiken und Wiederholung
+    description: |
+      On-Air-Grafiken, Anzeigetafeln und Sofortwiederholungs-
+      Betrieb für Live- und Near-Live-Produktionen.
+  BC-3700.50:
+    name: Nachbearbeitungs-Management
+    description: |
+      Bild-, Audio-, Farb- und Finishing-Workflows, die aufgenommenes
+      Material zum auslieferungsfertigen Master verarbeiten.
+  BC-3700.50.10:
+    name: Bildschnitt und Visuelle Effekte
+    description: |
+      Offline- und Online-Bildschnitt, Integration visueller Effekte
+      und Conform von Schnittentscheidungen.
+  BC-3700.50.20:
+    name: Audio-Nachbearbeitung
+    description: |
+      Dialogschnitt, ADR, Foley, Sounddesign und Endmix nach
+      Auslieferungs-Lautstärkevorgaben.
+  BC-3700.50.30:
+    name: Farbkorrektur und Finishing
+    description: |
+      Kreative und technische Farbkorrektur und Finishing über
+      HDR- und SDR-Auslieferungen hinweg.
+  BC-3700.50.40:
+    name: Mastering und Conform
+    description: |
+      Erstellung von Auslieferungsmasters, IMF- und
+      Broadcast-Mezzanine-Paketen und Conform gegen
+      Auslieferungsspezifikationen.
+  BC-3700.60:
+    name: Lokalisierungs- und Versionsmanagement
+    description: |
+      Untertitelung, Barrierefreiheits-Untertitel, Synchronisation
+      sowie regions- oder plattformspezifische Schnitte und
+      Versions-Master für die Distribution.
+  BC-3700.60.10:
+    name: Untertitel- und Untertitel-Produktion
+    description: |
+      Erstellung von Untertiteln und Closed Captions in mehreren
+      Sprachen und Formaten.
+  BC-3700.60.20:
+    name: Synchronisations-Produktion
+    description: |
+      Übersetzung, Casting und Aufnahme von Synchronspuren
+      für territoriale Auswertung.
+  BC-3700.60.30:
+    name: Sprachversions- und Regionalschnitt-Management
+    description: |
+      Erstellung von Sprach- und Regionalversions-Mastern
+      einschließlich territorialer Schnittfassungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-content-rights-licensing-management.yaml
+++ b/catalogue/i18n/de/L1-content-rights-licensing-management.yaml
@@ -1,0 +1,158 @@
+locale: de
+source: L1-content-rights-licensing-management.yaml
+entries:
+  BC-3720:
+    name: Inhaltsrechte und Lizenzverwaltung
+    description: |
+      Erwerb, Inventar, ausgehende Lizenzierung, Sport- und
+      Musikrechte, Lizenzeinnahmen sowie Freigabe- und
+      Chain-of-Title-Management für audiovisuelle, Audio-
+      und Redaktionsinhalte.
+  BC-3720.10:
+    name: Rechtserwerbs-Management
+    description: |
+      Verhandlung und Vertragserstellung für eingehende Rechte
+      bei Inhalten, die das Unternehmen von Rechteinhabern
+      oder Produzenten erwirbt.
+  BC-3720.10.10:
+    name: Rechtsverhandlungs-Unterstützung
+    description: |
+      Term-Sheet-Vorbereitung, Vergleichsdealanalyse und
+      Verhandlungsunterstützung für eingehende Inhaltsdeals.
+  BC-3720.10.20:
+    name: Erwerbsvertrags-Management
+    description: |
+      Erstellung, Abschluss und Lebenszyklusmanagement eingehender
+      Rechtsverträge und Änderungen.
+  BC-3720.10.30:
+    name: Rechts-Fenster-Erwerbs-Verfolgung
+    description: |
+      Verfolgung erworbener Fenster, Territorien, Plattformen und
+      Exklusivitätsbedingungen gegen den Vertrag.
+  BC-3720.20:
+    name: Rechtsinventar-Management
+    description: |
+      Pflege des konsolidierten Bestands gehaltener Rechte und
+      Verfügbarkeitsabfragen für nachgelagerte Programmierung
+      und Lizenzierung.
+  BC-3720.20.10:
+    name: Rechtsfenster- und Territorien-Verfolgung
+    description: |
+      Verfolgung verfügbarer Rechtsfenster nach Titel, Territorium,
+      Plattform und Sprache.
+  BC-3720.20.20:
+    name: Holdback- und Exklusivitäts-Verfolgung
+    description: |
+      Verfolgung von Holdback-Perioden und Exklusivitäts-
+      beschränkungen, die die nachgelagerte Nutzung einschränken.
+  BC-3720.20.30:
+    name: Rechtsverfügbarkeits-Anfrage
+    description: |
+      Anfragedienste zur Klärung, ob ein Titel für eine bestimmte
+      Nutzung, ein Fenster und ein Territorium lizenzierbar ist.
+  BC-3720.30:
+    name: Ausgehende Lizenzierungs-Management
+    description: |
+      Verkauf und Lebenszyklusmanagement von Rechten, die an
+      Sender, Plattformen und sonstige Dritte lizenziert werden.
+  BC-3720.30.10:
+    name: Lizenzierungs-Verkaufsmanagement
+    description: |
+      Pipeline, Deal-Strukturierung und Abschluss ausgehender
+      Lizenzdeals über Territorien und Plattformen hinweg.
+  BC-3720.30.20:
+    name: Output-Deal-Management
+    description: |
+      Multi-Titel-Output- und Volumen-Deal-Management mit
+      nachgelagerten Lizenznehmern.
+  BC-3720.30.30:
+    name: Format-Lizenzierungs-Management
+    description: |
+      Lizenzierung von Unscripted- und Scripted-Formaten und
+      Bibeln an lokale Produzenten und Sender.
+  BC-3720.40:
+    name: Sport- und Live-Event-Rechte-Management
+    description: |
+      Bieten, Verfolgung und Auswertung von Sport- und
+      Live-Event-Rechten einschließlich abgeleiteter Highlights.
+  BC-3720.40.10:
+    name: Sportrechte-Bieten
+    description: |
+      Angebotsvorbereitung, Bewertung und Ausschreibungsantwort
+      für Sport- und Live-Event-Rechte.
+  BC-3720.40.20:
+    name: Veranstaltungsplan-Rechte-Verfolgung
+    description: |
+      Verfolgung spieltagsbezogener Rechte gegen gehaltene
+      Wettbewerbs- und Turnierrechte.
+  BC-3720.40.30:
+    name: Highlights- und Clips-Rechte-Management
+    description: |
+      Management abgeleiteter Rechte für Highlights, Clips und
+      Kurzform-Social- und Digital-Verwertung.
+  BC-3720.50:
+    name: Musik- und Aufführungsrechte-Management
+    description: |
+      Lizenzierung und Berichterstattung von Musik- und
+      Aufführungsrechten einschließlich Synchronisation,
+      Mechanik und öffentlicher Aufführung.
+  BC-3720.50.10:
+    name: Mechanik- und Synchronisations-Lizenzierung
+    description: |
+      Freigabe und Lizenzierung von Mechanik- und Synchronisations-
+      rechten für Musik in Produktionen und Plattformen.
+  BC-3720.50.20:
+    name: Aufführungsrechte-Berichterstattung
+    description: |
+      Berichterstattung öffentlicher Aufführungs- und Sendungsnutzung
+      an Verwertungsgesellschaften.
+  BC-3720.50.30:
+    name: Musik-Cue-Sheet-Management
+    description: |
+      Erstellung und Verteilung von Musik-Cue-Sheets an
+      Gesellschaften und Rechteinhaber.
+  BC-3720.60:
+    name: Lizenz-Einnahmen-Management
+    description: |
+      Empfang, Abstimmung und Weiterverteilung von Lizenzeinnahmen,
+      die dem Unternehmen als Rechteinhaber zustehen.
+  BC-3720.60.10:
+    name: Lizenz-Abrechnungs-Abstimmung
+    description: |
+      Abstimmung eingehender Lizenzabrechnungen von Lizenznehmern
+      und Gesellschaften gegen gehaltene Rechte.
+  BC-3720.60.20:
+    name: Lizenz-Einnahmen-Buchung
+    description: |
+      Buchung von Lizenzeinnahmen gegen das Rechts-Ledger
+      und vorgelagerte Buchungserfassung.
+  BC-3720.60.30:
+    name: Zugrundeliegende Rechteinhaber-Distribution
+    description: |
+      Verteilung erhaltener Lizenzgebühren an zugrundeliegende
+      Rechteinhaber nach Beteiligungsbedingungen und
+      Subpublishing-Konditionen.
+  BC-3720.70:
+    name: Rechtsfreigabe- und Chain-of-Title-Management
+    description: |
+      Verifizierung und Dokumentation zugrundeliegender Rechte
+      und Chain of Title zur Unterstützung von Verwertung und
+      E&O-Versicherungsschutz.
+  BC-3720.70.10:
+    name: Zugrundeliegende Rechte-Verifizierung
+    description: |
+      Verifizierung zugrundeliegender literarischer, Musik- und
+      Bildrechte, die in das Werk eingeflossen sind.
+  BC-3720.70.20:
+    name: Freigabestatus-Verfolgung
+    description: |
+      Verfolgung des Freigabestatus nach Element mit ausstehenden
+      Aktionen-Management.
+  BC-3720.70.30:
+    name: Chain-of-Title-Dokumentation
+    description: |
+      Pflege von Chain-of-Title-Aufzeichnungen, die für E&O-Deckung
+      und nachgelagerte Lizenznehmer-Due-Diligence ausreichend sind.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-corporate-communications-management.yaml
+++ b/catalogue/i18n/de/L1-corporate-communications-management.yaml
@@ -1,0 +1,118 @@
+locale: de
+source: L1-corporate-communications-management.yaml
+entries:
+  BC-850:
+    name: Unternehmenskommunikations-Management
+    description: |
+      Interne und externe Unternehmenskommunikation.
+  BC-850.10:
+    name: Interne Kommunikations-Management
+    description: |
+      Mitarbeiterkommunikation und Führungskräftekommunikation.
+  BC-850.10.10:
+    name: Mitarbeiterkommunikation
+    description: |
+      Mitarbeiternewsletter, Intranet und Town Halls.
+  BC-850.10.20:
+    name: Führungskräftekommunikation
+    description: |
+      CEO- und Vorstandskommunikation sowie Botschaften der Führungsebene.
+  BC-850.10.30:
+    name: Change- und Transformationskommunikation
+    description: |
+      Interne Kommunikation zur Unterstützung von Veränderungen und Transformationen.
+  BC-850.10.40:
+    name: Internes Kanalmanagement
+    description: |
+      Management interner Kanäle (Intranet, Slack, Teams).
+  BC-850.20:
+    name: Externe Kommunikations-Management
+    description: |
+      Externe Unternehmenskommunikation und Stellungnahmen.
+  BC-850.20.10:
+    name: Externe Botschaftsarchitektur
+    description: |
+      Botschaftsarchitektur und Narrative für externe Zielgruppen.
+  BC-850.20.20:
+    name: Unternehmensstatements und Positionspapiere
+    description: |
+      Ausarbeitung von Unternehmensstatements und Positionspapieren.
+  BC-850.20.30:
+    name: Unternehmenswebsite und eigene Kanäle
+    description: |
+      Inhalte der Unternehmenswebsite und eigener externer Kanäle.
+  BC-850.30:
+    name: Public-Relations-Management
+    description: |
+      Reputationsmanagement und Stakeholder-PR.
+  BC-850.30.10:
+    name: Reputationsmanagement
+    description: |
+      Reputationsverfolgung, Stimmungsanalyse und Reputationsstrategie.
+  BC-850.30.20:
+    name: Thought-Leadership-Management
+    description: |
+      Thought-Leadership-Inhalte und Positionierung von Führungspersönlichkeiten.
+  BC-850.30.30:
+    name: Public Affairs und Government Relations
+    description: |
+      Government Relations und Engagement mit politischen Entscheidungsträgern.
+  BC-850.40:
+    name: Medienrelations-Management
+    description: |
+      Medienengagement, Pressemitteilungen und Briefings.
+  BC-850.40.10:
+    name: Pressemitteilungsmanagement
+    description: |
+      Ausarbeitung, Freigabe und Verbreitung von Pressemitteilungen.
+  BC-850.40.20:
+    name: Journalistenengagement
+    description: |
+      Journalistenbeziehungen, Interviews und Briefings.
+  BC-850.40.30:
+    name: Medienbeobachtung
+    description: |
+      Überwachung der Medienberichterstattung und des Share of Voice.
+  BC-850.40.40:
+    name: Mediensprecher-Vorbereitung
+    description: |
+      Identifikation, Schulung und Botschaftsvorbereitung für Mediensprecher.
+  BC-850.50:
+    name: Krisenkommunikations-Management
+    description: |
+      Kommunikation in Krisen und bei Vorfällen.
+  BC-850.50.10:
+    name: Krisenkommunikationsplanung
+    description: |
+      Vorgefertigte Krisenkommunikationspläne nach Szenarien.
+  BC-850.50.20:
+    name: Krisenstatement-Vorbereitung
+    description: |
+      Schnelle Ausarbeitung von Statements und Q&A bei Vorfällen.
+  BC-850.50.30:
+    name: Krisensprechermanagement
+    description: |
+      Sprechermanagement und Medienhandling in Krisen.
+  BC-850.50.40:
+    name: Reputationswiederherstellung nach Krisen
+    description: |
+      Kommunikation und Reputationswiederherstellung nach Krisen.
+  BC-850.60:
+    name: Stakeholder-Kommunikations-Management
+    description: |
+      Zielgerichtete Kommunikation an spezifische Stakeholdergruppen.
+  BC-850.60.10:
+    name: Stakeholder-Mapping
+    description: |
+      Erfassung und Segmentierung externer Stakeholder.
+  BC-850.60.20:
+    name: Stakeholder-Engagement-Planung
+    description: |
+      Maßgeschneiderte Engagement-Pläne für Stakeholdergruppen.
+  BC-850.60.30:
+    name: Gemeinschafts- und lokales Stakeholder-Engagement
+    description: |
+      Engagement mit lokalen Gemeinschaften und kommunalen Stakeholdern.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-corporate-governance.yaml
+++ b/catalogue/i18n/de/L1-corporate-governance.yaml
@@ -1,0 +1,102 @@
+locale: de
+source: L1-corporate-governance.yaml
+entries:
+  BC-110:
+    name: Unternehmenssteuerung
+    description: |
+      Vorstand-, Ausschuss- und Aktionärssteuerungsprozesse.
+  BC-110.10:
+    name: Vorstands- und Ausschussmanagement
+    description: |
+      Vorstandszusammensetzung, Sitzungen, Ausschüsse und Unterlagen.
+  BC-110.10.10:
+    name: Vorstandszusammensetzungsmanagement
+    description: |
+      Bestellung, Nachfolge, Unabhängigkeit und Kompetenzmatrix von Direktoren.
+  BC-110.10.20:
+    name: Vorstandssitzungsadministration
+    description: |
+      Tagesordnungen, Unterlagen, Protokolle und Beschlüsse für Vorstandssitzungen.
+  BC-110.10.30:
+    name: Ausschussoperationen
+    description: |
+      Betrieb von Revisions-, Risiko-, Vergütungs- und Nominierungsausschüssen.
+  BC-110.10.40:
+    name: Direktoreneinarbeitung und -weiterbildung
+    description: |
+      Einarbeitung, laufende Weiterbildung und Überprüfungen der Vorstandseffektivität.
+  BC-110.20:
+    name: Aktionärs- und Eigenkapitalmanagement
+    description: |
+      Eigenkapitalstruktur, Aktienregister und Aktionärsrechte.
+  BC-110.20.10:
+    name: Aktienregisterpflege
+    description: |
+      Pflege des Mitgliederregisters und der wirtschaftlichen Eigentümerschaftsunterlagen.
+  BC-110.20.20:
+    name: Aktionärsversammlungsmanagement
+    description: |
+      Einberufung von Haupt- und außerordentlichen Versammlungen, Einladungen, Abstimmungen und Beschlüsse.
+  BC-110.20.30:
+    name: Dividenden- und Ausschüttungsadministration
+    description: |
+      Dividendenbeschlüsse, Zahlungen und Kapitalausschüttungen.
+  BC-110.20.40:
+    name: Eigenkapitalstrukturmanagement
+    description: |
+      Aktiengattungen, Kapitalerhöhungen, Aktienrückkäufe und Aktiensplits.
+  BC-110.30:
+    name: Unternehmenssekretariatsmanagement
+    description: |
+      Pflichtmeldungen, Unternehmensunterlagen und Formalitäten.
+  BC-110.30.10:
+    name: Pflichtmeldungsadministration
+    description: |
+      Einreichungen bei Handelsregistern und Unternehmensbehörden.
+  BC-110.30.20:
+    name: Unternehmensunterlagenverwaltung
+    description: |
+      Pflege von Satzungsbüchern, Registern und Unternehmensarchiven.
+  BC-110.30.30:
+    name: Unternehmensbeschlussadministration
+    description: |
+      Entwurf, Ausführung und Dokumentation von Vorstands- und Aktionärsbeschlüssen.
+  BC-110.40:
+    name: Tochtergesellschafts- und Rechtsträgerträgermanagement
+    description: |
+      Rechtliche Konzernstruktur und gruppenweite Steuerung.
+  BC-110.40.10:
+    name: Rechtsträgerlebenszyklusmanagement
+    description: |
+      Gründung, Umstrukturierung, Ruhendstellung und Liquidation von Rechtsträgern.
+  BC-110.40.20:
+    name: Konzernstruktursteuerung
+    description: |
+      Pflege und Überwachung des Rechtsträgergruppenorganigramms und der Eigentumsketten.
+  BC-110.40.30:
+    name: Tochtergesellschafts-Governance-Standards
+    description: |
+      Gruppenweite Governance-Standards für alle Tochtergesellschaften.
+  BC-110.40.40:
+    name: Grenzüberschreitende Rechtsträger-Compliance
+    description: |
+      Einhaltung lokaler Pflicht- und Unternehmenssteuerungsvorschriften für ausländische Tochtergesellschaften.
+  BC-110.50:
+    name: Delegations- und Vollmachtsmanagement
+    description: |
+      Vollmachtsmatrizen, Delegationen und Unterzeichnungsrechte.
+  BC-110.50.10:
+    name: Delegationsrahmenwerk
+    description: |
+      Genehmigungsstufen, -schwellenwerte und Delegationshierarchien.
+  BC-110.50.20:
+    name: Unterzeichnungsvollmachtsadministration
+    description: |
+      Bevollmächtigtenlisten, Prokuren und Bankvollmachten.
+  BC-110.50.30:
+    name: Delegations-Compliance-Monitoring
+    description: |
+      Überwachung von Entscheidungen im Rahmen delegierter Vollmachtsgrenzen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-corporate-real-estate-management.yaml
+++ b/catalogue/i18n/de/L1-corporate-real-estate-management.yaml
@@ -1,0 +1,86 @@
+locale: de
+source: L1-corporate-real-estate-management.yaml
+entries:
+  BC-710:
+    name: Unternehmensimmobilienmanagement
+    description: |
+      Immobilienportfolio, Mietverhältnisse, Transaktionen und Flächenplanung.
+  BC-710.10:
+    name: Immobilienstrategie- und Portfoliomanagement
+    description: |
+      Immobilienstrategie, Portfoliostruktur und Flächenbedarfsplanung.
+  BC-710.10.10:
+    name: Immobilienstrategieentwicklung
+    description: |
+      Mehrjährige Immobilienstrategie im Einklang mit den Unternehmensanforderungen.
+  BC-710.10.20:
+    name: Portfolio-Flächenbedarfsplanung
+    description: |
+      Flächenbedarfsplanung, Standortstrategie und Konsolidierungsanalyse.
+  BC-710.10.30:
+    name: Immobilien-Performance-Management
+    description: |
+      Nachverfolgung von Kosten, Nutzung und Performance je Immobilie.
+  BC-710.10.40:
+    name: Immobilienrisikomanagement
+    description: |
+      Immobilienmarkt-, Länder- und Gegenparteirisiken.
+  BC-710.20:
+    name: Immobilienakquisitions- und -veräußerungsmanagement
+    description: |
+      Akquisitionen, Veräußerungen und Exits.
+  BC-710.20.10:
+    name: Immobilienakquisition
+    description: |
+      Erwerb eigener und gemieteter Immobilien einschließlich Due Diligence.
+  BC-710.20.20:
+    name: Immobilienveräußerung und Exit
+    description: |
+      Verkauf, Untervermietung und Exit von Immobilienvermögen und Mietverhältnissen.
+  BC-710.20.30:
+    name: Standortauswahl und Verhandlung
+    description: |
+      Standortanalyse, Standortauswahl und Mietverhandlung.
+  BC-710.30:
+    name: Mietverwaltungsmanagement
+    description: |
+      Mietlebenszyklus, Bilanzierung und Optionen.
+  BC-710.30.10:
+    name: Mietdokumentenverwaltung
+    description: |
+      Pflege von Mietverträgen, Zusammenfassungen und Schlüsselkonditionen.
+  BC-710.30.20:
+    name: Mietbilanzierung
+    description: |
+      Mietbilanzierung nach IFRS 16 / ASC 842.
+  BC-710.30.30:
+    name: Mietzahlung und -abstimmung
+    description: |
+      Miete, Nebenkosten und CAM-Zahlungen sowie Abstimmung.
+  BC-710.30.40:
+    name: Mietoptions- und Verlängerungsmanagement
+    description: |
+      Nachverfolgung und Ausübung von Mietoptionen, Kündigungsrechten und Verlängerungen.
+  BC-710.40:
+    name: Arbeitsplatzstrategiemanagement
+    description: |
+      Arbeitsplatzkonzepte, hybrides Arbeiten und Designstandards.
+  BC-710.40.10:
+    name: Arbeitsplatzkonzeptdesign
+    description: |
+      Definition von Arbeitsplatzkonzepten einschließlich aktivitätsbasiertem Arbeiten.
+  BC-710.40.20:
+    name: Arbeitsplatz-Designstandards
+    description: |
+      Designrichtlinien, Ausbaustandards und Markenstandards für Arbeitsplätze.
+  BC-710.40.30:
+    name: Hybrid-Arbeits-Richtlinien-Umsetzung
+    description: |
+      Umsetzung hybrider Arbeitsmodelle und unterstützender Flächen.
+  BC-710.40.40:
+    name: Arbeitsplatzerfahrungsmessung
+    description: |
+      Messung von Arbeitsplatzerfahrung und -zufriedenheit.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-credit-lending-management.yaml
+++ b/catalogue/i18n/de/L1-credit-lending-management.yaml
@@ -1,0 +1,138 @@
+locale: de
+source: L1-credit-lending-management.yaml
+entries:
+  BC-1320:
+    name: Kredit- und Kreditvergabe-Management
+    description: |
+      Kreditorigination, Zeichnung, Darlehensbetreuung, Inkasso und Portfoliomanagement.
+  BC-1320.10:
+    name: Kreditoriginationsmanagement
+    description: |
+      Kreditantragserfassung, Vorprüfung und Originationsworkflows.
+  BC-1320.10.10:
+    name: Kreditantragserfassung
+    description: |
+      Erfassung von Kreditanträgen über alle Kanäle.
+  BC-1320.10.20:
+    name: Vorprüfung und Tragbarkeitsbeurteilung
+    description: |
+      Vorprüfung, Tragbarkeits- und Dienstleistungsfähigkeitsprüfungen.
+  BC-1320.10.30:
+    name: Originationsworkflow-Orchestrierung
+    description: |
+      Orchestrierung von Kreditoriginationsworkflows und SLAs.
+  BC-1320.10.40:
+    name: Originationsdokumentenerhebung
+    description: |
+      Erhebung und Verifizierung von Originationsbelegen.
+  BC-1320.20:
+    name: Kreditzeichnungs- und Entscheidungsmanagement
+    description: |
+      Zeichnung, Finanzauswertung, Entscheidungsfindung und delegierte Vollmacht.
+  BC-1320.20.10:
+    name: Kreditrisikobewertung
+    description: |
+      Kreditrisikobewertung von Antragstellern und Engagements.
+  BC-1320.20.20:
+    name: Finanzkennzahlenanalyse
+    description: |
+      Aufbereitung von Jahresabschlüssen und Kennzahlenanalyse.
+  BC-1320.20.30:
+    name: Kreditentscheidung
+    description: |
+      Entscheidungsmaschinen und ermessensbasierte Entscheidung in Kreditfällen.
+  BC-1320.20.40:
+    name: Kreditgenehmigung und delegierte Vollmacht
+    description: |
+      Kreditgenehmigungsgovernance und Anwendung delegierter Vollmachten.
+  BC-1320.20.50:
+    name: Sicherheitenbewertung und -management
+    description: |
+      Sicherheitenidentifikation, -bewertung und Pfandrechtssicherung.
+  BC-1320.30:
+    name: Darlehensbetreuungsmanagement
+    description: |
+      Darlehensbetreuung, Zahlungen, Planänderungen und Modifikationen.
+  BC-1320.30.10:
+    name: Darlehensauszahlung
+    description: |
+      Darlehensauszahlung und Abnahmemanagement.
+  BC-1320.30.20:
+    name: Rückzahlungsverarbeitung
+    description: |
+      Rückzahlungsplanung, -verarbeitung und -abstimmung.
+  BC-1320.30.30:
+    name: Darlehensmodifikation
+    description: |
+      Darlehensvertragsänderungen, Restrukturierungen und Refinanzierungen.
+  BC-1320.30.40:
+    name: Darlehenstilgung und -abschluss
+    description: |
+      Darlehenstilgung, Kontostandsmitteilung und Abschlussvorgänge.
+  BC-1320.40:
+    name: Inkasso- und Forderungsmanagement
+    description: |
+      Inkasso, Restrukturierung, Verwertungsmaßnahmen und NPL-Abwicklung.
+  BC-1320.40.10:
+    name: Frühstufiges Inkasso
+    description: |
+      Frühzeitiges Rückstandsmanagement und Zahlungserinnerungen.
+  BC-1320.40.20:
+    name: Spätstufiges Inkasso
+    description: |
+      Spätstufiges Inkasso und Weiterverweisung an Rechtsabteilung.
+  BC-1320.40.30:
+    name: Restrukturierung und Stundung
+    description: |
+      Restrukturierungsangebote, Stundung und Unterstützung bei Kundenschwierigkeiten.
+  BC-1320.40.40:
+    name: Verwertung und Abschreibung
+    description: |
+      Verwertungsmaßnahmen, Abschreibung und nachgelagerte Aktivitäten.
+  BC-1320.40.50:
+    name: NPL-Abwicklung
+    description: |
+      Abwicklung, Verkauf und Verbriefung notleidender Kredite.
+  BC-1320.50:
+    name: Kreditportfolio-Management
+    description: |
+      Portfolioanalyse, -optimierung und Kapitalmanagement.
+  BC-1320.50.10:
+    name: Portfolio-Risikoanalyse
+    description: |
+      Portfolioanalyse einschließlich Vintage-, Konzentrations- und Stressanalysen.
+  BC-1320.50.20:
+    name: Portfolio-Optimierung
+    description: |
+      Optimierung von Portfoliomix, Preisgestaltung und Risiko-Rendite-Verhältnis.
+  BC-1320.50.30:
+    name: Portfolio-Kapitalmanagement
+    description: |
+      Kapitalmanagement für Kreditportfolios gemäß Basel-Regeln.
+  BC-1320.50.40:
+    name: Portfolio-Berichterstattung
+    description: |
+      Portfolioberichterstattung an Risikoausschüsse und Aufsichtsbehörden.
+  BC-1320.60:
+    name: Kreditrisikomodell-Management
+    description: |
+      PD/LGD/EAD-Modelle, IRB und IFRS-9-ECL.
+  BC-1320.60.10:
+    name: PD/LGD/EAD-Modellentwicklung
+    description: |
+      Entwicklung von PD-, LGD- und EAD-Modellen.
+  BC-1320.60.20:
+    name: IFRS-9-ECL-Modellierung
+    description: |
+      Entwicklung und Betrieb von IFRS-9-Erwarteter-Kreditverlust-Modellen.
+  BC-1320.60.30:
+    name: Modellvalidierung
+    description: |
+      Unabhängige Validierung von Kreditrisikomodellen.
+  BC-1320.60.40:
+    name: Modellüberwachung
+    description: |
+      Laufende Leistungsüberwachung und Rekalibrierung von Modellen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-crop-production-management.yaml
+++ b/catalogue/i18n/de/L1-crop-production-management.yaml
@@ -1,0 +1,193 @@
+locale: de
+source: L1-crop-production-management.yaml
+entries:
+  BC-3500:
+    name: Pflanzenbau-Management
+    description: |
+      Landwirtschaftliche Anbaubetriebe – Anbausystemplanung,
+      Bodenbearbeitung, Aussaat, Düngung, Pflanzenschutz,
+      Bewässerung, Überwachung und Ertragsschätzung für Acker-,
+      Gartenbau- und Spezialkulturen.
+  BC-3500.10:
+    name: Anbausystem-Planung
+    description: |
+      Mehrjährige Planung von Fruchtfolgen, Schlagverteilungen,
+      Aussaatfenstern und Sortenwahl über das gesamte Betriebsportfolio.
+    in_scope:
+      - Fruchtfolge-Design
+      - Schlagbasierte Kulturenverteilung
+      - Aussaatfenster-Planung
+      - Sorten- und Hybridauswahl
+    out_of_scope:
+      - Sortenverdurchführung (BC-3530.60)
+      - Agronomische Empfehlungen (BC-3530.20)
+  BC-3500.10.10:
+    name: Fruchtfolge-Planung
+    description: |
+      Mehrjährige Fruchtfolge-Planung zur Ausgewogenheit von
+      Bodengesundheit, Marktnachfrage und Schädlingszyklen.
+  BC-3500.10.20:
+    name: Schlagverteilungs-Planung
+    description: |
+      Zuweisung von Kulturen auf bestimmte Schläge und Parzellen
+      für die Anbausaison.
+  BC-3500.10.30:
+    name: Aussaatfenster-Planung
+    description: |
+      Planung optimaler Aussaatfenster nach Kultur, Sorte und
+      agrarklimatischer Zone.
+  BC-3500.10.40:
+    name: Sortenauswahl-Entscheidungen
+    description: |
+      Auswahl von Sorten und Hybriden für die Anbausaison auf Basis
+      agronomischer und marktlicher Kriterien.
+  BC-3500.20:
+    name: Bodenbearbeitungs-Betrieb
+    description: |
+      Bodenbearbeitung, Beetvorbereitung und Voraussaat-Boden-
+      verbesserungsmaßnahmen zur Herstellung eines keimfähigen Saatbetts.
+  BC-3500.20.10:
+    name: Bodenbearbeitungs-Betrieb
+    description: |
+      Konventionelle, reduzierte und Direktsaat-Feldvorbereitungen.
+  BC-3500.20.20:
+    name: Beet-Vorbereitungs-Betrieb
+    description: |
+      Beetforming, Dammkultur und Mulchen für Gartenbau-
+      und Reihenkulturen.
+  BC-3500.20.30:
+    name: Voraussaat-Bodenverbesserungs-Ausbringung
+    description: |
+      Ausbringung von Voraussaat-Bodenverbesserern wie Kalk,
+      Gips und organischem Material.
+  BC-3500.30:
+    name: Aussaat- und Pflanzungs-Betrieb
+    description: |
+      Saatgut- und Pflanzgutablage einschließlich Nachsaat-
+      Entscheidungen und Bestandsetablierung.
+  BC-3500.30.10:
+    name: Saatbett-Fertigstellung
+    description: |
+      Endgültige Saatbett-Vorbereitung unmittelbar vor der Aussaat.
+  BC-3500.30.20:
+    name: Saatgut- und Pflanzgut-Ablage
+    description: |
+      Mechanische und manuelle Ablage von Saatgut und Pflanzgut
+      auf dem Feld.
+  BC-3500.30.30:
+    name: Nachsaat- und Lückenschluss-Betrieb
+    description: |
+      Nachsaat und Lückenschluss bei unzureichender Bestandsetablierung.
+  BC-3500.40:
+    name: Pflanzenernährungs-Betrieb
+    description: |
+      Nährstoffzufuhr während der Saison durch Fest-, Flüssig-,
+      Blatt- und Fertigationsmethoden.
+  BC-3500.40.10:
+    name: Festdünger-Ausbringung
+    description: |
+      Breitband-, Reihen- und variabelraten Festdünger-Ausbringung.
+  BC-3500.40.20:
+    name: Blattdünger-Ausbringung
+    description: |
+      Blattapplikation von Makro- und Mikronährstoffen während
+      der Vegetationsperiode.
+  BC-3500.40.30:
+    name: Fertigations-Betrieb
+    description: |
+      Nährstoffzufuhr über Bewässerungssysteme einschließlich
+      Injektions- und Dosiersteuerung.
+  BC-3500.50:
+    name: Pflanzenschutz-Betrieb
+    description: |
+      Ausbringung chemischer, biologischer und mechanischer
+      Pflanzenschutzmaßnahmen sowie dazugehörige Aufzeichnungen.
+    in_scope:
+      - Pestizid- und Herbizid-Ausbringung
+      - Ausbringung biologischer Pflanzenschutzmittel
+      - Mechanische und thermische Unkrautbekämpfung
+      - Spritz- und Applikationsaufzeichnungen
+    out_of_scope:
+      - IPM-Planung (BC-3530.30)
+      - HHR-Konformitätsüberwachung (BC-3590.50)
+  BC-3500.50.10:
+    name: Pestizid-Ausbringung
+    description: |
+      Boden- und Luftpestizid-Ausbringung einschließlich
+      Abdrift-Management.
+  BC-3500.50.20:
+    name: Biologische Pflanzenschutz-Ausbringung
+    description: |
+      Freilassung von Nützlingen und Biopestizid-Produkten.
+  BC-3500.50.30:
+    name: Mechanische und Thermische Unkrautbekämpfung
+    description: |
+      Mechanische und thermische Unkrautbekämpfung einschließlich
+      Bearbeitung und Abflammung.
+  BC-3500.50.40:
+    name: Spritzapplikation-Aufzeichnung
+    description: |
+      Feldspezifische Spritzaufzeichnungen mit Produkt, Aufwandmenge,
+      Wetter und Bediener.
+  BC-3500.60:
+    name: Bewässerungs-Betrieb
+    description: |
+      Tägliche Bewässerungsplanung, Applikation und Drainage-
+      Entscheidungen zur Steuerung des Pflanzenwasserstatus.
+  BC-3500.60.10:
+    name: Bewässerungsplanung
+    description: |
+      Bodenfeuchte- und Pflanzenbedarf-basierte Bewässerungsplanung.
+  BC-3500.60.20:
+    name: Bewässerungsapplikations-Betrieb
+    description: |
+      Applikation von Bewässerungswasser über Regen-, Tropf- und
+      Oberflächensysteme.
+  BC-3500.60.30:
+    name: Feldentwässerungs-Betrieb
+    description: |
+      Oberflächen- und Unterdrainagebetrieb und Grundwasserspiegels-
+      Steuerung.
+  BC-3500.70:
+    name: Pflanzenüberwachung und -Scouting
+    description: |
+      Feldüberwachung von Pflanzengesundheit, Schädlingsdruck und
+      Phänologie durch Scouting-, Sensor- und Fernerkundungsmethoden.
+  BC-3500.70.10:
+    name: Feld-Scouting-Betrieb
+    description: |
+      Manuelle Scouting-Begehungen für Schädlings-, Krankheits-
+      und Pflanzenzustandsbeurteilung.
+  BC-3500.70.20:
+    name: Schädlings- und Krankheits-Surveillance
+    description: |
+      Fallen- und Sensor-basierte Überwachung von Schädlings-
+      und Krankheitsdruck.
+  BC-3500.70.30:
+    name: Pflanzen-Phänologie-Verfolgung
+    description: |
+      Verfolgung von Wachstumsstadien, Wärmeeinheiten und
+      phänologischen Meilensteinen.
+  BC-3500.70.40:
+    name: Fernerkundungs-Pflanzenüberwachung
+    description: |
+      Satelliten-, Drohnen- und Proximal-Sensor-basierte
+      Pflanzenstatusüberwachung.
+  BC-3500.80:
+    name: Ertragsschätzung
+    description: |
+      Saisonal und vor der Ernte Ertragsschätzungen für Originierung,
+      Logistik und kommerzielle Planung.
+  BC-3500.80.10:
+    name: Saisonale Ertragsschätzung
+    description: |
+      Midsaisonale Ertragschätzungen aus Kulturindizes und
+      Feldmessungen.
+  BC-3500.80.20:
+    name: Erntevorhersage
+    description: |
+      Erntevorhersagen vor der Ernte für Ernte-, Lager- und
+      Originierungspläne.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-cruise-voyage-operations-management.yaml
+++ b/catalogue/i18n/de/L1-cruise-voyage-operations-management.yaml
@@ -1,0 +1,172 @@
+locale: de
+source: L1-cruise-voyage-operations-management.yaml
+entries:
+  BC-4090:
+    name: Kreuzfahrtbetrieb Management
+    description: |
+      Betrieb von Kreuzfahrten – Reiseplanplanung, Hafen- und Landausflugsbetrieb,
+      Kabinen- und Gästeprogramme an Bord, Marine- und Brückenbetrieb,
+      Einschiffung sowie Gesundheits- und Hygienebetrieb an Bord –
+      gemäß internationalen Seeschifffahrtssicherheitsvorschriften.
+    in_scope:
+      - Reiseplangestaltung und -einsatz
+      - Hafenabfertigung, Tenderung und Landausflugskatalog, -verkauf und -erbringung
+      - Kabinen-, Programm- und Gästeservicebetrieb an Bord
+      - Marine-, Brücken- und Maschinenraumbetrieb
+      - Ein- und Ausschiffungsbetrieb
+      - Gesundheits- und Hygienebetrieb an Bord
+    out_of_scope:
+      - Kreuzfahrtverkauf und -vertrieb (BC-4010, BC-4020)
+      - Hotelbasierter Unterkunftsbetrieb (BC-4060)
+  BC-4090.10:
+    name: Reiseplanplanung
+    description: |
+      Planung von Reiseplänen, Einsatz, Repositionierung und
+      Reiseplansubstitutionsentscheidungen.
+  BC-4090.10.10:
+    name: Reiseplangestaltung und Einsatz
+    description: |
+      Gestaltung von Kreuzfahrtreiseplänen und Zuweisung von Schiffen zu Einsatzsaisonen.
+  BC-4090.10.20:
+    name: Repositionierungs- und Charterreiseplanung
+    description: |
+      Planung von Repositionierungsreisen und Charter-Einsätzen zwischen Saisonen.
+  BC-4090.10.30:
+    name: Hafenrufsequenzierung
+    description: |
+      Sequenzierung von Hafenrufen innerhalb eines Reiseplans gegen Gezeiten,
+      Umschlagzeiten und Partnervereinbarungen.
+  BC-4090.10.40:
+    name: Reiseplan-Änderung und Substitution
+    description: |
+      Live-Änderung und Substitution von Reiseplänen bei Wetter-, Gesundheits-
+      oder geopolitischen Ereignissen.
+  BC-4090.20:
+    name: Hafen- und Landausflugsbetrieb
+    description: |
+      Betrieb bei Hafenrufen einschließlich Abfertigung, Tenderung sowie
+      Landausflugskatalog, -verkauf und -erbringung.
+  BC-4090.20.10:
+    name: Hafenabfertigungsbetrieb
+    description: |
+      Koordination der Hafenabfertigung einschließlich Versorgung, Abfall und Besatzungswechsel.
+  BC-4090.20.20:
+    name: Tenderungsbetrieb
+    description: |
+      Betrieb von Tenderservices zu und von Reedereiankerpositionen.
+  BC-4090.20.30:
+    name: Landausflugskatalog und Verkauf
+    description: |
+      Katalog und Verkauf von Landausflügen an Gäste über Vorkreuzfahrt- und Bordkanäle.
+  BC-4090.20.40:
+    name: Landausflug-Erbringungskoordination
+    description: |
+      Koordination der Landausflug-Erbringung einschließlich lokaler Betreiberübergabe und Gästeabstimmung.
+  BC-4090.30:
+    name: Kabinen- und Staatskabinenbetrieb
+    description: |
+      Kabinen- und Staatskabinenbetrieb an Bord einschließlich Umrüstung,
+      Zuweisung, Upsell während der Reise und Spezialsuitenservice.
+  BC-4090.30.10:
+    name: Staatskabinen-Umrüstungsbetrieb
+    description: |
+      Betrieb der Staatskabinen-Umrüstung während Einschiffungs- und Gastwechseltagen.
+  BC-4090.30.20:
+    name: Kabinenzuweisung und Upsell
+    description: |
+      Zuweisung von Kabinen und Upsell-Entscheidungen vor und während der Reise.
+  BC-4090.30.30:
+    name: Kabineninstandhaltungsbetrieb
+    description: |
+      Instandhaltung von Kabinensystemen und -ausstattung während der Reise.
+  BC-4090.30.40:
+    name: Spezialsuitenservicebetrieb
+    description: |
+      Servicebetrieb für Spezialsuiten und Butler-betreute Kabinen.
+  BC-4090.40:
+    name: Gästeprogrammbetrieb an Bord
+    description: |
+      Bordunterhaltung, Aktivitäten, Kinderprogramme und
+      Spezialveranstaltungsbetrieb über die Reise.
+  BC-4090.40.10:
+    name: Unterhaltungsprogrammbetrieb
+    description: |
+      Betrieb von Theater-, Loungeund Starunterhaltungsprogrammen an Bord.
+  BC-4090.40.20:
+    name: Aktivitäts- und Bereicherungsprogrammbetrieb
+    description: |
+      Betrieb von Aktivitäts- und Bereicherungsprogrammen einschließlich Vorträge, Kurse und Sport.
+  BC-4090.40.30:
+    name: Kinder- und Jugendprogrammbetrieb
+    description: |
+      Betrieb von Kinder- und Jugendprogrammen mit altersgerechten Aktivitäten und Aufsicht.
+  BC-4090.40.40:
+    name: Spezialveranstaltungs-Reservierungen
+    description: |
+      Bordreservierungen für Spezialrestaurants, Spa und kostenpflichtige Veranstaltungen.
+  BC-4090.50:
+    name: Marine- und Brückenbetrieb
+    description: |
+      Marine- und Brückenbetrieb einschließlich Navigation, Antrieb,
+      Hafendokumentation und Versorgungskoordination.
+  BC-4090.50.10:
+    name: Brücken- und Navigationsbetrieb
+    description: |
+      Brückenwache und Navigationsbetrieb über die gesamte Reise.
+  BC-4090.50.20:
+    name: Maschinenraum- und Antriebsbetrieb
+    description: |
+      Maschinenraumwache und Antriebsbetrieb.
+  BC-4090.50.30:
+    name: Hafendokumentation und Zollabfertigung
+    description: |
+      Vorbereitung der Hafendokumentation und Management der Hafenstaat- und Zollabfertigung.
+  BC-4090.50.40:
+    name: Betankung- und Versorgungskoordination
+    description: |
+      Koordination von Betankung und Versorgung bei Hafenrufen.
+  BC-4090.60:
+    name: Einschiffungs- und Ausschiffungsbetrieb
+    description: |
+      Einschiffungs- und Ausschiffungsbetrieb einschließlich Vorboardingprüfung,
+      Zollabfertigung und Gepäckfluss an Bord.
+  BC-4090.60.10:
+    name: Vorboarding-Dokumentenprüfung
+    description: |
+      Prüfung von Gastereisedokumenten und Gesundheitsattestierungen vor dem Boarding.
+  BC-4090.60.20:
+    name: Einschiffungsfluss-Betrieb
+    description: |
+      Betrieb von Einschiffungsflüssen vom Terminal zum Schiff in gebündelten Ankunftsfenstern.
+  BC-4090.60.30:
+    name: Ausschiffung und Zollabfertigung
+    description: |
+      Betrieb von Ausschiffungsflüssen einschließlich Zoll- und Einwanderungsabfertigung im Hafen.
+  BC-4090.60.40:
+    name: Bordgepäckbetrieb
+    description: |
+      Betrieb des Gepäckflusses bei Einschiffung, Kabinlieferung und Ausschiffung.
+  BC-4090.70:
+    name: Kreuzfahrtgesundheits- und Hygienebetrieb
+    description: |
+      Gesundheits- und Hygienebetrieb an Bord einschließlich Inspektionsbereitschaft,
+      Ausbruchserkennung und -reaktion sowie Trinkwasser- und Poolhygiene.
+  BC-4090.70.10:
+    name: Hygieneinspektionsbereitschaft
+    description: |
+      Aufrechterhaltung der Inspektionsbereitschaft gegen VSP-, USPH- und gleichwertige Regimes.
+  BC-4090.70.20:
+    name: Bordausbruchserkennung
+    description: |
+      Erkennung gastrointestinaler und respiratorischer Ausbrüche durch Bordüberwachung.
+  BC-4090.70.30:
+    name: Ausbruchsreaktionsbetrieb
+    description: |
+      Reaktionsbetrieb bei Ausbrüchen einschließlich Eindämmung und Meldung.
+  BC-4090.70.40:
+    name: Trinkwasser- und Poolhygiene
+    description: |
+      Hygienebetrieb für Trinkwasser- und Freizeitwassersysteme an Bord.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-curriculum-programme-management.yaml
+++ b/catalogue/i18n/de/L1-curriculum-programme-management.yaml
@@ -1,0 +1,158 @@
+locale: de
+source: L1-curriculum-programme-management.yaml
+entries:
+  BC-4700:
+    name: Lehrplan- und Studienprogrammverwaltung
+    description: |
+      Definition, Strukturierung, Steuerung und kontinuierliche Verbesserung von
+      Studienprogrammen, Kursen, Modulen, Qualifikationen sowie der zugrundeliegenden
+      Lernergebnisse.
+  BC-4700.10:
+    name: Programmarchitektur
+    description: |
+      Definition der Programmstruktur, Qualifikationsstufe, Kreditgewichtung und der
+      angestrebten Lernergebnisse akademischer Abschlüsse.
+    in_scope:
+      - Programmstruktur und Studienpfaddefinition
+      - Abschluss- und Qualifikationsstruktur
+      - Angestrebte Lernergebnisse auf Programmebene
+    out_of_scope:
+      - Lehrplanentwicklung auf Kursebene (abgedeckt unter Kurs- und Modulgestaltung)
+      - Externe Akkreditierungsergebnisse (abgedeckt unter Akademische Qualität & Akkreditierungsmanagement)
+  BC-4700.10.10:
+    name: Programmdefinition
+    description: |
+      Definition von Programmzweck, Zielkohorte, Zulassungsvoraussetzungen und
+      struktureller Gestaltung.
+  BC-4700.10.20:
+    name: Qualifikations- und Abschlussstrukturierung
+    description: |
+      Strukturierung von Abschlüssen, Kreditwerten und stapelbaren
+      Qualifikationspfaden.
+  BC-4700.10.30:
+    name: Definition von Lernergebnissen
+    description: |
+      Formulierung angestrebter Lernergebnisse auf Programm- und Kursebene.
+  BC-4700.20:
+    name: Kurs- und Modulgestaltung
+    description: |
+      Spezifikation und Entwicklung einzelner Kurse, Module und Lerneinheiten,
+      die akademische Programme zusammensetzen.
+    in_scope:
+      - Kursspezifikationen und Moduldeskriptoren
+      - Lehrplanerstellung und -genehmigung
+      - Lernziele auf Einheitenebene und Prüfungspläne
+    out_of_scope:
+      - Produktion von Lehrmaterialien (abgedeckt unter Lehrinhalt- und Lernressourcenmanagement)
+  BC-4700.20.10:
+    name: Kursspezifikation
+    description: |
+      Erstellung und Genehmigung formaler Kursspezifikationen und -deskriptoren.
+  BC-4700.20.20:
+    name: Modul- und Einheitengestaltung
+    description: |
+      Gestaltung von Modulen und Lerneinheiten innerhalb von Kursen.
+  BC-4700.20.30:
+    name: Lehrplanerstellung
+    description: |
+      Erstellung von Lehrplänen, die Inhalte, Methoden und Prüfungen je Angebot
+      festlegen.
+  BC-4700.30:
+    name: Lehrplankartierung und -abstimmung
+    description: |
+      Zuordnung von Lehrplaninhalten zu Kompetenzrahmen, Qualifikationsrahmen
+      sowie nachgelagerten Kompetenz- oder Karrierepfaden.
+    in_scope:
+      - Kompetenz-Lehrplan-Zuordnung
+      - Abstimmung mit ISCED, EQF, NQF und gleichwertigen Rahmenwerken
+      - Kompetenz- und Karrierepfadzuordnung
+    out_of_scope:
+      - Individuelle Kompetenzerlangung von Lernenden (abgedeckt unter Prüfungs- und Bewertungswesen)
+  BC-4700.30.10:
+    name: Kompetenzrahmenabstimmung
+    description: |
+      Abstimmung des Lehrplans mit definierten Kompetenzrahmen (z. B. CASE).
+  BC-4700.30.20:
+    name: Qualifikationsrahmenzuordnung
+    description: |
+      Zuordnung von Qualifikationen zu ISCED, EQF, NQF und ähnlichen
+      Referenzrahmen.
+  BC-4700.30.30:
+    name: Kompetenz- und Karrierepfadzuordnung
+    description: |
+      Zuordnung des Lehrplans zu beruflichen, fachlichen und Karrierepfaden.
+  BC-4700.40:
+    name: Programmkatalogverwaltung
+    description: |
+      Erstellung, Versionierung und Veröffentlichung des institutionellen Katalogs
+      der für zukünftige und aktuelle Lernende verfügbaren Programme und Kurse.
+    in_scope:
+      - Katalogerstellung und redaktioneller Workflow
+      - Katalogversionierung und Gültigkeitsdatierung
+      - Interne und öffentliche Katalogveröffentlichung
+    out_of_scope:
+      - Rekrutierungsmarketingmaterialien (abgedeckt unter Studierendengewinnung & Zulassungsmanagement)
+  BC-4700.40.10:
+    name: Katalogerstellung
+    description: |
+      Erstellung von Katalogeinträgen für Programme, Kurse und Module.
+  BC-4700.40.20:
+    name: Katalogversionierung und Gültigkeitsdatierung
+    description: |
+      Versionskontrolle und Verwaltung des Gültigkeitsdatums für Katalogeinträge.
+  BC-4700.40.30:
+    name: Katalogveröffentlichung
+    description: |
+      Interne und öffentliche Veröffentlichung des Programm- und Kurskatalogs.
+  BC-4700.50:
+    name: Programmgenehmigung und -steuerung
+    description: |
+      Interne und externe Genehmigungswege für neue, geänderte und eingestellte
+      Programme, einschließlich Aussetzungs- und Schließungsentscheidungen.
+    in_scope:
+      - Interne akademische Genehmigung und Steuerung
+      - Externe Regulierungs- und Berufsverbandsgenehmigung
+      - Programmaussetzung und geordnete Schließung
+    out_of_scope:
+      - Laufende Lehrplanüberprüfung (abgedeckt unter Lehrplanüberprüfung & kontinuierliche Verbesserung)
+      - Zyklische Akkreditierung (abgedeckt unter Akademische Qualität & Akkreditierungsmanagement)
+  BC-4700.50.10:
+    name: Interne Programmgenehmigung
+    description: |
+      Interne akademische Genehmigung neuer und geänderter Programme.
+  BC-4700.50.20:
+    name: Externe Programmgenehmigung
+    description: |
+      Programmgenehmigung durch externe Regulierungsbehörden, Ministerien oder
+      Berufsverbände.
+  BC-4700.50.30:
+    name: Programmaussetzung und -schließung
+    description: |
+      Geordnete Aussetzung, Weiterbetrieb und Schließung von Programmen.
+  BC-4700.60:
+    name: Lehrplanüberprüfung und kontinuierliche Verbesserung
+    description: |
+      Periodische Überprüfung und Verbesserung von Lehrplaninhalten auf Basis
+      von Ergebnissen, Stakeholder-Beiträgen und externen Anforderungen.
+    in_scope:
+      - Periodische Lehrplanüberprüfungszyklen
+      - Beiträge von Stakeholdern, Arbeitgebern und Studierenden
+      - Verfolgung der Umsetzung von Lehrplanänderungen
+    out_of_scope:
+      - Qualitätssicherungsüberprüfungen von Programmen (abgedeckt unter Akademische Qualität & Akkreditierungsmanagement)
+  BC-4700.60.10:
+    name: Periodische Lehrplanüberprüfung
+    description: |
+      Zyklische Überprüfung der Lehrplanwirksamkeit und -relevanz.
+  BC-4700.60.20:
+    name: Stakeholder-Beiträge zum Lehrplan
+    description: |
+      Erfassung von Beiträgen der Studierenden, Arbeitgeber und Beiräte zur
+      Lehrplangestaltung.
+  BC-4700.60.30:
+    name: Umsetzung von Lehrplanänderungen
+    description: |
+      Verfolgung und Umsetzung genehmigter Lehrplanänderungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-customer-relationship-management.yaml
+++ b/catalogue/i18n/de/L1-customer-relationship-management.yaml
@@ -1,0 +1,90 @@
+locale: de
+source: L1-customer-relationship-management.yaml
+entries:
+  BC-420:
+    name: Kundenbeziehungsmanagement
+    description: |
+      Kundendaten, Segmentierung, Lebenszyklus und Kundenbindung.
+  BC-420.10:
+    name: Kundendatenmanagement
+    description: |
+      Kundenstamm, Identitätsauflösung und Golden Record.
+  BC-420.10.10:
+    name: Kundenstammdatenmanagement
+    description: |
+      Erstellung, Pflege und Steuerung von Kundenstammdatensätzen.
+  BC-420.10.20:
+    name: Kundenidentitätsauflösung
+    description: |
+      Abgleich, Zusammenführung und Deduplizierung von Kundendatensätzen.
+  BC-420.10.30:
+    name: Einwilligungs- und Präferenzmanagement
+    description: |
+      Erfassung und Durchsetzung von Marketingeinwilligungen und -präferenzen.
+  BC-420.10.40:
+    name: Kunden-360-Grad-Sicht
+    description: |
+      Aggregierte Kundensicht über Produkte, Kanäle und Interaktionen.
+  BC-420.20:
+    name: Kundensegmentierungsmanagement
+    description: |
+      Segmente, Personas und Behandlungsstrategien.
+  BC-420.20.10:
+    name: Verhaltenssegmentierung
+    description: |
+      Segmentierung nach Verhalten, RFM und Engagement-Signalen.
+  BC-420.20.20:
+    name: Wertebasierte Segmentierung
+    description: |
+      Segmentierung nach Kunden-Lifetime-Value und Rentabilität.
+  BC-420.20.30:
+    name: Kundenpersona-Entwicklung
+    description: |
+      Definition von Personas und Zielkunden-Archetypen.
+  BC-420.20.40:
+    name: Behandlungsstrategiedefinition
+    description: |
+      Differenzierte Behandlungsstrategien je Segment.
+  BC-420.30:
+    name: Kundenlebenszyklusmanagement
+    description: |
+      Akquisition, Wachstum, Bindung und Rückgewinnung.
+  BC-420.30.10:
+    name: Kundenakquisitionsmanagement
+    description: |
+      Akquisitionskampagnen, Konvertierung und Onboarding-Orchestrierung.
+  BC-420.30.20:
+    name: Kundenwachstum und Cross-Sell
+    description: |
+      Cross-Sell-, Up-Sell- und Kundenausbau-Programme.
+  BC-420.30.30:
+    name: Kundenbindungsmanagement
+    description: |
+      Abwanderungsvorhersage, Bindungsangebote und Kundenschutzteams.
+  BC-420.30.40:
+    name: Kundenrückgewinnungsmanagement
+    description: |
+      Rückgewinnungskampagnen und Reaktivierung inaktiver Kunden.
+  BC-420.40:
+    name: Loyalitäts- und Bindungsmanagement
+    description: |
+      Treueprogramme und Bindungsinitiativen.
+  BC-420.40.10:
+    name: Treueprogrammdesign
+    description: |
+      Gestaltung von Treueprogrammstrukturen, Stufen und Vorteilen.
+  BC-420.40.20:
+    name: Treueprogrammbetrieb
+    description: |
+      Verdienen, Einlösen und Mitgliederbetreuung für Treueprogramme.
+  BC-420.40.30:
+    name: Treueprogrammverbindlichkeitsmanagement
+    description: |
+      Bilanzierung und Verwaltung von Treueprogrammverbindlichkeiten und Verfallsquoten.
+  BC-420.40.40:
+    name: Treuepartner-Ökosystem-Management
+    description: |
+      Partnerintegration, Einlösung und Koalitionsarrangements.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-customer-service-management.yaml
+++ b/catalogue/i18n/de/L1-customer-service-management.yaml
@@ -1,0 +1,110 @@
+locale: de
+source: L1-customer-service-management.yaml
+entries:
+  BC-430:
+    name: Kundenservicemanagement
+    description: |
+      Anfragen, Beschwerden, Support und Callcenter-Betrieb.
+  BC-430.10:
+    name: Kundenanfragemanagement
+    description: |
+      Eingehende Kontakte, Weiterleitung und Lösung.
+  BC-430.10.10:
+    name: Anfrageaufnahme und -weiterleitung
+    description: |
+      Mehrkanalige Aufnahme, Klassifizierung und Weiterleitung von Anfragen.
+  BC-430.10.20:
+    name: Fallmanagement
+    description: |
+      Fallerstellung, Verantwortung und Lösungsverfolgung.
+  BC-430.10.30:
+    name: Serviceantragserfüllung
+    description: |
+      Erfüllung von Standard-Serviceanträgen und Kontoänderungen.
+  BC-430.10.40:
+    name: Eskalationsmanagement
+    description: |
+      Eskalationspfade, Schweregradungseinstufungsregeln und Verwaltung eskalierter Fälle.
+  BC-430.20:
+    name: Beschwerde- und Problemmanagement
+    description: |
+      Beschwerdeerfassung, Ursachenanalyse und Lösung.
+  BC-430.20.10:
+    name: Beschwerdeerfassung und -bestätigung
+    description: |
+      Erfassung, Bestätigung und Triage von Kundenbeschwerden.
+  BC-430.20.20:
+    name: Beschwerdeuntersuchung und -lösung
+    description: |
+      Untersuchung, Wiedergutmachung und Lösung von Beschwerden.
+  BC-430.20.30:
+    name: Ursachenanalyse
+    description: |
+      Ursachenanalyse und Trendidentifikation über Beschwerden.
+  BC-430.20.40:
+    name: Regulatorische Beschwerdeberichterstattung
+    description: |
+      Regulatorische Beschwerdeberichte und Ombudsmann-Fallbearbeitung.
+  BC-430.30:
+    name: Callcenter-Operationsmanagement
+    description: |
+      Callcenter-Betrieb, Personalplanung und Telefonie.
+  BC-430.30.10:
+    name: Callcenter-Personalmanagement
+    description: |
+      Prognose, Planung und Einhaltung im Callcenter-Betrieb.
+  BC-430.30.20:
+    name: Kontaktweiterleitung und IVR
+    description: |
+      IVR-Design, kompetenzbasierte Weiterleitung und Kanalorchestrierung.
+  BC-430.30.30:
+    name: Qualitätsmonitoring und Coaching
+    description: |
+      Gesprächsqualitätsmonitoring, Bewertung und Agentencoaching.
+  BC-430.30.40:
+    name: Callcenter-Performance-Berichterstattung
+    description: |
+      Servicelevel-, AHT-, FCR- und Betriebsleistungsberichterstattung.
+  BC-430.40:
+    name: Self-Service-Management
+    description: |
+      FAQ, Wissensdatenbank, Chatbots und Self-Service-Portale.
+  BC-430.40.10:
+    name: Wissensdatenbankverwaltung
+    description: |
+      Erstellung und Pflege kundenseitiger Wissensinhalte.
+  BC-430.40.20:
+    name: Self-Service-Portalverwaltung
+    description: |
+      Kunden-Self-Service-Portale und Kontoverwaltungsfunktionen.
+  BC-430.40.30:
+    name: Konversations-KI-Management
+    description: |
+      Design, Training und Betrieb von Chatbots und Sprachbots.
+  BC-430.40.40:
+    name: Community-Support-Management
+    description: |
+      Moderation von Nutzercommunities und Peer-to-Peer-Support.
+  BC-430.50:
+    name: Kundenfeedbackmanagement
+    description: |
+      Umfragen, NPS und Voice-of-Customer-Programme.
+  BC-430.50.10:
+    name: Voice-of-the-Customer-Programm
+    description: |
+      Strukturiertes Voice-of-Customer-Programm über alle Berührungspunkte.
+  BC-430.50.20:
+    name: Kundenbefragungsmanagement
+    description: |
+      Design, Verteilung und Analyse von NPS-, CSAT- und CES-Umfragen.
+  BC-430.50.30:
+    name: Closed-Loop-Feedback
+    description: |
+      Closed-Loop-Nachverfolgung bei negativem Feedback und Wiederherstellungsmaßnahmen.
+  BC-430.50.40:
+    name: Kundenerkenntnis-Berichterstattung
+    description: |
+      Berichterstattung von Kundenerkenntnissen an Produkt, Betrieb und Führung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-customer-success-management.yaml
+++ b/catalogue/i18n/de/L1-customer-success-management.yaml
@@ -1,0 +1,153 @@
+locale: de
+source: L1-customer-success-management.yaml
+entries:
+  BC-4260:
+    name: Customer Success Management
+    description: |
+      Kunden-Onboarding, Adoption, Gesundheitsmonitoring, Retention,
+      Expansionsbefürwortung und Referenzkundenpflege – abgegrenzt
+      vom reaktiven Kundendienst.
+  BC-4260.10:
+    name: Kunden-Onboarding und -Aktivierung
+    description: |
+      Strukturiertes Onboarding neuer Kunden bis zum Erstmehrwert und
+      zu Aktivierungsmeilensteinen.
+    in_scope:
+      - Onboarding-Pläne, Kick-off und Time-to-Value-Tracking
+    out_of_scope:
+      - Technische Mandantenbereitstellung (abgedeckt durch SaaS-Mandanten-Management)
+      - Abonnementbereitstellung (abgedeckt durch Abonnement-Lebenszyklus-Management)
+  BC-4260.10.10:
+    name: Onboarding-Plan-Definition
+    description: |
+      Definition von Onboarding-Plänen, abgestimmt auf Segment
+      und Anwendungsfall.
+  BC-4260.10.20:
+    name: Aktivierungsmeilenstein-Tracking
+    description: |
+      Verfolgung von Aktivierungsmeilensteinen gegen Time-to-Value-Ziele.
+  BC-4260.10.30:
+    name: Implementierungskoordination
+    description: |
+      Koordination kundenseitiger Implementierungsaktivitäten und
+      Partnereinbindung.
+  BC-4260.20:
+    name: Adoptions-Management
+    description: |
+      Programme zur Steigerung der Funktionsadoption und Nutzungsbreite
+      in der Kundenbasis.
+  BC-4260.20.10:
+    name: Adoptionsprogramm-Design
+    description: |
+      Design strukturierter Adoptionsprogramme für Segmente,
+      Produkte und Personas.
+  BC-4260.20.20:
+    name: Adoptionskampagnen-Ausführung
+    description: |
+      Ausführung von Adoptionskampagnen mit In-Produkt- und
+      ausgehenden Kontaktpunkten.
+  BC-4260.20.30:
+    name: Power-User-Befähigung
+    description: |
+      Befähigung kundenseitiger Power-User und interner Befürworter.
+  BC-4260.30:
+    name: Kunden-Gesundheits-Management
+    description: |
+      Modellierung und Monitoring der Kundengesundheit zur
+      Antizipation von Risiken und Steuerung von Interventionen.
+  BC-4260.30.10:
+    name: Kunden-Gesundheitsscore-Modellierung
+    description: |
+      Modellierung von Kunden-Gesundheitsscores aus Produkt-,
+      Support- und kommerziellen Signalen.
+  BC-4260.30.20:
+    name: Risikosignal-Monitoring
+    description: |
+      Monitoring von Risikosignalen über die Kundenbasis hinweg.
+  BC-4260.30.30:
+    name: Risikokunden-Intervention
+    description: |
+      Koordinierte Intervention bei als risikobehaftet identifizierten
+      Konten.
+  BC-4260.40:
+    name: Kunden-Lebenszyklus-Engagement
+    description: |
+      Wiederkehrende Lebenszyklus-Kontaktpunkte einschließlich
+      Business-Reviews, Executive-Sponsoring und gemeinsamer
+      Erfolgsplanung.
+  BC-4260.40.10:
+    name: Quartalsweise Business-Review-Management
+    description: |
+      Planung und Durchführung wiederkehrender Business-Reviews
+      mit Kunden.
+  BC-4260.40.20:
+    name: Executive-Sponsor-Programm
+    description: |
+      Betrieb von Executive-Sponsor-Paarungen zwischen Anbieter
+      und Kunde.
+  BC-4260.40.30:
+    name: Erfolgsplan-Pflege
+    description: |
+      Pflege gemeinsamer Erfolgspläne, die Kundenziele und
+      Meilensteine erfassen.
+  BC-4260.50:
+    name: Retention- und Verlängerungsbefürwortung
+    description: |
+      Befürwortung und Intervention im Verlängerungsprozess einschließlich
+      Rückgewinnungsmaßnahmen und Verlängerungsprognosebeitrag.
+  BC-4260.50.10:
+    name: Verlängerungsrisiko-Minderung
+    description: |
+      Minderung identifizierter Verlängerungsrisiken vor dem
+      Verlängerungsdatum.
+  BC-4260.50.20:
+    name: Rückgewinnungsmaßnahmen-Ausführung
+    description: |
+      Ausführung von Rückgewinnungsmaßnahmen bei Konten mit
+      Kündigungsabsicht.
+  BC-4260.50.30:
+    name: Verlängerungsprognose-Einreichung
+    description: |
+      Einreichung von Verlängerungsprognosen auf Basis von
+      Gesundheits- und Engagement-Signalen.
+  BC-4260.60:
+    name: Expansions- und Cross-Sell-Befürwortung
+    description: |
+      Identifikation und Qualifikation von Expansionschancen und
+      Koordination mit dem Vertrieb für Cross-Selling.
+  BC-4260.60.10:
+    name: Expansionschancen-Identifikation
+    description: |
+      Identifikation von Expansionschancen aus Nutzungs- und
+      Engagement-Signalen.
+  BC-4260.60.20:
+    name: Upsell-Qualifikation
+    description: |
+      Qualifikation von Upsell-Chancen vor der Vertriebseinbindung.
+  BC-4260.60.30:
+    name: Cross-Sell-Koordination
+    description: |
+      Koordination mit dem Vertrieb bei Cross-Sell-Aktivitäten über
+      die Kundenbasis hinweg.
+  BC-4260.70:
+    name: Kundenfürsprache und Referenz-Management
+    description: |
+      Pflege von Referenzen, Fallstudien und strukturierte Messung
+      der Kundenstimmung.
+  BC-4260.70.10:
+    name: Referenzprogramm-Management
+    description: |
+      Management des Kundenreferenzprogramms einschließlich
+      Opt-in, Governance und Nutzung.
+  BC-4260.70.20:
+    name: Fallstudien-Entwicklung
+    description: |
+      Entwicklung von Kundenfallstudien in Zusammenarbeit mit
+      dem Marketing.
+  BC-4260.70.30:
+    name: Net-Promoter-Umfrageprogramm
+    description: |
+      Betrieb von NPS- und gleichwertigen Kunden-Stimmungsumfrageprogrammen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-customs-trade-compliance-management.yaml
+++ b/catalogue/i18n/de/L1-customs-trade-compliance-management.yaml
@@ -1,0 +1,113 @@
+locale: de
+source: L1-customs-trade-compliance-management.yaml
+entries:
+  BC-2480:
+    name: Zoll- und Handelskonformität
+    description: |
+      Einhaltung von Zoll-, Sanktions-, Ursprungs- und Trusted-Trader-Regelungen bei
+      grenzüberschreitenden Bewegungen einschließlich Zoll- und indirekter Steuerermittlung.
+  BC-2480.10:
+    name: Zolltarifklassifizierungs-Management
+    description: |
+      Ermittlung und Pflege von HS-Klassifikationen für gehandelte Waren.
+    in_scope:
+      - HS-Code-Ermittlung je Artikel und Sendung
+      - Verbindliche Zolltarifauskunft
+    out_of_scope:
+      - Sanktionen und Parteiüberprüfung (BC-2480.40)
+  BC-2480.10.10:
+    name: HS-Code-Ermittlung
+    description: |
+      Ermittlung von HS-Codes je Artikel und Sendung.
+  BC-2480.10.20:
+    name: Klassifizierungsentscheidungs-Management
+    description: |
+      Beantragung und Verwaltung verbindlicher Zolltarifauskünfte.
+  BC-2480.10.30:
+    name: Klassifizierungsdatenbank-Pflege
+    description: |
+      Pflege von Master-Klassifizierungsdatenbanken für gehandelte Artikel.
+  BC-2480.20:
+    name: Zollanmeldungs-Management
+    description: |
+      Einreichung von Einfuhr-, Ausfuhr- und Durchfuhranmeldungen bei Zollbehörden.
+  BC-2480.20.10:
+    name: Einfuhranmeldungs-Einreichung
+    description: |
+      Vorbereitung und Einreichung von Einfuhranmeldungen.
+  BC-2480.20.20:
+    name: Ausfuhranmeldungs-Einreichung
+    description: |
+      Vorbereitung und Einreichung von Ausfuhranmeldungen.
+  BC-2480.20.30:
+    name: Durchfuhranmeldungs-Management
+    description: |
+      Einreichung und Erledigung von Durchfuhranmeldungen einschließlich TIR und NCTS.
+  BC-2480.30:
+    name: Ursprungs- und Freihandelsabkommens-Management
+    description: |
+      Ermittlung und Zertifizierung des präferenziellen Ursprungs im Rahmen von Freihandelsabkommen.
+  BC-2480.30.10:
+    name: Ursprungsermittlung
+    description: |
+      Ermittlung des präferenziellen und nichtpräferenziellen Ursprungs.
+  BC-2480.30.20:
+    name: FTA-Qualifikationsdokumentation
+    description: |
+      Ausstellung und Verwaltung von FTA-Ursprungszeugnissen.
+  BC-2480.30.30:
+    name: Ursprungs-Prüfpfad
+    description: |
+      Pflege von Nachweisen für Ursprungsaudits.
+  BC-2480.40:
+    name: Sanktionen- und Denied-Party-Screening-Management
+    description: |
+      Überprüfung von Parteien, Schiffen und Waren gegen Sanktions- und Denied-Party-Listen.
+  BC-2480.40.10:
+    name: Partei- und Schiffsüberprüfung
+    description: |
+      Überprüfung von Kunden, Empfängern und Transportmitteln gegen Sanktionslisten.
+  BC-2480.40.20:
+    name: Sanktionslisten-Management
+    description: |
+      Pflege konsolidierter Sanktions- und Denied-Party-Listen.
+  BC-2480.40.30:
+    name: Sperrung und Freigabe-Verarbeitung
+    description: |
+      Verarbeitung von Screening-Treffern, Sperren und autorisierten Freigaben.
+  BC-2480.50:
+    name: Trusted-Trader-Programm-Management
+    description: |
+      Beantragung, Pflege und Audit von Trusted-Trader-Programmen wie AEO und C-TPAT.
+  BC-2480.50.10:
+    name: AEO-Antragstellung und Pflege
+    description: |
+      AEO-Antragstellung und laufende Programmplege.
+  BC-2480.50.20:
+    name: C-TPAT-Programm-Management
+    description: |
+      C-TPAT-Einschreibung und Einhaltung der Mindestsicherheitskriterien.
+  BC-2480.50.30:
+    name: Zollprüfungs-Koordination
+    description: |
+      Koordination von Zoll- und Trusted-Trader-Prüfungen.
+  BC-2480.60:
+    name: Zoll- und indirektes Steuer-Management
+    description: |
+      Ermittlung, Zahlung und Rückerstattung von Zöllen, indirekten Steuern und
+      Erstattungen bei grenzüberschreitenden Bewegungen.
+  BC-2480.60.10:
+    name: Zollberechnung
+    description: |
+      Berechnung der auf Einfuhren und Ausfuhren anfallenden Zölle.
+  BC-2480.60.20:
+    name: Indirekte Steuerermittlung
+    description: |
+      Ermittlung von Mehrwertsteuer, GST und Verbrauchsteuer bei grenzüberschreitenden Flüssen.
+  BC-2480.60.30:
+    name: Zollrückerstattung und Rückforderung
+    description: |
+      Rückforderung von Zöllen durch Drawback-, Aussetzungs- und Erstattungsregelungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-cyber-operations-management.yaml
+++ b/catalogue/i18n/de/L1-cyber-operations-management.yaml
@@ -1,0 +1,94 @@
+locale: de
+source: L1-cyber-operations-management.yaml
+entries:
+  BC-1740:
+    name: Cyber-Operationen-Management
+    description: |
+      Defensive und offensive Cyber-Operationen sowie Cyber-Nachrichtengewinnung.
+  BC-1740.10:
+    name: Defensive-Cyber-Operationen-Management
+    description: |
+      Netzwerkverteidigung, Bedrohungssuche und Incident-Response.
+  BC-1740.10.10:
+    name: Netzwerkverteidigungs-Betrieb
+    description: |
+      Betrieb defensiver Cyber-Sensoren und -Werkzeuge.
+  BC-1740.10.20:
+    name: Cyber-Bedrohungssuche
+    description: |
+      Bedrohungssuche in militärischen Netzwerken.
+  BC-1740.10.30:
+    name: Cyber-Incident-Response
+    description: |
+      Vorfallserkennung, -reaktion und -wiederherstellung in Missionsnetzwerken.
+  BC-1740.10.40:
+    name: Defensive-Cyber-Manöver
+    description: |
+      Defensive Cyber-Manöver und aktive Verteidigung.
+  BC-1740.20:
+    name: Offensive-Cyber-Operationen-Management
+    description: |
+      Offensive Cyber-Fähigkeiten und Cyber-Wirkungsabgabe.
+  BC-1740.20.10:
+    name: Cyber-Fähigkeiten-Entwicklung
+    description: |
+      Autorisierte Entwicklung offensiver Cyber-Fähigkeiten.
+  BC-1740.20.20:
+    name: Cyber-Wirkungsabgabe
+    description: |
+      Autorisierte Abgabe von Cyber-Wirkungen gegen Gegner.
+  BC-1740.20.30:
+    name: Cyber-Operationen-Autorisierung
+    description: |
+      Autorisierungsrahmen für offensive Cyber-Operationen.
+  BC-1740.30:
+    name: Cyber-Nachrichtengewinnung-Management
+    description: |
+      Cyber-Bedrohungsnachrichtengewinnung und Gegnerverfolgung.
+  BC-1740.30.10:
+    name: Cyber-Bedrohungsnachrichten-Erstellung
+    description: |
+      Erstellung von Cyber-Bedrohungsnachrichten-Beurteilungen.
+  BC-1740.30.20:
+    name: Gegner-Verfolgung
+    description: |
+      Verfolgung gegnerischer Methoden und Infrastruktur.
+  BC-1740.30.30:
+    name: Cyber-Indikatoren-Management
+    description: |
+      Management von Cyber-Kompromittierungsindikatoren.
+  BC-1740.40:
+    name: Cyber-Wirkungen-Management
+    description: |
+      Zielauswahl, Wirkungskoordination und Entflechtung.
+  BC-1740.40.10:
+    name: Cyber-Zielauswahl
+    description: |
+      Cyber-spezifische Zielauswahl und Zielentwicklung.
+  BC-1740.40.20:
+    name: Cyber-Wirkungskoordination
+    description: |
+      Koordination von Cyber-Wirkungen mit kinetischen Operationen.
+  BC-1740.40.30:
+    name: Cyber-Entflechtung
+    description: |
+      Entflechtung von Cyber-Operationen über Verbände hinweg.
+  BC-1740.50:
+    name: Cyber-Einsatzsicherungs-Management
+    description: |
+      Cyber-Resilienz von Missionssystemen und Sicherung.
+  BC-1740.50.10:
+    name: Missionssystem-Cyber-Risikobewertung
+    description: |
+      Cyber-Risikobewertung von Missionssystemen.
+  BC-1740.50.20:
+    name: Missions-Resilienz-Technik
+    description: |
+      Cyber-Resilienz-Technik für Missionssysteme.
+  BC-1740.50.30:
+    name: Cyber-Einsatzsicherungs-Berichterstattung
+    description: |
+      Berichterstattung über die Cyber-Einsatzsicherungslage.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-cybersecurity-management.yaml
+++ b/catalogue/i18n/de/L1-cybersecurity-management.yaml
@@ -1,0 +1,146 @@
+locale: de
+source: L1-cybersecurity-management.yaml
+entries:
+  BC-620:
+    name: Cybersicherheitsmanagement
+    description: |
+      Sicherheitsstrategie, Kontrollen, Identität und Bedrohungsreaktion.
+  BC-620.10:
+    name: Sicherheitsstrategie- und Governance-Management
+    description: |
+      Sicherheitsstrategie, Richtlinien, Rahmenwerke und GRC.
+  BC-620.10.10:
+    name: Sicherheitsstrategieentwicklung
+    description: |
+      Mehrjährige Cybersicherheitsstrategie im Einklang mit dem Unternehmensrisiko.
+  BC-620.10.20:
+    name: Sicherheitsrichtlinien und -standards
+    description: |
+      Sicherheitsrichtlinien und -standards gemäß NIST CSF und ISO 27001.
+  BC-620.10.30:
+    name: Sicherheitsrisikomanagement
+    description: |
+      Cyberrisiko-Identifikation, -Bewertung und -Behandlung.
+  BC-620.10.40:
+    name: Sicherheits-Compliance-Management
+    description: |
+      Einhaltung von Cyber-Vorschriften (DORA, NIS2, branchenspezifisch).
+  BC-620.10.50:
+    name: Sicherheitskennzahlen und -berichterstattung
+    description: |
+      Sicherheits-KPIs, Dashboards und Vorstandsberichterstattung.
+  BC-620.20:
+    name: Identitäts- und Zugriffsmanagement
+    description: |
+      IAM, PAM, Föderierung und Joiners-Movers-Leavers.
+  BC-620.20.10:
+    name: Identitätslebenszyklusmanagement
+    description: |
+      Eintritts-, Versetzungs- und Austrittsprozesse sowie Identitätsbereitstellung.
+  BC-620.20.20:
+    name: Zugriffsmanagement und Authentifizierung
+    description: |
+      Authentifizierung, MFA, Single Sign-On und Föderierung.
+  BC-620.20.30:
+    name: Privilegiertes Zugriffsmanagement
+    description: |
+      PAM, Just-in-Time-Zugriff und Monitoring privilegierter Sitzungen.
+  BC-620.20.40:
+    name: Zugriffssteuerung und -rezertifizierung
+    description: |
+      Zugriffsüberprüfungen, Funktionstrennung und Rezertifizierung.
+  BC-620.20.50:
+    name: Kunden-Identitätsmanagement
+    description: |
+      CIAM für externe Kunden, Partner und Verbraucher.
+  BC-620.30:
+    name: Bedrohungserkennung und -reaktionsmanagement
+    description: |
+      SOC, SIEM und Incident Response.
+  BC-620.30.10:
+    name: Sicherheitsmonitoring und SIEM-Betrieb
+    description: |
+      SIEM, SOAR und Sicherheitstelemetrie-Monitoring.
+  BC-620.30.20:
+    name: Bedrohungsjagd
+    description: |
+      Proaktive hypothesengesteuerte Bedrohungsjagd.
+  BC-620.30.30:
+    name: Cyber-Bedrohungsintelligenz
+    description: |
+      Erfassung, Analyse und Weitergabe von Cyber-Bedrohungsintelligenz.
+  BC-620.30.40:
+    name: Cyber-Incident-Reaktion
+    description: |
+      Erkennung, Eindämmung, Beseitigung und Wiederherstellung bei Cyber-Incidents.
+  BC-620.30.50:
+    name: Digitale Forensik
+    description: |
+      Forensische Erfassung und Analyse zur Unterstützung von Incidents und Rechtsstreitigkeiten.
+  BC-620.40:
+    name: Schwachstellenmanagement
+    description: |
+      Schwachstellen-Scanning, Patching und Behebung.
+  BC-620.40.10:
+    name: Schwachstellen-Scanning
+    description: |
+      Authentifiziertes und nicht-authentifiziertes Scanning über den IT-Bestand.
+  BC-620.40.20:
+    name: Schwachstellentriage und -priorisierung
+    description: |
+      Risikobasierte Priorisierung von Schwachstellen zur Behebung.
+  BC-620.40.30:
+    name: Patch- und Behebungsmanagement
+    description: |
+      Koordination von Patching und Behebung über Eigentümer.
+  BC-620.40.40:
+    name: Penetrationstests und Red Teaming
+    description: |
+      Penetrationstests, Red-Team-Übungen und Adversary-Simulation.
+  BC-620.50:
+    name: Sicherheitsarchitekturmanagement
+    description: |
+      Sicheres Design, Sicherheitsmuster und Zero Trust.
+  BC-620.50.10:
+    name: Sicherheitsarchitekturmuster
+    description: |
+      Referenz-Sicherheitsmuster und wiederverwendbare Kontrollen.
+  BC-620.50.20:
+    name: Zero-Trust-Architektur
+    description: |
+      Zero-Trust-Prinzipien, Mikrosegmentierung und Richtliniendurchsetzung.
+  BC-620.50.30:
+    name: Anwendungssicherheits-Engineering
+    description: |
+      Secure-by-Design-Praktiken, SAST, DAST und Bedrohungsmodellierung.
+  BC-620.50.40:
+    name: Cloud-Sicherheitsarchitektur
+    description: |
+      Cloud-Sicherheitsbaselines, CSPM und Cloud-native Kontrollgestaltung.
+  BC-620.50.50:
+    name: Kryptografie und Schlüsselmanagement
+    description: |
+      Kryptografische Standards, Schlüsselmanagement und PKI-Betrieb.
+  BC-620.60:
+    name: Sicherheitsbewusstseinsmanagement
+    description: |
+      Bewusstseinstraining, Phishing-Simulationen und Kultur.
+  BC-620.60.10:
+    name: Sicherheitsbewusstseinstraining
+    description: |
+      Jährliches und rollenbasiertes Sicherheitsbewusstseinstraining.
+  BC-620.60.20:
+    name: Phishing-Simulation
+    description: |
+      Phishing-Simulationen und Folgecoaching.
+  BC-620.60.30:
+    name: Sicherheitskulturprogramm
+    description: |
+      Kulturwandelprogramme und Sicherheits-Champions-Netzwerke.
+  BC-620.60.40:
+    name: Sicherheitskommunikation
+    description: |
+      Sicherheitswarnungen, -hinweise und Stakeholder-Kommunikation.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-dangerous-goods-management.yaml
+++ b/catalogue/i18n/de/L1-dangerous-goods-management.yaml
@@ -1,0 +1,98 @@
+locale: de
+source: L1-dangerous-goods-management.yaml
+entries:
+  BC-2490:
+    name: Gefahrgut-Management
+    description: |
+      Annahme, Dokumentation, Handhabung, Schulung und Notfallreaktion bei
+      Gefahrguttransporten über Straße, Schiene, See und Luft gemäß IMDG, IATA DGR,
+      ADR und RID.
+  BC-2490.10:
+    name: Gefahrgut-Annahme-Management
+    description: |
+      Vorannahme-Prüfung von Gefahrgutsendungen gegen modale Vorschriften und Annahmeentscheidung.
+    in_scope:
+      - Prüfung der Absenderdeklaration
+      - Verträglichkeits-, Trennungs- und Mengenprüfungen
+    out_of_scope:
+      - Zollrechtliche Beschränkungen für Gefahrstoffe (BC-2480)
+      - Frachtansprüche für beschädigtes Gefahrgut (BC-2530.40)
+  BC-2490.10.10:
+    name: Absenderdeklarations-Prüfung
+    description: |
+      Prüfung der Gefahrstoffdeklarationen des Absenders und der Begleitdokumentation.
+  BC-2490.10.20:
+    name: Verträglichkeits- und Trennungsprüfung
+    description: |
+      Verträglichkeits-, Trennungs- und Mengenprüfungen gemäß modalen Vorschriften.
+  BC-2490.10.30:
+    name: Annahmeentscheidung und Bestätigung
+    description: |
+      Annahmeentscheidung, Bestätigung oder Ablehnung von Gefahrgutsendungen.
+  BC-2490.20:
+    name: Gefahrgut-Dokumentations-Management
+    description: |
+      Ausstellung und Pflege von Gefahrstoffdeklarationen, NOTOC und multimodaler Gefahrgutdokumentation.
+  BC-2490.20.10:
+    name: Gefahrstoffdeklarations-Ausstellung
+    description: |
+      Ausstellung von Gefahrstoffdeklarationen gemäß IMDG, DGR, ADR und RID.
+  BC-2490.20.20:
+    name: NOTOC und Manifest-Vorbereitung
+    description: |
+      Vorbereitung von Kapitänsbenachrichtigung und Gefahrgut-Manifest.
+  BC-2490.20.30:
+    name: Multimodale Dokumentenabstimmung
+    description: |
+      Abstimmung von Gefahrgutdokumenten bei modalen Übergaben.
+  BC-2490.30:
+    name: Gefahrgut-Handhabung und Stauung
+    description: |
+      Einhaltung der physischen Handhabung und Stauung gemäß Gefahrgutanforderungen.
+  BC-2490.30.10:
+    name: Trennungs- und Stauungs-Compliance
+    description: |
+      Bordeigene, Deckseite und Lager-Trennungs- und Stauungs-Compliance.
+  BC-2490.30.20:
+    name: Sperrbereiche-Lagerung
+    description: |
+      Lagerung von Gefahrgut in gesperrten, belüfteten und umwallten Bereichen.
+  BC-2490.30.30:
+    name: Spezialausrüstung-Einsatz
+    description: |
+      Einsatz von spezieller Gefahrgut-Handhabungsausrüstung und persönlicher Schutzausrüstung.
+  BC-2490.40:
+    name: Gefahrgut-Schulung und Kompetenzmanagement
+    description: |
+      Erst- und Folgeschulungen, Kompetenzbewertung und Nachweise für Gefahrgut-Handling-Personal.
+  BC-2490.40.10:
+    name: Gefahrgut-Erstschulung
+    description: |
+      Erstschulung im Gefahrgutbereich gemäß modalem Aufgabenträger.
+  BC-2490.40.20:
+    name: Gefahrgut-Folgeschulung
+    description: |
+      Wiederkehrende und Auffrischungsschulungen im Gefahrgutbereich.
+  BC-2490.40.30:
+    name: Kompetenznachweis-Management
+    description: |
+      Pflege von Gefahrgut-Kompetenznachweisen und Audit-Belegen.
+  BC-2490.50:
+    name: Gefahrgut-Vorfallmanagement
+    description: |
+      Erkennung, Reaktion, Benachrichtigung und Berichterstattung bei Gefahrgut-Vorfällen und Verschüttungen.
+  BC-2490.50.10:
+    name: Gefahrgut-Vorfallerkennung
+    description: |
+      Erkennung von Gefahrgut-Vorfällen bei Handhabung und Transport.
+  BC-2490.50.20:
+    name: Gefahrgut-Verschüttungs- und Freisetzungsreaktion
+    description: |
+      Leckeingrenzung, Freisetzungsreaktion und Dekontamination.
+  BC-2490.50.30:
+    name: Behördenbenachrichtigung und -berichterstattung
+    description: |
+      Benachrichtigung und Berichterstattung von Gefahrgut-Vorfällen an zuständige Behörden.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-dealer-network-management.yaml
+++ b/catalogue/i18n/de/L1-dealer-network-management.yaml
@@ -1,0 +1,164 @@
+locale: de
+source: L1-dealer-network-management.yaml
+entries:
+  BC-3430:
+    name: Händlernetzwerk-Management
+    description: |
+      Governance des Franchise- oder autorisierten Händlernetzwerks –
+      Ernennung, Vereinbarungen, Marken- und Einrichtungsstandards,
+      Leistung, Schulung und Netzwerkentwicklung nach EU-GVO und
+      gleichwertigen Handelsregeln.
+  BC-3430.10:
+    name: Händlernetzwerk-Strategie und -Planung
+    description: |
+      Strategische Planung von Händler-Footprint, Format, Abdeckung
+      und Markenstandards in allen Märkten.
+  BC-3430.10.10:
+    name: Markt- und Netzwerkabdeckungsplanung
+    description: |
+      Analyse von Marktabdeckungslücken und Definition des Ziel-
+      Händler-Footprints nach Region.
+  BC-3430.10.20:
+    name: Händler-Footprint-Optimierung
+    description: |
+      Optimierung des bestehenden Händler-Footprints einschließlich
+      Konsolidierung, Verlagerung und Kapazitätserweiterung.
+  BC-3430.10.30:
+    name: Netzwerkformat und Markenstandard-Definition
+    description: |
+      Definition von Händlerformaten, Handelskonzepten und
+      Marken-Erlebnis-Standards.
+  BC-3430.20:
+    name: Händler-Ernennung und Vertragsmanagement
+    description: |
+      Onboarding, Vertragsabschluss und Beendigung von Händlern
+      einschließlich Gebiets- und Markenrechtsmanagement.
+  BC-3430.20.10:
+    name: Händler-Bewerbung und -Prüfung
+    description: |
+      Entgegennahme und Prüfung von Händlerbewerbungen einschließlich
+      finanzieller, rechtlicher und betrieblicher Due Diligence.
+  BC-3430.20.20:
+    name: Händlervertrags-Ausarbeitung und -Abschluss
+    description: |
+      Ausarbeitung, Verhandlung und Abschluss von Händlerverträgen
+      im Einklang mit dem geltenden Wettbewerbsrecht.
+  BC-3430.20.30:
+    name: Gebiets- und Markenrechtsmanagement
+    description: |
+      Zuweisung und Management von Gebiets- und Markenrechten
+      einschließlich Verantwortungsbereichen.
+  BC-3430.20.40:
+    name: Händlervertrags-Beendigungsmanagement
+    description: |
+      Management von Händlervertragsbeendigungen, Auslaufplanung
+      und Neuzuweisung von Gebieten.
+  BC-3430.30:
+    name: Händlerstandards und Konformität
+    description: |
+      Pflege und Auditierung von Marken-, Einrichtungs- und
+      Betriebsstandards im gesamten Händlernetzwerk.
+  BC-3430.30.10:
+    name: Marken- und Einrichtungsstandards-Management
+    description: |
+      Pflege von Marken-, Einrichtungs- und Kundenerlebnis-Standards
+      für die Händlerkonformität.
+  BC-3430.30.20:
+    name: Händlerkonformitäts-Auditierung
+    description: |
+      Regelmäßige Auditierung von Händlern gegen Marken-, Verkaufs-
+      und Aftersales-Standards.
+  BC-3430.30.30:
+    name: Korrekturmaßnahmen-Management
+    description: |
+      Management von Korrekturmaßnahmen für nicht-konforme Händler
+      bis zur Behebung.
+  BC-3430.40:
+    name: Händlerleistungs-Management
+    description: |
+      Messung und Verbesserung der kaufmännischen und betrieblichen
+      Händlerleistung durch Scorecards und Anreizprogramme.
+  BC-3430.40.10:
+    name: Händler-Scorecard-Management
+    description: |
+      Definition und Betrieb von Händler-Scorecards in Verkauf,
+      Aftersales und Kundenerlebnis.
+  BC-3430.40.20:
+    name: Verkaufs- und Aftersales-Leistungsreviews
+    description: |
+      Regelmäßige Händlerleistungsreviews und gemeinsame
+      Geschäftsplanung mit Gebietsmanagern.
+  BC-3430.40.30:
+    name: Händleranreizprogramm-Management
+    description: |
+      Konzeption und Betrieb von Händlerbonus-, Marginal- und
+      Anreizprogrammen.
+  BC-3430.50:
+    name: Händlerfinanzierung und Lagerfinanzierung
+    description: |
+      Finanzierung von Händler-Großhandelsbeständen und Management
+      von Händlerforderungen sowie Betriebskapitalunterstützung.
+    in_scope:
+      - Verwaltung der Lagerfinanzierung (Floorplan)
+      - Händler-Kreditlimits und Risikoüberwachung
+      - OEM-gestützte Händler-Betriebskapitalunterstützung
+    out_of_scope:
+      - Captive-Autofinanzierung für Einzelhandelskredit (unter Unternehmenskredit und -vergabe abgedeckt)
+  BC-3430.50.10:
+    name: Lagerfinanzierungs-Verwaltung
+    description: |
+      Verwaltung der Lagerfinanzierung (Floorplan) für
+      Fahrzeugbestände der Händler.
+  BC-3430.50.20:
+    name: Händlerkredit- und Forderungsmanagement
+    description: |
+      Management von Händler-Kreditlimits, Forderungsalterung
+      und Inkasso.
+  BC-3430.50.30:
+    name: Händler-Betriebskapitalunterstützung
+    description: |
+      OEM-gestützte Betriebskapitalunterstützung, Teile-Finanzierung
+      und saisonale Hilfsprogramme.
+  BC-3430.60:
+    name: Händlerschulung und -Zertifizierung
+    description: |
+      Schulung und Zertifizierung von Händlerverkaufs-,
+      Aftersales- und Führungspersonal.
+  BC-3430.60.10:
+    name: Händlerverkaufs-Zertifizierung
+    description: |
+      Zertifizierung von Händlerverkaufsberatern in Produkt, Marke
+      und Kundenerlebnis-Standards.
+  BC-3430.60.20:
+    name: Händler-Servicetechniker-Zertifizierung
+    description: |
+      Zertifizierung von Händlerservicetechnikern in Diagnose-,
+      Reparatur- und EV/HV-Verfahren.
+  BC-3430.60.30:
+    name: Händlermanagement-Entwicklung
+    description: |
+      Führungs- und Managemententwicklungsprogramme für
+      Händlerinhaber und Bereichsleiter.
+  BC-3430.70:
+    name: Händlersystem- und Datenbetrieb
+    description: |
+      Betrieb händlerseitiger Systeme und Datenflüsse, die Händler
+      mit OEM-Handels-, Technik- und Berichtsplattformen verbinden.
+  BC-3430.70.10:
+    name: Händlermanagementsystem-Integration
+    description: |
+      Integration von Händlermanagementsystemen mit OEM-Bestell-,
+      Teile-, Garantie- und Berichts-Backbones.
+  BC-3430.70.20:
+    name: Händler-Stammdatenmanagement
+    description: |
+      Pflege von Händler-Stammdaten einschließlich Standorte,
+      Ansprechpartner und Autorisierungen.
+  BC-3430.70.30:
+    name: Händler-Berichterstattung und -Analyse
+    description: |
+      Händlerseitige Berichterstattung, Benchmarking und Analysen
+      in kaufmännischen und betrieblichen Dimensionen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-decommissioning-abandonment-management.yaml
+++ b/catalogue/i18n/de/L1-decommissioning-abandonment-management.yaml
@@ -1,0 +1,112 @@
+locale: de
+source: L1-decommissioning-abandonment-management.yaml
+entries:
+  BC-3120:
+    name: Stilllegung und Aufgabe (Anlage)
+    description: |
+      Spätphasen-Management von Petroleum-Anlagen - Bohrloch-Verfüllung und Aufgabe,
+      Anlagenstilllegung, Pipeline-Stilllegung, Standortwiederherstellung,
+      Stilllegungs-Haftungsrückstellungen und Nachverschluss-Monitoring.
+  BC-3120.10:
+    name: Bohrloch-Verfüllung und Aufgabe
+    description: |
+      Design und Ausführung permanenter Bohrloch-Verfüllungs- und Aufgabekampagnen.
+    in_scope:
+      - P&A-Design und Barriereüberprüfung
+      - Verfüllungs- und Aufgabeausführungsoperationen
+      - Bohrkopf- und Conductor-Abtrennung und -Bergung
+    out_of_scope:
+      - Förderbohrloch-Integritätsüberwachung (BC-3020.50)
+  BC-3120.10.10:
+    name: Verfüllungs- und Aufgabe-Design
+    description: |
+      Design permanenter Barrierekonfigurationen für die Bohrlochaufgabe.
+  BC-3120.10.20:
+    name: Verfüllungs- und Aufgabe-Ausführung
+    description: |
+      Ausführung von Zementierungs-, Pfropfenplatzierungs- und Barriereüberprüfungsoperationen.
+  BC-3120.10.30:
+    name: Bohrkopfabtrennung und -bergung
+    description: |
+      Abtrennung und Bergung von Bohrköpfen, Conductors und Verrohrungsstrings.
+  BC-3120.20:
+    name: Oberflächenanlage-Stilllegung
+    description: |
+      Stilllegung, Entfernung und Bergung von Upstream- und Midstream-
+      Oberflächen- und Unterwasseranlagen.
+  BC-3120.20.10:
+    name: Topsides-Entfernungsplanung
+    description: |
+      Engineering der Topsides-Entfernung und Rückinstallationsmethodik.
+  BC-3120.20.20:
+    name: Topsides-Entfernungsausführung
+    description: |
+      Ausführung von Einzelhub-, Modul- oder Stückkleiner-Topsides-Entfernung.
+  BC-3120.20.30:
+    name: Unterwasserausrüstungs-Bergung
+    description: |
+      Bergung von Unterwasser-Trees, Manifolds, Jumpers und Umbilicals.
+  BC-3120.30:
+    name: Pipeline-Stilllegung
+    description: |
+      Stilllegung, Entfernung oder In-situ-Lassen-Entscheidungen für redundante Pipelines.
+  BC-3120.30.10:
+    name: Pipeline-Spülung und Reinigung
+    description: |
+      Spülung, Reinigung und Inertisierung von Pipelines vor der Stilllegung.
+  BC-3120.30.20:
+    name: Pipeline-Stilllegungsentscheidung
+    description: |
+      Vergleichende Bewertung von Pipeline-Entfernung versus In-situ-Stilllegung.
+  BC-3120.30.30:
+    name: Pipeline-Stilllegungsausführung
+    description: |
+      Ausführung von Pipeline-Entfernung, Schnitt-und-Heben oder In-situ-Lassen-Operationen.
+  BC-3120.40:
+    name: Standortwiederherstellung und Sanierung
+    description: |
+      Onshore- und Unterwasser-Standortwiederherstellung, Boden- und Sedimentsanierung
+      sowie Meeresbodenfreigabe-Verifikation.
+  BC-3120.40.10:
+    name: Boden- und Sedimentsanierung
+    description: |
+      Sanierung kontaminierter Böden und Sedimente an stillgelegten Standorten.
+  BC-3120.40.20:
+    name: Vegetative Wiederherstellung
+    description: |
+      Renaturierung und Konturierung onshore stillgelegter Standorte.
+  BC-3120.40.30:
+    name: Unterwasser-Standortfreigabe
+    description: |
+      Meeresbodenfreigabe-Verifikation und Bergung abgestürzter Objekte.
+  BC-3120.50:
+    name: Stilllegungshaftungs-Management
+    description: |
+      Kostenschätzung, Rückstellungen und Sicherheitsleistung für Stilllegungsverpflichtungen.
+  BC-3120.50.10:
+    name: Aufgabekostenschätzung
+    description: |
+      Probabilistische Kostenschätzung für Stilllegung und Aufgabe.
+  BC-3120.50.20:
+    name: Stilllegungsrückstellungen
+    description: |
+      Pflege von Stilllegungsrückstellungen gemäß Rechnungslegungsstandards.
+  BC-3120.50.30:
+    name: Stilllegungs-Sicherheitsleistung
+    description: |
+      Stellung und Erneuerung von Stilllegungs-Sicherheitsleistungen gegenüber Gastregierungen.
+  BC-3120.60:
+    name: Nachverschluss-Monitoring
+    description: |
+      Langzeit-Umweltmonitoring und Restschulden-Tracking nach der Schließung.
+  BC-3120.60.10:
+    name: Langzeit-Umweltmonitoring
+    description: |
+      Langzeit-Monitoring von Grundwasser, Böden und mariner Umwelt.
+  BC-3120.60.20:
+    name: Restschuld-Tracking
+    description: |
+      Tracking von Restschulden und Freistellungen nach der Schließung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-defense-capture-bid-management.yaml
+++ b/catalogue/i18n/de/L1-defense-capture-bid-management.yaml
@@ -1,0 +1,98 @@
+locale: de
+source: L1-defense-capture-bid-management.yaml
+entries:
+  BC-1750:
+    name: Verteidigungs-Akquisitions- und Angebotswesen-Management
+    description: |
+      Akquisitionsmanagement, Kundenintelligenz und Angebotsentwicklung für Verteidigungsaufträge.
+  BC-1750.10:
+    name: Akquisitions-Management
+    description: |
+      Vor-Ausschreibungs-Aktivitäten, Kundengestaltung und Gewinnstrategie.
+  BC-1750.10.10:
+    name: Opportunitätsidentifikation
+    description: |
+      Identifikation von Verteidigungsopportunitäten und Verfolgung.
+  BC-1750.10.20:
+    name: Kunden-Gestaltungsaktivitäten
+    description: |
+      Vor-Ausschreibungs-Kundengestaltung und Anforderungsbeeinflussung.
+  BC-1750.10.30:
+    name: Gewinnstrategie-Entwicklung
+    description: |
+      Entwicklung von Gewinnstrategie, Themen und Unterscheidungsmerkmalen.
+  BC-1750.10.40:
+    name: Black-Hat- und Wettbewerbsanalyse
+    description: |
+      Black-Hat-Überprüfungen und Wettbewerbsanalyse.
+  BC-1750.20:
+    name: Verteidigungs-Kundenintelligenz-Management
+    description: |
+      Kundenbeziehungen und Intelligenz über Anforderungen und Budgets.
+  BC-1750.20.10:
+    name: Kunden-Beziehungskartierung
+    description: |
+      Kartierung von Kundenorganisationen und Hauptinteressenträgern.
+  BC-1750.20.20:
+    name: Budget- und Beschaffungsintelligenz
+    description: |
+      Informationen über Budgets, Beschaffungszyklen und Prioritäten.
+  BC-1750.20.30:
+    name: Anforderungsintelligenz-Erfassung
+    description: |
+      Erfassung aufkommender Kundenanforderungen.
+  BC-1750.30:
+    name: Verteidigungs-Angebotswesen-Management
+    description: |
+      Angebotsabgabe/-abgabe-Entscheidungen, Angebotsgovernance und -ressourcierung.
+  BC-1750.30.10:
+    name: Angebotsabgabe-Entscheidung
+    description: |
+      Governance und Genehmigungen für Angebotsabgabe-Entscheidungen.
+  BC-1750.30.20:
+    name: Angebots-Ressourcierung und -Finanzierung
+    description: |
+      Angebotsressourcen und Angebots- und Vorschlagsfinanzierungsallokation.
+  BC-1750.30.30:
+    name: Angebots-Risikomanagement
+    description: |
+      Identifikation und Management von Angebotsrisiken.
+  BC-1750.40:
+    name: Verteidigungs-Angebotsunterlagen-Management
+    description: |
+      Angebotserstellung, Farbbesprechungen und Angebotsproduktion.
+  BC-1750.40.10:
+    name: Angebotsunterlagen-Authoring
+    description: |
+      Erstellung von Verteidigungsangebots-Bänden.
+  BC-1750.40.20:
+    name: Farbbesprechungs-Durchführung
+    description: |
+      Pink-, Rot-, Gold-Farbbesprechungen und abschließende Angebotsüberprüfung.
+  BC-1750.40.30:
+    name: Angebotsproduktion und -Einreichung
+    description: |
+      Produktion und fristgerechte Einreichung von Angeboten.
+  BC-1750.40.40:
+    name: Angebots-Compliance-Verifizierung
+    description: |
+      Compliance-Verifizierung gegenüber RFP-Anweisungen und L/M.
+  BC-1750.50:
+    name: Teambildungs- und Unterauftragnehmer-Strategie-Management
+    description: |
+      Teamvereinbarungen und Unterauftragnehmer-Auswahl für Angebote.
+  BC-1750.50.10:
+    name: Teambildungs-Strategie-Definition
+    description: |
+      Definition der Teambildungs- und Hauptauftragnehmer-/Unterauftragnehmer-Strategie für Angebote.
+  BC-1750.50.20:
+    name: Teamvereinbarungs-Verhandlung
+    description: |
+      Verhandlung und Abschluss von Team- und NDA-Vereinbarungen.
+  BC-1750.50.30:
+    name: Angebotszeit-Unterauftragnehmer-Auswahl
+    description: |
+      Auswahl von Unterauftragnehmern und Kleinunternehmen für Angebote.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-defense-logistics-management.yaml
+++ b/catalogue/i18n/de/L1-defense-logistics-management.yaml
@@ -1,0 +1,106 @@
+locale: de
+source: L1-defense-logistics-management.yaml
+entries:
+  BC-1720:
+    name: Verteidigungslogistik-Management
+    description: |
+      Materielverfügbarkeit, Versorgungsunterstützung, Verlegelogistik und Logistik im Einsatzgebiet.
+  BC-1720.10:
+    name: Material-Bereitschafts-Management
+    description: |
+      Bereitschaftsmeldung und Flotten-/Ausrüstungsverfügbarkeit.
+  BC-1720.10.10:
+    name: Ausrüstungsverfügbarkeits-Verfolgung
+    description: |
+      Verfolgung von Ausrüstungsverfügbarkeit und Einsatzbereitschaft.
+  BC-1720.10.20:
+    name: Bereitschaftsmeldung
+    description: |
+      Periodische Bereitschaftsmeldung an die Führung.
+  BC-1720.10.30:
+    name: Einsatzbereitschaftsrate-Verbesserung
+    description: |
+      Maßnahmen zur Verbesserung der Einsatzbereitschaftsraten.
+  BC-1720.20:
+    name: Verteidigungs-Bestandsmanagement
+    description: |
+      Militärische Versorgungsklassen I–IX und Kriegsreserven.
+  BC-1720.20.10:
+    name: Versorgungsklassen-I-V-Bestandsmanagement
+    description: |
+      Bestandsmanagement für Verpflegung, Kraftstoff, Munition und Verbrauchsgüter.
+  BC-1720.20.20:
+    name: Versorgungsklassen-VII-IX-Bestandsmanagement
+    description: |
+      Bestandsmanagement für Hauptausrüstungsgegenstände und Ersatzteile.
+  BC-1720.20.30:
+    name: Kriegsreserve-Material-Management
+    description: |
+      Management von Kriegsreserven und vorgelagerten Beständen.
+  BC-1720.20.40:
+    name: Munitions-Bestandsmanagement
+    description: |
+      Munitions- und Sprengstoff-Bestandsmanagement.
+  BC-1720.30:
+    name: Verlege- und Distributionsmanagement
+    description: |
+      Strategische und taktische Verlegelogistik.
+  BC-1720.30.10:
+    name: Strategische-Verlegeplanung
+    description: |
+      Strategische Verlegeplanung und TPFDD-Planung.
+  BC-1720.30.20:
+    name: Strategische-Transportmittel-Betrieb
+    description: |
+      Luft-, See- und Landstrategietransportbetrieb.
+  BC-1720.30.30:
+    name: Distribution-im-Einsatzgebiet
+    description: |
+      Distribution und Versorgungslogistik im Einsatzgebiet.
+  BC-1720.30.40:
+    name: Gemeinschaftliche-Aufnahme und -Weiterbewegung
+    description: |
+      Gemeinschaftliche Aufnahme, Aufstellung und Weiterbewegung.
+  BC-1720.40:
+    name: Verteidigungs-Instandhaltungsmanagement
+    description: |
+      Organische und Auftragnehmer-Instandhaltung auf Truppenführungs-, Zwischen- und Depotebene.
+  BC-1720.40.10:
+    name: Truppenführungsebene-Instandhaltung
+    description: |
+      Instandhaltung auf Einheitsebene (O-Level).
+  BC-1720.40.20:
+    name: Zwischenebene-Instandhaltung
+    description: |
+      Instandhaltung und Reparatur auf Zwischenebene (I-Level).
+  BC-1720.40.30:
+    name: Depotebene-Instandhaltung
+    description: |
+      Instandhaltung und Generalüberholung auf Depotebene (D-Level).
+  BC-1720.40.40:
+    name: Auftragnehmer-Logistikunterstützung
+    description: |
+      Auftragnehmer-Logistikunterstützungsvereinbarungen.
+  BC-1720.50:
+    name: Ersatzteile- und Bereitstellungs-Management
+    description: |
+      Erstausstattung, Nachschub und Bedarfsbefriedigung.
+  BC-1720.50.10:
+    name: Erstausstattung
+    description: |
+      Erstausstattung mit Ersatzteilen für neue Plattformen.
+  BC-1720.50.20:
+    name: Ersatzteile-Nachschub
+    description: |
+      Nachschub von Ersatzteilen basierend auf Bedarf und Prognosen.
+  BC-1720.50.30:
+    name: Bedarfsbefriedigung-Verfolgung
+    description: |
+      Bedarfsbefriedigung und Erfüllungsquoten-Verfolgung.
+  BC-1720.50.40:
+    name: Katalogisierung und NSN-Management
+    description: |
+      NATO-Lagernummern-Katalogisierung und Artikelidentifikation.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-defense-programme-management.yaml
+++ b/catalogue/i18n/de/L1-defense-programme-management.yaml
@@ -1,0 +1,118 @@
+locale: de
+source: L1-defense-programme-management.yaml
+entries:
+  BC-1760:
+    name: Verteidigungsprogramm-Management
+    description: |
+      Großprogramm-Durchführung, EVM, Programmgovernance und Unterauftragnehmer-Management.
+  BC-1760.10:
+    name: Programm-Beschaffungs-Management
+    description: |
+      Beschaffungsstrategie, Programmplanung und Meilensteinüberprüfungen.
+  BC-1760.10.10:
+    name: Beschaffungsstrategie-Definition
+    description: |
+      Definition der Beschaffungsstrategie gemäß DoD 5000 / Äquivalent.
+  BC-1760.10.20:
+    name: Programmplanung und -Baseline
+    description: |
+      Programmplanung und Integrierter-Hauptplan-Baselinebildung.
+  BC-1760.10.30:
+    name: Meilenstein-Entscheidungsüberprüfungen
+    description: |
+      Vorbereitung und Durchführung von Meilenstein-Entscheidungsüberprüfungen.
+  BC-1760.20:
+    name: Programm-Earned-Value-Management
+    description: |
+      EVM, Kostenleistung, Zeitplanleistung und IBR.
+  BC-1760.20.10:
+    name: EVM-System-Betrieb
+    description: |
+      Betrieb eines EIA-748-konformen EVM-Systems.
+  BC-1760.20.20:
+    name: Integrierte-Baseline-Überprüfung
+    description: |
+      Durchführung von Integrierten-Baseline-Überprüfungen mit dem Kunden.
+  BC-1760.20.30:
+    name: Kosten- und Zeitplan-Leistungsanalyse
+    description: |
+      Analyse von CV-, SV-, CPI- und SPI-Metriken und -Trends.
+  BC-1760.20.40:
+    name: Schätzung-bei-Abschluss-Prognose
+    description: |
+      EAC-Prognose und TCPI-Analyse.
+  BC-1760.30:
+    name: Programm-Kosten- und Preismanagement
+    description: |
+      Kostenrechnungsstandards und Preisgestaltung für Regierungsaufträge.
+  BC-1760.30.10:
+    name: Kostenrechnungsstandards-Compliance
+    description: |
+      Compliance mit Kostenrechnungsstandards (CAS).
+  BC-1760.30.20:
+    name: Regierungsauftrags-Preisgestaltung
+    description: |
+      Preisgestaltung von Regierungsaufträgen einschließlich FAR/DFARS.
+  BC-1760.30.30:
+    name: Programm-Kostenschätzung
+    description: |
+      Programm-Kostenschätzung und Schätzungsgrundlagen-Dokumentation.
+  BC-1760.30.40:
+    name: Gemeinkostensatz-Management
+    description: |
+      Gemeinkosten-Satzberechnung und Regierungsverhandlung.
+  BC-1760.40:
+    name: Behörden-Kunden-Management
+    description: |
+      Regierungskundenschnittstelle und Vertragsbeauftragter-Schnittstelle.
+  BC-1760.40.10:
+    name: Vertragsbeauftragter-Schnittstelle
+    description: |
+      Schnittstelle mit Vertragsbeauftragten und Vertragsbeauftrager-Vertretern.
+  BC-1760.40.20:
+    name: Programmamt-Engagement
+    description: |
+      Engagement mit Regierungs-Programmämtern und PMOs.
+  BC-1760.40.30:
+    name: Kunden-Berichterstattung und -Überprüfungen
+    description: |
+      Periodische Kunden-Berichterstattung und Programmmanagement-Überprüfungen.
+  BC-1760.50:
+    name: Verteidigungs-Unterauftragnehmer-Management
+    description: |
+      Verteidigungs-Lieferkette, Flow-Down und Kleinunternehmen-Pläne.
+  BC-1760.50.10:
+    name: Unterauftragnehmer-Auswahl und -Vergabe
+    description: |
+      Auswahl und Vergabe von Verteidigungs-Unterauftragnehmern.
+  BC-1760.50.20:
+    name: Flow-Down-Klausel-Verwaltung
+    description: |
+      Verwaltung von FAR/DFARS-Flow-Down-Klauseln an Unterauftragnehmer.
+  BC-1760.50.30:
+    name: Unterauftragnehmer-Leistungsmanagement
+    description: |
+      Leistung und Überwachung von Verteidigungs-Unterauftragnehmern.
+  BC-1760.50.40:
+    name: Kleinunternehmen-Plan-Management
+    description: |
+      Kleinunternehmen-Unterbeauftragungsplan-Durchführung und -Berichterstattung.
+  BC-1760.60:
+    name: Programm-Lebenszyklus-Management
+    description: |
+      DoD-5000-/Äquivalenz-Lebenszyklusmanagement und Meilensteine.
+  BC-1760.60.10:
+    name: Lebenszyklus-Phasen-Management
+    description: |
+      Management von Programm-Lebenszyklusphasen gemäß DoD 5000 / Äquivalent.
+  BC-1760.60.20:
+    name: Programm-Risikomanagement
+    description: |
+      Programm-Risiko- und Chancen-Management.
+  BC-1760.60.30:
+    name: Programm-Abschluss und -Übergabe
+    description: |
+      Programmabschluss, Übergabe und Vertragsabschluss.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-defense-sustainment-support-management.yaml
+++ b/catalogue/i18n/de/L1-defense-sustainment-support-management.yaml
@@ -1,0 +1,114 @@
+locale: de
+source: L1-defense-sustainment-support-management.yaml
+entries:
+  BC-1780:
+    name: Verteidigungsdurchhaltefähigkeit- und Versorgungsunterstützung-Management
+    description: |
+      Instandhaltungsunterstützung im Betrieb, Depot-Instandhaltung, RAM-Technik, Ersatzteile und Reparatur sowie Obsoleszenz.
+  BC-1780.10:
+    name: Instandhaltungsunterstützungs-Management-im-Betrieb
+    description: |
+      Durchlebenszeit-Unterstützungsverträge und Ingenieurunterstützung.
+  BC-1780.10.10:
+    name: Durchlebenszeit-Unterstützungsvertrags-Betrieb
+    description: |
+      Betrieb von Durchlebenszeit-Unterstützungsverträgen.
+  BC-1780.10.20:
+    name: Ingenieurunterstützung
+    description: |
+      Ingenieurunterstützung für stationierte Waffensysteme.
+  BC-1780.10.30:
+    name: Flottenmanagement-Unterstützung
+    description: |
+      Flottenmanagement-Unterstützung einschließlich Konfigurationsverfolgung.
+  BC-1780.20:
+    name: Depot-Instandhaltungs-Management
+    description: |
+      Depot-Reparatur, Generalüberholung und Instandsetzung.
+  BC-1780.20.10:
+    name: Depot-Reparatur-Betrieb
+    description: |
+      Betrieb von Depot-Reparaturwerkstätten.
+  BC-1780.20.20:
+    name: Depot-Generalüberholungs-Programme
+    description: |
+      Periodische Depot-Generalüberholungs- und Reset-Programme.
+  BC-1780.20.30:
+    name: Depot-Kapazitäts-Management
+    description: |
+      Management von Depot-Kapazität und Durchlaufzeiten.
+  BC-1780.30:
+    name: RAM-Technik-Management
+    description: |
+      Zuverlässigkeits-, Verfügbarkeits- und Instandhaltbarkeitstechnik.
+  BC-1780.30.10:
+    name: Zuverlässigkeitstechnik
+    description: |
+      Zuverlässigkeitsvorhersage, -zuteilung und -wachstum.
+  BC-1780.30.20:
+    name: Verfügbarkeits-Modellierung
+    description: |
+      Betriebsverfügbarkeits-Modellierung und -Analyse.
+  BC-1780.30.30:
+    name: Instandhaltbarkeitstechnik
+    description: |
+      Instandhaltbarkeitsanalysen und Designbeeinflussung.
+  BC-1780.30.40:
+    name: Logistik-Unterstützungsanalyse
+    description: |
+      Logistik-Unterstützungsanalyse gemäß MIL-HDBK-502.
+  BC-1780.40:
+    name: Verteidigungs-Ersatzteile- und Reparatur-Management
+    description: |
+      Ersatzteile, Reparaturlinien und Tauscheinheiten.
+  BC-1780.40.10:
+    name: Verteidigungs-Ersatzteile-Bereitstellung
+    description: |
+      Bereitstellung von Ersatzteilen für Verteidigungssysteme.
+  BC-1780.40.20:
+    name: Reparaturleitungs-Management
+    description: |
+      Management von Reparatur-und-Rückgabe-Linien.
+  BC-1780.40.30:
+    name: Tauscheinheit-Pool-Betrieb
+    description: |
+      Betrieb von rotierbaren und Tauscheinheiten-Pools.
+  BC-1780.50:
+    name: Technische-Publikationen-Management
+    description: |
+      Technische Aufträge, IETMs, Handbücher und S1000D-Dokumentation.
+  BC-1780.50.10:
+    name: S1000D-Technische-Dokumentation
+    description: |
+      Erstellung und Pflege von S1000D-technischen Publikationen.
+  BC-1780.50.20:
+    name: Interaktive-Elektronische-Technische-Handbuchs-Betrieb
+    description: |
+      Betrieb und Aktualisierung von IETMs im Feld.
+  BC-1780.50.30:
+    name: Technische-Auftrag-Änderungs-Management
+    description: |
+      Management von TO-Änderungen und Feldupdates.
+  BC-1780.60:
+    name: Verteidigungs-Obsoleszenz-Management
+    description: |
+      DMSMS, Obsoleszenzprognose und Minderungsmaßnahmen.
+  BC-1780.60.10:
+    name: DMSMS-Überwachung
+    description: |
+      DMSMS-Überwachung von Komponenten und Lieferanten.
+  BC-1780.60.20:
+    name: Obsoleszenz-Prognose
+    description: |
+      Prognose von Bauteil- und Materialobsoleszenz.
+  BC-1780.60.30:
+    name: Obsoleszenz-Minderung
+    description: |
+      Minderungsstrategien einschließlich LTB, Redesign und Substitution.
+  BC-1780.60.40:
+    name: Obsoleszenzmanagementplan-Pflege
+    description: |
+      Pflege von Programm-Obsoleszenzmanagementplänen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-defense-systems-engineering-management.yaml
+++ b/catalogue/i18n/de/L1-defense-systems-engineering-management.yaml
@@ -1,0 +1,114 @@
+locale: de
+source: L1-defense-systems-engineering-management.yaml
+entries:
+  BC-1770:
+    name: Systemtechnik-Verteidigung-Management
+    description: |
+      MIL-STD-Systemtechnik – Anforderungen, Architektur, V&V, Konfiguration und Integration.
+  BC-1770.10:
+    name: Verteidigungs-Anforderungstechnik-Management
+    description: |
+      Anforderungserhellung, -zerlegung und -rückverfolgbarkeit.
+  BC-1770.10.10:
+    name: Interessenträger-Anforderungserhellung
+    description: |
+      Erhellung von Interessenträgerbedürfnissen und Einsatzanforderungen.
+  BC-1770.10.20:
+    name: System-Anforderungszerlegung
+    description: |
+      Zerlegung von Systemanforderungen in Teilsysteme.
+  BC-1770.10.30:
+    name: Anforderungsrückverfolgbarkeit
+    description: |
+      Bidirektionale Rückverfolgbarkeit von Anforderungen zu Design und Tests.
+  BC-1770.10.40:
+    name: Anforderungsverifizierungs-Planung
+    description: |
+      Definition von Verifizierungsmethoden und Abnahmekriterien.
+  BC-1770.20:
+    name: Verteidigungs-System-Architektur-Management
+    description: |
+      Systemarchitektur, Modelle und Baselines.
+  BC-1770.20.10:
+    name: Betriebs- und System-Architektur-Modellierung
+    description: |
+      Modellierung von Betriebs- und Systemarchitekturen (DoDAF/MoDAF).
+  BC-1770.20.20:
+    name: Architektur-Trade-off-Analyse
+    description: |
+      Trade-off-Analyse zwischen Architekturoptionen.
+  BC-1770.20.30:
+    name: Architektur-Baseline-Management
+    description: |
+      Definition und Kontrolle von Architektur-Baselines.
+  BC-1770.30:
+    name: Verteidigungs-Schnittstellendefinitions-Management
+    description: |
+      Schnittstellenkontrolle, ICDs und Schnittstellenmanagementpläne.
+  BC-1770.30.10:
+    name: Schnittstellen-Identifikation
+    description: |
+      Identifikation interner und externer Systemschnittstellen.
+  BC-1770.30.20:
+    name: Schnittstellenkontroll-Dokument-Management
+    description: |
+      Erstellung und Kontrolle von ICDs und IRSs.
+  BC-1770.30.30:
+    name: Schnittstellen-Verifizierung
+    description: |
+      Verifizierung der Schnittstellenkonformität während der Integration.
+  BC-1770.40:
+    name: Verteidigungs-Verifikations- und Validierungs-Management
+    description: |
+      V&V-Planung, -Durchführung und -Zertifizierung.
+  BC-1770.40.10:
+    name: V&V-Planung
+    description: |
+      Verifikations- und Validierungsstrategie und -Planung.
+  BC-1770.40.20:
+    name: V&V-Durchführung
+    description: |
+      Durchführung von V&V über Analysen, Demonstrationen, Inspektionen und Tests.
+  BC-1770.40.30:
+    name: V&V-Ergebnis-Berichterstattung
+    description: |
+      Berichterstattung über V&V-Ergebnisse und Abweichungen.
+  BC-1770.50:
+    name: Verteidigungs-Konfigurationsmanagement
+    description: |
+      Konfigurationsidentifikation, -kontrolle, -statusbuchführung und -Audits.
+  BC-1770.50.10:
+    name: Verteidigungs-Konfigurationsidentifikation
+    description: |
+      Konfigurationsidentifikation gemäß MIL-HDBK-61.
+  BC-1770.50.20:
+    name: Verteidigungs-Konfigurationsänderungs-Kontrolle
+    description: |
+      ECP-, RFD- und DD-1694-Änderungskontrolle.
+  BC-1770.50.30:
+    name: Verteidigungs-Konfigurationsstatus-Buchführung
+    description: |
+      Konfigurationsstatus-Buchführung und -Berichterstattung.
+  BC-1770.50.40:
+    name: Konfigurations-Audits
+    description: |
+      Funktionale und physische Konfigurations-Audits.
+  BC-1770.60:
+    name: Verteidigungs-Systemintegrations-Management
+    description: |
+      Teilsystemintegration, Integriertes Testing und System-of-Systems-Integration.
+  BC-1770.60.10:
+    name: Teilsystemintegrations-Durchführung
+    description: |
+      Durchführung von Teilsystemintegrationssequenzen.
+  BC-1770.60.20:
+    name: Integriertes-Test-Durchführung
+    description: |
+      Durchführung integrierter Tests in Labor- und Feldumgebungen.
+  BC-1770.60.30:
+    name: System-of-Systems-Integration
+    description: |
+      Integration mit übergeordneten System-of-Systems und gemeinsamen Architekturen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-defense-test-evaluation-management.yaml
+++ b/catalogue/i18n/de/L1-defense-test-evaluation-management.yaml
@@ -1,0 +1,98 @@
+locale: de
+source: L1-defense-test-evaluation-management.yaml
+entries:
+  BC-1800:
+    name: Erprobung und Bewertung (Verteidigung) Management
+    description: |
+      Entwicklungs- und Betriebserprobung, Bereichsbetrieb, Testpläne und Testdaten.
+  BC-1800.10:
+    name: Entwicklungserprobung & Bewertung Management
+    description: |
+      Entwicklungserprobung, Auftragnehmer-Tests, Qualifikationserprobung.
+  BC-1800.10.10:
+    name: Auftragnehmer-Testprogramm
+    description: |
+      Management des auftragnehmergeführten Entwicklungstestprogramms.
+  BC-1800.10.20:
+    name: Regierungs-Entwicklungserprobung Koordination
+    description: |
+      Koordination von staatlichen Entwicklungserprobungsaktivitäten.
+  BC-1800.10.30:
+    name: Qualifikationstest-Durchführung
+    description: |
+      Durchführung von Qualifikationstests gegen Spezifikationen.
+  BC-1800.20:
+    name: Betriebserprobung & Bewertung Management
+    description: |
+      Betriebserprobung, Nutzererprobung, Betriebseignung.
+  BC-1800.20.10:
+    name: Erstbetriebserprobung und -bewertung
+    description: |
+      Durchführung und Berichterstattung der IOT&E.
+  BC-1800.20.20:
+    name: Folgebetriebserprobung
+    description: |
+      Folgebetriebserprobung und -bewertung.
+  BC-1800.20.30:
+    name: Betriebseignungsbewertung
+    description: |
+      Bewertung der Betriebseignung und -wirksamkeit.
+  BC-1800.30:
+    name: Testbereich-Betriebsmanagement
+    description: |
+      Testbereichsplanung, Bereichssicherheit, Bereichsdaten.
+  BC-1800.30.10:
+    name: Bereichszeitplanung
+    description: |
+      Planung der Testbereichsnutzung und der eingesetzten Mittel.
+  BC-1800.30.20:
+    name: Bereichssicherheitsbetrieb
+    description: |
+      Sicherheits- und Freigabebetrieb im Testbereich.
+  BC-1800.30.30:
+    name: Bereichsdatenerfassung
+    description: |
+      Telemetrie-, Optik- und Instrumentierungsdatenerfassung im Testbereich.
+  BC-1800.30.40:
+    name: Bereichsmittel-Instandhaltung
+    description: |
+      Instandhaltung der Bereichsinstrumentierung und -infrastruktur.
+  BC-1800.40:
+    name: Testplan- & Verfahrens-Management
+    description: |
+      Testpläne, Verfahren, Testbereitschaftsüberprüfungen.
+  BC-1800.40.10:
+    name: Test- und Bewertungs-Masterplan
+    description: |
+      Pflege des TEMP gemäß Programmanforderungen.
+  BC-1800.40.20:
+    name: Detaillierte Testverfahrens-Erstellung
+    description: |
+      Erstellung detaillierter Testverfahren und Vor-Test-Karten.
+  BC-1800.40.30:
+    name: Testbereitschaftsüberprüfung
+    description: |
+      Testbereitschaftsüberprüfungen vor der Testdurchführung.
+  BC-1800.50:
+    name: Testdaten-Management
+    description: |
+      Testdatenerfassung, -analyse und -archivierung.
+  BC-1800.50.10:
+    name: Testdatenerfassung
+    description: |
+      Erfassung von Telemetrie- und Instrumentierungstestdaten.
+  BC-1800.50.20:
+    name: Testdatenanalyse
+    description: |
+      Auswertung und Analyse von Testdaten.
+  BC-1800.50.30:
+    name: Testdatenarchivierung und -wiederverwendung
+    description: |
+      Archivierung und Wiederverwendung historischer Testdatensätze.
+  BC-1800.50.40:
+    name: Testanomalie-Berichterstattung
+    description: |
+      Berichterstattung und Verfolgung von Testanomalien und -mängeln.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-deposits-savings-management.yaml
+++ b/catalogue/i18n/de/L1-deposits-savings-management.yaml
@@ -1,0 +1,102 @@
+locale: de
+source: L1-deposits-savings-management.yaml
+entries:
+  BC-1330:
+    name: Einlagen- und Ersparnismanagement
+    description: |
+      Lebenszyklus von Girokonten, Ersparnissen und Termineinlagen.
+  BC-1330.10:
+    name: Einlagenkonto-Management
+    description: |
+      Sichteinlagenkonten und Girokonten.
+  BC-1330.10.10:
+    name: Girokonto-Betrieb
+    description: |
+      Betrieb von Girokonten einschließlich Überziehungsmanagement.
+  BC-1330.10.20:
+    name: Gemeinschafts- und Vollmachtskonto-Management
+    description: |
+      Verwaltung von gemeinschaftlichen, treuhänderischen und Vollmachtskonten.
+  BC-1330.10.30:
+    name: Einlagenkonto-Kontoauszüge
+    description: |
+      Erstellung und Zustellung von Kontoauszügen für Einlagenkonten.
+  BC-1330.20:
+    name: Sparprodukt-Management
+    description: |
+      Ersparnisse, regelmäßige Sparpläne, ISAs und steuerlich begünstigte Produkte.
+  BC-1330.20.10:
+    name: Tagesgeldkonto-Betrieb
+    description: |
+      Betrieb von täglich verfügbaren und Kündigungssparkonten.
+  BC-1330.20.20:
+    name: Regelmäßiger-Sparplan-Betrieb
+    description: |
+      Betrieb von regelmäßigen Sparplänen und Daueraufträgen.
+  BC-1330.20.30:
+    name: Steuerlich-Begünstigter-Sparkonten-Betrieb
+    description: |
+      Betrieb von ISA-, IRA- und gleichwertigen steuerlich begünstigten Sparkonten.
+  BC-1330.30:
+    name: Termineinlagen-Management
+    description: |
+      Termingelder, CDs und strukturierte Einlagen.
+  BC-1330.30.10:
+    name: Termineinlagen-Buchung
+    description: |
+      Buchung und Bestätigung von Termineinlagen.
+  BC-1330.30.20:
+    name: Termineinlagen-Fälligkeitsbehandlung
+    description: |
+      Fälligkeitsbehandlung, Verlängerungs- und Erneuerungsoptionen.
+  BC-1330.30.30:
+    name: Strukturierte-Einlagen-Betrieb
+    description: |
+      Betrieb von strukturierten und Doppelwährungs-Einlagen.
+  BC-1330.30.40:
+    name: Vorzeitige-Kündigung und Vorfälligkeitsentschädigung
+    description: |
+      Bearbeitung vorzeitiger Kündigungen und Berechnung von Vorfälligkeitsentschädigungen.
+  BC-1330.40:
+    name: Konto-Lebenszyklus-Betriebsmanagement
+    description: |
+      Kontoeröffnung, Ruhekonto- und Abschlussvorgänge.
+  BC-1330.40.10:
+    name: Kontoeröffnungs-Betrieb
+    description: |
+      Betriebliche Eröffnung neuer Einlagenkonten.
+  BC-1330.40.20:
+    name: Ruhekonto-Management
+    description: |
+      Identifikation und Behandlung von ruhenden Konten.
+  BC-1330.40.30:
+    name: Kontoabschluss-Betrieb
+    description: |
+      Kontoabschlussvorgänge und Schlussabrechnung.
+  BC-1330.40.40:
+    name: Herrenlose-Guthaben-Meldung
+    description: |
+      Meldung und Abführung herrenloser Guthaben.
+  BC-1330.50:
+    name: Einlagenpreisgestaltungs- und Zinsmanagement
+    description: |
+      Zinssätze, Kontoauszüge und Abgrenzungen.
+  BC-1330.50.10:
+    name: Einlagenzins-Festsetzung
+    description: |
+      Festsetzung von Einlagenzinssätzen und Zinskarten.
+  BC-1330.50.20:
+    name: Zinsabgrenzung und -berechnung
+    description: |
+      Tägliche Zinsabgrenzung und periodische Zinsgutschrift.
+  BC-1330.50.30:
+    name: Quellensteuer auf Zinsen
+    description: |
+      Quellensteuerabzug auf Einlagenzinsen und Meldung.
+  BC-1330.50.40:
+    name: Einlagensicherungs-Meldung
+    description: |
+      Meldung und Beiträge an Einlagensicherungssysteme.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-design-management.yaml
+++ b/catalogue/i18n/de/L1-design-management.yaml
@@ -1,0 +1,118 @@
+locale: de
+source: L1-design-management.yaml
+entries:
+  BC-1120:
+    name: Design-Management
+    description: |
+      Ingenieurdesign-Lebenszyklus vom Konzept bis zum Detaildesign und zur Verifikation.
+  BC-1120.10:
+    name: Konzeptdesign-Management
+    description: |
+      Konzeptstudien, Machbarkeit, Optionsanalyse und Pre-FEED.
+  BC-1120.10.10:
+    name: Konzeptstudiendefinition
+    description: |
+      Konzeptsstudienumfang, Designgrundlage und Annahmen.
+  BC-1120.10.20:
+    name: Machbarkeitsanalyse
+    description: |
+      Technische, terminliche und wirtschaftliche Machbarkeitsanalyse.
+  BC-1120.10.30:
+    name: Optionsanalyse und -auswahl
+    description: |
+      Multikriteriell-Optionsanalyse und Konzeptauswahl.
+  BC-1120.20:
+    name: Front-End-Engineering-Design-Management
+    description: |
+      FEED, Basic Engineering, Scope- und Kostendefinition.
+  BC-1120.20.10:
+    name: Basic Engineering Design
+    description: |
+      Basic Engineering von Verfahrens-, Maschinen- und Elektrodisziplinen.
+  BC-1120.20.20:
+    name: FEED-Kosten- und Terminschätzung
+    description: |
+      Klasse-3/Klasse-2-Kosten- und Terminschätzungen aus dem FEED.
+  BC-1120.20.30:
+    name: FEED-Liefergegenstände-Erstellung
+    description: |
+      Erstellung von FEED-Liefergegenständen und Designgrundlage.
+  BC-1120.30:
+    name: Detaildesign-Management
+    description: |
+      Detailliertes Ingenieurwesen, Arbeitszeichnungen, Spezifikationen und Mengenlisten.
+  BC-1120.30.10:
+    name: Detaillierte Ingenieurwesen-Berechnungen
+    description: |
+      Fachliche Detailberechnungen und Analysen.
+  BC-1120.30.20:
+    name: Arbeitszeichnungs-Erstellung
+    description: |
+      Erstellung von freigegebenen Konstruktionszeichnungen.
+  BC-1120.30.30:
+    name: Detaillierte Spezifikations-Erstellung
+    description: |
+      Ausarbeitung von Detailspezifikationen für Anlagen und Materialien.
+  BC-1120.30.40:
+    name: Mengenlisten-Erstellung
+    description: |
+      Erstellung und Verwaltung von Mengenlisten für Beschaffung und Bau.
+  BC-1120.40:
+    name: Design-Review- und Verifikations-Management
+    description: |
+      HAZOP, Design-Reviews, Verifikation und Validierung.
+  BC-1120.40.10:
+    name: HAZOP- und HAZID-Workshops
+    description: |
+      Gefahrenidentifikation und HAZOP-Workshop-Moderation.
+  BC-1120.40.20:
+    name: Design-Review-Gates
+    description: |
+      Stage-Gate-Design-Reviews (30 %, 60 %, 90 %).
+  BC-1120.40.30:
+    name: Design-Verifikation
+    description: |
+      Verifikation des Designs gegenüber Anforderungen und Standards.
+  BC-1120.40.40:
+    name: Design-Validierung
+    description: |
+      Validierung des Designs gegenüber Verwendungszweck und Kundenanforderungen.
+  BC-1120.50:
+    name: Design-Software- und CAD-Management
+    description: |
+      CAD/CAE-Werkzeuge, 3D-Modellierung, BIM und digitale Designumgebung.
+  BC-1120.50.10:
+    name: CAD-Standards-Management
+    description: |
+      CAD-Standards, Layer-Schemata und Vorlagenbibliotheken.
+  BC-1120.50.20:
+    name: 3D-Modell-Management
+    description: |
+      Management integrierter 3D-Modelle über Disziplinen hinweg.
+  BC-1120.50.30:
+    name: BIM-Umgebungs-Management
+    description: |
+      BIM-Common-Data-Environment und ISO-19650-Ausrichtung.
+  BC-1120.50.40:
+    name: Ingenieurwesen-Software-Administration
+    description: |
+      Administration und Lizenzierung von Ingenieurwesen-Softwarewerkzeugen.
+  BC-1120.60:
+    name: Multidisziplinäres Design-Koordinations-Management
+    description: |
+      Disziplinübergreifende Koordination, Kollisionserkennung und integriertes Modellmanagement.
+  BC-1120.60.10:
+    name: Kollisionserkennung
+    description: |
+      Kollisionserkennung über disziplinäre 3D-Modelle hinweg.
+  BC-1120.60.20:
+    name: Integriertes Modell-Koordination
+    description: |
+      Koordination integrierter multidisziplinärer Modelle.
+  BC-1120.60.30:
+    name: Design-Issue-Lösung
+    description: |
+      Lösung von Design-Koordinationsproblemen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-developer-platform-api-ecosystem-management.yaml
+++ b/catalogue/i18n/de/L1-developer-platform-api-ecosystem-management.yaml
@@ -1,0 +1,167 @@
+locale: de
+source: L1-developer-platform-api-ecosystem-management.yaml
+entries:
+  BC-4270:
+    name: Entwicklerplattform und API-Ökosystem
+    description: |
+      Öffentliche APIs, SDKs, Entwicklerportal, Entwickleridentität,
+      API-Nutzungsgovernance, Partner-Apps, Software-Marketplace-Einträge
+      und ausgehende Webhook-Abonnements für das SaaS-Ökosystem.
+  BC-4270.10:
+    name: API-Lebenszyklusmanagement (öffentlich)
+    description: |
+      Spezifikation, Versionierung und Abkündigung öffentlicher APIs,
+      die externen Entwicklern bereitgestellt werden.
+  BC-4270.10.10:
+    name: API-Spezifikationserstellung
+    description: |
+      Erstellung und Überprüfung öffentlicher API-Spezifikationen in
+      maschinenlesbarer Form.
+  BC-4270.10.20:
+    name: API-Versionierung
+    description: |
+      Versionierung öffentlicher APIs mit dokumentierten
+      Kompatibilitätsgarantien.
+  BC-4270.10.30:
+    name: API-Abkündigungsmanagement
+    description: |
+      Kommunikation und Durchführung von API-Abkündigungen mit
+      angemessener Vorankündigung.
+  BC-4270.20:
+    name: SDK- und Client-Bibliotheksverwaltung
+    description: |
+      Generierung, Sprachabdeckung und Pflege von Beispielen für SDKs
+      und Client-Bibliotheken, die öffentliche APIs kapseln.
+  BC-4270.20.10:
+    name: SDK-Generierung und -Veröffentlichung
+    description: |
+      Generierung und Veröffentlichung von SDKs, die an API-Versionen
+      ausgerichtet sind.
+  BC-4270.20.20:
+    name: SDK-Sprachabdeckungsmanagement
+    description: |
+      Auswahl und Pflege der unterstützten SDK-Sprachen und
+      Laufzeitumgebungen.
+  BC-4270.20.30:
+    name: SDK-Beispielpflege
+    description: |
+      Pflege von SDK-Codebeispielen und Einstiegsprojekten.
+  BC-4270.30:
+    name: Entwicklerportalverwaltung
+    description: |
+      Dokumentation, interaktive Referenzen und Onboarding-Abläufe,
+      die Entwicklern die Integration in die Plattform erleichtern.
+  BC-4270.30.10:
+    name: Entwicklerdokumentation
+    description: |
+      Erstellung konzeptioneller, aufgabenorientierter und
+      referenzbezogener Dokumentation für Entwickler.
+  BC-4270.30.20:
+    name: Interaktive API-Referenz
+    description: |
+      Betrieb interaktiver API-Referenzen und Try-it-now-Erlebnisse.
+  BC-4270.30.30:
+    name: Entwickler-Onboarding
+    description: |
+      Onboarding-Abläufe, die Entwickler von der Registrierung bis zum
+      ersten erfolgreichen API-Aufruf begleiten.
+  BC-4270.40:
+    name: Entwickleridentität und Zugangsdatenverwaltung
+    description: |
+      Ausstellung und Verwaltung von Entwicklerzugangsdaten,
+      OAuth-Clients und föderierter Entwickleridentität.
+  BC-4270.40.10:
+    name: API-Schlüsselausstellung
+    description: |
+      Ausstellung, Rotation und Widerruf von Entwickler-API-Schlüsseln.
+  BC-4270.40.20:
+    name: OAuth-Client-Registrierung
+    description: |
+      Registrierung und Verwaltung von OAuth-Client-Anwendungen.
+  BC-4270.40.30:
+    name: Entwickleridentitätsföderation
+    description: |
+      Förderation der Entwickleridentität von externen
+      Identitätsanbietern.
+  BC-4270.50:
+    name: API-Nutzungsgovernance
+    description: |
+      Kontingente, Ratenlimits, Nutzungsanalysen und Zuordnung des
+      API-Verbrauchs zu kommerziellen Plantarifen.
+  BC-4270.50.10:
+    name: API-Kontingent- und Ratenlimitverwaltung
+    description: |
+      Definition und Durchsetzung von API-Kontingenten und
+      Ratenlimits pro Verbraucher.
+  BC-4270.50.20:
+    name: API-Nutzungsanalyse
+    description: |
+      Analyse von API-Nutzungsmustern nach Endpunkt, Verbraucher
+      und Plan.
+  BC-4270.50.30:
+    name: API-Tarifplanzuordnung
+    description: |
+      Zuordnung von API-Zugriffstarifen zu Abonnementplänen und
+      Berechtigungen.
+  BC-4270.60:
+    name: Partner-App-Programmverwaltung
+    description: |
+      Verwaltung von Drittanbieter-Partneranwendungen einschließlich
+      Listung, Zertifizierung und Umsatzbeteiligung.
+  BC-4270.60.10:
+    name: Partner-App-Listungsverwaltung
+    description: |
+      Aufnahme von Partneranwendungen in das App-Verzeichnis der
+      Plattform.
+  BC-4270.60.20:
+    name: Partner-App-Zertifizierung
+    description: |
+      Zertifizierung von Partneranwendungen gegen Sicherheits- und
+      Qualitätsanforderungen.
+  BC-4270.60.30:
+    name: Partner-App-Umsatzbeteiligung
+    description: |
+      Umsatzbeteiligungsvereinbarungen mit Entwicklern von
+      Partneranwendungen.
+  BC-4270.70:
+    name: Software-Marketplace-Eintragsmanagement
+    description: |
+      Listung und Pflege des SaaS-Angebots auf Drittanbieter- und
+      Cloud-Marktplätzen.
+  BC-4270.70.10:
+    name: Marketplace-Eintragsautorschaft
+    description: |
+      Erstellung von Marketplace-Einträgen einschließlich Metadaten,
+      Preisgestaltung und Assets.
+  BC-4270.70.20:
+    name: Marketplace-Eintrags-Pflege
+    description: |
+      Laufende Pflege von Marketplace-Einträgen bei Weiterentwicklung
+      des Angebots.
+  BC-4270.70.30:
+    name: Marketplace-Co-Sell-Koordination
+    description: |
+      Koordination von Co-Sell-Aktivitäten mit Marketplace-Betreibern.
+  BC-4270.80:
+    name: Webhook- und Ereignisabonnementverwaltung
+    description: |
+      Lebenszyklus ausgehender Webhook-Abonnements,
+      Ereignisschemata und Zustellungszuverlässigkeit.
+  BC-4270.80.10:
+    name: Webhook-Abonnementlebenszyklus
+    description: |
+      Lebenszyklus ausgehender Webhook-Abonnements von der
+      Registrierung bis zur Abkündigung.
+  BC-4270.80.20:
+    name: Ereignisschema-Katalog
+    description: |
+      Katalog ausgehender Ereignisschemata und ihrer
+      Kompatibilitätsgarantien.
+  BC-4270.80.30:
+    name: Webhook-Zustellungszuverlässigkeitsmanagement
+    description: |
+      Wiederholung, Backoff und Dead-Letter-Behandlung für ausgehende
+      Webhook-Zustellungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-diagnostic-services-management.yaml
+++ b/catalogue/i18n/de/L1-diagnostic-services-management.yaml
@@ -1,0 +1,136 @@
+locale: de
+source: L1-diagnostic-services-management.yaml
+entries:
+  BC-2860:
+    name: Diagnostische Dienste
+    description: |
+      Labor, anatomische Pathologie, bildgebende Diagnostik, kardiopulmonale
+      Diagnostik, Point-of-Care-Testung und lückenlose Ergebnisssteuerung.
+  BC-2860.10:
+    name: Labordienstleistungen
+    description: |
+      Probenentnahme, klinische Chemie, Hämatologie, Mikrobiologie,
+      Molekulardiagnostik und Betrieb des Laborinformationssystems.
+  BC-2860.10.10:
+    name: Probenentnahme und -transport
+    description: |
+      Phlebotomie, Probenentnahme und Transportlogistik.
+  BC-2860.10.20:
+    name: Klinische Chemie und Hämatologie
+    description: |
+      Betrieb der klinischen Chemie, Hämatologie und Gerinnungsanalytik.
+  BC-2860.10.30:
+    name: Mikrobiologie und Molekulardiagnostik
+    description: |
+      Mikrobiologische, virologische und molekulardiagnostische Testung.
+  BC-2860.10.40:
+    name: Laborinformationssystem-Betrieb
+    description: |
+      Betrieb des Laborinformationssystems und der Geräteschnittstellen.
+  BC-2860.20:
+    name: Anatomische Pathologiedienste
+    description: |
+      Histologie, Zytologie, chirurgische Pathologie und digitale Pathologie.
+  BC-2860.20.10:
+    name: Histologische Verarbeitung
+    description: |
+      Gewebeverarbeitung, Einbettung, Schnitt und Färbung für die Histologie.
+  BC-2860.20.20:
+    name: Zytologiedienste
+    description: |
+      Zytologische Probenvorbereitung, Screening und Befundung.
+  BC-2860.20.30:
+    name: Chirurgisch-pathologische Befundung
+    description: |
+      Pathologische Beurteilung und Befundung chirurgischer Pathologiefälle.
+  BC-2860.20.40:
+    name: Digitale Pathologie
+    description: |
+      Ganzpräparat-Scannen, Archivierung und digitale Pathologie-Workflows.
+  BC-2860.30:
+    name: Bildgebende Diagnostik
+    description: |
+      Bildaufnahme, Befundung, Archivierung und Dosismanagement für
+      diagnostische Bildgebungsmodalitäten.
+  BC-2860.30.10:
+    name: Bildaufnahme
+    description: |
+      Bildaufnahme über Radiographie, CT, MRT, Ultraschall und Nuklearmedizin.
+  BC-2860.30.20:
+    name: Bildbefundung und -berichterstattung
+    description: |
+      Radiologische Befundung und strukturierte Berichterstattung bildgebender Untersuchungen.
+  BC-2860.30.30:
+    name: Bildarchivbetrieb
+    description: |
+      Betrieb von Bildarchiven und einrichtungsübergreifendem Bildaustausch.
+  BC-2860.30.40:
+    name: Strahlendosismanagement
+    description: |
+      Strahlendosis-Tracking, Optimierung und Patientendosisberichterstattung.
+  BC-2860.40:
+    name: Kardiopulmonale Diagnostik
+    description: |
+      Elektrokardiographie, Echokardiographie, Herzkatheteruntersuchungen und
+      Lungenfunktionstestdienste.
+  BC-2860.40.10:
+    name: Elektrokardiographie und Telemetrie
+    description: |
+      EKG-Aufnahme, Telemetriemonitoring und Arrhythmieinterpretation.
+  BC-2860.40.20:
+    name: Echokardiographie
+    description: |
+      Transthorakale, transösophageale und Stress-Echokardiographiedienste.
+  BC-2860.40.30:
+    name: Herzkatheterdiagnostik
+    description: |
+      Diagnostische Herzkatheteruntersuchungen und elektrophysiologische Studien.
+  BC-2860.40.40:
+    name: Lungenfunktionstestung
+    description: |
+      Spirometrie, Lungenvolumen-, Diffusions- und Belastungs-Lungenfunktionstestung.
+  BC-2860.50:
+    name: Point-of-Care-Testung
+    description: |
+      Governance, Qualitätskontrolle, Anwender-Kompetenz und Ergebnisintegration
+      für Point-of-Care-Testung im gesamten Unternehmen.
+  BC-2860.50.10:
+    name: Point-of-Care-Geräteverwaltung
+    description: |
+      Bestands- und Lebenszyklusmanagement von Point-of-Care-Testgeräten.
+  BC-2860.50.20:
+    name: Qualitätskontrolle Point-of-Care
+    description: |
+      Qualitätskontrolle und Eignungstestung für Point-of-Care-Geräte.
+  BC-2860.50.30:
+    name: Anwender-Kompetenzmanagement
+    description: |
+      Zertifizierung und Kompetenzbewertung der Anwender für Point-of-Care-Testung.
+  BC-2860.50.40:
+    name: Point-of-Care-Ergebnisintegration
+    description: |
+      Integration von Point-of-Care-Ergebnissen in die Laborakte und die Krankenakte.
+  BC-2860.60:
+    name: Diagnostisches Ergebnismanagement
+    description: |
+      Validierung, Verteilung und Reflexregel-Management diagnostischer
+      Ergebnisse über alle Modalitäten hinweg.
+  BC-2860.60.10:
+    name: Ergebnisvalidierung
+    description: |
+      Technische und klinische Validierung diagnostischer Ergebnisse.
+  BC-2860.60.20:
+    name: Kritische Werte Benachrichtigung
+    description: |
+      Zeitgebundene Benachrichtigung über kritische Werte an anfordernde Ärzte.
+  BC-2860.60.30:
+    name: Ergebnisverteilung
+    description: |
+      Verteilung von Ergebnissen an anfordernde Ärzte, Patienten und externe Systeme.
+  BC-2860.60.40:
+    name: Reflextest-Regeln
+    description: |
+      Erstellung und Betrieb von Reflextest-Regeln und Erweiterungslogik.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-distributed-energy-resource-management.yaml
+++ b/catalogue/i18n/de/L1-distributed-energy-resource-management.yaml
@@ -1,0 +1,132 @@
+locale: de
+source: L1-distributed-energy-resource-management.yaml
+entries:
+  BC-3840:
+    name: Dezentrale Energieressourcen Management
+    description: |
+      Registrierung, Aggregation und operative Koordination dezentraler
+      Energieressourcen am Verteilungsnetz – Dachsolar, hinter dem Zähler befindliche
+      Speicher, Lastmanagement, EV-Laden und Mikronetze – sowie deren Teilnahme
+      an Großhandels- und Flexibilitätsmärkten.
+  BC-3840.10:
+    name: DER-Registrierung und Anschluss
+    description: |
+      Registrierung dezentraler Energieressourcen, technische Qualifikation
+      und Anschlussabnahme gemäß IEEE 1547 / EU-Anforderungen an Erzeugungsanlagen.
+  BC-3840.10.10:
+    name: DER-Antragsbeurteilung
+    description: |
+      Beurteilung von DER-Anschlussanträgen gegen die Aufnahmekapazität.
+  BC-3840.10.20:
+    name: Technische DER-Qualifikation
+    description: |
+      Typprüfung und Vor-Ort-Verifikation von DER-Fähigkeiten und Schutzeinrichtungen.
+  BC-3840.10.30:
+    name: DER-Registerpflege
+    description: |
+      Pflege des Registers angeschlossener DER-Anlagen und ihrer Fähigkeiten.
+  BC-3840.20:
+    name: Virtuelles Kraftwerk Betrieb
+    description: |
+      Aggregation und Dispatch verteilter Ressourcen als einheitliche
+      Betriebseinheit in Großhandels- und Ausgleichsmärkte.
+  BC-3840.20.10:
+    name: VKW-Portfoliomanagement
+    description: |
+      Zusammensetzung und Neugewichtung des VKW-Portfolios über Anlagekategorien hinweg.
+  BC-3840.20.20:
+    name: VKW-Dispatchbetrieb
+    description: |
+      Echtzeit-Dispatchanweisungen über aggregierte DER-Anlagen.
+  BC-3840.20.30:
+    name: VKW-Leistungsabrechnung
+    description: |
+      Abrechnung der VKW-Leistung gegen Markt- und bilaterale Verpflichtungen.
+  BC-3840.30:
+    name: Lastmanagementbetrieb
+    description: |
+      Rekrutierung, Dispatch und Abrechnung von Lastmanagementprogrammen
+      für Haus-, Gewerbe- und Industriekunden.
+  BC-3840.30.10:
+    name: Lastmanagementprogramm-Anmeldung
+    description: |
+      Kundeanmeldung und Einwilligungsmanagement für Lastmanagementprogramme.
+  BC-3840.30.20:
+    name: Lastmanagement-Eventdispatch
+    description: |
+      Dispatch von Lastmanagementvorgaben und Abregelungsanweisungen an Teilnehmer.
+  BC-3840.30.30:
+    name: Lastmanagement-Leistungsverifikation
+    description: |
+      Verifikation der Lastmanagementerbringung gegen Kundenbezugswerte.
+  BC-3840.40:
+    name: EV-Netzintegration Management
+    description: |
+      Management der Interaktion von Elektrofahrzeugladevorgängen mit dem
+      Netz einschließlich gesteuertem Laden, V2G und EV-spezifischen Tarifen.
+  BC-3840.40.10:
+    name: Gesteuerter Ladebetrieb
+    description: |
+      Betrieb gesteuerter und intelligenter Ladesysteme für EV-Flotten und Eigenheime.
+  BC-3840.40.20:
+    name: Vehicle-to-Grid-Koordination
+    description: |
+      Koordination bidirektionaler V2G-Einspeisung ins Netz oder hinter dem Zähler.
+  BC-3840.40.30:
+    name: EV-Aufnahmekapazitätsanalyse
+    description: |
+      Feldebenen-Aufnahmekapazitätsanalyse für EV-Ladepenetration.
+  BC-3840.50:
+    name: Hinter-dem-Zähler-Speicherkoordination
+    description: |
+      Koordination der Beteiligung von Hinter-dem-Zähler-Batteriespeichern
+      an Versorgerprogrammen und Netzdiensten.
+  BC-3840.50.10:
+    name: BTM-Batterieanmeldung
+    description: |
+      Anmeldung und Einwilligung für die Beteiligung von Hinter-dem-Zähler-Batterien.
+  BC-3840.50.20:
+    name: BTM-Speicherdispatch
+    description: |
+      Dispatchanweisungen an Hinter-dem-Zähler-Speicheranlagen.
+  BC-3840.50.30:
+    name: BTM-Speicherleistungsverfolgung
+    description: |
+      Verfolgung der BTM-Batterieerbringung gegen Versorperverpflichtungen.
+  BC-3840.60:
+    name: DER-Prognose
+    description: |
+      Kurzfristprognose dezentraler Erzeugung und flexibler Last
+      als Beitrag zu Netzbetreiber- und Marktfahrplänen.
+  BC-3840.60.10:
+    name: Hinter-dem-Zähler-Solarprognose
+    description: |
+      Prognose der Hinter-dem-Zähler-PV-Erzeugung auf Feld- und Zonenebene.
+  BC-3840.60.20:
+    name: Flexible Lastprognose
+    description: |
+      Prognose von EV-Lade- und Flexiblelastprofilen.
+  BC-3840.60.30:
+    name: DER-Prognosequalitätsüberwachung
+    description: |
+      Überwachung von Prognosebias und -güte gegen Istwerte.
+  BC-3840.70:
+    name: Mikronetzbetrieb
+    description: |
+      Betrieb von Versorger- und Kundenmikronetzen einschließlich
+      netzsynchronem und Inselbetrieb sowie nahtloser Übergangsteuerung.
+  BC-3840.70.10:
+    name: Mikronetzreglerbetrieb
+    description: |
+      Betrieb von Mikronetzreglern und Dispatch interner Ressourcen.
+  BC-3840.70.20:
+    name: Inselbetriebsübergangsbetrieb
+    description: |
+      Geplante und Notfallübergänge zwischen netzsynchronem und Inselbetrieb.
+  BC-3840.70.30:
+    name: Mikronetz-Resilienzübungen
+    description: |
+      Resilienzübungen und Übergangsübungen für kritische Last-Mikronetze.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-drilling-wells-management.yaml
+++ b/catalogue/i18n/de/L1-drilling-wells-management.yaml
@@ -1,0 +1,160 @@
+locale: de
+source: L1-drilling-wells-management.yaml
+entries:
+  BC-3020:
+    name: Bohrlochs- und Bohrungs-Management
+    description: |
+      Engineering, Ausführung und Lebenszeit-Integrität von Bohrungen - von
+      Bohrloch-Design und Bohroperationen bis zu Komplettierungen, Intervention,
+      Workover und Bohrlochkontrolle.
+  BC-3020.10:
+    name: Bohrloch-Engineering und Design
+    description: |
+      Design von Bohrlocharchitektur, Verrohrung, Steigrohr, Bohrflüssigkeiten und
+      Kostenschätzungen für Bohrprogramme.
+  BC-3020.10.10:
+    name: Bohrlocharchitektur-Design
+    description: |
+      Trajektorie, Bohrloch-Abschnitts- und Gesamtbohrlocharchitektur-Design.
+  BC-3020.10.20:
+    name: Verrohrung- und Steigrohr-Design
+    description: |
+      Verrohrung-, Liner- und Steigrohrstring-Design einschließlich Stress- und Burst-Kollaps-Prüfungen.
+  BC-3020.10.30:
+    name: Bohrflüssigkeits-Design
+    description: |
+      Schlammsystem-Auswahl und Rheologie-Design für Bohrabschnitte.
+  BC-3020.10.40:
+    name: Bohrloch-Kostenschätzung
+    description: |
+      Ausgaben-Genehmigungskostenschätzung für Bohr- und Komplettierungsprogramme.
+  BC-3020.20:
+    name: Bohroperations-Management
+    description: |
+      Ausführung von Bohroperationen einschließlich Koordination, Echtzeit-Monitoring,
+      Richtungsbohrung und Zementierung.
+    in_scope:
+      - Vor-Ort-Bohraufsicht
+      - Echtzeit-Bohrdaten-Monitoring
+      - Richtungsbohrung und Managed-Pressure-Drilling
+      - Zementierungs- und Verrohrungsoperationen
+    out_of_scope:
+      - Bohrloch-Komplettierungsinstallation (BC-3020.30)
+      - Prozesssicherheit auf Bohranlagen (BC-3050)
+  BC-3020.20.10:
+    name: Bohranlagen-Koordination
+    description: |
+      Tägliche Koordination von Bohranlagenoperationen und Auftragnehmeraktivitäten.
+  BC-3020.20.20:
+    name: Echtzeit-Bohrmonitoring
+    description: |
+      Echtzeit-Bohrdaten-Monitoring aus operativen Unterstützungszentren.
+  BC-3020.20.30:
+    name: Richtungsbohrausführung
+    description: |
+      Ausführung von Richtungs-, Horizontal- und Extended-Reach-Bohrungen.
+  BC-3020.20.40:
+    name: Bohrflüssigkeits-Betrieb
+    description: |
+      Schlamm-Engineering, -Behandlung und Feststoffkontrolle beim Bohren.
+  BC-3020.20.50:
+    name: Zementierungsoperationen
+    description: |
+      Primäre und remediale Zementierungsoperationen.
+  BC-3020.30:
+    name: Bohrloch-Komplettierungsmanagement
+    description: |
+      Design und Installation von Komplettierungen einschließlich Perforierungs- und Stimulationsoperationen.
+  BC-3020.30.10:
+    name: Komplettierungs-Design
+    description: |
+      Design von Ober- und Unterkomplettierungen einschließlich Sandkontrolle.
+  BC-3020.30.20:
+    name: Komplettierungsinstallation
+    description: |
+      Einbau und Installation von Komplettierungsstrings und Zubehör.
+  BC-3020.30.30:
+    name: Perforierungsoperationen
+    description: |
+      Perforierungskanonen-Auswahl und Ausführung zur Herstellung von Fließwegen.
+  BC-3020.30.40:
+    name: Stimulationsoperationen
+    description: |
+      Hydraulisches Fracturing, Säurestimulation und andere Stimulationsmaßnahmen.
+  BC-3020.40:
+    name: Bohrloch-Intervention und Workover-Management
+    description: |
+      Lebenszeit-Bohrlochinterventionen von Drahtleinoperationen bis zu vollständigen Workovers.
+  BC-3020.40.10:
+    name: Coiled-Tubing-Operationen
+    description: |
+      Coiled-Tubing-Interventionsoperationen.
+  BC-3020.40.20:
+    name: Drahtlein- und Slickline-Operationen
+    description: |
+      Drahtlein- und Slickline-Datenakquisition und Interventionsoperationen.
+  BC-3020.40.30:
+    name: Workover-Operationen
+    description: |
+      Größere Workover-Operationen an Produktions- und Injektionsbohrungen.
+  BC-3020.40.40:
+    name: Through-Tubing-Intervention
+    description: |
+      Remediale und Stimulations-Interventionen durch das Steigrohr.
+  BC-3020.50:
+    name: Bohrloch-Integritätsmanagement
+    description: |
+      Verifikation und Überwachung von Bohrlochbarrieren über den gesamten Lebenszyklus,
+      einschließlich Ringraumdruck- und Gehäuse-Dauerdruckmanagement.
+  BC-3020.50.10:
+    name: Bohrlochbarrieren-Verifikation
+    description: |
+      Verifikation primärer und sekundärer Bohrlochbarrieren nach Integritätsstandards.
+  BC-3020.50.20:
+    name: Ringraumdruck-Monitoring
+    description: |
+      Kontinuierliches und periodisches Monitoring des Bohrloch-Ringraumdrucks.
+  BC-3020.50.30:
+    name: Bohrloch-Integritätsrisikobewertung
+    description: |
+      Risikobewertung des Bohrloch-Integritätsstatus über das Bohrungsportfolio.
+  BC-3020.50.40:
+    name: Gehäuse-Dauerdruck-Management
+    description: |
+      Diagnose und Management von Gehäuse-Dauerdruckereignissen.
+  BC-3020.60:
+    name: Bohrlochkontroll-Management
+    description: |
+      Prävention und Reaktion auf Bohrlochkontrollereignisse einschließlich Kick-
+      Erkennung, BOP-Betrieb und Bohrlochkontroll-Kompetenz.
+  BC-3020.60.10:
+    name: Kick-Erkennung und Reaktion
+    description: |
+      Kick-Erkennungsmethoden und Bohrlochkontroll-Reaktionsverfahren.
+  BC-3020.60.20:
+    name: BOP-Betrieb
+    description: |
+      Betrieb, Funktionsprüfung und Wartung von Blowout-Preventer-Stacks.
+  BC-3020.60.30:
+    name: Bohrlochkontroll-Kompetenz-Sicherung
+    description: |
+      Koordination von IWCF- und IADC-WellCAP-Kompetenzzertifizierungsprogrammen.
+  BC-3020.70:
+    name: Bohrauftragnehmer-Management
+    description: |
+      Sicherstellung, Leistungsmanagement und vertragliche Überwachung von Bohranlagen- und Dienstleistungsunternehmern.
+  BC-3020.70.10:
+    name: Bohranlagen-Sicherstellung und Audit
+    description: |
+      Vorabnahme- und laufende Prüfung von Bohranlagen und Unternehmern.
+  BC-3020.70.20:
+    name: Bohrauftragnehmer-Leistungsmanagement
+    description: |
+      Leistungsmanagement gegen Bohranlagenverträge und Service-KPIs.
+  BC-3020.70.30:
+    name: Bohrdienstvertrag-Management
+    description: |
+      Management von Bohrdienstleistungsverträgen (Schlamm, Zementierung, Richtungsbohrung etc.).
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-driver-crew-operations-management.yaml
+++ b/catalogue/i18n/de/L1-driver-crew-operations-management.yaml
@@ -1,0 +1,99 @@
+locale: de
+source: L1-driver-crew-operations-management.yaml
+entries:
+  BC-2440:
+    name: Fahrer- und Besatzungsbetrieb-Management
+    description: |
+      Qualifikation, Dienstplanung, Lenk- und Ruhezeitenkonformität, Müdigkeitsmanagement
+      und Leistung von Fahrern und Besatzungen auf der Straße, Schiene, See und in der Luft.
+  BC-2440.10:
+    name: Fahrer- und Besatzungsqualifikations-Management
+    description: |
+      Pflege von Führerscheinen, Genehmigungen, Berechtigungen und Gesundheitsunterlagen
+      für Fahrer und Besatzungen.
+    in_scope:
+      - CDL, STCW, ATPL und vergleichbare Berufsqualifikationen
+      - Medizinische und psychologische Eignungsnachweise
+    out_of_scope:
+      - Allgemeine HR-Daten und Gehaltsabrechnung (BC-300)
+      - Fluglotsen-Kompetenz (BC-1290)
+  BC-2440.10.10:
+    name: Führerschein- und Genehmigungsverfolgung
+    description: |
+      Verfolgung von Berufslizenzen, Genehmigungen und Ablaufdaten.
+  BC-2440.10.20:
+    name: Modusspezifisches Berechtigungs-Management
+    description: |
+      Verwaltung modusspezifischer Berechtigungen wie STCW-Endorsements und Flugzeugtyp-Berechtigungen.
+  BC-2440.10.30:
+    name: Medizinische Eignungszertifizierung
+    description: |
+      Regelmäßige medizinische und körperliche Eignungszertifizierungen für Betriebspersonal.
+  BC-2440.20:
+    name: Dienstplan- und Zeitplanungs-Management
+    description: |
+      Erstellung von Dienstplänen, Wachsystemen und Besatzungspaarungen unter
+      Service- und Regulierungseinschränkungen.
+  BC-2440.20.10:
+    name: Dienstplanungsplanung
+    description: |
+      Planung von Dienstplänen nach Stützpunkt, Depot und Service.
+  BC-2440.20.20:
+    name: Besatzungspaarung und -rotation
+    description: |
+      Paarung und Rotation von Besatzungen bei mehrtägigen oder mehrstufigen Fahrten.
+  BC-2440.20.30:
+    name: Bereitschafts- und Reserve-Management
+    description: |
+      Bereitschafts-, Reserve- und Rufbereitschafts-Regelungen.
+  BC-2440.30:
+    name: Lenk- und Ruhezeiten sowie Müdigkeitsmanagement
+    description: |
+      Einhaltung von Lenk- und Ruhezeiten und Betrieb von Müdigkeitsrisikomanagementsystemen.
+  BC-2440.30.10:
+    name: Lenk- und Ruhezeitenkonformität
+    description: |
+      Aufzeichnung und Durchsetzung von HOS-Grenzen über Fahrtenschreiber, ELD und Äquivalente.
+  BC-2440.30.20:
+    name: Müdigkeitsrisiko-Management
+    description: |
+      Betrieb von Müdigkeitsmanagementsystemen und biomathematischer Modellierung.
+  BC-2440.30.30:
+    name: Ruhezeitdurchsetzung
+    description: |
+      Durchsetzung von Pflichtruhezeiten, Übernachtungen und Wochengrenzen.
+  BC-2440.40:
+    name: Fahrer- und Besatzungsleistungs-Management
+    description: |
+      Leistungsbewertung, Coaching und Vorfallbehandlung für Fahrer und Besatzungen.
+  BC-2440.40.10:
+    name: Fahrer- und Besatzungsleistungs-Scoring
+    description: |
+      Bewertung des Betriebspersonals nach Sicherheits-, Kraftstoff- und Service-KPIs.
+  BC-2440.40.20:
+    name: Coaching und wiederkehrende Schulung
+    description: |
+      Coaching, Auffrischungskurse und Korrekturschulungen.
+  BC-2440.40.30:
+    name: Vorfall- und Verstoß-Management
+    description: |
+      Verfolgung und Lösung von Betriebsvorfällen und Regelverstößen.
+  BC-2440.50:
+    name: Besatzungsreise- und -unterkunfts-Management
+    description: |
+      Besatzungsreisen, Unterkünfte und Besatzungswechsel-Logistik für See-, Luft- und Schienenrotationen.
+  BC-2440.50.10:
+    name: Besatzungsreise-Buchung
+    description: |
+      Buchung von Positionierungsreisen für Besatzungsrotationen.
+  BC-2440.50.20:
+    name: Besatzungsunterkunfts-Management
+    description: |
+      Hotel- und Unterkunftsmanagement für Übernachtungen und Rotationen.
+  BC-2440.50.30:
+    name: Besatzungswechsel-Koordination
+    description: |
+      Koordination von Besatzungswechseln in Häfen, Flughäfen und Depots.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-drug-development-management.yaml
+++ b/catalogue/i18n/de/L1-drug-development-management.yaml
@@ -1,0 +1,118 @@
+locale: de
+source: L1-drug-development-management.yaml
+entries:
+  BC-1510:
+    name: Arzneimittelentwicklungs-Management
+    description: |
+      Präklinische und klinische Entwicklung über alle Phasen.
+  BC-1510.10:
+    name: Präklinische-Entwicklungs-Management
+    description: |
+      Präklinische Pharmakologie, Toxikologie und ADME.
+  BC-1510.10.10:
+    name: Präklinische Pharmakologie
+    description: |
+      Präklinische Pharmakologiestudien und -modellierung.
+  BC-1510.10.20:
+    name: Präklinische Toxikologie
+    description: |
+      GLP-Toxikologiestudien zur Sicherheitsbewertung.
+  BC-1510.10.30:
+    name: ADME- und PK-Studien
+    description: |
+      ADME- und pharmakokinetische Studien.
+  BC-1510.10.40:
+    name: Präklinische Bioanalytik
+    description: |
+      Bioanalytische Methodenentwicklung und Analyse.
+  BC-1510.20:
+    name: Phase-I-Klinische-Entwicklungsmanagement
+    description: |
+      First-in-Human, Sicherheit und PK/PD.
+  BC-1510.20.10:
+    name: First-in-Human-Studiendurchführung
+    description: |
+      Planung und Durchführung von First-in-Human-Studien.
+  BC-1510.20.20:
+    name: Phase-I-Sicherheitsüberwachung
+    description: |
+      Sicherheitsüberwachung und Dosiseskalation in Phase I.
+  BC-1510.20.30:
+    name: Klinische PK/PD-Modellierung
+    description: |
+      Klinische PK/PD-Modellierung und Dosisauswahl.
+  BC-1510.30:
+    name: Phase-II-Klinische-Entwicklungsmanagement
+    description: |
+      Konzeptnachweis und Dosistitration.
+  BC-1510.30.10:
+    name: Phase-II-Konzeptnachweis-Studien
+    description: |
+      Durchführung von Konzeptnachweis-Studien.
+  BC-1510.30.20:
+    name: Phase-II-Dosistitrations-Studien
+    description: |
+      Dosistitrations- und Dosis-Wirkungs-Studien.
+  BC-1510.30.30:
+    name: Phase-II-Adaptive-Studienoperationen
+    description: |
+      Betrieb adaptiver Phase-II-Designs.
+  BC-1510.40:
+    name: Phase-III-Klinische-Entwicklungsmanagement
+    description: |
+      Pivotalstudien und Zulassungsstudien.
+  BC-1510.40.10:
+    name: Phase-III-Studiendurchführung
+    description: |
+      Durchführung von Phase-III-Pivotalstudien.
+  BC-1510.40.20:
+    name: Pivotalstudie-Statistische-Analyse
+    description: |
+      Statistische Analyse von Pivotalstudien gemäß ICH E9.
+  BC-1510.40.30:
+    name: Pivotalstudie-Berichterstattung
+    description: |
+      Berichterstattung und Offenlegung von Pivotalstudien-Ergebnissen.
+  BC-1510.50:
+    name: Phase-IV-Nachmarketing-Entwicklungsmanagement
+    description: |
+      Nachmarketing-Studien und Real-World-Evidenz.
+  BC-1510.50.10:
+    name: Nachmarketing-Verpflichtungsstudien
+    description: |
+      Durchführung von Nachmarketing-Verpflichtungs- und Anforderungsstudien.
+  BC-1510.50.20:
+    name: Real-World-Evidenz-Generierung
+    description: |
+      Generierung von Real-World-Evidenz und Beobachtungsstudien.
+  BC-1510.50.30:
+    name: Lebenszyklus-Indikationserweiterung
+    description: |
+      Lebenszyklusentwicklung und Indikationserweiterung.
+  BC-1510.60:
+    name: CMC-Entwicklungsmanagement
+    description: |
+      Entwicklung von Chemie, Herstellung und Kontrolle.
+  BC-1510.60.10:
+    name: Wirkstoff-Entwicklung
+    description: |
+      Entwicklung der Wirkstoffsynthese und des Herstellungsprozesses.
+  BC-1510.60.20:
+    name: Arzneimittelprodukt-Entwicklung
+    description: |
+      Entwicklung von Darreichungsform und Arzneimittelproduktformulierung.
+  BC-1510.60.30:
+    name: Analytische-Methoden-Entwicklung
+    description: |
+      Entwicklung und Validierung analytischer Methoden.
+  BC-1510.60.40:
+    name: Stabilitätsprogramm-Management
+    description: |
+      Stabilitätsprogramm gemäß ICH Q1.
+  BC-1510.60.50:
+    name: Prozessvalidierung
+    description: |
+      Prozessvalidierung gemäß ICH Q7–Q12.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-drug-discovery-management.yaml
+++ b/catalogue/i18n/de/L1-drug-discovery-management.yaml
@@ -1,0 +1,118 @@
+locale: de
+source: L1-drug-discovery-management.yaml
+entries:
+  BC-1500:
+    name: Arzneimittelforschungs-Management
+    description: |
+      Zielidentifikation, Hit-to-Lead und Lead-Optimierung.
+  BC-1500.10:
+    name: Zielidentifikations- und Validierungsmanagement
+    description: |
+      Krankheitsbiologie, Zielidentifikation und -validierung.
+  BC-1500.10.10:
+    name: Krankheitsbiologie-Forschung
+    description: |
+      Forschung zu Krankheitsmechanismen und -signalwegen.
+  BC-1500.10.20:
+    name: Zielidentifikation
+    description: |
+      Identifikation biologischer Ziele durch Omics und Genetik.
+  BC-1500.10.30:
+    name: Zielvalidierung
+    description: |
+      Validierung von Zielen durch In-vitro- und In-vivo-Modelle.
+  BC-1500.10.40:
+    name: Ziel-Wirkstoffeignungs-Bewertung
+    description: |
+      Bewertung der Wirkstoffeignung und Erreichbarkeit von Zielen.
+  BC-1500.20:
+    name: Hit-Entdeckungs-Management
+    description: |
+      Hochdurchsatz-Screening, virtuelles Screening und Hit-Identifikation.
+  BC-1500.20.10:
+    name: Assay-Entwicklung
+    description: |
+      Entwicklung biochemischer und zellulärer Assays.
+  BC-1500.20.20:
+    name: Hochdurchsatz-Screening
+    description: |
+      Durchführung von Hochdurchsatz-Screening-Kampagnen.
+  BC-1500.20.30:
+    name: Virtuelles und KI-gestütztes Screening
+    description: |
+      Virtuelles Screening und KI-gestützte Hit-Identifikation.
+  BC-1500.20.40:
+    name: Hit-Triage und -Bestätigung
+    description: |
+      Triage, Bestätigung und Priorisierung von Screening-Hits.
+  BC-1500.30:
+    name: Lead-Optimierungs-Management
+    description: |
+      Medizinalchemie, SAR und Lead-Optimierung.
+  BC-1500.30.10:
+    name: Medizinalchemie-Synthese
+    description: |
+      Medizinalchemische Synthese und Wirkstoffdesign.
+  BC-1500.30.20:
+    name: Struktur-Aktivitäts-Beziehungsanalyse
+    description: |
+      SAR-Analyse zur Steuerung der strukturellen Optimierung.
+  BC-1500.30.30:
+    name: ADMET-Profiling
+    description: |
+      In-vitro-ADMET-Profiling von Optimierungsserien.
+  BC-1500.30.40:
+    name: Lead-Serienauswahl
+    description: |
+      Auswahl von Lead-Serien aus Optimierungskampagnen.
+  BC-1500.40:
+    name: Präklinische-Kandidatenauswahl-Management
+    description: |
+      Kandidatenauswahl und IND-vorbereitende Studien.
+  BC-1500.40.10:
+    name: Präklinische-Kandidaten-Profiling
+    description: |
+      Profiling präklinischer Kandidaten gegenüber dem Zielproduktprofil.
+  BC-1500.40.20:
+    name: Kandidatennominierung-Governance
+    description: |
+      Governance und Nominierung präklinischer Kandidaten.
+  BC-1500.40.30:
+    name: IND-Vorbereitende-Studien-Koordination
+    description: |
+      Koordination von IND-vorbereitenden Toxikologie- und Sicherheitsstudien.
+  BC-1500.50:
+    name: Translationale-Forschungs-Management
+    description: |
+      Translationale Wissenschaft und Biomarker-Entwicklung.
+  BC-1500.50.10:
+    name: Translationale Wissenschaft
+    description: |
+      Translationale Wissenschaft als Brücke zwischen Forschung und klinischer Entwicklung.
+  BC-1500.50.20:
+    name: Biomarker-Entdeckung und -Entwicklung
+    description: |
+      Entdeckung und Entwicklung von Biomarkern.
+  BC-1500.50.30:
+    name: Patientenstratifizierungsstrategie
+    description: |
+      Patientenstratifizierungsstrategien für das Studiendesign.
+  BC-1500.60:
+    name: Substanz- und Bibliotheks-Management
+    description: |
+      Substanzbibliotheken, Proben und Depot-Management.
+  BC-1500.60.10:
+    name: Substanzbibliotheks-Pflege
+    description: |
+      Pflege und Registrierung von Substanzbibliotheken.
+  BC-1500.60.20:
+    name: Proben- und Depot-Management
+    description: |
+      Probenlagerung, -entnahme und Rückverfolgbarkeit.
+  BC-1500.60.30:
+    name: Reagenzien- und Biomaterial-Management
+    description: |
+      Verwaltung von Reagenzien und biologischen Materialien.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-education-compliance-regulatory-reporting-management.yaml
+++ b/catalogue/i18n/de/L1-education-compliance-regulatory-reporting-management.yaml
@@ -1,0 +1,160 @@
+locale: de
+source: L1-education-compliance-regulatory-reporting-management.yaml
+entries:
+  BC-4810:
+    name: Bildungskonformität und Regulatorisches Berichtswesen
+    description: |
+      Bildungssektorspezifische Regulierungskonformität und gesetzliches Berichtswesen,
+      einschließlich Datenschutz für Studierende, Bürgerrechtsregimes, gesetzliche
+      Sonderpädagogikpflichten, internationale Studierendenvisums-Compliance und
+      Compliance für öffentliche Finanzierung. Ergänzt das branchenübergreifende
+      Compliance-Management für allgemeine Regulierungspflichten.
+  BC-4810.10:
+    name: Compliance für Studierendendatenschutz
+    description: |
+      Compliance mit bildungssektorspezifischen Datenschutzregimes für Studierende,
+      einschließlich FERPA, COPPA und gleichwertigen Regimes.
+    in_scope:
+      - FERPA-Compliance-Betrieb
+      - COPPA-Compliance-Betrieb
+      - Management von Studierendendaten-Weitergabevereinbarungen
+    out_of_scope:
+      - Allgemeiner Datenschutz (abgedeckt unter branchenübergreifendem Informations- und Datenmanagement)
+  BC-4810.10.10:
+    name: FERPA-Compliance-Betrieb
+    description: |
+      Tägliche FERPA-Compliance, Einwilligungen und Offenlegungen.
+  BC-4810.10.20:
+    name: COPPA-Compliance-Betrieb
+    description: |
+      COPPA-Compliance für Dienste, die sich an Kinder unter 13 Jahren richten.
+  BC-4810.10.30:
+    name: Management von Studierendendaten-Weitergabevereinbarungen
+    description: |
+      Verhandlung und Management von Studierendendaten-Weitergabevereinbarungen
+      mit Anbietern.
+  BC-4810.20:
+    name: Gesetzliches Bildungsberichtswesen
+    description: |
+      Einreichung gesetzlicher Bildungsstatistiken und Leistungsmeldungen an
+      nationale, staatliche und lokale Behörden.
+    in_scope:
+      - Nationale Statistikeinreichung (z. B. IPEDS, HESA)
+      - Staatliche und lokale Bildungsbehördenmeldungen
+      - Finanzierungs- und Leistungsoffenlegung
+    out_of_scope:
+      - Internes Leistungsberichtswesen (abgedeckt unter Akademische Qualität & Akkreditierungsmanagement)
+  BC-4810.20.10:
+    name: Nationale Statistikeinreichung
+    description: |
+      Einreichung von Meldungen bei nationalen Bildungsstatistikbehörden.
+  BC-4810.20.20:
+    name: Staatliche und lokale Bildungsbehördenmeldungen
+    description: |
+      Meldungen an staatliche, provinciale und lokale Bildungsbehörden.
+  BC-4810.20.30:
+    name: Finanzierungs- und Leistungsoffenlegung
+    description: |
+      Öffentliche Offenlegung von Finanzierungsverwendung und
+      Bildungsleistungskennzahlen.
+  BC-4810.30:
+    name: Bürgerrechts-Compliance
+    description: |
+      Compliance mit bildungsspezifischen Bürgerrechtsregimes einschließlich
+      Title IX, Section 504 und ADA im akademischen Kontext.
+    in_scope:
+      - Title-IX-Untersuchung und -Berichtswesen
+      - Section-504/ADA-Compliance
+      - Durchsetzung von Nichtdiskriminierungsrichtlinien
+    out_of_scope:
+      - Tägliche Nachteilsausgleiche (abgedeckt unter Studierendenbetreuung & Wohlbefindenmanagement)
+  BC-4810.30.10:
+    name: Title-IX-Untersuchung und -Berichtswesen
+    description: |
+      Title-IX-Aufnahme, Untersuchung, Anhörung und gesetzliches Berichtswesen.
+  BC-4810.30.20:
+    name: Section-504/ADA-Compliance
+    description: |
+      Section-504- und ADA-Compliance im akademischen und Zulassungskontext.
+  BC-4810.30.30:
+    name: Durchsetzung von Nichtdiskriminierungsrichtlinien
+    description: |
+      Durchsetzung von Bildungsnichtdiskriminierungsrichtlinien und
+      Beschwerdebearbeitung.
+  BC-4810.40:
+    name: Sonderpädagogik-Compliance
+    description: |
+      Compliance mit gesetzlichen Sonderpädagogikregimes für schulpflichtige
+      und Frühförderungspopulationen.
+    in_scope:
+      - IDEA-Teil-B-Compliance
+      - IDEA-Teil-C-/Frühförderungs-Compliance
+      - Gleichwertige SEN/ALN-gesetzliche Compliance
+    out_of_scope:
+      - Bereitstellung von Sonderpädagogikdiensten (abgedeckt unter Studierendenbetreuung & Wohlbefindenmanagement)
+  BC-4810.40.10:
+    name: IDEA-Teil-B-Compliance
+    description: |
+      IDEA-Teil-B-Gesetzliche Compliance für schulpflichtige Sonderpädagogik.
+  BC-4810.40.20:
+    name: IDEA-Teil-C-/Frühförderungs-Compliance
+    description: |
+      IDEA-Teil-C-Compliance für Frühförderungsdienste.
+  BC-4810.40.30:
+    name: Gleichwertige SEN-ALN-Gesetzliche Compliance
+    description: |
+      Gleichwertige SEN-, ALN- und inklusive Bildungs-Gesetzliche Compliance
+      außerhalb der USA.
+  BC-4810.50:
+    name: Internationale Studierenden-Compliance
+    description: |
+      Visumssponsoring-Compliance und gesetzliche Nachverfolgung internationaler
+      Studierender unter Regimes wie SEVIS und der britischen Student Route.
+    in_scope:
+      - SEVIS-/I-20-Compliance-Betrieb
+      - Studierendenvisum-Berichtswesen (UK Student Route, Äquivalente)
+      - Nachverfolgung und Berichtswesen für internationale Studierende
+    out_of_scope:
+      - Erstmalige Ausstellung von Visumssponsoring-Dokumenten (abgedeckt unter Studierendengewinnung & Zulassungsmanagement)
+  BC-4810.50.10:
+    name: SEVIS-/I-20-Compliance-Betrieb
+    description: |
+      Täglicher SEVIS- und I-20-Compliance-Betrieb für US-gesponserte Studierende.
+  BC-4810.50.20:
+    name: Studierendenvisum-Berichtswesen
+    description: |
+      Gesetzliches Berichtswesen für gesponserte Studierende unter nicht-US-amerikanischen
+      Visumregimes.
+  BC-4810.50.30:
+    name: Internationale Studierendennachverfolgung
+    description: |
+      Nachverfolgung des Status, der Anwesenheit und Adresse internationaler
+      Studierender gemäß Sponsoring-Pflichten.
+  BC-4810.60:
+    name: Title-IV und öffentliche Finanzierungs-Compliance
+    description: |
+      Compliance mit öffentlichen Studienförderungs- und Bildungsfinanzierungs-
+      regimes, einschließlich Title IV in den USA und gleichwertigen Regimes.
+    in_scope:
+      - Title-IV-Berechtigung und Auszahlungs-Compliance
+      - Fondsrückgabe und Förderungsabstimmung
+      - Öffentliche Finanzierungsprüfungsreaktion
+    out_of_scope:
+      - Vergabe von Finanzierungsangeboten (abgedeckt unter Studierendengewinnung & Zulassungsmanagement)
+  BC-4810.60.10:
+    name: Title-IV-Berechtigungs- und Auszahlungs-Compliance
+    description: |
+      Title-IV-Institutionsberechtigung und Studienförderungs-Auszahlungs-Compliance.
+  BC-4810.60.20:
+    name: Fondsrückgabe und Förderungsabstimmung
+    description: |
+      Abstimmung und Rückgabe nicht verdienter Förderungen gemäß
+      Finanzierungsregimes.
+  BC-4810.60.30:
+    name: Öffentliche Finanzierungsprüfungsreaktion
+    description: |
+      Reaktion auf Prüfungen und Überprüfungen öffentlicher Studienförderungs-
+      und Bildungsfinanzierung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-educational-content-learning-resource-management.yaml
+++ b/catalogue/i18n/de/L1-educational-content-learning-resource-management.yaml
@@ -1,0 +1,156 @@
+locale: de
+source: L1-educational-content-learning-resource-management.yaml
+entries:
+  BC-4790:
+    name: Lehrinhalt- und Lernressourcenmanagement
+    description: |
+      Erstellung, Katalogisierung, Lizenzierung und Bereitstellung von Lehrinhalten
+      und Lernressourcen für den Unterricht, einschließlich Kursmaterialien, digitaler
+      Lernobjekte, offener Bildungsressourcen, Bibliothekssammlungen und Lehrbücher.
+  BC-4790.10:
+    name: Kursmaterialerstellung und -produktion
+    description: |
+      Instruktionsdesign und Produktion von Kursmaterialien, einschließlich
+      Multimedia-Inhalten und Kurspaketen.
+    in_scope:
+      - Instruktionsdesign
+      - Multimedia-Inhaltsproduktion
+      - Kurspaket-Zusammenstellung
+    out_of_scope:
+      - Unterrichtsdurchführung (abgedeckt unter Lehr- und Lernbetriebsmanagement)
+  BC-4790.10.10:
+    name: Instruktionsdesign
+    description: |
+      Instruktionsdesign von Kursen, Modulen und Lernerfahrungen.
+  BC-4790.10.20:
+    name: Multimedia-Inhaltsproduktion
+    description: |
+      Produktion von Video-, Audio- und interaktiven Multimedia-Lerninhalten.
+  BC-4790.10.30:
+    name: Kurspaket-Zusammenstellung
+    description: |
+      Zusammenstellung von Kurspaketen und Lernbündeln für die Bereitstellung.
+  BC-4790.20:
+    name: Digitaler Lernobjekt-Katalog
+    description: |
+      Katalogisierung, Versionierung und Wiederverwendung digitaler Lernobjekte
+      über Programme und Modalitäten hinweg.
+    in_scope:
+      - Lernobjekt-Katalogisierung und Metadaten
+      - Lernobjekt-Versionierung
+      - Wiederverwendbare Objekt-Entdeckung und -Wiederverwendung
+    out_of_scope:
+      - Operativer LMS-Betrieb (abgedeckt unter Lehr- und Lernbetriebsmanagement)
+  BC-4790.20.10:
+    name: Lernobjekt-Katalogisierung und Metadaten
+    description: |
+      Katalogisierung von Lernobjekten und Metadaten gemäß Interoperabilitätsstandards.
+  BC-4790.20.20:
+    name: Lernobjekt-Versionierung
+    description: |
+      Versionierung und Lebenszyklusmanagement von Lernobjekten.
+  BC-4790.20.30:
+    name: Wiederverwendbare Objekt-Entdeckung und -Wiederverwendung
+    description: |
+      Entdeckung und Wiederverwendung von Lernobjekten über Kurse und
+      Disziplinen hinweg.
+  BC-4790.30:
+    name: Management offener Bildungsressourcen
+    description: |
+      Beschaffung, Lizenzierung und Beitrag offener Bildungsressourcen (OER)
+      für den Unterricht.
+    in_scope:
+      - OER-Beschaffung und -Kuratierung
+      - OER-Lizenz-Compliance
+      - OER-Beitrag und -Teilen
+    out_of_scope:
+      - Kommerzielle Lehrbuchbeschaffung (abgedeckt unter Lehrbuch- und Kursmaterialbeschaffung)
+  BC-4790.30.10:
+    name: OER-Beschaffung und -Kuratierung
+    description: |
+      Beschaffung und Kuratierung offener Bildungsressourcen für den
+      institutionellen Einsatz.
+  BC-4790.30.20:
+    name: OER-Lizenz-Compliance
+    description: |
+      Compliance mit OER-Lizenzen (z. B. Creative Commons) bei Nutzung
+      und Wiederverwendung.
+  BC-4790.30.30:
+    name: OER-Beitrag und -Teilen
+    description: |
+      Beitrag institutionell erstellter Inhalte zum OER-Ökosystem.
+  BC-4790.40:
+    name: Bibliotheks- und Informationsressourcenbetrieb
+    description: |
+      Bibliothekssammlungsentwicklung, Leselistenmanagement und
+      Informationskompetenzunterstützung für Lehre und Forschung.
+    in_scope:
+      - Sammlungsentwicklung
+      - Leselisten- und Reservierungsmanagement
+      - Informationskompetenzunterstützung
+    out_of_scope:
+      - Öffentliche Bibliotheksbetriebe, die nicht Teil der Bildungsbereitstellung sind
+  BC-4790.40.10:
+    name: Sammlungsentwicklung
+    description: |
+      Entwicklung von Bibliotheks-Druck- und elektronischen Sammlungen.
+  BC-4790.40.20:
+    name: Leselisten- und Reservierungsmanagement
+    description: |
+      Verwaltung von Kursleselisten und Reservierungssammlungen.
+  BC-4790.40.30:
+    name: Informationskompetenzunterstützung
+    description: |
+      Unterstützung und Unterricht in Informationskompetenz und Recherchefähigkeiten.
+  BC-4790.50:
+    name: Inhaltslizenzierung und Rechteverwaltung
+    description: |
+      Lizenzierung, Urheberrechtsgenehmigung und Management von Bildungsausnahmen
+      für die Nutzung von Drittanbieterinhalten im Unterricht.
+    in_scope:
+      - Lizenzierung von Bildungsinhalten
+      - Urheberrechtsgenehmigung
+      - Management von Fair-Use- und Bildungsausnahmen
+    out_of_scope:
+      - Institutionelles geistiges Eigentum (abgedeckt unter branchenübergreifendem Intellectual-Property-Management)
+  BC-4790.50.10:
+    name: Lizenzierung von Bildungsinhalten
+    description: |
+      Lizenzierung von Drittanbieterinhalten für den Bildungseinsatz.
+  BC-4790.50.20:
+    name: Urheberrechtsgenehmigung
+    description: |
+      Genehmigung von Urheberrechten für Inhalte, die im Unterricht und in
+      Prüfungen verwendet werden.
+  BC-4790.50.30:
+    name: Fair-Use und Bildungsausnahmenmanagement
+    description: |
+      Management von Fair-Use-, Fair-Dealing- und urheberrechtlichen
+      Bildungsausnahmen.
+  BC-4790.60:
+    name: Lehrbuch- und Kursmaterialbeschaffung
+    description: |
+      Spezifikation und Beschaffung von Lehrbüchern und Kursmaterialien,
+      einschließlich Programmen für erschwingliche Materialien.
+    in_scope:
+      - Spezifikation der Pflichtliteratur
+      - Lehrbuchbeschaffung
+      - Programme für erschwingliche Materialien (z. B. inklusive Zugangsprogramme)
+    out_of_scope:
+      - Allgemeine Beschaffung (abgedeckt unter branchenübergreifendem Beschaffungsmanagement)
+  BC-4790.60.10:
+    name: Spezifikation der Pflichtliteratur
+    description: |
+      Spezifikation von Pflicht- und empfohlener Literatur für Kurse.
+  BC-4790.60.20:
+    name: Lehrbuchbeschaffung
+    description: |
+      Beschaffung von Lehrbüchern und Kursmaterialien.
+  BC-4790.60.30:
+    name: Programm für erschwingliche Materialien
+    description: |
+      Betrieb von Programmen für erschwingliche Materialien und inklusive
+      Zugangsprogramme.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-educator-workforce-management.yaml
+++ b/catalogue/i18n/de/L1-educator-workforce-management.yaml
@@ -1,0 +1,180 @@
+locale: de
+source: L1-educator-workforce-management.yaml
+entries:
+  BC-4760:
+    name: Lehrpersonal-Workforce-Management
+    description: |
+      Lebenszyklusmanagement akademischer und Lehrpersonen spezifisch für das
+      Bildungswesen, umfassend Rekrutierung, Qualifikationsnachweise, Festanstellung
+      und Beförderung, Lehrbelastungszuweisung, berufliche Entwicklung sowie
+      Management von Honorar-/Lehrbeauftragten. Ergänzt das branchenübergreifende
+      Personalmanagement für allgemeine HR-Aufgaben.
+  BC-4760.10:
+    name: Professurenrekrutierung und -berufung
+    description: |
+      Definition, Suche, Auswahl und Berufung akademischer Lehrpersonen,
+      einschließlich spezialisierter akademischer Suchpraktiken.
+    in_scope:
+      - Definition von Lehrpositionen
+      - Suche und Auswahl von Lehrpersonen
+      - Berufung und Einführung von Lehrpersonen
+    out_of_scope:
+      - Allgemeine Personalrekrutierung (abgedeckt unter branchenübergreifendem Personalmanagement)
+  BC-4760.10.10:
+    name: Definition von Lehrpositionen
+    description: |
+      Definition von Lehrpositionen, Rängen und fachlichen Schwerpunkten.
+  BC-4760.10.20:
+    name: Lehrpersonensuche und -auswahl
+    description: |
+      Betrieb akademischer Suchausschüsse und Auswahl von Lehrpersonenkandidaten.
+  BC-4760.10.30:
+    name: Lehrpersonenberufung und -einführung
+    description: |
+      Berufung, Vertragsabschluss und akademische Einführung neuer Lehrpersonen.
+  BC-4760.20:
+    name: Akademische Qualifikationsnachweise und -verifizierung
+    description: |
+      Verifizierung und laufende Pflege akademischer und beruflicher
+      Qualifikationsnachweise sowie fachlicher Kompetenzen der Lehrpersonen.
+    in_scope:
+      - Verifizierung von Lehrpersonenqualifikationen
+      - Fachliche Qualifikationsnachweise
+      - Laufende Pflege von Qualifikationsnachweisen
+    out_of_scope:
+      - Branchenübergreifende Mitarbeiterzertifizierungen (abgedeckt unter branchenübergreifendem Personalmanagement)
+  BC-4760.20.10:
+    name: Lehrpersonenqualifikationsverifizierung
+    description: |
+      Verifizierung von Abschlüssen, Zertifikaten und Lizenzen der Lehrpersonen.
+  BC-4760.20.20:
+    name: Fachliche Qualifikationsnachweise
+    description: |
+      Qualifikationsnachweise für Lehrpersonen gegenüber fachlichen und
+      pädagogischen Kompetenzen.
+  BC-4760.20.30:
+    name: Laufende Qualifikationspflege
+    description: |
+      Nachverfolgung laufender beruflicher Qualifikationsnachweise und Verlängerungen.
+  BC-4760.30:
+    name: Festanstellungs- und Beförderungsmanagement
+    description: |
+      Verwaltung von Festanstellungsverläufen, Festanstellungsentscheidungen und
+      akademischen Beförderungsprozessen.
+    in_scope:
+      - Management von Festanstellungsverläufen und Probezeiten
+      - Festanstellungsüberprüfung und -entscheidung
+      - Beförderungsüberprüfung und -entscheidung
+    out_of_scope:
+      - Allgemeines Leistungsmanagement (abgedeckt unter branchenübergreifendem Personalmanagement)
+  BC-4760.30.10:
+    name: Festanstellungsverlauf und Probezeit
+    description: |
+      Management des Festanstellungsfortschritts und der Probezeiten.
+  BC-4760.30.20:
+    name: Festanstellungsüberprüfung und -entscheidung
+    description: |
+      Festanstellungsüberprüfungsausschussverfahren und abschließende
+      Festanstellungsentscheidungen.
+  BC-4760.30.30:
+    name: Beförderungsüberprüfung und -entscheidung
+    description: |
+      Akademische Beförderungsüberprüfung und Entscheidungsfindung über
+      Lehrpersonenränge.
+  BC-4760.40:
+    name: Lehrbelastungs- und Arbeitslastmanagement
+    description: |
+      Zuweisung und Ausgleich von Lehr-, Forschungs- und Dienstarbeitslast sowie
+      Planung akademischer Beurlaubung einschließlich Forschungsfreisemester.
+    in_scope:
+      - Zuweisung von Lehraufträgen
+      - Arbeitslastausgleich zwischen Lehre, Forschung und Dienst
+      - Planung von Forschungsfreisemestern und akademischen Beurlaubungen
+    out_of_scope:
+      - Allgemeine HR-Urlaubsverwaltung (abgedeckt unter branchenübergreifendem Personalmanagement)
+  BC-4760.40.10:
+    name: Lehrauftragszuweisung
+    description: |
+      Zuweisung von Lehraufträgen an Lehrpersonen und Dozierende.
+  BC-4760.40.20:
+    name: Arbeitslastausgleich
+    description: |
+      Ausgleich von Lehr-, Forschungs- und Dienstverpflichtungen über
+      Lehrpersonen hinweg.
+  BC-4760.40.30:
+    name: Forschungsfreisemester und Beurlaubungsplanung
+    description: |
+      Planung von Forschungsfreisemestern und akademischen Beurlaubungsvertretungen.
+  BC-4760.50:
+    name: Akademische Berufsentwicklung
+    description: |
+      Pädagogische, disziplinäre und einführungsorientierte Berufsentwicklung
+      für akademische und Lehrpersonen.
+    in_scope:
+      - Entwicklung von Pädagogik und Lehrpraxis
+      - Fachliche Disziplinentwicklung
+      - Mentoring und Einführung von Lehrpersonen
+    out_of_scope:
+      - Allgemeines Lernen und Entwicklung (abgedeckt unter branchenübergreifendem Personalmanagement)
+  BC-4760.50.10:
+    name: Pädagogik und Lehrpraxisentwicklung
+    description: |
+      Entwicklung pädagogischer und lehrpraktischer Kompetenzen der Lehrpersonen.
+  BC-4760.50.20:
+    name: Fachliche Disziplinentwicklung
+    description: |
+      Entwicklung von Fach- und Disziplinexpertise.
+  BC-4760.50.30:
+    name: Lehrpersonenmentoring und -einführung
+    description: |
+      Mentoring- und Einführungsprogramme für neue Lehrpersonen.
+  BC-4760.60:
+    name: Lehrpersonenleistung und Peer-Review
+    description: |
+      Lehrpersonenspezifische Leistungsüberprüfung einschließlich Unterrichts-
+      beobachtung, Peer-Review und akademischer Anerkennung.
+    in_scope:
+      - Unterrichtsbeobachtung und Peer-Review
+      - Jährliche Leistungsüberprüfung von Lehrpersonen
+      - Anerkennung und Auszeichnungen für Lehrpersonen
+    out_of_scope:
+      - Allgemeines Mitarbeiterleistungsmanagement (abgedeckt unter branchenübergreifendem Personalmanagement)
+  BC-4760.60.10:
+    name: Unterrichtsbeobachtung und Peer-Review
+    description: |
+      Unterrichtsbeobachtung und Peer-Review der Lehrpersonenpraxis.
+  BC-4760.60.20:
+    name: Jährliche Leistungsüberprüfung
+    description: |
+      Jährliche Leistungsüberprüfung akademischer und Lehrpersonen.
+  BC-4760.60.30:
+    name: Lehrpersonenanerkennung und -auszeichnungen
+    description: |
+      Anerkennungs- und Auszeichnungsprogramme für Lehrpersonen.
+  BC-4760.70:
+    name: Honorar- und Lehrbeauftragtenmanagement
+    description: |
+      Management von Teilzeit-, Honorar- und Lehrbeauftragten einschließlich
+      Beschaffung, Vertragsabschluss und Qualitätssicherung.
+    in_scope:
+      - Beschaffung eines Honorarkraftpools
+      - Vertragsverwaltung für Lehrbeauftragte
+      - Integration und Qualitätssicherung von Honorarkräften
+    out_of_scope:
+      - Allgemeines Auftragnehmer-Management (abgedeckt unter branchenübergreifendem Lieferantenmanagement)
+  BC-4760.70.10:
+    name: Beschaffung des Honorarkraftpools
+    description: |
+      Beschaffung und Pflege eines aktiven Pools von Honorarlehrenden.
+  BC-4760.70.20:
+    name: Lehrbeauftragtenvertragsverwaltung
+    description: |
+      Verwaltung von Lehrbeauftragten- und Honorarverträgen.
+  BC-4760.70.30:
+    name: Integration und Qualitätssicherung von Honorarkräften
+    description: |
+      Integration von Honorarkräften in akademische Normen und laufende
+      Qualitätssicherung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-electoral-administration-management.yaml
+++ b/catalogue/i18n/de/L1-electoral-administration-management.yaml
@@ -1,0 +1,150 @@
+locale: de
+source: L1-electoral-administration-management.yaml
+entries:
+  BC-3330:
+    name: Wahlverwaltung
+    description: |
+      Verwaltung von Wahlen einschließlich Wählerregistrierung, Wahlkreisverwaltung,
+      Kandidaten- und Parteiregistrierung, Stimmzettelgestaltung und -produktion,
+      Wahllokal-Betrieb, Stimmenauszählung und Ergebnistabellierung sowie
+      Wahlkampffinanzierungs-Offenlegung.
+  BC-3330.10:
+    name: Wählerregistrierungs-Verwaltung
+    description: |
+      Pflege autoritativer Wählerlisten einschließlich Registrierung,
+      Adressänderungen und Listenpflegemaßnahmen.
+    in_scope:
+      - Wählereinschreibung und Neuregistrierung
+      - Wählerlistenpflege
+      - Berechtigungsverifikation
+    out_of_scope:
+      - Personenstands-Identitätsregistrierung (durch Personenstandsregister und Identitätsverwaltung abgedeckt)
+  BC-3330.10.10:
+    name: Wählereinschreibung
+    description: |
+      Einschreibung wahlberechtigter Wähler in das Wählerverzeichnis über alle Kanäle.
+  BC-3330.10.20:
+    name: Wählerlistenpflege
+    description: |
+      Listenpflege einschließlich Adressaktualisierungen, Verstorbenen-Entfernung und Duplikatbehandlung.
+  BC-3330.10.30:
+    name: Wählerberechtigungs-Verifikation
+    description: |
+      Verifikation der Wahlberechtigung anhand von Staatsangehörigkeits-, Alters- und Wohnsitzkriterien.
+  BC-3330.10.40:
+    name: Wählerinformation-Bereitstellung
+    description: |
+      Bereitstellung von Wahlausweisen, Wahllokal-Suchdiensten und Wählerbildungsinformationen.
+  BC-3330.20:
+    name: Wahlkreis- und Bezirksverwaltung
+    description: |
+      Pflege von Wahlkreisen, Wahllokal-Geographien und
+      Wahlkreiseinteilungszyklen.
+  BC-3330.20.10:
+    name: Wahlkreispflege
+    description: |
+      Pflege von Wahlkreis- und Wahlbezirksgrenzen.
+  BC-3330.20.20:
+    name: Wahllokal-Bestimmung
+    description: |
+      Bestimmung, Barrierefreiheitsbewertung und Veröffentlichung von Wahllokalen.
+  BC-3330.20.30:
+    name: Wahlkreiseinteilungs-Koordination
+    description: |
+      Koordination gesetzlicher Wahlkreiseinteilungs- und Grenzkommissionszyklen.
+  BC-3330.30:
+    name: Kandidaten- und Parteiregistrierung
+    description: |
+      Registrierung politischer Parteien, Kandidaten, Nominierungseinreichungen
+      und Wahlzulassungen.
+  BC-3330.30.10:
+    name: Politische Parteiregistrierung
+    description: |
+      Registrierung und Anerkennung politischer Parteien und Parteibezeichnungen.
+  BC-3330.30.20:
+    name: Kandidatennominierung-Einreichung
+    description: |
+      Eingang und Verifikation von Kandidatennominierungen und gesetzlichen Erklärungen.
+  BC-3330.30.30:
+    name: Wahlzulassungs-Bestimmung
+    description: |
+      Bestimmung der Wahlzulassung einschließlich Unterschriftenerfordernisse und Qualifikationsschwellen.
+  BC-3330.40:
+    name: Stimmzettelgestaltung und -produktion
+    description: |
+      Gestaltung, Layout, Barrierefreiheit, Übersetzung und Produktion von Stimmzetteln
+      in Papier- und elektronischen Formaten.
+  BC-3330.40.10:
+    name: Stimmzettel-Layout-Gestaltung
+    description: |
+      Gestaltung und Layout von Stimmzetteln für Übersichtlichkeit, Barrierefreiheit und Sprachabdeckung.
+  BC-3330.40.20:
+    name: Stimmzettelübersetzung und Barrierefreiheit
+    description: |
+      Bereitstellung übersetzter Stimmzettel und barrierefreier Formate für Wähler mit Behinderungen.
+  BC-3330.40.30:
+    name: Stimmzettelproduktion und -verteilung
+    description: |
+      Druck, Programmierung und sichere Verteilung von Papier- und elektronischen Stimmzetteln.
+  BC-3330.50:
+    name: Wahllokal-Betrieb
+    description: |
+      Betrieb von Wahllokalen am Wahltag einschließlich Wahlhelfer-Management,
+      Wähler-Check-in und Stimmabgabe unter VVSG-konformen Kontrollen.
+  BC-3330.50.10:
+    name: Wahlhelfer-Management
+    description: |
+      Rekrutierung, Ausbildung und Einsatz von Wahlhelfern und Wahlbeamten.
+  BC-3330.50.20:
+    name: Wähler-Check-in
+    description: |
+      Wähler-Check-in, Identitätsverifikation und Stimmzettelausgabe im Wahllokal.
+  BC-3330.50.30:
+    name: Persönliche Stimmabgabe
+    description: |
+      Persönliche Stimmabgabe auf Papier oder mit VVSG-zertifizierten Wahlgeräten.
+  BC-3330.50.40:
+    name: Briefwahl-Operationen
+    description: |
+      Operationen zur Unterstützung von Brief-, Post- und Auslandswahl.
+  BC-3330.60:
+    name: Stimmenauszählung und Ergebnistabellierung
+    description: |
+      Auszählung der Stimmzettel, Tabellierung der Ergebnisse, Prüfungen und
+      Zertifizierung von Wahlergebnissen.
+  BC-3330.60.10:
+    name: Stimmzettelauszählung
+    description: |
+      Auszählung von Papier- und elektronischen Stimmzetteln gemäß gesetzlichem Verfahren.
+  BC-3330.60.20:
+    name: Ergebnistabellierung und -berichterstattung
+    description: |
+      Aggregation der Ergebnisse über Wahlbezirke und Berichterstattung an die Öffentlichkeit.
+  BC-3330.60.30:
+    name: Nach-Wahl-Prüfung
+    description: |
+      Risikobegrenzende und nach-Wahl-Prüfungen von Stimmenzählungen und Wahlgeräten.
+  BC-3330.60.40:
+    name: Wahlergebnis-Zertifizierung
+    description: |
+      Gesetzliche Zertifizierung von Wahlergebnissen und Erklärung gewählter Amtsträger.
+  BC-3330.70:
+    name: Wahlkampffinanzierungs-Offenlegung
+    description: |
+      Registrierung politischer Komitees, Spenden- und Ausgaben-Offenlegung
+      sowie Durchsetzung von Wahlkampffinanzierungsgrenzen.
+  BC-3330.70.10:
+    name: Politisches Komitee-Registrierung
+    description: |
+      Registrierung politischer Komitees, Parteien und PAC-äquivalenter Organisationen.
+  BC-3330.70.20:
+    name: Spenden- und Ausgaben-Berichterstattung
+    description: |
+      Eingang, Validierung und Veröffentlichung von Spenden- und Ausgaben-Offenlegungen.
+  BC-3330.70.30:
+    name: Wahlkampffinanzierungs-Vollstreckung
+    description: |
+      Untersuchung und Durchsetzung von Verstößen gegen Wahlkampffinanzierungsgrenzen und Offenlegungspflichten.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-electrical-equipment-service-operations-management.yaml
+++ b/catalogue/i18n/de/L1-electrical-equipment-service-operations-management.yaml
@@ -1,0 +1,143 @@
+locale: de
+source: L1-electrical-equipment-service-operations-management.yaml
+entries:
+  BC-1960:
+    name: Elektrogeräte-Service Management
+    description: |
+      OEM-geführte Dienstleistungen an gelieferten Anlagen — Standortinspektion, FAT und SAT, Inbetriebnahme,
+      Schutzeinstellungen, Konfiguration der installierten Basis, Nachrüstungen, Leistungsverträge und Zustandsüberwachung.
+  BC-1960.10:
+    name: Standortinspektion & Vorkommissionierungs-Engineering
+    description: |
+      Standortbewertung und technische Vorbereitung vor der Gerätekommissionierung.
+  BC-1960.10.10:
+    name: Standortinspektion-Durchführung
+    description: |
+      Durchführung von Standortinspektionen zur Erfassung des Vorzustands.
+  BC-1960.10.20:
+    name: Standortbereitschafts-Bewertung
+    description: |
+      Bewertung der Standortbereitschaft für Gerätelieferung und Inbetriebnahme.
+  BC-1960.10.30:
+    name: Vorkommissionierungs-Engineering-Studien
+    description: |
+      Technische Studien vor der Inbetriebnahme, einschließlich Koordinations- und Erdungsstudien.
+  BC-1960.20:
+    name: Werksabnahmetest-Koordination
+    description: |
+      Planung und Durchführung von Werksabnahmetests mit Kundenzeugschaft.
+  BC-1960.20.10:
+    name: FAT-Plan-Erstellung
+    description: |
+      Erstellung von FAT-Plänen entsprechend vertraglicher Anforderungen.
+  BC-1960.20.20:
+    name: FAT-Zeugen-Koordination
+    description: |
+      Koordination von Kunden- und Zertifiziererzeugen beim FAT.
+  BC-1960.20.30:
+    name: FAT-Mängellisten-Management
+    description: |
+      Verfolgung und Abschluss von FAT-Mängellistenpunkten.
+  BC-1960.30:
+    name: Standortabnahmetest- & Inbetriebnahme-Management
+    description: |
+      Standortabnahmetests, Inbetriebnahme und anfängliche Betriebsüberwachung.
+  BC-1960.30.10:
+    name: Standortabnahmetest-Durchführung
+    description: |
+      Durchführung von Standortabnahmetests an installierten Anlagen.
+  BC-1960.30.20:
+    name: Inbetriebnahme-Verfahrensdurchführung
+    description: |
+      Kontrollierte Inbetriebnahme von Anlagen gemäß Schaltverfahren.
+  BC-1960.30.30:
+    name: Anfangsbetriebsüberwachung
+    description: |
+      Überwachung des Anfangsbetriebs und Zuverlässigkeitslaufes.
+  BC-1960.30.40:
+    name: Übergabedokumentation
+    description: |
+      Zusammenstellung von Übergabedossiers und Inbetriebnahme-Aufzeichnungen.
+  BC-1960.40:
+    name: Schutz- & Steuerungs-Einstellungs-Management
+    description: |
+      Entwicklung und Bereitstellung von Schutz- und Steuerungseinstellungen an installierten Anlagen.
+  BC-1960.40.10:
+    name: Schutzkoordinationsstudie
+    description: |
+      Koordinationsstudien für Schutzgeräte am installierten Netz.
+  BC-1960.40.20:
+    name: Relaiseinstellungs-Berechnung
+    description: |
+      Berechnung von Schutzrelaiseinstellungen.
+  BC-1960.40.30:
+    name: Einstellungsdatei-Bereitstellung & Verifizierung
+    description: |
+      Bereitstellung von Einstellungsdateien in Relais und Vor-Ort-Verifizierung.
+  BC-1960.50:
+    name: Installierte Basis Konfigurations-Management
+    description: |
+      Pflege der Ist-Konfigurationsdaten über die globale installierte Basis.
+  BC-1960.50.10:
+    name: Installierte Basis-Registrierung
+    description: |
+      Registrierung installierter Anlagen nach Seriennummer, Standort und Kunde.
+  BC-1960.50.20:
+    name: Ist-Konfigurationserfassung
+    description: |
+      Erfassung der Ist-Konfiguration bei der Inbetriebnahme.
+  BC-1960.50.30:
+    name: Installierte Basis-Änderungsaufzeichnungen
+    description: |
+      Aufzeichnungen nachträglicher Änderungen an installierten Anlagen.
+  BC-1960.60:
+    name: Anlagen-Nachrüstungs- & Upgrade-Dienstleistungen
+    description: |
+      Entwicklung und Durchführung von Nachrüstungen und Leistungsupgrades an installierten Anlagen.
+  BC-1960.60.10:
+    name: Nachrüstungs-Engineering
+    description: |
+      Entwicklungsdesign von Nachrüstungs- und Upgrade-Paketen.
+  BC-1960.60.20:
+    name: Nachrüstungs-Durchführung
+    description: |
+      Vor-Ort-Durchführung von Nachrüstungen und Upgrade-Installationen.
+  BC-1960.60.30:
+    name: Upgrade-Validierung
+    description: |
+      Validierungstests nach Nachrüstung oder Upgrade.
+  BC-1960.70:
+    name: Leistungsbasierter Servicevertrag-Betrieb
+    description: |
+      Betrieb leistungs- und ergebnisbasierter Serviceverträge.
+  BC-1960.70.10:
+    name: Leistungsvertrag-Durchführung
+    description: |
+      Durchführung leistungsbasierter Serviceverpflichtungen.
+  BC-1960.70.20:
+    name: Service-Level-Ergebnis-Berichterstattung
+    description: |
+      Berichterstattung über vertragliche Ergebnisse und Service-Level-Metriken.
+  BC-1960.70.30:
+    name: Risikoteilungs-Mechanismus-Betrieb
+    description: |
+      Betrieb von Bonus- und Malus-Risikoteilungsmechanismen.
+  BC-1960.80:
+    name: Zustandsüberwachungs-Servicelieferung
+    description: |
+      Lieferung von Remote-Zustandsüberwachungs- und Predictive-Insight-Diensten.
+  BC-1960.80.10:
+    name: Remote-Zustandsüberwachungs-Betrieb
+    description: |
+      Operationszentrum für Remote-Zustandsüberwachung installierter Anlagen.
+  BC-1960.80.20:
+    name: Diagnoseinformations-Lieferung
+    description: |
+      Lieferung von Diagnoseinformationen an Kunden.
+  BC-1960.80.30:
+    name: Predictive Maintenance-Empfehlungen
+    description: |
+      Empfehlungen zur vorausschauenden Instandhaltung für installierte Anlagen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-electrical-product-catalogue-management.yaml
+++ b/catalogue/i18n/de/L1-electrical-product-catalogue-management.yaml
@@ -1,0 +1,115 @@
+locale: de
+source: L1-electrical-product-catalogue-management.yaml
+entries:
+  BC-1940:
+    name: Elektrogeräte-Katalog Management
+    description: |
+      Verkaufsfähige Produktstruktur für elektrische Produkte — Varianten, Konfiguratorregeln,
+      jurisdiktionsspezifische SKUs, Einführung und Auslauf, Datenblätter und Marketingmaterial.
+  BC-1940.10:
+    name: Verkaufsfähige Produktstamm-Management
+    description: |
+      Pflege verkaufsfähiger Produktstammdaten und Familienhierarchien.
+  BC-1940.10.10:
+    name: Verkaufsfähiger Produktdatensatz-Management
+    description: |
+      Erstellung und Pflege verkaufsfähiger Produktstammdaten.
+  BC-1940.10.20:
+    name: Produkthierarchie- & Familien-Management
+    description: |
+      Definition von Produktfamilien- und Hierarchiestrukturen.
+  BC-1940.10.30:
+    name: Produktattribut-Standardisierung
+    description: |
+      Standardisierung von Attributen über Produktfamilien hinweg.
+  BC-1940.20:
+    name: Produktvarianten- & Options-Management
+    description: |
+      Verwaltung von Spannungs-, Frequenz-, Schutz-, Protokoll- und Zubehörvarianten.
+  BC-1940.20.10:
+    name: Spannungs- & Frequenzvarianten-Management
+    description: |
+      Verwaltung von Spannungs- und Frequenznennungsvarianten.
+  BC-1940.20.20:
+    name: Schutzart- & Gehäusevarianten-Management
+    description: |
+      Verwaltung von Schutzart- und Gehäusevarianten.
+  BC-1940.20.30:
+    name: Kommunikationsprotokoll-Varianten-Management
+    description: |
+      Verwaltung von Kommunikationsprotokolloptionen an vernetzten Produkten.
+  BC-1940.20.40:
+    name: Zubehör- & Options-Management
+    description: |
+      Verwaltung von Zubehör- und optionalen Feature-Definitionen.
+  BC-1940.30:
+    name: Produktkonfigurator-Regelmanagement
+    description: |
+      Erstellung und Validierung von Konfigurationsregeln.
+  BC-1940.30.10:
+    name: Konfigurationsregel-Erstellung
+    description: |
+      Erstellung von Gültigkeitskombinationsregeln für konfigurierbare Produkte.
+  BC-1940.30.20:
+    name: Kompatibilitätsbeschränkungs-Management
+    description: |
+      Verwaltung von Kompatibilitätsbeschränkungen zwischen Optionen.
+  BC-1940.30.30:
+    name: Konfigurator-Validierungstest
+    description: |
+      Validierungstests von Konfiguratorregelsätzen.
+  BC-1940.40:
+    name: Jurisdiktionsspezifische SKU-Management
+    description: |
+      Verwaltung jurisdiktionsspezifischer SKUs, Steckernormen und Sprachvarianten.
+  BC-1940.40.10:
+    name: Jurisdiktionsvarianten-Definition
+    description: |
+      Definition verkaufsfähiger Varianten nach Zielanforderungen der Jurisdiktion.
+  BC-1940.40.20:
+    name: Stecker- & Verbindungsnormen-Management
+    description: |
+      Verwaltung von Stecker- und Verbindungsnormvarianten nach Region.
+  BC-1940.40.30:
+    name: Landessprachliche Dokumentationsvariante
+    description: |
+      Landessprachliche Handbücher und Kennzeichnungsvarianten nach Jurisdiktion.
+  BC-1940.50:
+    name: Produkt-Einführungs- & Auslauf-Management
+    description: |
+      Katalogaktivierung, Ersatzzuordnung, End-of-Sale und Last-Buy-Fenster.
+  BC-1940.50.10:
+    name: Produkteinführung-Katalogaktivierung
+    description: |
+      Aktivierung neuer Produkte im verkaufsfähigen Katalog bei der Einführung.
+  BC-1940.50.20:
+    name: Ersatzprodukt-Zuordnung
+    description: |
+      Zuordnung abgelöster Produkte zu Ersatz-SKUs.
+  BC-1940.50.30:
+    name: End-of-Sale-Benachrichtigung
+    description: |
+      Benachrichtigung der Vertriebskanäle und Kunden über End-of-Sale-Termine.
+  BC-1940.50.40:
+    name: Last-Buy- & Service-Fenster-Management
+    description: |
+      Verwaltung von Last-Buy-Fenstern und nur-Service-Verfügbarkeit.
+  BC-1940.60:
+    name: Produktdokumentation & Datenblatt-Management
+    description: |
+      Erstellung und Pflege von Datenblättern, Handbüchern und Marketingmaterial verknüpft mit SKUs.
+  BC-1940.60.10:
+    name: Datenblatt-Erstellung
+    description: |
+      Erstellung von Produktdatenblättern und technischen Spezifikationen.
+  BC-1940.60.20:
+    name: Technisches Handbuch-Erstellung
+    description: |
+      Erstellung von Installations- und Betriebshandbüchern.
+  BC-1940.60.30:
+    name: Katalog-Marketingmaterial
+    description: |
+      Marketingmaterial verknüpft mit Katalog-SKUs.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-electrical-product-certification-management.yaml
+++ b/catalogue/i18n/de/L1-electrical-product-certification-management.yaml
@@ -1,0 +1,119 @@
+locale: de
+source: L1-electrical-product-certification-management.yaml
+entries:
+  BC-1910:
+    name: Elektrogeräte-Zertifizierung Management
+    description: |
+      Multijurisdiktionelle Produktsicherheits-, EMV- und Energiezertifizierung — Strategie, technische Unterlagen,
+      Zertifizierungsstelleneinbindung, Markenlizenzen, Überwachung und Umgang mit Nichtkonformitäten im Feld.
+  BC-1910.10:
+    name: Zertifizierungsstrategie & Fahrplan
+    description: |
+      Definition der benötigten Prüfzeichen und Zulassungen sowie deren Reihenfolge.
+  BC-1910.10.10:
+    name: Marktzugangsanforderungsanalyse
+    description: |
+      Identifikation von Zertifizierungsanforderungen nach Zielmarkt.
+  BC-1910.10.20:
+    name: Zertifizierungsschema-Auswahl
+    description: |
+      Auswahl von Zertifizierungsschemata und Anerkennungswegen.
+  BC-1910.10.30:
+    name: Zertifizierungsfahrplan-Planung
+    description: |
+      Sequenzierung von Zulassungen gegenüber Produkteinführungs-Meilensteinen.
+  BC-1910.20:
+    name: Technische Unterlagen & Nachweismanagement
+    description: |
+      Erstellung und Verwaltung von technischen Konstruktionsdossiers und unterstützenden Nachweisen.
+  BC-1910.20.10:
+    name: Technische Konstruktionsdatei-Erstellung
+    description: |
+      Erstellung von technischen Konstruktionsdateien zur Unterstützung der Typzulassung.
+  BC-1910.20.20:
+    name: Prüfberichts-Aggregation
+    description: |
+      Aggregation und Indexierung akkreditierter Prüfberichte.
+  BC-1910.20.30:
+    name: Konformitätserklärung-Erstellung
+    description: |
+      Erstellung und Unterzeichnung von Konformitätserklärungen.
+  BC-1910.20.40:
+    name: Compliance-Nachweisarchiv
+    description: |
+      Langzeitarchivierung von Compliance-Nachweisen gemäß regulatorischen Aufbewahrungsfristen.
+  BC-1910.30:
+    name: Zertifizierungsstellen- & Zulassungsmanagement
+    description: |
+      Einbindung von Benannten Stellen und nationalen Zertifizierungsstellen bis zur Typzulassungserteilung.
+  BC-1910.30.10:
+    name: Benannte Stellen-Auswahl
+    description: |
+      Auswahl von Benannten Stellen und nationalen Zertifizierungsstellen.
+  BC-1910.30.20:
+    name: Zertifizierungseinreichungs-Management
+    description: |
+      Einreichung von Zertifizierungsdossiers und Koordination der Nachverfolgung.
+  BC-1910.30.30:
+    name: Zeugentest-Koordination
+    description: |
+      Koordination von prüferbezeugten Tests in Lieferanten- oder Hauslabors.
+  BC-1910.30.40:
+    name: Typzulassungserteilungs-Tracking
+    description: |
+      Verfolgung erteilter Typzulassungen und Zertifikatsgültigkeiten.
+  BC-1910.40:
+    name: Markenlizenzierung & Etiketten-Compliance
+    description: |
+      Lizenzierung von Zertifizierungszeichen und Kontrolle des Produktkennzeichnungsdesigns.
+  BC-1910.40.10:
+    name: Markennutzungsgenehmigung
+    description: |
+      Genehmigung der Markennutzung auf zertifizierten Produkten.
+  BC-1910.40.20:
+    name: Produktetikett-Artwork-Kontrolle
+    description: |
+      Kontrolle von Etiketteninhalten, Kennzeichnungen und Typenschilder-Artwork.
+  BC-1910.40.30:
+    name: Marken-Lizenzgebühren-Berichterstattung
+    description: |
+      Berichterstattung der Stückzahlen für Marken-Lizenzgebührenpflichten.
+  BC-1910.50:
+    name: Zulassungsüberwachung & -erneuerung
+    description: |
+      Pflege von Zulassungen durch Überwachungsaudits, Variationen und Erneuerungen.
+  BC-1910.50.10:
+    name: Werksinspektion-Koordination
+    description: |
+      Koordination von Zertifizierer-Werksinspektionen und Folgemaßnahmen.
+  BC-1910.50.20:
+    name: Periodische Überwachungsprüfung
+    description: |
+      Überwachungs-Nachprüfung zertifizierter Produkte gegen die ursprüngliche Baseline.
+  BC-1910.50.30:
+    name: Zulassungs-Variationseinreichung
+    description: |
+      Einreichung von Variationen und technischen Änderungen gegen erteilte Zulassungen.
+  BC-1910.50.40:
+    name: Zulassungserneuerungs-Management
+    description: |
+      Erneuerung von ablaufenden Zulassungen und Zertifikaten.
+  BC-1910.60:
+    name: Feld-Compliance-Vorfall-Management
+    description: |
+      Behandlung von Produktnichtkonformitäten, die nach der Marktfreigabe entdeckt werden.
+  BC-1910.60.10:
+    name: Nichtkonformitäts-Vorfall-Triage
+    description: |
+      Triage vermuteter Produktnichtkonformitäten, die aus dem Feld gemeldet werden.
+  BC-1910.60.20:
+    name: Regulierungsbehörden-Benachrichtigung
+    description: |
+      Pflichtmeldung an Behörden und Zertifizierer bei bestätigten Nichtkonformitäten.
+  BC-1910.60.30:
+    name: Feldrückruf- & Lieferstopps-Koordination
+    description: |
+      Koordination von Rückrufen, Lieferstopps und Korrekturmaßnahmenkampagnen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-electrical-product-engineering-management.yaml
+++ b/catalogue/i18n/de/L1-electrical-product-engineering-management.yaml
@@ -1,0 +1,171 @@
+locale: de
+source: L1-electrical-product-engineering-management.yaml
+entries:
+  BC-1900:
+    name: Elektrogeräte-Entwicklung Management
+    description: |
+      Multidisziplinäre Entwicklung elektrischer und elektronischer Produkte: Schaltkreis-, Leistungselektronik-,
+      Embedded-, EMV-, Thermik- und Mechanikentwicklung bis hin zur Designverifizierung.
+  BC-1900.10:
+    name: Elektrische Schaltkreisentwicklung
+    description: |
+      Schematische Entwicklung von Analog-, Digital-, Mischsignal- und HF-Schaltkreisen.
+  BC-1900.10.10:
+    name: Analogschaltkreis-Entwicklung
+    description: |
+      Entwicklung von analogen Signal- und Leistungsaufbereitungsschaltkreisen.
+  BC-1900.10.20:
+    name: Digitalschaltkreis-Entwicklung
+    description: |
+      Entwicklung von Digitallogik- und Taktschaltkreisen.
+  BC-1900.10.30:
+    name: Mischsignal-Schaltkreisentwicklung
+    description: |
+      Entwicklung von Mischsignal-Schnittstellen, ADC/DAC-Subsystemen und Wandlerstufen.
+  BC-1900.10.40:
+    name: HF-Schaltkreisentwicklung
+    description: |
+      Entwicklung von Hochfrequenz-Front-Ends, Anpassnetzwerken und Antennen.
+  BC-1900.20:
+    name: Leistungselektronik-Entwicklung
+    description: |
+      Entwicklung von Leistungsumrichtern, Motorantrieben und Schalttopologien.
+  BC-1900.20.10:
+    name: Leistungsumrichter-Entwicklung
+    description: |
+      Entwicklung von AC/DC-, DC/DC- und DC/AC-Leistungsumrichtern.
+  BC-1900.20.20:
+    name: Motorantriebstopologie-Entwicklung
+    description: |
+      Topologieauswahl und Entwicklung drehzahlgeregelter Motorantriebe.
+  BC-1900.20.30:
+    name: Magnetics & Filter-Entwicklung
+    description: |
+      Entwicklung von Induktoren, Transformatoren und EMV-Filtern.
+  BC-1900.20.40:
+    name: Schaltregelkreis-Entwicklung
+    description: |
+      Closed-Loop-Regelungsentwicklung für Leistungsschaltstufen.
+  BC-1900.30:
+    name: Leiterplatten- & Elektronikgehäuse-Entwicklung
+    description: |
+      Leiterplattendesign, elektronisches Gehäusedesign und Verbindungstechnik.
+  BC-1900.30.10:
+    name: Leiterplatten-Layout
+    description: |
+      Mehrlagen-Leiterplatten-Stackup und physisches Layout.
+  BC-1900.30.20:
+    name: Elektronisches Gehäusedesign
+    description: |
+      Modul-, Gehäuse- und Ball-Grid-Array-Gehäusedesign.
+  BC-1900.30.30:
+    name: Verbindungs- & Kabelbaum-Entwicklung
+    description: |
+      Kabelbaum-, Stromschienen- und Platinen-Verbindungsdesign.
+  BC-1900.30.40:
+    name: Bauteil-Footprint-Bibliotheks-Management
+    description: |
+      Pflege von CAD-Footprint- und Symbolbibliotheken.
+  BC-1900.40:
+    name: Embedded-Hardware-Entwicklung
+    description: |
+      Entwicklung von Mikrocontroller-, FPGA-, Sensorschnittstellen- und Energieverwaltungs-Hardware.
+  BC-1900.40.10:
+    name: Mikrocontroller-Plattform-Entwicklung
+    description: |
+      Auswahl und Integration von Mikrocontroller-Plattformen.
+  BC-1900.40.20:
+    name: FPGA & SoC-Integration
+    description: |
+      Integration von FPGA- und SoC-Bausteinen in Produkthardware.
+  BC-1900.40.30:
+    name: Sensor- & Aktor-Schnittstellenentwicklung
+    description: |
+      Analoge und digitale Schnittstellen zu Sensoren und Aktoren.
+  BC-1900.40.40:
+    name: Energieverwaltungsschaltkreis-Entwicklung
+    description: |
+      Platineninterne Energieverwaltungs- und Regelschaltkreise.
+  BC-1900.50:
+    name: Embedded-Firmware-Entwicklung
+    description: |
+      Firmware-Entwicklungsdisziplin für RTOS, Treiber, Anwendungslogik und Verifizierung.
+  BC-1900.50.10:
+    name: Echtzeit-Softwarearchitektur
+    description: |
+      Echtzeitbetriebssystem- und Aufgabenarchitektur.
+  BC-1900.50.20:
+    name: Gerätetreiber-Entwicklung
+    description: |
+      Low-Level-Treiber- und Board-Support-Package-Entwicklung.
+  BC-1900.50.30:
+    name: Embedded-Anwendungsentwicklung
+    description: |
+      Embedded-Anwendungslogik und Feature-Entwicklung.
+  BC-1900.50.40:
+    name: Firmware-Verifizierung & Test
+    description: |
+      Unit-, Integrations- und Hardware-in-the-Loop-Firmware-Verifizierung.
+  BC-1900.60:
+    name: EMV & Signalintegritäts-Entwicklung
+    description: |
+      Entwurfsseitige Steuerung der elektromagnetischen Verträglichkeit und Signalintegrität.
+  BC-1900.60.10:
+    name: EMV-Designanalyse
+    description: |
+      Analyse von Emissionen und Immunität in der Designphase.
+  BC-1900.60.20:
+    name: Signalintegritätsanalyse
+    description: |
+      Analyse von Hochgeschwindigkeits-Signalintegrität und Übersprechen.
+  BC-1900.60.30:
+    name: Abschirmungs- & Erdungsdesign
+    description: |
+      Abschirmungs-, Verbindungs- und Erdungsstrategien.
+  BC-1900.60.40:
+    name: EMV-Vorkonformitätsbewertung
+    description: |
+      Vorkonformitäts-Scans und EMV-Bewertung in der Designphase.
+  BC-1900.70:
+    name: Thermik- & Mechanik-Entwicklung
+    description: |
+      Thermische, Gehäuse- und Mechanikentwicklung elektrischer Produkte.
+  BC-1900.70.10:
+    name: Thermikanalyse & Kühldesign
+    description: |
+      Thermikmodellierung und Kühlstrategieentwicklung.
+  BC-1900.70.20:
+    name: Gehäuse- & Schutzart-Design
+    description: |
+      Mechanisches Gehäusedesign und Schutzart-Konformität.
+  BC-1900.70.30:
+    name: Vibrations- & Schockentwicklung
+    description: |
+      Mechanische Robustheit gegen Vibrations- und Schockbelastungen.
+  BC-1900.70.40:
+    name: Stecker- & Mechanische Schnittstellen-Entwicklung
+    description: |
+      Steckerauswahl und mechanisches Schnittstellendesign.
+  BC-1900.80:
+    name: Elektrische Designverifizierung
+    description: |
+      Entwurfsseitige Verifizierung durch Simulation, Prototypenbau und Test.
+  BC-1900.80.10:
+    name: Designsimulation
+    description: |
+      Schaltkreis-, elektromagnetische und thermische Simulationsstudien.
+  BC-1900.80.20:
+    name: Prototypenbau & Inbetriebnahme
+    description: |
+      Prototypenmontage und erstmalige funktionale Inbetriebnahme.
+  BC-1900.80.30:
+    name: Designverifizierungstest
+    description: |
+      Verifizierungstest gegen Designspezifikationen.
+  BC-1900.80.40:
+    name: Design-Review-Steuerung
+    description: |
+      Stage-Gate-Designüberprüfungen und Design-Qualitätssicherung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-electrical-product-qualification-management.yaml
+++ b/catalogue/i18n/de/L1-electrical-product-qualification-management.yaml
@@ -1,0 +1,171 @@
+locale: de
+source: L1-electrical-product-qualification-management.yaml
+entries:
+  BC-1920:
+    name: Elektrogeräte-Qualifizierung Management
+    description: |
+      Typprüfungssteuerung an repräsentativen Mustern — dielektrische, Kurzschluss-, EMV-, klimatische,
+      mechanische und Lebensdauertests — einschließlich akkreditiertem Laborbetrieb.
+  BC-1920.10:
+    name: Testplan- & Spezifikations-Management
+    description: |
+      Erstellung und Genehmigung von Testplänen und -spezifikationen aus Produktnormen.
+  BC-1920.10.10:
+    name: Testspezifikations-Erstellung
+    description: |
+      Erstellung detaillierter Testspezifikationen.
+  BC-1920.10.20:
+    name: Testplan-Genehmigung
+    description: |
+      Genehmigung von Testplänen durch Entwicklungs-, Qualitäts- und Zertifizierungsstakeholder.
+  BC-1920.10.30:
+    name: Testmuster-Zuteilung
+    description: |
+      Zuteilung und Verwaltung repräsentativer Testmuster.
+  BC-1920.10.40:
+    name: Testverfahrens-Pflege
+    description: |
+      Pflege und Überarbeitung standardisierter Testverfahren.
+  BC-1920.20:
+    name: Dielektrische & Hochspannungsprüfung
+    description: |
+      Isolations-, dielektrische Standspannungs-, Teilentladungs- und Stoßprüfungen.
+  BC-1920.20.10:
+    name: Isolationswiderstandsprüfung
+    description: |
+      Messung des Isolationswiderstands unter spezifizierten Bedingungen.
+  BC-1920.20.20:
+    name: Dielektrische Standspannungsprüfung
+    description: |
+      AC- und DC-Spannungsstandhaltigkeit bei Nennspannungen.
+  BC-1920.20.30:
+    name: Teilentladungsmessung
+    description: |
+      Messung von Teilentladungen in Isolationssystemen.
+  BC-1920.20.40:
+    name: Stoßspannungsprüfung
+    description: |
+      Blitz- und Schaltstoß-Standspannungsprüfung.
+  BC-1920.30:
+    name: Kurzschluss- & Schalttestung
+    description: |
+      Verifizierung der Kurzschluss- und Schaltleistung unter Nennfehlerbedingungen.
+  BC-1920.30.10:
+    name: Kurzschlusseinschaltvermögen-Prüfung
+    description: |
+      Verifizierung des Einschaltvermögens in Nennkurzschlüsse.
+  BC-1920.30.20:
+    name: Kurzschlussabschaltvermögen-Prüfung
+    description: |
+      Verifizierung des Abschaltvermögens bei Nennfehlerströmen.
+  BC-1920.30.30:
+    name: Schalt-Lebensdauerprüfung
+    description: |
+      Mechanische und elektrische Lebensdauer bei Wiederholungsschalten.
+  BC-1920.30.40:
+    name: Lichtbogenfehlerprüfung
+    description: |
+      Lichtbogenfehlereindämmung und Lichtbogenblitz-Leistungsprüfung.
+  BC-1920.40:
+    name: EMV & EMI-Prüfung
+    description: |
+      Leitungsgebundene und abgestrahlte Emissions- und Immunitätsprüfung.
+  BC-1920.40.10:
+    name: Leitungsgebundene Emissionsprüfung
+    description: |
+      Messung leitungsgebundener Emissionen auf Strom- und Signalleitungen.
+  BC-1920.40.20:
+    name: Abgestrahlte Emissionsprüfung
+    description: |
+      Messung abgestrahlter elektromagnetischer Emissionen.
+  BC-1920.40.30:
+    name: EMV-Immunitätsprüfung
+    description: |
+      Verifizierung der Immunität gegen leitungsgebundene und abgestrahlte Störungen.
+  BC-1920.40.40:
+    name: ESD & Überspannungsimmunitätsprüfung
+    description: |
+      Elektrostatische Entladungs- und Überspannungsimmunitätsprüfung.
+  BC-1920.50:
+    name: Umwelt- & Klimaprüfung
+    description: |
+      Klimatische, Korrosions-, Schutzart- und Belichtungsprüfung von Produkten.
+  BC-1920.50.10:
+    name: Temperatur- & Feuchtigkeitswechsel
+    description: |
+      Temperatur- und Feuchtigkeitswechselbelastung und stationäre Beanspruchung.
+  BC-1920.50.20:
+    name: Salzsprüh- & Korrosionsprüfung
+    description: |
+      Salzsprüh- und korrosionsatmosphärische Belichtungsprüfung.
+  BC-1920.50.30:
+    name: Schutzartzertifizierungsprüfung
+    description: |
+      Verifizierung des Schutzartgrades gegen Staub und Wasser.
+  BC-1920.50.40:
+    name: Solar- & UV-Belichtungsprüfung
+    description: |
+      Sonnenstrahlung und ultraviolette Belichtungsprüfung.
+  BC-1920.60:
+    name: Mechanik- & Vibrationsprüfung
+    description: |
+      Vibrations-, Schock-, mechanische Lebensdauer- und seismische Qualifikationsprüfung.
+  BC-1920.60.10:
+    name: Vibrations- & Schockprüfung
+    description: |
+      Sinus-, Breitband- und Schockvibrationsprüfung.
+  BC-1920.60.20:
+    name: Mechanische Lebensdauerprüfung
+    description: |
+      Mechanische Lebensdauer unter Betriebszyklen.
+  BC-1920.60.30:
+    name: Fall- & Stoßprüfung
+    description: |
+      Fall-, Freifallstufen- und Stoßprüfung von Produkten und Verpackungen.
+  BC-1920.60.40:
+    name: Seismische Qualifikationsprüfung
+    description: |
+      Seismische Qualifikation für Energie- und Unterwerksanlagen.
+  BC-1920.70:
+    name: Beschleunigte Lebensdauer- & Zuverlässigkeitsprüfung
+    description: |
+      Beschleunigte Lebensdauer-, Belastungsscreening- und Zuverlässigkeitsnachweistests.
+  BC-1920.70.10:
+    name: Hochbeschleunigte Lebensdauerprüfung
+    description: |
+      HALT zur Aufdeckung von Designreserven durch Stufenbelastung.
+  BC-1920.70.20:
+    name: Hochbeschleunigtes Belastungsscreening
+    description: |
+      HASS-Produktionsscreening zur Erkennung latenter Defekte.
+  BC-1920.70.30:
+    name: Zuverlässigkeitsnachweistest
+    description: |
+      Nachweistests gegen Zuverlässigkeitsziele.
+  BC-1920.70.40:
+    name: Burn-In-Test
+    description: |
+      Unter Spannung stehender Burn-In zur Ausfällung von Frühausfällen.
+  BC-1920.80:
+    name: Testlabors-Betriebsmanagement
+    description: |
+      Betrieb akkreditierter interner Testlabors.
+  BC-1920.80.10:
+    name: Testlabor-Akkreditierung
+    description: |
+      Pflege des ISO/IEC 17025-Akkreditierungsumfangs.
+  BC-1920.80.20:
+    name: Prüfmittel-Kalibrierung
+    description: |
+      Kalibrierung und Rückverfolgbarkeit von Prüfmitteln.
+  BC-1920.80.30:
+    name: Testdaten-Aufzeichnungsmanagement
+    description: |
+      Langzeitige Aufzeichnungsverwaltung von Testdaten und -berichten.
+  BC-1920.80.40:
+    name: Interlabor-Vergleich
+    description: |
+      Ringversuch-Eignungsprüfung über mehrere Labors.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-electricity-distribution-operations-management.yaml
+++ b/catalogue/i18n/de/L1-electricity-distribution-operations-management.yaml
@@ -1,0 +1,160 @@
+locale: de
+source: L1-electricity-distribution-operations-management.yaml
+entries:
+  BC-3820:
+    name: Stromverteilungsbetrieb Management
+    description: |
+      Betrieb von Mittel- und Niederspannungsverteilungsnetzen –
+      Leitstellendispatch, Fehlerreaktion und Wiederversorgung, Schalthandlungen,
+      Primär- und Sekundärumspannwerksbetrieb sowie Feldtruppenkoordination
+      zur Stromversorgung von Endkunden.
+  BC-3820.10:
+    name: Verteilungsleitstellenbetrieb
+    description: |
+      24/7-Leitstellenbetrieb des Verteilungsnetzes mittels
+      DMS/OMS/ADMS, Lagebilderstellung und Lastflussanalyse.
+  BC-3820.10.10:
+    name: ADMS-Betrieb
+    description: |
+      Betrieb fortgeschrittener Verteilungsmanagementsysteme zur Überwachung und Steuerung.
+  BC-3820.10.20:
+    name: Verteiler-SCADA-Betrieb
+    description: |
+      Echtzeit-SCADA-Erfassung und Steuerung von Verteilungsfeldern und Schaltern.
+  BC-3820.10.30:
+    name: Netztopologiemanagement
+    description: |
+      Pflege der betriebsaktuellen Netztopologie im Leitsystem.
+  BC-3820.20:
+    name: Schalt- und Wiederversorgungsbetrieb
+    description: |
+      Netzkonfiguration und Wiederversorgung nach geplanten und
+      ungeplanten Abschaltungen einschließlich FLISR-gestützter Selbstheilung.
+  BC-3820.20.10:
+    name: Schaltprogrammausführung
+    description: |
+      Autorisierte Ausführung von Verteilungsschaltprogrammen.
+  BC-3820.20.20:
+    name: Fehlerortung, Isolierung und Wiederversorgung
+    description: |
+      FLISR-gestützte Erkennung, Isolierung und Wiederversorgung bei Fehlern auf Abgangsfeldern.
+  BC-3820.20.30:
+    name: Rückspeisung und Inselnetzbetrieb
+    description: |
+      Koordination von Feldrückspeisungen und beabsichtigtem Inselnetzbetrieb zur Wiederversorgung.
+  BC-3820.30:
+    name: Fehlerbehebungsbetrieb
+    description: |
+      Durchgängige Reaktion auf Fehler im Verteilungsnetz von der
+      Erkennung über die Feldreparatur bis zur Kundenkommunikation.
+    in_scope:
+      - Fehlererkennung und Patrouille
+      - Truppzuweisung zu Fehlerstellen
+      - Abschaltkommunikation an Kunden
+    out_of_scope:
+      - DER-bezogene Abschaltbehandlung (BC-3840)
+      - Großhandelserzeugungsabschaltungen (BC-3800.10)
+  BC-3820.30.10:
+    name: Fehlerpriorisierung
+    description: |
+      Priorisierung von Fehlermeldungen aus Feld-, Kunden- und Telemetriequellen.
+  BC-3820.30.20:
+    name: Feldstörungspatrouille
+    description: |
+      Feldpatrouille zur Lokalisierung und Bestätigung von Fehlern an Freileitungs- und Kabelanlagen.
+  BC-3820.30.30:
+    name: Wiederversorgungsverfolgung
+    description: |
+      Verfolgung des Wiederversorgungsfortschritts und der Kundenminnuten-Verluststatistiken.
+  BC-3820.30.40:
+    name: Großereignisreaktion
+    description: |
+      Sturm- und Großereignis-Verteilungsreaktion einschließlich gegenseitiger Hilfstrupps.
+  BC-3820.40:
+    name: Feldtruppdispatchbetrieb
+    description: |
+      Dispatch, Routenplanung und Feldeinsatzunterstützung für Verteilungsfeldtrupps
+      bei Fehlern, geplanten Arbeiten und Kundenaufträgen.
+  BC-3820.40.10:
+    name: Truppschichtplanung
+    description: |
+      Tägliche Planung von Truppbesetzungen und Bereitschaftsrotationen.
+  BC-3820.40.20:
+    name: Auftragsdispatch und Routenplanung
+    description: |
+      Dispatch und Routenplanung von Aufträgen zu Feldtrupps aus Arbeitsmanagementsystemen.
+  BC-3820.40.30:
+    name: Feldauftragabschluss
+    description: |
+      Erfassung von Bestandsänderungen, verwendeten Materialien und Zeiten beim Auftragsabschluss.
+  BC-3820.50:
+    name: Verteilungsanlageninspektion
+    description: |
+      Routine- und zustandsorientierte Inspektion von Freileitungen,
+      Masten, Erdkabeln und Verteilungsumspannwerken.
+  BC-3820.50.10:
+    name: Mast- und Freileitungsinspektion
+    description: |
+      Zyklische Mast- und Freileitungsinspektion einschließlich thermografischer Aufnahmen.
+  BC-3820.50.20:
+    name: Erdnetzinspektion
+    description: |
+      Inspektion und Zustandserhebung von Erdkabeln, Verbindungsboxen und Muffen.
+  BC-3820.50.30:
+    name: Verteilungsumspannwerksinspektion
+    description: |
+      Routinemäßige Inspektion von Primär-, Sekundär- und Kundenumspannwerken.
+  BC-3820.60:
+    name: Vegetation und Schutzstreifenmanagement
+    description: |
+      Vegetationsbeseitigung und Schutzstreifenpflege auf Verteilungsleitungen
+      zur Beherrschung von Abschaltrisiken und gesetzlich vorgeschriebenen Abstanden.
+  BC-3820.60.10:
+    name: Vegetationszyklusplanung
+    description: |
+      Zyklusbasierte und risikobasierte Planung von Vegetationsarbeiten an Verteilungsleitungen.
+  BC-3820.60.20:
+    name: Vegetationsfeldbetrieb
+    description: |
+      Felddurchführung von Schnitt-, Fäll- und Herbizidarbeiten.
+  BC-3820.60.30:
+    name: Waldbrandrisikominderungsbetrieb
+    description: |
+      PSPS-, Schnellauslöse- und Leitungsverhärtungsmaßnahmen in Waldbrandrisikobereichen.
+  BC-3820.70:
+    name: Neuanschlussbetrieb
+    description: |
+      Herstellung neuer und geänderter elektrischer Anschlüsse für
+      Haus-, Gewerbe- und Industriekunden sowie Projektentwickler.
+  BC-3820.70.10:
+    name: Anschlussbewertung
+    description: |
+      Technische Bewertung von Neuantragsanträgen und verfügbarer Kapazität.
+  BC-3820.70.20:
+    name: Anschlussplanung
+    description: |
+      Detaillierte Anschlussplanung, Netzanschlusspunkt und Verstärkungsanforderungen.
+  BC-3820.70.30:
+    name: Anschlussinbetriebnahme
+    description: |
+      Inbetriebnahme neuer Anschlüsse und Einschaltabnahme.
+  BC-3820.80:
+    name: Spannungsqualitätsmanagement
+    description: |
+      Überwachung und Behebung von Verteilungsspannungsniveaus,
+      Flicker, Oberwellen und Kundenbeschwerden zur Spannungsqualität.
+  BC-3820.80.10:
+    name: Spannungsüberwachung
+    description: |
+      Überwachung von Feldspannungsprofilen gegen gesetzliche Grenzwerte.
+  BC-3820.80.20:
+    name: Oberwellen- und Flickerüberwachung
+    description: |
+      Netzüberwachung von Oberwellenverzerrungen und Spannungsflicker.
+  BC-3820.80.30:
+    name: Kundenbeschwerdeuntersuchung Spannungsqualität
+    description: |
+      Untersuchung und Behebung von kundengemeldeten Spannungsqualitätsproblemen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-electricity-transmission-operations-management.yaml
+++ b/catalogue/i18n/de/L1-electricity-transmission-operations-management.yaml
@@ -1,0 +1,144 @@
+locale: de
+source: L1-electricity-transmission-operations-management.yaml
+entries:
+  BC-3810:
+    name: Stromübertragungsbetrieb Management
+    description: |
+      Betrieb des Hochspannungsübertragungsnetzes – Leitstellen-Dispatch,
+      Schalthandlungen, Leitungs- und Umspannwerksbetrieb, Stillstandskoordination,
+      Schutz sowie physische und Cybersicherheit des Übertragungssystems.
+  BC-3810.10:
+    name: Übertragungsleitstellenbetrieb
+    description: |
+      24/7-Leitstellenbetrieb des Übertragungsnetzes mittels
+      EMS/SCADA, Lagebilderstellung und Kontingenzanalyse.
+  BC-3810.10.10:
+    name: EMS-Betrieb
+    description: |
+      Betrieb des Energiemanagementsystems, Zustandsschätzers und Kontingenzanalysetools.
+  BC-3810.10.20:
+    name: Übertragungs-SCADA-Betrieb
+    description: |
+      Echtzeit-SCADA-Erfassung und Fernwirken von Übertragungsanlagen.
+  BC-3810.10.30:
+    name: Betriebstagebuchführung
+    description: |
+      Führung von Betriebstagebüchern, Schichtübergaben und Betriebsereignisprotokollen.
+  BC-3810.20:
+    name: Schalt- und Trennungsoperationen
+    description: |
+      Planung und Ausführung von Schalthandlungen, Trennungen und
+      Arbeiten unter Spannung am Übertragungssystem.
+  BC-3810.20.10:
+    name: Schaltprogrammerstellung
+    description: |
+      Erstellung und Prüfung von Schaltprogrammen für geplante Arbeiten.
+  BC-3810.20.20:
+    name: Arbeitserlaubniserteilung
+    description: |
+      Ausstellung und Kontrolle von Arbeitserlaubnissen und Freischaltgenehmigungen.
+  BC-3810.20.30:
+    name: Arbeiten unter Spannung
+    description: |
+      Koordination von Arbeiten unter Spannung an energetisierten Leitungen.
+  BC-3810.30:
+    name: Freileitungsbetrieb
+    description: |
+      Betrieb, Inspektion und Spannungsarbeiten an Freileitungen,
+      Masten und unterirdischen Übertragungskabeln.
+  BC-3810.30.10:
+    name: Freileitungsinspektion
+    description: |
+      Routinemäßige, Besteiger- und Luftinspektionen von Hochspannungsfreileitungen.
+  BC-3810.30.20:
+    name: Erdkabelbetrieb
+    description: |
+      Betrieb, Teilentladungsüberwachung und Muffentrassen-Management von HV-Kabeln.
+  BC-3810.30.30:
+    name: Schutzstreifen- und Vegetationspflege
+    description: |
+      Vegetationsbeseitigung und Schutzstreifenpflege nach NERC FAC-003 bzw. gleichwertigen Normen.
+  BC-3810.30.40:
+    name: Mastinstandhaltung
+    description: |
+      Anstrich-, Fundament- und Tragwerksarbeiten an Übertragungsmasten.
+  BC-3810.40:
+    name: Umspannwerksbetrieb
+    description: |
+      Betrieb und Überwachung von HV-Umspannwerken, Transformatoren,
+      Schaltanlagen und Blindleistungsanlagen.
+  BC-3810.40.10:
+    name: Leistungstransformatorbetrieb
+    description: |
+      Überwachung, Ölgasanalyse und Stufenschalterbetrieb von HV-Transformatoren.
+  BC-3810.40.20:
+    name: Schaltanlagenbetrieb
+    description: |
+      Betrieb und Zustandsüberwachung von HV-Leistungsschaltern und Trennschaltern.
+  BC-3810.40.30:
+    name: Blindleistungskompensationsbetrieb
+    description: |
+      Betrieb von Kondensatorbänken, Drosseln, SVCs und STATCOMs zur Blindleistungsstützung.
+  BC-3810.40.40:
+    name: HGÜ-Umrichterstationsbetrieb
+    description: |
+      Betrieb von HGÜ-Umrichterstationen und DC-Verbindungssteuerung.
+  BC-3810.50:
+    name: Übertragungsstillstandskoordination
+    description: |
+      Planung, Terminierung und Genehmigung geplanter und ungeplanter
+      Stillstände von Übertragungselementen mit Systemsicherheits- und Marktfolgebewertung.
+  BC-3810.50.10:
+    name: Stillstandsplaneinreichung
+    description: |
+      Einreichung und Revision von Übertragungsstillstandsplänen beim Netzbetreiber.
+  BC-3810.50.20:
+    name: Stillstandsrisikobewertung
+    description: |
+      Bewertung der Systemsicherheits- und Marktfolgen geplanter Stillstände.
+  BC-3810.50.30:
+    name: Zwangsstillstandsmeldung
+    description: |
+      Meldung von Zwangsstillständen und Nichtverfügbarkeiten an Netzbetreiber und Regulierer.
+  BC-3810.60:
+    name: Übertragungsschutz und Steuerung
+    description: |
+      Einstellung, Überwachung und Nachanalyse von Übertragungsschutz- und
+      Sonderschutzprogrammen.
+  BC-3810.60.10:
+    name: Schutzeinstellungsmanagement
+    description: |
+      Berechnung, Genehmigung und Ausgabe von Schutzrelaiseinstellungen.
+  BC-3810.60.20:
+    name: Sonderschutzprogrammbetrieb
+    description: |
+      Betrieb und Überwachung von Maßnahmenautomatiken und Sonderschutzprogrammen.
+  BC-3810.60.30:
+    name: Störungsereignisanalyse
+    description: |
+      Analyse von Störungsaufzeichnungen und Schutzleistung nach Netzereignissen.
+  BC-3810.70:
+    name: Übertragungssystemsicherheitsmanagement
+    description: |
+      Cyber- und physische Sicherheit des Hochspannungssystems,
+      einschließlich NERC-CIP-Maßnahmenumsetzung, Perimetersicherung
+      und Registrierung BES-relevanter Anlagen.
+  BC-3810.70.10:
+    name: BES-Cyber-Asset-Identifikation
+    description: |
+      Identifizierung und Einstufung von BES-Cybersystemen gemäß NERC CIP-002.
+  BC-3810.70.20:
+    name: Elektronischer Sicherheitsperimetermebetrieb
+    description: |
+      Betrieb elektronischer Sicherheitsperimeter und interaktiver Fernzugangskontrollen.
+  BC-3810.70.30:
+    name: Physischer Sicherheitsperimeterbetrieb
+    description: |
+      Physische Sicherheitsmaßnahmen für Leitstellen und kritische Umspannwerke (NERC CIP-014).
+  BC-3810.70.40:
+    name: NERC-CIP-Compliance-Nachweismanagement
+    description: |
+      Nachweissammlung, Attestierung und Prüfungsreaktion für NERC-CIP-Standards.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-electronic-component-sourcing-management.yaml
+++ b/catalogue/i18n/de/L1-electronic-component-sourcing-management.yaml
@@ -1,0 +1,131 @@
+locale: de
+source: L1-electronic-component-sourcing-management.yaml
+entries:
+  BC-1930:
+    name: Elektronikkomponenten-Beschaffung Management
+    description: |
+      Beschaffung und Lebenszykluspflege elektronischer Komponenten — genehmigte Lieferantenlisten,
+      Obsoleszenzbehandlung, Zuteilung, Fälschungsprävention, Qualifizierung und Stoffdaten.
+  BC-1930.10:
+    name: Genehmigter Lieferantenlisten-Management
+    description: |
+      Pflege genehmigter Komponentenquellen, Alternativen und Querverweise.
+  BC-1930.10.10:
+    name: Bevorzugte Teilelisten-Management
+    description: |
+      Pflege bevorzugter Komponentenlisten mit technischer Genehmigung.
+  BC-1930.10.20:
+    name: Alternativquellen-Qualifizierung
+    description: |
+      Qualifizierung alternativer Komponentenquellen.
+  BC-1930.10.30:
+    name: Querverweis-Management
+    description: |
+      Zuordnung äquivalenter Komponenten verschiedener Hersteller.
+  BC-1930.20:
+    name: Komponenten-Lebenszyklus- & Obsoleszenz-Management
+    description: |
+      Verfolgung des Komponentenlebenszyklus und Umgang mit Obsoleszenzereignissen.
+  BC-1930.20.10:
+    name: Produktänderungsbenachrichtigungs-Triage
+    description: |
+      Triage und Folgenabschätzung von Lieferanten-Produktänderungsbenachrichtigungen.
+  BC-1930.20.20:
+    name: End-of-Life-Meldungs-Triage
+    description: |
+      Triage von End-of-Life-Meldungen und Auswirkungen auf Stücklisten.
+  BC-1930.20.30:
+    name: Last-Time-Buy-Entscheidung
+    description: |
+      Entscheidungsfindung zu Last-Time-Buy-Mengen und Überbrückungsbeständen.
+  BC-1930.20.40:
+    name: Komponenten-Lebenszyklus-Prognose
+    description: |
+      Prognose von Komponenten-Lebenszyklusstadien über die Stückliste hinweg.
+  BC-1930.30:
+    name: Halbleiter-Zuteilungs-Management
+    description: |
+      Verwaltung der Halbleiterzuteilung in Mangelsituationen.
+  BC-1930.30.10:
+    name: Zuteilungsprognose-Management
+    description: |
+      Prognose der Nachfrage zur Unterstützung der Lieferantenzuteilungspositionierung.
+  BC-1930.30.20:
+    name: Lieferanten-Zuteilungsverhandlung
+    description: |
+      Verhandlung des Zuteilungsanteils mit Halbleiterlieferanten.
+  BC-1930.30.30:
+    name: Zuteilungsbedarfs-Priorisierung
+    description: |
+      Interne Priorisierung der zugeteilten Versorgung über Produktlinien hinweg.
+  BC-1930.40:
+    name: Fälschungskomponenten-Prävention
+    description: |
+      Erkennung und Prävention gefälschter elektronischer Komponenten in der Lieferkette.
+  BC-1930.40.10:
+    name: Fälschungsrisikobewertung
+    description: |
+      Risikobewertung von Beschaffungskanälen hinsichtlich Fälschungsexposition.
+  BC-1930.40.20:
+    name: Eingehende Komponenten-Authentifizierung
+    description: |
+      Authentifizierung und Inspektion eingehender Komponenten.
+  BC-1930.40.30:
+    name: Lieferanten-Rückverfolgbarkeit
+    description: |
+      Rückverfolgbarkeit von Komponenten bis zu autorisierten Herstellern.
+  BC-1930.50:
+    name: Elektronische Komponenten-Qualifizierung
+    description: |
+      Qualifizierung elektronischer Komponenten für den Produktionseinsatz.
+  BC-1930.50.10:
+    name: Erstmuster-Inspektion
+    description: |
+      Erstmusterinspektion von Komponenten gegen Spezifikationen.
+  BC-1930.50.20:
+    name: Komponenten-Zuverlässigkeitsqualifizierung
+    description: |
+      Zuverlässigkeitsqualifizierung von Komponenten gegen Betriebsprofile.
+  BC-1930.50.30:
+    name: Automotive AEC-Q-Qualifizierung
+    description: |
+      Qualifizierung von Komponenten nach AEC-Q100/AEC-Q200-Stressprofile.
+  BC-1930.50.40:
+    name: Halbleiter-JEDEC-Qualifizierung
+    description: |
+      Qualifizierung von Halbleitern nach JEDEC-Normen.
+  BC-1930.60:
+    name: Distributor- & Broker-Management
+    description: |
+      Verwaltung autorisierter Distributor- und Brokerkanäle.
+  BC-1930.60.10:
+    name: Autorisierter Distributor-Onboarding
+    description: |
+      Onboarding autorisierter Elektronikkomponenten-Distributoren.
+  BC-1930.60.20:
+    name: Broker-Quellen-Risikobewertung
+    description: |
+      Risikobewertung unabhängiger Broker-Beschaffung.
+  BC-1930.60.30:
+    name: Distributor-Leistungsüberprüfung
+    description: |
+      Periodische Überprüfung von Distributor-Leistung und -Compliance.
+  BC-1930.70:
+    name: Komponenten-Compliance-Datenverwaltung
+    description: |
+      Sammlung und Verwaltung von Stoff- und Compliance-Daten zu Komponenten.
+  BC-1930.70.10:
+    name: Stoffdatensammlung
+    description: |
+      Sammlung von Stoffzusammensetzungsdaten von Komponentenlieferanten.
+  BC-1930.70.20:
+    name: Konfliktmineralien-Schmelzerdaten
+    description: |
+      Sammlung von Schmelzer-Daten für Konfliktmineralien-Sorgfaltspflicht.
+  BC-1930.70.30:
+    name: REACH-SVHC-Tracking
+    description: |
+      Verfolgung von besonders besorgniserregenden Stoffen auf Komponentenebene.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-energy-trading-settlement-management.yaml
+++ b/catalogue/i18n/de/L1-energy-trading-settlement-management.yaml
@@ -1,0 +1,144 @@
+locale: de
+source: L1-energy-trading-settlement-management.yaml
+entries:
+  BC-3850:
+    name: Energiehandel und Abrechnungs Management
+    description: |
+      Großhandel von Strom, Gas und Umweltkommoditäten –
+      Marktbeteiligung in Day-ahead-, Intraday- und Ausgleichszeiträumen,
+      Energierisikoverwaltung, Scheduling und Nominierungen,
+      Kapazitätsmarktbeteiligung sowie Back-Office-Abrechnung und
+      regulatorische Meldepflichten unter REMIT/EMIR/Dodd-Frank-Regimes.
+  BC-3850.10:
+    name: Großhandel Stromhandel
+    description: |
+      Front-Office-Handel physischer und finanzieller Energie über
+      Day-ahead-, Intraday- und Terminmärkte.
+  BC-3850.10.10:
+    name: Day-ahead-Markthandel
+    description: |
+      Einreichung und Verwaltung von Day-ahead-Marktgeboten und -angeboten.
+  BC-3850.10.20:
+    name: Intraday-Markthandel
+    description: |
+      Kontinuierlicher und auktionsbasierter Intraday-Handel gegen Positionsveränderungen.
+  BC-3850.10.30:
+    name: Termin- und bilateraler Handel
+    description: |
+      Physischer Terminhandel und bilateraler OTC-Handel zur Absicherung und Herkunft.
+  BC-3850.10.40:
+    name: Grenzüberschreitender Kapazitätshandel
+    description: |
+      Handel grenzüberschreitender Interkonnektorkapazitätsprodukte.
+  BC-3850.20:
+    name: Energierisikoverwaltung
+    description: |
+      Markt-, Kredit- und operationelle Risikoüberwachung des Handelsportfolios
+      mit Limitverwaltung und Stresstests.
+    in_scope:
+      - VaR- und Earnings-at-Risk-Berechnung
+      - Counterparty-Kreditlimitmanagement
+      - Hedge-Effektivitätstests
+    out_of_scope:
+      - Unternehmensweites Risikomanagement (BC-120)
+      - Kreditrisiko gegenüber Privatkunden (BC-3910)
+  BC-3850.20.10:
+    name: Marktrisiko-Überwachung
+    description: |
+      VaR-, Earnings-at-Risk- und Exposureüberwachung des Handelsbuchs.
+  BC-3850.20.20:
+    name: Gegenpartei-Kreditrisikomanagement
+    description: |
+      Gegenpartei-Kreditlimite, Sicherheiten und Exposureüberwachung.
+  BC-3850.20.30:
+    name: Absicherungsprogrammmanagement
+    description: |
+      Konzeption und Umsetzung von Absicherungsprogrammen gegen Brennstoff- und Stromexposure.
+  BC-3850.30:
+    name: Positionsmanagement und Scheduling
+    description: |
+      Aggregation von Handels- und physischen Positionen sowie Einreichung von
+      Schedules und Nominierungen bei Netz- und Leitungsbetreibern.
+  BC-3850.30.10:
+    name: Handelspositionsaggregation
+    description: |
+      Aggregation von Positionen über Produkte, Bücher und Gegenparteien.
+  BC-3850.30.20:
+    name: Stromfahrplaneinreichung
+    description: |
+      Einreichung physischer Stromfahrpläne bei ÜNBs und Bilanzkreisverantwortlichen.
+  BC-3850.30.30:
+    name: Gasnominierungseinreichung
+    description: |
+      Einreichung von Gasnominierungen und Wiederausgleich auf Übertragungsleitungen.
+  BC-3850.40:
+    name: Kapazitätsmarktbeteiligung
+    description: |
+      Beteiligung an Kapazitätsmarkt- und Versorgungssicherheitsmechanismen
+      einschließlich Auktionsstrategie, Qualifikation und Lieferüberwachung.
+  BC-3850.40.10:
+    name: Kapazitätsauktionstrategie
+    description: |
+      Strategie und Gebotsvorbereitung für Kapazitätsmarktauktionen.
+  BC-3850.40.20:
+    name: Kapazitätsanbieterqualifikation
+    description: |
+      Anlagenqualifikation und Deratierungsfaktormanagement für Kapazitätsprodukte.
+  BC-3850.40.30:
+    name: Kapazitätslieferungsüberwachung
+    description: |
+      Überwachung der Kapazitätslieferung bei Stressereignissen und Strafexposure.
+  BC-3850.50:
+    name: Umweltkommoditätenhandel
+    description: |
+      Handel und Abgabe von Kohlenstoffzertifikaten, erneuerbaren Zertifikaten,
+      Herkunftsnachweisen und Weißen Zertifikaten.
+  BC-3850.50.10:
+    name: Kohlenstoffzertifikathandel
+    description: |
+      Handel mit EUA, CCA und anderen Compliance-Kohlenstoffzertifikaten.
+  BC-3850.50.20:
+    name: Erneuerbare Zertifikate Handel
+    description: |
+      Handel mit RECs, ROCs und Herkunftsnachweisen.
+  BC-3850.50.30:
+    name: Weiße Zertifikate Betrieb
+    description: |
+      Handel und Abgabe von Energieeffizienz-Weißzertifikaten.
+  BC-3850.60:
+    name: Handelsabrechnungsbetrieb
+    description: |
+      Back-Office-Bestätigung, Abrechnungsberechnung, Rechnungsstellung und
+      Cash-Management von Großhandelsenergegeschäften.
+  BC-3850.60.10:
+    name: Handelsbestätigung
+    description: |
+      Ausgehende und eingehende Handelsbestätigungen und Differenzklärung.
+  BC-3850.60.20:
+    name: Abrechnungsberechnung
+    description: |
+      Berechnung physischer und finanzieller Abrechnungsbeträge je Kontrakt.
+  BC-3850.60.30:
+    name: Handelsabrechnung und Cash-Management
+    description: |
+      Rechnungsstellung, Zahlung und Abstimmung von Großhandelshandels-Cashflows.
+  BC-3850.70:
+    name: Handels-Regulierungsberichterstattung
+    description: |
+      Regulatorische Meldung von Großhandelsenergegeschäften unter
+      REMIT-, EMIR-, MiFID-II- und Dodd-Frank-Regimes.
+  BC-3850.70.10:
+    name: REMIT-Transaktionsmeldung
+    description: |
+      Tabellen 1- und 2-Meldung von Großhandelsenergegeschäften an die ACER.
+  BC-3850.70.20:
+    name: EMIR- und Dodd-Frank-Meldung
+    description: |
+      Meldung von Derivategeschäften an Transaktionsregister unter EMIR und Dodd-Frank.
+  BC-3850.70.30:
+    name: Insiderinformationsveröffentlichung
+    description: |
+      Veröffentlichung von Insiderinformationen gemäß REMIT Art. 4.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-engagement-quality-management.yaml
+++ b/catalogue/i18n/de/L1-engagement-quality-management.yaml
@@ -1,0 +1,146 @@
+locale: de
+source: L1-engagement-quality-management.yaml
+entries:
+  BC-4340:
+    name: Auftragsqualitätssicherung
+    description: |
+      Qualitätsmanagementsystem der Kanzlei, Auftragsqualitätsreviews,
+      Aktenreviews, technische Beratung, Überwachung und Reaktion auf
+      externe Praxisinspektionen bei professionellen Dienstleistungs-
+      aufträgen.
+  BC-4340.10:
+    name: Kanzlei-Qualitätsmanagementsystem
+    description: |
+      Konzeption, Implementierung und Betrieb des kanzleiweiten
+      Qualitätsmanagementsystems gemäß ISQM 1 und gleichwertigen
+      Regimen.
+  BC-4340.10.10:
+    name: Qualitätsrisikobewertung
+    description: |
+      Identifikation und Bewertung von Qualitätsrisiken über die
+      Aufträge und den Betrieb der Kanzlei hinweg.
+  BC-4340.10.20:
+    name: Qualitätsmaßnahmendesign
+    description: |
+      Konzeption von Grundsätzen und Verfahren als Reaktion auf
+      identifizierte Qualitätsrisiken.
+  BC-4340.10.30:
+    name: Qualitätsgovernance und Verantwortlichkeit
+    description: |
+      Zuweisung der Verantwortung für das QMS an geschäftsführende
+      Partner, Qualitätsleitung und Auftragspartner.
+  BC-4340.10.40:
+    name: Jährliche QMS-Bewertung
+    description: |
+      Jährliche Bewertung der Betriebswirksamkeit des kanzleiweiten
+      Qualitätsmanagementsystems.
+  BC-4340.20:
+    name: Auftragsqualitätsreview
+    description: |
+      Unabhängiger Auftragsqualitätsreview (EQR) durch einen nicht
+      am Auftrag beteiligten Reviewer vor der Berichtsveröffentlichung
+      bei Aufträgen, die Risiko- oder regulatorische Auslöser erfüllen.
+  BC-4340.20.10:
+    name: EQR-Berechtigung und Auslöserprüfung
+    description: |
+      Identifikation von Aufträgen, die EQR aufgrund regulatorischer,
+      Risiko- oder Kanzleirichtlinienauslöser erfordern.
+  BC-4340.20.20:
+    name: EQR-Reviewer-Zuweisung
+    description: |
+      Zuweisung qualifizierter, unabhängiger EQR-Reviewer für
+      ausgelöste Aufträge.
+  BC-4340.20.30:
+    name: EQR-Durchführung und Freigabe
+    description: |
+      Durchführung von EQR-Verfahren und Freigabe als Voraussetzung
+      für die Leistungsveröffentlichung.
+  BC-4340.30:
+    name: Auftragsaktenreview
+    description: |
+      Post-Veröffentlichungs-Hot- und Cold-File-Reviews an einer
+      Stichprobe abgeschlossener Auftragsakten zur Bewertung der
+      Compliance mit Kanzleimethodik und Berufsstandards.
+  BC-4340.30.10:
+    name: Hot-File-Review
+    description: |
+      Vor-Veröffentlichungs-Aktenreview bei ausgewählten Aufträgen,
+      bei denen zusätzliche Sicherheit über die Compliance erforderlich
+      ist.
+  BC-4340.30.20:
+    name: Cold-File-Review
+    description: |
+      Post-Veröffentlichungs-retrospektiver Aktenreview auf
+      Stichprobenbasis zur Bewertung der Methodikkonformität und
+      Qualität.
+  BC-4340.30.30:
+    name: Aktenreview-Befundbehandlung
+    description: |
+      Behandlung von Aktenreview-Befunden einschließlich Behebung,
+      Schulungsimplikationen und Auftragspartner-Feedback.
+  BC-4340.40:
+    name: Technisches Beratungsmanagement
+    description: |
+      Pflichtgemäße und freiwillige technische Beratung bei komplexen
+      Auftragsfragen mit der Landesgeschäftsstelle, technischen oder
+      Spezialfunktionen.
+  BC-4340.40.10:
+    name: Pflichtgemäße technische Beratung
+    description: |
+      Durch Kanzleirichtlinie vorgeschriebene Beratung bei definierten
+      komplexen Situationen wie Going-Concern, Betrugsrisiko oder
+      neuartigen Sachverhalten.
+  BC-4340.40.20:
+    name: Freiwillige technische Beratung
+    description: |
+      Ermessensgemäße Beratung auf Anfrage des Auftragsteams bei
+      komplexen technischen Fragen.
+  BC-4340.40.30:
+    name: Technische Beratungsdokumentation
+    description: |
+      Dokumentation von Beratungsanfragen, erteiltem Rat und
+      erreichten Schlussfolgerungen in der Auftragsakte.
+  BC-4340.50:
+    name: Qualitätsüberwachung und Behebung
+    description: |
+      Laufende Überwachungsaktivitäten, Ursachenanalyse von
+      Qualitätsmängeln und Behebungsprogramme.
+  BC-4340.50.10:
+    name: Qualitätsindikatorenüberwachung
+    description: |
+      Überwachung von Früh- und Spätindikatoren der Qualität über
+      das Auftragsportfolio hinweg.
+  BC-4340.50.20:
+    name: Mängelursachenanalyse
+    description: |
+      Ursachenanalyse identifizierter Qualitätsmängel und
+      systemischer Befunde.
+  BC-4340.50.30:
+    name: Behebungsmaßnahmenmanagement
+    description: |
+      Definition, Durchführung und Verifizierung von Behebungs-
+      maßnahmen aus Überwachung und Inspektionen.
+  BC-4340.60:
+    name: Praxisinspektionsreaktion
+    description: |
+      Koordination der Reaktionen auf externe Praxisinspektionen durch
+      Regulatoren und Aufsichtsbehörden wie PCAOB, FRC, IAASA, ICAEW
+      und gleichwertige Regime.
+  BC-4340.60.10:
+    name: Inspektionsakte-Auswahlkoordination
+    description: |
+      Koordination von Aktenauswahlen und Informationsanfragen
+      der prüfenden Behörden.
+  BC-4340.60.20:
+    name: Inspektionsbefundreaktion
+    description: |
+      Entwurf und Einreichung formaler Reaktionen auf Inspektions-
+      befunde und erforderliche Abhilfepläne.
+  BC-4340.60.30:
+    name: Inspektionsergebniskommunikation
+    description: |
+      Interne und, wo erforderlich, externe Kommunikation von
+      Inspektionsergebnissen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-engineering-discipline-management.yaml
+++ b/catalogue/i18n/de/L1-engineering-discipline-management.yaml
@@ -1,0 +1,150 @@
+locale: de
+source: L1-engineering-discipline-management.yaml
+entries:
+  BC-1100:
+    name: Ingenieurdisziplin-Management
+    description: |
+      Multidisziplinäre Ingenieurfähigkeitspools – Mechanik, Elektro, Bau, Verfahrenstechnik, Messtechnik, Rohrleitungen.
+  BC-1100.10:
+    name: Maschinenbau-Management
+    description: |
+      Maschinenbaukompetenz – Anlagen, rotierende Maschinen, mechanische Systeme.
+  BC-1100.10.10:
+    name: Statische Anlagen-Ingenieurwesen
+    description: |
+      Druckbehälter, Wärmetauscher und sonstige statische Anlagendesigns.
+  BC-1100.10.20:
+    name: Rotierende Maschinen-Ingenieurwesen
+    description: |
+      Pumpen, Kompressoren, Turbinen und rotierende Maschinentechnik.
+  BC-1100.10.30:
+    name: HVAC-Ingenieurwesen
+    description: |
+      HVAC-Systemdesign und -analyse.
+  BC-1100.10.40:
+    name: Werkstoffe und Schweißtechnik-Ingenieurwesen
+    description: |
+      Werkstoffauswahl, Schweißspezifikationen und Korrosionsschutzdesign.
+  BC-1100.20:
+    name: Elektrotechnik-Management
+    description: |
+      Energie, Stromverteilung und elektrotechnisches Steuerungsingenieurwesen.
+  BC-1100.20.10:
+    name: Energiesysteme-Ingenieurwesen
+    description: |
+      Hoch- und Mittelspannungs-Energiesystemingenieurwesen.
+  BC-1100.20.20:
+    name: Elektroverteilungsdesign
+    description: |
+      Niederspannungsverteilung, Schaltanlagen und Lastpläne.
+  BC-1100.20.30:
+    name: Elektrische Betriebsmittelspezifikation
+    description: |
+      Spezifikation von Motoren, Transformatoren und elektrischen Betriebsmitteln.
+  BC-1100.20.40:
+    name: Erdungs- und Blitzschutzdesign
+    description: |
+      Erdung, Potentialausgleich und Blitzschutzdesign.
+  BC-1100.30:
+    name: Bau- und Tragwerksplanungs-Management
+    description: |
+      Tiefbau, Stahlbau, Beton, Fundamente und Geotechnik.
+  BC-1100.30.10:
+    name: Stahlbau-Design
+    description: |
+      Design von Stahlkonstruktionen und Verbindungen.
+  BC-1100.30.20:
+    name: Beton- und Fundament-Design
+    description: |
+      Betonkonstruktionen, Fundamente und Bewehrungsdesign.
+  BC-1100.30.30:
+    name: Geotechnik-Ingenieurwesen
+    description: |
+      Geotechnische Untersuchung und Erdbauingenieurwesen.
+  BC-1100.30.40:
+    name: Baustelleninfrastruktur-Ingenieurwesen
+    description: |
+      Geländemodellierung, Entwässerung und Tiefbauinfrastruktur-Design.
+  BC-1100.40:
+    name: Verfahrenstechnik-Management
+    description: |
+      Prozessdesign, Simulation, R&I-Fließschemata, Stoff- und Energiebilanzen, Hydraulik.
+  BC-1100.40.10:
+    name: Prozesssimulation und -modellierung
+    description: |
+      Stationäre und dynamische Prozesssimulation.
+  BC-1100.40.20:
+    name: R&I-Fließschema- und PFD-Entwicklung
+    description: |
+      Prozessfließdiagramme und Rohrleitungs- und Instrumentierungsfließschemata.
+  BC-1100.40.30:
+    name: Stoff- und Energiebilanz-Ingenieurwesen
+    description: |
+      Wärme- und Stoffbilanzen sowie Auslegung von Prozessanlagen.
+  BC-1100.40.40:
+    name: Prozesssicherheits-Ingenieurwesen
+    description: |
+      Sicherheits- und Fackeleinrichtungen, SIL-Klassifizierung und Prozesssicherheit.
+  BC-1100.50:
+    name: Mess- und Regeltechnik-Management
+    description: |
+      Feldmesstechnik, Automatisierung und Steuerungssystemingenieurwesen.
+  BC-1100.50.10:
+    name: Feldmesstechnik-Ingenieurwesen
+    description: |
+      Spezifikation von Feldtransmittern, Sensoren und Stellgeräten.
+  BC-1100.50.20:
+    name: Steuerungssystem-Design
+    description: |
+      DCS- und SPS-Architektur und Regelkreisdesign.
+  BC-1100.50.30:
+    name: Sicherheitsinstrumentiertes System-Design
+    description: |
+      SIS-Design gemäß IEC 61511 und SIL-Verifikation.
+  BC-1100.50.40:
+    name: Automatisierungs- und Steuerungssoftware-Ingenieurwesen
+    description: |
+      Konfiguration von Steuerungslogik und Automatisierungssoftware-Ingenieurwesen.
+  BC-1100.60:
+    name: Rohrleitungs-Ingenieurwesen-Management
+    description: |
+      Rohrleitungsdesign, Layouts, Isometrien, Spannungsanalyse und Werkstoffauswahl.
+  BC-1100.60.10:
+    name: Rohrleitungslayout-Design
+    description: |
+      Rohrleitungsgesamtanordnung und 3D-Rohrleitungslayout.
+  BC-1100.60.20:
+    name: Rohrleitungs-Spannungsanalyse
+    description: |
+      Rohrleitungsspannungsanalyse und Unterstützungsdesign.
+  BC-1100.60.30:
+    name: Rohrleitungswerkstoffauswahl
+    description: |
+      Werkstoffklassen, Dichtungen, Armaturen und Isolierungsauswahl.
+  BC-1100.60.40:
+    name: Isometriezeichnungs-Erstellung
+    description: |
+      Erstellung von Rohrleitungsisometrien und Stücklisten.
+  BC-1100.70:
+    name: Disziplin-Ressourcen- und Kompetenzmanagement
+    description: |
+      Disziplinpools, Kompetenzrahmen und technische Karrierepfade.
+  BC-1100.70.10:
+    name: Ingenieur-Ressourcenpool-Management
+    description: |
+      Zuteilung von Fachressourcen über Projekte hinweg.
+  BC-1100.70.20:
+    name: Ingenieur-Kompetenzrahmen
+    description: |
+      Disziplinkompetenzrahmen und Fähigkeitsmatrizen.
+  BC-1100.70.30:
+    name: Technischer Karrierepfad-Management
+    description: |
+      Technische Karriereleitern und Entwicklung zum Chartered Engineer.
+  BC-1100.70.40:
+    name: Ingenieur-Wissensmanagement
+    description: |
+      Ingenieurwissensaustausch, Communities und Lessons Learned.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-engineering-document-management.yaml
+++ b/catalogue/i18n/de/L1-engineering-document-management.yaml
@@ -1,0 +1,106 @@
+locale: de
+source: L1-engineering-document-management.yaml
+entries:
+  BC-1130:
+    name: Ingenieurwesen-Dokumentenmanagement
+    description: |
+      Kontrollierte Ingenieurwesen-Dokumente, Zeichnungen, Spezifikationen und Lieferantendaten.
+  BC-1130.10:
+    name: Dokumentensteuerungsmanagement
+    description: |
+      Dokumentennummerierung, Revisionssteuerung und Stammdokumentenregister.
+  BC-1130.10.10:
+    name: Dokumentennummerierung und -kodierung
+    description: |
+      Dokumentennummerierungsschemata, Taxonomie und Kodierung.
+  BC-1130.10.20:
+    name: Revisionssteuerung
+    description: |
+      Revisionsverfolgung, Status und Versionshistorie.
+  BC-1130.10.30:
+    name: Stammdokumentenregister
+    description: |
+      Pflege des Stammdokumentenregisters und der Statusinformationen.
+  BC-1130.20:
+    name: Zeichnungsmanagement
+    description: |
+      Zeichnungslebenszyklus, Verteilung und Freigaben.
+  BC-1130.20.10:
+    name: Zeichnungsproduktions-Workflow
+    description: |
+      Zeichnungsproduktions-Workflow mit Prüfung, Review und Ausgabe.
+  BC-1130.20.20:
+    name: Zeichnungsfreigabe und -ausgabe
+    description: |
+      Freigabe und Ausgabe von Zeichnungen an Bau und Stakeholder.
+  BC-1130.20.30:
+    name: Zeichnungslebenszyklus-Verfolgung
+    description: |
+      Lebenszyklusverfolgung vom Vorentwurf bis zum As-Built.
+  BC-1130.30:
+    name: Spezifikationsmanagement
+    description: |
+      Technische Spezifikationen, Datenblätter und Normeneinhaltung.
+  BC-1130.30.10:
+    name: Technische Spezifikations-Erstellung
+    description: |
+      Ausarbeitung von technischen Spezifikationen und Datenblättern.
+  BC-1130.30.20:
+    name: Ingenieurwesen-Normenbibliothek
+    description: |
+      Pflege der Ingenieurwesen-Normenbibliothek und -referenzen.
+  BC-1130.30.30:
+    name: Spezifikationsfreigabe und -ausgabe
+    description: |
+      Freigabe und Ausgabe von Spezifikationen an die Beschaffung.
+  BC-1130.40:
+    name: Lieferantendokumenten-Management
+    description: |
+      Lieferantendatenanforderungen, Einreichungen, Reviews und Dispositionen.
+  BC-1130.40.10:
+    name: Lieferantendatenanforderungs-Definition
+    description: |
+      Definition von Lieferantendatenanforderungslisten für Bestellungen.
+  BC-1130.40.20:
+    name: Lieferantendokumenten-Einreichungsverfolgung
+    description: |
+      Verfolgung von Lieferantendokumenten-Einreichungen und Status.
+  BC-1130.40.30:
+    name: Lieferantendokumenten-Review und Disposition
+    description: |
+      Review und Disposition von Lieferantendokumenten (Code 1/2/3).
+  BC-1130.50:
+    name: Dokumentenverteilungs- und Transmittal-Management
+    description: |
+      Transmittals, formale Korrespondenz und Empfängerverfolgung.
+  BC-1130.50.10:
+    name: Transmittal-Ausgabe
+    description: |
+      Formale Ausgabe von Dokumenten-Transmittals.
+  BC-1130.50.20:
+    name: Verteilermatrix-Management
+    description: |
+      Verteilermatrizen und Empfängerdefinitionen.
+  BC-1130.50.30:
+    name: Empfangsbestätigungs-Verfolgung
+    description: |
+      Empfangsbestätigung und Prüfpfad von Quittierungen.
+  BC-1130.60:
+    name: As-Built-Dokumentations-Management
+    description: |
+      Rotlinie-Markierungen, As-Built-Konsolidierung und Übergabedokumentation.
+  BC-1130.60.10:
+    name: Rotlinie-Markierungs-Erfassung
+    description: |
+      Erfassung von Baustellenrötmarkierungen während der Bauphase.
+  BC-1130.60.20:
+    name: As-Built-Konsolidierung
+    description: |
+      Konsolidierung von Rotlinien zu As-Built-Liefergegenständen.
+  BC-1130.60.30:
+    name: Übergabedokumenten-Zusammenstellung
+    description: |
+      Zusammenstellung von Betriebs- und Wartungsübergabepaketen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-engineering-tendering-estimation-management.yaml
+++ b/catalogue/i18n/de/L1-engineering-tendering-estimation-management.yaml
@@ -1,0 +1,114 @@
+locale: de
+source: L1-engineering-tendering-estimation-management.yaml
+entries:
+  BC-1140:
+    name: Ingenieurwesen-Ausschreibungs- und Kalkulations-Management
+    description: |
+      Angebotserstellung und Entwicklung technischer sowie kaufmännischer Angebote.
+  BC-1140.10:
+    name: Anbieten-oder-Nicht-Anbieten-Entscheidungsmanagement
+    description: |
+      Gelegenheitsqualifizierung, strategische Angebotsentscheidungen und Akquisitionsplanung.
+  BC-1140.10.10:
+    name: Gelegenheitsqualifizierung
+    description: |
+      Qualifizierung von Gelegenheiten anhand von Angebotskriterien.
+  BC-1140.10.20:
+    name: Anbieten-oder-Nicht-Anbieten-Entscheidungssteuerung
+    description: |
+      Steuerung von Angebotsentscheidungen und Gateway-Freigaben.
+  BC-1140.10.30:
+    name: Akquisitionsplanung
+    description: |
+      Akquisitionspläne, Gewinnthemen und Wettbewerbspositionierung.
+  BC-1140.20:
+    name: Ingenieurwesen-Kalkulationsmanagement
+    description: |
+      Ingenieurstunden, Komplexitätsfaktoren und liefergegenstände-basierte Kalkulation.
+  BC-1140.20.10:
+    name: Ingenieurstunden-Kalkulation
+    description: |
+      Bottom-up-Kalkulation von Ingenieurstunden je Disziplin.
+  BC-1140.20.20:
+    name: Kalkulationsnormen und -benchmarks
+    description: |
+      Pflege von Kalkulationsnormen, Faktoren und Benchmarks.
+  BC-1140.20.30:
+    name: Liefergegenständebasierte Kalkulation
+    description: |
+      Liefergegenstände-basierte Kalkulation einschließlich Komplexitätsfaktoren.
+  BC-1140.30:
+    name: Kosten- und Terminkalkulationsmanagement
+    description: |
+      Baukostenkalkulation, Anlagenkostenkalkulation und Projektterminkalkulation.
+  BC-1140.30.10:
+    name: Anlagenkostenkalkulation
+    description: |
+      Anlagenkostenkalkulation durch Angebote und parametrische Methoden.
+  BC-1140.30.20:
+    name: Baukostenkalkulation
+    description: |
+      Baukostenkalkulation gemäß AACE-Klasse.
+  BC-1140.30.30:
+    name: Projektterminkalkulation
+    description: |
+      Top-down- und Bottom-up-Projektterminkalkulation.
+  BC-1140.30.40:
+    name: Kalkulationsqualitätssicherung
+    description: |
+      Unabhängige QS von Kalkulationen und Benchmarking.
+  BC-1140.40:
+    name: Angebotsentwicklungsmanagement
+    description: |
+      Ausarbeitung technischer und kaufmännischer Angebote und Angebotsmanagement.
+  BC-1140.40.10:
+    name: Technische Angebots-Ausarbeitung
+    description: |
+      Ausarbeitung technischer Angebotsteile.
+  BC-1140.40.20:
+    name: Kaufmännische Angebots-Ausarbeitung
+    description: |
+      Ausarbeitung kaufmännischer Angebotsteile und Preistabellen.
+  BC-1140.40.30:
+    name: Angebotsproduktion und -review
+    description: |
+      Angebotsproduktion, Farb-Reviews und abschließende Konformitätsprüfung.
+  BC-1140.50:
+    name: Ausschreibungseinreichungsmanagement
+    description: |
+      Einreichungsprozess, Klärungen, Verhandlungen und Auftragserteilung.
+  BC-1140.50.10:
+    name: Ausschreibungseinreichungs-Logistik
+    description: |
+      Einreichungslogistik und Plattformkonformität.
+  BC-1140.50.20:
+    name: Ausschreibungsklärungsmanagement
+    description: |
+      Bearbeitung von Klärungen vor und nach der Angebotsabgabe.
+  BC-1140.50.30:
+    name: Verhandlung und Auftragserteilung
+    description: |
+      Verhandlungsunterstützung und Übergabe der Auftragserteilung an die Lieferung.
+  BC-1140.60:
+    name: Ausschreibungspreisgestaltungs- und Margenmanagement
+    description: |
+      Preisstrategie, Margenanalyse, Risikopreisgestaltung und Reserven.
+  BC-1140.60.10:
+    name: Angebotspreisgestaltungsstrategie
+    description: |
+      Angebotspreisgestaltungsstrategie und Wettbewerbspositionierung.
+  BC-1140.60.20:
+    name: Margen- und Reservenfestsetzung
+    description: |
+      Entscheidungen zu Marge, Reserven und Risikopreisgestaltung.
+  BC-1140.60.30:
+    name: Angebotsrisikorückstellung
+    description: |
+      Risikorückstellungen, die auf Basis des Risikoregisters in Angeboten eingepreist werden.
+  BC-1140.60.40:
+    name: Angebotsfreigabe-Steuerung
+    description: |
+      Angebotspreisfreigabe-Gates und Steuerung durch das Senior Management.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-enterprise-risk-management.yaml
+++ b/catalogue/i18n/de/L1-enterprise-risk-management.yaml
@@ -1,0 +1,110 @@
+locale: de
+source: L1-enterprise-risk-management.yaml
+entries:
+  BC-120:
+    name: Unternehmensweites Risikomanagement
+    description: |
+      Identifikation, Bewertung, Steuerung und Überwachung von Risiken auf Unternehmensebene.
+  BC-120.10:
+    name: Risikorahmen- und Risikobereitschaftsmanagement
+    description: |
+      Risikotaxonomie, Rahmenwerk, Risikobereitschaft und -toleranz.
+  BC-120.10.10:
+    name: Risikotaxonomiemanagement
+    description: |
+      Definition und Pflege der unternehmensweiten Risikotaxonomie und -kategorien.
+  BC-120.10.20:
+    name: Risikobereitschaftsdefinition
+    description: |
+      Risikobereitschaftsaussagen und vom Vorstand genehmigte Toleranzschwellen.
+  BC-120.10.30:
+    name: Risikorichtlinien- und Standardsmanagement
+    description: |
+      Gruppenweite Risikorichtlinien, Standards und Methoden.
+  BC-120.10.40:
+    name: Risikokulturmanagement
+    description: |
+      Bewertung, Förderung und Verantwortlichkeitsprogramme der Risikokultur.
+  BC-120.20:
+    name: Risikoidentifikation und -bewertung
+    description: |
+      Risikoerkennung, -bewertung, -bewertung und -priorisierung.
+  BC-120.20.10:
+    name: Risikoidentifikation
+    description: |
+      Workshops, Scans und Inputs zur Aufdeckung neuer und aufkommender Risiken.
+  BC-120.20.20:
+    name: Risikoanalyse und -bewertung
+    description: |
+      Eintrittswahrscheinlichkeit, Auswirkung, Geschwindigkeit sowie Analyse von Brutto- und Nettorisiken.
+  BC-120.20.30:
+    name: Szenario- und Stressanalyse
+    description: |
+      Zukunftsorientierte Szenario-, Stress- und Reverse-Stress-Analyse.
+  BC-120.20.40:
+    name: Aufkommende Risikobeobachtung
+    description: |
+      Frühwarnscan für aufkommende Risiken und schwache Signale.
+  BC-120.30:
+    name: Risikobehandlungsmanagement
+    description: |
+      Entscheidungen zu Minderung, Transfer, Vermeidung und Akzeptanz.
+  BC-120.30.10:
+    name: Risikoreduzierungsplanung
+    description: |
+      Definition von Maßnahmen zur Risikoreduzierung, Verantwortlichen und Zieldaten.
+  BC-120.30.20:
+    name: Risikotransfermanagement
+    description: |
+      Risikotransfer durch Versicherung, Verträge und Absicherung.
+  BC-120.30.30:
+    name: Risikoakzeptanzsteuerung
+    description: |
+      Formale Akzeptanz von Restrisiken oberhalb der Risikobereitschaft mit Genehmigungen.
+  BC-120.30.40:
+    name: Kontrolldesign und -wirksamkeit
+    description: |
+      Definition und Beurteilung der Wirksamkeit von Risikokontrollen.
+  BC-120.40:
+    name: Risikoüberwachung und -berichterstattung
+    description: |
+      Risikoindikatoren, Dashboards und Berichterstattung an Steuerungsgremien.
+  BC-120.40.10:
+    name: Schlüsselrisikoindikatorenmanagement
+    description: |
+      Definition, Schwellenwertfestlegung und Nachverfolgung von Schlüsselrisikoindikatoren.
+  BC-120.40.20:
+    name: Risikoereignis- und Verlusterfassung
+    description: |
+      Erfassung operativer Risikoereignisse, Beinahe-Schäden und Verluste.
+  BC-120.40.30:
+    name: Risikoberichterstattung und Dashboards
+    description: |
+      Periodische Berichte an Exekutivkomitee, Vorstand und Risikoausschuss.
+  BC-120.40.40:
+    name: Risikoaggregation und Konzentrationsanalyse
+    description: |
+      Aggregation von Risiken über das Unternehmen und Konzentrationsbetrachtungen.
+  BC-120.50:
+    name: Unternehmensversicherungsmanagement
+    description: |
+      Beschaffung und Verwaltung unternehmensweiter Versicherungsprogramme.
+  BC-120.50.10:
+    name: Versicherungsprogrammdesign
+    description: |
+      Deckungsstrategie, Selbstbehalt und Limits über alle Versicherungssparten.
+  BC-120.50.20:
+    name: Versicherungsplatzierung und -erneuerung
+    description: |
+      Maklersteuerung, Marktplatzierung und Policenerneuerung.
+  BC-120.50.30:
+    name: Versicherungsschadenmanagement
+    description: |
+      Meldung, Abwicklung und Erstattung von Unternehmensversicherungsschäden.
+  BC-120.50.40:
+    name: Captive-Versicherungsmanagement
+    description: |
+      Betrieb und Steuerung von Captive-Versicherungsvehikeln.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-ev-charging-network-operations-management.yaml
+++ b/catalogue/i18n/de/L1-ev-charging-network-operations-management.yaml
@@ -1,0 +1,177 @@
+locale: de
+source: L1-ev-charging-network-operations-management.yaml
+entries:
+  BC-3480:
+    name: Ladeinfrastruktur-Betrieb (Elektrofahrzeuge)
+    description: |
+      Betrieb von Elektrofahrzeug-Ladenetzen für Ladepunkt-Betreiber
+      und E-Mobility-Dienstleister – Standortplanung, Ladepunkt-Betrieb,
+      Energie- und Tarifmanagement, Kunden- und Roaming-Betrieb,
+      Abrechnung und Abwicklung, Laderwartung sowie Netzdienstleistungen.
+  BC-3480.10:
+    name: Ladestandort-Planung und -Deployment
+    description: |
+      Standortauswahl, Genehmigung, Netzanschluss und physische
+      Bereitstellung von Ladeinfrastruktur.
+  BC-3480.10.10:
+    name: Ladestandort-Auswahl
+    description: |
+      Identifikation und Qualifizierung von Ladestandorten nach
+      Nachfrage-, Grund- und Netzkriterien.
+  BC-3480.10.20:
+    name: Standortgenehmigung und Netzanschluss
+    description: |
+      Genehmigung, Baugenehmigung und Netzanschluss-Koordination
+      für Ladestandorte.
+  BC-3480.10.30:
+    name: Lader-Installationskoordination
+    description: |
+      Koordination von Lader-Installation, Tiefbau, Inbetriebnahme
+      und Übergabe an den Betrieb.
+  BC-3480.20:
+    name: Ladepunkt-Betrieb
+    description: |
+      Täglicher Betrieb von Ladepunkten einschließlich Überwachung,
+      Sitzungslebenszyklus und Firmware-Steuerung über OCPP.
+  BC-3480.20.10:
+    name: Ladepunkt-Überwachung
+    description: |
+      Echtzeitüberwachung von Ladepunkt-Gesundheit, Verfügbarkeit
+      und Alarmzuständen.
+  BC-3480.20.20:
+    name: Ladesitzungs-Lebenszyklusmanagement
+    description: |
+      Management des Ladesitzungs-Lebenszyklus von Autorisierung
+      über Energielieferung bis zur Beendigung.
+  BC-3480.20.30:
+    name: Lader-Firmware- und Konfigurationsmanagement
+    description: |
+      Management von Lader-Firmware-Versionen, Konfigurationsprofilen
+      und Remote-Updates.
+  BC-3480.30:
+    name: Ladeenergie- und Tarifmanagement
+    description: |
+      Management von Energiebeschaffungskoordination, Ladetarifen
+      und Tageszeit-Optimierung im Ladenetz.
+  BC-3480.30.10:
+    name: Großhandels-Energiebeschaffungs-Koordination
+    description: |
+      Koordination mit der Energiebeschaffung zu Volumina, Hedging
+      und PPAs zur Unterstützung des Ladebetriebs.
+  BC-3480.30.20:
+    name: Ladetarif-Definition
+    description: |
+      Definition von öffentlichen, Mitglieder- und Roaming-Ladetarifen
+      in allen Märkten.
+  BC-3480.30.30:
+    name: Lastspitzen- und Tageszeit-Optimierung
+    description: |
+      Optimierung des Ladebetriebs gegen Lastspitzen- und
+      Tageszeit-Energiestrukturen.
+  BC-3480.40:
+    name: Ladekunden- und Abonnement-Management
+    description: |
+      Kunden-Onboarding, Abonnementpläne und Authentifizierung
+      für Ladedienste.
+  BC-3480.40.10:
+    name: Ladekunden-Onboarding
+    description: |
+      Onboarding von Ladekunden einschließlich Identität, Zahlung
+      und Planauswahl.
+  BC-3480.40.20:
+    name: Ladeabonnementplan-Management
+    description: |
+      Management von Abonnement-, Mitgliedschafts- und Prepaid-Plänen
+      für Ladekunden.
+  BC-3480.40.30:
+    name: Ladeauthentifizierung und -Autorisierung
+    description: |
+      Authentifizierung und Autorisierung von Ladesitzungen per RFID,
+      App oder Plug-and-Charge.
+  BC-3480.50:
+    name: Ladeabrechnung und -Abwicklung
+    description: |
+      Abrechnung von Ladesitzungen, Abwicklung mit Roaming-Partnern
+      und Quittungsmanagement für Ladekunden.
+  BC-3480.50.10:
+    name: Ladesitzungs-Abrechnung
+    description: |
+      Bewertung und Abrechnung von Ladesitzungen für direkte und
+      Roaming-Kunden.
+  BC-3480.50.20:
+    name: Roaming-Abwicklung
+    description: |
+      Abwicklung von Roaming-Sitzungen mit Partner-CPOs und EMSPs
+      über OCPI und gleichwertige Protokolle.
+  BC-3480.50.30:
+    name: Erstattungs- und Quittungsmanagement
+    description: |
+      Ausstellung von Quittungen, Auslagenerstattungsunterstützung
+      und Steuerdokumentation für Ladekunden.
+  BC-3480.60:
+    name: Ladenetz-Interoperabilität
+    description: |
+      Interoperabilität mit Roaming-Partnern und Konformität mit
+      Ladestandards für Steckverbinder und Protokolle.
+  BC-3480.60.10:
+    name: Roaming-Partner-Management
+    description: |
+      Onboarding und Management von Roaming-Partnern und -Hubs.
+  BC-3480.60.20:
+    name: Plug-and-Charge-Betrieb
+    description: |
+      Betrieb von ISO-15118-Plug-and-Charge-Vertragszertifikaten
+      und Authentifizierungsabläufen.
+  BC-3480.60.30:
+    name: Ladestecker-Kompatibilitätsmanagement
+    description: |
+      Management von CCS-, NACS-, CHAdeMO- und GB/T-Stecker-
+      Kompatibilität und Adapterlösungen.
+  BC-3480.70:
+    name: Lade-Außendienst und Wartung
+    description: |
+      Außendienst und Wartung von Ladeanlagen einschließlich
+      Einsatzplanung, vorbeugender Wartung und Ersatzteile.
+  BC-3480.70.10:
+    name: Laderfehler-Einsatzplanung
+    description: |
+      Disposition von Außendiensttechnikern zur Reaktion auf
+      Laderfehler und Kundenberichte.
+  BC-3480.70.20:
+    name: Vorbeugende Laderwartung
+    description: |
+      Geplante Wartung und Inspektion von Ladeanlagen.
+  BC-3480.70.30:
+    name: Lader-Ersatzteilmanagement
+    description: |
+      Management von Lader-Ersatzteilbeständen, Reparaturpools
+      und Obsoleszenz.
+  BC-3480.80:
+    name: Netz- und Energiedienstleistungs-Teilnahme
+    description: |
+      Teilnahme von Ladeanlagen an Netz- und Energiemärkten
+      einschließlich Demand-Response, V2G und Smart Charging.
+    in_scope:
+      - V2G-Energieexport und Kapazitätsdienste
+      - Demand-Response-Programmteilnahme
+      - Smart-Charging-Zeitplanoptimierung
+    out_of_scope:
+      - Erzeugungsanlage-Betrieb und Großhandels-Energiehandel
+  BC-3480.80.10:
+    name: Vehicle-to-Grid-Dienst-Betrieb
+    description: |
+      Betrieb von V2G-Diensten zur Lieferung von Energie- und
+      Kapazitätsprodukten an Netz und Regelenergiemärkte.
+  BC-3480.80.20:
+    name: Demand-Response-Programmteilnahme
+    description: |
+      Teilnahme an Demand-Response-Programmen einschließlich
+      Einsatzreaktion und Abwicklung.
+  BC-3480.80.30:
+    name: Smart-Charging-Zeitplanmanagement
+    description: |
+      Zeitplanbasiertes Smart-Charging über Standorte und Fahrzeuge
+      zur Optimierung von Kosten und Netzauswirkungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-events-group-operations-management.yaml
+++ b/catalogue/i18n/de/L1-events-group-operations-management.yaml
@@ -1,0 +1,174 @@
+locale: de
+source: L1-events-group-operations-management.yaml
+entries:
+  BC-4110:
+    name: Veranstaltungs- und Gruppenbetrieb Management
+    description: |
+      Betrieb von Meetings, Incentives, Konferenzen, Ausstellungen und
+      Bankettveranstaltungen in Hospitality-Venues – einschließlich Gruppenvertrieb,
+      Veranstaltungsraum-Zuteilung, Veranstaltungsauftragsausführung,
+      Gruppen-Zimmerblock-Management, AV und Produktion, Abrechnung
+      und Nachveranstaltungsberichterstattung.
+    in_scope:
+      - Gruppenanfragen, Vertragsabschluss und Preisgestaltung
+      - Veranstaltungsraum-Zuteilung und Konfliktlösung
+      - Veranstaltungsauftragserfassung und -ausführung
+      - Gruppen-Zimmerblock-Vertrag, -Liste und Pickup
+      - AV, Bühne und hybride Veranstaltungsproduktion
+      - Masterkonto-Abrechnung und Endabrechnung
+      - Block-vs-Pickup- und Nachveranstaltungs-Leistungsberichterstattung
+    out_of_scope:
+      - Allgemeines Unternehmens-Event-Marketing (BC-410)
+      - Bankett-Küchenproduktion und Lebensmittelsicherheit (BC-4070)
+      - Front-Office-Check-in für Gruppenanreisen (BC-4060.10)
+  BC-4110.10:
+    name: Gruppen- und Veranstaltungsvertriebsmanagement
+    description: |
+      Qualifikation von Gruppenanfragen, Angebots- und Vertragsoperationen,
+      Preisnachlässe und Pipeline-Berichterstattung für das Gruppengeschäft.
+  BC-4110.10.10:
+    name: Gruppenanfragenqualifikation
+    description: |
+      Qualifikation eingehender Gruppenanfragen gegen Zielort-, Raum- und Rateneignung.
+  BC-4110.10.20:
+    name: Gruppenangebots- und Vertragsoperationen
+    description: |
+      Erstellung von Angeboten und Ausführung von Gruppenvertriebsverträgen.
+  BC-4110.10.30:
+    name: Gruppenpreisgestaltungs- und Nachlass-Management
+    description: |
+      Management von Gruppenpreisgestaltung und Nachlass-Verhandlung gegen Erlösvorgaben.
+  BC-4110.10.40:
+    name: Gruppen-Pipeline-Berichterstattung
+    description: |
+      Berichterstattung über die Gruppenvertriebspipeline und Conversion über Stufen.
+  BC-4110.20:
+    name: Veranstaltungsraum- und Funktionskalendermanagement
+    description: |
+      Definition und Zuteilung des Veranstaltungsraum-Inventars,
+      Konfliktlösung sowie Aufbauart- und Kapazitätsplanung.
+  BC-4110.20.10:
+    name: Veranstaltungsraum-Inventardefinition
+    description: |
+      Definition des Veranstaltungsraum-Inventars einschließlich Kapazitäten,
+      Aufbauarten und kombinierbaren Räumen.
+  BC-4110.20.20:
+    name: Raum-Buchung und -Zuteilung
+    description: |
+      Buchung und Zuteilung von Veranstaltungsräumen für bestätigte und vorläufige Veranstaltungen.
+  BC-4110.20.30:
+    name: Raumkonfliktlösung
+    description: |
+      Lösung von Raumkonflikten bei überlappenden Anfragen und Nachbarraum-Abhängigkeiten.
+  BC-4110.20.40:
+    name: Aufbauart- und Kapazitätsplanung
+    description: |
+      Planung von Aufbauarten und Kapazitäten je Veranstaltung unter Brandschutz- und Barrierefreiheitsvorgaben.
+  BC-4110.30:
+    name: Veranstaltungsauftragsausführung
+    description: |
+      Erfassung von Veranstaltungsaufträgen, Verteilung an operative Teams,
+      Aufbau-Service-Abbau-Ausführung und Veranstaltungsauftrags-Änderungsbearbeitung.
+  BC-4110.30.10:
+    name: Veranstaltungsauftragserfassung
+    description: |
+      Erfassung von Veranstaltungsaufträgen mit F&B-, AV-, Aufbau- und Zeitangaben.
+  BC-4110.30.20:
+    name: Veranstaltungsauftrags-Verteilung und Briefing
+    description: |
+      Verteilung von Veranstaltungsaufträgen an operative Teams und Briefing des Ausführungspersonals.
+  BC-4110.30.30:
+    name: Aufbau-, Service- und Abbauoperationen
+    description: |
+      Aufbau-, Service- und Abbauoperationen gemäß Veranstaltungsauftrag und Zeitplan.
+  BC-4110.30.40:
+    name: Veranstaltungsauftrags-Änderungsbetrieb
+    description: |
+      Betrieb zur Bearbeitung von Veranstaltungsauftrags-Änderungen einschließlich Anforderungsänderungen.
+  BC-4110.40:
+    name: Gruppen-Zimmerblock- und Zimmerlisten-Management
+    description: |
+      Konfiguration von Gruppen-Zimmerblock-Verträgen, Zimmerlistenoperationen,
+      Stichtermin, Bereinigung und Pickup-Berichterstattung auf Veranstaltungsebene.
+  BC-4110.40.10:
+    name: Blockvertragskonfiguration
+    description: |
+      Konfiguration der Blockvertragsbedingungen in operativen Systemen für die Veranstaltung.
+  BC-4110.40.20:
+    name: Zimmerlisten-Operationen
+    description: |
+      Operationen an Zimmerlisten einschließlich Aktualisierungen, Sonderwünschen und Ankunftssequenzierung.
+  BC-4110.40.30:
+    name: Block-Stichtermin- und Bereinigungsoperationen
+    description: |
+      Stichtermin- und Bereinigungsoperationen zur Freigabe ungenutzten Blockinventars.
+  BC-4110.40.40:
+    name: Block-Pickup-Berichterstattung
+    description: |
+      Berichterstattung über Block-Pickup gegen Vertrag für Erlös- und Leistungsrechnung.
+  BC-4110.50:
+    name: Veranstaltungs-AV- und Produktionsbetrieb
+    description: |
+      Audio-visuelle und Produktionsoperationen einschließlich Haus-AV,
+      Bühne, hybrides Streaming und externer Anbieterkoordination.
+  BC-4110.50.10:
+    name: Haus-AV-Betrieb
+    description: |
+      Betrieb von Haus-AV-Ausrüstung und -Teams für Veranstaltungen.
+  BC-4110.50.20:
+    name: Bühnen- und Setproduktion
+    description: |
+      Bühnen- und Setproduktion für Veranstaltungen einschließlich Szenografik und Rigging.
+  BC-4110.50.30:
+    name: Live-Streaming- und Hybrid-Veranstaltungsbetrieb
+    description: |
+      Betrieb von Live-Streaming und hybrider Veranstaltungserbringung für Remote- und Saalpublikum.
+  BC-4110.50.40:
+    name: Externe AV-Anbieterkoordination
+    description: |
+      Koordination externer AV-Anbieter gegen Venue- und Versicherungsanforderungen.
+  BC-4110.60:
+    name: Veranstaltungsabrechnung und Masterkontoverwaltung
+    description: |
+      Einrichtung von Masterkonten, Einzel- und Zusatzabrechnung,
+      Anzahlungen sowie Veranstaltungs-Endabrechnung und -Abstimmung.
+  BC-4110.60.10:
+    name: Masterkonto-Einrichtung
+    description: |
+      Einrichtung von Veranstaltungs-Masterkonten und Buchungsregeln für abrechenbare Posten.
+  BC-4110.60.20:
+    name: Einzel- und Zusatzabrechnungsoperationen
+    description: |
+      Betrieb der Einzel- und Zusatzabrechnung für Teilnehmer jenseits des Masterkontos.
+  BC-4110.60.30:
+    name: Anzahlungs- und Vorauszahlungsmanagement
+    description: |
+      Management von Anzahlungen und Vorauszahlungen gegen Veranstaltungs-Meilensteine.
+  BC-4110.60.40:
+    name: Veranstaltungs-Endabrechnung und Abstimmung
+    description: |
+      Endabrechnung und Abstimmung des Veranstaltungs-Masterkontos gegen Vertrag und Verbrauch.
+  BC-4110.70:
+    name: Veranstaltungsleistungs- und Nachveranstaltungsberichterstattung
+    description: |
+      Leistungsberichterstattung zu Gruppenveranstaltungen einschließlich Block-vs-Pickup,
+      Finanzergebnissen, Teilnehmerfeedback und Verlängerungs-Tracking.
+  BC-4110.70.10:
+    name: Block-vs-Pickup-Berichterstattung
+    description: |
+      Berichterstattung über Block-vs-Pickup-Leistung für abgeschlossene Veranstaltungen.
+  BC-4110.70.20:
+    name: Veranstaltungs-Finanzleistungsberichterstattung
+    description: |
+      Berichterstattung über Veranstaltungs-Finanzleistung gegen Budget und Prognose.
+  BC-4110.70.30:
+    name: Teilnehmerfeedback-Erfassung
+    description: |
+      Erfassung von Teilnehmerfeedback über Nachveranstaltungsumfragen und Live-Signalkanäle.
+  BC-4110.70.40:
+    name: Wiederholungsbuchungs- und Verlängerungs-Tracking
+    description: |
+      Tracking von Wiederholungsbuchungspipelines und Verlängerungsmöglichkeiten nach abgeschlossenen Veranstaltungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-export-control-defense-trade-management.yaml
+++ b/catalogue/i18n/de/L1-export-control-defense-trade-management.yaml
@@ -1,0 +1,94 @@
+locale: de
+source: L1-export-control-defense-trade-management.yaml
+entries:
+  BC-1790:
+    name: Exportkontrolle & Rüstungsexport Management
+    description: |
+      Exportlizenzen, ITAR/EAR-Compliance, Technologietransfer-Kontrolle und Offenlegung gegenüber Ausländern.
+  BC-1790.10:
+    name: Exportlizenz-Management
+    description: |
+      ITAR-, EAR-Lizenzen, Anträge und Bedingungen.
+  BC-1790.10.10:
+    name: Exportzuständigkeit und -klassifizierung
+    description: |
+      ITAR/EAR-Zuständigkeit und ECCN-Klassifizierung von Gütern.
+  BC-1790.10.20:
+    name: Exportlizenzantrag
+    description: |
+      Antragstellung für ITAR-DSP-Lizenzen und EAR-BIS-Lizenzen.
+  BC-1790.10.30:
+    name: Lizenzbedingungs-Compliance
+    description: |
+      Verfolgung und Einhaltung von Lizenzauflagen und -bedingungen.
+  BC-1790.10.40:
+    name: Lizenznutzungsberichterstattung
+    description: |
+      Periodische Berichterstattung über die Nutzung erteilter Lizenzen.
+  BC-1790.20:
+    name: Handels-Compliance-Screening Management
+    description: |
+      Sanktions-, Sperrlisten- und Embargo-Überprüfung.
+  BC-1790.20.10:
+    name: Sperrlisten-Screening
+    description: |
+      Überprüfung gegen Sperrlisten und Listen eingeschränkter Parteien.
+  BC-1790.20.20:
+    name: Sanktionierte Länder-Screening
+    description: |
+      Überprüfung auf Sanktionen und embargierte Länder.
+  BC-1790.20.30:
+    name: Beschränkte Endnutzung Screening
+    description: |
+      Sorgfaltsprüfung hinsichtlich Endverwendung und Endnutzer.
+  BC-1790.30:
+    name: Technologietransfer-Kontroll-Management
+    description: |
+      Kontrollierte Technologiefreigabe und technische Hilfeleistungsvereinbarungen.
+  BC-1790.30.10:
+    name: Technische Datenfreigabe-Kontrolle
+    description: |
+      Kontrolle der Freigabe kontrollierter technischer Daten.
+  BC-1790.30.20:
+    name: Technische Hilfeleistungsvertrags-Management
+    description: |
+      Verwaltung von TAAs, MLAs und Lagervereinbarungen.
+  BC-1790.30.30:
+    name: Deemed-Export-Management
+    description: |
+      Verwaltung von Deemed Exports an ausländische Staatsangehörige.
+  BC-1790.40:
+    name: Zoll- & Tarif-Compliance-Management
+    description: |
+      Verteidigungszoll, ATA-Carnets, Import-/Exportdokumentation.
+  BC-1790.40.10:
+    name: Verteidigungs-Zollbetrieb
+    description: |
+      Zollabwicklung speziell für Verteidigungsgüter.
+  BC-1790.40.20:
+    name: ATA-Carnet-Management
+    description: |
+      ATA-Carnet-Management für vorübergehende Verteidigungsexporte.
+  BC-1790.40.30:
+    name: Zolltarifklassifizierung und -bewertung
+    description: |
+      HS-Zolltarifklassifizierung und Zollwertermittlung.
+  BC-1790.50:
+    name: Ausländische Offenlegung Management
+    description: |
+      Entscheidungen zur ausländischen Offenlegung, Freigabefähigkeit und kontrollierte Freigaben.
+  BC-1790.50.10:
+    name: Ausländische Offenlegungs-Entscheidungsfindung
+    description: |
+      Entscheidungsfindung bei der ausländischen Offenlegung von kontrollierten Informationen.
+  BC-1790.50.20:
+    name: Freigabekennzeichnung
+    description: |
+      Freigabekennzeichnung und Verbreitungskontrolle.
+  BC-1790.50.30:
+    name: Ausländische Besucherkontrolle
+    description: |
+      Kontrolle ausländischer Besucher und Genehmigung von Anfragen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-facilities-management.yaml
+++ b/catalogue/i18n/de/L1-facilities-management.yaml
@@ -1,0 +1,118 @@
+locale: de
+source: L1-facilities-management.yaml
+entries:
+  BC-700:
+    name: Facilitymanagement
+    description: |
+      Gebäudedienste, Arbeitsplatz sowie technisches und infrastrukturelles Facilitymanagement.
+  BC-700.10:
+    name: Arbeitsplatz-Dienstemanagement
+    description: |
+      Empfang, Post und Arbeitsplatzerfahrungsdienste.
+  BC-700.10.10:
+    name: Empfang und Besucherverwaltung
+    description: |
+      Besuchervoranmeldung, Empfang und Zugang.
+  BC-700.10.20:
+    name: Post- und Verteilungsdienste
+    description: |
+      Ein- und ausgehende Post, Pakete und interne Verteilung.
+  BC-700.10.30:
+    name: Arbeitsplatz-Concierge und Helpdesk
+    description: |
+      Arbeitsplatz-Concierge, Helpdesk und Serviceantragsbearbeitung.
+  BC-700.10.40:
+    name: Besprechungsraum- und Veranstaltungsdienste
+    description: |
+      Besprechungsraumbuchung, AV-Einrichtung und Veranstaltungsunterstützung.
+  BC-700.20:
+    name: Technisches Facilitymanagement
+    description: |
+      Gebäudetechnik – HLK, Elektro, Sanitär und Gebäudehülle.
+  BC-700.20.10:
+    name: HLK-Systembetrieb
+    description: |
+      Betrieb und Wartung von Heizungs-, Lüftungs- und Klimaanlagen.
+  BC-700.20.20:
+    name: Elektroanlagenbetrieb
+    description: |
+      Betrieb und Wartung gebäudetechnischer Elektroanlagen.
+  BC-700.20.30:
+    name: Mechanik- und Sanitärbetrieb
+    description: |
+      Mechanik-, Sanitär- und Wasseranlagenbetrieb.
+  BC-700.20.40:
+    name: Gebäudehüllenwartung
+    description: |
+      Wartung von Gebäudehülle, Tragwerk und Außenhaut.
+  BC-700.20.50:
+    name: Gebäudeenergiemanagement
+    description: |
+      Gebäudeenergiemonitoring und -optimierung.
+  BC-700.30:
+    name: Infrastrukturelles Facilitymanagement
+    description: |
+      Reinigung, Catering, Sicherheit und Außenanlagen.
+  BC-700.30.10:
+    name: Reinigungsdienste
+    description: |
+      Tagesreinigung, Grundreinigung und Hygieneservices.
+  BC-700.30.20:
+    name: Verpflegungs- und Gastronomiedienste
+    description: |
+      Betriebsgastronomie, Automaten und Bewirtungsservices.
+  BC-700.30.30:
+    name: Physischer Sicherheitsbetrieb
+    description: |
+      Sicherheitsdienst, Patrouillen, Videoüberwachung und Zutrittskontrolle.
+  BC-700.30.40:
+    name: Außenanlagen und Begrünung
+    description: |
+      Pflege von Außenanlagen, Begrünung und Außenbereichen.
+  BC-700.30.50:
+    name: Abfallmanagementdienste
+    description: |
+      Abfallentsorgung, Mülltrennung und Recycling an Standorten.
+  BC-700.40:
+    name: Flächenmanagement
+    description: |
+      Flächenplanung, Belegungsmanagement und Umzüge.
+  BC-700.40.10:
+    name: Flächenplanung
+    description: |
+      Flächenplanung, -zuweisung und Stapelplanung.
+  BC-700.40.20:
+    name: Belegungsmonitoring
+    description: |
+      Belegungsmessung, Nutzungsanalytik und Prognose.
+  BC-700.40.30:
+    name: Umzugsmanagement
+    description: |
+      Planung und Durchführung von Umzügen, Ergänzungen und Änderungen.
+  BC-700.40.40:
+    name: Schreibtischbuchung und Hot-Desking
+    description: |
+      Schreibtischbuchungsplattformen und Hybridarbeitsplatzbetrieb.
+  BC-700.50:
+    name: Facility-Gesundheits- und Sicherheitsmanagement
+    description: |
+      Gebäudesicherheit, Brandschutz und Notfallsysteme.
+  BC-700.50.10:
+    name: Brandschutzmanagement
+    description: |
+      Brandmeldung, -unterdrückung und Evakuierungsübungen.
+  BC-700.50.20:
+    name: Notfallreaktionskoordination
+    description: |
+      Standort-Notfallreaktion und Ersthelferkoordination.
+  BC-700.50.30:
+    name: Freigabescheinmanagement
+    description: |
+      Freigabeschein-Steuerung für gefährliche Facilityaufgaben.
+  BC-700.50.40:
+    name: Gesetzliche Gebäude-Compliance
+    description: |
+      Gesetzliche Prüfungen und Zertifizierungen für Gebäudesicherheit.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-farm-land-asset-management.yaml
+++ b/catalogue/i18n/de/L1-farm-land-asset-management.yaml
@@ -1,0 +1,139 @@
+locale: de
+source: L1-farm-land-asset-management.yaml
+entries:
+  BC-3540:
+    name: Landwirtschaftliche Flächen und Anlagen
+    description: |
+      Landbesitz- und Pachtaufzeichnungen, Schlag- und
+      Parzellenmanagement, Betriebsmaschinentechnik und ISOBUS-
+      Telemetrie, Bewässerungsinfrastruktur, Wirtschaftsgebäude
+      und betriebliche Energieanlagen.
+  BC-3540.10:
+    name: Landbesitz- und Pacht-Management
+    description: |
+      Aufzeichnungen zu Eigentumsrechten, Pacht, Dienstbarkeiten
+      und Wegerechten zur Absicherung der Bewirtschaftungsrechte
+      über das Betriebsportfolio.
+    in_scope:
+      - Titel- und Besitzaufzeichnungen
+      - Pachtvertragsverwaltung
+      - Dienstbarkeits- und Wegerechtsaufzeichnungen
+    out_of_scope:
+      - Unternehmensimmobilien (BC-1410)
+  BC-3540.10.10:
+    name: Landtitel- und Besitzaufzeichnungen
+    description: |
+      Aufzeichnungen zu Eigentum, Pacht und Gewohnheitsbesitz
+      über das Betriebsportfolio.
+  BC-3540.10.20:
+    name: Pachtvertragsverwaltung
+    description: |
+      Verwaltung landwirtschaftlicher Pachtverträge und
+      -Verlängerungen.
+  BC-3540.10.30:
+    name: Landdienstebarkeits-Management
+    description: |
+      Management von Zugangs-Dienstbarkeiten, Wegerechten und
+      Naturschutzdienstebarkeiten.
+  BC-3540.20:
+    name: Schlag- und Parzellen-Management
+    description: |
+      Schlaggrenzaufzeichnungen, Schlaggeschichte und
+      Produktivitätszonen auf Schlag- und Parzellenebene.
+  BC-3540.20.10:
+    name: Schlaggrenz-Aufzeichnung
+    description: |
+      Schlaggrenzerfassung und -Pflege in Betriebs-GIS-Systemen.
+  BC-3540.20.20:
+    name: Schlaghistorie-Aufzeichnungen
+    description: |
+      Mehrjährige Schlaghistorie-Aufzeichnungen von Kulturen,
+      Betriebsmitteln und Erträgen.
+  BC-3540.20.30:
+    name: Schlag-Produktivitätszonen
+    description: |
+      Produktivitätszonen und Bewirtschaftungszonen-Abgrenzung
+      innerhalb von Schlägen.
+  BC-3540.30:
+    name: Betriebsmaschinen-Management
+    description: |
+      Betriebsmaschinerieinventar, Maschineneinsatz, ISOBUS-
+      Telemetrie und Maschinenleih-Vereinbarungen.
+  BC-3540.30.10:
+    name: Betriebsmaschinen-Inventar
+    description: |
+      Inventar von Traktoren, Geräten und Selbstfahrmaschinen.
+  BC-3540.30.20:
+    name: Feldmaschineneinsatz
+    description: |
+      Täglicher Feldmaschineneinsatz und Bediener-Zuweisung.
+  BC-3540.30.30:
+    name: ISOBUS-Telemetrie-Integration
+    description: |
+      Integration ISOBUS-konformer Maschinentelemetrie mit
+      Betriebs-Management-Systemen.
+  BC-3540.30.40:
+    name: Maschinenleih und -Auftragnehmer
+    description: |
+      Maschinenleih-, Auftragnehmer- und Lohnunternehmer-
+      Vereinbarungen.
+  BC-3540.40:
+    name: Bewässerungsinfrastruktur-Management
+    description: |
+      Lebenszyklusmanagement von Bewässerungssystemen,
+      Wasserkontingenten und Bewässerungsinfrastruktur-Wartung.
+  BC-3540.40.10:
+    name: Bewässerungssystem-Design
+    description: |
+      Design und Kapazitätsdimensionierung betrieblicher
+      Bewässerungssysteme.
+  BC-3540.40.20:
+    name: Wasserentnahme-Konformität
+    description: |
+      Konformität mit Oberflächen- und Grundwasserentnahmen
+      und Messerfassungen.
+  BC-3540.40.30:
+    name: Bewässerungsinfrastruktur-Wartung
+    description: |
+      Wartung von Pumpen, Hauptleitungen, Verteilleitungen
+      und Tropfern.
+  BC-3540.50:
+    name: Wirtschaftsgebäude- und Hofbetrieb
+    description: |
+      Betrieb und Instandhaltung von Betriebslagergebäuden,
+      Viehställen, Höfen und Zufahrtswegen.
+  BC-3540.50.10:
+    name: Lagergebäude-Betrieb
+    description: |
+      Betrieb von Getreide-, Heu- und Chemikalienlagergebäuden.
+  BC-3540.50.20:
+    name: Viehstall-Betrieb
+    description: |
+      Betrieb und Einstreumanagement von Viehunterkünften.
+  BC-3540.50.30:
+    name: Hof- und Zufahrtswege-Wartung
+    description: |
+      Wartung von Betriebshöfen, Zufahrtswegen und
+      Viehhandhabungseinrichtungen.
+  BC-3540.60:
+    name: Betriebsenergie-Management
+    description: |
+      Betriebseigene Energieerzeugung, Kraftstoff- und
+      Energiebeschaffungskoordination sowie Energieverbrauchserfassung.
+  BC-3540.60.10:
+    name: Betriebseigene Energieerzeugung
+    description: |
+      Betriebseigene Solar-, Wind- und Biogasenergieerzeugung.
+  BC-3540.60.20:
+    name: Kraftstoff- und Energiebeschaffungs-Koordination
+    description: |
+      Koordination der Betriebs-Kraftstoff-, Strom- und
+      Gasbeschaffung.
+  BC-3540.60.30:
+    name: Energieverbrauch-Aufzeichnung
+    description: |
+      Aufzeichnung des betrieblichen Energieverbrauchs nach
+      Tätigkeit und Anlage.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-field-service-management.yaml
+++ b/catalogue/i18n/de/L1-field-service-management.yaml
@@ -1,0 +1,114 @@
+locale: de
+source: L1-field-service-management.yaml
+entries:
+  BC-1050:
+    name: Außendienstmanagement
+    description: |
+      Installationsbasis-Service, Außendienst-Techniker, Vor-Ort-Reparatur und Inbetriebnahme.
+  BC-1050.10:
+    name: Serviceanforderungsmanagement
+    description: |
+      Serviceanforderungserfassung, Triage und Qualifizierung.
+  BC-1050.10.10:
+    name: Serviceanforderungsaufnahme
+    description: |
+      Mehrkanalige Aufnahme von Kundendienst-Anforderungen.
+  BC-1050.10.20:
+    name: Serviceanforderungs-Triage
+    description: |
+      Triage, Klassifizierung und Weiterleitung von Serviceanforderungen.
+  BC-1050.10.30:
+    name: Ferndiagnose und -behebung
+    description: |
+      Ferndiagnose und erstmalige Remote-Lösung.
+  BC-1050.20:
+    name: Service-Dispatch-Management
+    description: |
+      Technikereinsatzplanung, Routenoptimierung und Disposition.
+  BC-1050.20.10:
+    name: Technikerterminierung
+    description: |
+      Einplanung von Technikern nach Qualifikation und Verfügbarkeit.
+  BC-1050.20.20:
+    name: Routenoptimierung
+    description: |
+      Optimierung von Routen und Fahrstrecken für Serviceeinsätze.
+  BC-1050.20.30:
+    name: Dispatch-Ausführung
+    description: |
+      Echtzeit-Dispatching und Neuzuteilung von Serviceaufträgen.
+  BC-1050.30:
+    name: Serviceausführungsmanagement
+    description: |
+      Vor-Ort-Serviceausführung und Berichterstattung.
+  BC-1050.30.10:
+    name: Vor-Ort-Serviceerbringung
+    description: |
+      Vor-Ort-Ausführung von Serviceaufgaben gemäß Arbeitsauftrag.
+  BC-1050.30.20:
+    name: Servicedokumentations-Erfassung
+    description: |
+      Erfassung von Serviceberichten, Fotos und Unterschriften.
+  BC-1050.30.30:
+    name: Kundenabnahmemanagement
+    description: |
+      Kundenunterschrift und Abnahme des abgeschlossenen Service.
+  BC-1050.40:
+    name: Serviceteile-Management
+    description: |
+      Im Feld eingesetzte Teile, Fahrzeuglager und Nachschub.
+  BC-1050.40.10:
+    name: Fahrzeuglager-Management
+    description: |
+      Definition und Management von Fahrzeug- und Vorortlagerbeständen.
+  BC-1050.40.20:
+    name: Serviceteile-Nachschub
+    description: |
+      Nachschub von Vorort-Lagerstandorten und Technikern.
+  BC-1050.40.30:
+    name: Serviceteile-Rücknahmen
+    description: |
+      Rücknahmen ungenutzter, defekter oder reparierbarer Teile aus dem Feld.
+  BC-1050.50:
+    name: Servicevertrag-Management
+    description: |
+      Servicevereinbarungen, SLAs und Leistungsansprüche.
+  BC-1050.50.10:
+    name: Servicevertrags-Erstellung
+    description: |
+      Ausarbeitung von Serviceverträgen, Leistungsstufen und Bedingungen.
+  BC-1050.50.20:
+    name: Serviceanspruchs-Management
+    description: |
+      Anspruchsprüfung bei Serviceanforderung und Disposition.
+  BC-1050.50.30:
+    name: Servicevertragsverlängerung
+    description: |
+      Verlängerung und Aufwertung von Serviceverträgen.
+  BC-1050.50.40:
+    name: Serviceabrechnung
+    description: |
+      Abrechnung von Serviceverträgen und Zeit-und-Material-Arbeiten.
+  BC-1050.60:
+    name: Außendienst-Leistungsmanagement
+    description: |
+      Erstlösungsquote, Reaktionszeit, NPS und Technikerproduktivität.
+  BC-1050.60.10:
+    name: Erstlösungsquoten-Verfolgung
+    description: |
+      Messung und Verbesserung der Erstlösungsrate.
+  BC-1050.60.20:
+    name: Reaktions- und Lösungszeitverfolgung
+    description: |
+      SLA-basierte Verfolgung von Reaktions- und Lösungszeiten.
+  BC-1050.60.30:
+    name: Technikerproduktivitäts-Berichterstattung
+    description: |
+      Berichterstattung zu Technikerauslastung, Werkzeugzeit und Produktivität.
+  BC-1050.60.40:
+    name: Service-NPS und -Zufriedenheit
+    description: |
+      Messung von servicebezogenem NPS und Kundenzufriedenheit.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-financial-crime-management.yaml
+++ b/catalogue/i18n/de/L1-financial-crime-management.yaml
@@ -1,0 +1,106 @@
+locale: de
+source: L1-financial-crime-management.yaml
+entries:
+  BC-1400:
+    name: Finanzkriminalitäts-Management
+    description: |
+      AML-Transaktionsüberwachung, Sanktionsscreening, Betrugserkennung und Verdachtsmeldungen.
+  BC-1400.10:
+    name: AML-Transaktionsüberwachungs-Management
+    description: |
+      AML-Überwachungsregeln, Alarme und Szenarien.
+  BC-1400.10.10:
+    name: AML-Szenario- und Regelgestaltung
+    description: |
+      Gestaltung von AML-Szenarien, Regeln und Schwellenwerten.
+  BC-1400.10.20:
+    name: AML-Alarmgenerierung
+    description: |
+      Generierung von AML-Alarmen aus der Transaktionsüberwachung.
+  BC-1400.10.30:
+    name: AML-Alarm-Triage
+    description: |
+      Triage und risikobasierte Priorisierung von AML-Alarmen.
+  BC-1400.10.40:
+    name: AML-Modell-Kalibrierung und -Validierung
+    description: |
+      Kalibrierung, Validierung und Wirksamkeitsüberprüfung von AML-Modellen.
+  BC-1400.20:
+    name: Sanktionsscreenings-Management
+    description: |
+      Sanktionslisten, Namens- und Transaktionsscreening sowie Trefferverwaltung.
+  BC-1400.20.10:
+    name: Sanktionslisten-Management
+    description: |
+      Aggregation und Pflege von Sanktions-Watchlists.
+  BC-1400.20.20:
+    name: Kunden-Namensscreening
+    description: |
+      Screening von Kunden und Gegenparteien gegen Sanktionslisten.
+  BC-1400.20.30:
+    name: Transaktions-Sanktionsscreening
+    description: |
+      Echtzeit-Screening von Transaktionen gegen Sanktionslisten.
+  BC-1400.20.40:
+    name: Sanktionstreffer-Bearbeitung
+    description: |
+      Untersuchung und Disposition von Sanktionstreffern.
+  BC-1400.30:
+    name: Betrugserkennungs- und Untersuchungsmanagement
+    description: |
+      Betrugserkennung über Produkte und Kanäle, Untersuchungen.
+  BC-1400.30.10:
+    name: Antrags-Betrugserkennung
+    description: |
+      Erkennung von Betrug auf der Antrags- oder Produktstufe.
+  BC-1400.30.20:
+    name: Transaktions-Betrugserkennung
+    description: |
+      Echtzeit-Erkennung betrügerischer Transaktionen.
+  BC-1400.30.30:
+    name: Betrugsfalluntersuchung
+    description: |
+      Untersuchung und Lösung von Betrugsfällen.
+  BC-1400.30.40:
+    name: Betrugsverlust- und Erstattungsmanagement
+    description: |
+      Verfolgung von Betrugsverlusten und Erstattungsbemühungen.
+  BC-1400.30.50:
+    name: Autorisierter-Überweisungsbetrug-Bearbeitung
+    description: |
+      Bearbeitung von APP-Betrugsfällen und Rückerstattung.
+  BC-1400.40:
+    name: Verdachtsmeldungs-Management
+    description: |
+      SAR/STR-Einreichung und regulatorische Meldepflichten.
+  BC-1400.40.10:
+    name: SAR-Erstellung und -Einreichung
+    description: |
+      Erstellung und Einreichung von SARs/STRs bei FIUs.
+  BC-1400.40.20:
+    name: Regulatorische Finanzkriminalitätsmeldung
+    description: |
+      Periodische regulatorische Berichterstattung über Finanzkriminalität.
+  BC-1400.40.30:
+    name: Strafverfolgungsbehörden-Liaison
+    description: |
+      Zusammenarbeit mit Strafverfolgungsbehörden und Bearbeitung von Auskunftsersuchen.
+  BC-1400.50:
+    name: Finanzkriminalitätsuntersuchungs-Management
+    description: |
+      Fallmanagement, Untersuchungen und Eskalation.
+  BC-1400.50.10:
+    name: Fallmanagement
+    description: |
+      Fallmanagement für Finanzkriminalitätsuntersuchungen.
+  BC-1400.50.20:
+    name: Untersuchungsdurchführung
+    description: |
+      Durchführung von Untersuchungen und Beweiserhebung.
+  BC-1400.50.30:
+    name: Eskalation und Fallabschluss
+    description: |
+      Eskalation, Entscheidungsfindung und Abschluss von Untersuchungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-financial-management.yaml
+++ b/catalogue/i18n/de/L1-financial-management.yaml
@@ -1,0 +1,162 @@
+locale: de
+source: L1-financial-management.yaml
+entries:
+  BC-200:
+    name: Finanzmanagement
+    description: |
+      Buchhaltung, Controlling, gesetzliche und Management-Berichterstattung sowie Budgetierung.
+  BC-200.10:
+    name: Hauptbuchmanagement
+    description: |
+      Kontenrahmen, Buchungen und Periodenabschluss.
+  BC-200.10.10:
+    name: Kontenrahmenmanagement
+    description: |
+      Definition und Steuerung des Kontenrahmens und der Kontenhierarchien.
+  BC-200.10.20:
+    name: Buchungsverarbeitung
+    description: |
+      Manuelle und automatisierte Buchungen mit Genehmigungsworkflow.
+  BC-200.10.30:
+    name: Konzerninternetbuchhaltung
+    description: |
+      Konzerninterne Transaktionen, Eliminierungen und Abstimmungen.
+  BC-200.10.40:
+    name: Periodenabschluss
+    description: |
+      Periodenabschlusskalender, Rückstellungen und Abschlusszertifizierungen.
+  BC-200.10.50:
+    name: Kontenabstimmung
+    description: |
+      Bilanzkontenabstimmungen und Substantiierung.
+  BC-200.20:
+    name: Kreditorenmanagement
+    description: |
+      Rechnungsverarbeitung, Zahlungen und Lieferantenbuchhaltung.
+  BC-200.20.10:
+    name: Lieferantenrechnungserfassung und -prüfung
+    description: |
+      Empfang, Erfassung und Drei-Wege-Abgleich von Lieferantenrechnungen.
+  BC-200.20.20:
+    name: Zahlungslaufdurchführung
+    description: |
+      Terminplanung und Durchführung von Lieferantenzahlungsläufen.
+  BC-200.20.30:
+    name: Lieferantenstammdaten-Finanzdatenverwaltung
+    description: |
+      Finanzielle Stammdaten, Bankverbindungen und Steuerattribute von Lieferanten.
+  BC-200.20.40:
+    name: Reise- und Spesenkostenverarbeitung
+    description: |
+      Spesenerfassung, Genehmigung und Erstattung durch Mitarbeitende.
+  BC-200.20.50:
+    name: Kreditorenkontenabstimmung
+    description: |
+      Lieferantenkontoauszugs- und Kreditorennebenbuchabstimmung.
+  BC-200.30:
+    name: Debitorenmanagement
+    description: |
+      Kundenrechnungsstellung, Mahnwesen und Zahlungserfassung.
+  BC-200.30.10:
+    name: Kundenrechnungsstellung
+    description: |
+      Erstellung und Ausgabe von Kundenrechnungen und Gutschriften.
+  BC-200.30.20:
+    name: Zahlungserfassung
+    description: |
+      Zuordnung eingehender Kundenzahlungen zu offenen Forderungen.
+  BC-200.30.30:
+    name: Mahnwesenmanagement
+    description: |
+      Mahnwesen, Inkassostrategie und Kundenzahlungsverfolgung.
+  BC-200.30.40:
+    name: Kreditrisiko und Kundenlimite
+    description: |
+      Kundenkreditbewertung, Limitfestsetzung und Kreditsperren.
+  BC-200.30.50:
+    name: Streit- und Abzugsmanagement
+    description: |
+      Untersuchung und Lösung von Rechnungsstreitigkeiten und Abzügen.
+  BC-200.40:
+    name: Anlagebuchhaltung
+    description: |
+      Anlageverzeichnisse, Abschreibung und Wertminderung.
+  BC-200.40.10:
+    name: Anlagenverzeichnispflege
+    description: |
+      Aktivierung, Klassifizierung und Nachverfolgung von Anlagevermögen.
+  BC-200.40.20:
+    name: Abschreibung und Amortisation
+    description: |
+      Abschreibungsmethoden, -pläne und -buchungen.
+  BC-200.40.30:
+    name: Anlagenwertminderung und -neubewertung
+    description: |
+      Wertminderungstests und Neubewertung von Vermögenswerten nach IFRS oder lokalen GAAP.
+  BC-200.40.40:
+    name: Anlagenabgangsbuchhaltung
+    description: |
+      Buchung von Abgängen, Verkäufen und Abschreibungen von Anlagevermögen.
+  BC-200.50:
+    name: Kostenrechnungsmanagement
+    description: |
+      Kostenträger, Kostenzuordnungen und Standardkostenrechnung.
+  BC-200.50.10:
+    name: Kostenträger- und Kostenstellen-Management
+    description: |
+      Definition von Kostenstellen, Innenaufträgen und Projektkostenträgern.
+  BC-200.50.20:
+    name: Standardkostenrechnung
+    description: |
+      Standardkostenfestsetzung, Abweichungsanalyse und Neubewertung.
+  BC-200.50.30:
+    name: Kostenzuordnung und -absorption
+    description: |
+      Umlagezyklen, Treiber und Gemeinkostenabsorption.
+  BC-200.50.40:
+    name: Produkt- und Dienstleistungskalkulation
+    description: |
+      Kalkulation von Produkten, Dienstleistungen und Kundenengagements.
+  BC-200.60:
+    name: Finanzberichterstattungsmanagement
+    description: |
+      Interne Finanzberichterstattung und Konsolidierung.
+  BC-200.60.10:
+    name: Finanzkonsolidierung
+    description: |
+      Konsolidierung von Rechtsträgern einschließlich Eliminierungen und Fremdwährungsumrechnung.
+  BC-200.60.20:
+    name: Interne Finanzberichterstattung
+    description: |
+      Erstellung interner GuV-, Bilanz- und Cashflow-Berichte.
+  BC-200.60.30:
+    name: Segment- und Management-Reporting
+    description: |
+      Segmentberichterstattung und Reporting nach Managementperspektive.
+  BC-200.60.40:
+    name: Finanzoffenlegungserstellung
+    description: |
+      Entwurf von Anhängen und Offenlegungen zu Finanzberichten.
+  BC-200.70:
+    name: Gesetzliche und regulatorische Berichterstattung
+    description: |
+      Jahresabschlüsse und regulatorische Finanzeinreichungen.
+  BC-200.70.10:
+    name: Jahresabschlusserstellung
+    description: |
+      Erstellung gesetzlicher Einzelabschlüsse von Rechtsträgern.
+  BC-200.70.20:
+    name: Regulatorische Finanzeinreichungen
+    description: |
+      Branchenregulatorische Finanzberichte und aufsichtsrechtliche Einreichungen.
+  BC-200.70.30:
+    name: Externe Prüfungskoordination
+    description: |
+      Abstimmung mit externen Prüfern und Verwaltung von Prüfungsunterlagen.
+  BC-200.70.40:
+    name: Nachhaltigkeits- und Nicht-Finanzberichterstattung
+    description: |
+      Nicht-finanzielle und Nachhaltigkeitsoffenlegungen (z. B. CSRD, IFRS S1/S2).
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-financial-planning-analysis.yaml
+++ b/catalogue/i18n/de/L1-financial-planning-analysis.yaml
@@ -1,0 +1,110 @@
+locale: de
+source: L1-financial-planning-analysis.yaml
+entries:
+  BC-230:
+    name: Finanzplanung und -analyse
+    description: |
+      Prognose, Planung, Performance-Analyse und Management-Reporting.
+  BC-230.10:
+    name: Budgetierungsmanagement
+    description: |
+      Jährlicher Budgetprozess und Konsolidierung.
+  BC-230.10.10:
+    name: Budgetkalender und Prozesssteuerung
+    description: |
+      Budgetkalender, Vorlagen und Prozesssteuerung.
+  BC-230.10.20:
+    name: Top-Down-Zielsetzung
+    description: |
+      Festlegung strategisch abgestimmter Top-Down-Finanzziele.
+  BC-230.10.30:
+    name: Bottom-Up-Budgetaufbau
+    description: |
+      Bottom-Up-Budgetierung nach Kostenstelle, Projekt und Produkt.
+  BC-230.10.40:
+    name: Budgetkonsolidierung und -genehmigung
+    description: |
+      Konzernkonsolidierung, Iterationsrunden und abschließende Budgetgenehmigung.
+  BC-230.20:
+    name: Prognosemanagement
+    description: |
+      Rollende Prognosen und Szenarioplanung.
+  BC-230.20.10:
+    name: Rollende Prognoseerstellung
+    description: |
+      Rollende Prognosen für Umsatz, Kosten und Cashflow im Monats- oder Quartalsrhythmus.
+  BC-230.20.20:
+    name: Treiberbasierte Prognose
+    description: |
+      Einsatz operativer Treiber zur Prognose finanzieller Ergebnisse.
+  BC-230.20.30:
+    name: Szenario- und Sensitivitätsmodellierung
+    description: |
+      Mehrszenarien-Prognose und Sensitivitätsanalyse.
+  BC-230.20.40:
+    name: Prognosegenauigkeitsverfolgung
+    description: |
+      Nachverfolgung und Verbesserung der Prognosegenauigkeit nach Einzelposten.
+  BC-230.30:
+    name: Management-Reporting
+    description: |
+      Periodisches Management-Reporting, KPIs und Dashboards.
+  BC-230.30.10:
+    name: Führungs- und Vorstandsberichterstattung
+    description: |
+      Executive Dashboards und Performance-Berichte auf Vorstandsebene.
+  BC-230.30.20:
+    name: Geschäftsbereichs-Performance-Reporting
+    description: |
+      Berichterstattung nach Geschäftsbereich, Segment und Produktlinie.
+  BC-230.30.30:
+    name: KPI-Definition und -Steuerung
+    description: |
+      KPI-Taxonomie, Definitionen und Steuerung von Kennzahlen.
+  BC-230.30.40:
+    name: Management-Self-Service-Analytics
+    description: |
+      Self-Service-Analytics-Befähigung für Finance-Business-Partner.
+  BC-230.40:
+    name: Performance-Analysemanagement
+    description: |
+      Abweichungs-, Rentabilitäts- und Tiefenanalysen.
+  BC-230.40.10:
+    name: Abweichungs- und Plan-Ist-Analyse
+    description: |
+      Abweichungsanalyse zwischen Ist, Budget und Prognose.
+  BC-230.40.20:
+    name: Rentabilitätsanalyse
+    description: |
+      Kunden-, Produkt- und Kanalrentabilitätsanalyse.
+  BC-230.40.30:
+    name: Kosten- und Effizienzanalyse
+    description: |
+      Kostenträgeranalyse, Effizienzquoten und Benchmarking.
+  BC-230.40.40:
+    name: Betriebskapitalanalyse
+    description: |
+      Analyse von Forderungs-, Verbindlichkeits- und Bestandszyklen.
+  BC-230.50:
+    name: Business-Case-Management
+    description: |
+      Business-Case-Entwicklung, Bewertung und Post-Implementierungsüberprüfung.
+  BC-230.50.10:
+    name: Business-Case-Entwicklung
+    description: |
+      Standardisierte Vorlagen und Methoden für Business Cases.
+  BC-230.50.20:
+    name: Investitionsbewertung
+    description: |
+      Kapitalwert, IRR, Amortisation und qualitative Investitionsbewertung.
+  BC-230.50.30:
+    name: Kapitalallokationssteuerung
+    description: |
+      Kapitalgenehmigungskomitees, Schwellenwerte und Priorisierung.
+  BC-230.50.40:
+    name: Nutzenverfolgung
+    description: |
+      Post-Implementierungsüberprüfungen und Nutzenverfolgung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-fleet-mobile-asset-management.yaml
+++ b/catalogue/i18n/de/L1-fleet-mobile-asset-management.yaml
@@ -1,0 +1,128 @@
+locale: de
+source: L1-fleet-mobile-asset-management.yaml
+entries:
+  BC-2430:
+    name: Flotten- und Mobile-Betriebsmittel-Management
+    description: |
+      Bereitstellung, Instandhaltung, Auslastung und Entsorgung von Fahrzeugen, Schiffen,
+      Flugzeugen, Schienenfahrzeugen und gepoolten Betriebsmitteln wie Containern, Trailern
+      und ULDs.
+  BC-2430.10:
+    name: Flottenakquisition und -entsorgung
+    description: |
+      Spezifikation, Akquisition, Leasing, Charterung und Entsorgung am Ende des Lebenszyklus
+      mobiler Betriebsmittel.
+    in_scope:
+      - Beschaffung von Fahrzeugen, Schiffen, Flugzeugen und Schienenfahrzeugen
+      - Nass-, Trocken- und Bareboat-Charter-Vereinbarungen
+      - Entscheidungen über Entsorgung und Wiederverkauf am Lebensende
+    out_of_scope:
+      - Allgemeine Beschaffung von Nicht-Produktionsgütern (BC-500)
+      - Anlagebuchhaltung (BC-200)
+  BC-2430.10.10:
+    name: Flottenspezifikation und -beschaffung
+    description: |
+      Spezifikation und Beschaffung neuer Flottenassets.
+  BC-2430.10.20:
+    name: Leasing- und Charter-Management
+    description: |
+      Operating-Leasing, Finanzierungsleasing und Charter-Vereinbarungen für Flottenassets.
+  BC-2430.10.30:
+    name: Lebensende-Entsorgung
+    description: |
+      Wiederverkauf, Verschrottung und Recycling ausgemusterter Flottenassets.
+  BC-2430.20:
+    name: Flotten-Instandhaltungs-Management
+    description: |
+      Präventive, korrektive und Großinstandhaltung von Fahrzeugen, Schiffen,
+      Flugzeugen und Schienenfahrzeugen.
+  BC-2430.20.10:
+    name: Präventive Instandhaltungsplanung
+    description: |
+      Zeit- und zustandsbasierte Präventive-Instandhaltungs-Planung.
+  BC-2430.20.20:
+    name: Korrektive Instandhaltungsdurchführung
+    description: |
+      Reparatur von Pannen und korrektive Arbeiten an mobilen Betriebsmitteln.
+  BC-2430.20.30:
+    name: Pflichtinspektion-Compliance
+    description: |
+      Einhaltung gesetzlicher Inspektionen und Lufttüchtigkeits- oder Seetüchtigkeitsanweisungen.
+  BC-2430.20.40:
+    name: Großinstandhaltung und Überholung
+    description: |
+      Generalüberholung, Trockendock und schwere Inspektionsereignisse.
+  BC-2430.30:
+    name: Ausrüstungspool-Management
+    description: |
+      Verwaltung gepoolter Container, Trailer, Chassis und ULDs über Lager, Kunden und Partner.
+  BC-2430.30.10:
+    name: Container-Pool-Management
+    description: |
+      Verfolgung und Ausbalancierung von Container-Flotten über Lager.
+  BC-2430.30.20:
+    name: Trailer- und Chassis-Pool-Management
+    description: |
+      Pool-Management von Trailern und Chassis einschließlich Gray-Pool-Sharing.
+  BC-2430.30.30:
+    name: ULD-Pool-Management
+    description: |
+      Verfolgung, Reparatur und Ausbalancierung von ULDs über Stationen.
+  BC-2430.30.40:
+    name: Leerausrüstungs-Repositionierungsbetrieb
+    description: |
+      Durchführung von Leer-Repositionierungsbewegungen zwischen Überschuss- und Defizitlagern.
+  BC-2430.40:
+    name: Flotten-Telematik und -Überwachung
+    description: |
+      Kontinuierliche Überwachung von Assetposition, -zustand und Fahrverhalten
+      zur Information von Instandhaltung und Betrieb.
+  BC-2430.40.10:
+    name: Flotten-Telematik-Betrieb
+    description: |
+      Betrieb von Telematikplattformen zur Erfassung von Positions- und Motordaten.
+  BC-2430.40.20:
+    name: Asset-Zustandsüberwachung
+    description: |
+      Zustandsüberwachung mobiler Betriebsmittel einschließlich Kühlketten- und Frachtsstatus.
+  BC-2430.40.30:
+    name: Fahrerverhaltens-Überwachung
+    description: |
+      Überwachung von Fahrverhaltens-Signalen wie Hartem Bremsen und Geschwindigkeitsübertretungen.
+  BC-2430.50:
+    name: Flotten-Compliance und -Zertifizierung
+    description: |
+      Registrierung, Zertifizierung und Emissionskonformität der Flottenassets
+      bei Behörden und Klassifizierungsgesellschaften.
+  BC-2430.50.10:
+    name: Fahrzeug-, Schiff- und Flugzeugregistrierung
+    description: |
+      Erst- und Folgeregistrierung bei nationalen und internationalen Behörden.
+  BC-2430.50.20:
+    name: Gesetzliche Inspektion und Zertifizierung
+    description: |
+      Klassen-, Lufttüchtigkeits- und Straßenzulassungszertifikate und Audits.
+  BC-2430.50.30:
+    name: Emissionen und Umwelt-Compliance
+    description: |
+      Einhaltung von Emissionsvorschriften für Fahrzeuge, Schiffe und Flugzeuge.
+  BC-2430.60:
+    name: Flottenauslastung und Leistungsmanagement
+    description: |
+      Messung von Assetauslastung, Umlaufzeiten und Gesamtbetriebskosten
+      zur Steuerung von Flottenentscheidungen.
+  BC-2430.60.10:
+    name: Asset-Auslastungs-Berichterstattung
+    description: |
+      Berichterstattung über Auslastung nach Assettyp, Strecke und Lager.
+  BC-2430.60.20:
+    name: Ausrüstungs-Umlaufzeit-Analyse
+    description: |
+      Analyse von Container-, Trailer- und ULD-Umlaufzeiten.
+  BC-2430.60.30:
+    name: Gesamtbetriebskosten-Analyse
+    description: |
+      Gesamtbetriebskosten-Analyse über Flottentypen und Anbieter.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-food-beverage-operations-management.yaml
+++ b/catalogue/i18n/de/L1-food-beverage-operations-management.yaml
@@ -1,0 +1,169 @@
+locale: de
+source: L1-food-beverage-operations-management.yaml
+entries:
+  BC-4070:
+    name: Gastronomie- und Getränkebetrieb Management
+    description: |
+      Betrieb von Speisen- und Getränkediensten in Restaurant, Bar,
+      Zimmerservice, Bankett und Küche – einschließlich Rezept- und Menü-Engineering,
+      Beschaffung, Küchenproduktion, Service, Hygiene und Lebensmittelsicherheitskonformität.
+    in_scope:
+      - Menü- und Rezeptmanagement mit Allergen- und Nährwertdaten
+      - F&B-Beschaffung, Getränkekeller und Inventarbetrieb
+      - Küchenproduktionsplanung und Linienausführung
+      - Restaurant-, Zimmerservice- und Bankettservicebetrieb
+      - HACCP- und Lebensmittelsicherheitsbetrieb
+    out_of_scope:
+      - Property-Haustechnik (BC-4060.30)
+      - Veranstaltungsauftragsursprung und Gruppenvertrieb (BC-4110)
+      - Kreuzfahrtbordspeisebetrieb (BC-4090)
+  BC-4070.10:
+    name: Menü-Engineering und Rezeptmanagement
+    description: |
+      Engineering von Menüs und Rezepten einschließlich Spezifikationen,
+      Allergen- und Nährwertdeklarationen, Kalkulation und Versionierung.
+  BC-4070.10.10:
+    name: Rezept- und Spezifikationsmanagement
+    description: |
+      Management von Rezepten, Sub-Rezepten und Produktspezifikationen über Outlets.
+  BC-4070.10.20:
+    name: Allergen- und Nährwertdeklaration
+    description: |
+      Deklaration von Allergenen und Nährwerten für Menüposten konform mit Regulierung.
+  BC-4070.10.30:
+    name: Rezeptkalkulation und Margenenineering
+    description: |
+      Kalkulation von Rezepten und Engineering der Menümarge gegen Zielwareneinsatz.
+  BC-4070.10.40:
+    name: Menüversionierung und Rollout
+    description: |
+      Versionierung und Rollout von Menüs über Saisonen, Outlets und Märkte.
+  BC-4070.20:
+    name: F&B-Beschaffung und Inventar
+    description: |
+      Beschaffung von F&B-Lieferungen, Getränkekellerinventar,
+      Mindestbestandsauffüllung und Theorie-Ist-Abweichungsanalyse.
+  BC-4070.20.10:
+    name: F&B-Lieferantenbeschaffung
+    description: |
+      Beschaffung von F&B-Lieferanten einschließlich Genehmigung und Vertragsbedingungen.
+  BC-4070.20.20:
+    name: Getränke- und Kellerinventarmanagement
+    description: |
+      Inventarmanagement von Getränken und Kellerbestand einschließlich Jahrgangsverfolgung.
+  BC-4070.20.30:
+    name: Mindestbestandsmanagement
+    description: |
+      Management von Mindestbeständen und Auffüllungszyklen über Outlets.
+  BC-4070.20.40:
+    name: Theorie-Ist-Abweichungsanalyse
+    description: |
+      Analyse von Theorie-Ist-Lebensmittel- und Getränkekostenabweichungen.
+  BC-4070.30:
+    name: Küchenproduktionsbetrieb
+    description: |
+      Betrieb der Küchenproduktion einschließlich Planung, Linienausführung,
+      Anrichten und Lebensmittelkostenkontrolle.
+  BC-4070.30.10:
+    name: Produktionsplanung und Mise-en-Place
+    description: |
+      Planung von Küchenproduktionszyklen und Mise-en-Place vor dem Service.
+  BC-4070.30.20:
+    name: Linien- und Serviceproduktionsbetrieb
+    description: |
+      Live-Linienproduktion und Pass-Koordination während Serviceperioden.
+  BC-4070.30.30:
+    name: Anrichten und Qualitätskontrolle
+    description: |
+      Anrichten und Qualitätskontrolle am Pass vor dem Service.
+  BC-4070.30.40:
+    name: Küchen-Lebensmittelkostenbetrieb
+    description: |
+      Betrieb zur Lebensmittelkostenverwaltung einschließlich Ausbeute-Prüfungen und Abfallerfassung.
+  BC-4070.40:
+    name: Restaurant- und Outlet-Servicebetrieb
+    description: |
+      Servicebetrieb in Restaurants und Outlets einschließlich Reservierung,
+      Platzierung, Couvermanagement und Outlet-Reset.
+  BC-4070.40.10:
+    name: Reservierungs- und Sitzplatzmanagement
+    description: |
+      Management von Reservierungen, Sitzplatzzuweisung und Warteliste über Outlets.
+  BC-4070.40.20:
+    name: Couvert- und Tempo-Management
+    description: |
+      Management von Couverzahlen und Service-Tempo über Serviceperioden.
+  BC-4070.40.30:
+    name: Tisch-Servicebetrieb
+    description: |
+      Tisch-Servicebetrieb einschließlich Bestellaufnahme, Servicestandards und Rechnungsvorlage.
+  BC-4070.40.40:
+    name: Outlet-Schließ- und Reset-Betrieb
+    description: |
+      Outlet-Schließung, Kassenabrechnung und Reset für die nächste Serviceperiode.
+  BC-4070.50:
+    name: Zimmerservice- und Minibar-Betrieb
+    description: |
+      Zimmerservice-Bestellaufnahme und -Lieferung, Minibar-Auffüllung
+      und Willkommensgeschenk-Betrieb.
+  BC-4070.50.10:
+    name: Zimmerservice-Bestellaufnahme
+    description: |
+      Bestellaufnahme für Zimmerservice über Telefon-, App- und Türhänger-Kanäle.
+  BC-4070.50.20:
+    name: Zimmerservice-Lieferbetrieb
+    description: |
+      Lieferung von Zimmerservice-Bestellungen innerhalb der Servicezeit-Standards.
+  BC-4070.50.30:
+    name: Minibar-Auffüllungsbetrieb
+    description: |
+      Auffüllung und Verbrauchserfassung des Minibar-Inventars.
+  BC-4070.50.40:
+    name: Amenity- und Willkommensgeschenk-Betrieb
+    description: |
+      Betrieb von Zimmer-Amenities und Willkommensgeschenkbereitstellung für VIPs.
+  BC-4070.60:
+    name: Bankett- und Cateringbetrieb
+    description: |
+      Bankett- und Cateringbetrieb einschließlich Aufbau, Service,
+      Außenhaus-Catering und Getränkeservice für Veranstaltungen.
+  BC-4070.60.10:
+    name: Bankett-Aufbau- und Reset-Betrieb
+    description: |
+      Aufbau, Umbau und Reset von Bankettälen zwischen aufeinanderfolgenden Veranstaltungen.
+  BC-4070.60.20:
+    name: Plated- und Buffet-Servicebetrieb
+    description: |
+      Servicebetrieb für plated, Buffet- und family-style-Bankettveranstaltungen.
+  BC-4070.60.30:
+    name: Außenhaus-Cateringbetrieb
+    description: |
+      Betrieb von Cateringdiensten außerhalb des Stammhauses.
+  BC-4070.60.40:
+    name: Bankett-Getränkebetrieb
+    description: |
+      Getränkeservicebetrieb bei Bankettveranstaltungen einschließlich Bar-Aufbau.
+  BC-4070.70:
+    name: F&B-Hygiene- und Lebensmittelsicherheitsbetrieb
+    description: |
+      Hygiene- und Lebensmittelsicherheitsbetrieb einschließlich HACCP-Planausführung,
+      Temperaturüberwachung, Allergenkontrollen und Vorfallbehandlung.
+  BC-4070.70.10:
+    name: HACCP-Planausführung
+    description: |
+      Ausführung von HACCP-Plänen über Anlieferung, Lagerung, Vorbereitung, Garen und Warmhalten.
+  BC-4070.70.20:
+    name: Temperatur- und Kühlkettenüberwachung
+    description: |
+      Überwachung von Temperatur und Kühlkettenintegrität bei F&B-Lagerung und -Service.
+  BC-4070.70.30:
+    name: Allergen-Kreuzkontaminationskontrollen
+    description: |
+      Betrieb von Allergen-Kreuzkontaminationskontrollen bei Anlieferung, Vorbereitung und Service.
+  BC-4070.70.40:
+    name: Lebensmittelsicherheitsvorfallbehandlung
+    description: |
+      Behandlung von Lebensmittelsicherheitsvorfällen einschließlich Berichte über vermutete Lebensmittelvergiftungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-food-beverage-processing-operations-management.yaml
+++ b/catalogue/i18n/de/L1-food-beverage-processing-operations-management.yaml
@@ -1,0 +1,182 @@
+locale: de
+source: L1-food-beverage-processing-operations-management.yaml
+entries:
+  BC-3580:
+    name: Lebensmittel- und Getränkeverarbeitung
+    description: |
+      Industrielle Lebensmittel- und Getränkeherstellungsbetriebe –
+      Rohstoffannahme, Erst- und Weiterverarbeitung, Verpackung,
+      Kühlkettenherstellung, Sanitärmaßnahmen, Tiernahrungsherstellung
+      und Nebenproduktgewinnung bei Fleisch, Milch, Mühlen, Brauereien,
+      Backwaren und frisch geschnittenem Gemüse.
+  BC-3580.10:
+    name: Rohstoffannahme und -Inspektion
+    description: |
+      Annahme, sensorische und Laborprüfung sowie Chargenabnahme
+      von landwirtschaftlichen Rohrohstoffen in Verarbeitungsanlagen.
+  BC-3580.10.10:
+    name: Rohstoffannahme
+    description: |
+      Annahme von Nutzvieh, Milch, Getreide, Obst- und
+      Gemüseinputs.
+  BC-3580.10.20:
+    name: Rohstoff-Sensorik- und Qualitätsprüfung
+    description: |
+      Sensorische und Laborprüfung eingehender Rohstoffe.
+  BC-3580.10.30:
+    name: Rohstoffchargen-Abnahme
+    description: |
+      Chargenabnahme-, Ablehnungs- und Umeinstufungsentscheidungen.
+  BC-3580.20:
+    name: Erstverarbeitungs-Betrieb
+    description: |
+      Erste Transformation landwirtschaftlicher Rohstoffe –
+      Schlachtung und Dressing, Milchseparation, Mahlen und
+      Erzeugnisaufbereitung.
+    in_scope:
+      - Schlachtung und Schlachtkörper-Dressing
+      - Milchannahme und -Separation
+      - Getreidemahlen und Ölsaatenpressung
+      - Obst- und Gemüseaufbereitung
+    out_of_scope:
+      - Generelle Herstellungsbetriebe (BC-1010)
+  BC-3580.20.10:
+    name: Schlachtung und Schlachtkörper-Dressing
+    description: |
+      Schlachtung, Dressing und Kühlung von Nutzvieh- und
+      Geflügelschlachtkörpern.
+  BC-3580.20.20:
+    name: Milchannahme und -Separation
+    description: |
+      Milchannahme, Standardisierung und Rahmseparationsbetrieb.
+  BC-3580.20.30:
+    name: Getreidemahlen und Ölsaatenpressung
+    description: |
+      Getreidemahlen und Ölsaatenpressung einschließlich Expeller
+      und Lösungsmittelextraktion.
+  BC-3580.20.40:
+    name: Obst- und Gemüse-Aufbereitung
+    description: |
+      Waschen, Schälen, Schneiden und Blanchieren von Obst und Gemüse.
+  BC-3580.30:
+    name: Weiterverarbeitungs-Betrieb
+    description: |
+      Mischen, Kochen, Fermentation und Konzentration zur
+      Herstellung von Fertig-Lebensmitteln und Getränken.
+  BC-3580.30.10:
+    name: Misch- und Blending-Betrieb
+    description: |
+      Mischen und Blending von formulierten Lebensmittel- und
+      Getränkerezepturen.
+  BC-3580.30.20:
+    name: Koch- und Thermoverarbeitungs-Betrieb
+    description: |
+      Koch-, Pasteurisierungs- und Sterilisationsbetrieb.
+  BC-3580.30.30:
+    name: Fermentations- und Brau-Betrieb
+    description: |
+      Fermentations-, Brau- und Reifungsbetrieb von Getränken und
+      fermentierten Produkten.
+  BC-3580.30.40:
+    name: Trocknungs- und Konzentrations-Betrieb
+    description: |
+      Sprühtrocknung, Eindampfung und Konzentration von
+      Flüssigprodukten.
+  BC-3580.40:
+    name: Verpackungs- und Abfüllungs-Betrieb
+    description: |
+      Abfüllung, Versiegelung, Etikettierung und Palettierung
+      von fertigen Lebensmitteln und Getränken.
+  BC-3580.40.10:
+    name: Abfüllungs- und Versiegelungs-Betrieb
+    description: |
+      Abfüllung und Versiegelung von Flaschen, Dosen, Beuteln
+      und Starrbehältern.
+  BC-3580.40.20:
+    name: Etikettierungs-Betrieb
+    description: |
+      Etikettierung, Datumskodierung und Manipulationsschutz-Anbringung.
+  BC-3580.40.30:
+    name: Kartonverpackung und Palettierung
+    description: |
+      Kartonverpackung, Schrumpffolie und Palettierung von
+      Fertigwaren.
+  BC-3580.50:
+    name: Kühlketten-Herstellungsbetrieb
+    description: |
+      Betriebsinterne Kühlung, Gefrieren und Kühlkettenüberwachung
+      über Verarbeitungs- und Verpackungslinien.
+  BC-3580.50.10:
+    name: Kühl- und Gefrierbetrieb
+    description: |
+      Betrieb von betriebsinternen Kühlern, Schockgefrieranlagen
+      und Gefrierkanälen.
+  BC-3580.50.20:
+    name: Betriebsinterne Kühlkettenüberwachung
+    description: |
+      Kühlkettenüberwachung über betriebsinterne Zonen und Lagerräume.
+  BC-3580.60:
+    name: Sanitärmaßnahmen und Allergen-Kontrollbetrieb
+    description: |
+      CIP-Reinigung, Allergenumstellungskontrolle und Umgebungs-
+      überwachungsprogramme zum Schutz der Produktsicherheit.
+    in_scope:
+      - Cleaning-in-Place-Programme
+      - Allergenumstellungsvalidierung
+      - Umgebungspathogen-Überwachung
+    out_of_scope:
+      - Einzelhandelseitige Lebensmittelsicherheitsprogramme (BC-2380.10)
+  BC-3580.60.10:
+    name: CIP-Betrieb
+    description: |
+      CIP-Durchführung und -Validierung über Produktumstellungen hinweg.
+  BC-3580.60.20:
+    name: Allergenumstellungs-Kontrolle
+    description: |
+      Allergenumstellungskontrollen und Verifikationsabstriche.
+  BC-3580.60.30:
+    name: Umgebungsüberwachungs-Programme
+    description: |
+      Umgebungspathogen-Überwachung über Anlagenzonen hinweg.
+  BC-3580.70:
+    name: Tiernahrungsherstellungs-Betrieb
+    description: |
+      Mischfutterherstellung einschließlich Futterinhaltsstoffannahme,
+      Mischen, Pelletierung und Arzneifutterproduktion für die
+      nachgelagerte Tierhaltung.
+  BC-3580.70.10:
+    name: Futterinhaltsstoff-Annahme
+    description: |
+      Annahme von Getreide, Eiweißfuttermitteln und Additiven
+      in Futtermühlen.
+  BC-3580.70.20:
+    name: Futtermisch- und Pelletierungsbetrieb
+    description: |
+      Mischen und Pelletieren von Mischfutter nach Rationenformulierungen.
+  BC-3580.70.30:
+    name: Arzneifutter-Produktion
+    description: |
+      Arzneifutterproduktion auf Rezept mit Übertragungs-Kontrollen.
+  BC-3580.80:
+    name: Neben- und Koprodukt-Management
+    description: |
+      Gewinnung und Weiterleitung von Prozessnebenerzeugnissen und
+      Koprodukten wie Tierfett, Molke und Biertreber.
+  BC-3580.80.10:
+    name: Tierfettverwertungs-Betrieb
+    description: |
+      Tierfettverwertung von Fleischverarbeitungsnebenerzeugnissen
+      zu Talg und Tiermehl.
+  BC-3580.80.20:
+    name: Molken- und Permeat-Gewinnung
+    description: |
+      Gewinnung von Molken- und Permeatströmen aus der
+      Milchverarbeitung.
+  BC-3580.80.30:
+    name: Biertreber-Gewinnung
+    description: |
+      Gewinnung und Weiterleitung von Brauerei- und
+      Brennerei-Biertreber.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-food-safety-traceability-management.yaml
+++ b/catalogue/i18n/de/L1-food-safety-traceability-management.yaml
@@ -1,0 +1,129 @@
+locale: de
+source: L1-food-safety-traceability-management.yaml
+entries:
+  BC-2380:
+    name: Lebensmittelsicherheit und Rückverfolgbarkeit
+    description: |
+      Lebensmittelsicherheitsprogramme, Chargen-Rückverfolgbarkeit, Rückrufkoordination,
+      Frischeprodukt-Haltbarkeitsmanagement und Kühlketten-Compliance für den Lebensmitteleinzelhandel
+      und die Lebensmittelproduktion.
+  BC-2380.10:
+    name: Lebensmittelsicherheitsprogramm-Management
+    description: |
+      Lebensmittelsicherheitsrichtlinien, HACCP und Zertifizierungsprogramme (BRCGS, SQF,
+      FSSC 22000, IFS Food, ISO 22000) zur Steuerung von Lebensmittelhandhabung und -versorgung.
+    in_scope:
+      - HACCP und Lebensmittelsicherheitsrichtlinien
+      - Drittanbieter-Zertifizierung (BRCGS, SQF, FSSC 22000, IFS Food)
+      - Lebensmittelsicherheits-Vorfallmanagement
+    out_of_scope:
+      - Allgemeines Qualitätsmanagement (BC-720)
+  BC-2380.10.10:
+    name: Lebensmittelsicherheitsrichtlinien-Management
+    description: |
+      Erstellung und Stewardship von Lebensmittelsicherheitsrichtlinien im gesamten Netzwerk.
+  BC-2380.10.20:
+    name: HACCP-Plan-Management
+    description: |
+      HACCP-Plan-Entwicklung, Gefahrenanalyse und Überwachung kritischer Kontrollpunkte.
+  BC-2380.10.30:
+    name: Lebensmittelsicherheits-Zertifizierungsmanagement
+    description: |
+      Zertifizierung nach BRCGS, SQF, FSSC 22000, IFS Food und ISO 22000.
+  BC-2380.10.40:
+    name: Lebensmittelsicherheits-Vorfallmanagement
+    description: |
+      Vorfallbehandlung bei Lebensmittelsicherheitsereignissen einschließlich Erregernachweise.
+  BC-2380.20:
+    name: Chargen-Rückverfolgbarkeits-Management
+    description: |
+      Einstufige Vorwärts-/Rückwärts-Rückverfolgbarkeit von Chargen in der Lieferkette
+      mittels GS1 EPCIS-Ereigniserfassung und Handelspartnerdatenaustausch.
+  BC-2380.20.10:
+    name: Chargen-Codierung
+    description: |
+      Generierung und Druck von Chargencodes gemäß GS1-Standards.
+  BC-2380.20.20:
+    name: EPCIS-Ereigniserfassung
+    description: |
+      Erfassung von EPCIS-Ereignissen (Inbetriebnahme, Versand, Empfang) in der Lieferkette.
+  BC-2380.20.30:
+    name: Einstufige Vorwärts-/Rückwärts-Nachverfolgung
+    description: |
+      Einstufige Vor- und Rückwärtsnachverfolgung von Inputs und Outputs an jedem Handlingknoten.
+  BC-2380.20.40:
+    name: Handelspartner-Rückverfolgungsdatenaustausch
+    description: |
+      Austausch von Rückverfolgungsdaten mit Lieferanten und nachgelagerten Handelspartnern.
+  BC-2380.30:
+    name: Rückruf- und Rücknahmekoordination
+    description: |
+      Koordination von Lebensmittel- und Konsumgüter-Rückrufen und -Rücknahmen
+      einschließlich Behördenbenachrichtigung und Verbraucherkommunikation.
+    in_scope:
+      - Rückrufklassifizierung und Entscheidungsfindung
+      - Behördenbenachrichtigung und Berichterstattung
+      - Verbraucher- und Handelspartnerkommunikation
+  BC-2380.30.10:
+    name: Rückrufentscheidung und Klassifizierung
+    description: |
+      Entscheidung und Klassifizierung von Rückrufumfang und Schweregrad.
+  BC-2380.30.20:
+    name: Behördenbenachrichtigung
+    description: |
+      Benachrichtigung der Lebensmittelsicherheitsbehörden gemäß jurisdiktionellen Regeln.
+  BC-2380.30.30:
+    name: Verbraucher- und Handelspartnerkommunikation
+    description: |
+      Kommunikation mit Verbrauchern und Handelspartnern über Rückrufmaßnahmen.
+  BC-2380.30.40:
+    name: Rückrufeffektivitäts-Verifikation
+    description: |
+      Überprüfung der Rückrufeffektivität und Rückholquoten.
+  BC-2380.40:
+    name: Frischeprodukt- und Haltbarkeits-Management
+    description: |
+      Haltbarkeitsüberwachung, FEFO-Rotation, Datierungsdisziplin und Abfallreduzierung
+      bei verderblichen Waren.
+  BC-2380.40.10:
+    name: Haltbarkeit und Datumskodierung
+    description: |
+      Festlegung und Druck von Haltbarkeits- und Datumscodes gemäß Marktregeln.
+  BC-2380.40.20:
+    name: First-Expire-First-Out-Rotation
+    description: |
+      FEFO-Rotation in Filialen und Distributionszentren.
+  BC-2380.40.30:
+    name: Frischeprodukt-Preisreduzierungskoordination
+    description: |
+      Koordination von Preisreduzierungen bei Frischeprodukten vor Ablauf zur Abfallreduzierung.
+  BC-2380.40.40:
+    name: Lebensmittelabfall-Reduktionsprogramme
+    description: |
+      Programme zur Lebensmittelabfallreduzierung, -spende und -kreislaufführung.
+  BC-2380.50:
+    name: Kühlketten-Compliance-Management
+    description: |
+      Kühlkettenintegrität für gekühlte und gefrorene Lebensmittel einschließlich
+      Temperaturüberwachung, Abweichungsbehandlung und Dispositionsentscheidungen.
+    in_scope:
+      - Kühlketten-Temperaturüberwachung an allen Knoten
+      - Abweichungsuntersuchung und Disposition
+      - Kühlketten-SOPs und Audits
+    out_of_scope:
+      - Pharmazeutische Kühlkette (BC-1570.10)
+  BC-2380.50.10:
+    name: Kühlketten-Temperaturüberwachung
+    description: |
+      Ende-zu-Ende-Temperaturüberwachung der Lebensmittel-Kühlkette.
+  BC-2380.50.20:
+    name: Kühlketten-Abweichungsdisposition
+    description: |
+      Untersuchung und Disposition von Temperaturabweichungen in der Kühlkette.
+  BC-2380.50.30:
+    name: Kühlketten-Audit und Verifikation
+    description: |
+      Audit und Überprüfung der Kühlkettenpraktiken im gesamten Netzwerk.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-freight-billing-settlement-management.yaml
+++ b/catalogue/i18n/de/L1-freight-billing-settlement-management.yaml
@@ -1,0 +1,104 @@
+locale: de
+source: L1-freight-billing-settlement-management.yaml
+entries:
+  BC-2530:
+    name: Frachtabrechnung
+    description: |
+      Ausstellung von Frachtrechungen, Prüfung und Zahlung von Carrier-Rechnungen,
+      Interline- und Pool-Abrechnung, Frachtansprüche und Frachtumsatzbuchhaltung.
+  BC-2530.10:
+    name: Frachtabrechnung-Management
+    description: |
+      Generierung und Verteilung von Fracht-, Nebenentgelt- und Selbstrechnungs-Rechnungen an Kunden.
+    in_scope:
+      - Frachtrechnung-Generierung
+      - Kunden-Selbstabrechnungsabstimmung
+    out_of_scope:
+      - Allgemeine Debitorenbuchhaltungsprozesse (BC-200)
+      - Kundenstrategie Preisgestaltung (BC-440)
+  BC-2530.10.10:
+    name: Frachtrechnung-Generierung
+    description: |
+      Generierung von Frachtrechnungen aus abgeschlossenen Transporten.
+  BC-2530.10.20:
+    name: Nebenentgelt-Rechnung-Generierung
+    description: |
+      Generierung von Nebenentgelt- und Zuschlagsrechnungen.
+  BC-2530.10.30:
+    name: Kunden-Selbstabrechnungs-Koordination
+    description: |
+      Abstimmung von Kunden-Selbstabrechnungsaufstellungen gegen Sendungen.
+  BC-2530.20:
+    name: Frachtprüfung und Zahlungsmanagement
+    description: |
+      Prüfung von Carrier-Rechnungen und Durchführung von Carrier-Zahlungen
+      durch Versender und Spediteure.
+  BC-2530.20.10:
+    name: Carrier-Rechnungsprüfung
+    description: |
+      Prüfung von Carrier-Rechnungen gegen Verträge, Tarife und Sendungen.
+  BC-2530.20.20:
+    name: Vor- und Nachprüfungs-Abstimmung
+    description: |
+      Vor- und Nachprüfungs-Abstimmung von Carrier-Rechnungen.
+  BC-2530.20.30:
+    name: Carrier-Zahlungsdurchführung
+    description: |
+      Durchführung von Carrier-Zahlungen und Überweisungsberichten.
+  BC-2530.30:
+    name: Interline- und Multi-Carrier-Abrechnungsmanagement
+    description: |
+      Abrechnung von Erlösen und Kosten über Interline-Partner, Allianzen und Spediteur-Niederlassungen.
+  BC-2530.30.10:
+    name: Interline-Pro-Rata-Berechnung
+    description: |
+      Berechnung der Interline-Erlöspro-Rata über Partner.
+  BC-2530.30.20:
+    name: IATA-CASS-Abrechnungsbetrieb
+    description: |
+      Betrieb der IATA-CASS-Abrechnung für Luftfracht.
+  BC-2530.30.30:
+    name: Zwischenniederlassungs-Abrechnung
+    description: |
+      Zwischenniederlassungs-Abrechnung von Spediteur-Erlösen und -Kosten.
+  BC-2530.40:
+    name: Frachtanspruchs-Management
+    description: |
+      Entgegennahme, Beurteilung und Abwicklung von Frachtansprüchen unter
+      Transporthaftungsübereinkommen.
+  BC-2530.40.10:
+    name: Anspruchserfassung und -bestätigung
+    description: |
+      Entgegennahme und Bestätigung von Frachtverlust- und Beschädigungsansprüchen.
+  BC-2530.40.20:
+    name: Haftungsbeurteilung
+    description: |
+      Beurteilung der Carrier-Haftung gemäß Haager-Visby-Regeln, Montreal, CMR und COTIF.
+  BC-2530.40.30:
+    name: Anspruchsabwicklung und Rückforderung
+    description: |
+      Abwicklung anerkannter Ansprüche und Kundenzahlung.
+  BC-2530.40.40:
+    name: Anspruchsregress und Subrogation
+    description: |
+      Regress gegen zugrunde liegende Carrier und Subrogation gegen Versicherer.
+  BC-2530.50:
+    name: Frachtumsatzbuchhaltungs-Management
+    description: |
+      Erfassung, Verfolgung und Berichterstattung von Frachterlösen einschließlich
+      nicht fakturierter und zurückgestellter Positionen.
+  BC-2530.50.10:
+    name: Frachterlöserfassung
+    description: |
+      Erfassung von Frachterlösen gemäß geltenden Rechnungslegungsstandards.
+  BC-2530.50.20:
+    name: Nicht fakturierter Erlös-Verfolgung
+    description: |
+      Verfolgung nicht fakturierter und aufgelaufener Frachterlöse.
+  BC-2530.50.30:
+    name: Frachterlös-Berichterstattung
+    description: |
+      Berichterstattung von Frachterlösen an Finanz- und Vertriebsfunktionen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-freight-capacity-management.yaml
+++ b/catalogue/i18n/de/L1-freight-capacity-management.yaml
@@ -1,0 +1,109 @@
+locale: de
+source: L1-freight-capacity-management.yaml
+entries:
+  BC-2400:
+    name: Frachtkapazitäts-Management
+    description: |
+      Verkauf, Zuweisung und Yield Management von Transportkapazitäten über Schiffsfahrten,
+      Flüge, LKW- und Eisenbahnstrecken sowie Ausrüstungspools.
+  BC-2400.10:
+    name: Kapazitätsinventar-Management
+    description: |
+      Pflege der verfügbaren Transportkapazität nach Verkehrsträger, Strecke, Fahrplan und
+      Ausrüstungstyp als Grundlage für Zuweisung und Buchung.
+    in_scope:
+      - Kapazitätsdatensätze für Schiffe, Flüge, Fahrzeuge und Schienenfahrzeuge
+      - Ausrüstungspool-Kapazität (Container, Trailer, ULDs)
+      - Fahrplangebundene Streckenkapazität
+    out_of_scope:
+      - Langfristiges Netzwerk- und Fahrplandesign (BC-2410)
+      - Buchungs- und Reservierungsannahme (BC-2400.40)
+  BC-2400.10.10:
+    name: Schiff- und Beförderungsmittel-Kapazitätsinventar
+    description: |
+      Erfassung von Nutzlast-, Deck- und Kabinenkapazität je Schiff, Flugzeug, Zug oder Fahrzeug.
+  BC-2400.10.20:
+    name: Ausrüstungskapazitäts-Inventar
+    description: |
+      Inventar verfügbarer Container, Trailer, Chassis und ULDs nach Standort und Zustand.
+  BC-2400.10.30:
+    name: Strecken- und Fahrplankapazität
+    description: |
+      Kapazität je geplantem Service auf einer Strecke einschließlich Anschlussstrecken.
+  BC-2400.10.40:
+    name: Kapazitätspooling und Slot-Tausch
+    description: |
+      Gebündelte Kapazitäten über Allianzen und Slot-Tausch-Vereinbarungen mit Partnerreedereien.
+  BC-2400.20:
+    name: Kapazitätszuweisungs-Management
+    description: |
+      Zuweisung verfügbarer Kapazitäten auf Kundenverträge, Marktsegmente und Spot-Nachfrage.
+  BC-2400.20.10:
+    name: Vertragskapazitäts-Zuweisung
+    description: |
+      Zuweisung von Kapazitäten an Kunden mit Mindestmengen-Verpflichtungen und Namenkonten.
+  BC-2400.20.20:
+    name: Spotmarkt-Kapazitätszuweisung
+    description: |
+      Zuweisung von Kapazitäten, die für Spotmarkt-Buchungskanäle freigegeben werden.
+  BC-2400.20.30:
+    name: Kapazitäts-Umzuweisung und Rückgewinnung
+    description: |
+      Neuzuweisung ungenutzter oder zurückgewonnener Kapazitäten vor Annahmeschluss.
+  BC-2400.30:
+    name: Yield- und Revenue-Management
+    description: |
+      Optimierung des Umsatzes je Kapazitätseinheit durch Preis-, Mix- und Overbooking-Entscheidungen.
+  BC-2400.30.10:
+    name: Kapazitätsnachfrage-Prognose
+    description: |
+      Prognose von Buchungen, No-Shows und Entladerisiken je Service.
+  BC-2400.30.20:
+    name: Yield-Optimierung
+    description: |
+      Optimierung des Tarif- und Ratenklassen-Mix zur Maximierung des Yields je Tonne, Slot oder TEU.
+  BC-2400.30.30:
+    name: Overbooking-Management
+    description: |
+      Festlegung und Überwachung von Overbooking-Grenzen und Entladerisiken.
+  BC-2400.30.40:
+    name: Umsatzmix-Management
+    description: |
+      Steuerung des Umsatzmix zwischen Vertrags-, Spot- und Nebenerlösen.
+  BC-2400.40:
+    name: Buchungs- und Reservierungsmanagement
+    description: |
+      Annahme, Änderung und Stornierung von Kapazitätsbuchungen gegenüber
+      veröffentlichten Fahrplänen und Angeboten.
+  BC-2400.40.10:
+    name: Kapazitätsbuchung
+    description: |
+      Buchungsannahme gegen verfügbare Kapazitäten und Ratengültigkeit.
+  BC-2400.40.20:
+    name: Buchungsänderung und -stornierung
+    description: |
+      Buchungsänderungen, Umladungen und Stornierungen einschließlich No-Show-Gebühren.
+  BC-2400.40.30:
+    name: Stand-by- und Wartelisten-Management
+    description: |
+      Verwaltung von Stand-by- und wartelistierten Frachten für bestätigte Kapazitäten.
+  BC-2400.50:
+    name: Kapazitätsleistungs-Management
+    description: |
+      Überwachung von Auslastungsgrad, Füllgrad und Nutzung zur Steuerung von
+      Kapazitätsmix-Entscheidungen und Netzwerkanpassungen.
+  BC-2400.50.10:
+    name: Auslastungsgrad-Analyse
+    description: |
+      Analyse des Auslastungsgrads nach Service, Strecke und Segment.
+  BC-2400.50.20:
+    name: Kapazitätsauslastungs-Berichterstattung
+    description: |
+      Berichterstattung über Kapazitätsauslastung an Vertriebs- und Betriebsteams.
+  BC-2400.50.30:
+    name: Kapazitätsleistungsverbesserung
+    description: |
+      Maßnahmen zur Verbesserung des Umsatzes je Slot und Reduzierung von Leerfahrten.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-freight-forwarding-brokerage-management.yaml
+++ b/catalogue/i18n/de/L1-freight-forwarding-brokerage-management.yaml
@@ -1,0 +1,100 @@
+locale: de
+source: L1-freight-forwarding-brokerage-management.yaml
+entries:
+  BC-2450:
+    name: Spedition und Frachtmakler-Management
+    description: |
+      Arrangierung von Transporten im Namen von Versendern als Spediteur, NVOCC,
+      Frachtmakler oder Zollagent, einschließlich multimodaler Koordination und
+      Partnernetzwerkbetrieb.
+  BC-2450.10:
+    name: Versenderangebots-Management
+    description: |
+      Entgegennahme von Versenderanfragen und Ausstellung von Spediteursraten
+      über verschiedene Verkehrsträger und Carrier.
+    in_scope:
+      - Multi-Carrier-Ratenrecherche für Versenderanfragen
+      - Angebotsgültigkeit und Bestätigungsverfolgung
+    out_of_scope:
+      - Carrier-seitige Raten- und Tarifverwaltung (BC-2520)
+  BC-2450.10.10:
+    name: Angebotsanfrage-Erfassung
+    description: |
+      Erfassung von Versenderangebotsanfragen über verschiedene Kanäle.
+  BC-2450.10.20:
+    name: Multi-Carrier-Ratenrecherche
+    description: |
+      Recherche und Vergleich von Raten über die zugrunde liegenden Carrier.
+  BC-2450.10.30:
+    name: Angebotsausstellung und Gültigkeit
+    description: |
+      Ausstellung verbindlicher und indikativer Angebote und Verfolgung der Gültigkeit.
+  BC-2450.20:
+    name: Carrier-Beschaffung und -Zuweisungs-Management
+    description: |
+      Buchung von Kapazitäten bei Carriern und Verwaltung von Carrier-Zuteilungen und Ausgaben.
+  BC-2450.20.10:
+    name: Carrier-Auswahl
+    description: |
+      Auswahl der zugrunde liegenden Carrier je Sendung.
+  BC-2450.20.20:
+    name: Carrier-Buchungsdurchführung
+    description: |
+      Buchung von Kapazitäten bei ausgewählten Carriern.
+  BC-2450.20.30:
+    name: Zuteilungsausgaben-Optimierung
+    description: |
+      Optimierung der Spediteur-Ausgaben über Carrier-Zuteilungen.
+  BC-2450.30:
+    name: Multimodale Speditionskoordination
+    description: |
+      Koordination von mehrstufigen, multimodalen Transporten einschließlich Konsolidierung,
+      Dekonsolidierung und Hausfrachtbriefen.
+  BC-2450.30.10:
+    name: Hausfrachtbrief-Ausstellung
+    description: |
+      Ausstellung von Spediteur-Hausfrachtbriefen für Versender.
+  BC-2450.30.20:
+    name: Mehrstufige Transportkoordination
+    description: |
+      Koordination mehrstufiger Transporte über Carrier und Verkehrsträger.
+  BC-2450.30.30:
+    name: Konsolidierung und Dekonsolidierung
+    description: |
+      Frachtkonsolidierung am Ursprung und Dekonsolidierung am Ziel.
+  BC-2450.40:
+    name: Zollagenten-Management
+    description: |
+      Erbringung von Zollagenten-Dienstleistungen im Namen von Importeuren und Exporteuren.
+  BC-2450.40.10:
+    name: Zollanmeldungs-Vorbereitung
+    description: |
+      Vorbereitung von Zollanmeldungen im Namen von Kunden.
+  BC-2450.40.20:
+    name: Zoll- und Steuerberechnung
+    description: |
+      Berechnung und Abführung von Zöllen und indirekten Steuern für Kunden.
+  BC-2450.40.30:
+    name: Zollagenten-Statusverfolgung
+    description: |
+      Verfolgung des Zollagenten-Fortschritts und Ausnahmelösung.
+  BC-2450.50:
+    name: Spediteursnetzwerk-Koordination
+    description: |
+      Koordination mit Ursprungs-, Ziel- und Partneragenten in einem Spediteursnetzwerk
+      einschließlich zwischenbetrieblicher Abrechnung.
+  BC-2450.50.10:
+    name: Ursprungs- und Zielagenten-Koordination
+    description: |
+      Koordination von Aktivitäten mit Ursprungs- und Zielagenten.
+  BC-2450.50.20:
+    name: Zwischenbetriebliche Abrechnung
+    description: |
+      Zwischenbetriebliche Abrechnung von Speditionserlösen und -kosten.
+  BC-2450.50.30:
+    name: Partneragenten-Leistungsmanagement
+    description: |
+      Verwaltung von Partneragenten-Servicequalität und Compliance.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-freight-rating-tariff-management.yaml
+++ b/catalogue/i18n/de/L1-freight-rating-tariff-management.yaml
@@ -1,0 +1,99 @@
+locale: de
+source: L1-freight-rating-tariff-management.yaml
+entries:
+  BC-2520:
+    name: Frachtpreisfestsetzung und Tarif-Management
+    description: |
+      Definition und Betrieb von Frachtpreisen, Tarifen, Vertragspreisen, Spotpreisen,
+      Nebenentgelten und der Preisberechnungs-Engine für Frachttransporte.
+  BC-2520.10:
+    name: Tarif- und Ratenkarten-Management
+    description: |
+      Definition, Veröffentlichung und Versionierung öffentlicher Tarife und Basis-Ratenkarten.
+    in_scope:
+      - Basisratenkartendefinition nach Strecke und Einheit
+      - Öffentliche Tarifeinreichung wo erforderlich
+    out_of_scope:
+      - Kundenseitiges Angebot im Speditionskontext (BC-2450.10)
+      - Allgemeine Unternehmenspreismethoden (BC-440)
+  BC-2520.10.10:
+    name: Basisratendefinition
+    description: |
+      Definition von Frachtbasisraten nach Strecke, Einheit und Servicestufe.
+  BC-2520.10.20:
+    name: Öffentliche Tarifeinreichung
+    description: |
+      Einreichung öffentlicher Tarife bei Behörden und Konferenzen wo erforderlich.
+  BC-2520.10.30:
+    name: Ratenkarten-Versionsverwaltung
+    description: |
+      Versionskontrolle und Gültigkeitsdatenverwaltung von Ratenkarten.
+  BC-2520.20:
+    name: Vertragsraten-Management
+    description: |
+      Einrichtung und Pflege ausgehandelter Vertragspreise mit benannten Kunden
+      und Volumenverpflichtungen.
+  BC-2520.20.10:
+    name: Vertragsraten-Einrichtung
+    description: |
+      Einrichtung ausgehandelter Raten gegenüber benannten Kundenverträgen.
+  BC-2520.20.20:
+    name: Volumenverpflichtungs-Verfolgung
+    description: |
+      Verfolgung von Kunden-Volumenverpflichtungen und Mindestmengenzielen.
+  BC-2520.20.30:
+    name: Vertragsraten-Erneuerung
+    description: |
+      Erneuerung und Neuverhandlung ablaufender Vertragsraten.
+  BC-2520.30:
+    name: Spotpreis-Management
+    description: |
+      Preisgestaltung, Annahme und Benchmarking von Spotmarkt-Frachtpreisen.
+  BC-2520.30.10:
+    name: Spotpreis-Angebot
+    description: |
+      Angebotserteilung von Spotmarktpreisen je Sendung.
+  BC-2520.30.20:
+    name: Spotpreis-Annahme
+    description: |
+      Annahme und Bestätigung von Spotpreis-Buchungen.
+  BC-2520.30.30:
+    name: Spotpreis-Index-Benchmarking
+    description: |
+      Benchmarking von Spotpreisen gegen Marktindizes.
+  BC-2520.40:
+    name: Nebenentgelte und Zuschläge-Management
+    description: |
+      Definition und Anwendung von Nebenentgelten, Zuschlägen, Liegegeldern und Detentions-Tarifen.
+  BC-2520.40.10:
+    name: Kraftstoffzuschlag-Management
+    description: |
+      Definition und Anwendung von Kraftstoff- und Bunker-Zuschlägen.
+  BC-2520.40.20:
+    name: Nebenentgelt-Definition
+    description: |
+      Definition von Nebenentgelten für Wartezeiten, Sonderbehandlung und Ausrüstung.
+  BC-2520.40.30:
+    name: Liegegelds- und Detentions-Tarife
+    description: |
+      Definition von Liegegelds- und Detentions-Tarifen für Ausrüstung und Terminalnutzung.
+  BC-2520.50:
+    name: Preisberechnungs-Engine-Betrieb
+    description: |
+      Betrieb der Preisberechnungs-Engine zur Berechnung und Validierung von Frachtentgelten
+      über Aufträge und Sendungen.
+  BC-2520.50.10:
+    name: Ratenberechnungs-Durchführung
+    description: |
+      Durchführung von Ratenberechnungen über Aufträge und Sendungen.
+  BC-2520.50.20:
+    name: Ratenblatt-Verteilung
+    description: |
+      Verteilung von Ratenblättern an Kunden, Partner und Kanäle.
+  BC-2520.50.30:
+    name: Raten-Audit und Validierung
+    description: |
+      Validierung angewendeter Raten gegen Vertrags- und Tarifgrundlagen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-functional-safety-reliability-management.yaml
+++ b/catalogue/i18n/de/L1-functional-safety-reliability-management.yaml
@@ -1,0 +1,131 @@
+locale: de
+source: L1-functional-safety-reliability-management.yaml
+entries:
+  BC-1970:
+    name: Funktionssicherheit / Zuverlässigkeit Management
+    description: |
+      Produktbezogene Funktionssicherheitsanalyse (IEC 61508/61511/13849, ISO 26262) und Zuverlässigkeits-Engineering —
+      getrennt von generischer Qualität und Produktionstestdurchführung.
+  BC-1970.10:
+    name: Funktionssicherheitsanalyse-Management
+    description: |
+      Gefährdungs-, Risiko- und Sicherheitskonzeptanalyse für sicherheitsrelevante elektrische Produkte.
+  BC-1970.10.10:
+    name: Gefährdungs- & Risikoanalyse
+    description: |
+      Gefährdungsidentifikation und Risikoanalyse für sicherheitsrelevante Produkte.
+  BC-1970.10.20:
+    name: Sicherheitskonzept-Definition
+    description: |
+      Definition von funktionalen und technischen Sicherheitskonzepten.
+  BC-1970.10.30:
+    name: Sicherheitsanforderungs-Zuteilung
+    description: |
+      Zuteilung von Sicherheitsanforderungen an Subsysteme und Komponenten.
+  BC-1970.10.40:
+    name: Safety-Case-Erstellung
+    description: |
+      Erstellung von Safety-Cases zur Unterstützung der Produktfreigabe.
+  BC-1970.20:
+    name: Sicherheits-Integritätslevel-Bestimmung
+    description: |
+      Festlegung von Integritätszielen gemäß IEC 61508, ISO 26262 und ISO 13849.
+  BC-1970.20.10:
+    name: SIL-Ziel-Festlegung
+    description: |
+      Bestimmung von Sicherheits-Integritätsleveln gemäß IEC 61508.
+  BC-1970.20.20:
+    name: ASIL-Dekomposition
+    description: |
+      ASIL-Dekomposition für automotive sicherheitsrelevante Elektronik.
+  BC-1970.20.30:
+    name: Performance-Level-Bestimmung
+    description: |
+      Performance-Level-Bestimmung gemäß ISO 13849.
+  BC-1970.30:
+    name: Zuverlässigkeits-Engineering-Management
+    description: |
+      Definition, Vorhersage, Zuteilung und Wachstumsplanung von Zuverlässigkeitsanforderungen.
+  BC-1970.30.10:
+    name: Zuverlässigkeitsanforderungs-Definition
+    description: |
+      Definition von Zuverlässigkeitsanforderungen entsprechend Missionsprofilen.
+  BC-1970.30.20:
+    name: Zuverlässigkeits-Vorhersagemodellierung
+    description: |
+      Vorhersagemodellierung mit Teilezählung und Stressmethoden.
+  BC-1970.30.30:
+    name: Zuverlässigkeitszuteilung
+    description: |
+      Top-Down-Zuteilung von Zuverlässigkeitsbudgets an Subsysteme.
+  BC-1970.30.40:
+    name: Zuverlässigkeitswachstums-Planung
+    description: |
+      Zuverlässigkeitswachstums- und Korrekturmaßnahmenplanung.
+  BC-1970.40:
+    name: Komponenten-Derating- & Spannungsanalyse
+    description: |
+      Elektrische, thermische und mechanische Spannungs- und Deratinganalyse an Komponenten.
+  BC-1970.40.10:
+    name: Elektrisches Spannungs-Derating
+    description: |
+      Anwendung elektrischer Deratingregeln auf Komponenten.
+  BC-1970.40.20:
+    name: Thermisches Derating
+    description: |
+      Thermische Deratinganalyse für Komponenten in ihrer Betriebsumgebung.
+  BC-1970.40.30:
+    name: Mechanische Spannungsanalyse
+    description: |
+      Mechanische Spannungs- und Ermüdungsanalyse an Komponenten.
+  BC-1970.50:
+    name: Fehlermodenanalyse
+    description: |
+      Design- und Prozess-FMEA sowie FMECA-Kritikalitätsanalyse.
+  BC-1970.50.10:
+    name: Design-FMEA
+    description: |
+      Design-Fehlermoden- und -einflussanalyse an Produkten.
+  BC-1970.50.20:
+    name: Prozess-FMEA
+    description: |
+      Prozess-Fehlermoden- und -einflussanalyse an der Produktion.
+  BC-1970.50.30:
+    name: FMECA-Kritikalitätsanalyse
+    description: |
+      Kritikalitätsanalyse auf Basis von FMEA-Ergebnissen.
+  BC-1970.60:
+    name: Feldausfall- & Zuverlässigkeitswachstums-Management
+    description: |
+      Erfassung und Analyse von Feldausfällen für Zuverlässigkeitswachstum.
+  BC-1970.60.10:
+    name: Feldausfallsdatenerfassung
+    description: |
+      Erfassung von Ausfalldaten aus der installierten Basis.
+  BC-1970.60.20:
+    name: Fehlermoden-Trendanalyse
+    description: |
+      Trendanalyse beobachteter Fehlermoden.
+  BC-1970.60.30:
+    name: Zuverlässigkeitswachstums-Tracking
+    description: |
+      Verfolgung des Zuverlässigkeitswachstums über Produktgenerationen.
+  BC-1970.70:
+    name: Funktionssicherheits-Zertifizierungs-Koordination
+    description: |
+      Einbindung von Funktionssicherheits-Gutachtern und Zertifizierungsstellen.
+  BC-1970.70.10:
+    name: Funktionssicherheits-Gutachter-Einbindung
+    description: |
+      Einbindung unabhängiger Funktionssicherheits-Gutachter.
+  BC-1970.70.20:
+    name: Sicherheitszertifizierungs-Einreichung
+    description: |
+      Einreichung von Funktionssicherheitsdossiers zur Zertifizierung.
+  BC-1970.70.30:
+    name: Funktionssicherheits-Überwachung
+    description: |
+      Periodische Überwachungsaudits von Funktionssicherheitsprozessen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-gas-processing-lng-operations-management.yaml
+++ b/catalogue/i18n/de/L1-gas-processing-lng-operations-management.yaml
@@ -1,0 +1,114 @@
+locale: de
+source: L1-gas-processing-lng-operations-management.yaml
+entries:
+  BC-3070:
+    name: Gasverarbeitung und LNG-Betrieb
+    description: |
+      Betrieb der Gasbehandlung, NGL-Fraktionierung, LNG-Verflüssigung (Flüssigerdgas),
+      Beladung und Versendung, Regasifizierung sowie Gasqualitätssicherung
+      in Midstream-Gaswertketten.
+  BC-3070.10:
+    name: Gasanlage-Betrieb
+    description: |
+      Betrieb von Eingangsempfang, Behandlung, Trocknung und Schwefelrückgewinnung in Gasverarbeitungsanlagen.
+  BC-3070.10.10:
+    name: Gasempfang und Eingangsmanagement
+    description: |
+      Empfang, Slug-Auffang und Eingangskonditionierung von Einspeisungsgas.
+  BC-3070.10.20:
+    name: Sauergas-Behandlungsbetrieb
+    description: |
+      Amin- und physikalische Lösungsmittel-Sauergas-Behandlungsoperationen.
+  BC-3070.10.30:
+    name: Gas-Trocknungsbetrieb
+    description: |
+      Glykol- und Molekularsieb-Trocknung von Erdgas.
+  BC-3070.10.40:
+    name: Schwefelrückgewinnungsbetrieb
+    description: |
+      Claus- und Tailgas-Behandlungsoperationen für die Schwefelrückgewinnung.
+  BC-3070.20:
+    name: NGL-Fraktionierungsbetrieb
+    description: |
+      Betrieb von Demethanisierern, Deethanisierern und nachgelagerten Fraktioniertürmen
+      zur Produktion von Ethan, Propan, Butan und Naturgasolin.
+  BC-3070.20.10:
+    name: Demethanisierer-Betrieb
+    description: |
+      Betrieb kryogener Demethanisierer-Kolonnen zur Ethangewinnung.
+  BC-3070.20.20:
+    name: Deethanisierer- und Depropanisierer-Betrieb
+    description: |
+      Betrieb von Deethanisierer-, Depropanisierer- und Debutanisierer-Kolonnen.
+  BC-3070.20.30:
+    name: NGL-Lagerbetrieb
+    description: |
+      Betrieb druckbeaufschlagter und gekühlter NGL-Lager.
+  BC-3070.30:
+    name: LNG-Verflüssigungsbetrieb
+    description: |
+      Betrieb von Verflüssigungszügen, Kältekreisläufen und LNG-Lagertanks.
+  BC-3070.30.10:
+    name: Kältekreislauf-Betrieb
+    description: |
+      Betrieb von Mischkältemittel- und Kaskaden-Kältekreisläufen.
+  BC-3070.30.20:
+    name: LNG-Zug-Betrieb
+    description: |
+      End-to-End-Betrieb von LNG-Verflüssigungszügen.
+  BC-3070.30.30:
+    name: LNG-Lagertank-Betrieb
+    description: |
+      Betrieb kryogener LNG-Lagertanks einschließlich Rollover-Prävention.
+  BC-3070.40:
+    name: LNG-Beladung und Versendungsbetrieb
+    description: |
+      Schiffsbeladung, Cargo-Abkühlung und Pipelineversendungs-Verdampfung an Verflüssigungsterminals.
+  BC-3070.40.10:
+    name: LNG-Schiffsbeladung
+    description: |
+      Schiffsbeladungsoperationen an LNG-Exportanlegern.
+  BC-3070.40.20:
+    name: Versendungs-Verdampfung
+    description: |
+      Versendungs-Verdampfung und Pipeline-Export von Verflüssigungsstandorten.
+  BC-3070.40.30:
+    name: Cargo-Abkühlungskoordination
+    description: |
+      Abkühlungskoordination von LNG-Schiffen vor der Beladung.
+  BC-3070.50:
+    name: LNG-Regasifizierungsbetrieb
+    description: |
+      Betrieb von Import-LNG-Terminals - Verdampfung, Versendungsdruckregelung
+      und Boil-off-Gas-Handhabung.
+  BC-3070.50.10:
+    name: Verdampfer-Betrieb
+    description: |
+      Betrieb von Open-Rack-, Tauchbrenner- und Rohrbündel-Verdampfern.
+  BC-3070.50.20:
+    name: Versendungsdruckregelung
+    description: |
+      Versendungsdruckregelung und Netzeinspeisegruppierung von Import-Terminals.
+  BC-3070.50.30:
+    name: Boil-off-Gas-Handhabung
+    description: |
+      Rückverflüssigung oder Versendung von Boil-off-Gas aus Lagertanks.
+  BC-3070.60:
+    name: Gasqualitätsmanagement
+    description: |
+      Einhaltung von Pipeline- und LNG-Gasqualitätsspezifikationen und Handhabung von Außerspezifikations-Strömen.
+  BC-3070.60.10:
+    name: Spezifikations-Compliance-Monitoring
+    description: |
+      Kontinuierliches Monitoring der Pipeline- und LNG-Qualitätsspezifikationen.
+  BC-3070.60.20:
+    name: Gasprobenahme und -analyse
+    description: |
+      Routinemäßige Gasprobenahme, Chromatographie und Zertifikatserstellung.
+  BC-3070.60.30:
+    name: Außerspezifikations-Gas-Handhabung
+    description: |
+      Umleitung, Mischung und Wiederaufarbeitung von Außerspezifikations-Gas-Strömen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-government-grants-funding-management.yaml
+++ b/catalogue/i18n/de/L1-government-grants-funding-management.yaml
@@ -1,0 +1,122 @@
+locale: de
+source: L1-government-grants-funding-management.yaml
+entries:
+  BC-3260:
+    name: Staatliche Fördermittel und Subventionen
+    description: |
+      Vergabe und Administration von wettbewerblichen und Formel-Fördermitteln sowie staatlicher
+      Finanzierung an Organisationen, Gemeinschaften und Einzelpersonen, einschließlich
+      Ausschreibung, Antragsüberprüfung, Vergabe, Monitoring und Abschluss.
+  BC-3260.10:
+    name: Förderprogramm-Design
+    description: |
+      Design von Förderprogrammen einschließlich Zielen, Berechtigung, Finanzierungsformeln
+      und Bewertungskriterien.
+  BC-3260.10.10:
+    name: Programmziele-Definition
+    description: |
+      Definition von Förderprogrammzielen, Ergebnissen und Wirkungstheorie.
+  BC-3260.10.20:
+    name: Finanzierungsallokations-Modellierung
+    description: |
+      Modellierung von Finanzierungsallokationen einschließlich Formel-, Wettbewerbs- und Kofinanzierungsdesigns.
+  BC-3260.10.30:
+    name: Bewertungskriterien-Festlegung
+    description: |
+      Festlegung von Fachbereichsprüfungs- und Bewertungskriterien für die Förderauswahl.
+  BC-3260.20:
+    name: Ausschreibungs- und Bekanntmachungsmanagement
+    description: |
+      Veröffentlichung von Finanzierungsmöglichkeiten, Bekanntmachungen über
+      Finanzierungsverfügbarkeit und Ausschreibungsunterlagen.
+  BC-3260.20.10:
+    name: Finanzierungsmöglichkeits-Veröffentlichung
+    description: |
+      Veröffentlichung von Förderausschreibungen, Bekanntmachungen über Finanzierungsverfügbarkeit und Ausschreibungsunterlagen.
+  BC-3260.20.20:
+    name: Antragsteller-Outreach und Unterstützung
+    description: |
+      Outreach, Informationsveranstaltungen und Antragsteller-Unterstützung für Förderprogramme.
+  BC-3260.20.30:
+    name: Vor-Vergabe-Fragenbearbeitung
+    description: |
+      Bearbeitung von Vor-Vergabe-Fragen und Klarstellungen von potenziellen Antragstellern.
+  BC-3260.30:
+    name: Antragseingang und Überprüfung
+    description: |
+      Eingang, Vorprüfung und Fachbereichsprüfung von Förderanträgen einschließlich
+      Gremien-Überprüfung und Bewertung.
+  BC-3260.30.10:
+    name: Antragseinreichung
+    description: |
+      Einreichung und Eingang von Förderanträgen und unterstützenden Unterlagen.
+  BC-3260.30.20:
+    name: Berechtigungs-Screening
+    description: |
+      Screening von Anträgen gegen Berechtigungs- und Schwellenkriterien.
+  BC-3260.30.30:
+    name: Fachbereichsprüfung und Bewertung
+    description: |
+      Gremien-Überprüfung, Bewertung und Rangfolge von Anträgen nach veröffentlichten Kriterien.
+  BC-3260.30.40:
+    name: Gutachter- und Interessenkonflikt-Management
+    description: |
+      Rekrutierung von Gutachtern und Management von Interessenkonflikten.
+  BC-3260.40:
+    name: Vergabe und Finanzierungsentscheidung
+    description: |
+      Vergabeentscheidungen, Zuwendungsbescheid-Ausstellung und Mittelbindung
+      gegenüber Empfängern.
+  BC-3260.40.10:
+    name: Vergabe-Auswahl
+    description: |
+      Endauswahl der geförderten Anträge und Förderbeträge.
+  BC-3260.40.20:
+    name: Zuwendungsbescheid-Ausstellung
+    description: |
+      Entwurf und Ausstellung von Zuwendungsbescheiden und Auflagen.
+  BC-3260.40.30:
+    name: Mittelbindung und Auszahlungseinrichtung
+    description: |
+      Mittelbindung und Einrichtung von Auszahlungsplänen.
+  BC-3260.50:
+    name: Empfänger-Monitoring und Berichterstattung
+    description: |
+      Monitoring der Förderempfänger-Leistung, Finanzberichterstattung und
+      Compliance mit Förderbedingungen.
+  BC-3260.50.10:
+    name: Leistungsberichts-Überprüfung
+    description: |
+      Überprüfung der Empfänger-Leistung und Fortschrittsberichte gegenüber Meilensteinen.
+  BC-3260.50.20:
+    name: Finanzbericht-Überprüfung
+    description: |
+      Überprüfung von Empfänger-Finanzberichten und Auszahlungsanträgen.
+  BC-3260.50.30:
+    name: Vor-Ort-Monitoring und Verifikation
+    description: |
+      Vor-Ort-Besuche und Verifikation von Empfängeraktivitäten und Leistungen.
+  BC-3260.50.40:
+    name: Unterempfänger-Aufsicht
+    description: |
+      Aufsicht über Weiterleitungs- und Unterempfänger-Vereinbarungen.
+  BC-3260.60:
+    name: Förderabschluss und Prüflösungen
+    description: |
+      Abschlussbericht, Abschluss, Prüfungslösungen und Rückforderung
+      nicht anerkannter Kosten.
+  BC-3260.60.10:
+    name: Abschlussbericht und Leistungsabnahme
+    description: |
+      Abnahme von Abschlussberichten und Leistungen am Programmende.
+  BC-3260.60.20:
+    name: Einzelprüfungs- und Compliance-Prüflösung
+    description: |
+      Lösung von Einzelprüfungs- und Compliance-Prüfungsbefunden gegen Förderempfänger.
+  BC-3260.60.30:
+    name: Nicht anerkannte Kosten-Rückforderung
+    description: |
+      Rückforderung nicht anerkannter Kosten und nicht gebundener Mittel beim Abschluss.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-grid-control-balancing-management.yaml
+++ b/catalogue/i18n/de/L1-grid-control-balancing-management.yaml
@@ -1,0 +1,132 @@
+locale: de
+source: L1-grid-control-balancing-management.yaml
+entries:
+  BC-3830:
+    name: Netzsteuerung und Netzausgleich Management
+    description: |
+      Netzbetreiberfunktion für das Hochspannungsnetz – Echtzeit-
+      Ausgleich von Erzeugung und Nachfrage, Frequenz- und Spannungsregelung,
+      Reserven und Systemdienstleistungen, Betriebsplanung, grenzüberschreitende
+      Koordination sowie Schwarzstart-Bereitschaft.
+  BC-3830.10:
+    name: Echtzeit-Systembetrieb
+    description: |
+      Kontinuierliche Echtzeit-Aufsicht und Steuerung der Systemerzeugung,
+      Nachfrage und des Austauschs zur Aufrechterhaltung eines sicheren Betriebs.
+  BC-3830.10.10:
+    name: Systemlagebild
+    description: |
+      Kontinuierliches Lagebild von Erzeugung, Last und Kontingenzmargen aus der Leitstelle.
+  BC-3830.10.20:
+    name: Echtzeit-Kontingenzanalyse
+    description: |
+      Echtzeit-N-1- und N-1-1-Kontingenzanalyse und Auslösung von Maßnahmenautomatiken.
+  BC-3830.10.30:
+    name: Betriebsanweisungserteilung
+    description: |
+      Erteilung von Betriebsanweisungen an Bilanzkreisverantwortliche und ÜNBs.
+  BC-3830.20:
+    name: Frequenz- und Spannungsregelung
+    description: |
+      Aktive Frequenz- und Spannungsregelung durch automatische
+      Erzeugungssteuerung und Blindleistungsdispatch.
+  BC-3830.20.10:
+    name: Automatische Erzeugungssteuerung
+    description: |
+      AGC-Dispatch und Regelzonenfehlermanagement zur Frequenzregelung.
+  BC-3830.20.20:
+    name: Blindleistungsdispatch
+    description: |
+      Dispatch von Blindleistungsressourcen zur Aufrechterhaltung des Spannungsprofils im Netz.
+  BC-3830.20.30:
+    name: Trägheits- und Frequenzreaktionsmanagement
+    description: |
+      Management von Trägheit, schneller Frequenzreaktion und Droop-Diensten.
+  BC-3830.30:
+    name: Betriebsplanung
+    description: |
+      Day-ahead- und Intraday-Systemsicherheitsanalyse, Stillstandsbewertung
+      und Betriebsmargenplanung.
+  BC-3830.30.10:
+    name: Day-ahead-Sicherheitsanalyse
+    description: |
+      Engpassbehafteter Kraftwerkseinsatz und Kontingenzanalyse für den Betriebstag.
+  BC-3830.30.20:
+    name: Intraday-Redispatch
+    description: |
+      Intraday-Redispatch von Erzeugung und Nachfrage gegen Prognoseupdates.
+  BC-3830.30.30:
+    name: Saisonale Betriebsmargenbeurteilung
+    description: |
+      Saisonale Kapazitätsmargenbewertung und Ausreichenheitsprüfung.
+  BC-3830.40:
+    name: Reserven und Systemdienstleistungen
+    description: |
+      Beschaffung und Aktivierung von Betriebsreserven und Systemdienstleistungen
+      einschließlich Frequenz-, Spannungs- und Trägheitsprodukten.
+  BC-3830.40.10:
+    name: Reservenbeschaffung
+    description: |
+      Beschaffung von Primär-, Sekundär- und Tertiärreserveprodukten.
+  BC-3830.40.20:
+    name: Systemdienstleistungsaktivierung
+    description: |
+      Aktivierung und Dispatch vertraglich gebundener Systemdienstleistungsanbieter.
+  BC-3830.40.30:
+    name: Reserveleistungsüberwachung
+    description: |
+      Überwachung der Leistung und Verfügbarkeit von Reserveanbietern.
+  BC-3830.50:
+    name: Ausgleichsenergieabrechnungsbetrieb
+    description: |
+      Netzbetreiberseitige Berechnung und Benachrichtigung von Ausgleichsenergienmengen
+      und -preisen für Bilanzkreisverantwortliche.
+  BC-3830.50.10:
+    name: Mengenaggregation
+    description: |
+      Aggregation von Messwerten je Bilanzkreisverantwortlichem.
+  BC-3830.50.20:
+    name: Ausgleichsenergiepreisberechnung
+    description: |
+      Berechnung von Systemausgleichsenergiepreisen gemäß Marktregeln.
+  BC-3830.50.30:
+    name: BRP-Abrechnungsbenachrichtigung
+    description: |
+      Benachrichtigung von Bilanzkreisverantwortlichen über Ausgleichsenergienmengen und -kosten.
+  BC-3830.60:
+    name: Grenzüberschreitende Koordination
+    description: |
+      Koordination von Interkonnektorflüssen, Redispatch und Netzsicherheit
+      mit benachbarten ÜNBs und regionalen Sicherheitskoordinatoren.
+  BC-3830.60.10:
+    name: Interkonnektorfaplanung
+    description: |
+      Scheduling physischer und kommerzieller Flüsse auf Interkonnektoren.
+  BC-3830.60.20:
+    name: Koordinierte Kapazitätsberechnung
+    description: |
+      Koordinierte Kapazitätsberechnung über Gebotszonen mit Nachbarn hinweg.
+  BC-3830.60.30:
+    name: Grenzüberschreitender Redispatch und Gegensatz
+    description: |
+      Grenzüberschreitender Redispatch und Gegensatz zur Engpassbehebung.
+  BC-3830.70:
+    name: Schwarzstart- und Wiederaufbauplanung
+    description: |
+      Pflege von Schwarzstartverträgen, Wiederaufbauplänen und
+      Wiederaufbauübungen für vollständige oder teilweise Systemzusammenbruchszenarien.
+  BC-3830.70.10:
+    name: Schwarzstartvertragsmanagement
+    description: |
+      Beschaffung und Überwachung von Schwarzstartdienstleistungsverträgen.
+  BC-3830.70.20:
+    name: Systemwiederaufbauplanpflege
+    description: |
+      Pflege von Wiederaufbausequenzen und Inselnetzplänen.
+  BC-3830.70.30:
+    name: Wiederaufbauübungen
+    description: |
+      Betreiber- und interutility-Wiederaufbauübungen und Nachbesprechungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-guest-traveller-management.yaml
+++ b/catalogue/i18n/de/L1-guest-traveller-management.yaml
@@ -1,0 +1,161 @@
+locale: de
+source: L1-guest-traveller-management.yaml
+entries:
+  BC-4040:
+    name: Gast und Reisender Management
+    description: |
+      Stewardship des zentralen Gast- und Reisendenprofils über das gesamte Unternehmen –
+      Identität, Präferenzen, Einwilligung, Erkennung, Segmentierung
+      und Reisedokument-/Compliance-Daten, unabhängig von Kanal oder Property.
+    in_scope:
+      - Zentrales Gast- und Reisendenprofil und Identität
+      - Präferenzen, Ernährungs- und Barrierefreiheitsanforderungen
+      - Einwilligung, Marketingerlaubnis und Betroffenenrechte
+      - Erkennungssignalisierung und Tierstatus-Lieferung
+      - Gastsegmentierung und Lifetime-Value-Analyse
+      - Reisedokument-, APIS- und Watchlist-Screening-Daten
+    out_of_scope:
+      - Treuepunkte-Earn/Burn-Engines (BC-4050)
+      - Front-Office-Check-in-Ausführung (BC-4060.10)
+      - Allgemeines branchenübergreifendes CRM (BC-400)
+  BC-4040.10:
+    name: Gastprofil- und Identitätsmanagement
+    description: |
+      Erstellung, Deduplizierung und Identitätsverifikation des zentralen
+      Gastprofils über Buchungs- und Betriebssysteme hinweg.
+  BC-4040.10.10:
+    name: Gastprofilanlegung
+    description: |
+      Anlage von Gastprofilen aus beliebigen Ursprungskanälen oder Berührungspunkten.
+  BC-4040.10.20:
+    name: Gastprofil-Deduplizierung
+    description: |
+      Deduplizierung von Gastprofilen mittels deterministischem und probabilistischem Matching.
+  BC-4040.10.30:
+    name: Gastidentitätsverifikation
+    description: |
+      Verifikation der Gastidentität für hochwertige oder regulierte Interaktionen.
+  BC-4040.10.40:
+    name: Profilzusammenführung und Survivorship
+    description: |
+      Zusammenführung doppelter Profile und Auflösung von Attribut-Survivorship.
+  BC-4040.20:
+    name: Gast-Präferenz- und Personalisierungsmanagement
+    description: |
+      Erfassung und Stewardship von Gastpräferenzen zu Aufenthalt,
+      Ernährung und Barrierefreiheitsanforderungen sowie Personalisierungsregeln.
+  BC-4040.20.10:
+    name: Aufenthaltspräferenz-Erfassung
+    description: |
+      Erfassung von Aufenthaltspräferenzen wie Betttyp, Etage und Ankunftszeitpräferenzen.
+  BC-4040.20.20:
+    name: Ernährungs- und Allergenpräferenz-Management
+    description: |
+      Management von Ernährungs-, religiösen und Allergenpräferenzen
+      für F&B- und Borddienste.
+  BC-4040.20.30:
+    name: Barrierefreiheitsanforderungsmanagement
+    description: |
+      Management von Barrierefreiheitsanforderungen und Sonderhilfsbedarf
+      an Reisekontaktpunkten.
+  BC-4040.20.40:
+    name: Personalisierungsregeldefinition
+    description: |
+      Definition von Personalisierungsregeln zur Anwendung von Präferenzen
+      auf Service- und Merchandising-Interaktionen.
+  BC-4040.30:
+    name: Gast-Einwilligungs- und Datenschutzmanagement
+    description: |
+      Management von Gasteinwilligung, Marketingerlaubnis, Betroffenenrechten
+      und grenzüberschreitender Übertragungskonformität für Reisedaten.
+  BC-4040.30.10:
+    name: Einwilligungserfassung und -management
+    description: |
+      Erfassung und laufendes Management von Einwilligungsaufzeichnungen
+      über Zwecke und Kanäle.
+  BC-4040.30.20:
+    name: Marketingerlaubnis-Management
+    description: |
+      Management von Marketingerlaubnissen einschließlich kanalspezifischer Opt-in- und Opt-out-Zustände.
+  BC-4040.30.30:
+    name: Betroffenenanfragebearbeitung
+    description: |
+      Bearbeitung von Auskunfts-, Datenübertragbarkeits-, Berichtigungs- und Löschanfragen.
+  BC-4040.30.40:
+    name: Grenzüberschreitende Übertragungskonformität
+    description: |
+      Konformität mit grenzüberschreitenden Übertragungsanforderungen
+      für Reisende- und Gastdaten.
+  BC-4040.40:
+    name: Gasterkennung- und Tier-Status-Lieferung
+    description: |
+      Lieferung von Erkennungssignalen und Tierstatus an operative Teams
+      zur konsistenten Gasterkennung an allen Berührungspunkten.
+    in_scope:
+      - Erkennungsanstoß vor Ankunft und vor Ort
+      - Protokollierung und Abschluss der Erkennungslieferung
+    out_of_scope:
+      - Treueprogrammgestaltung und Earn/Burn (BC-4050)
+  BC-4040.40.10:
+    name: Erkennungsanstoß vor Ankunft
+    description: |
+      Anstoß von Erkennungserwartungen an operative Teams vor Gästeankunft.
+  BC-4040.40.20:
+    name: Gasterkennungslieferung vor Ort
+    description: |
+      Erkennungslieferung durch Front-Office-, F&B- und Concierge-Teams während des Aufenthalts.
+  BC-4040.40.30:
+    name: Erkennungsdienstprotokollierung
+    description: |
+      Protokollierung von Erkennungslieferungsereignissen für Serviceprüfung und Rückmeldeschleifen.
+  BC-4040.40.40:
+    name: Erkennungsabschluss-Berichterstattung
+    description: |
+      Berichterstattung über Erkennungsabschlussraten gegen Vorankünfts-Erkennungsanstosse.
+  BC-4040.50:
+    name: Gastsegmentierungs- und Analyse-Management
+    description: |
+      Definition von Gastsegmenten, Lifetime-Value- und Abwanderungsmodellierung
+      sowie Kohorteneinblicke und Verhaltensanalysen.
+  BC-4040.50.10:
+    name: Gastsegmentierungsdefinition
+    description: |
+      Definition und Pflege von Gastsegmenten für Marketing und Merchandising.
+  BC-4040.50.20:
+    name: Lifetime-Value-Modellierung
+    description: |
+      Modellierung des Gast-Lifetime-Value als Eingang für Investitions- und Anerkennungsentscheidungen.
+  BC-4040.50.30:
+    name: Gast-Abwanderungs- und Bindungsanalyse
+    description: |
+      Analyse von Gast-Abwanderungstreibern und Bindungsmöglichkeiten über Segmente.
+  BC-4040.50.40:
+    name: Kohortenanalyse und Verhaltenseinblicke
+    description: |
+      Generierung von Kohorten- und Verhaltenseinblicken aus Buchungs-, Aufenthalts- und Engagementvorgängen.
+  BC-4040.60:
+    name: Reisendedokument- und Compliance-Datenmanagement
+    description: |
+      Management von Reisedokument-, APIS-, Visa- und Watchlist-Daten
+      zur Erfüllung von Beförderungs- und Grenzübertrittsverpflichtungen.
+  BC-4040.60.10:
+    name: Reisedokumenterfassung
+    description: |
+      Erfassung von Reisepass-, Ausweis- und Visadaten für Reiseeignungs-
+      und Dokumentenprüfungen.
+  BC-4040.60.20:
+    name: APIS- und Vorab-Passagierinformations-Einreichung
+    description: |
+      Einreichung von APIS und Vorab-Passagierinformationen an Grenzkontrollbehörden.
+  BC-4040.60.30:
+    name: Visa- und ESTA-Berechtigungsreferenz
+    description: |
+      Referenzprüfungen gegen Visa-, ESTA- und gleichwertige Berechtigungsregimes.
+  BC-4040.60.40:
+    name: Secure-Flight- und No-Fly-Watchlist-Screening
+    description: |
+      Screening von Reisenden gegen Secure-Flight- und gleichwertige
+      No-Fly- und Watchlist-Programme.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-harvest-post-harvest-operations-management.yaml
+++ b/catalogue/i18n/de/L1-harvest-post-harvest-operations-management.yaml
@@ -1,0 +1,138 @@
+locale: de
+source: L1-harvest-post-harvest-operations-management.yaml
+entries:
+  BC-3560:
+    name: Ernte und Nachernte-Betrieb
+    description: |
+      Erntetermin- und Erntedurchführung, Feld- und Nacherntekon-
+      ditionierung, betriebliche Lagerung, Sortierung und Abpackung
+      sowie Eingangsannahme zum nächsten Punkt in der
+      Agrar-Lebensmittelkette.
+  BC-3560.10:
+    name: Ernte-Planung und -Terminierung
+    description: |
+      Erntefensterplanung, Ernte- und Maschinenplanung sowie
+      Erntelogistikkoordination über Schläge und Kulturen.
+  BC-3560.10.10:
+    name: Erntefenster-Planung
+    description: |
+      Schlagbezogene Erntefensterplanung nach Reife und Wetter.
+  BC-3560.10.20:
+    name: Erntebelegschaft- und Maschinenplanung
+    description: |
+      Planung von Erntebelegschaft, Auftragnehmern und Maschinen.
+  BC-3560.10.30:
+    name: Erntelogistik-Koordination
+    description: |
+      Koordination von Lastwagen, Behältern und Anhängern über
+      aktive Erntebereiche.
+  BC-3560.20:
+    name: Feldernte-Betrieb
+    description: |
+      Mechanische und manuelle Erntebetriebe einschließlich
+      Feldsortierung und feldseitigem Transfer.
+  BC-3560.20.10:
+    name: Mechanische Ernte
+    description: |
+      Mähdrescher-, Mähaufbereiter- und Spezialmaschinenernte.
+  BC-3560.20.20:
+    name: Manuelle Ernte
+    description: |
+      Handpflück- und selektive manuelle Ernte von Gartenbaukulturen.
+  BC-3560.20.30:
+    name: Feldsortierung
+    description: |
+      Feldsortierung und -Putzen von Erntegut.
+  BC-3560.30:
+    name: Nachernte-Konditionierung
+    description: |
+      Trocknung, Kühlung, Kuring und Dekontamination von Erntegut
+      zur Stabilisierung für Lagerung oder Weiterverwendung.
+    in_scope:
+      - Getreide- und Saatguttrocknung
+      - Vorkühlung von Gartenbauerzeugnissen
+      - Kuring von Wurzel- und Zwiebelkulturen
+      - Feldreinigung und Dekontamination
+  BC-3560.30.10:
+    name: Trocknungs-Betrieb
+    description: |
+      Trocknung von Getreide, Saatgut und Futterpflanzen auf sichere
+      Feuchtigkeitsgehalte.
+  BC-3560.30.20:
+    name: Kühl- und Vorkühlungs-Betrieb
+    description: |
+      Hydro-, Vakuum- und Zwangsluftvorkühlung von Gartenbauerzeugnissen.
+  BC-3560.30.30:
+    name: Kuring-Betrieb
+    description: |
+      Kuring von Kartoffeln, Zwiebeln, Süßkartoffeln und ähnlichen
+      Kulturen.
+  BC-3560.30.40:
+    name: Reinigung und Dekontamination
+    description: |
+      Reinigung und Dekontamination von Erntegut vor der Einlagerung.
+  BC-3560.40:
+    name: Betriebslager-Betrieb
+    description: |
+      Betrieb von betrieblichen Behältern, Silos und Kältespeichern
+      einschließlich Belüftung und Vorratsschädlingsmanagement.
+  BC-3560.40.10:
+    name: Behälter- und Silo-Management
+    description: |
+      Befüllung, Überwachung und Entleerung von Getreide-
+      behältern und Silos.
+  BC-3560.40.20:
+    name: Kältespeicher-Betrieb
+    description: |
+      Betrieb betrieblicher Kühl- und Kontrollatspeicher.
+  BC-3560.40.30:
+    name: Getreide-Lagerbelüftung
+    description: |
+      Belüftungsmanagement von Getreideschüttgut zur Temperatur-
+      und Feuchtigkeitserhaltung.
+  BC-3560.40.40:
+    name: Vorratsschädlings-Management
+    description: |
+      Überwachung und Behandlung von Insekten- und Nagetierbefall
+      in Lagern.
+  BC-3560.50:
+    name: Erzeugnissortierung und -Abpackung
+    description: |
+      Sortierungs-, Packhaus- und Lotetikettierungsbetriebe zur
+      Vorbereitung von Erzeugnissen für den Weiterverkehr.
+  BC-3560.50.10:
+    name: Qualitätssortierungs-Betrieb
+    description: |
+      Sortierung von Erzeugnissen nach Größen-, Farb- und
+      Fehlerspezifikationen.
+  BC-3560.50.20:
+    name: Packhaus-Betrieb
+    description: |
+      Packhauslinienbetrieb einschließlich Waschen, Wachsen und Abpacken.
+  BC-3560.50.30:
+    name: Lotkennzeichnung und -Etikettierung
+    description: |
+      Los-, Chargen- und GS1-Identifikatorzuweisung und Etikettendrucken.
+  BC-3560.60:
+    name: Eingangsannahme beim Verarbeiter
+    description: |
+      Koordination der Eingangsannahme vom Betrieb oder Aggregator
+      in Verarbeitungs- oder Käuferstandorte.
+  BC-3560.60.10:
+    name: Lastwagen-Terminierung und Annahme
+    description: |
+      Terminierung und Annahme eingehender Lastwagen an
+      Verarbeiter-Toren.
+  BC-3560.60.20:
+    name: Annahme-Probenahme
+    description: |
+      Eingangsbeprobung von Getreide-, Vieh-, Milch- und
+      Erzeugnisladungen.
+  BC-3560.60.30:
+    name: Annahme-Qualitätsprüfung
+    description: |
+      Qualitätsprüfung eingehender Ladungen zur Unterstützung
+      von Annahme und Preisgestaltung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-health-information-management.yaml
+++ b/catalogue/i18n/de/L1-health-information-management.yaml
@@ -1,0 +1,137 @@
+locale: de
+source: L1-health-information-management.yaml
+entries:
+  BC-2900:
+    name: Gesundheitsinformationsmanagement
+    description: |
+      Patientenstammindex, Kodierungsoperationen, Informationsfreigabe, Lebenszyklus
+      der Krankenakte, klinische Registermeldungen und Interoperabilitätsbetrieb im
+      Gesundheitswesen für Leistungserbringer.
+  BC-2900.10:
+    name: Patientenstammindex-Management
+    description: |
+      Pflege des Patientenstammindex und Bereinigung von Dubletten- und
+      Überlagerungseinträgen.
+  BC-2900.10.10:
+    name: Patientenstammindex-Pflege
+    description: |
+      Tägliche Pflege des unternehmensweiten Patientenstammindex.
+  BC-2900.10.20:
+    name: Dubletten-Bereinigung
+    description: |
+      Identifikation und Bereinigung von Dubletten- und Überlagerungspatientenakten.
+  BC-2900.10.30:
+    name: Patientenabgleichs-Algorithmen
+    description: |
+      Konfiguration und Anpassung von Patientenabgleichs-Algorithmen.
+  BC-2900.10.40:
+    name: Identitäts-Querverweise
+    description: |
+      Querverweise von Patientenidentitäten über verbundene Organisationen und Netzwerke.
+  BC-2900.20:
+    name: Kodierungsbetrieb
+    description: |
+      Produktionskodierung für stationäre und ambulante Fälle einschließlich
+      Prüfung und Rückstandsmanagement.
+  BC-2900.20.10:
+    name: Stationäre Kodierungsproduktion
+    description: |
+      Produktionsseitige stationäre Kodierungsworkflows und -zuweisungen.
+  BC-2900.20.20:
+    name: Ambulante Kodierungsproduktion
+    description: |
+      Produktionsseitige ambulante und tagesstationäre Kodierungsworkflows.
+  BC-2900.20.30:
+    name: Kodierungs-Rückstandsmanagement
+    description: |
+      Management von noch nicht endkodierten entlassenen Patienten und Kodierungsrückständen.
+  BC-2900.20.40:
+    name: Kodierer-Prüfung
+    description: |
+      Interne Prüfung der Kodiergenauigkeit und Rückmeldung an Kodierer.
+  BC-2900.30:
+    name: Informationsfreigabe
+    description: |
+      Eingang, Validierung und Erfüllung von Anfragen zu geschützten
+      Gesundheitsinformationen.
+  BC-2900.30.10:
+    name: Informationsanforderungseingang
+    description: |
+      Eingang von Patienten-, Kostenträger-, Rechts- und Leistungserbringer-Anfragen zu Gesundheitsinformationen.
+  BC-2900.30.20:
+    name: Genehmigungsvalidierung
+    description: |
+      Validierung von Genehmigungen und zulässigen Offenlegungen gemäß Datenschutzvorschriften.
+  BC-2900.30.30:
+    name: Offenlegungs-Tracking
+    description: |
+      Nachverfolgung von Offenlegungen geschützter Gesundheitsinformationen für Buchführungszwecke.
+  BC-2900.30.40:
+    name: Vorladungen und Rechtsanfragen
+    description: |
+      Bearbeitung von Vorladungen, Gerichtsbeschlüssen und rechtlichen Aktenanforderungen.
+  BC-2900.40:
+    name: Krankenakte-Lebenszyklus
+    description: |
+      Lebenszyklusmanagement von Krankenakten von der Erstellung bis zur
+      Aufbewahrung und Vernichtung.
+  BC-2900.40.10:
+    name: Fallabschluss
+    description: |
+      Überprüfung und Nachverfolgung von Voraussetzungen zum Fallabschluss.
+  BC-2900.40.20:
+    name: Vervollständigungs-Tracking
+    description: |
+      Tracking ausstehender Aktenergänzungen und Nachverfolgung bei Ärzten.
+  BC-2900.40.30:
+    name: Aufbewahrungsplanung
+    description: |
+      Aufbewahrungsplanung für Krankenakten gemäß gesetzlichen Anforderungen.
+  BC-2900.40.40:
+    name: Aktenvernichtung
+    description: |
+      Autorisierte Vernichtung von Krankenakten nach Ablauf der Aufbewahrungsfrist.
+  BC-2900.50:
+    name: Klinische Register und Meldungen
+    description: |
+      Meldung an Krankheits-, Krebs-, Trauma- und Qualitätsregister.
+  BC-2900.50.10:
+    name: Krankheitsregistermeldung
+    description: |
+      Meldung an Gesundheitsbehörden und Krankheitsregister.
+  BC-2900.50.20:
+    name: Krebsregisterbetrieb
+    description: |
+      Abstraktion und Meldebetrieb des Krebsregisters.
+  BC-2900.50.30:
+    name: Traumaregisterbetrieb
+    description: |
+      Abstraktion und Meldebetrieb des Traumaregisters.
+  BC-2900.50.40:
+    name: Qualitätsregistermeldung
+    description: |
+      Meldung an fachspezifische Qualitätsregister zur Unterstützung klinischer Forschung und Benchmarking.
+  BC-2900.60:
+    name: Interoperabilitätsbetrieb im Gesundheitswesen
+    description: |
+      Betrieb von Gesundheitsinformationsaustausch-Verbindungen, FHIR-Endpunkten,
+      patienteninitiiertem Datenaustausch und Leistungserbringer-Verzeichnis.
+  BC-2900.60.10:
+    name: Gesundheitsinformationsaustausch-Betrieb
+    description: |
+      Betrieb von eingehenden und ausgehenden Gesundheitsinformationsaustausch-Verbindungen.
+  BC-2900.60.20:
+    name: FHIR-Endpunkt-Management
+    description: |
+      Verwaltung von FHIR-Endpunkten für App- und Partner-Integration.
+  BC-2900.60.30:
+    name: Patienteninitiierter Datenaustausch
+    description: |
+      Patientengesteuerter Austausch von Gesundheitsinformationen mit Drittanwendungen.
+  BC-2900.60.40:
+    name: Leistungserbringer-Verzeichnispflege
+    description: |
+      Pflege von Leistungserbringer-Verzeichnisdaten für interne und externe Nutzer.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-health-safety-environment-management.yaml
+++ b/catalogue/i18n/de/L1-health-safety-environment-management.yaml
@@ -1,0 +1,118 @@
+locale: de
+source: L1-health-safety-environment-management.yaml
+entries:
+  BC-730:
+    name: Gesundheits-, Sicherheits- und Umweltmanagement
+    description: |
+      GSU-Richtlinien, Vorfälle, Standortsicherheit und Betriebsgesundheit.
+  BC-730.10:
+    name: Betriebsgesundheitsmanagement
+    description: |
+      Betriebsgesundheit, Ergonomie und Wohlbefinden.
+  BC-730.10.10:
+    name: Gesundheitsüberwachung
+    description: |
+      Periodische medizinische Überwachung für gefährdete Beschäftigtengruppen.
+  BC-730.10.20:
+    name: Ergonomie und Betriebsgesundheit
+    description: |
+      Ergonomische Bewertungen und Betriebsgesundheitsprogramme.
+  BC-730.10.30:
+    name: Betriebshygienemonitoring
+    description: |
+      Überwachung von Lärm-, Staub-, Chemikalien- und biologischen Expositionen.
+  BC-730.10.40:
+    name: Mitarbeiter-Wohlbefindensprogramme
+    description: |
+      Programme für mentales, physisches und soziales Wohlbefinden.
+  BC-730.20:
+    name: Sicherheitsmanagement
+    description: |
+      Arbeitssicherheit, Verhaltenssicherheit und PSA.
+  BC-730.20.10:
+    name: Gefahrenidentifikation und Risikobewertung
+    description: |
+      Gefahrenidentifikation und Risikobewertung für Aufgaben und Standorte.
+  BC-730.20.20:
+    name: Freigabeschein und sichere Arbeitssysteme
+    description: |
+      Freigabeschein, Absperrung und sichere Arbeitssysteme.
+  BC-730.20.30:
+    name: Persönliche-Schutzausrüstung-Management
+    description: |
+      PSA-Auswahl, Ausgabe, Training und Inspektion.
+  BC-730.20.40:
+    name: Verhaltenssicherheitsprogramm
+    description: |
+      Verhaltenssicherheitsbeobachtungen, Führungsrundgänge und Coaching.
+  BC-730.20.50:
+    name: Auftragnehmer-Sicherheitsmanagement
+    description: |
+      Auftragnehmervorqualifizierung, Einweisung und Sicherheitsaufsicht vor Ort.
+  BC-730.30:
+    name: Umweltmanagement
+    description: |
+      Emissionen, Wasser, Abfall und Umwelt-Compliance.
+  BC-730.30.10:
+    name: Umweltaspekte und Auswirkungsbewertung
+    description: |
+      Identifikation von Umweltaspekten und Auswirkungsbewertung.
+  BC-730.30.20:
+    name: Emissionsmanagement
+    description: |
+      Luftemissionen, THG und Schadstoffmanagement an Standorten.
+  BC-730.30.30:
+    name: Wasser- und Abwassermanagement
+    description: |
+      Wasserverbrauch, Abwasserbehandlung und Einleitungsmanagement.
+  BC-730.30.40:
+    name: Abfallmanagement
+    description: |
+      Management und Entsorgung gefährlicher und nicht gefährlicher Abfälle.
+  BC-730.30.50:
+    name: Biodiversität und Landbewirtschaftung
+    description: |
+      Biodiversität, Landnutzung und Sanierungsmaßnahmen.
+  BC-730.40:
+    name: Vorfall- und Untersuchungsmanagement
+    description: |
+      GSU-Vorfälle, Beinahe-Unfälle und Untersuchungen.
+  BC-730.40.10:
+    name: Vorfall- und Beinahe-Unfall-Berichterstattung
+    description: |
+      Erfassung und Klassifizierung von GSU-Vorfällen und Beinahe-Unfällen.
+  BC-730.40.20:
+    name: GSU-Vorfallsuntersuchung
+    description: |
+      Untersuchungsmethodik, Ursachenanalyse und Lessons Learned.
+  BC-730.40.30:
+    name: Notfallvorbereitung und -reaktion
+    description: |
+      Standort-Notfallpläne, Übungen und Reaktionskoordination.
+  BC-730.40.40:
+    name: Prozesssicherheitsmanagement
+    description: |
+      Prozesssicherheitsgefahren, Änderungsmanagement und Kontrollen für schwere Unfallgefahren.
+  BC-730.50:
+    name: GSU-Compliance und -Berichterstattung
+    description: |
+      Regulatorische GSU-Berichterstattung und Audits.
+  BC-730.50.10:
+    name: GSU-Regulatorische Compliance
+    description: |
+      Identifikation und Nachverfolgung regulatorischer GSU-Pflichten.
+  BC-730.50.20:
+    name: GSU-Audit und -Inspektion
+    description: |
+      Interne und externe GSU-Audits und Inspektionen.
+  BC-730.50.30:
+    name: GSU-Performance-Berichterstattung
+    description: |
+      GSU-KPI-Nachverfolgung und Management-Reporting (TRIR, LTIFR).
+  BC-730.50.40:
+    name: GSU-Managementsystem-Zertifizierung
+    description: |
+      ISO-45001/ISO-14001-Managementsystem-Zertifizierung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-healthcare-revenue-cycle-management.yaml
+++ b/catalogue/i18n/de/L1-healthcare-revenue-cycle-management.yaml
@@ -1,0 +1,156 @@
+locale: de
+source: L1-healthcare-revenue-cycle-management.yaml
+entries:
+  BC-2870:
+    name: Erlöszyklus im Gesundheitswesen
+    description: |
+      Leistungserfassung und Preisliste, medizinische Kodierung, Anspruchserstellung und
+      -einreichung, Ablehnungen und Widersprüche, Zahlungsverbuchung, Patientenfinanzdienstleistungen
+      und Kostenträgermanagement für Leistungserbringer.
+  BC-2870.10:
+    name: Leistungserfassung und Preislistenverwaltung
+    description: |
+      Erfassung klinischer Leistungen und Pflege der Preisliste
+      über Leistungsbereiche hinweg.
+  BC-2870.10.10:
+    name: Leistungserfassung
+    description: |
+      Erfassung von Leistungen aus klinischer Dokumentation und Nebensystemen.
+  BC-2870.10.20:
+    name: Preislistenpflege
+    description: |
+      Pflege von Preislistenpositionen, Codes und Preisen.
+  BC-2870.10.30:
+    name: Leistungsabgleich
+    description: |
+      Abgleich erwarteter versus erfasster Leistungen nach Versorgungsbereich.
+  BC-2870.10.40:
+    name: Leistungsprüfung
+    description: |
+      Interne und externe Prüfung der Leistungsgenauigkeit und -vollständigkeit.
+  BC-2870.20:
+    name: Medizinische Kodierungsverwaltung
+    description: |
+      Stationäre, ambulante und ärztliche Honorarkodierung sowie Compliance-Prüfung.
+  BC-2870.20.10:
+    name: Stationäre Kodierung
+    description: |
+      Kodierung stationärer Fälle nach DRG-Methodik.
+  BC-2870.20.20:
+    name: Ambulante Kodierung
+    description: |
+      Kodierung ambulanter Fälle nach APC-Methodik.
+  BC-2870.20.30:
+    name: Ärztliche Honorarkodierung
+    description: |
+      Kodierung ärztlicher Honorarleistungen mit Prozedur- und E&M-Codes.
+  BC-2870.20.40:
+    name: Kodierprüfung und Compliance
+    description: |
+      Kodierprüfungs-, Compliance- und Schulungsprogramme.
+  BC-2870.30:
+    name: Anspruchserstellung und -einreichung
+    description: |
+      Erstellung, Überprüfung, Einreichung und Statusverfolgung von Abrechnungsansprüchen
+      an Kostenträger.
+  BC-2870.30.10:
+    name: Abrechnungsprüfung und -bereinigung
+    description: |
+      Anwendung von Vorab-Prüfregeln und Bereinigungslogik für Abrechnungen.
+  BC-2870.30.20:
+    name: Abrechnungseinreichung
+    description: |
+      Elektronische Einreichung von Abrechnungen an Kostenträger und Clearinghouses.
+  BC-2870.30.30:
+    name: Abrechnungsstatus-Abfrage
+    description: |
+      Elektronische und manuelle Statusabfrage und Nachverfolgung von Abrechnungen.
+  BC-2870.30.40:
+    name: Leistungskoordination und Sequenzierung
+    description: |
+      Sequenzierung von Erst-, Zweit- und Drittansprüchen bei mehreren Kostenträgern.
+  BC-2870.40:
+    name: Ablehnungs- und Widerspruchsmanagement
+    description: |
+      Triage, Widerspruch und Prävention von Kostenträgerablehnungen und Unterzahlungen.
+  BC-2870.40.10:
+    name: Ablehnungs-Triage
+    description: |
+      Triage und Weiterleitung abgelehnter Abrechnungen nach Grund und Rückgewinnungswahrscheinlichkeit.
+  BC-2870.40.20:
+    name: Widerspruchsformulierung und -einreichung
+    description: |
+      Formulierung und Einreichung klinischer und technischer Widersprüche.
+  BC-2870.40.30:
+    name: Unterzahlungsanalyse
+    description: |
+      Identifikation und Rückforderung von Kostenträger-Unterzahlungen gegenüber Vertragssätzen.
+  BC-2870.40.40:
+    name: Ablehnungspräventionsanalytik
+    description: |
+      Ursachenanalytik zur Verhinderung wiederkehrender Ablehnungen.
+  BC-2870.50:
+    name: Zahlungsverbuchung und Kostenträgerabgleich
+    description: |
+      Verbuchung von Kostenträger-Rücküberweisungen und Patientenzahlungen sowie Abgleich
+      mit der erwarteten Erstattung.
+  BC-2870.50.10:
+    name: Rücküberweisungsverbuchung
+    description: |
+      Verbuchung und Abgleich elektronischer Rücküberweisungsanzeigen.
+  BC-2870.50.20:
+    name: Patientenzahlungsverbuchung
+    description: |
+      Verbuchung von Patientenzahlungen über alle Kanäle.
+  BC-2870.50.30:
+    name: Vertragsabzugsanwendung
+    description: |
+      Anwendung vertraglicher Abzüge auf Basis von Kostenträgervereinbarungen.
+  BC-2870.50.40:
+    name: Nicht zugeordnete Zahlungsklärung
+    description: |
+      Klärung und Zuordnung nicht identifizierter und nicht zugeordneter Zahlungen.
+  BC-2870.60:
+    name: Patientenfinanzdienstleistungen
+    description: |
+      Patientenabrechnung, Inkasso, Ratenzahlungen und Forderungsabtretung bei Zahlungsausfall.
+  BC-2870.60.10:
+    name: Patientenrechnungserstellung
+    description: |
+      Erstellung von Patientenrechnungen über Papier- und digitale Kanäle.
+  BC-2870.60.20:
+    name: Patienteninkasso
+    description: |
+      Inkasso-Operationen und Outreach für Selbstzahler-Patienten.
+  BC-2870.60.30:
+    name: Ratenzahlungsmanagement
+    description: |
+      Einrichtung und Verwaltung von Patientenratenvereinbarungen.
+  BC-2870.60.40:
+    name: Forderungsabtretung bei Uneinbringlichkeit
+    description: |
+      Abtretung und Verwaltung von Forderungen an externe Inkassounternehmen.
+  BC-2870.70:
+    name: Kostenträgervertragsmanagement
+    description: |
+      Modellierung, Verhandlungsunterstützung, Abweichungsanalyse und
+      Leistungsüberwachung von Kostenträgerverträgen.
+  BC-2870.70.10:
+    name: Vertragsmodellierung
+    description: |
+      Modellierung von Kostenträgervertragsbedingungen und Erstattungsmethodik.
+  BC-2870.70.20:
+    name: Erstattungsabweichungsanalyse
+    description: |
+      Abweichungsanalyse zwischen vertraglich vereinbarter und tatsächlicher Erstattung.
+  BC-2870.70.30:
+    name: Vertragsverhandlungsunterstützung
+    description: |
+      Analytische und operative Unterstützung für Kostenträgervertragsverhandlungen.
+  BC-2870.70.40:
+    name: Kostenträger-Leistungsüberwachung
+    description: |
+      Laufende Überwachung der Kostenträger-Leistung gegenüber vertraglichen SLAs.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-human-capital-management.yaml
+++ b/catalogue/i18n/de/L1-human-capital-management.yaml
@@ -1,0 +1,210 @@
+locale: de
+source: L1-human-capital-management.yaml
+entries:
+  BC-300:
+    name: Humankapitalmanagement
+    description: |
+      Vollständiger Mitarbeiterlebenszyklus. Auch als Personalwesensmanagement bekannt.
+  BC-300.10:
+    name: Talentgewinnungsmanagement
+    description: |
+      Sourcing, Recruiting, Einstellung und Onboarding.
+  BC-300.10.10:
+    name: Mitarbeiter-Sourcing
+    description: |
+      Gewinnung von Kandidaten über Kanäle, Empfehlungen und Talent-Pipelines.
+  BC-300.10.20:
+    name: Kandidatenprüfung und -auswahl
+    description: |
+      Kandidatenprüfung, Assessments und Interviewmanagement.
+  BC-300.10.30:
+    name: Angebots- und Einstellungsmanagement
+    description: |
+      Angebotserstellung, Verhandlung, Hintergrundprüfungen und Vertragsabschluss.
+  BC-300.10.40:
+    name: Mitarbeiter-Onboarding
+    description: |
+      Preboarding, Tag-eins-Erfahrung und Onboarding-Journeys.
+  BC-300.10.50:
+    name: Arbeitgebermarkenmanagement
+    description: |
+      Employer-Value-Proposition, Arbeitgebermarkenkampagnen und Reputation.
+  BC-300.20:
+    name: Talentmanagement
+    description: |
+      Performance, Nachfolge und Karriereentwicklung.
+  BC-300.20.10:
+    name: Performance-Management
+    description: |
+      Zielsetzung, Leistungsbeurteilungen und Feedback-Zyklen.
+  BC-300.20.20:
+    name: Nachfolgeplanung
+    description: |
+      Identifikation und Entwicklung von Nachfolgekandidaten für Schlüsselrollen.
+  BC-300.20.30:
+    name: Karriereentwicklung und interne Mobilität
+    description: |
+      Karrierewege, interne Mobilität und Entwicklungsplanung.
+  BC-300.20.40:
+    name: Talentüberprüfung und -kalibrierung
+    description: |
+      Talentüberprüfungsgespräche, Kalibrierung und 9-Box-Bewertungen.
+  BC-300.20.50:
+    name: Führungskräfteentwicklung
+    description: |
+      Führungskräftepipelines, Executive-Development und Coaching.
+  BC-300.30:
+    name: Vergütungs- und Leistungsmanagement
+    description: |
+      Gehaltsstrukturen, Boni, Eigenkapital und Leistungsadministration.
+  BC-300.30.10:
+    name: Job-Architektur und Eingruppierung
+    description: |
+      Jobkatalog, Leveling und Eingruppierungsstrukturen.
+  BC-300.30.20:
+    name: Grundgehaltsmanagement
+    description: |
+      Gehaltsbänder, Markt-Benchmarking und Gehaltsüberprüfungszyklen.
+  BC-300.30.30:
+    name: Variable Vergütungs- und Anreizverwaltung
+    description: |
+      Administration von Bonus-, Vertriebsanreiz- und kurzfristigen Incentive-Plänen.
+  BC-300.30.40:
+    name: Eigenkapital- und Langzeitanreizverwaltung
+    description: |
+      Eigenkapitalpläne, RSUs, Optionen und langfristige Incentive-Pläne.
+  BC-300.30.50:
+    name: Leistungsadministration
+    description: |
+      Administration von Gesundheits-, Altersvorsorge- und sonstigen Mitarbeiterleistungen.
+  BC-300.40:
+    name: Lern- und Entwicklungsmanagement
+    description: |
+      Training, Kompetenzaufbau und Zertifizierungen.
+  BC-300.40.10:
+    name: Schulungsbedarfsanalyse
+    description: |
+      Identifikation von Kompetenzlücken und Trainingsbedarfen nach Funktion.
+  BC-300.40.20:
+    name: Lerninhaltskuratierung
+    description: |
+      Kuration und Erstellung interner und externer Lerninhalte.
+  BC-300.40.30:
+    name: Lerndurchführung und -administration
+    description: |
+      Durchführung und Nachverfolgung von Trainings, Präsenzveranstaltungen und digitalem Lernen.
+  BC-300.40.40:
+    name: Kompetenz- und Zertifizierungsmanagement
+    description: |
+      Kompetenzinventar, Fähigkeitsprofile und Zertifizierungsverfolgung.
+  BC-300.40.50:
+    name: Lernwirksamkeitsbewertung
+    description: |
+      Bewertung des Lerneffekts und des ROI von Trainingsinvestitionen.
+  BC-300.50:
+    name: Personalplanungsmanagement
+    description: |
+      Strategische Personalbedarfs- und -angebotsplanung.
+  BC-300.50.10:
+    name: Personalbedarfsprognose
+    description: |
+      Prognose des Personalbedarfs nach Kompetenz, Rolle und Standort.
+  BC-300.50.20:
+    name: Personalangebotsanalyse
+    description: |
+      Interne Verfügbarkeit, Fluktuation und Arbeitsmarktanalyse.
+  BC-300.50.30:
+    name: Strategische Personalplanentwicklung
+    description: |
+      Mehrjährige strategische Personalpläne und Szenarien.
+  BC-300.50.40:
+    name: Kopfzahlplanung und -kontrolle
+    description: |
+      Operative Kopfzahlbudgetierung und Genehmigungsworkflows.
+  BC-300.60:
+    name: Mitarbeitererfahrungsmanagement
+    description: |
+      Engagement, interne Kommunikation und Arbeitsplatzerfahrung.
+  BC-300.60.10:
+    name: Mitarbeiterengagementmessung
+    description: |
+      Engagementumfragen, Puls-Checks und Zuhörprogramme.
+  BC-300.60.20:
+    name: Mitarbeiter-Journey-Design
+    description: |
+      Gestaltung bedeutsamer Mitarbeitermomente und Journey-Maps.
+  BC-300.60.30:
+    name: Betriebliches Wohlbefinden
+    description: |
+      Programme für mentales, physisches und finanzielles Wohlbefinden.
+  BC-300.60.40:
+    name: Anerkennung und Belohnungen
+    description: |
+      Anerkennungsprogramme und nicht-monetäre Belohnungssysteme.
+  BC-300.70:
+    name: Personaloperationsmanagement
+    description: |
+      Mitarbeiterdaten, Lohnadministration und HR-Serviceleistung.
+  BC-300.70.10:
+    name: Mitarbeiterstammdatenmanagement
+    description: |
+      Mitarbeiterdatensätze, Lebenszyklusereignisse und Stammdatenintegrität.
+  BC-300.70.20:
+    name: Lohnadministration
+    description: |
+      Lohnabrechnung, gesetzliche Abzüge und Gehaltszettelverteilung.
+  BC-300.70.30:
+    name: Zeit- und Abwesenheitsmanagement
+    description: |
+      Zeiterfassung, Urlaubs- und Abwesenheitsmanagement.
+  BC-300.70.40:
+    name: HR-Case- und Service-Desk
+    description: |
+      HR-Servicedesk, Case-Management und Bearbeitung von Tier-1-Anfragen.
+  BC-300.70.50:
+    name: HR-Analytik und -Berichterstattung
+    description: |
+      Personalanalytik, Dashboards und gesetzliche HR-Berichterstattung.
+  BC-300.80:
+    name: Mitarbeiter- und Arbeitsbeziehungen
+    description: |
+      Betriebsräte, Gewerkschaften, Beschwerden und Arbeitsrecht.
+  BC-300.80.10:
+    name: Tarifverhandlung und Gewerkschaftsengagement
+    description: |
+      Tarifverhandlungen, Tarifverträge und Gewerkschaftsbeziehungen.
+  BC-300.80.20:
+    name: Betriebsrat und Mitarbeitervertretung
+    description: |
+      Betriebsratskonsultation und Mitarbeitervertretungsgremien.
+  BC-300.80.30:
+    name: Beschwerde- und Disziplinarmanagement
+    description: |
+      Bearbeitung von Beschwerden, Disziplinarverfahren und Untersuchungen.
+  BC-300.80.40:
+    name: Arbeitsrechtliche Compliance
+    description: |
+      Einhaltung von Arbeitsrecht, Arbeitszeitregelungen und Arbeitsstandards.
+  BC-300.90:
+    name: Diversitäts-, Gleichstellungs- und Inklusionsmanagement
+    description: |
+      DEI-Strategie, Programme und Berichterstattung.
+  BC-300.90.10:
+    name: DEI-Strategie und -Steuerung
+    description: |
+      DEI-Strategie, Sponsoring und Steuerungsstrukturen.
+  BC-300.90.20:
+    name: Inklusive Talentpraktiken
+    description: |
+      Inklusive Sourcing-, Einstellungs- und Förderungspraktiken.
+  BC-300.90.30:
+    name: DEI-Programmdurchführung
+    description: |
+      Mitarbeiternetzwerke, Sensibilisierungsmaßnahmen und DEI-Programme.
+  BC-300.90.40:
+    name: Lohngleichheit und DEI-Berichterstattung
+    description: |
+      Lohngleichheitsanalysen und DEI-Kennzahlen sowie -Offenlegungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-hvac-bas-service-operations-management.yaml
+++ b/catalogue/i18n/de/L1-hvac-bas-service-operations-management.yaml
@@ -1,0 +1,177 @@
+locale: de
+source: L1-hvac-bas-service-operations-management.yaml
+entries:
+  BC-2060:
+    name: HLK/GAS-Servicemanagement
+    description: |
+      OEM-geführter und auftragnehmergeführter Service an installierten HLK-Geräten und GAS —
+      Konfigurationsmanagement der installierten Basis, vorbeugende und reaktive Wartung, GAS-Neuprogrammierung
+      und Software-Service, Geräte-Nachrüstung und -Modernisierung, leistungsbasierte Serviceverträge
+      und Remote-Connected-Service.
+  BC-2060.10:
+    name: Installierte Basis Konfigurations-Management
+    description: |
+      Pflege von Ist- und Ist-Wartungs-Konfigurationsdaten für die globale installierte Basis.
+  BC-2060.10.10:
+    name: Anlagen-Asset-Registrierung
+    description: |
+      Registrierung installierter HLK-Geräte nach Seriennummer, Standort und Kunde.
+  BC-2060.10.20:
+    name: GAS-Konfigurations-Registrierung
+    description: |
+      Registrierung von GAS-Konfigurationen, Reglern, Punkten und Sequenzen im Betrieb.
+  BC-2060.10.30:
+    name: Ist-Wartungs-Aufzeichnungen
+    description: |
+      Aufzeichnungen der Ist-Wartungskonfiguration nach jedem Service-Ereignis.
+  BC-2060.10.40:
+    name: Installierte Basis-Änderungs-Aufzeichnungen
+    description: |
+      Aufzeichnungen nach-Übergabe-Änderungen an installierten Geräten und GAS.
+  BC-2060.20:
+    name: Vorbeugende Wartungs-Servicebetrieb
+    description: |
+      Lieferung geplanter vorbeugender Wartung unter Vertrag.
+  BC-2060.20.10:
+    name: Wartungsvertrag-Durchführung
+    description: |
+      Durchführung vorbeugender Wartung gegen vertraglichen Umfang.
+  BC-2060.20.20:
+    name: Geplante Besuchs-Routenführung
+    description: |
+      Routenführung und Entsendung geplanter Service-Besuche.
+  BC-2060.20.30:
+    name: Filter- & Riemen-Service
+    description: |
+      Routinemäßiger Filter-, Riemen- und Verbrauchsmaterialaustausch-Service.
+  BC-2060.20.40:
+    name: Kältemittel- & Rohr-Service
+    description: |
+      Routinemäßige Kältemittel-Nachfüllung und Rohrreinigungsservice.
+  BC-2060.20.50:
+    name: Wartungs-Compliance-Berichterstattung
+    description: |
+      Berichterstattung über vorbeugende Wartungs-Compliance an Kunden.
+  BC-2060.30:
+    name: Reaktiver & Notfall-Service-Betrieb
+    description: |
+      Reaktiver und Notdienst an installierten Geräten außerhalb der Arbeitszeiten.
+  BC-2060.30.10:
+    name: Service-Anfrage-Triage
+    description: |
+      Triage eingehender Service-Anfragen nach Dringlichkeit und Fähigkeit.
+  BC-2060.30.20:
+    name: Notfall-Reaktions-Entsendung
+    description: |
+      Entsendung von Notfall-Respondenten bei kritischen Geräteausfällen.
+  BC-2060.30.30:
+    name: Vor-Ort-Reparatur-Durchführung
+    description: |
+      Vor-Ort-Reparaturdurchführung durch Service-Techniker.
+  BC-2060.30.40:
+    name: Kältemittelleckage-Notfall-Reaktion
+    description: |
+      Notfallreaktion auf Kältemittelfreisetzungen und größere Leckagen.
+  BC-2060.40:
+    name: GAS-Neuprogrammierung & Software-Service
+    description: |
+      Software-seitiger Service an installierten GAS — Sequenzupdates, Firmware-Upgrades und Konfigurationsänderungen.
+  BC-2060.40.10:
+    name: Sequenz-Update-Bereitstellung
+    description: |
+      Bereitstellung aktualisierter Regelsequenzen für installierte Regler.
+  BC-2060.40.20:
+    name: Regler-Firmware-Upgrade
+    description: |
+      Firmware-Upgrade installierter GAS-Regler.
+  BC-2060.40.30:
+    name: Punkte- & Zeitplan-Modifikation
+    description: |
+      Feldmodifikation von GAS-Punkten, Zeitplänen und Trends.
+  BC-2060.40.40:
+    name: GAS-Backup & Recovery-Betrieb
+    description: |
+      Backup der GAS-Konfiguration und Recovery bei Ausfällen.
+  BC-2060.50:
+    name: HLK-Geräte-Nachrüstungs- & Modernisierungs-Service
+    description: |
+      Nachrüstungs-, Austausch- und Modernisierungsservices für die installierte HLK-Basis.
+  BC-2060.50.10:
+    name: Vor-Ort-Nachrüstungs-Engineering
+    description: |
+      Vor-Ort-Engineering von auf die Installation zugeschnittenen Nachrüstungspaketen.
+  BC-2060.50.20:
+    name: Geräteaustausch-Durchführung
+    description: |
+      Vor-Ort-Durchführung von Geräteaustauscharbeiten.
+  BC-2060.50.30:
+    name: Kältemittelkonversions-Service
+    description: |
+      Konversion installierter Geräte auf alternative Kältemittel.
+  BC-2060.50.40:
+    name: Nachrüstungs-Validierungstest
+    description: |
+      Validierungstests nach Nachrüstungs- oder Modernisierungsarbeiten.
+  BC-2060.60:
+    name: Leistungs-Servicevertrag-Betrieb
+    description: |
+      Betrieb leistungs- und ergebnisbasierter Serviceverträge.
+  BC-2060.60.10:
+    name: Leistungsvertrag-Durchführung
+    description: |
+      Durchführung leistungsbasierter Serviceverpflichtungen.
+  BC-2060.60.20:
+    name: Garantierte Einsparungen-Tracking
+    description: |
+      Verfolgung garantierter Einsparargebnisse gegen Baseline.
+  BC-2060.60.30:
+    name: Risikoteilungs-Mechanismus-Betrieb
+    description: |
+      Betrieb von Bonus- und Malus-Risikoteilungsmechanismen.
+  BC-2060.60.40:
+    name: Ergebnis-Berichterstattung
+    description: |
+      Berichterstattung über vertragliche Ergebnisse und Service-Level-Metriken.
+  BC-2060.70:
+    name: Remote-Connected-Service-Betrieb
+    description: |
+      Remote-Service-Zentrum-Betrieb unter Nutzung vernetzter HLK- und GAS-Daten.
+  BC-2060.70.10:
+    name: Remote-Diagnose-Zentrum-Betrieb
+    description: |
+      Betrieb des Remote-Diagnose-Zentrums für vernetzte Geräte.
+  BC-2060.70.20:
+    name: Remote-Problem-Triage
+    description: |
+      Triage von Problemen, die durch Remote-Telemetrie identifiziert werden.
+  BC-2060.70.30:
+    name: Remote-Lösung-Durchführung
+    description: |
+      Durchführung von Remote-only-Lösungen, bei denen kein Standortbesuch erforderlich ist.
+  BC-2060.70.40:
+    name: Connected-Service-Kunden-Onboarding
+    description: |
+      Onboarding von Kunden in vernetzte Service-Angebote.
+  BC-2060.80:
+    name: Service-Qualität & SLA-Management
+    description: |
+      Management von Servicequalität, Service-Level-Vereinbarungen und Kundenzufriedenheit.
+  BC-2060.80.10:
+    name: Service-Level-Vereinbarungs-Tracking
+    description: |
+      Verfolgung der SLA-Leistung.
+  BC-2060.80.20:
+    name: Kundenzufriedenheits-Erfassung
+    description: |
+      Erfassung der Kundenzufriedenheit über Service-Interaktionen.
+  BC-2060.80.30:
+    name: Service-Eskalations-Management
+    description: |
+      Management von Service-Eskalationen und Recovery-Maßnahmen.
+  BC-2060.80.40:
+    name: Service-Leistungs-Berichterstattung
+    description: |
+      Periodische Berichterstattung über Service-Leistung an Kunden und Management.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-hvac-equipment-certification-management.yaml
+++ b/catalogue/i18n/de/L1-hvac-equipment-certification-management.yaml
@@ -1,0 +1,149 @@
+locale: de
+source: L1-hvac-equipment-certification-management.yaml
+entries:
+  BC-2030:
+    name: HLK-Gerätezertifizierung Management
+    description: |
+      Multijurisdiktionelle HLK-Produktzertifizierung — Leistungszertifizierung (AHRI, Eurovent),
+      Sicherheitslisting (UL, CSA, IEC 60335-2-40, CE-Kennzeichnung), Kältemittelzulassungen (F-Gas, EPA SNAP)
+      und Energieeffizienz-Kennzeichnung (ENERGY STAR, EU Ökodesign/ErP, MEPS) — bis zu
+      Markenlizenzierung, Etiketten-Compliance und Normüberwachung.
+  BC-2030.10:
+    name: Zertifizierungsstrategie & Fahrplan
+    description: |
+      Definition von Zertifizierungsumfang, Schemata und Sequenzierung über Zielmärkte.
+  BC-2030.10.10:
+    name: Marktzugangsanforderungsanalyse
+    description: |
+      Identifikation von Zertifizierungs- und Kennzeichnungspflichten nach Zielmarkt.
+  BC-2030.10.20:
+    name: Zertifizierungsschema-Auswahl
+    description: |
+      Auswahl von Zertifizierungsschemata und Anerkennungswegen für HLK-Geräte.
+  BC-2030.10.30:
+    name: Zertifizierungsfahrplan-Planung
+    description: |
+      Sequenzierung von Zertifizierungen gegen Geräteeinführungs-Meilensteine.
+  BC-2030.20:
+    name: Leistungszertifizierungs-Management
+    description: |
+      Einbindung in HLK-Leistungszertifizierungsprogramme und Veröffentlichung bewerteter Leistungsdaten.
+  BC-2030.20.10:
+    name: Leistungstest-Programm-Koordination
+    description: |
+      Koordination von Gerätebewertungstests mit akkreditierten Labors.
+  BC-2030.20.20:
+    name: Leistungsbewertungs-Einreichung
+    description: |
+      Einreichung zertifizierter Bewertungen an Leistungszertifizierungsprogramme.
+  BC-2030.20.30:
+    name: Leistungszeichen-Erteilungs-Tracking
+    description: |
+      Verfolgung erteilter Leistungszertifikate und Gültigkeitsfenster.
+  BC-2030.20.40:
+    name: Freiwillige Programm-Einbindung
+    description: |
+      Einbindung in freiwillige Leistungs- und Qualitätsprogramme.
+  BC-2030.30:
+    name: Geräte-Sicherheitslisting-Management
+    description: |
+      Einbindung in Sicherheitslisting-Schemata für HLK-Geräte über Jurisdiktionen hinweg.
+  BC-2030.30.10:
+    name: Sicherheitslisting-Einreichung
+    description: |
+      Einreichung von Sicherheitslistings gegen IEC 60335-2-40 und gleichwertige Normen.
+  BC-2030.30.20:
+    name: Sicherheitsnorm-Compliance-Verifizierung
+    description: |
+      Verifizierung der Normkonformität durch interne Audits.
+  BC-2030.30.30:
+    name: Internationales Sicherheitszeichen-Koordination
+    description: |
+      Koordination über mehrere nationale Sicherheitszeichen und Anerkennungsvereinbarungen.
+  BC-2030.30.40:
+    name: Feld-Sicherheits-Modifikations-Management
+    description: |
+      Verwaltung von Feld-Sicherheitsmodifikationen und Korrekturmaßnahmen, die Listingänderungen betreffen.
+  BC-2030.40:
+    name: Kältemittel-Compliance-Management
+    description: |
+      Produktbezogene Kältemittelzulassungen, Phase-Down-Compliance und Stoffoffenlegung für Zertifizierung.
+  BC-2030.40.10:
+    name: Kältemittel-Zulassungs-Tracking
+    description: |
+      Verfolgung genehmigter Kältemittel für jede Produktfamilie nach Jurisdiktion.
+  BC-2030.40.20:
+    name: Kältemittel-Phase-Down-Compliance
+    description: |
+      Compliance gegenüber HFKW-Phase-Down-Zeitplänen und Kigali-Verpflichtungen auf Produktebene.
+  BC-2030.40.30:
+    name: GWP- & ODP-Compliance-Aufzeichnungen
+    description: |
+      Aufzeichnungen zum globalen Erwärmungspotenzial und Ozonabbaupotenzial gegen regulatorische Schwellenwerte.
+  BC-2030.40.40:
+    name: Kältemittel-Stoff-Berichterstattung
+    description: |
+      Stoffberichterstattung als Teil von Produktzertifizierungsdossiers.
+  BC-2030.50:
+    name: Energie- & Effizienz-Etiketten-Management
+    description: |
+      Registrierung und laufende Compliance mit Energieeffizienz-Kennzeichnungs- und Mindesteffizienzspeogrammen.
+  BC-2030.50.10:
+    name: Energieetiketten-Registrierung
+    description: |
+      Registrierung von Geräte-Energieetiketten bei nationalen Programmen.
+  BC-2030.50.20:
+    name: Ökodesign-Compliance
+    description: |
+      Compliance mit EU-Ökodesign und gleichwertigen Regimen.
+  BC-2030.50.30:
+    name: Mindest-Effizienz-Leistungsnormen-Compliance
+    description: |
+      Compliance mit Mindest-Effizienz-Leistungsnormen über Märkte hinweg.
+  BC-2030.50.40:
+    name: Freiwillige Öko-Etiketten-Einbindung
+    description: |
+      Einbindung in freiwillige Öko-Etikettenprogramme für nachhaltige Geräte.
+  BC-2030.60:
+    name: Zertifizierungszeichen- & Etiketten-Compliance-Management
+    description: |
+      Lebenszyklusmanagement von Zertifizierungszeichen und Produktetikett-Artwork.
+  BC-2030.60.10:
+    name: Zeichen-Ausgabe
+    description: |
+      Ausgabe und Produktanwendung von Zertifizierungszeichen.
+  BC-2030.60.20:
+    name: Zeichen-Erneuerung
+    description: |
+      Erneuerung von Zertifizierungszeichen vor Ablauf.
+  BC-2030.60.30:
+    name: Zeichen-Rücknahme
+    description: |
+      Rücknahme von Zertifizierungszeichen für ausgemusterte oder nicht-konforme Geräte.
+  BC-2030.60.40:
+    name: Produktetikett-Compliance
+    description: |
+      Kontrolle des Produktetikett-Artworks gegen genehmigten Zertifizierungsinhalt.
+  BC-2030.70:
+    name: Normüberwachungs-Management
+    description: |
+      Überwachung von HLK-Normen und -Vorschriften mit Folgenabschätzung und Fahrplankommunikation.
+  BC-2030.70.10:
+    name: HLK-Normen-Intelligence
+    description: |
+      Informationssammlung zu neuen und überarbeiteten HLK-Normen.
+  BC-2030.70.20:
+    name: Normenänderungs-Folgenabschätzung
+    description: |
+      Bewertung der Auswirkungen von Normenänderungen auf bestehende Zertifizierungen.
+  BC-2030.70.30:
+    name: Industrieverbands-Teilnahme
+    description: |
+      Teilnahme an Branchennormungsgremien und technischen Ausschüssen.
+  BC-2030.70.40:
+    name: Normenfahrplan-Kommunikation
+    description: |
+      Kommunikation von Normenfahrplänen an Entwicklungs- und Produktteams.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-hvac-equipment-engineering-management.yaml
+++ b/catalogue/i18n/de/L1-hvac-equipment-engineering-management.yaml
@@ -1,0 +1,192 @@
+locale: de
+source: L1-hvac-equipment-engineering-management.yaml
+entries:
+  BC-2000:
+    name: HLK-Gerätetechnik Management
+    description: |
+      Mechanische, Kältetechnik- und thermofluide Produktentwicklung von HLK-Geräten —
+      Kältemaschinen, Wärmepumpen, Lüftungsgeräten, Dachgeräten, VRF, Gebläsekonvektoren, Endgeräten —
+      bis zur Leistungsverifizierung und AHRI/Eurovent-Bewertungstest-Bereitschaft.
+  BC-2000.10:
+    name: Kältekreis-Engineering
+    description: |
+      Engineering von Dampfkompression-, Absorptions- und Wärmepumpenkreisläufen für HLK-Geräte.
+  BC-2000.10.10:
+    name: Dampfkompressions-Kreislauf-Design
+    description: |
+      Design von Dampfkompressions-Kältekreisläufen für Kühl- und Heizgeräte.
+  BC-2000.10.20:
+    name: Absorptions-Kreislauf-Design
+    description: |
+      Design von Absorptionskältemaschinen und -wärmepumpen.
+  BC-2000.10.30:
+    name: Wärmepumpen-Kreislauf-Design
+    description: |
+      Design reversibler Wärmepumpenkreisläufe für Luft-, Wasser- und Erdquellvarianten.
+  BC-2000.10.40:
+    name: Kältemittel-Auswahl-Engineering
+    description: |
+      Auswahl von Kältemitteln nach thermodynamischen, regulatorischen, GWP- und Entflammbarkeitszielen.
+  BC-2000.10.50:
+    name: Kreislauf-Leistungs-Optimierung
+    description: |
+      Optimierung der Kreislaufleistung über Auslegungspunkte und Teillastbedingungen.
+  BC-2000.20:
+    name: Wärmeübertragungs- & Rohr-Engineering
+    description: |
+      Engineering von Verdampfern, Kondensatoren, Wärmerückgewinnungsrädern und Platten-/Rohrbündelwärmetauschern.
+  BC-2000.20.10:
+    name: Verdampfer-Rohr-Design
+    description: |
+      Design von Rippenrohr- und Microchannel-Verdampferrohren.
+  BC-2000.20.20:
+    name: Kondensator-Rohr-Design
+    description: |
+      Design von luftgekühlten und wassergekühlten Kondensatorrohren.
+  BC-2000.20.30:
+    name: Luft-Wärmerückgewinnungs-Design
+    description: |
+      Design von Wärmerückgewinnungsrädern, Plattenwärmetauschern und Kreislaufverbundsystemen.
+  BC-2000.20.40:
+    name: Gelötete Platten- & Rohrbündel-Design
+    description: |
+      Design gelöteter Plattenwärmetauscher und Rohrbündelwärmetauscher für Wasser- und Kältemittelbetrieb.
+  BC-2000.20.50:
+    name: Rohr-Material- & Beschichtungs-Engineering
+    description: |
+      Auswahl von Rohrmetallurgie und Schutzschichten für Umweltbeständigkeit.
+  BC-2000.30:
+    name: Luftführungs-Geräte-Engineering
+    description: |
+      Engineering von Ventilatoren, Gebläsen, Lüftungsgeräten, Klappen und Filtrationsanlagen.
+  BC-2000.30.10:
+    name: Radialventilator-Design
+    description: |
+      Aerodynamisches und mechanisches Design von Radialventilatoren.
+  BC-2000.30.20:
+    name: Axial- & Plug-Ventilator-Design
+    description: |
+      Aerodynamisches und mechanisches Design von Axial- und Plug-Ventilatoren.
+  BC-2000.30.30:
+    name: Lüftungsgeräte-Engineering
+    description: |
+      Modulares Lüftungsgeräte-Abschnitts-, Gehäuse- und Luftstrom-Engineering.
+  BC-2000.30.40:
+    name: Klappe- & Jalousie-Engineering
+    description: |
+      Engineering von Regelklappen, Brand-/Rauchschutzklappen und Außenluftjalousien.
+  BC-2000.30.50:
+    name: Filtrationsystem-Engineering
+    description: |
+      Engineering von Partikel-, Gasphase- und HEPA-Filtrationsabschnitten.
+  BC-2000.40:
+    name: Hydraulik- & Fluidsystem-Engineering
+    description: |
+      Engineering von Pumpen, Leitungen, Hydraulikkreisläufen und Zubehör in HLK-Geräten.
+  BC-2000.40.10:
+    name: Pumpen-Engineering
+    description: |
+      Auswahl und Integration von Umwälz- und Kreiselpumpen in Geräterahmen.
+  BC-2000.40.20:
+    name: Leitungs- & Verteiler-Design
+    description: |
+      Design interner Leitungen, Verteiler und Sammelrohre in verpackten Geräten.
+  BC-2000.40.30:
+    name: Kaltwasser- & Warmwasserkreis-Engineering
+    description: |
+      Engineering integrierter Kaltwasser- und Warmwasserkreisläufe auf Geräteebene.
+  BC-2000.40.40:
+    name: Hydraulik-Zubehör-Engineering
+    description: |
+      Engineering von Ausdehnungsgefäßen, Luftabscheidern und Schlammfängern als verpacktes Zubehör.
+  BC-2000.50:
+    name: Verdichter- & Antrieb-Engineering
+    description: |
+      Engineering von Verdichterfamilien und den sie antreibenden Antrieben.
+  BC-2000.50.10:
+    name: Scroll-Verdichter-Engineering
+    description: |
+      Engineering von Scroll-Verdichtern für leichte Gewerbegeräte.
+  BC-2000.50.20:
+    name: Schrauben-Verdichter-Engineering
+    description: |
+      Engineering von Schraubenverdichtern für kommerzielle und industrielle Kältemaschinen.
+  BC-2000.50.30:
+    name: Turbo-Verdichter-Engineering
+    description: |
+      Engineering von Turboverdichtern für Großkältemaschinen.
+  BC-2000.50.40:
+    name: Kolben-Verdichter-Engineering
+    description: |
+      Engineering von Kolbenverdichtern für Wärmepumpen und Kältetechnik.
+  BC-2000.50.50:
+    name: Frequenzumrichter-Integration
+    description: |
+      Integration von Frequenzumrichtern mit HLK-Verdichtern und Ventilatoren.
+  BC-2000.60:
+    name: HLK-Akustik- & Schwingungs-Engineering
+    description: |
+      Akustik-, Schwingungs- und Lärm-Engineering auf Geräteebene.
+  BC-2000.60.10:
+    name: Schallleistungs-Modellierung
+    description: |
+      Schallleistungs- und Schalldruck-Modellierung von HLK-Geräten.
+  BC-2000.60.20:
+    name: Schwingungs-Isolations-Design
+    description: |
+      Design von Schwingungsisolierungen für Verdichter, Ventilatoren und Pumpen.
+  BC-2000.60.30:
+    name: Akustik-Gehäuse-Engineering
+    description: |
+      Engineering akustischer Gehäuse und Schalldämpfer integriert in Geräten.
+  BC-2000.60.40:
+    name: Psychoakustische Leistungs-Abstimmung
+    description: |
+      Abstimmung der wahrgenommenen Klangqualität über aggregierte Schallleistungsmetriken hinaus.
+  BC-2000.70:
+    name: Gerätesteuerungs- & Embedded-Engineering
+    description: |
+      Engineering von integrierten Gerätesteuerungen, Firmware und Konnektivitäts-Stacks in HLK-Geräten.
+  BC-2000.70.10:
+    name: Integrierte Steuerung-Engineering
+    description: |
+      Engineering geräteinterner Steuerungen und Einheitensteuerungen.
+  BC-2000.70.20:
+    name: Geräte-Firmware-Engineering
+    description: |
+      Firmware-Entwicklung für HLK-Geräte, einschließlich Einheitensteuerungen und Antriebe.
+  BC-2000.70.30:
+    name: Smart-Gerät-Kommunikations-Engineering
+    description: |
+      Engineering gerätseitiger GAS-Kommunikation, einschließlich BACnet und Modbus.
+  BC-2000.70.40:
+    name: Gerät-Diagnoselogik-Engineering
+    description: |
+      Engineering von Gerätediagnose-, Alarm- und Fehlercode-Logik.
+  BC-2000.80:
+    name: HLK-Geräte-Verifizierung & Test
+    description: |
+      Geräteebene Leistungsverifizierung, AHRI/Eurovent-Bewertungstest-Durchführung und Dauerhaftigkeitstests.
+  BC-2000.80.10:
+    name: Psychrometrische Kammer-Testung
+    description: |
+      Prüfung von HLK-Geräten in psychrometrischen Kammern unter kontrollierten Bedingungen.
+  BC-2000.80.20:
+    name: Leistungsbewertungstest-Durchführung
+    description: |
+      Durchführung standardisierter Leistungsbewertungstests an HLK-Geräten.
+  BC-2000.80.30:
+    name: Thermische Leistungsverifizierung
+    description: |
+      Verifizierung von Kapazität, COP, IPLV und anderen thermischen Leistungsmetriken.
+  BC-2000.80.40:
+    name: Lebensdauer- & Zuverlässigkeitstestung
+    description: |
+      Lebensdauer-, beschleunigte Lebensdauer- und Zuverlässigkeitstests von HLK-Geräten.
+  BC-2000.80.50:
+    name: Gerätetest-Plan-Erstellung
+    description: |
+      Erstellung geräteebener Verifizierungs- und Qualifikationstestpläne.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-hvac-system-integration-management.yaml
+++ b/catalogue/i18n/de/L1-hvac-system-integration-management.yaml
@@ -1,0 +1,173 @@
+locale: de
+source: L1-hvac-system-integration-management.yaml
+entries:
+  BC-2020:
+    name: HLK-Systemintegration Management
+    description: |
+      Projektbezogenes Engineering integrierter HLK- und GAS-Lösungen für ein spezifisches Gebäude —
+      Lastberechnung, Geräteauswahl, schematisches Design, GAS-Punkteliste und -Architektur,
+      Regelablauf-Erstellung, BIM/MEP-Koordination, Projektspezifikationen, Einreichungsmanagement
+      und Vor-Ort-Engineering-Unterstützung.
+  BC-2020.10:
+    name: Gebäude-HLK-Dimensionierung & -Auswahl
+    description: |
+      Projektspezifische Dimensionierung von Lasten und Auswahl von HLK-Geräten zur Erfüllung des Designkonzepts.
+  BC-2020.10.10:
+    name: Kühl- & Heizlast-Berechnung
+    description: |
+      Berechnung von Gebäude-Kühl- und Heizlasten.
+  BC-2020.10.20:
+    name: Geräteauswahl & -liste
+    description: |
+      Auswahl von Gerätemodellen entsprechend berechneter Lasten und Listen.
+  BC-2020.10.30:
+    name: Hydraulikkreis-Dimensionierung
+    description: |
+      Dimensionierung von Hydraulikkreisläufen, Pumpen und Rohrdurchmessern.
+  BC-2020.10.40:
+    name: Kanal-Dimensionierung & Druckverlust-Analyse
+    description: |
+      Dimensionierung von Kanälen und Analyse des Systemdruckverlusts.
+  BC-2020.10.50:
+    name: Energiemodellierung für Auswahl
+    description: |
+      Energiesimulation zur Unterstützung von Geräteauswahl-Kompromissen.
+  BC-2020.20:
+    name: HLK-System-Schematisches Design
+    description: |
+      Schematisches Design der integrierten mechanischen, hydraulischen und Kältemittelsysteme.
+  BC-2020.20.10:
+    name: Mechanisches Schema-Design
+    description: |
+      Schematisches Design mechanischer luftseitiger Systeme.
+  BC-2020.20.20:
+    name: Hydraulik-Schema-Design
+    description: |
+      Schematisches Design von Kaltwasser-, Warmwasser- und Kühlwasserkreisläufen.
+  BC-2020.20.30:
+    name: Kältemittelleitung-Schema-Design
+    description: |
+      Schematisches Design von Kältemittelleitungen für VRF- und Split-Systeme.
+  BC-2020.20.40:
+    name: Einleitern-Steuerungs-Schema-Design
+    description: |
+      Einleiter-Schemata zur Darstellung der GAS-Steuerungsüberlagerung auf mechanischen Systemen.
+  BC-2020.30:
+    name: GAS-Punkteliste & Architektur-Design
+    description: |
+      Projektspezifische Punktelisten, GAS-Netzwerktopologie und Panel-Zuteilung.
+  BC-2020.30.10:
+    name: Punkteliste-Erstellung
+    description: |
+      Erstellung projektspezifischer GAS-Punktelisten.
+  BC-2020.30.20:
+    name: GAS-Netzwerktopologie-Design
+    description: |
+      Design der GAS-Netzwerktopologie und -Segmentierung für das Projekt.
+  BC-2020.30.30:
+    name: Regler-Zuteilung & Panel-Layout
+    description: |
+      Zuteilung von Reglern und Design von Steuertafeln für das Projekt.
+  BC-2020.30.40:
+    name: Tag- & Namenskonventions-Anwendung
+    description: |
+      Anwendung von Tag- und Namenskonventionen auf Projektpunkte und Assets.
+  BC-2020.40:
+    name: Regelablauf-Erstellung
+    description: |
+      Projektspezifische Erstellung von Regelabläufen für HLK-Systeme.
+  BC-2020.40.10:
+    name: Zonen-Sequenz-Erstellung
+    description: |
+      Erstellung projektspezifischer Zonen-Regelsequenzen.
+  BC-2020.40.20:
+    name: Zentralanlage-Sequenz-Erstellung
+    description: |
+      Erstellung projektspezifischer Zentralanlagen-Regelsequenzen.
+  BC-2020.40.30:
+    name: Energieeinspar-Strategie-Erstellung
+    description: |
+      Erstellung projektbezogener Energieeinspar-Regelstrategien.
+  BC-2020.40.40:
+    name: Alarm- & Übersteuerungs-Sequenz-Erstellung
+    description: |
+      Erstellung projektbezogener Alarmlogik und Betreiber-Übersteuerungssequenzen.
+  BC-2020.50:
+    name: BIM & MEP-Koordination
+    description: |
+      BIM-Modellierung und fachübergreifende Koordination des HLK-Umfangs im Projekt.
+  BC-2020.50.10:
+    name: HLK-BIM-Modellierung
+    description: |
+      BIM-Modellierung des HLK-Umfangs für das Projekt.
+  BC-2020.50.20:
+    name: MEP-Kollisionserkennung
+    description: |
+      Koordinations-Kollisionserkennung über MEP-Fachbereiche hinweg.
+  BC-2020.50.30:
+    name: Modell-Austausch-Koordination
+    description: |
+      Koordination von BIM-Modellaustaschformaten und -lieferungen.
+  BC-2020.50.40:
+    name: Koordinationsmodell-Ausgabe
+    description: |
+      Ausgabe koordinierter BIM-Modelle an Projektstakeholder.
+  BC-2020.60:
+    name: HLK-Projektspezifikation-Erstellung
+    description: |
+      Erstellung von Projektspezifikationen für HLK- und Steuerungsumfang.
+  BC-2020.60.10:
+    name: Mechanische Spezifikation-Erstellung
+    description: |
+      Erstellung mechanischer Spezifikationen für das Projekt.
+  BC-2020.60.20:
+    name: Steuerungsspezifikation-Erstellung
+    description: |
+      Erstellung von GAS- und Steuerungsspezifikationen für das Projekt.
+  BC-2020.60.30:
+    name: Leistungs- & Abnahmekriterien-Erstellung
+    description: |
+      Erstellung von Leistungskriterien und Abnahmetests für das Projekt.
+  BC-2020.70:
+    name: Systemintegrations-Einreichungs-Management
+    description: |
+      Verwaltung von Einreichungen, Werkstattzeichnungen und RFIs während der Projektdurchführungsphase.
+  BC-2020.70.10:
+    name: Einreichungspaket-Vorbereitung
+    description: |
+      Vorbereitung von Einreichungspaketen für Eigentümer- und Ingenieurprüfung.
+  BC-2020.70.20:
+    name: Werkstattzeichnungs-Koordination
+    description: |
+      Koordination von Werkstattzeichnungen mit dem Designkonzept.
+  BC-2020.70.30:
+    name: RFI-Reaktions-Management
+    description: |
+      Verwaltung von Design-RFIs vom Auftragnehmer und Integrator.
+  BC-2020.70.40:
+    name: Substitutions-Überprüfung
+    description: |
+      Überprüfung von Anfragen zur Ausrüstungs- und Materialsubstitution.
+  BC-2020.80:
+    name: Vor-Ort-Engineering-Unterstützung
+    description: |
+      Engineering-Unterstützung während der Bau- und Installationsphase, einschließlich Feldlösungen und Ist-Aufzeichnungen.
+  BC-2020.80.10:
+    name: Feld-Engineering-Lösung
+    description: |
+      Lösung von Feld-Engineering-Problemen während der Installation.
+  BC-2020.80.20:
+    name: Änderungsauftrag-Engineering
+    description: |
+      Engineering-Arbeiten zur Unterstützung von Änderungsaufträgen während des Baus.
+  BC-2020.80.30:
+    name: Ist-Zeichnungs-Aktualisierung
+    description: |
+      Aktualisierung von Zeichnungen entsprechend Ist-Installationszustand.
+  BC-2020.80.40:
+    name: Installations-Zeugnis-Inspektion
+    description: |
+      Zeugenschaft bei Installationsmeilensteinen für technische Abnahme.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-hydrocarbon-exploration-management.yaml
+++ b/catalogue/i18n/de/L1-hydrocarbon-exploration-management.yaml
@@ -1,0 +1,150 @@
+locale: de
+source: L1-hydrocarbon-exploration-management.yaml
+entries:
+  BC-3000:
+    name: Kohlenwasserstoff-Exploration
+    description: |
+      Identifikation und Akquisition neuer Kohlenwasserstoffressourcen durch
+      geophysikalische Erkundung, Becken- und Prospektbewertung, Lizenz- und
+      Konzessionserwerb sowie Explorationsbohrentscheidungen.
+  BC-3000.10:
+    name: Geophysikalische Erkundungsverwaltung
+    description: |
+      Akquisition, Verarbeitung und Interpretation seismischer und nicht-seismischer
+      geophysikalischer Daten zur Abbildung des Untergrunds.
+    in_scope:
+      - 2D- und 3D-Seismik-Akquisitionskampagnen
+      - Seismische Verarbeitung und Wiederverarbeitung
+      - Seismische Interpretation zur Prospektgenerierung
+    out_of_scope:
+      - Reservoir-Geomodellierung für Entwicklungslagerstätten (BC-3010)
+  BC-3000.10.10:
+    name: 3D-Seismik-Akquisition
+    description: |
+      Marine, Land- und Ozeanboden-3D-Seismik-Akquisitionsoperationen.
+  BC-3000.10.20:
+    name: 2D-Seismik-Akquisition
+    description: |
+      Erkundungsmaßstäbliche 2D-Seismik-Akquisitionsoperationen.
+  BC-3000.10.30:
+    name: Nicht-seismische Geophysik-Akquisition
+    description: |
+      Gravimetrie, Magnetik, Elektromagnetik und andere nicht-seismische Erkundungen.
+  BC-3000.10.40:
+    name: Seismische Datenverarbeitung
+    description: |
+      Vor-Stack- und Nach-Stack-Verarbeitung, Tiefenmigration und Wiederverarbeitung seismischer Daten.
+  BC-3000.10.50:
+    name: Seismische Dateninterpretation
+    description: |
+      Strukturelle und stratigraphische Interpretation seismischer Volumen zur Prospektgenerierung.
+  BC-3000.20:
+    name: Becken- und Prospektbewertung
+    description: |
+      Erdölsystemanalyse, Play-Fairway-Kartierung und Risiko-Volumen-Bewertung
+      von Explorationsperspektiven.
+    in_scope:
+      - Petroleum-Systemmodellierung
+      - Prospektinventar und -rangfolge
+      - Risikobehaftete Volumenschätzung
+    out_of_scope:
+      - Reservenklassifizierung entdeckter Mengen (BC-3010.30)
+  BC-3000.20.10:
+    name: Erdölsystemanalyse
+    description: |
+      Quell-, Reservoir-, Abdichtungs-, Fallen- und Zeitanalyse zur Qualifizierung von Erdölsystemen.
+  BC-3000.20.20:
+    name: Play-Fairway-Kartierung
+    description: |
+      Kartierung regionaler Plays und gemeinsamer Risikosegmente über Lizenzen.
+  BC-3000.20.30:
+    name: Prospektinventarverwaltung
+    description: |
+      Pflege des ranggeordneten Prospekt- und Lead-Inventars und dessen Reifung.
+  BC-3000.20.40:
+    name: Prospekt-Risikobewertung
+    description: |
+      Probabilistische geologische Erfolgswahrscheinlichkeits-Bewertung für Prospekte.
+  BC-3000.20.50:
+    name: Volumenschätzung
+    description: |
+      Vorbohrungsprobabilistische Schätzung von in-situ und förderbaren Mengen.
+  BC-3000.30:
+    name: Lizenz- und Konzessionserwerb
+    description: |
+      Erwerb von Explorationslizenzen durch Lizenzrunden, Direktverhandlungen
+      und Farm-in-Transaktionen.
+    in_scope:
+      - Gebotsrunden-Screening und -Teilnahme
+      - Konzessions- und PSC-Gebote
+      - Farm-in- und Farm-out-Verhandlungen
+    out_of_scope:
+      - Laufende Lizenzverpflichtungsnachverfolgung (BC-3110.40)
+  BC-3000.30.10:
+    name: Lizenzrunden-Screening
+    description: |
+      Screening von staatlichen Lizenzrunden für Teilnahmeentscheidungen.
+  BC-3000.30.20:
+    name: Konzessionsgebote
+    description: |
+      Vorbereitung und Einreichung von Wettbewerbsgeboten für Konzessionen und Produktionsteilungsverträge.
+  BC-3000.30.30:
+    name: Farm-in- und Farm-out-Verhandlungen
+    description: |
+      Verhandlung von Farm-in-, Farm-out- und Flächentausch-Transaktionen.
+  BC-3000.30.40:
+    name: Lizenzportfolio-Management
+    description: |
+      Pflege des Explorations-Lizenzportfolios und Rationalisierungsentscheidungen.
+  BC-3000.40:
+    name: Explorations-Bohrprogramm-Management
+    description: |
+      Definition, Genehmigung und Nachbohrungsbewertung von Wildcat- und Bewertungsbohrprogrammen.
+  BC-3000.40.10:
+    name: Explorationsbohrprogramm-Definition
+    description: |
+      Definition von Wildcat- und Bewertungsbohr-Zielen und Reihenfolge.
+  BC-3000.40.20:
+    name: Wildcat-Bohr-Genehmigung
+    description: |
+      Interne und Partnergenehmigungssteuerung für Wildcat-Explorationsbohrungen.
+  BC-3000.40.30:
+    name: Bewertungsbohrprogramm-Management
+    description: |
+      Management von Bewertungsbohrprogrammen nach Entdeckungen.
+  BC-3000.40.40:
+    name: Nachbohrungsbewertung
+    description: |
+      Unterirdische Nachbohrungsbewertung und Lernerfassung für das Prospektinventar.
+  BC-3000.50:
+    name: Explorationsportfolio-Steuerung
+    description: |
+      Strategische Steuerung des Explorationsportfolios über Regionen, Plays und Risikoklassen.
+  BC-3000.50.10:
+    name: Explorationsstrategie-Definition
+    description: |
+      Definition der Explorationsstrategie über Becken, Plays und Risikoklassen.
+  BC-3000.50.20:
+    name: Explorationskapital-Allokation
+    description: |
+      Allokation von Explorationskapital über Regionen und Play-Typen.
+  BC-3000.50.30:
+    name: Explorations-Leistungstracking
+    description: |
+      Tracking von Explorationsfindungskosten, Erfolgsquoten und Ressourcenzugängen.
+  BC-3000.60:
+    name: Entdeckungsberichterstattung Untertagebau
+    description: |
+      Meldung von Entdeckungen an Gastregierungen, Partner und Kapitalmärkte
+      sowie Tracking der Ressourcenreifung bis zur Entwicklungsgenehmigung.
+  BC-3000.60.10:
+    name: Entdeckungsmeldung
+    description: |
+      Entdeckungsmeldung an Gastregierungen, Partner und Offenlegungen an Kapitalmärkte.
+  BC-3000.60.20:
+    name: Ressourcenreifungs-Tracking
+    description: |
+      Tracking von Kontingentressourcen von der Entdeckung bis zur Entwicklungsgenehmigung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-hydrocarbon-logistics-management.yaml
+++ b/catalogue/i18n/de/L1-hydrocarbon-logistics-management.yaml
@@ -1,0 +1,103 @@
+locale: de
+source: L1-hydrocarbon-logistics-management.yaml
+entries:
+  BC-3100:
+    name: Kohlenwasserstoff-Logistik
+    description: |
+      Marine-Frachtoperationen, Terminal- und Massenlager-Betrieb für Rohöl,
+      Raffinerieprodukte und LNG, plus Abnahmekoordination und Bunkerkraftstoff-
+      Management. Abgegrenzt von branchenübergreifendem Transport (BC-2400-Serie),
+      der Frachtnetze, Flottenmanagement und intermodale Transporte umfasst.
+  BC-3100.10:
+    name: Marine-Frachtbetrieb
+    description: |
+      Betrieb von Rohöltankern, Produktentankern, LNG-Schiffen und Schiff-zu-Schiff-Transfers in Petroleum-Diensten.
+    in_scope:
+      - Tanker- und Gas-Carrier-Betriebskoordination
+      - Schiff-zu-Schiff-Leichtern und Rückleichtern
+    out_of_scope:
+      - Generisches Schifffahrtsflottenmanagement (BC-2430)
+      - Liner-Schifffahrts-Frachtbuchungen (BC-2400)
+  BC-3100.10.10:
+    name: Rohöltanker-Betrieb
+    description: |
+      Betriebskoordination von Rohöltankern unter Reise- und Zeitcharter.
+  BC-3100.10.20:
+    name: Produktentanker-Betrieb
+    description: |
+      Betriebskoordination von Raffinerieprodukten-Tankern einschließlich Parzel-Ladungen.
+  BC-3100.10.30:
+    name: LNG-Carrier-Betrieb
+    description: |
+      Betriebskoordination von LNG-Schiffen einschließlich Abkühlung und Tank-Druckmanagement.
+  BC-3100.10.40:
+    name: Schiff-zu-Schiff-Transfer-Koordination
+    description: |
+      Koordination von STS-Transfers für Rohöl, Produkte und LNG.
+  BC-3100.20:
+    name: Terminal-Betrieb
+    description: |
+      Betrieb von Import-, Export- und Zwischen-Petroleum-Terminals - Anlegeplätze, Verladearme und Tankempfang.
+  BC-3100.20.10:
+    name: Verladearm und Anleger-Betrieb
+    description: |
+      Betrieb von Anlegerausrüstung und marinen Verladearmen.
+  BC-3100.20.20:
+    name: Tankempfangs-Betrieb
+    description: |
+      Empfang und Peilung von Frachten in Terminal-Lagertanks.
+  BC-3100.20.30:
+    name: Tank-Beladungsbetrieb
+    description: |
+      Beladung aus Terminal-Lager in Schiffe und Pipelines.
+  BC-3100.20.40:
+    name: Liegeplatz-Zeitplanung
+    description: |
+      Liegeplatz-Zuweisung und Zeitplanung für Schiffsankünfte.
+  BC-3100.30:
+    name: Massenlager-Management
+    description: |
+      Tankzuweisung, Bewegungs-Tracking und Tankkalibrierung für Rohöl, Produkte und NGLs.
+  BC-3100.30.10:
+    name: Tankzuweisung
+    description: |
+      Zuweisung von Tankkapazität zu Qualitäten, Eigentümern und Pools.
+  BC-3100.30.20:
+    name: Tank-zu-Tank-Bewegungs-Tracking
+    description: |
+      Tracking interner Terminal-Bewegungen und Inventarpositionen.
+  BC-3100.30.30:
+    name: Tank-Kalibrierung und Eichung
+    description: |
+      Tank-Eichtabellen-Kalibrierung und Pflege für Fiskalgenauigkeit.
+  BC-3100.40:
+    name: Frachtplanung und Abnahmekoordination
+    description: |
+      Abnahmenominierungen, Schiffsbestätigung und Liegegeld-Tracking für Petroleum-Frachten.
+  BC-3100.40.10:
+    name: Abnahmenominierungs-Management
+    description: |
+      Eingang und Bestätigung von Kunden- und Eigenkapital-Abnahmenominierungen.
+  BC-3100.40.20:
+    name: Schiffsbestätigung
+    description: |
+      Parzellen- und Frachtbestätigung gegenüber vertraglichen Verpflichtungen.
+  BC-3100.40.30:
+    name: Betriebliches Liegegeld-Tracking
+    description: |
+      Betriebliches Tracking von Liegegeldereignissen an Lade- und Löschhäfen.
+  BC-3100.50:
+    name: Bunker- und Marine-Kraftstoff-Management
+    description: |
+      Bunkerbeschaffung und Qualitätssicherung für die betriebene und gecharterte Flotte.
+  BC-3100.50.10:
+    name: Bunkerbeschaffung
+    description: |
+      Spot- und Terminbeschaffung von Schiffstreibstoffen für die Flotte.
+  BC-3100.50.20:
+    name: Bunker-Qualitätssicherung
+    description: |
+      Probenahme, Prüfung und Streitbeilegung für gelieferte Bunker.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-hydrocarbon-measurement-allocation-management.yaml
+++ b/catalogue/i18n/de/L1-hydrocarbon-measurement-allocation-management.yaml
@@ -1,0 +1,102 @@
+locale: de
+source: L1-hydrocarbon-measurement-allocation-management.yaml
+entries:
+  BC-3040:
+    name: Kohlenwasserstoff-Messung und Allokation
+    description: |
+      Fiskaltaugliche Messung und Allokation geförderter Kohlenwasserstoffe -
+      Custody-Transfer-Messtechnik, Allokation über Reservoire und Miteigentümer,
+      Produktionsbuchhaltung, Förderstellenabrechnungen und
+      Mess-Varianzen-Untersuchung.
+  BC-3040.10:
+    name: Fiskalische Custody-Transfer-Messtechnik
+    description: |
+      Betrieb, Kalibrierung und Sicherstellung fiskaltauglicher Messgeräte an Übergabepunkten.
+  BC-3040.10.10:
+    name: Fiskalmesser-Betrieb
+    description: |
+      Täglicher Betrieb von fiskaltauglichen Flüssigkeits- und Gasmessgeräten.
+  BC-3040.10.20:
+    name: Messer-Proving und Kalibrierung
+    description: |
+      Periodisches Proving und Kalibrierung fiskaltauglicher Messgeräteinstallationen.
+  BC-3040.10.30:
+    name: Custody-Transfer-Dokumentation
+    description: |
+      Ausstellung und Austausch von Custody-Transfer-Tickets und Zertifikaten.
+  BC-3040.10.40:
+    name: Fehlmessungs-Untersuchung
+    description: |
+      Untersuchung und Behebung vermuteter Fehlmessungsereignisse.
+  BC-3040.20:
+    name: Produktionsallokation
+    description: |
+      Allokation gemessener Mengen auf Bohrungen, Reservoire und Miteigentümer.
+  BC-3040.20.10:
+    name: Bohrungsallokation
+    description: |
+      Allokation des Anlagenoutputs auf beitragende Bohrungen.
+  BC-3040.20.20:
+    name: Reservoir-Allokation
+    description: |
+      Allokation über gemischte Reservoire und Lagerstätten.
+  BC-3040.20.30:
+    name: Miteigentümer-Allokation
+    description: |
+      Allokation von Produktionsmengen unter Arbeitseigentümern.
+  BC-3040.20.40:
+    name: Allokationsabgleich
+    description: |
+      Abgleich von Allokationsergebnissen über Mess-, Bohrlochtest- und Buchhaltungsdaten.
+  BC-3040.30:
+    name: Produktionsbuchhaltung
+    description: |
+      Tägliche Produktionsberichterstattung, Massenbilanz und monatlicher Produktionsbuchhaltungsabschluss.
+  BC-3040.30.10:
+    name: Tägliche Produktionsberichterstattung
+    description: |
+      Tägliche Produktionsmengen-Berichterstattung an interne und externe Stakeholder.
+  BC-3040.30.20:
+    name: Kohlenwasserstoff-Massenbilanz
+    description: |
+      End-to-End-Kohlenwasserstoff-Massenbilanz über Fördersysteme.
+  BC-3040.30.30:
+    name: Produktionsbuchhaltungsabschluss
+    description: |
+      Monatlicher Abschluss der Produktionsbuchhaltungsbücher und Zulieferung an Finanzsysteme.
+  BC-3040.40:
+    name: Förderstellenabrechnung-Management
+    description: |
+      Erstellung von Förderstellenabrechnungen, Lizenzgebühren-Volumenberechnung und
+      Berichterstattung über Förder- und Produktionssteuern.
+  BC-3040.40.10:
+    name: Förderstellenabrechnung-Erstellung
+    description: |
+      Erstellung von Förderstellenabrechnungs-Berichten für Arbeitseigentümer.
+  BC-3040.40.20:
+    name: Lizenzgebühren-Volumenberechnung
+    description: |
+      Berechnung von Lizenzgeber-Mengen und -Wert auf Förderstellenebene.
+  BC-3040.40.30:
+    name: Förder- und Produktionssteuer-Berichterstattung
+    description: |
+      Berichterstattung über Förder- und Produktionssteuern an Steuerbehörden.
+  BC-3040.50:
+    name: Verlust- und Varianzanalyse
+    description: |
+      Untersuchung von Messvariationen, Verlustreignissen und Kohlenwasserstoff-Inventar-Ungleichgewichten.
+  BC-3040.50.10:
+    name: Messvarianzen-Analyse
+    description: |
+      Analyse von Messvariationen gegenüber Toleranzbändern.
+  BC-3040.50.20:
+    name: Verlustuntersuchung
+    description: |
+      Untersuchung nicht zugeordneter Verluste über Messpunkte hinweg.
+  BC-3040.50.30:
+    name: Kohlenwasserstoff-Inventarabgleich
+    description: |
+      Abgleich des physischen Kohlenwasserstoff-Inventars mit Buchhaltungsunterlagen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-hydrocarbon-production-operations-management.yaml
+++ b/catalogue/i18n/de/L1-hydrocarbon-production-operations-management.yaml
@@ -1,0 +1,143 @@
+locale: de
+source: L1-hydrocarbon-production-operations-management.yaml
+entries:
+  BC-3030:
+    name: Kohlenwasserstoff-Förderung
+    description: |
+      Betrieb von Bohrkopf bis Export der oberirdischen Upstream-Anlagen -
+      Separierung, Behandlung, künstliche Förderung, Fließ-Sicherung,
+      Produktionsüberwachung und Reservoirdruckerhaltung.
+  BC-3030.10:
+    name: Bohrkopf-Betriebsmanagement
+    description: |
+      Täglicher Betrieb von Bohrkopfausrüstung, Drosselventil-Management und Bohrlochtest.
+  BC-3030.10.10:
+    name: Bohrkopf-Überwachung
+    description: |
+      Kontinuierliche Überwachung von Bohrkopfdruck, Temperatur und Förderparametern.
+  BC-3030.10.20:
+    name: Bohrkopf-Drosselventil-Management
+    description: |
+      Anpassung von Oberflächen-Drosselventilen zur Steuerung von Förderrate und Druckabsenkung.
+  BC-3030.10.30:
+    name: Bohrlochtest-Betrieb
+    description: |
+      Routine- und Überwachungsbohrlochtests für Allokations- und Reservoirinput.
+  BC-3030.20:
+    name: Oberflächen-Separierungs- und Behandlungsbetrieb
+    description: |
+      Betrieb von Oberflächen-Anlagen zur Öl-Wasser-Gas-Separierung,
+      Rohöl-Stabilisierung, Produktionswasserbehandlung und Gaskonditionierung.
+  BC-3030.20.10:
+    name: Öl-, Wasser- und Gas-Separierung
+    description: |
+      Dreiphasen-Separierung geförderter Fluide in Upstream-Anlagen.
+  BC-3030.20.20:
+    name: Rohöl-Stabilisierung
+    description: |
+      Stabilisierung des geförderten Rohöls auf Exportspezifikationen.
+  BC-3030.20.30:
+    name: Produktionswasserbehandlung
+    description: |
+      Behandlung von Produktionswasser für Reinjektion oder Einleitung.
+  BC-3030.20.40:
+    name: Gastrocknung und -entschwefelung
+    description: |
+      Feldtrocknung und -entschwefelung von Begleitgasströmen.
+  BC-3030.30:
+    name: Künstliche Förderungs-Management
+    description: |
+      Auswahl, Betrieb und Optimierung von Systemen zur künstlichen Förderung.
+  BC-3030.30.10:
+    name: Gaslift-Betrieb
+    description: |
+      Kontinuierlicher und intermittierender Gaslift-Betrieb und Überwachung.
+  BC-3030.30.20:
+    name: Elektrische Tauchpumpen-Betrieb
+    description: |
+      Betrieb, Überwachung und Laufzeit-Management von ESP-Installationen.
+  BC-3030.30.30:
+    name: Stangenpumpen-Betrieb
+    description: |
+      Betrieb und Dynamometer-Überwachung von Stangenpumpen.
+  BC-3030.30.40:
+    name: Optimierung künstlicher Förderung
+    description: |
+      Methodenübergreifende Optimierung der Auswahl und Parameter künstlicher Förderung.
+  BC-3030.40:
+    name: Produktionsoptimierung und Überwachung
+    description: |
+      Echtzeit-Überwachung und Optimierung von Förderraten,
+      Engpässen und Bohrleistung gegenüber Prognose.
+  BC-3030.40.10:
+    name: Echtzeit-Produktionsüberwachung
+    description: |
+      Echtzeit-Überwachung von Bohr- und Feldproduktion aus operativen Zentren.
+  BC-3030.40.20:
+    name: Bohrleistungs-Diagnostik
+    description: |
+      Diagnostische Analyse unterperformender Bohrungen und Empfehlungen.
+  BC-3030.40.30:
+    name: Produktionsverlust-Abrechnung
+    description: |
+      Kategorisierung und Berichterstattung von Produktionsverlusten gegenüber Potenzial.
+  BC-3030.40.40:
+    name: Engpass-Identifikation
+    description: |
+      Identifikation von Systemengpässen über Reservoir, Bohrung und Anlage hinweg.
+  BC-3030.50:
+    name: Fließ-Sicherungs-Management
+    description: |
+      Prävention und Management von Fließ-Sicherungsproblemen wie Hydraten,
+      Wachsen, Asphaltenen und Erosions-Korrosion in Fördersystemen.
+  BC-3030.50.10:
+    name: Hydrat-Management
+    description: |
+      Hydrat-Prävention und -Remediation in Fließleitungen und Steigrohren.
+  BC-3030.50.20:
+    name: Wachs- und Asphalthen-Management
+    description: |
+      Prävention und Remediation von Wachs- und Asphalten-Ablagerungen.
+  BC-3030.50.30:
+    name: Erosions- und Korrosions-Monitoring
+    description: |
+      Monitoring von Erosion und Korrosion in Förderfluss-Leitungen und Ausrüstungen.
+  BC-3030.50.40:
+    name: Molch-Betrieb
+    description: |
+      Betriebliches Molchen von Fließleitungen zur Reinigung und Inspektion.
+  BC-3030.60:
+    name: Produktionschemikalien-Management
+    description: |
+      Auswahl, Dosierung und Wirksamkeits-Monitoring von Produktionschemikalien.
+  BC-3030.60.10:
+    name: Chemikalienauswahl und Dosierung
+    description: |
+      Auswahl und Dosierstrategie für Produktionschemikalien auf Bohr- und Anlagenebene.
+  BC-3030.60.20:
+    name: Korrosionsinhibitor-Management
+    description: |
+      Anwendung und Monitoring von Korrosionsinhibitor-Programmen.
+  BC-3030.60.30:
+    name: Ablagerungsinhibitor-Management
+    description: |
+      Ablagerungsinhibitor-Verpressung und kontinuierliches Behandlungsmanagement.
+  BC-3030.70:
+    name: Reservoirdruck-Erhaltungsbetrieb
+    description: |
+      Betrieb von Wasser- und Gasinjektionssystemen und Tracking des Lückenersatzes.
+  BC-3030.70.10:
+    name: Wasserinjektions-Betrieb
+    description: |
+      Betrieb der Injektionswasseraufbereitung und Injektionsbohrungen.
+  BC-3030.70.20:
+    name: Gasinjektions-Betrieb
+    description: |
+      Betrieb der Gasinjektions-Kompression und Gasinjektionsbohrungen.
+  BC-3030.70.30:
+    name: Lückenersatz-Tracking
+    description: |
+      Tracking von Lückenersatzverhältnissen über Produktionsanlagen hinweg.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-hydrocarbon-trading-marketing-management.yaml
+++ b/catalogue/i18n/de/L1-hydrocarbon-trading-marketing-management.yaml
@@ -1,0 +1,137 @@
+locale: de
+source: L1-hydrocarbon-trading-marketing-management.yaml
+entries:
+  BC-3090:
+    name: Kohlenwasserstoffhandel und -vermarktung
+    description: |
+      Physischer und Papierhandel mit Rohöl, Raffinerieprodukten, Erdgas und
+      LNG; Warenrisikomanagement; Handelsabwicklung und Compliance;
+      Terminvertragsmarketing sowie Frachtcharterung für den Handel.
+  BC-3090.10:
+    name: Physischer Handelsbetrieb
+    description: |
+      Physische Handelsabteilungen für Rohöl, Raffinerieprodukte, Erdgas und LNG.
+  BC-3090.10.10:
+    name: Rohölhandel
+    description: |
+      Physischer Handel mit Rohölsorten auf regionalen Märkten.
+  BC-3090.10.20:
+    name: Raffinerieprodukt-Handel
+    description: |
+      Physischer Handel mit Benzin, Destillaten, Kerosin, Heizöl und NGLs.
+  BC-3090.10.30:
+    name: Erdgashandel
+    description: |
+      Physischer Handel mit Pipeline-Erdgas über Hubs.
+  BC-3090.10.40:
+    name: LNG-Handel
+    description: |
+      Physischer Handel mit LNG-Frachten einschließlich Umleitungs- und Reload-Geschäften.
+  BC-3090.20:
+    name: Derivate- und Papierhandel
+    description: |
+      Börsengehandelte und OTC-Derivate für Hedging und eigenständige Positionierung.
+  BC-3090.20.10:
+    name: Futures- und Optionenhandel
+    description: |
+      Handel mit börsennotierten Futures und Optionen auf Energierohstoffe.
+  BC-3090.20.20:
+    name: Swaps und Hedging-Geschäfte
+    description: |
+      OTC-Swap-Handel für Preis- und Basis-Hedging.
+  BC-3090.20.30:
+    name: Rohstoffindex-Exposure-Management
+    description: |
+      Management des Exposures gegenüber Rohstoffindex-Instrumenten.
+  BC-3090.30:
+    name: Handelsrisikomanagement
+    description: |
+      Positionsrisikomanagement, Kontrahenten-Kreditrisiko und Waren-VaR für Handelsaktivitäten.
+  BC-3090.30.10:
+    name: Positionsrisikomanagement
+    description: |
+      Positions-Monitoring gegenüber genehmigten Handelsmandate und Limits.
+  BC-3090.30.20:
+    name: Mark-to-Market-Bewertung
+    description: |
+      Tägliche Mark-to-Market-Bewertung von Handelspositionen und Kurven.
+  BC-3090.30.30:
+    name: Kontrahenten-Kreditrisikomanagement
+    description: |
+      Handelsspezifische Kontrahenten-Kreditlimit-Festsetzung und Exposure-Tracking.
+  BC-3090.30.40:
+    name: Waren-VaR-Berechnung
+    description: |
+      Berechnung von Value-at-Risk und Stressszenarien für Rohstoffportfolios.
+  BC-3090.40:
+    name: Handelsbestätigung und Abwicklung
+    description: |
+      Handelserfassung, -bestätigung sowie Nachhandel-Abwicklung und -Abgleich.
+  BC-3090.40.10:
+    name: Handelserfassung
+    description: |
+      Erfassung ausgeführter Geschäfte vom Front-Office in Handelssysteme.
+  BC-3090.40.20:
+    name: Handelsbestätigung
+    description: |
+      Ausstellung und Abgleich von Handelsbestätigungen mit Kontrahenten.
+  BC-3090.40.30:
+    name: Handelsabwicklung
+    description: |
+      Bar- und physische Abwicklung von Geschäften bis zur Fälligkeit.
+  BC-3090.40.40:
+    name: Handelsabgleich
+    description: |
+      Abgleich von Geschäften gegenüber Broker-, Börsen- und Kontrahenten-Unterlagen.
+  BC-3090.50:
+    name: Handels-Compliance-Management
+    description: |
+      Sanktions-Screening, Marktverhaltsüberwachung und regulatorische
+      Berichterstattung für Energiehandelsaktivitäten.
+  BC-3090.50.10:
+    name: Sanktions-Screening
+    description: |
+      Vor- und Nachhandel-Sanktions-Screening von Kontrahenten und Frachten.
+  BC-3090.50.20:
+    name: Marktverhaltsüberwachung
+    description: |
+      Überwachung des Handelsverhaltens gegenüber Marktmissbrauchsstandards (REMIT, Dodd-Frank).
+  BC-3090.50.30:
+    name: Regulatorische Handelsberichterstattung
+    description: |
+      Meldung von Geschäften an Regulierungsbehörden nach REMIT, EMIR und Dodd-Frank.
+  BC-3090.60:
+    name: Marketing und Terminvertragsverwaltung
+    description: |
+      Management von Terminverkaufsverträgen und Abnahmeprogrammen mit Kunden.
+  BC-3090.60.10:
+    name: Terminvertrags-Verhandlung
+    description: |
+      Verhandlung von Terminverkaufsverträgen mit Raffinerien und Versorgungsunternehmen.
+  BC-3090.60.20:
+    name: Abnahmeprogramm-Management
+    description: |
+      Management monatlicher und quartalsweiser Abnahmeprogramme gegenüber Terminverträgen.
+  BC-3090.60.30:
+    name: Kunden-Allokationsmanagement
+    description: |
+      Allokation begrenzter Versorgung über Termin- und Spot-Kunden.
+  BC-3090.70:
+    name: Handelsfrachtcharterung
+    description: |
+      Reise- und Zeitcharterung sowie Liegegeldmanagement zur Unterstützung von Handelspositionen.
+  BC-3090.70.10:
+    name: Reisecharterung
+    description: |
+      Reisecharterung von Tankschiffen und Gascarriern für Handelsfrachten.
+  BC-3090.70.20:
+    name: Zeitcharterung
+    description: |
+      Zeitcharterung und Schiffspositionsoptimierung.
+  BC-3090.70.30:
+    name: Liegezeit- und Liegegeldmanagement
+    description: |
+      Berechnung und Abwicklung von Liegezeit- und Liegegeldforderungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-independence-and-conflicts-management.yaml
+++ b/catalogue/i18n/de/L1-independence-and-conflicts-management.yaml
@@ -1,0 +1,149 @@
+locale: de
+source: L1-independence-and-conflicts-management.yaml
+entries:
+  BC-4350:
+    name: Unabhängigkeit und Interessenkonflikte
+    description: |
+      Prüferunabhängigkeit, berufliche Interessenkonflikte,
+      Informationsbarikerenbetrieb, Interessendeklarationen sowie
+      Auftragsannahme- und Fortführungsfreigabe, die für
+      professionelle Dienstleistungskanzleien charakteristisch sind.
+  BC-4350.10:
+    name: Prüferunabhängigkeitsmanagement
+    description: |
+      Anwendung der Unabhängigkeitsregeln für Prüfungskanzleien
+      einschließlich verbotener Leistungen, Partnerrotation,
+      Honorarabhängigkeitsgrenzen und PIE-spezifischer Anforderungen.
+  BC-4350.10.10:
+    name: Prüfungsmandantenidentifikation
+    description: |
+      Identifikation und Pflege der Population eingeschränkter
+      Prüfungsmandanten einschließlich verbundener Unternehmen und
+      wirtschaftlicher Beziehungen.
+  BC-4350.10.20:
+    name: Vorabfreigabe verbotener Leistungen
+    description: |
+      Vorabfreigabe von Nichtprüfungsleistungen an Prüfungsmandanten
+      gegenüber Listen verbotener Leistungen.
+  BC-4350.10.30:
+    name: Prüfungspartnerrotationsmanagement
+    description: |
+      Rotationsverfolgung und -durchsetzung für Auftragspartner und
+      EQR-Partner bei Prüfungsmandanten.
+  BC-4350.10.40:
+    name: Honorarabhängigkeitsüberwachung
+    description: |
+      Überwachung von Prüfungs- und Gesamthonoraren relativ zum
+      Kanzleieinkommen zur Identifikation von
+      Honorarabhängigkeitsbedrohungen.
+  BC-4350.20:
+    name: Interessenkonfliktmanagement
+    description: |
+      Identifikation, Bewertung und Lösung von Interessenkonflikten
+      zwischen Aufträgen, zwischen Mandanten und zwischen Mandanten-
+      und Kanzleiinteressen.
+  BC-4350.20.10:
+    name: Konfliktrecherche und -identifikation
+    description: |
+      Recherche in Mandanten- und Mandatsunterlagen zur Identifikation
+      potenzieller Konflikte bei potenziellen Aufträgen.
+  BC-4350.20.20:
+    name: Konfliktbewertung und -kategorisierung
+    description: |
+      Bewertung identifizierter Konflikte gegenüber Kanzleirichtlinien
+      und Berufsregeln zur Bestimmung der Konfliktkategorie und
+      -behandlung.
+  BC-4350.20.30:
+    name: Konfliktlösung und Verzichtsmanagement
+    description: |
+      Lösung von Konflikten einschließlich Einholung von informierter
+      Zustimmung, Verzichten und Auftragsablehnung nach Bedarf.
+  BC-4350.30:
+    name: Informationsbarrierenmanagement
+    description: |
+      Konzeption, Einführung und Betrieb von ethischen Schranken,
+      Informationsbarrieren und Screening-Vereinbarungen für sensible
+      Aufträge.
+  BC-4350.30.10:
+    name: Informationsbarrierendesign
+    description: |
+      Definition des Barrierenumfangs, der gesperrten Mitarbeiter und
+      der physischen oder systemseitigen Kontrollen für einen Auftrag.
+  BC-4350.30.20:
+    name: Informationsbarriereneinsatz
+    description: |
+      Operativer Einsatz von Zugangsbeschränkungen in Dokumenten-,
+      E-Mail- und Praxissystemen.
+  BC-4350.30.30:
+    name: Barrierenbruchentdeckung und -reaktion
+    description: |
+      Entdeckung und Reaktion auf potenzielle oder tatsächliche
+      Barrierenverletzungen einschließlich Eskalation und Behebung.
+  BC-4350.40:
+    name: Persönliche Interessen- und Beziehungsmanagement
+    description: |
+      Erfassung, Deklaration und Überwachung persönlicher finanzieller
+      Interessen, Familienbeziehungen und früherer Beschäftigungen, die
+      die Unabhängigkeit gefährden oder Konflikte verursachen können.
+  BC-4350.40.10:
+    name: Persönliche Investitionsdeklaration
+    description: |
+      Erfassung und Pflege von Partner- und Mitarbeitererklärungen
+      persönlicher Investitionen gegenüber der Liste eingeschränkter
+      Unternehmen.
+  BC-4350.40.20:
+    name: Familien- und Nahbeziehungsdeklaration
+    description: |
+      Erfassung von Erklärungen über enge Familienmitglieder und
+      andere enge Verbindungen, die für die Unabhängigkeit relevant
+      sind.
+  BC-4350.40.30:
+    name: Frühere Beschäftigung und Abkühlungszeit-Verfolgung
+    description: |
+      Verfolgung früherer Beschäftigung bei Prüfungsmandanten und
+      Abkühlungszeiten vor Auftragseinbindung.
+  BC-4350.50:
+    name: Auftragsannahmefreigabe
+    description: |
+      Workflow, der Unabhängigkeits-, Konflikt- und Integritätsfreigaben
+      zu einem einzigen Entscheidungsinput für die Auftragsannahme
+      kombiniert.
+  BC-4350.50.10:
+    name: Freigabe-Workflow-Koordination
+    description: |
+      Orchestrierung der vor der Auftragsannahme erforderlichen
+      Unabhängigkeits-, Konflikt- und AML-Freigaben.
+  BC-4350.50.20:
+    name: Freigabeentscheidungserfassung
+    description: |
+      Erfassung von Freigabeentscheidungen, -bedingungen und
+      -begründungen auf der Auftragsakte.
+  BC-4350.50.30:
+    name: Fortführungs-Neufreigabemanagement
+    description: |
+      Periodische Neufreigabe von Unabhängigkeit und Konflikten bei
+      laufenden Aufträgen und wiederkehrenden Prüfungsbeziehungen.
+  BC-4350.60:
+    name: Unabhängigkeits- und Konfliktüberwachung
+    description: |
+      Laufende Überwachung der Unabhängigkeits- und Konfliktsituation
+      während der Auftragsdurchführung und über das Auftragsportfolio
+      hinweg.
+  BC-4350.60.10:
+    name: Neue-Leistung-an-Prüfungsmandant-Überwachung
+    description: |
+      Überwachung neuer Leistungsvorschläge an bestehende
+      Prüfungsmandanten auf Exposition durch verbotene Leistungen.
+  BC-4350.60.20:
+    name: Eingeschränkte-Einheiten-Liste-Pflege
+    description: |
+      Pflege und Verteilung der Liste eingeschränkter Einheiten und
+      zugehöriger Hinweise an Fachkräfte.
+  BC-4350.60.30:
+    name: Unabhängigkeitsverletzungsuntersuchung
+    description: |
+      Untersuchung und Meldung vermuteter oder tatsächlicher
+      Unabhängigkeitsverletzungen und Abhilfemaßnahmen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-information-data-management.yaml
+++ b/catalogue/i18n/de/L1-information-data-management.yaml
@@ -1,0 +1,142 @@
+locale: de
+source: L1-information-data-management.yaml
+entries:
+  BC-610:
+    name: Informations- und Datenmanagement
+    description: |
+      Daten-Governance, Stammdaten, Datenqualität, Analytik und KI.
+  BC-610.10:
+    name: Daten-Governance-Management
+    description: |
+      Dateneigentümerschaft, Data Stewardship, Richtlinien und Standards.
+  BC-610.10.10:
+    name: Dateneigentümerschaft und Data Stewardship
+    description: |
+      Zuweisung und Ausführung von Dateneigentümer- und Data-Steward-Rollen.
+  BC-610.10.20:
+    name: Datenrichtlinien und -standards
+    description: |
+      Definition von Datenrichtlinien, Standards und Referenzrahmen.
+  BC-610.10.30:
+    name: Datenkatalogisierung und Datenherkunft
+    description: |
+      Datenkatalog, Glossar und End-to-End-Datenherkunft.
+  BC-610.10.40:
+    name: Datenschutz und Datenklassifizierung
+    description: |
+      Klassifizierung von Daten und Durchsetzung von Datenschutzkontrollen.
+  BC-610.10.50:
+    name: Datenrisiko- und Compliance-Monitoring
+    description: |
+      Monitoring von Datenrisiken und regulatorischer Compliance (z. B. BCBS 239, DSGVO).
+  BC-610.20:
+    name: Stammdatenmanagement
+    description: |
+      MDM für Kunden-, Produkt-, Lieferanten-, Mitarbeiterdaten usw.
+  BC-610.20.10:
+    name: Kundenstammdaten
+    description: |
+      Mastering und Steuerung von Kundenstammdaten.
+  BC-610.20.20:
+    name: Produktstammdaten
+    description: |
+      Mastering und Steuerung von Produkt- und Materialstammdaten.
+  BC-610.20.30:
+    name: Lieferantenstammdaten
+    description: |
+      Mastering und Steuerung von Lieferantenstammdaten.
+  BC-610.20.40:
+    name: Mitarbeiterstammdaten
+    description: |
+      Mastering und Steuerung von Mitarbeiterstammdaten.
+  BC-610.20.50:
+    name: Referenzdatenmanagement
+    description: |
+      Referenzdatensätze, Codelisten und Hierarchien.
+  BC-610.30:
+    name: Datenqualitätsmanagement
+    description: |
+      Datenqualitätsmonitoring, -profiling und -behebung.
+  BC-610.30.10:
+    name: Datenqualitätsprofiling
+    description: |
+      Profiling, Basiswertermittlung und Bewertung der Datenqualität.
+  BC-610.30.20:
+    name: Datenqualitätsregeln-Management
+    description: |
+      Definition, Bereitstellung und Monitoring von Datenqualitätsregeln.
+  BC-610.30.30:
+    name: Datenqualitätsproblem-Lösung
+    description: |
+      Triage, Behebung und Ursachenanalyse von Datenqualitätsproblemen.
+  BC-610.30.40:
+    name: Datenqualitätsberichterstattung
+    description: |
+      DQ-Scorecards und Berichterstattung an Dateneigentümer und Führungskräfte.
+  BC-610.40:
+    name: Datenarchitekturmanagement
+    description: |
+      Logische und physische Datenarchitektur.
+  BC-610.40.10:
+    name: Konzeptionelle und logische Datenmodellierung
+    description: |
+      Unternehmensweite konzeptionelle und logische Datenmodelle.
+  BC-610.40.20:
+    name: Datenplattform-Architektur
+    description: |
+      Architektur von Data Lakes, Data Warehouses, Lakehouse und Data Mesh.
+  BC-610.40.30:
+    name: Datenintegrationsarchitektur
+    description: |
+      Muster für Batch-, Streaming- und CDC-Datenintegration.
+  BC-610.40.40:
+    name: Datenspeicherungs- und Aufbewahrungsdesign
+    description: |
+      Speicherdesign einschließlich Aufbewahrung, Archivierung und Tiering.
+  BC-610.50:
+    name: Analytik- und BI-Management
+    description: |
+      Berichterstattung, Analytik und Business-Intelligence-Lieferung.
+  BC-610.50.10:
+    name: Berichts- und Dashboard-Lieferung
+    description: |
+      Lieferung operativer und Management-Berichte und Dashboards.
+  BC-610.50.20:
+    name: Self-Service-Analytik
+    description: |
+      Befähigung zur Self-Service-Analytik und zu Datenprodukten im Unternehmen.
+  BC-610.50.30:
+    name: Erweiterte Analytik und Data Science
+    description: |
+      Erweiterte Analytik, Data-Science-Modelle und Experimente.
+  BC-610.50.40:
+    name: Analyseplattform-Betrieb
+    description: |
+      Betrieb von BI- und Analyseplattformen und Inhaltsbibliotheken.
+  BC-610.60:
+    name: Künstliche-Intelligenz-Management
+    description: |
+      KI/ML-Modell-Lebenszyklus, MLOps und verantwortungsvolle KI.
+  BC-610.60.10:
+    name: KI-Anwendungsfallidentifikation
+    description: |
+      Identifikation und Priorisierung von KI/ML-Anwendungsfällen.
+  BC-610.60.20:
+    name: ML-Modellentwicklung
+    description: |
+      Feature Engineering, Training und Validierung von ML-Modellen.
+  BC-610.60.30:
+    name: MLOps und Modellbereitstellung
+    description: |
+      Modellbereitstellung, Monitoring und Lebenszyklusmanagement (MLOps).
+  BC-610.60.40:
+    name: Verantwortungsvolle-KI-Steuerung
+    description: |
+      Grundsätze verantwortungsvoller KI, Risikobewertung und Bias-Monitoring.
+  BC-610.60.50:
+    name: Generative-KI-Management
+    description: |
+      Generative KI-Anwendungsfälle, Basismodellauswahl und Leitplanken.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-information-technology-management.yaml
+++ b/catalogue/i18n/de/L1-information-technology-management.yaml
@@ -1,0 +1,194 @@
+locale: de
+source: L1-information-technology-management.yaml
+entries:
+  BC-600:
+    name: Informationstechnologiemanagement
+    description: |
+      IT-Strategie, Architektur, Dienste und Betrieb.
+  BC-600.10:
+    name: IT-Strategie- und Architekturmanagement
+    description: |
+      IT-Strategie, Unternehmensarchitektur und Technologiestandards.
+  BC-600.10.10:
+    name: IT-Strategieentwicklung
+    description: |
+      Definition der IT-Strategie im Einklang mit der Unternehmensstrategie.
+  BC-600.10.20:
+    name: Unternehmensarchitekturmanagement
+    description: |
+      TOGAF-konforme Unternehmensarchitektur für Geschäft, Daten, Anwendung und Technologie.
+  BC-600.10.30:
+    name: Technologiestandardsmanagement
+    description: |
+      Definition und Steuerung von Technologiestandards und -mustern.
+  BC-600.10.40:
+    name: Technologie-Roadmap-Management
+    description: |
+      Mehrjährige Technologie-Roadmaps und Fähigkeitsentwicklung.
+  BC-600.10.50:
+    name: Architektursteuerung und -überprüfung
+    description: |
+      Architekturüberprüfungsgremium, Design Authority und Ausnahmeverwaltung.
+  BC-600.20:
+    name: IT-Portfolio- und Bedarfsmanagement
+    description: |
+      IT-Portfolio, Bedarfsaufnahme und Priorisierung.
+  BC-600.20.10:
+    name: IT-Bedarfsaufnahme
+    description: |
+      Erfassung und Triage neuer IT-Bedarfe aus dem Unternehmen.
+  BC-600.20.20:
+    name: IT-Investitionsportfoliomanagement
+    description: |
+      Portfolioübersicht von IT-Investitionen, Projekten und Nutzen.
+  BC-600.20.30:
+    name: IT-Kapazitäts- und Ressourcenplanung
+    description: |
+      IT-Lieferkapazitätsplanung über Teams und Kompetenzen.
+  BC-600.20.40:
+    name: Business-Relationship-Management
+    description: |
+      Business-Partnerschaft zwischen IT und Unternehmensfunktionen.
+  BC-600.30:
+    name: IT-Servicemanagement
+    description: |
+      Incident, Problem, Change, Servicekatalog und ITSM.
+  BC-600.30.10:
+    name: Servicekatalogmanagement
+    description: |
+      Definition und Pflege des Servicekatalogs und der SLAs.
+  BC-600.30.20:
+    name: Incident-Management
+    description: |
+      Incident-Erkennung, Triage, Lösung und Kommunikation.
+  BC-600.30.30:
+    name: Problem-Management
+    description: |
+      Ursachenanalyse und Prävention wiederkehrender Incidents.
+  BC-600.30.40:
+    name: Change- und Release-Management
+    description: |
+      IT-Änderungsgenehmigung und Release-Management.
+  BC-600.30.50:
+    name: Servicelevel-Management
+    description: |
+      Definition, Messung und Berichterstattung von Servicelevels.
+  BC-600.30.60:
+    name: Konfigurationsmanagement
+    description: |
+      Konfigurationselemente, CMDB und Abhängigkeitsverwaltung.
+  BC-600.40:
+    name: IT-Operationsmanagement
+    description: |
+      Täglicher IT-Betrieb, Monitoring und Automatisierung.
+  BC-600.40.10:
+    name: Ereignis- und Monitoring-Management
+    description: |
+      Telemetrie, Observability, Ereigniskorrelation und Alarmierung.
+  BC-600.40.20:
+    name: IT-Job-Scheduling und Batch-Betrieb
+    description: |
+      Job-Scheduling, Batch-Orchestrierung und Workload-Automatisierung.
+  BC-600.40.30:
+    name: IT-Kapazitäts- und Performance-Management
+    description: |
+      Kapazitätsplanung und Leistungsoptimierung über Dienste.
+  BC-600.40.40:
+    name: IT-Dienstkontinuitätsbetrieb
+    description: |
+      IT-Dienstkontinuitätstests und Wiederherstellungsbetrieb.
+  BC-600.40.50:
+    name: IT-Automatisierungsmanagement
+    description: |
+      Automatisierung, Runbooks und Orchestrierung für den IT-Betrieb.
+  BC-600.50:
+    name: IT-Infrastrukturmanagement
+    description: |
+      Rechenleistung, Speicher, Netzwerk und Cloud-Infrastruktur.
+  BC-600.50.10:
+    name: Rechen- und Servermanagement
+    description: |
+      Bereitstellung und Betrieb physischer und virtueller Rechenressourcen.
+  BC-600.50.20:
+    name: Speichermanagement
+    description: |
+      Speicherbereitstellung, -tiering und -schutz.
+  BC-600.50.30:
+    name: Netzwerkmanagement
+    description: |
+      LAN, WAN, SD-WAN und Netzwerkdienstmanagement.
+  BC-600.50.40:
+    name: Cloud-Plattform-Management
+    description: |
+      Betrieb öffentlicher, privater und hybrider Cloud-Plattformen.
+  BC-600.50.50:
+    name: Endbenutzer-Computing-Management
+    description: |
+      Arbeitsplatzgeräte, Endpunkt-Management und Kollaborationswerkzeuge.
+  BC-600.60:
+    name: IT-Anwendungsmanagement
+    description: |
+      Anwendungslebenszyklus, Rationalisierung und AMS.
+  BC-600.60.10:
+    name: Anwendungsportfoliomanagement
+    description: |
+      Anwendungskatalog, Eigentümerschaft und Lebenszyklusstatus.
+  BC-600.60.20:
+    name: Anwendungsentwicklung und -engineering
+    description: |
+      Softwareentwicklung, Engineering-Praktiken und DevOps.
+  BC-600.60.30:
+    name: Anwendungswartung und -support
+    description: |
+      AMS, Fehlerbehebung und Lieferung geringfügiger Erweiterungen.
+  BC-600.60.40:
+    name: Anwendungsrationalisierung
+    description: |
+      Rationalisierung, Konsolidierung und Außerbetriebnahme von Anwendungen.
+  BC-600.60.50:
+    name: Integrations- und API-Management
+    description: |
+      Integrationsplattformen, APIs und Event-Streaming.
+  BC-600.70:
+    name: IT-Lieferantenmanagement
+    description: |
+      IT-Lieferantenverträge, -leistung und -ökosystem.
+  BC-600.70.10:
+    name: IT-Lieferanteneinführung
+    description: |
+      Einführung und Vertragsabschluss mit IT-Lieferanten und -Partnern.
+  BC-600.70.20:
+    name: IT-Lieferantenleistungsmanagement
+    description: |
+      Leistungsscorecards und SLA-Management für IT-Lieferanten.
+  BC-600.70.30:
+    name: Softwarelizenzmanagement
+    description: |
+      Softwarelizenzierung, -berechtigungen und Auditmanagement.
+  BC-600.70.40:
+    name: IT-Sourcing-Strategie
+    description: |
+      Make-or-Buy- und Managed-Service-Sourcing-Strategie für IT.
+  BC-600.80:
+    name: IT-Finanzmanagement
+    description: |
+      IT-Ausgaben, Chargeback/Showback und IT-Kostenoptimierung.
+  BC-600.80.10:
+    name: IT-Budgetierung und -Prognose
+    description: |
+      IT-Budgetplanung, -Prognose und Abweichungsanalyse.
+  BC-600.80.20:
+    name: IT-Kostenzuordnung und Chargeback
+    description: |
+      Showback, Chargeback und TBM-basierte Kostenzuordnung.
+  BC-600.80.30:
+    name: Cloud-FinOps-Management
+    description: |
+      FinOps-Praktiken für Cloud-Kostentransparenz und -optimierung.
+  BC-600.80.40:
+    name: IT-Wert- und Nutzenverfolgung
+    description: |
+      Nachverfolgung des IT-Investitionswerts und der Nutzenrealisierung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-innovation-management.yaml
+++ b/catalogue/i18n/de/L1-innovation-management.yaml
@@ -1,0 +1,106 @@
+locale: de
+source: L1-innovation-management.yaml
+entries:
+  BC-800:
+    name: Innovationsmanagement
+    description: |
+      Ideengenerierung, Inkubation, Innovationsportfolio und Ventures.
+  BC-800.10:
+    name: Ideen- und Chancenmanagement
+    description: |
+      Ideenerfassung, Screening und Chancenbewertung.
+  BC-800.10.10:
+    name: Ideenerfassung und -einreichung
+    description: |
+      Crowd-, Mitarbeiter- und partnerbasierte Ideenerfassungskanäle.
+  BC-800.10.20:
+    name: Ideenscreening und -bewertung
+    description: |
+      Screening, Bewertung und Shortlisting von Ideen.
+  BC-800.10.30:
+    name: Chancenrahmung
+    description: |
+      Ausformulierung von Geschäftschancen, Problemstellungen und Wertfällen.
+  BC-800.20:
+    name: Innovationsportfoliomanagement
+    description: |
+      Innovationsportfolio über Zeithorizonte (H1/H2/H3).
+  BC-800.20.10:
+    name: Innovationspipeline-Management
+    description: |
+      Pipeline von Innovationsinitiativen über Entwicklungsstufen.
+  BC-800.20.20:
+    name: Drei-Horizont-Portfolio-Ausbalancierung
+    description: |
+      Portfolioausbalancierung über H1-, H2- und H3-Horizonte.
+  BC-800.20.30:
+    name: Stage-Gate-Steuerung
+    description: |
+      Stage-Gate-Überprüfung und Entscheidungssteuerung für Innovationen.
+  BC-800.20.40:
+    name: Innovationsfinanzierungsmanagement
+    description: |
+      Finanzierungsallokation über Innovationsinitiativen.
+  BC-800.30:
+    name: Innovationsinkubation und -beschleunigung
+    description: |
+      Inkubatoren, Acceleratoren und internes Corporate Venturing.
+  BC-800.30.10:
+    name: Innovationsinkubatorbetrieb
+    description: |
+      Betrieb von Unternehmensinkubatoren und Innovationslabs.
+  BC-800.30.20:
+    name: Internes Corporate Venturing
+    description: |
+      Spin-outs und interne Unternehmensgründungen.
+  BC-800.30.30:
+    name: Minimum-Viable-Product-Entwicklung
+    description: |
+      MVP-Entwicklung, Kundenvalidierung und Iteration.
+  BC-800.30.40:
+    name: Innovationsskalierung
+    description: |
+      Überführung validierter Innovationen in skalierte Angebote.
+  BC-800.40:
+    name: Corporate-Venturing-Management
+    description: |
+      Corporate-VC-Investitionen und Startup-Partnerschaften.
+  BC-800.40.10:
+    name: Startup-Sourcing und -Scouting
+    description: |
+      Identifikation von Startups im Einklang mit strategischen Themen.
+  BC-800.40.20:
+    name: Corporate-Venture-Investition
+    description: |
+      Direkte Eigenkapitalinvestitionen und CVC-Fondsbetrieb.
+  BC-800.40.30:
+    name: Startup-Partnerschaftsmanagement
+    description: |
+      Kommerzielle Partnerschaften und Pilotprojekte mit Startups.
+  BC-800.40.40:
+    name: Venture-Portfolio-Management
+    description: |
+      Performance-Monitoring des Venture-Portfolio-Investments.
+  BC-800.50:
+    name: Open-Innovation-Management
+    description: |
+      Externe Innovationsnetzwerke, Crowdsourcing und akademische Partnerschaften.
+  BC-800.50.10:
+    name: Akademische und Forschungspartnerschaften
+    description: |
+      Partnerschaften mit Universitäten und Forschungseinrichtungen.
+  BC-800.50.20:
+    name: Innovationsherausforderungen und Crowdsourcing
+    description: |
+      Externe Innovationsherausforderungen, Hackathons und Crowdsourcing.
+  BC-800.50.30:
+    name: Innovationsökosystem-Engagement
+    description: |
+      Engagement mit Innovationshubs, Acceleratoren und Ökosystemen.
+  BC-800.50.40:
+    name: Externe Technologiebeschaffung
+    description: |
+      In-Licensing und Erwerb externer Technologien.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-institutional-advancement-alumni-management.yaml
+++ b/catalogue/i18n/de/L1-institutional-advancement-alumni-management.yaml
@@ -1,0 +1,153 @@
+locale: de
+source: L1-institutional-advancement-alumni-management.yaml
+entries:
+  BC-4800:
+    name: Hochschulförderung und Alumni-Management
+    description: |
+      Engagement mit Alumni-Gemeinschaften, Pflege von Spendern und Management
+      von Fundraising-Kampagnen, Spenden, Verwaltung und Endowment-bezogener
+      Spendenberichterstattung.
+  BC-4800.10:
+    name: Alumni-Engagement
+    description: |
+      Engagement von Alumni-Gemeinschaften durch Programme, Veranstaltungen und
+      Kommunikation, die lebenslange Beziehungen zur Institution pflegen.
+    in_scope:
+      - Alumni-Gemeinschaftsbetrieb
+      - Alumni-Veranstaltungen und Klassentreffen
+      - Alumni-Kommunikation
+    out_of_scope:
+      - Karrieredienste für aktuelle Studierende (abgedeckt unter Studierendenbetreuung & Wohlbefindenmanagement)
+  BC-4800.10.10:
+    name: Alumni-Gemeinschaftsbetrieb
+    description: |
+      Betrieb von Alumni-Verbänden, regionalen Gruppen und Online-Gemeinschaften.
+  BC-4800.10.20:
+    name: Alumni-Veranstaltungen und Klassentreffen
+    description: |
+      Planung und Durchführung von Alumni-Veranstaltungen und Klassentreffen.
+  BC-4800.10.30:
+    name: Alumni-Kommunikation
+    description: |
+      Redaktionelle und kommunikative Kanäle für Alumni-Zielgruppen.
+  BC-4800.20:
+    name: Spenderbeziehungsmanagement
+    description: |
+      Identifizierung, Pflege und Beziehungsmanagement potenzieller und
+      bestehender Spender.
+    in_scope:
+      - Spenderrecherche und -identifizierung
+      - Spenderpflege und -anfrage
+      - Großspender-Beziehungsmanagement
+    out_of_scope:
+      - Allgemeiner CRM-Betrieb (abgedeckt unter branchenübergreifendem Kundenbeziehungsmanagement)
+  BC-4800.20.10:
+    name: Spenderrecherche und -identifizierung
+    description: |
+      Recherche und Identifizierung von Spenderpotenzial.
+  BC-4800.20.20:
+    name: Spenderpflege und -anfrage
+    description: |
+      Pflege und Anfrage von Spenderunterstützung.
+  BC-4800.20.30:
+    name: Großspender-Beziehungsmanagement
+    description: |
+      Maßgeschneidertes Beziehungsmanagement für Großspender.
+  BC-4800.30:
+    name: Fundraising-Kampagnenmanagement
+    description: |
+      Planung und Betrieb von Fundraising-Kampagnen über jährliche Spenden-,
+      Kapital- und digitale Kanäle.
+    in_scope:
+      - Jährliche Spendenkampagnen
+      - Kapital-Kampagnenmanagement
+      - Crowdfunding- und Peer-to-Peer-Kampagnen
+    out_of_scope:
+      - Marketingkampagnen ohne Fundraising-Bezug (abgedeckt unter branchenübergreifendem Marketingmanagement)
+  BC-4800.30.10:
+    name: Jährliche Spendenkampagnen
+    description: |
+      Betrieb von jährlichen Spenden- und Dauerspendenkampagnen.
+  BC-4800.30.20:
+    name: Kapital-Kampagnenmanagement
+    description: |
+      Management von mehrjährigen Kapital-Kampagnen.
+  BC-4800.30.30:
+    name: Crowdfunding- und Peer-to-Peer-Kampagnen
+    description: |
+      Betrieb von Crowdfunding- und Peer-to-Peer-Fundraising-Kampagnen.
+  BC-4800.40:
+    name: Spenden- und Zusageverwaltung
+    description: |
+      Empfang, Erfassung und Verwaltung von Spenden und Zusagen einschließlich
+      geplanter Schenkungsinstrumente.
+    in_scope:
+      - Spendenempfang und -verarbeitung
+      - Zusagennachverfolgung
+      - Geplante und aufgeschobene Spendenverwaltung
+    out_of_scope:
+      - Allgemeine Forderungsbuchhaltung (abgedeckt unter branchenübergreifendem Finanzmanagement)
+  BC-4800.40.10:
+    name: Spendenempfang und -verarbeitung
+    description: |
+      Empfang und Verarbeitung von Bar-, Scheck-, Online- und Sachspenden.
+  BC-4800.40.20:
+    name: Zusagennachverfolgung
+    description: |
+      Nachverfolgung von Spendenzusagen und Zahlungsplänen.
+  BC-4800.40.30:
+    name: Geplante und aufgeschobene Spendenverwaltung
+    description: |
+      Verwaltung von Erbschaften, gemeinnützigen Trusts und anderen
+      geplanten Schenkungsinstrumenten.
+  BC-4800.50:
+    name: Spenderverwaltung und Anerkennung
+    description: |
+      Pflege von Spenderbeziehungen durch Dankbarkeitsbekundung, Anerkennung
+      und laufendes Engagement von Spendern benannter Fonds.
+    in_scope:
+      - Spenderdankbarkeitsbekundung
+      - Spenderanerkennungsprogramme
+      - Stiftungsfonds-Verwaltung
+    out_of_scope:
+      - Öffentlichkeitsarbeit (abgedeckt unter branchenübergreifendem Unternehmenskommunikationsmanagement)
+  BC-4800.50.10:
+    name: Spenderdankbarkeitsbekundung
+    description: |
+      Dankbarkeitsbekundung für Spenden und Zusagen.
+  BC-4800.50.20:
+    name: Spenderanerkennungsprogramme
+    description: |
+      Betrieb von Spenderanerkennungsprogrammen und -gesellschaften.
+  BC-4800.50.30:
+    name: Stiftungsfonds-Verwaltung
+    description: |
+      Verwaltung von Spendern von Stiftungs- und benannten Fonds.
+  BC-4800.60:
+    name: Endowment-bezogene Spendenberichterstattung
+    description: |
+      Berichterstattung an Spender über Verwendung, Leistung und Wirkung
+      von zweckgebundenen und Stiftungsfonds.
+    in_scope:
+      - Berichterstattung über zweckgebundene Fondsmittelverwendung
+      - Leistungsberichterstattung für benannte Stiftungsfonds
+      - Spenderwirkungsberichterstattung
+    out_of_scope:
+      - Institutionelles Finanzberichtswesen (abgedeckt unter branchenübergreifendem Finanzmanagement)
+      - Endowment-Investitionsmanagement selbst (abgedeckt unter branchenübergreifendem Treasury-Management)
+  BC-4800.60.10:
+    name: Berichterstattung über zweckgebundene Fondsmittelverwendung
+    description: |
+      Berichterstattung über die Verwendung zweckgebundener und
+      spendergewidmeter Fonds.
+  BC-4800.60.20:
+    name: Leistungsberichterstattung für benannte Stiftungsfonds
+    description: |
+      Leistungsberichterstattung für benannte Stiftungsfonds an ihre Spender.
+  BC-4800.60.30:
+    name: Spenderwirkungsberichterstattung
+    description: |
+      Berichterstattung spenderorientierter Wirkungsdarstellungen und -ergebnisse.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-insurance-claims-management.yaml
+++ b/catalogue/i18n/de/L1-insurance-claims-management.yaml
@@ -1,0 +1,168 @@
+locale: de
+source: L1-insurance-claims-management.yaml
+entries:
+  BC-2160:
+    name: Schadensmanagement (Versicherung)
+    description: |
+      Erstmeldung des Schadens, Triage, Untersuchung, Rückstellung, Regulierung,
+      Vergleich, Regress und Subrogation, Rechtsstreit, Betrug/SIU und
+      Katastrophenschadensreaktion über alle Versicherungssparten.
+  BC-2160.10:
+    name: Schadenerstmeldungs-Management
+    description: |
+      Multichannel-FNOL-Aufnahme, Deckungsverifizierung, Registrierung und Bestätigung.
+  BC-2160.10.10:
+    name: FNOL-Multichannel-Aufnahme
+    description: |
+      Aufnahme der Schadenerstmeldung über Telefon, Digital-, Makler- und IoT-Kanäle.
+  BC-2160.10.20:
+    name: Erstmalige Deckungsverifizierung
+    description: |
+      Verifizierung, dass der Schaden im Deckungsumfang am Schadendatum liegt.
+  BC-2160.10.30:
+    name: Schadenregistrierung
+    description: |
+      Registrierung neuer Schäden und Zuweisung von Schadenkennnummern.
+  BC-2160.10.40:
+    name: Bestätigung und Kommunikation
+    description: |
+      Erstbestätigung an den Anspruchsteller und laufende Schadenstatus-Kommunikation.
+  BC-2160.20:
+    name: Schadens-Triage & Segmentierung
+    description: |
+      Schwerebewertung, Direktabwicklung-Weiterleitung, Schadensachbearbeiter-Zuweisung und Spezialisten-Weiterleitung.
+  BC-2160.20.10:
+    name: Schwere- und Komplexitäts-Bewertung
+    description: |
+      Bewertung von Schadenschwere und -komplexität für Weiterleitungsentscheidungen.
+  BC-2160.20.20:
+    name: Direktabwicklungs-Weiterleitung
+    description: |
+      Weiterleitung geringfügiger Schäden durch Direktabwicklung.
+  BC-2160.20.30:
+    name: Schadensachbearbeiter-Zuweisung
+    description: |
+      Zuweisung von Schäden an Sachbearbeiter nach Fachkenntnis, Kapazität und Region.
+  BC-2160.20.40:
+    name: Spezialisten- und Rechtsstreit-Weiterleitung
+    description: |
+      Weiterleitung komplexer, spezialistischer und bestrittener Schäden an dedizierte Teams.
+  BC-2160.30:
+    name: Schadens-Untersuchung & Regulierung
+    description: |
+      Vor-Ort- und Schreibtisch-Regulierung, Schadensabschätzung, Haftungsfeststellung und Fachberatung.
+  BC-2160.30.10:
+    name: Vor-Ort- und Schreibtisch-Regulierung
+    description: |
+      Vor-Ort- und Schreibtisch-Regulierung von Schäden, einschließlich Standortinspektionen.
+  BC-2160.30.20:
+    name: Schadens- und Verlust-Abschätzung
+    description: |
+      Abschätzung von Schäden, Schadenhöhe und Reparatur-/Ersatzumfang.
+  BC-2160.30.30:
+    name: Haftungs-Feststellung
+    description: |
+      Feststellung der Haftung und Policenreaktion bei Drittpartei-Schäden.
+  BC-2160.30.40:
+    name: Fachexperten-Beratung
+    description: |
+      Beratung durch Gutachter, Ingenieure, medizinische Experten und Forensic Accountants.
+  BC-2160.40:
+    name: Schadens-Rückstellungs-Management
+    description: |
+      Erstmalige Fallrückstellungs-Festsetzung, Neuschätzung und IBNR-Koordination.
+  BC-2160.40.10:
+    name: Erstmalige Fallrückstellungs-Festsetzung
+    description: |
+      Festsetzung erstmaliger Fallrückstellungen bei registrierten Schäden.
+  BC-2160.40.20:
+    name: Rückstellungs-Neuschätzung
+    description: |
+      Periodische Neuschätzung von Fallrückstellungen bei neuen Informationen.
+  BC-2160.40.30:
+    name: IBNR-Koordination mit Versicherungsmathematik
+    description: |
+      Koordination mit Versicherungsmathematik zu IBNR-Rückstellungen auf Portfolio-Ebene.
+  BC-2160.50:
+    name: Schadens-Vergleich & Zahlung
+    description: |
+      Vergleichsverhandlung, Entschädigungs- und Kostenzahlungen, Bergung sowie Regress und Subrogation.
+  BC-2160.50.10:
+    name: Vergleichs-Verhandlung
+    description: |
+      Verhandlung von Vergleichsbeträgen mit Anspruchstellern und Dritten.
+  BC-2160.50.20:
+    name: Entschädigungs-Zahlungsausgabe
+    description: |
+      Ausgabe von Entschädigungszahlungen an Versicherte und Dritte.
+  BC-2160.50.30:
+    name: Kosten-Zahlungsausgabe
+    description: |
+      Ausgabe von zugewiesenen und nicht-zugewiesenen Schadensregulierungskosten-Zahlungen.
+  BC-2160.50.40:
+    name: Bergungs-Verfügung
+    description: |
+      Verfügung und Rückgewinnung von Bergung aus regulierten Schäden.
+  BC-2160.50.50:
+    name: Regress und Subrogation
+    description: |
+      Regress und Subrogation gegen Dritte und andere Versicherer.
+  BC-2160.60:
+    name: Schadens-Rechtsstreit-Management
+    description: |
+      Rechtsstreitstrategie, Verteidigungsanwalts-Koordination und Rechtsstreitkosten-Tracking.
+  BC-2160.60.10:
+    name: Rechtsstreit-Strategie
+    description: |
+      Strategiefestlegung bei bestrittenen Schäden und Vergleichs- vs. Gerichtsentscheidungen.
+  BC-2160.60.20:
+    name: Verteidigungsanwalts-Koordination
+    description: |
+      Koordination von Kanzlei- und beauftragten Verteidigungsanwälten.
+  BC-2160.60.30:
+    name: Rechtsstreitkosten-Tracking
+    description: |
+      Verfolgung von Rechtsstreitkosten gegen Kanzleisätze und Budgets.
+  BC-2160.70:
+    name: Schadensbetrug- & SIU-Management
+    description: |
+      Verdächtige Schadens-Erkennung, SIU-Untersuchung, Betrugsweiterleitung und Antibetruganalytik.
+  BC-2160.70.10:
+    name: Verdächtiger Schadens-Erkennung
+    description: |
+      Erkennung verdächtiger Schäden mittels Regeln, Modellen und Rotflaggen-Indikatoren.
+  BC-2160.70.20:
+    name: SIU-Untersuchung
+    description: |
+      Sonderermittlungseinheit-Fallarbeit bei vermuteten Betrugsfällen.
+  BC-2160.70.30:
+    name: Betrugsweiterleitungs und -Strafverfolgung
+    description: |
+      Weiterleitung von Betrugsfällen an Strafverfolgungsbehörden und Branchenregister.
+  BC-2160.70.40:
+    name: Antibetrug-Analytik
+    description: |
+      Antibetrug-Analytik auf Schadenportfolios und Netzwerkanalyse.
+  BC-2160.80:
+    name: Katastrophenschadens-Management
+    description: |
+      CAT-Ereignis-Aktivierung, Kapazitätserweiterung, CAT-Schadens-Tracking und CAT-Recovery-Koordination.
+  BC-2160.80.10:
+    name: CAT-Ereignis-Aktivierung
+    description: |
+      Aktivierung von Katastrophenreaktionsverfahren bei deklarierten Ereignissen.
+  BC-2160.80.20:
+    name: Kapazitätserweiterungs-Mobilisierung
+    description: |
+      Mobilisierung von Surge-Regulierern, Auftragnehmern und Call-Center-Kapazität.
+  BC-2160.80.30:
+    name: CAT-Schadens-Triage und -Tracking
+    description: |
+      Triage und Tracking von CAT-kodierten Schäden bis zur Regulierung.
+  BC-2160.80.40:
+    name: CAT-Recovery-Koordination
+    description: |
+      Koordination von Rückversicherungs- und Pool-Recoveries bei CAT-Ereignissen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-insurance-customer-management.yaml
+++ b/catalogue/i18n/de/L1-insurance-customer-management.yaml
@@ -1,0 +1,111 @@
+locale: de
+source: L1-insurance-customer-management.yaml
+entries:
+  BC-2120:
+    name: Versicherungskunden-Management
+    description: |
+      Versicherungsnehmer-Identität, Haushalts- und Gruppen-Aggregation, KYC, Einwilligungen
+      und Lifecycle-Servicing von Versicherungskunden über alle Kanäle.
+  BC-2120.10:
+    name: Versicherungsnehmer-Onboarding-Management
+    description: |
+      Antragserfassung, Identitätsverifizierung, Aktivierung und Onboarding-Kommunikation.
+  BC-2120.10.10:
+    name: Antragserfassung
+    description: |
+      Erfassung neuer Versicherungsnehmer-Anträge über Kanäle.
+  BC-2120.10.20:
+    name: Identitäts- und Wirtschaftlich-Berechtigte-Verifizierung
+    description: |
+      Identitätsverifizierung und Identifizierung wirtschaftlich Berechtigter für natürliche und juristische Versicherungsnehmer.
+  BC-2120.10.30:
+    name: Versicherungsnehmer-Aktivierung
+    description: |
+      Aktivierung von Versicherungsnehmer-Datensätzen, Konten und Kanalzugängen.
+  BC-2120.10.40:
+    name: Onboarding-Kommunikation
+    description: |
+      Kommunikation des Onboarding-Status, Willkommenspakete und nächste Schritte.
+  BC-2120.20:
+    name: Versicherungs-KYC- & Sanktions-Management
+    description: |
+      Kunden-Risikoeinstufung, KYC-Dokumentation, Sanktions- und PEP-Screening und periodische Aktualisierung.
+  BC-2120.20.10:
+    name: Kunden-Risikoeinstufung
+    description: |
+      Risikoeinstufung von Versicherungskunden auf Basis von AML- und Verhaltensrisikofaktoren.
+  BC-2120.20.20:
+    name: KYC-Dokumentensammlung
+    description: |
+      Sammlung und Validierung von KYC-Dokumentation für Versicherungskunden.
+  BC-2120.20.30:
+    name: Sanktions- und PEP-Screening
+    description: |
+      Sanktions-, PEP- und Adverse-Media-Screening von Versicherungsnehmern und Begünstigten.
+  BC-2120.20.40:
+    name: Periodische KYC-Aktualisierung
+    description: |
+      Periodische Aktualisierung von KYC-Informationen und Risiko-Neueinstufung.
+  BC-2120.30:
+    name: Versicherungsnehmer-Servicing-Management
+    description: |
+      Selbst-Service-Pflege, eingehende Service-Anfragen, Dokumentenbereitstellung und Begünstigten-Pflege.
+  BC-2120.30.10:
+    name: Selbst-Service-Kontopflege
+    description: |
+      Selbst-Service-Aktualisierung von Adress-, Kontakt- und Präferenzdaten.
+  BC-2120.30.20:
+    name: Eingehende Service-Anfragen-Bearbeitung
+    description: |
+      Bearbeitung eingehender Versicherungsnehmer-Service-Anfragen über Kanäle.
+  BC-2120.30.30:
+    name: Dokument- und Kontoauszug-Bereitstellung
+    description: |
+      Bereitstellung von Policendokumenten, Kontoauszügen und Versicherungsbescheinigungen.
+  BC-2120.30.40:
+    name: Begünstigten- und Nominierter-Pflege
+    description: |
+      Erfassung und Pflege von Begünstigten und Nominierten auf Lebens- und Pensionsverträgen.
+  BC-2120.40:
+    name: Kundeninformations- & Einwilligungs-Management
+    description: |
+      Profil, Haushalts- und Gruppen-Aggregation, Einwilligungsmanagement und Golden Record.
+  BC-2120.40.10:
+    name: Versicherungsnehmer-Profil-Pflege
+    description: |
+      Pflege von Versicherungsnehmer-Profil- und demografischen Daten.
+  BC-2120.40.20:
+    name: Haushalts- und Gruppen-Aggregation
+    description: |
+      Aggregation von Versicherungsnehmern in Haushalte, Gruppen und Unternehmensgruppen.
+  BC-2120.40.30:
+    name: Marketing- und Datenweitergabe-Einwilligung
+    description: |
+      Erfassung und Durchsetzung von Marketing- und Datenweitergabe-Einwilligungen.
+  BC-2120.40.40:
+    name: Kunden-Golden-Record-Management
+    description: |
+      Pflege des Versicherungsnehmer-Golden-Records über Systeme hinweg.
+  BC-2120.50:
+    name: Kundenerlebnis- & Retentions-Management
+    description: |
+      Feedback-Erfassung, Treueprogramme, Beschwerdebearbeitung und Abwanderungs-Prognose.
+  BC-2120.50.10:
+    name: Kunden-Feedback-Erfassung
+    description: |
+      Erfassung von Kunden-Feedback, NPS- und CSAT-Signalen.
+  BC-2120.50.20:
+    name: Treue- und Retentionsprogramm-Betrieb
+    description: |
+      Betrieb von Treue-, Retentions- und betriebszeitbasierten Belohnungsprogrammen.
+  BC-2120.50.30:
+    name: Beschwerde- und Eskalations-Bearbeitung
+    description: |
+      Bearbeitung von Versicherungsnehmer-Beschwerden, Eskalationen und Ombudsmann-Fällen.
+  BC-2120.50.40:
+    name: Abwanderungs- und Lapse-Prognose
+    description: |
+      Prädiktive Analytik zu Abwanderungs- und Lapse-Risiken für Retentionsinterventionen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-insurance-distribution-management.yaml
+++ b/catalogue/i18n/de/L1-insurance-distribution-management.yaml
@@ -1,0 +1,136 @@
+locale: de
+source: L1-insurance-distribution-management.yaml
+entries:
+  BC-2110:
+    name: Versicherungsvertrieb Management
+    description: |
+      Versicherungsvertreter-, Makler-, Agenten-, MGA- und Direktkanal-Beziehungen,
+      einschließlich Zulassungen, Provisionen, Lizenzen, Delegated Authorities
+      und Angebots- und Einreichungsfluss in die Zeichnung.
+  BC-2110.10:
+    name: Vertreter- & Intermediärs-Management
+    description: |
+      Onboarding, Hierarchie, Leistungsverfolgung und Offboarding von Vertretern und Intermediären.
+  BC-2110.10.10:
+    name: Vertreter-Onboarding
+    description: |
+      Onboarding von Vertretern, Intermediären, Maklern und MGAs.
+  BC-2110.10.20:
+    name: Vertreter-Hierarchie und Kontopflege
+    description: |
+      Pflege von Vertreter-Hierarchie, Kontostrukturen und Kontaktdaten.
+  BC-2110.10.30:
+    name: Vertreter-Leistungs-Tracking
+    description: |
+      Verfolgung von Vertreterproduktion, Schadensquote und Profitabilität.
+  BC-2110.10.40:
+    name: Vertreter-Offboarding
+    description: |
+      Offboarding von Vertretern, Run-off laufender Bücher und Abschlussabrechnung.
+  BC-2110.20:
+    name: Vertreter-Lizenzierungs- & Zulassungs-Management
+    description: |
+      Lizenzverifizierung, jurisdiktionelle Zulassungen, Weiterbildung und Vertreter-Compliance.
+  BC-2110.20.10:
+    name: Lizenzverifizierung
+    description: |
+      Verifizierung von Vertreterlizenzen gegen staatliche und jurisdiktionelle Register.
+  BC-2110.20.20:
+    name: Jurisdiktions-Zulassungs-Management
+    description: |
+      Verwaltung staatlicher und jurisdiktioneller Zulassungen, Beendigungen und Erneuerungen.
+  BC-2110.20.30:
+    name: Weiterbildungs-Tracking
+    description: |
+      Verfolgung von Vertreter-Weiterbildungsgutschriften und Erneuerungseignung.
+  BC-2110.20.40:
+    name: Vertreter-Compliance-Überwachung
+    description: |
+      Überwachung von Vertreterverhalten, Beschwerden und Disziplinarmaßnahmen.
+  BC-2110.30:
+    name: Provisions- & Incentive-Management
+    description: |
+      Konfiguration, Berechnung, Übersteuerung und Bonusberechnung von Provisionsplänen sowie Kontoauszugs-Erstellung.
+  BC-2110.30.10:
+    name: Provisionsplan-Konfiguration
+    description: |
+      Konfiguration von Provisionsplänen und -sätzen nach Produkt und Vertreter.
+  BC-2110.30.20:
+    name: Provisions-Berechnung
+    description: |
+      Berechnung von Provisionen auf Prämien-Ereignisse, einschließlich Stornierungen bei Kündigung.
+  BC-2110.30.30:
+    name: Übersteuerung und Bonus-Berechnung
+    description: |
+      Berechnung von Übersteuerungen, Gewinnbeteiligungen und Incentive-Boni.
+  BC-2110.30.40:
+    name: Provisions-Kontoauszug-Erstellung
+    description: |
+      Erstellung und Verteilung von Vertreter-Provisionskontoauszügen.
+  BC-2110.40:
+    name: Vertriebskanal-Management
+    description: |
+      Betrieb von Agenten-, Makler-, digitalen Direkt-, Bancassurance-, Affinitäts- und Aggregatorkanälen.
+  BC-2110.40.10:
+    name: Agenten-Kanal-Betrieb
+    description: |
+      Betrieb von gebundenen und unabhängigen Agenten-Kanälen.
+  BC-2110.40.20:
+    name: Makler-Kanal-Betrieb
+    description: |
+      Betrieb von Makler- und Großmakler-Kanälen.
+  BC-2110.40.30:
+    name: Direkter Digitalkanal-Betrieb
+    description: |
+      Betrieb von Direkt-Digitalversicherungskanälen.
+  BC-2110.40.40:
+    name: Bancassurance- und Affinitäts-Kanal-Betrieb
+    description: |
+      Betrieb von Bancassurance-Partnerschaften und Affinitätsgruppen-Kanälen.
+  BC-2110.40.50:
+    name: Aggregator- und Vergleichs-Kanal-Betrieb
+    description: |
+      Betrieb von Aggregator- und Preisvergleichs-Website-Kanälen.
+  BC-2110.50:
+    name: Delegated-Authority-Management
+    description: |
+      Coverholder-Vollmacht-Setup, Leistungsüberwachung, Bordereau-Aufnahme und Vollmacht-Audit.
+  BC-2110.50.10:
+    name: Delegated-Authority-Setup
+    description: |
+      Setup von Bindungsvollmachten und delegierten Zeichnungsvereinbarungen.
+  BC-2110.50.20:
+    name: Coverholder-Leistungs-Überwachung
+    description: |
+      Überwachung der Coverholder-Zeichnungsleistung und Einhaltung der Vollmacht.
+  BC-2110.50.30:
+    name: Bordereau-Empfang und Abstimmung
+    description: |
+      Empfang, Aufnahme und Abstimmung von Prämien- und Schaden-Bordereaux.
+  BC-2110.50.40:
+    name: Vollmacht-Audit und Entzug
+    description: |
+      Audit des Coverholder-Betriebs und Entzug von Bindungsvollmachten falls erforderlich.
+  BC-2110.60:
+    name: Angebots- & Einreichungs-Management
+    description: |
+      Einreichungsaufnahme, Angebotserstellung, Vergleich und Quote-to-Bind-Konversions-Tracking.
+  BC-2110.60.10:
+    name: Einreichungs-Aufnahme
+    description: |
+      Aufnahme von Versicherungseinreichungen über Kanäle und Maklerportale.
+  BC-2110.60.20:
+    name: Angebots-Erstellung
+    description: |
+      Erstellung von Versicherungsangeboten aus Produkt- und Tarifierkonfiguration.
+  BC-2110.60.30:
+    name: Angebotsvergleich und Gegenangebot
+    description: |
+      Multi-Carrier-Angebotsvergleich und Gegenangebot-Behandlung.
+  BC-2110.60.40:
+    name: Quote-to-Bind-Konversions-Tracking
+    description: |
+      Verfolgung von Quote-to-Bind-Konversionsraten und Gründen für Nicht-Konversion.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-insurance-investment-management.yaml
+++ b/catalogue/i18n/de/L1-insurance-investment-management.yaml
@@ -1,0 +1,112 @@
+locale: de
+source: L1-insurance-investment-management.yaml
+entries:
+  BC-2200:
+    name: Versicherungsanlage Management
+    description: |
+      Aktivseitige Steuerung von Versicherungsverpflichtungen durch den Versicherer als
+      Anlageeigentümer — Anlagepolitik, ALM, strategische und taktische Asset-Allokation,
+      Mandatsaufsicht, Anlagerisiko und Compliance sowie Anlageberichterstattung.
+  BC-2200.10:
+    name: Anlagepolitik & Strategie Management
+    description: |
+      Investment-Policy-Statement, Mandatsdefinition und ESG-Anlagepolitik-Integration.
+  BC-2200.10.10:
+    name: Investment-Policy-Statement-Pflege
+    description: |
+      Pflege des Investment-Policy-Statements und Ausrichtung am Grundsatz der unternehmerischen Sorgfalt.
+  BC-2200.10.20:
+    name: Anlagemandat-Definition
+    description: |
+      Definition von Anlagemandaten nach Portfolio, Geschäftsfeld und Risikoprofil.
+  BC-2200.10.30:
+    name: ESG-Anlagepolitik-Integration
+    description: |
+      Integration von ESG- und Stewardship-Richtlinien in Anlagemandate.
+  BC-2200.20:
+    name: Asset-Liability-Management
+    description: |
+      ALM-Modellierung und Cashflow-Matching, Duration- und Konvexitätsüberwachung sowie Liquiditätspuffer-Dimensionierung.
+  BC-2200.20.10:
+    name: ALM-Modellierung und Cashflow-Matching
+    description: |
+      ALM-Modellierung und Cashflow-Matching von Aktiva gegenüber Versicherungsverpflichtungen.
+  BC-2200.20.20:
+    name: Duration- und Konvexitäts-Überwachung
+    description: |
+      Überwachung von Duration- und Konvexitätslücken zwischen Aktiva und Passiva.
+  BC-2200.20.30:
+    name: Liquiditätspuffer-Dimensionierung
+    description: |
+      Dimensionierung von Liquiditätspuffern zur Deckung erwarteter und gestresster Schadenabflüsse.
+  BC-2200.30:
+    name: Strategische & Taktische Asset-Allokation
+    description: |
+      Strategische und taktische Asset-Allokationsentscheidungen und Rebalancing.
+  BC-2200.30.10:
+    name: Strategische Asset-Allokation-Festlegung
+    description: |
+      Festlegung langfristiger strategischer Asset-Allokationen über Anlageklassen.
+  BC-2200.30.20:
+    name: Taktische Asset-Allokations-Entscheidung
+    description: |
+      Taktische Allokationsentscheidungen innerhalb strategischer Bandbreiten.
+  BC-2200.30.30:
+    name: Allokations-Rebalancing
+    description: |
+      Periodisches und ereignisgesteuertes Rebalancing zurück auf Ziel-Allokationen.
+  BC-2200.40:
+    name: Anlagemandat- & Manager-Oversight
+    description: |
+      Externer Manager-Auswahl, Mandats-Compliance, Performance-Review und Manager-Honorar-Oversight.
+  BC-2200.40.10:
+    name: Externer Manager-Auswahl
+    description: |
+      Auswahl und Onboarding externer Anlagemanager.
+  BC-2200.40.20:
+    name: Mandats-Compliance-Überwachung
+    description: |
+      Überwachung der Mandats-Compliance und Behandlung von Verstößen.
+  BC-2200.40.30:
+    name: Manager-Performance-Review
+    description: |
+      Periodischer Performance-Review externer Anlagemanager.
+  BC-2200.40.40:
+    name: Manager-Honorar-Oversight
+    description: |
+      Oversight von Manager-Honoraren und Kosten-Nutzen-Bewertungen.
+  BC-2200.50:
+    name: Anlagerisiko- & Compliance-Überwachung
+    description: |
+      Anlagelimit-Überwachung, Gegenpartei- und Emittentenlimite sowie Solvency-II-Anlageeignung.
+  BC-2200.50.10:
+    name: Anlagelimit-Überwachung
+    description: |
+      Überwachung von Anlagelimiten über Anlageklassen und Risikofaktoren.
+  BC-2200.50.20:
+    name: Gegenpartei- und Emittentenlimit-Überwachung
+    description: |
+      Überwachung von Gegenpartei- und Emittentenkonzentration sowie Limiten.
+  BC-2200.50.30:
+    name: Solvency-II-Anlageeignungs-Überwachung
+    description: |
+      Überwachung der Anlageeignung gegenüber Solvency-II- und äquivalenten Vorschriften.
+  BC-2200.60:
+    name: Anlage-Performance & Berichterstattung
+    description: |
+      Performance-Messung, -Attribution und Anlageberichterstattung an Vorstand und Aufsichtsbehörde.
+  BC-2200.60.10:
+    name: Portfolio-Performance-Messung
+    description: |
+      Messung der Portfolio-Performance gegenüber Benchmarks und Verpflichtungen.
+  BC-2200.60.20:
+    name: Attributionsanalyse
+    description: |
+      Performance-Attribution nach Allokation, Selektion und Währung.
+  BC-2200.60.30:
+    name: Anlageberichterstattung an Vorstand und Regulatoren
+    description: |
+      Erstellung von Anlageberichten für Vorstand, ALCO und Aufsichtsbehörde.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-insurance-product-management.yaml
+++ b/catalogue/i18n/de/L1-insurance-product-management.yaml
@@ -1,0 +1,125 @@
+locale: de
+source: L1-insurance-product-management.yaml
+entries:
+  BC-2100:
+    name: Versicherungsprodukt Management
+    description: |
+      Versicherungsprodukt-Fabrik — Deckungsdefinitionen, Bedingungen, Tariftabellen,
+      Bündelangebote und Lebenszyklus für Lebens-, Schaden-, Kranken- und Spezialsparten,
+      einschließlich Programm- und Coverholder-Produktstrukturen in Delegated-Authority-Märkten.
+  BC-2100.10:
+    name: Versicherungsprodukt-Katalog-Management
+    description: |
+      Versicherungsprodukt-Katalog, Stammdaten, Deckungsform-Bibliothek,
+      Offenlegungsdokumentation und Katalogveröffentlichung.
+  BC-2100.10.10:
+    name: Produktstammdaten-Management
+    description: |
+      Pflege von Versicherungsprodukt-Stammdaten und Produkthierarchien.
+  BC-2100.10.20:
+    name: Deckungs- und Formular-Bibliothek
+    description: |
+      Pflege standardisierter Deckungsdefinitionen, Policenformulare und Endossements-Bibliothek.
+  BC-2100.10.30:
+    name: Produktoffenlegungs-Dokumentation
+    description: |
+      Erstellung und Pflege von Produktoffenlegungsdokumenten und Kurzinformationsblättern.
+  BC-2100.10.40:
+    name: Produktkatalog-Veröffentlichung
+    description: |
+      Veröffentlichung des Versicherungsprodukt-Katalogs über Kanäle und Partner.
+  BC-2100.20:
+    name: Produkt-Tarif- & Preis-Konfiguration
+    description: |
+      Konfiguration von Tarifierungsalgorithmen, Faktoren, eingereichten Tarifen, Rabatten und Zuschlägen.
+  BC-2100.20.10:
+    name: Tarifierungsalgorithmus-Konfiguration
+    description: |
+      Konfiguration von Tarifierungsalgorithmen und Preismodellen für Versicherungsprodukte.
+  BC-2100.20.20:
+    name: Tarifffaktor- und Variablen-Pflege
+    description: |
+      Pflege von Tarifffaktoren, Tabellen und Tarifffierungsvariablen.
+  BC-2100.20.30:
+    name: Eingereichte Tarif-Management
+    description: |
+      Verwaltung eingereicherter Tarife, Abweichungen und Genehmigungen über Jurisdiktionen.
+  BC-2100.20.40:
+    name: Rabatt- und Zuschlag-Konfiguration
+    description: |
+      Konfiguration von Prämienrabatten, Zuschlägen und Gutschriftprogrammen.
+  BC-2100.30:
+    name: Produkt-Eignungs- & Zeichnungsregel-Konfiguration
+    description: |
+      Konfiguration von Eignungs-, Zeichnungsrichtlinien- sowie Weiterleitungs- und Ablehnungsregeln im Produkt.
+  BC-2100.30.10:
+    name: Eignungsregel-Konfiguration
+    description: |
+      Konfiguration von Kunden- und Risikoeignungsregeln pro Produkt.
+  BC-2100.30.20:
+    name: Zeichnungsrichtlinien-Kodierung
+    description: |
+      Kodierung von Zeichnungsrichtlinien in die Produktkonfiguration.
+  BC-2100.30.30:
+    name: Weiterleitungs- und Ablehnungsregel-Konfiguration
+    description: |
+      Konfiguration automatisierter Weiterleitungs- und Ablehnungsregeln pro Produkt.
+  BC-2100.40:
+    name: Versicherungsprodukt-Lebenszyklus-Management
+    description: |
+      Neue Produkteinführung, regulatorische Einreichung, Markteinführungsbereitschaft, Leistungsüberprüfung und Rücknahme.
+  BC-2100.40.10:
+    name: Neues Produktkonzept
+    description: |
+      Konzeptdefinition neuer Versicherungsprodukte und Produktausschuss-Governance.
+  BC-2100.40.20:
+    name: Produkt-Einreichung und Genehmigung
+    description: |
+      Regulatorische Einreichung von Versicherungsprodukten und Genehmigungsverfolgung über Jurisdiktionen.
+  BC-2100.40.30:
+    name: Produkt-Markteinführungsbereitschaft
+    description: |
+      Betriebs- und Kanalbereitschaft für die Markteinführung von Versicherungsprodukten.
+  BC-2100.40.40:
+    name: Produkt-Leistungsüberprüfung
+    description: |
+      Periodische Leistungs- und Preis-Leistungs-Überprüfungen von Versicherungsprodukten.
+  BC-2100.40.50:
+    name: Produkt-Rücknahme und -Ersatz
+    description: |
+      Rücknahme, Ersatz und Versicherungsnehmer-Migration zu Nachfolgeprodukten.
+  BC-2100.50:
+    name: Versicherungsprodukt-Bündelungs-Management
+    description: |
+      Multi-Sparten-Bündel, Paketprodukte und Bündel-Leistungsverfolgung.
+  BC-2100.50.10:
+    name: Multi-Sparten-Bündel-Definition
+    description: |
+      Definition von Multi-Sparten-Produktbündeln und Verpackungsregeln.
+  BC-2100.50.20:
+    name: Bündel-Eignungsregel-Konfiguration
+    description: |
+      Eignungs- und Qualifikationsregeln für Versicherungsproduktbündel.
+  BC-2100.50.30:
+    name: Bündel-Leistungs-Tracking
+    description: |
+      Verfolgung von Bündel-Aufnahme, -Retention und -Wirtschaftlichkeit.
+  BC-2100.60:
+    name: Spezialsparte & Programm-Produkt-Management
+    description: |
+      Programm-Geschäftsdefinition, Coverholder-Produktvollmacht und Spezialformular-Bibliothek.
+  BC-2100.60.10:
+    name: Programm-Definition
+    description: |
+      Definition von Programm-Geschäften und Bindungsvollmacht-Produktstrukturen.
+  BC-2100.60.20:
+    name: Coverholder-Produktvollmacht
+    description: |
+      Definition von Produktumfang und Vollmacht für Coverholder.
+  BC-2100.60.30:
+    name: Spezialformular- und Endossements-Bibliothek
+    description: |
+      Bibliothek von Spezialformulierungen, Manuskript-Endossements und Marktklauseln.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-insurance-risk-management.yaml
+++ b/catalogue/i18n/de/L1-insurance-risk-management.yaml
@@ -1,0 +1,142 @@
+locale: de
+source: L1-insurance-risk-management.yaml
+entries:
+  BC-2190:
+    name: Versicherungsrisiko Management
+    description: |
+      Versicherungsspezifische Risikoarten — Zeichnungsrisiko, Katastrophen- und
+      Kumulationsrisiko, Reserverisiko, Solvabilitäts- und Kapitalrisiko, Rückversicherungs-
+      Gegenparteirisiko, Lebens- und Langlebigkeitsrisiko, Stornierungs- und Persistenzrisiko
+      sowie operationelles und Conduct-Risiko in der Versicherung — abgegrenzt vom allgemeinen
+      Unternehmensrisikomanagement.
+  BC-2190.10:
+    name: Zeichnungsrisiko Management
+    description: |
+      Zeichnungsrisikobereitschaft, Limitüberwachung und Adverses-Selektions-Überwachung.
+  BC-2190.10.10:
+    name: Zeichnungsrisikobereitschaft
+    description: |
+      Definition und Formulierung der Zeichnungsrisikobereitschaft.
+  BC-2190.10.20:
+    name: Zeichnungslimit-Überwachung
+    description: |
+      Überwachung von Zeichnungsvollmachten und Kumulationslimiten.
+  BC-2190.10.30:
+    name: Adverse-Selektion-Überwachung
+    description: |
+      Überwachung auf adverse Selektions- und Antisektionsmuster.
+  BC-2190.20:
+    name: Katastrophen- & Kumulationsrisiko Management
+    description: |
+      Exponierungs-Kumulationsüberwachung, PML- und Realistic-Disaster-Scenario-Management sowie CAT-Minderungsplanung.
+  BC-2190.20.10:
+    name: Exponierungs-Kumulations-Überwachung
+    description: |
+      Überwachung der Exponierungskumulation nach Schadensart, Geografie und Nutzung.
+  BC-2190.20.20:
+    name: PML- und Katastrophenszenario-Management
+    description: |
+      Management von PML und realistischen Katastrophenszenarien.
+  BC-2190.20.30:
+    name: CAT-Risiko-Minderungsplanung
+    description: |
+      Planung von Minderungsmaßnahmen einschließlich Rückversicherung und Risikotransfer.
+  BC-2190.30:
+    name: Versicherungsreserve- & Reservierungsrisiko Management
+    description: |
+      Reserveadäquanz-Überwachung, Reservevolatilitätsanalyse und Reserverisiko-Stresstesting.
+  BC-2190.30.10:
+    name: Reserveadäquanz-Überwachung
+    description: |
+      Überwachung der Reserveadäquanz gegenüber Best-Estimate- und externen Benchmarks.
+  BC-2190.30.20:
+    name: Reservevolatilitäts-Analyse
+    description: |
+      Analyse der Reservevolatilität und des einjährigen Reserverisikos.
+  BC-2190.30.30:
+    name: Reserverisiko-Stresstesting
+    description: |
+      Stress- und Szenariotesting der Reserveadäquanz.
+  BC-2190.40:
+    name: Solvabilitäts- & Kapitalrisiko Management
+    description: |
+      Kapitaladäquanz-Überwachung, ORSA-Betrieb, Solvabilitäts-Stresstesting und Sanierungs- und Abwicklungsplanung.
+  BC-2190.40.10:
+    name: Kapitaladäquanz-Überwachung
+    description: |
+      Überwachung von Solvabilitätskapitalquoten und Kapitalauslösern.
+  BC-2190.40.20:
+    name: ORSA-Betrieb
+    description: |
+      Durchführung des Zyklus zur Eigenen Risiko- und Solvabilitätsbewertung (ORSA).
+  BC-2190.40.30:
+    name: Solvabilitäts-Stress- und Szenariotesting
+    description: |
+      Stress- und Reverse-Stresstesting von Solvabilitätspositionen.
+  BC-2190.40.40:
+    name: Sanierungs- und Abwicklungsplanung
+    description: |
+      Sanierungs- und Abwicklungsplanung für Versicherer-Abwicklungsszenarien.
+  BC-2190.50:
+    name: Rückversicherungs-Gegenpartei- & Kreditrisiko Management
+    description: |
+      Rückversicherer-Gegenparteiüberwachung, Sicherheitenausreichung und Gegenpartei-Ausfall-Stresstesting.
+  BC-2190.50.10:
+    name: Rückversicherer-Gegenpartei-Überwachung
+    description: |
+      Überwachung der Finanzkraft und Exponierungskonzentration von Rückversicherern.
+  BC-2190.50.20:
+    name: Sicherheiten- und Akkreditiv-Adäquanz-Überwachung
+    description: |
+      Überwachung der Ausreichung von Sicherheiten und Akkreditiven von Rückversicherern.
+  BC-2190.50.30:
+    name: Gegenparteiausfall-Stresstesting
+    description: |
+      Stresstesting der Auswirkungen von Rückversicherer-Ausfällen auf die Solvabilität.
+  BC-2190.60:
+    name: Lebens- & Langlebigkeitsrisiko Management
+    description: |
+      Sterblichkeitsrisiko-Überwachung, Langlebigkeitsabsicherungs-Oversight und Pandemierisiko-Management.
+  BC-2190.60.10:
+    name: Sterblichkeitsrisiko-Überwachung
+    description: |
+      Überwachung des Sterblichkeitsrisikos bei Lebens- und Schutzportfolios.
+  BC-2190.60.20:
+    name: Langlebigkeitsabsicherungs-Oversight
+    description: |
+      Oversight von Langlebigkeitsabsicherungsinstrumenten und Gegenparteiexposure.
+  BC-2190.60.30:
+    name: Pandemierisiko Management
+    description: |
+      Management von Pandemie- und Epidemie-Sterblichkeits- und Morbiditätsrisiken.
+  BC-2190.70:
+    name: Storno- & Persistenzrisiko Management
+    description: |
+      Stornorisiko-Überwachung und Persistenz-Stresstesting.
+  BC-2190.70.10:
+    name: Stornorisiko-Überwachung
+    description: |
+      Überwachung von Stornoquoten und stornobedingten Verlusten bei Lebens- und Sparprodukten.
+  BC-2190.70.20:
+    name: Persistenz-Stresstesting
+    description: |
+      Stresstesting von Persistenzannahmen und dynamischem Stornoverhalten.
+  BC-2190.80:
+    name: Versicherungs-Betriebs- & Conduct-Risiko Management
+    description: |
+      Versicherungs-Conduct-Risiko, Schadenbearbeitungsrisiko und Vertriebsrisiko-Überwachung.
+  BC-2190.80.10:
+    name: Versicherungs-Conduct-Risiko-Überwachung
+    description: |
+      Überwachung von Conduct-Risikoindikatoren über Produkt, Vertrieb und Schadenbearbeitung.
+  BC-2190.80.20:
+    name: Schadenbearbeitungsrisiko-Oversight
+    description: |
+      Oversight des Schadenbearbeitungsrisikos und fairer Versicherungsnehmer-Ergebnisse.
+  BC-2190.80.30:
+    name: Vertriebsrisiko-Überwachung
+    description: |
+      Überwachung von Vertriebsrisiken einschließlich Falschberatung und Intermediär-Conduct.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-insurance-underwriting-management.yaml
+++ b/catalogue/i18n/de/L1-insurance-underwriting-management.yaml
@@ -1,0 +1,124 @@
+locale: de
+source: L1-insurance-underwriting-management.yaml
+entries:
+  BC-2130:
+    name: Versicherungszeichnung / Underwriting Management
+    description: |
+      Risikobewertung, Preisfindung, Annahme, Ablehnung und Bindung von
+      Versicherungsanträgen in Privatkunden-, Gewerbe- und Spezialsparten,
+      einschließlich Zeichnungsvollmacht-Durchsetzung und Portfolio-Steuerung.
+  BC-2130.10:
+    name: Underwriting-Risikoaufnahme
+    description: |
+      Einreichungs-Triage, Risikodatenerfassung, Schadenshistorie-Abruf und Drittdaten-Anreicherung.
+  BC-2130.10.10:
+    name: Einreichungs-Triage
+    description: |
+      Triage von Underwriting-Einreichungen und Weiterleitung an Underwriting-Teams.
+  BC-2130.10.20:
+    name: Risikodaten-Erfassung
+    description: |
+      Erfassung risikorelevanter Daten aus Antragsteller-, Makler- und Besichtigungsquellen.
+  BC-2130.10.30:
+    name: Schadenshistorie-Abruf
+    description: |
+      Abruf von Schadenshistorien aus Büros, Vorversicherern und gemeinsamen Registern.
+  BC-2130.10.40:
+    name: Drittdaten-Anreicherung
+    description: |
+      Anreicherung von Einreichungen mit Drittdaten, Telematik- und IoT-Daten.
+  BC-2130.20:
+    name: Risikobewertung & -Selektion
+    description: |
+      Risikobeurteilung, Exponierungs-Aggregation, Schadenverhütungs-Besichtigungen und Underwriting-Weiterleitungen.
+  BC-2130.20.10:
+    name: Risikobewertung und -Modellierung
+    description: |
+      Anwendung von Underwriting-Modellen, Scorecards und maschinellen Lernrisiko-Scores.
+  BC-2130.20.20:
+    name: Exponierungs-Aggregations-Bewertung
+    description: |
+      Bewertung der Exponierungs-Aggregation gegen laufendes Portfolio.
+  BC-2130.20.30:
+    name: Schadenverhütungs-Besichtigungs-Koordination
+    description: |
+      Koordination von Schadenverhütungs-Besichtigungen und Risikotechnik-Berichten.
+  BC-2130.20.40:
+    name: Underwriting-Weiterleitungs-Bearbeitung
+    description: |
+      Bearbeitung von Weiterleitungen an leitende Zeichner, Linienvollmachten und Rückversicherer.
+  BC-2130.30:
+    name: Underwriting-Preis-Management
+    description: |
+      Manuelle Tariffierung, Staffeltarif-Gutschriften, Erfahrungsrating und bespoke Spezialpreisfindung.
+  BC-2130.30.10:
+    name: Manuelle Tariff-Anwendung
+    description: |
+      Anwendung manueller Tarife aus eingereichten Produktkonfigurationen.
+  BC-2130.30.20:
+    name: Staffeltarif- und Gutschrift-Anwendung
+    description: |
+      Anwendung von Staffeltarif-Gutschriften und -Zuschlägen.
+  BC-2130.30.30:
+    name: Erfahrungsrating
+    description: |
+      Erfahrungsbasierte Preisfindung unter Nutzung der Versicherungsnehmer-Schadenshistorie.
+  BC-2130.30.40:
+    name: Spezialsparte und Bespoke-Preisfindung
+    description: |
+      Bespoke-Preisfindung für Spezialsparten, Großkunden und komplexe Risiken.
+  BC-2130.40:
+    name: Underwriting-Entscheidungs- & Vollmachts-Management
+    description: |
+      Annahme- und Ablehnungs-Entscheidung, Bedingungsfestsetzung, Vollmachts-Durchsetzung und Bindung.
+  BC-2130.40.10:
+    name: Annahme- und Ablehnungs-Entscheidung
+    description: |
+      Entscheidungsfindung bei Annahme, Ablehnung oder Gegenangebot von Einreichungen.
+  BC-2130.40.20:
+    name: Deckungsbedingungen- und -konditionen-Festlegung
+    description: |
+      Festlegung von Deckungsbedingungen, -konditionen, Ausschlüssen und Garantien.
+  BC-2130.40.30:
+    name: Underwriting-Vollmachts-Durchsetzung
+    description: |
+      Durchsetzung von Underwriting-Vollmachtsgrenzen und Weiterleitungsschwellen.
+  BC-2130.40.40:
+    name: Angebots-Ausgabe und Bindung
+    description: |
+      Ausgabe bindender Angebote und Deckungsbestätigung.
+  BC-2130.50:
+    name: Underwriting-Portfolio-Management
+    description: |
+      Portfolio-Mix- und Limitüberwachung, Profitabilitätsanalyse und Underwriting-Aktionsplanung.
+  BC-2130.50.10:
+    name: Portfolio-Mix- und Limit-Überwachung
+    description: |
+      Überwachung des Portfolio-Mix gegen Risikobereitschaft und Konzentrationslimite.
+  BC-2130.50.20:
+    name: Underwriting-Profitabilitäts-Analyse
+    description: |
+      Analyse der Underwriting-Profitabilität nach Segment, Produkt und Vertreter.
+  BC-2130.50.30:
+    name: Underwriting-Aktions-Planung
+    description: |
+      Planung von Underwriting-Maßnahmen, Sanierung und Segment-Exits.
+  BC-2130.60:
+    name: Underwriting-Betrug- & Falschdarstellungs-Management
+    description: |
+      Antragsbetrugs-Screening, wesentliche Falschdarstellungs-Untersuchung und Underwriting-Betrugs-Meldung.
+  BC-2130.60.10:
+    name: Antragsbetrugs-Screening
+    description: |
+      Screening von Versicherungsanträgen auf Betrugsindikatoren.
+  BC-2130.60.20:
+    name: Wesentliche Falschdarstellungs-Untersuchung
+    description: |
+      Untersuchung vermuteter wesentlicher Falschdarstellungen bei Anträgen.
+  BC-2130.60.30:
+    name: Underwriting-Betrugs-Meldung
+    description: |
+      Meldung bestätigter Underwriting-Betrugsfälle an Branchenregister und Regulatoren.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-intellectual-property-management.yaml
+++ b/catalogue/i18n/de/L1-intellectual-property-management.yaml
@@ -1,0 +1,102 @@
+locale: de
+source: L1-intellectual-property-management.yaml
+entries:
+  BC-840:
+    name: Schutzrechtsmanagement
+    description: |
+      Patente, Marken, Urheberrechte, Geschäftsgeheimnisse und Lizenzierung.
+  BC-840.10:
+    name: Patentportfolio-Management
+    description: |
+      Patentstrategie, Anmeldung, Pflege und Portfolioüberprüfung.
+  BC-840.10.10:
+    name: Erfindungsmeldungsmanagement
+    description: |
+      Erfassung, Bewertung und Entscheidung über Erfindungsmeldungen.
+  BC-840.10.20:
+    name: Patentanmeldung und -verfolgung
+    description: |
+      Ausarbeitung, Einreichung und Verfolgung von Patentanmeldungen.
+  BC-840.10.30:
+    name: Patentpflege
+    description: |
+      Jahresgebühren und Pflege erteilter Patente.
+  BC-840.10.40:
+    name: Patentportfolioüberprüfung
+    description: |
+      Periodische Überprüfung und Bereinigung des Patentportfolios.
+  BC-840.20:
+    name: Markenmanagement
+    description: |
+      Markenanmeldung, -überwachung und -verteidigung.
+  BC-840.20.10:
+    name: Markenrecherche und -anmeldung
+    description: |
+      Kollisionsrecherchen und Markenanmeldungen.
+  BC-840.20.20:
+    name: Markenüberwachung und -surveillance
+    description: |
+      Überwachung auf kollidierende Markenanmeldungen und -verwendungen.
+  BC-840.20.30:
+    name: Markenerneuerungsmanagement
+    description: |
+      Erneuerung und Pflege von Markeneintragungen.
+  BC-840.30:
+    name: Urheberrechts- und Geschäftsgeheimnis-Management
+    description: |
+      Urheberrechtlich geschützte Assets, Geschäftsgeheimnisse und Vertraulichkeit.
+  BC-840.30.10:
+    name: Urheberrechtsasset-Registrierung
+    description: |
+      Identifikation und Registrierung urheberrechtsfähiger Assets.
+  BC-840.30.20:
+    name: Geschäftsgeheimnis-Identifikation und -Schutz
+    description: |
+      Identifikation und Schutz von Geschäftsgeheimnissen.
+  BC-840.30.30:
+    name: Vertraulichkeits- und NDA-Management
+    description: |
+      NDAs, Vertraulichkeitsvereinbarungen und Zugriffskontrollen.
+  BC-840.40:
+    name: IP-Lizenzmanagement
+    description: |
+      In-Lizenzierung, Out-Lizenzierung und Lizenzgebühren.
+  BC-840.40.10:
+    name: In-Lizenzierungsverhandlung
+    description: |
+      Verhandlung und Abschluss von eingehenden IP-Lizenzen.
+  BC-840.40.20:
+    name: Out-Lizenzierung und Kommerzialisierung
+    description: |
+      Out-Lizenzierung von Schutzrechten und Kommerzialisierung von Patenten.
+  BC-840.40.30:
+    name: Lizenzgebühren-Administration
+    description: |
+      Berechnung, Einzug und Zahlung von IP-Lizenzgebühren.
+  BC-840.40.40:
+    name: Kreuzlizenzierung und Patent-Pooling
+    description: |
+      Kreuzlizenzierungsvereinbarungen und Beteiligung an Patentpools.
+  BC-840.50:
+    name: IP-Verteidigung und -Durchsetzung
+    description: |
+      Verletzungserkennung und Durchsetzungsmaßnahmen.
+  BC-840.50.10:
+    name: Verletzungsüberwachung
+    description: |
+      Überwachung auf mutmaßliche IP-Verletzungen.
+  BC-840.50.20:
+    name: IP-Durchsetzungsmaßnahmen
+    description: |
+      Abmahnung, Widerspruch und Durchsetzungsklage.
+  BC-840.50.30:
+    name: IP-Verteidigung und Gegenklage
+    description: |
+      Verteidigung gegen IP-Ansprüche und Gegenklage.
+  BC-840.50.40:
+    name: Fälschungsbekämpfung und Markenschutz
+    description: |
+      Erkennung und Beseitigung von Fälschungen und Markenmissbrauch.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-intelligence-operations-management.yaml
+++ b/catalogue/i18n/de/L1-intelligence-operations-management.yaml
@@ -1,0 +1,102 @@
+locale: de
+source: L1-intelligence-operations-management.yaml
+entries:
+  BC-1730:
+    name: Nachrichtendienstliche-Operationen-Management
+    description: |
+      Nachrichtendienstliche Beschaffung, Analyse, Weitergabe und Fusion.
+  BC-1730.10:
+    name: Nachrichtendienstliche-Beschaffungs-Management
+    description: |
+      HUMINT-, SIGINT-, GEOINT-, IMINT- und OSINT-Beschaffung.
+  BC-1730.10.10:
+    name: Beschaffungsanforderungs-Management
+    description: |
+      Definition und Management nachrichtendienstlicher Beschaffungsanforderungen.
+  BC-1730.10.20:
+    name: HUMINT-Beschaffung
+    description: |
+      Menschliche Nachrichtenbeschaffungsvorgänge.
+  BC-1730.10.30:
+    name: SIGINT-Beschaffung
+    description: |
+      Signalnachrichtenbeschaffungsvorgänge.
+  BC-1730.10.40:
+    name: GEOINT- und IMINT-Beschaffung
+    description: |
+      Geospatiale und Bildnachrichtenbeschaffung.
+  BC-1730.10.50:
+    name: OSINT-Beschaffung
+    description: |
+      Open-Source-Nachrichtenbeschaffung und -Kuratierung.
+  BC-1730.20:
+    name: Nachrichtendienstliche-Analyse-Management
+    description: |
+      All-Source-Analyse, Fusion und nachrichtendienstliche Produkte.
+  BC-1730.20.10:
+    name: All-Source-Analyse
+    description: |
+      All-Source-Nachrichtenanalyse und -Beurteilung.
+  BC-1730.20.20:
+    name: Nachrichtendienstliche Fusion
+    description: |
+      Fusion von Multi-INT-Daten zu integrierten Beurteilungen.
+  BC-1730.20.30:
+    name: Nachrichtendienstliche-Produkt-Authoring
+    description: |
+      Erstellung von Nachrichten-Produkten und -Beurteilungen.
+  BC-1730.20.40:
+    name: Nachrichtendienstliche-Qualitätssicherung
+    description: |
+      Qualitätssicherung nachrichtendienstlicher Produkte.
+  BC-1730.30:
+    name: Nachrichtendienstliche-Weitergabe-Management
+    description: |
+      Nachrichtenberichterstattung, Weitergabe und Entscheidungsunterstützung.
+  BC-1730.30.10:
+    name: Nachrichtendienstliche Berichterstattung
+    description: |
+      Erstellung von Nachrichtenberichten und Briefings.
+  BC-1730.30.20:
+    name: Nachrichtendienstliche-Weitergabe-Kontrolle
+    description: |
+      Weitergabekontrolle und Need-to-Know-Durchsetzung.
+  BC-1730.30.30:
+    name: Nachrichtendienstliche-Kunden-Engagement
+    description: |
+      Engagement mit Nachrichtenempfängern und Rückmeldung.
+  BC-1730.40:
+    name: Gegenaufklärungs-Management
+    description: |
+      Gegenaufklärung, Insider-Bedrohung und Täuschungserkennung.
+  BC-1730.40.10:
+    name: Gegenaufklärungs-Operationen
+    description: |
+      Gegenaufklärungsvorgänge gegen ausländische Dienste.
+  BC-1730.40.20:
+    name: Insider-Bedrohungs-Programm
+    description: |
+      Erkennung und Management von Insider-Bedrohungen.
+  BC-1730.40.30:
+    name: Täuschungs- und Verweigerungserkennung
+    description: |
+      Erkennung von Täuschungs- und Verweigerungsaktivitäten.
+  BC-1730.50:
+    name: Nachrichtendienstliche-Quellen- und Methoden-Management
+    description: |
+      Quellenmanagement, Methodenschutz und Analysemethoden.
+  BC-1730.50.10:
+    name: Quellen-Management
+    description: |
+      Management und Schutz nachrichtendienstlicher Quellen.
+  BC-1730.50.20:
+    name: Analysemethoden-Standards-Management
+    description: |
+      Pflege analytischer Methodenstandards (ICD 203).
+  BC-1730.50.30:
+    name: Methodenschutz
+    description: |
+      Schutz nachrichtendienstlicher Beschaffungsmethoden.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-internal-audit-management.yaml
+++ b/catalogue/i18n/de/L1-internal-audit-management.yaml
@@ -1,0 +1,78 @@
+locale: de
+source: L1-internal-audit-management.yaml
+entries:
+  BC-140:
+    name: Interne Revisionsverwaltung
+    description: |
+      Unabhängige Prüfung der Wirksamkeit von Steuerung, Risiken und Kontrollen.
+  BC-140.10:
+    name: Revisionsplanungsmanagement
+    description: |
+      Risikobasierte Revisionsplanung und Prüfungsuniversumverwaltung.
+  BC-140.10.10:
+    name: Prüfungsuniversumverwaltung
+    description: |
+      Definition und Pflege des prüfbaren Universums und der Risikoeinstufungen.
+  BC-140.10.20:
+    name: Risikobasierte Jahresplanerstellung
+    description: |
+      Risikopriorisierter Jahresprüfungsplan und Ressourcenzuweisung.
+  BC-140.10.30:
+    name: Prüfungsauftragsabgrenzung
+    description: |
+      Prüfungsziele, -umfang, -kriterien und Prüfungsprogrammdesign.
+  BC-140.20:
+    name: Prüfungsdurchführungsmanagement
+    description: |
+      Prüfungshandlungen, Beweiserhebung und Berichterstattung.
+  BC-140.20.10:
+    name: Prüfungshandlungen
+    description: |
+      Walkthroughs, Kontrollprüfungen und Beweiserhebung.
+  BC-140.20.20:
+    name: Prüfungsarbeitspapierverwaltung
+    description: |
+      Dokumentation von Nachweisen, Schlussfolgerungen und Überprüfung durch Vorgesetzte.
+  BC-140.20.30:
+    name: Prüfungsberichterstattung
+    description: |
+      Entwurf, Abstimmung und Herausgabe von Prüfungsberichten und Stellungnahmen.
+  BC-140.20.40:
+    name: Kontinuierliche und datengestützte Prüfung
+    description: |
+      Einsatz von Analysen und kontinuierlicher Überwachung in Prüfungen.
+  BC-140.30:
+    name: Prüfungsfeststellungs- und Abhilfemaßnahmenmanagement
+    description: |
+      Feststellungsverfolgung, Managementmaßnahmen und Nachverfolgung.
+  BC-140.30.10:
+    name: Feststellungserfassung und -bewertung
+    description: |
+      Standardisierte Erfassung und Bewertung von Prüfungsfeststellungen.
+  BC-140.30.20:
+    name: Managementmaßnahmenverfolgung
+    description: |
+      Nachverfolgung vereinbarter Managementmaßnahmen bis zum Abschluss.
+  BC-140.30.30:
+    name: Abhilfemaßnahmenvalidierung
+    description: |
+      Unabhängige Validierung der Wirksamkeit von Abhilfemaßnahmen.
+  BC-140.40:
+    name: Prüfungsqualitätssicherung
+    description: |
+      Qualitätssicherung der Prüfungsmethodik und -durchführung.
+  BC-140.40.10:
+    name: Prüfungsmethodikmanagement
+    description: |
+      Pflege der Prüfungsmethodik im Einklang mit IIA-Standards.
+  BC-140.40.20:
+    name: Interne Qualitätsüberprüfungen
+    description: |
+      Periodische interne QA-Überprüfungen von Prüfungsaufträgen.
+  BC-140.40.30:
+    name: Externe Qualitätsbewertung
+    description: |
+      Externe Qualitätsbewertungen und Konformität mit professionellen Standards.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-inventory-management.yaml
+++ b/catalogue/i18n/de/L1-inventory-management.yaml
@@ -1,0 +1,94 @@
+locale: de
+source: L1-inventory-management.yaml
+entries:
+  BC-530:
+    name: Bestandsmanagement
+    description: |
+      Lagerbestände, Nachschub und Zuteilung im Liefernetzwerk.
+  BC-530.10:
+    name: Lagerbestandsmanagement
+    description: |
+      Zielbestandsniveaus, Sicherheitsbestände und Bestellpunkte.
+  BC-530.10.10:
+    name: Zielbestands- und Sicherheitsbestandsfestlegung
+    description: |
+      Festlegung von Zielbestandsniveaus und Sicherheitsbeständen nach SKU und Standort.
+  BC-530.10.20:
+    name: Bestellpunkt- und Min/Max-Management
+    description: |
+      Bestellpunkte, Mindest- und Höchstbestandsrichtlinien.
+  BC-530.10.30:
+    name: Servicegrad-Optimierung
+    description: |
+      Abwägungsoptimierung zwischen Servicegrad und Bestandskosten.
+  BC-530.10.40:
+    name: Bestandssegmentierung und ABC-Analyse
+    description: |
+      ABC/XYZ-Segmentierung zur Differenzierung der Bestandsrichtlinien.
+  BC-530.20:
+    name: Nachschubmanagement
+    description: |
+      Nachschubrichtlinien und automatisierter Nachschub.
+  BC-530.20.10:
+    name: Nachschubrichtlinien-Definition
+    description: |
+      Definition von Nachschubrichtlinien (Push, Pull, Kanban).
+  BC-530.20.20:
+    name: Automatisierter Nachschubbetrieb
+    description: |
+      Ausführung automatisierter Nachschubbestellungen an Versorgungsknoten.
+  BC-530.20.30:
+    name: Vendor-Managed-Inventory-Betrieb
+    description: |
+      VMI- und Konsignationslagerarrangements mit Lieferanten.
+  BC-530.30:
+    name: Bestandszuteilungsmanagement
+    description: |
+      Netzwerkübergreifende Zuteilung und Reservierungen.
+  BC-530.30.10:
+    name: Netzwerkübergreifende Zuteilung
+    description: |
+      Zuteilung verfügbarer Bestände über Distributionszentren, Filialen und Kanäle.
+  BC-530.30.20:
+    name: Kunden- und Auftragsreservierungen
+    description: |
+      Reservierung von Beständen für Kundenaufträge oder Konten.
+  BC-530.30.30:
+    name: Bestandsneuausgleich
+    description: |
+      Neuausgleich von Beständen zwischen Standorten zur Nachfrageabdeckung.
+  BC-530.40:
+    name: Bestandsgenauigkeitsmanagement
+    description: |
+      Inventurzyklen, physische Inventur und Differenzauflösung.
+  BC-530.40.10:
+    name: Zyklische Inventur
+    description: |
+      Zyklische Inventurprogramme nach Häufigkeit und ABC-Klassifizierung.
+  BC-530.40.20:
+    name: Physische Inventur
+    description: |
+      Jährliche oder periodische vollständige physische Inventurprogramme.
+  BC-530.40.30:
+    name: Differenzuntersuchung und -korrektur
+    description: |
+      Untersuchung, Ursachenanalyse und Korrektur von Bestandsdifferenzen.
+  BC-530.50:
+    name: Langsam-drehende und veraltete Bestandsverwaltung
+    description: |
+      Identifikation, Abschreibung und Entsorgung von SLOB-Beständen.
+  BC-530.50.10:
+    name: Identifikation langsam drehender Bestände
+    description: |
+      Identifikation und Altersstrukturierung langsam drehender und veralteter Bestände.
+  BC-530.50.20:
+    name: Bestandsrückstellung und -abschreibung
+    description: |
+      Rückstellung, Wertminderung und Abschreibung veralteter Bestände.
+  BC-530.50.30:
+    name: Bestandsentsorgung
+    description: |
+      Entsorgung veralteter Bestände durch Liquidation oder Verschrottung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-investor-relations-management.yaml
+++ b/catalogue/i18n/de/L1-investor-relations-management.yaml
@@ -1,0 +1,82 @@
+locale: de
+source: L1-investor-relations-management.yaml
+entries:
+  BC-240:
+    name: Investor-Relations-Management
+    description: |
+      Kommunikation mit Aktionären, Analysten und Kapitalmärkten.
+  BC-240.10:
+    name: Kapitalmarktkommunikation
+    description: |
+      IR-Strategie, Equity Story und Kapitalmarkttage.
+  BC-240.10.10:
+    name: IR-Strategie und Equity Story
+    description: |
+      Definition der Investor-Relations-Strategie und der Equity Story.
+  BC-240.10.20:
+    name: Kapitalmarkttagsmanagement
+    description: |
+      Planung und Durchführung von Kapitalmarkttagen und Investorenveranstaltungen.
+  BC-240.10.30:
+    name: IR-Offenlegungsmanagement
+    description: |
+      Offenlegungskontrollen, faire Offenlegung und Kommunikation wesentlicher Ereignisse.
+  BC-240.10.40:
+    name: ESG- und Nachhaltigkeitskommunikation
+    description: |
+      ESG-Narrativ für Kapitalmärkte und Ratingagenturen-Engagement.
+  BC-240.20:
+    name: Ergebniszyklusmanagement
+    description: |
+      Quartalsberichte, Analysten-Calls und Mitschriften.
+  BC-240.20.10:
+    name: Ergebnismitteilungserstellung
+    description: |
+      Entwurf und Herausgabe von Ergebnispressemitteilungen.
+  BC-240.20.20:
+    name: Ergebnisanrufmanagement
+    description: |
+      Skripte, Q&A-Vorbereitung und Durchführung von Analystenkonferenzen.
+  BC-240.20.30:
+    name: Konsens- und Guidancemanagement
+    description: |
+      Verfolgung von Konsensschätzungen und Bereitstellung von Guidance.
+  BC-240.30:
+    name: Aktionärsengagementmanagement
+    description: |
+      Hauptversammlungen, Aktionärsversammlungen und Privatanleger-Outreach.
+  BC-240.30.10:
+    name: Institutionelles Investorenengagement
+    description: |
+      Roadshows, Einzelgespräche und laufender Dialog mit institutionellen Investoren.
+  BC-240.30.20:
+    name: Privataktionärsengagement
+    description: |
+      Kommunikation und Outreach-Programme für Privataktionäre.
+  BC-240.30.30:
+    name: Hauptversammlungskoordination
+    description: |
+      IR-Beitrag zu Logistik, Unterlagen und Q&A der Hauptversammlung.
+  BC-240.30.40:
+    name: Proxy- und Governance-Engagement
+    description: |
+      Engagement mit Stimmrechtsberatern und Governance-Investoren.
+  BC-240.40:
+    name: Analysten-Relations-Management
+    description: |
+      Engagement mit Sell-Side- und Buy-Side-Analysten.
+  BC-240.40.10:
+    name: Sell-Side-Analystencoverage-Management
+    description: |
+      Coverage-Aufbau, Modellüberprüfungen und Sell-Side-Engagement.
+  BC-240.40.20:
+    name: Buy-Side-Investorenansprache
+    description: |
+      Identifikation und Ansprache von Buy-Side-Investoren.
+  BC-240.40.30:
+    name: Investorenwahrnehmungsstudien
+    description: |
+      Wahrnehmungsstudien und Feedback-Erhebungen bei der Investorenbasis.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-justice-court-administration-management.yaml
+++ b/catalogue/i18n/de/L1-justice-court-administration-management.yaml
@@ -1,0 +1,162 @@
+locale: de
+source: L1-justice-court-administration-management.yaml
+entries:
+  BC-3320:
+    name: Justiz- und Gerichtsverwaltung
+    description: |
+      Gerichtsverwaltung einschließlich Verfahrenseinleitung, Terminkalender und
+      Terminplanung, Verhandlungs- und Prozessbetrieb, Verurteilungs- und
+      Beschluss-Vollstreckung, Strafvollzug und Verwahrung, Bewährungs- und
+      Parolenverwaltung sowie Gerichtsakten-Zugang.
+  BC-3320.10:
+    name: Verfahrenseinreichung und -einleitung
+    description: |
+      Einreichung von Zivil-, Straf-, Familien- und Verwaltungssachen einschließlich
+      E-Filing, Gebührenberechnung und erster Sachklassifizierung.
+    in_scope:
+      - Einreichung zivil- und strafrechtlicher Verfahren
+      - E-Filing und Dokumenteneingang
+      - Einreichungsgebühren-Berechnung
+    out_of_scope:
+      - Angebotseinspruchs-Adjudizierung bei Beschaffung (durch Öffentliche Beschaffung und Auftragsvergabe abgedeckt)
+  BC-3320.10.10:
+    name: Verfahrenseinleitung
+    description: |
+      Eingang von Klageschriften, Anklagen und Ausgangsdokumenten zur Verfahrenseinleitung.
+  BC-3320.10.20:
+    name: Gerichtliches E-Filing
+    description: |
+      Elektronische Einreichung von Gerichtsdokumenten durch Parteien und Rechtsanwälte.
+  BC-3320.10.30:
+    name: Sachklassifizierung und Aktenzeichenvergabe
+    description: |
+      Klassifizierung von Sachen nach Art und Abteilung sowie Vergabe von Aktenzeichen.
+  BC-3320.10.40:
+    name: Gerichtsgebühren-Berechnung
+    description: |
+      Berechnung, Einzug und Erlass von Gerichtseinreichungs- und Antragsgebühren.
+  BC-3320.20:
+    name: Gerichtsterminkalender- und Terminplanungsverwaltung
+    description: |
+      Führung des Gerichtskalenders, Terminierung und Richter-Zuweisung
+      für Sachen, Anhörungen und Prozesse.
+  BC-3320.20.10:
+    name: Terminkalender-Führung
+    description: |
+      Führung von Haupt- und Abteilungskalender sowie Verlaufsdokumentation.
+  BC-3320.20.20:
+    name: Anhörungs- und Prozessterminium-Planung
+    description: |
+      Terminierung von Anhörungen, Prozessen und Antragskalendern über Gerichtssäle und Richter.
+  BC-3320.20.30:
+    name: Richterzuweisung
+    description: |
+      Zuweisung von Sachen an Richter und Rotation über Abteilungen.
+  BC-3320.20.40:
+    name: Vertagungs- und Aufschub-Bearbeitung
+    description: |
+      Bearbeitung von Vertagungs- und Aufschubanträgen sowie Neuterminierung.
+  BC-3320.30:
+    name: Anhörungs- und Prozess-Betrieb
+    description: |
+      Operativer Betrieb von Anhörungen und Prozessen einschließlich Juryverwaltung,
+      Gerichtssaal-Logistik und Dolmetschen.
+  BC-3320.30.10:
+    name: Juryverwaltung
+    description: |
+      Vorladung, Qualifizierung, Auswahl und Dienstleistungsverwaltung von Geschworenen.
+  BC-3320.30.20:
+    name: Gerichtssaal-Betrieb
+    description: |
+      Gerichtssaal-Logistik, Sicherheitskoordination und audiovisuelle Aufzeichnung.
+  BC-3320.30.30:
+    name: Gerichtsdolmetscher-Dienste
+    description: |
+      Bereitstellung von Gerichtsdolmetscher- und Übersetzungsdiensten.
+  BC-3320.30.40:
+    name: Zeugen- und Opferunterstützung
+    description: |
+      Unterstützungsdienste für Zeugen und Opfer sowie Koordination besonderer Maßnahmen.
+  BC-3320.40:
+    name: Verurteilung und Beschluss-Vollstreckung
+    description: |
+      Aufzeichnung von Urteilen und Strafen, Bußgeldern und Schadenersatz sowie
+      Vollstreckung gerichtlicher Beschlüsse.
+  BC-3320.40.10:
+    name: Urteils- und Strafaufzeichnung
+    description: |
+      Aufzeichnung von Urteilen, Strafen und Dispositionsbeschlüssen.
+  BC-3320.40.20:
+    name: Bußgeld- und Schadenersatz-Verwaltung
+    description: |
+      Verwaltung von Bußgeldern, Schadenersatzbeschlüssen und Opferentschädigungen.
+  BC-3320.40.30:
+    name: Zivilurteil-Vollstreckung
+    description: |
+      Vollstreckung zivilgerichtlicher Urteile durch Vollstreckungsbescheide, Pfändungen und Beschlagnahmen.
+  BC-3320.40.40:
+    name: Gerichtlicher Haftbefehl-Ausstellung
+    description: |
+      Ausstellung von Haft-, Sitz- und Durchsuchungsbefehlen auf richterliche Anordnung.
+  BC-3320.50:
+    name: Strafvollzug und Gewahrsam-Verwaltung
+    description: |
+      Gewahrsamsverwaltung von Untersuchungsgefangenen und verurteilten Strafgefangenen
+      in Gefängnissen und Strafanstalten.
+  BC-3320.50.10:
+    name: Häftlingsaufnahme und Einbuchung
+    description: |
+      Aufnahme, Einbuchung und Risikoeinstufung von Häftlingen bei Gewahrsamsbeginn.
+  BC-3320.50.20:
+    name: Gewahrsams-Betrieb
+    description: |
+      Täglicher Gewahrsams-Betrieb einschließlich Belegungsmanagement und Bewegungen.
+  BC-3320.50.30:
+    name: Häftlings-Gesundheitsversorgungskoordination
+    description: |
+      Koordination medizinischer, psychiatrischer und suchtbezogener Versorgung von Häftlingen.
+  BC-3320.50.40:
+    name: Häftlingsprogramme und Resozialisierung
+    description: |
+      Verwaltung von Bildungs-, Berufsausbildungs- und Resozialisierungsprogrammen im Gewahrsam.
+  BC-3320.60:
+    name: Bewährungs- und Parolenverwaltung
+    description: |
+      Gemeindliche Beaufsichtigung von Straftätern auf Bewährung, Parole
+      und bedingter Entlassung.
+  BC-3320.60.10:
+    name: Vor-Urteil-Untersuchung
+    description: |
+      Vor-Urteil-Untersuchungsberichte und Risiko-Bedarfs-Bewertungen für das Gericht.
+  BC-3320.60.20:
+    name: Gemeinschaftliche Überwachung
+    description: |
+      Tägliche Überwachung von Straftätern in der Gemeinschaft.
+  BC-3320.60.30:
+    name: Parole-Anhörungs-Verwaltung
+    description: |
+      Verwaltung von Parole-Ausschuss-Anhörungen und Entscheidungen über bedingte Entlassung.
+  BC-3320.60.40:
+    name: Verstoß- und Widerrufs-Bearbeitung
+    description: |
+      Bearbeitung von Beaufsichtigungsverstößen und Widerrufsverfahren.
+  BC-3320.70:
+    name: Gerichtsakten und Öffentlicher Zugang
+    description: |
+      Führung von Gerichtsakten und Bereitstellung des öffentlichen Zugangs vorbehaltlich
+      Aktenverschluss, Schwärzung und gesetzlicher Beschränkungen.
+  BC-3320.70.10:
+    name: Gerichtsakten-Führung
+    description: |
+      Führung autoritativer Gerichtsakten und Fallunterlagen.
+  BC-3320.70.20:
+    name: Öffentlicher Zugang und PACER-äquivalente Dienste
+    description: |
+      Bereitstellung des öffentlichen Zugangs zu Gerichtsakten über PACER-äquivalente Dienste.
+  BC-3320.70.30:
+    name: Aktenverschluss und Löschung
+    description: |
+      Bearbeitung von Aktenverschluss-, Löschungs- und Aktenunterdrückungsbeschlüssen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-knowledge-management.yaml
+++ b/catalogue/i18n/de/L1-knowledge-management.yaml
@@ -1,0 +1,74 @@
+locale: de
+source: L1-knowledge-management.yaml
+entries:
+  BC-830:
+    name: Wissensmanagement
+    description: |
+      Erfassung, Pflege und Weitergabe von organisationalem Wissen.
+  BC-830.10:
+    name: Wissenserfassungs-Management
+    description: |
+      Erfassung von Experten-, Projekt- und Lessons-Learned-Wissen.
+  BC-830.10.10:
+    name: Implizites Wissen Erheben
+    description: |
+      Erhebung impliziten Expertenwissens durch Interviews und Begleitung.
+  BC-830.10.20:
+    name: Lessons-Learned-Erfassung
+    description: |
+      Erfassung von Lessons Learned aus Projekten und dem Betrieb.
+  BC-830.10.30:
+    name: Wissensasset-Erstellung
+    description: |
+      Erstellung von Artikeln, Playbooks und prozeduralen Wissensassets.
+  BC-830.20:
+    name: Wissenskuratierungs- und Taxonomiemanagement
+    description: |
+      Taxonomien, Ontologien und Inhaltskuratierung.
+  BC-830.20.10:
+    name: Taxonomie- und Ontologiemanagement
+    description: |
+      Pflege von Taxonomien, Ontologien und Metadatenschemata.
+  BC-830.20.20:
+    name: Inhaltskuratierung und -überprüfung
+    description: |
+      Kuratierungszyklen und Aktualitätsprüfungen von Wissensinhalten.
+  BC-830.20.30:
+    name: Such- und Entdeckungsmanagement
+    description: |
+      Unternehmensweite Suche und Inhaltsentdeckungserlebnisse.
+  BC-830.30:
+    name: Wissensteilungs- und Kollaborationsmanagement
+    description: |
+      Communities of Practice und Kollaborationsplattformen.
+  BC-830.30.10:
+    name: Community-of-Practice-Betrieb
+    description: |
+      Stewardship und Betrieb von Communities of Practice.
+  BC-830.30.20:
+    name: Kollaborationsplattform-Management
+    description: |
+      Betrieb von Kollaborations- und Intranetplattformen für den Wissensaustausch.
+  BC-830.30.30:
+    name: Wissensveranstaltungen und Foren
+    description: |
+      Interne Veranstaltungen, Brown Bags und Lernforen.
+  BC-830.40:
+    name: Best-Practice-Management
+    description: |
+      Identifikation, Kodifizierung und Verbreitung von Best Practices.
+  BC-830.40.10:
+    name: Best-Practice-Identifikation
+    description: |
+      Identifikation interner und externer Best Practices.
+  BC-830.40.20:
+    name: Best-Practice-Kodifizierung
+    description: |
+      Kodifizierung von Best Practices in wiederverwendbare Assets und Standards.
+  BC-830.40.30:
+    name: Best-Practice-Verbreitung
+    description: |
+      Verbreitung, Schulung und Adoptionsunterstützung für Best Practices.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-legal-management.yaml
+++ b/catalogue/i18n/de/L1-legal-management.yaml
@@ -1,0 +1,110 @@
+locale: de
+source: L1-legal-management.yaml
+entries:
+  BC-150:
+    name: Rechtsmanagement
+    description: |
+      Rechtsberatung, Verträge, Rechtsstreitigkeiten und gesellschaftsrechtliche Angelegenheiten.
+  BC-150.10:
+    name: Vertragsmanagement
+    description: |
+      Vertragslebenszyklus vom Entwurf bis zum Abschluss.
+  BC-150.10.10:
+    name: Vertragsgestaltung und Vorlagen
+    description: |
+      Pflege von Klauselbibliotheken, Vorlagen und Playbooks.
+  BC-150.10.20:
+    name: Vertragsverhandlungsunterstützung
+    description: |
+      Rechtsunterstützung bei Verhandlung, Redlining und Risikopositionierung.
+  BC-150.10.30:
+    name: Vertragsunterzeichnungsmanagement
+    description: |
+      Genehmigungsworkflows, Unterzeichnung und Ausführungskontrolle.
+  BC-150.10.40:
+    name: Vertragsablage und Verpflichtungsverfolgung
+    description: |
+      Zentrales Archiv, Schlüsseldaten und Verpflichtungsmonitoring.
+  BC-150.10.50:
+    name: Vertragserneuerung und -kündigung
+    description: |
+      Administration von Verlängerungen, Änderungen und Kündigungen.
+  BC-150.20:
+    name: Rechtsstreitigkeits- und Streitbeilegungsmanagement
+    description: |
+      Streitigkeiten, Rechtsstreitigkeiten und Schiedsverfahren.
+  BC-150.20.10:
+    name: Vorprozessuales Streithandling
+    description: |
+      Abmahnschreiben, Mediation und vorprozessuale Verhandlung.
+  BC-150.20.20:
+    name: Prozessmanagement
+    description: |
+      End-to-End-Verwaltung von Gerichtsverfahren.
+  BC-150.20.30:
+    name: Schiedsverfahren und alternative Streitbeilegung
+    description: |
+      Schiedsverfahren, Mediation und sonstige ADR-Mechanismen.
+  BC-150.20.40:
+    name: Legal Hold und eDiscovery
+    description: |
+      Legal-Hold-Anordnungen, Aufbewahrung und elektronische Offenlegung.
+  BC-150.30:
+    name: Gesellschafts- und Handelsrecht
+    description: |
+      Gesellschaftsrecht, rechtliche M&A-Unterstützung und kommerzielle Transaktionen.
+  BC-150.30.10:
+    name: Gesellschaftsrechtliche Beratung
+    description: |
+      Beratung zu Gesellschaftsrecht, Steuerung und Rechtsträgerstrukturierung.
+  BC-150.30.20:
+    name: M&A-Rechtsunterstützung
+    description: |
+      Rechtliche Due Diligence, Transaktionsdokumentation und Abschluss.
+  BC-150.30.30:
+    name: Handelsrechtliche Transaktionsberatung
+    description: |
+      Rechtsunterstützung für Handelsabschlüsse, Partnerschaften und Lizenzierungen.
+  BC-150.30.40:
+    name: Kapitalmarktrechtliche Beratung
+    description: |
+      Wertpapierrecht, Börsennotierung und Kapitalmarkttransaktionen.
+  BC-150.40:
+    name: Regulatorische Rechtsangelegenheiten
+    description: |
+      Rechtliche Auslegung von Vorschriften und Behördenkommunikation.
+  BC-150.40.10:
+    name: Regulatorische Rechtsauslegung
+    description: |
+      Rechtsgutachten zur Anwendbarkeit und Auslegung von Vorschriften.
+  BC-150.40.20:
+    name: Behördenkontakt und Eingaben
+    description: |
+      Rechtsunterstützung bei Behördenkontakten und formellen Eingaben.
+  BC-150.40.30:
+    name: Rechtsunterstützung Regierung und öffentliche Angelegenheiten
+    description: |
+      Rechtsunterstützung für Lobbying, öffentliche Konsultationen und Politikadvokatur.
+  BC-150.50:
+    name: Rechtsbetriebs-Management
+    description: |
+      Betrieb der Rechtsabteilung, E-Billing und Mandatsverwaltung.
+  BC-150.50.10:
+    name: Mandatsverwaltung
+    description: |
+      Mandatsaufnahme, Zuweisung und Lebenszyklusverfolgung.
+  BC-150.50.20:
+    name: Externe Rechtsberaterverwaltung
+    description: |
+      Panel-Management, Beauftragung und Leistung externer Anwälte.
+  BC-150.50.30:
+    name: Rechtsausgaben und E-Billing
+    description: |
+      Rechtsbudgetierung, E-Billing und Ausgabenanalyse.
+  BC-150.50.40:
+    name: Rechtswissensmanagement
+    description: |
+      Präzedenzfälle, Know-how und Einsatz von Legal-Tech.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-legislative-regulatory-drafting-management.yaml
+++ b/catalogue/i18n/de/L1-legislative-regulatory-drafting-management.yaml
@@ -1,0 +1,128 @@
+locale: de
+source: L1-legislative-regulatory-drafting-management.yaml
+entries:
+  BC-3210:
+    name: Gesetzgebung und Regulierungsausarbeitung
+    description: |
+      Ausarbeitung, Rechtsprüfung, Folgenabschätzung, parlamentarische Prozesskoordination
+      und Kodifizierung von Primärgesetzgebung, Sekundärverordnungen, Rechtsverordnungen
+      und Exekutivverordnungen.
+  BC-3210.10:
+    name: Gesetzgebungsentwurf
+    description: |
+      Ausarbeitung von Primärgesetzgebung, Gesetzesentwürfen und Änderungsanträgen
+      durch parlamentarische Rechtsberater oder Gesetzgebungsverfasser.
+    in_scope:
+      - Gesetzesentwurfs- und Änderungsausarbeitung
+      - Bearbeitung von Ausarbeitungsanweisungen
+      - Klare Sprache und zweisprachige Ausarbeitung
+    out_of_scope:
+      - Verordnungen und Rechtsverordnungen (durch Regulierungsausarbeitung abgedeckt)
+  BC-3210.10.10:
+    name: Ausarbeitungsanweisungs-Eingang
+    description: |
+      Eingang und Klärung von Ausarbeitungsanweisungen von Politiksponsoren und Ministerien.
+  BC-3210.10.20:
+    name: Gesetzesentwurfs- und Änderungsausarbeitung
+    description: |
+      Ausarbeitung von Gesetzesentwürfen, Änderungsanträgen und Folgebestimmungen.
+  BC-3210.10.30:
+    name: Qualitätsprüfung des Entwurfs
+    description: |
+      Leitende Rechtsberater-Überprüfung von Gesetzesentwürfen auf Klarheit, Konsistenz und Wirkung.
+  BC-3210.20:
+    name: Regulierungsentwurf
+    description: |
+      Ausarbeitung von Sekundärverordnungen, Rechtsverordnungen, Exekutivverordnungen
+      und Verwaltungsregeln.
+  BC-3210.20.10:
+    name: Verordnungs- und Rechtsverordnungsausarbeitung
+    description: |
+      Ausarbeitung von Verordnungen und Rechtsverordnungen auf Basis von Ermächtigungsgesetzen.
+  BC-3210.20.20:
+    name: Exekutivverordnungsausarbeitung
+    description: |
+      Ausarbeitung von Exekutivverordnungen, Dekreten und Proklamationen.
+  BC-3210.20.30:
+    name: Verwaltungsregel-Ausarbeitung
+    description: |
+      Ausarbeitung von Behörden-Verwaltungsregeln und Bekanntmachungen.
+  BC-3210.30:
+    name: Rechtsprüfung und Verfassungskonformität
+    description: |
+      Rechtliche Überprüfung von Entwurfsinstrumenten auf verfassungsrechtliche,
+      menschenrechtliche und völkerrechtliche Konformität.
+  BC-3210.30.10:
+    name: Verfassungskonformitätsprüfung
+    description: |
+      Überprüfung von Entwürfen gegenüber verfassungsrechtlichen Befugnissen, Rechten und Beschränkungen.
+  BC-3210.30.20:
+    name: Menschenrechtsverträglichkeitsbewertung
+    description: |
+      Bewertung der Verträglichkeit mit Menschenrechtsverträgen und Charten.
+  BC-3210.30.30:
+    name: Völkerrechts-Konformitätsprüfung
+    description: |
+      Überprüfung von Entwürfen auf Konformität mit Vertrags- und supranationalen Verpflichtungen.
+  BC-3210.40:
+    name: Regulierungsfolgenabschätzung
+    description: |
+      Bewertung erwarteter Kosten, Nutzen und Verteilungseffekte vorgeschlagener Instrumente
+      nach OECD-Grundsätzen für bessere Rechtsetzung.
+  BC-3210.40.10:
+    name: Folgenabschätzungs-Scoping
+    description: |
+      Scoping von Regulierungsfolgenabschätzungen und Verhältnismäßigkeitsbestimmung.
+  BC-3210.40.20:
+    name: Kosten-Nutzen-Analyse
+    description: |
+      Quantifizierung regulatorischer Kosten und Nutzen einschließlich Compliance-Belastung.
+  BC-3210.40.30:
+    name: Kleinunternehmen- und KMU-Test
+    description: |
+      Bewertung unverhältnismäßiger Auswirkungen auf Kleinunternehmen und KMUs.
+  BC-3210.40.40:
+    name: Folgenabschätzungs-Veröffentlichung
+    description: |
+      Veröffentlichung von Folgenabschätzungen neben dem Instrument und unterstützender Evidenz.
+  BC-3210.50:
+    name: Gesetzgebungsprozess-Koordination
+    description: |
+      Koordination der parlamentarischen oder gesetzgebenden Verabschiedung von Gesetzesentwürfen,
+      einschließlich Ausschussaussagen, Änderungsanträgen und königlicher Zustimmung oder Verkündung.
+  BC-3210.50.10:
+    name: Parlamentarisches Verbindungsbüro
+    description: |
+      Verbindung zu parlamentarischen oder gesetzgebenden Körperschaften zu Regierungsgesetzen.
+  BC-3210.50.20:
+    name: Ausschussaussagen-Vorbereitung
+    description: |
+      Vorbereitung von Aussagen, Briefings und Zeugen für Gesetzgebungsausschüsse.
+  BC-3210.50.30:
+    name: Änderungstracking
+    description: |
+      Tracking und Bewertung von Gesetzesänderungen durch die Stadien.
+  BC-3210.50.40:
+    name: Verkündungs- und Königliche Zustimmungs-Koordination
+    description: |
+      Koordination der abschließenden Verkündung, königlichen Zustimmung oder exekutiven Unterzeichnung.
+  BC-3210.60:
+    name: Rechtliche Kodifizierung und Veröffentlichung
+    description: |
+      Zusammenstellung, Konsolidierung, Amtsblatt-Veröffentlichung und
+      Pflege von Gesetzes- und Verordnungstexten.
+  BC-3210.60.10:
+    name: Amtsblatt-Veröffentlichung
+    description: |
+      Veröffentlichung erlassener Instrumente im Amtsblatt oder offiziellen Journal.
+  BC-3210.60.20:
+    name: Konsolidierung und Kodifizierung
+    description: |
+      Konsolidierung von Änderungen und Kodifizierung in Gesetzeskodizes.
+  BC-3210.60.30:
+    name: Rechtstextpflege
+    description: |
+      Laufende Pflege und maschinenlesbare Veröffentlichung von Gesetzes- und Verordnungstexten.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-livestock-production-management.yaml
+++ b/catalogue/i18n/de/L1-livestock-production-management.yaml
@@ -1,0 +1,200 @@
+locale: de
+source: L1-livestock-production-management.yaml
+entries:
+  BC-3510:
+    name: Tierhaltung und Viehwirtschaft
+    description: |
+      Landwirtschaftliche Tierhaltung für terrestrisches Nutzvieh –
+      Herden- und Bestandsplanung, Zucht, Ernährung, Tiergesundheit,
+      Tierschutz, Geburt, Wachstumserfassung und Schlachtbereitschaft
+      für Rinder, Schafe, Schweine und Geflügel.
+  BC-3510.10:
+    name: Herden- und Bestandsplanung
+    description: |
+      Besatz-, Remontierungs- und Produktionszyklusplanung über
+      Tierhaltungsbetriebe hinweg.
+  BC-3510.10.10:
+    name: Besatzstärke-Planung
+    description: |
+      Besatzstärke-Entscheidungen abgestimmt auf Futterangebot
+      und Tragfähigkeit.
+  BC-3510.10.20:
+    name: Remontierungs-Planung
+    description: |
+      Remontierungsplanung für Zuchttiere und Legeherden.
+  BC-3510.10.30:
+    name: Produktionszyklus-Planung
+    description: |
+      Kalenderplanung von Produktionszyklen einschließlich
+      Gruppenabferkelung und saisonaler Abkalbung.
+  BC-3510.20:
+    name: Tierzucht-Management
+    description: |
+      Genetische Selektion, Anpaarung, Besamung, Abstammungserfassung
+      und Zuchtleistungsverfolgung.
+    in_scope:
+      - Genetik- und Merkmalselektions-Entscheidungen
+      - Natursprung und Künstliche Besamung
+      - Abstammungs- und Vaterschaftserfassung
+      - Zuchtwert-Bewertung
+  BC-3510.20.10:
+    name: Genetische Selektions-Entscheidungen
+    description: |
+      Selektion von Zuchttieren nach geschätzten Zuchtwerten
+      und Merkmalszielen.
+  BC-3510.20.20:
+    name: Anpaarungs- und Besamungs-Betrieb
+    description: |
+      Natursprung-, Künstliche-Besamungs- und
+      Embryotransfer-Betrieb.
+  BC-3510.20.30:
+    name: Abstammungs- und Vaterschaftserfassung
+    description: |
+      Erfassung von Abstammung, Vaterschaft und
+      Herdenbuchregistrierungen.
+  BC-3510.20.40:
+    name: Zuchtleistungs-Bewertung
+    description: |
+      Bewertung der Zuchtleistung und Zuchtwert-Aktualisierungen.
+  BC-3510.30:
+    name: Tierernährungs-Management
+    description: |
+      Rationenformulierung, Futterverteilung, Weidemanagement und
+      Futterverwertungsverfolgung über Tierkategorien hinweg.
+  BC-3510.30.10:
+    name: Rationenformulierung
+    description: |
+      Kostenminimale Rationenformulierung nach Art- und
+      Entwicklungsstadium-Anforderungen.
+  BC-3510.30.20:
+    name: Futterausgabe und -Verteilung
+    description: |
+      Tägliche Futterausgabe, -Mischung und -Verteilung an
+      Buchten, Ställe und Koppeln.
+  BC-3510.30.30:
+    name: Weidemanagement
+    description: |
+      Rotations- und kontinuierliches Weidemanagement und
+      Weiderestüberwachung.
+  BC-3510.30.40:
+    name: Futterverwertungs-Verfolgung
+    description: |
+      Verfolgung von Futterverwertungs- und Tageszunahme-Kennzahlen.
+  BC-3510.40:
+    name: Tiergesundheits-Management
+    description: |
+      Veterinärbehandlung, Impfung, Parasitenbekämpfung,
+      Krankheitsüberwachung und Wartezeiten-Management.
+    in_scope:
+      - Veterinärbehandlungsaufzeichnungen
+      - Impf- und Parasitenbekämpfungsprogramme
+      - Meldepflichtige Krankheiten-Surveillance
+      - Wartezeiten-Verfolgung für Tierarzneimittel
+    out_of_scope:
+      - Tierschutz-Audits (BC-3510.50)
+      - HHR-Rückstandsüberwachung (BC-3590.50)
+  BC-3510.40.10:
+    name: Veterinärbehandlungs-Aufzeichnungen
+    description: |
+      Aufzeichnung von Veterinärbehandlungen, Rezepten und Ergebnissen.
+  BC-3510.40.20:
+    name: Impfprogramm-Durchführung
+    description: |
+      Durchführung von Herden- und Bestandsimpfprogrammen.
+  BC-3510.40.30:
+    name: Parasitenbekämpfungs-Programme
+    description: |
+      Innen- und Außenparasitenbekämpfungsprogramme und
+      Resistenzmanagement.
+  BC-3510.40.40:
+    name: Krankheitsüberwachung und -Meldung
+    description: |
+      Überwachung und gesetzliche Meldung von anzeigepflichtigen
+      und zoonotischen Krankheiten.
+  BC-3510.40.50:
+    name: Wartezeiten-Management
+    description: |
+      Verfolgung von Wartezeiten für Tierarzneimittel und
+      Futterzusatzstoffe.
+  BC-3510.50:
+    name: Tierschutz-Management
+    description: |
+      Tägliche Tierschutzpraktiken zu Haltung, Umgang und
+      Tierschutzüberwachung nach Zertifizierungsstandards.
+  BC-3510.50.10:
+    name: Haltungs- und Besatzbedingungen
+    description: |
+      Haltungs-, Lüftungs- und Besatzdichtemanagement für
+      Nutztierkategorien.
+  BC-3510.50.20:
+    name: Umgangsstandards
+    description: |
+      Stressarme Umgangs- und Tierpflege-Praktikstandards.
+  BC-3510.50.30:
+    name: Tierschutz-Ergebnisüberwachung
+    description: |
+      Tierschutz-Ergebnismessung und Tierschutzreviews auf dem Betrieb.
+  BC-3510.60:
+    name: Reproduktions- und Geburtsbetrieb
+    description: |
+      Brunsterkennung, Geburten und Neugeborenen-Pflegebetrieb für
+      Rinder, Schafe, Schweine und Geflügel.
+  BC-3510.60.10:
+    name: Brunsterkennung
+    description: |
+      Brunsterkennung durch Beobachtung, Sensoren und
+      Synchronisationsprogramme.
+  BC-3510.60.20:
+    name: Geburtsbetrieb
+    description: |
+      Kalbung, Lammung, Abferkelung und Schlupfbetrieb und -Hilfe.
+  BC-3510.60.30:
+    name: Neugeborenen-Pflegebetrieb
+    description: |
+      Neugeborenenernährung, Kolostrummanagement und
+      Frühlebenspflege.
+  BC-3510.70:
+    name: Wachstums- und Leistungserfassung
+    description: |
+      Aufzeichnung von Wachstum, Milch-, Ei- und Schlachtkörperleistung
+      für Produktions- und Zuchtentscheidungen.
+  BC-3510.70.10:
+    name: Gewichtszunahme-Aufzeichnung
+    description: |
+      Periodische Wägung und Tageszunahme-Aufzeichnung.
+  BC-3510.70.20:
+    name: Milchleistungs-Aufzeichnung
+    description: |
+      Kuh- und Tankmilchleistungs- und Inhaltsstoffaufzeichnung.
+  BC-3510.70.30:
+    name: Eierproduktions-Aufzeichnung
+    description: |
+      Tägliche Eierproduktionsaufzeichnung je Stallabschnitt und Herde.
+  BC-3510.70.40:
+    name: Schlachtkörperleistungs-Verfolgung
+    description: |
+      Verfolgung von Schlachtkörperausbeute, Klassifizierung und
+      Teilstückleistung.
+  BC-3510.80:
+    name: Schlachtbereitschaft und -Vermarktung
+    description: |
+      Selektion schlachtreifen Viehs und Dispositionskoordination
+      zu Schlachthöfen einschließlich Begleitpapieren.
+  BC-3510.80.10:
+    name: Vorsortierung für Schlachtung
+    description: |
+      Selektion schlachtreifen Viehs nach Gewichts-, Fett- und
+      Vertragsspezifikationen.
+  BC-3510.80.20:
+    name: Tierbewegung-Dokumentation
+    description: |
+      Tierbewegungsdokumentation und Informationsübertragung
+      in der Lebensmittelkette.
+  BC-3510.80.30:
+    name: Schlachthof-Dispositionskoordination
+    description: |
+      Dispositions- und Transportkoordination vom Betrieb
+      zum Schlachthof.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-manufacturing-engineering-management.yaml
+++ b/catalogue/i18n/de/L1-manufacturing-engineering-management.yaml
@@ -1,0 +1,118 @@
+locale: de
+source: L1-manufacturing-engineering-management.yaml
+entries:
+  BC-1020:
+    name: Fertigungstechnik-Management
+    description: |
+      Prozesstechnik, Betriebsmittel, Anlagendesign und Industrialisierung.
+  BC-1020.10:
+    name: Produktionsprozessingenieurwesen-Management
+    description: |
+      Produktionsprozessdesign, Arbeitspläne und Arbeitsanweisungen.
+  BC-1020.10.10:
+    name: Prozessdesign und Arbeitsplan
+    description: |
+      Definition von Fertigungsarbeitsplänen und Prozessschritten.
+  BC-1020.10.20:
+    name: Arbeitsanweisungs-Erstellung
+    description: |
+      Erstellung von Standardarbeit und visuellen Arbeitsanweisungen.
+  BC-1020.10.30:
+    name: Prozessvalidierung
+    description: |
+      Validierung von Produktionsprozessen und Fähigkeitsstudien.
+  BC-1020.10.40:
+    name: Prozessänderungssteuerung
+    description: |
+      Änderungssteuerung für Fertigungsprozesse und Arbeitspläne.
+  BC-1020.20:
+    name: Werkzeug- und Vorrichtungsmanagement
+    description: |
+      Werkzeuge, Vorrichtungen und Spannmittel-Lebenszyklus.
+  BC-1020.20.10:
+    name: Werkzeugdesign
+    description: |
+      Design von Werkzeugen, Spann- und Prüfvorrichtungen für die Produktion.
+  BC-1020.20.20:
+    name: Werkzeugbeschaffung und -bau
+    description: |
+      Beschaffung, Bau und Validierung von Betriebsmitteln.
+  BC-1020.20.30:
+    name: Werkzeugwartung und -inspektion
+    description: |
+      Wartung, Inspektion und Instandsetzung von Produktionswerkzeugen.
+  BC-1020.20.40:
+    name: Werkzeugbestandsmanagement
+    description: |
+      Werkzeugkrib-Management und Rückverfolgbarkeit.
+  BC-1020.30:
+    name: Anlagentechnik-Management
+    description: |
+      Anlagenspezifikation, Qualifikation und Modifikation.
+  BC-1020.30.10:
+    name: Anlagenspezifikation
+    description: |
+      Benutzer- und Funktionsspezifikation von Produktionsanlagen.
+  BC-1020.30.20:
+    name: Anlagenqualifikation
+    description: |
+      IQ-, OQ-, PQ-Qualifikation von Produktionsanlagen.
+  BC-1020.30.30:
+    name: Anlagenmodifikations-Management
+    description: |
+      Konstruktionsänderungen und Upgrades von installierten Anlagen.
+  BC-1020.40:
+    name: Industrialisierungsmanagement
+    description: |
+      Überführung von F&E in die Produktion und Hochlauf.
+  BC-1020.40.10:
+    name: Produktionsübernahmemanagement
+    description: |
+      Überführung von Produkten aus F&E oder Pilotfertigung in die Produktion.
+  BC-1020.40.20:
+    name: Vorserie und Pilotproduktion
+    description: |
+      Vorserien- und Pilotlosproduktion und Lernkurve.
+  BC-1020.40.30:
+    name: Produktionshochlauf-Management
+    description: |
+      Produktionshochlauf auf Nennvolumen und -ausbeuten.
+  BC-1020.50:
+    name: Fertigungsmethoden-Management
+    description: |
+      Methoden, Zeitstudien und Ergonomie.
+  BC-1020.50.10:
+    name: Zeit- und Bewegungsstudien
+    description: |
+      Zeitstudien, MTM und Vorgabezeitermittlung.
+  BC-1020.50.20:
+    name: Arbeitsplatzergonomie
+    description: |
+      Ergonomische Gestaltung von Arbeitsplätzen und Aufgaben.
+  BC-1020.50.30:
+    name: Standardarbeitsdefinition
+    description: |
+      Definition von Standardarbeit und optimalen Arbeitsfolgen.
+  BC-1020.60:
+    name: Fertigungs-Kontinuierliche-Verbesserungs-Management
+    description: |
+      Kaizen an Produktionsprozessen und Lean-Transformationen.
+  BC-1020.60.10:
+    name: Kaizen-Veranstaltungs-Durchführung
+    description: |
+      Durchführung von Kaizen-Veranstaltungen an Produktionsprozessen.
+  BC-1020.60.20:
+    name: Lean-Transformationsmanagement
+    description: |
+      Durchgängige Lean-Transformationsprogramme in Werken.
+  BC-1020.60.30:
+    name: Wertstromkartierung
+    description: |
+      Ist- und Soll-Wertstromkartierung.
+  BC-1020.60.40:
+    name: KVP-Kompetenzaufbau
+    description: |
+      Kompetenzaufbau und Coaching in Methoden der kontinuierlichen Verbesserung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-manufacturing-operations-management.yaml
+++ b/catalogue/i18n/de/L1-manufacturing-operations-management.yaml
@@ -1,0 +1,138 @@
+locale: de
+source: L1-manufacturing-operations-management.yaml
+entries:
+  BC-1010:
+    name: Fertigungsbetriebsmanagement
+    description: |
+      Shopfloor-Ausführung, Arbeitsauftragsmanagement und MES-Betrieb.
+  BC-1010.10:
+    name: Arbeitsauftragsmanagement
+    description: |
+      Arbeitsauftrags-Erstellung, -Freigabe, -Verfolgung und -Abschluss.
+  BC-1010.10.10:
+    name: Arbeitsauftrags-Erstellung
+    description: |
+      Erstellung von Arbeitsaufträgen aus Produktionsaufträgen und Stücklisten/Arbeitsplänen.
+  BC-1010.10.20:
+    name: Arbeitsauftrags-Freigabe
+    description: |
+      Freigabe von Arbeitsaufträgen an den Shopfloor mit Materialprüfungen.
+  BC-1010.10.30:
+    name: Arbeitsauftrags-Rückmeldung
+    description: |
+      Rückmeldung von Vorgängen, Mengen und Zeiten auf Arbeitsaufträge.
+  BC-1010.10.40:
+    name: Arbeitsauftrags-Abschluss
+    description: |
+      Endabschluss und Abrechnung von Arbeitsaufträgen.
+  BC-1010.20:
+    name: Shopfloor-Ausführungsmanagement
+    description: |
+      Shopfloor-Steuerung und MES-Ausführung.
+  BC-1010.20.10:
+    name: Produktionsdefinitions-Management
+    description: |
+      ISA-95-Produktionsdefinition für Produkte und Prozesse.
+  BC-1010.20.20:
+    name: Produktionsressourcenmanagement
+    description: |
+      Management der Verfügbarkeit und Fähigkeit von Produktionsressourcen.
+  BC-1010.20.30:
+    name: Produktionsausführungs-Koordination
+    description: |
+      Echtzeit-Koordination der Ausführung über Arbeitszentren hinweg.
+  BC-1010.20.40:
+    name: Produktionsverfolgung und -genealogie
+    description: |
+      Los-, Chargen- und Seriengenalogie sowie As-Built-Aufzeichnungen.
+  BC-1010.30:
+    name: Maschinenbetriebsmanagement
+    description: |
+      Maschinenrüstung, Betrieb, Umrüstung und Überwachung.
+  BC-1010.30.10:
+    name: Maschinenrüstung und Umrüstung
+    description: |
+      Maschinenrüstung, SMED-basierte Umrüstung und Qualifikation.
+  BC-1010.30.20:
+    name: Maschinenbetrieb
+    description: |
+      Maschinenbetrieb, Parametersteuerung und Prozessüberwachung.
+  BC-1010.30.30:
+    name: Maschinenüberwachung
+    description: |
+      Echtzeit-Maschinenüberwachung und Zustandsverfolgung.
+  BC-1010.40:
+    name: Bedienerführungs-Management
+    description: |
+      Arbeitsanweisungen, digitales Andon und Bedienerunterstützung.
+  BC-1010.40.10:
+    name: Digitale Arbeitsanweisungs-Bereitstellung
+    description: |
+      Bereitstellung digitaler Arbeitsanweisungen am Arbeitsplatz.
+  BC-1010.40.20:
+    name: Andon- und Eskalationsmanagement
+    description: |
+      Andon-Signale, Eskalation und Bedienerunterstützung.
+  BC-1010.40.30:
+    name: Bediener-Qualifikation und -Autorisierung
+    description: |
+      Bedienzertifizierung und Autorisierung für Aufgaben.
+  BC-1010.50:
+    name: Materialhandhabungs-Betriebsmanagement
+    description: |
+      Innerbetrieblicher Materialtransport, Kommissionierung und Linienversorgung.
+  BC-1010.50.10:
+    name: Linienseitiger Nachschub
+    description: |
+      Just-in-time-Linienversorgung und Milkruns.
+  BC-1010.50.20:
+    name: Materialkits-Bereitstellung
+    description: |
+      Kommissionierung und Vorkommissionierung von Komponenten für Produktionslinien.
+  BC-1010.50.30:
+    name: Innerbetrieblicher Materialtransport
+    description: |
+      Innerbetriebliche Logistik und Förderung zwischen Arbeitsbereichen.
+  BC-1010.60:
+    name: Fertigungsdatenerfassungs-Management
+    description: |
+      Sensordaten, Maschinendaten und OT-IT-Integration.
+  BC-1010.60.10:
+    name: Maschinendatenerfassung
+    description: |
+      Erfassung von Maschinensignalen und Prozessdaten.
+  BC-1010.60.20:
+    name: Sensor- und IoT-Integration
+    description: |
+      Integration von Sensoren und IIoT-Geräten im Shopfloor.
+  BC-1010.60.30:
+    name: OT-IT-Datenintegration
+    description: |
+      Integration von OT-Daten mit IT-Systemen entsprechend ISA-95.
+  BC-1010.60.40:
+    name: Fertigungsdaten-Historian-Betrieb
+    description: |
+      Historian-basierte Zeitreihendatenerfassung und -zugriff.
+  BC-1010.70:
+    name: Fertigungsleistungsmanagement
+    description: |
+      Echtzeit-Leistung, Ausfallzeiten und Mikrostoppenanalyse.
+  BC-1010.70.10:
+    name: Echtzeit-Leistungsüberwachung
+    description: |
+      Echtzeit-Überwachung von OEE und Shopfloor-KPIs.
+  BC-1010.70.20:
+    name: Mikrostoppen-Analyse
+    description: |
+      Analyse von Mikrostoppen und wiederkehrenden Verlusten.
+  BC-1010.70.30:
+    name: Schichtübergabe-Berichterstattung
+    description: |
+      Strukturierte Schichtübergabeberichte und digitale Tafeln.
+  BC-1010.70.40:
+    name: Produktionsanomalien-Erkennung
+    description: |
+      Anomalieerkennung und Alertierung bei Produktionsdaten.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-market-access-reimbursement-management.yaml
+++ b/catalogue/i18n/de/L1-market-access-reimbursement-management.yaml
@@ -1,0 +1,94 @@
+locale: de
+source: L1-market-access-reimbursement-management.yaml
+entries:
+  BC-1600:
+    name: Marktzugangs- und Kostenerstattungs-Management
+    description: |
+      Zahler-Strategie, HEOR, Preis-/Erstattungseinreichungen, Ausschreibungen und behördliche Preisgestaltung.
+  BC-1600.10:
+    name: Zahler-Strategie-Management
+    description: |
+      Zahler-Engagement, Zahler-Landschaft und Wertversprechen.
+  BC-1600.10.10:
+    name: Zahler-Landschaftsanalyse
+    description: |
+      Analyse der Zahler-Landschaft und Entscheidungsorgane.
+  BC-1600.10.20:
+    name: Zahler-Wertversprechen-Entwicklung
+    description: |
+      Entwicklung zahlerorientierter Wertversprechen.
+  BC-1600.10.30:
+    name: Zahler-Engagement-Betrieb
+    description: |
+      Operatives Engagement mit Zahlern und Account-Managern.
+  BC-1600.20:
+    name: Gesundheitsökonomie- und Versorgungsforschungs-Management
+    description: |
+      HEOR-Studien, Kosteneffektivität und Real-World-Evidenz für Zahler.
+  BC-1600.20.10:
+    name: Kosteneffektivitäts-Modellierung
+    description: |
+      Kosteneffektivitäts- und Budgetauswirkungs-Modellierung.
+  BC-1600.20.20:
+    name: HEOR-Studien-Durchführung
+    description: |
+      Durchführung von HEOR-Studien und Wirtschaftlichkeitsanalysen.
+  BC-1600.20.30:
+    name: Real-World-Evidenz für Zugangszwecke
+    description: |
+      RWE-Generierung zur Unterstützung von Zahler-Evidenzanforderungen.
+  BC-1600.20.40:
+    name: Indirekter-Behandlungsvergleich
+    description: |
+      Indirekter Behandlungsvergleich und Netzwerk-Metaanalyse.
+  BC-1600.30:
+    name: Preis- und Erstattungseinreichungs-Management
+    description: |
+      Preisdossiers, HTA-Einreichungen und Erstattungsanträge.
+  BC-1600.30.10:
+    name: HTA-Dossier-Authoring
+    description: |
+      Erstellung von HTA-Dossiers (NICE, IQWiG, HAS, CADTH).
+  BC-1600.30.20:
+    name: Erstattungsantrag-Einreichung
+    description: |
+      Erstattungsanträge und Preisanträge.
+  BC-1600.30.30:
+    name: HTA-Verhandlung und -Einspruch
+    description: |
+      HTA-Verhandlung, Antwort und Einsprüche.
+  BC-1600.40:
+    name: Ausschreibungs- und Behördenpreismanagement
+    description: |
+      Behördenausschreibungen, Ausschreibungspreisgestaltung und öffentliche Beschaffung.
+  BC-1600.40.10:
+    name: Ausschreibungsangebots-Management
+    description: |
+      Vorbereitung und Einreichung öffentlicher Ausschreibungsangebote.
+  BC-1600.40.20:
+    name: Behördenpreisgestaltungs-Betrieb
+    description: |
+      Behördenpreisgestaltung und gesetzliche Preismeldungen.
+  BC-1600.40.30:
+    name: Rabatt- und Preisnachlass-Verwaltung
+    description: |
+      Verwaltung gesetzlicher Rabatte und Preisnachlässe.
+  BC-1600.50:
+    name: Patientenzugangs-Programm-Management
+    description: |
+      Patientenhilfsprogramme und Zuzahlungsunterstützung.
+  BC-1600.50.10:
+    name: Patientenhilfsprogramm-Betrieb
+    description: |
+      Betrieb von Patienten-Hilfs- und Zugangsprogrammen.
+  BC-1600.50.20:
+    name: Zuzahlungs- und Coupon-Programm-Management
+    description: |
+      Zuzahlungshilfe- und Coupon-Programm-Management.
+  BC-1600.50.30:
+    name: Managed-Access-Programm-Betrieb
+    description: |
+      Mitgefühlsgebrauch- und Managed-Access-Programmbetrieb.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-marketing-management.yaml
+++ b/catalogue/i18n/de/L1-marketing-management.yaml
@@ -1,0 +1,154 @@
+locale: de
+source: L1-marketing-management.yaml
+entries:
+  BC-400:
+    name: Marketing-Management
+    description: |
+      Marke, Marktintelligenz, Nachfragegenerierung und Marketing-Operations.
+  BC-400.10:
+    name: Marketingstrategiemanagement
+    description: |
+      Marketingstrategie, Positionierung und Go-to-Market-Planung.
+  BC-400.10.10:
+    name: Marktsegmentierung und Zielgruppenauswahl
+    description: |
+      Definition von Zielmärkten, Segmenten und Personas.
+  BC-400.10.20:
+    name: Positionierung und Wertversprechen
+    description: |
+      Ausformulierung von Positionierung, Botschaften und Wertversprechen.
+  BC-400.10.30:
+    name: Go-to-Market-Planung
+    description: |
+      Go-to-Market-Modelle, Einführungspläne und Kanalstrategie.
+  BC-400.10.40:
+    name: Marketing-Mix-Planung
+    description: |
+      Marketing-Mix, Kanalallokation und integrierte Marketingpläne.
+  BC-400.20:
+    name: Markenmanagement
+    description: |
+      Markenstrategie, Identität, Equity und Steuerung.
+  BC-400.20.10:
+    name: Markenstrategie und -architektur
+    description: |
+      Markenportfolio, -architektur und Markenstrategie.
+  BC-400.20.20:
+    name: Markenidentität und -standards
+    description: |
+      Erscheinungsbild, Ton, Sprachstil und Markenstandards.
+  BC-400.20.30:
+    name: Markenequity-Messung
+    description: |
+      Nachverfolgung von Markenbekanntheit, Consideration und Equity.
+  BC-400.20.40:
+    name: Marken-Compliance und -Pflege
+    description: |
+      Pflege der Markennutzung über Kanäle und Partner.
+  BC-400.30:
+    name: Marktintelligenzmanagement
+    description: |
+      Marktforschung, Wettbewerbsbeobachtung und Kundenerkenntnisse.
+  BC-400.30.10:
+    name: Marktforschung
+    description: |
+      Primäre und sekundäre Marktforschung sowie Trendanalysen.
+  BC-400.30.20:
+    name: Wettbewerbsbeobachtung
+    description: |
+      Wettbewerbermonitoring, Battlecards und Wettbewerbsanalyse.
+  BC-400.30.30:
+    name: Kundenerkenntnisgenerierung
+    description: |
+      Synthese von Kundenerkenntnissen aus Daten und qualitativer Forschung.
+  BC-400.30.40:
+    name: Marktgrößen und -prognosen
+    description: |
+      Marktgrößenbestimmung, Marktanteile und Nachfrageprognosen.
+  BC-400.40:
+    name: Nachfragegenerierungsmanagement
+    description: |
+      Lead-Generierungskampagnen und Lifecycle-Marketing.
+  BC-400.40.10:
+    name: Kampagnenplanung
+    description: |
+      Kampagnenplanung, Zielgruppenauswahl und Angebotsentwicklung.
+  BC-400.40.20:
+    name: Lead-Generierung
+    description: |
+      Inbound-, Outbound- und ereignisgesteuerte Lead-Generierung.
+  BC-400.40.30:
+    name: Lead-Nurturing und -Scoring
+    description: |
+      Lead-Scoring, Nurture-Journeys und MQL-Übergabe an Vertrieb.
+  BC-400.40.40:
+    name: Lifecycle- und Kundenbindungsmarketing
+    description: |
+      Lifecycle-Marketing, Cross-Sell und Kundenbindungskampagnen.
+  BC-400.50:
+    name: Marketing-Operations-Management
+    description: |
+      Marketingbudget, -technologie, -prozesse und -messung.
+  BC-400.50.10:
+    name: Marketingbudgetmanagement
+    description: |
+      Marketingbudgetierung, Allokation und Ausgabenverfolgung.
+  BC-400.50.20:
+    name: Marketing-Technologiestack-Management
+    description: |
+      Auswahl und Integration von Marketing-Automatisierungs- und Analysewerkzeugen.
+  BC-400.50.30:
+    name: Marketing-Performance-Messung
+    description: |
+      Marketing-Attribution, ROI und Performance-Dashboards.
+  BC-400.50.40:
+    name: Marketing-Compliance-Management
+    description: |
+      Marketing-Compliance in Bezug auf Einwilligung, Datenschutz und Werberegeln.
+  BC-400.60:
+    name: Digitalmarketing-Management
+    description: |
+      Web, SEO, Paid Media, Social Media und Marketing-Automatisierung.
+  BC-400.60.10:
+    name: Website-Erfahrungsmanagement
+    description: |
+      Unternehmenswebauftritte, Content-Management und Personalisierung.
+  BC-400.60.20:
+    name: Suchmaschinenoptimierung
+    description: |
+      Organische Suchoptimierung und Auffindbarkeit von Inhalten.
+  BC-400.60.30:
+    name: Paid-Media-Management
+    description: |
+      Suchanzeigen, Display, Video und programmatischer Media-Einkauf.
+  BC-400.60.40:
+    name: Social-Media-Management
+    description: |
+      Organische Social-Media-Präsenz, Community-Management und Influencer-Engagement.
+  BC-400.60.50:
+    name: Marketing-Automatisierungsbetrieb
+    description: |
+      E-Mail-, Journey-Orchestrierung und Marketing-Automatisierungsbetrieb.
+  BC-400.70:
+    name: Content-Marketing-Management
+    description: |
+      Redaktionsplanung, Inhaltserstellung und Inhaltsverteilung.
+  BC-400.70.10:
+    name: Redaktionsplanung
+    description: |
+      Redaktionskalender, Themen und Content-Strategie.
+  BC-400.70.20:
+    name: Inhaltserstellung
+    description: |
+      Produktion von Artikeln, Videos, Podcasts und Multimedia-Assets.
+  BC-400.70.30:
+    name: Digitales Asset-Management
+    description: |
+      Speicherung, Verschlagwortung und Wiederverwendung digitaler Marketing-Assets.
+  BC-400.70.40:
+    name: Inhaltsverteilung und -syndizierung
+    description: |
+      Verteilung von Inhalten über eigene, verdiente und bezahlte Kanäle.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-materials-management.yaml
+++ b/catalogue/i18n/de/L1-materials-management.yaml
@@ -1,0 +1,94 @@
+locale: de
+source: L1-materials-management.yaml
+entries:
+  BC-1070:
+    name: Materialwirtschaft
+    description: |
+      Werksebenes Rohmaterial-, Halbfertigerzeugnismanagement und Stücklistenmanagement.
+  BC-1070.10:
+    name: Stücklistenmanagement
+    description: |
+      Stücklistenstruktur, Engineering- und Fertigungsstücklisten.
+  BC-1070.10.10:
+    name: Engineering-Stücklisten-Management
+    description: |
+      Engineering-Stücklisten abgestimmt auf Produktdesign und -revisionen.
+  BC-1070.10.20:
+    name: Fertigungsstücklisten-Management
+    description: |
+      Fertigungsstücklisten, die werksspezifische Montagefolgen widerspiegeln.
+  BC-1070.10.30:
+    name: Stücklistenänderungs- und Gültigkeitsmanagement
+    description: |
+      Stücklistenänderungssteuerung, Revision und Gültigkeitsdatierung.
+  BC-1070.10.40:
+    name: Stücklistenvarianten-Management
+    description: |
+      Konfigurierbare und Variantenstücklisten für Produktoptionen.
+  BC-1070.20:
+    name: Rohmaterialmanagement
+    description: |
+      Rohmaterialbestand, Qualität und Rückverfolgbarkeit.
+  BC-1070.20.10:
+    name: Rohmaterialbestandssteuerung
+    description: |
+      Verfolgung von Rohmaterialbeständen an Werks- und Lagerstandorten.
+  BC-1070.20.20:
+    name: Rohmaterialqualitätsprüfung
+    description: |
+      Wareneingangsprüfung, Stichprobennahme und Freigabe von Rohmaterialien.
+  BC-1070.20.30:
+    name: Rohmaterial-Rückverfolgbarkeit
+    description: |
+      Los-, Chargen- und Serienrückverfolgbarkeit für Rohmaterialien.
+  BC-1070.30:
+    name: Halbfabrikate-Management
+    description: |
+      WIP-Verfolgung, -Bewertung und -Steuerung.
+  BC-1070.30.10:
+    name: WIP-Verfolgung
+    description: |
+      Verfolgung von Halbfertigerzeugnissen durch Fertigungsvorgänge.
+  BC-1070.30.20:
+    name: WIP-Bewertung
+    description: |
+      Kostenakkumulation und Bewertung von WIP-Positionen.
+  BC-1070.30.30:
+    name: WIP-Steuerung und Alterung
+    description: |
+      Alterung und Steuerung von gestrandeten oder stagnierenden WIP.
+  BC-1070.40:
+    name: Fertigerzeugnismanagement
+    description: |
+      Fertigerzeugnisbestand auf Werksebene.
+  BC-1070.40.10:
+    name: Fertigerzeugnis-Einlagerung
+    description: |
+      Einlagerung von Fertigerzeugnissen aus der Produktion in den Werkslagerbestand.
+  BC-1070.40.20:
+    name: Fertigerzeugnis-Lagerung
+    description: |
+      Lagerung und Handhabung von Fertigerzeugnissen in Werkslagern.
+  BC-1070.40.30:
+    name: Fertigerzeugnis-Versand
+    description: |
+      Versand und Lieferung von Fertigerzeugnissen an nachgelagerte Knoten.
+  BC-1070.50:
+    name: Materialplanungsmanagement
+    description: |
+      MRP, Materialbedarf und werksebene Versorgungsplanung.
+  BC-1070.50.10:
+    name: Materialbedarfsplanung
+    description: |
+      MRP-Läufe zur Ableitung des Nettomaterialbedarfs aus Bedarf und Stückliste.
+  BC-1070.50.20:
+    name: Materialdeckungsanalyse
+    description: |
+      Deckungsanalyse, Ausnahmenachrichten und Bestellvorschläge.
+  BC-1070.50.30:
+    name: Werksseitige Versorgungsplanausführung
+    description: |
+      Umwandlung von Materialplänen in Einkaufs- und Produktionsaufträge.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-media-asset-management.yaml
+++ b/catalogue/i18n/de/L1-media-asset-management.yaml
@@ -1,0 +1,143 @@
+locale: de
+source: L1-media-asset-management.yaml
+entries:
+  BC-3710:
+    name: Medienobjekte und Media Assets
+    description: |
+      Aufnahme, Katalogisierung, Speicherung, Transformation,
+      Archivierung und Identifikatoren-Management von Medienobjekten
+      über den Inhalts-Lebenszyklus von der Produktion bis
+      zur Distribution.
+  BC-3710.10:
+    name: Medienobjekt-Aufnahme und Qualitätskontrolle
+    description: |
+      Onboarding von Quellmaterial auf die Asset-Plattform mit
+      technischer und redaktioneller Qualitätskontrolle vor
+      der weiteren Nutzung.
+  BC-3710.10.10:
+    name: Quell-Medienobjekt-Aufnahme
+    description: |
+      Aufnahme von Quelldateien sowie Band-zu-Datei- oder
+      Feed-zu-Datei-Capture auf die Asset-Plattform.
+  BC-3710.10.20:
+    name: Qualitätskontroll-Inspektion
+    description: |
+      Automatisierte und operatorgeführte QC-Inspektion auf
+      Bild-, Audio- und Metadatenmängel.
+  BC-3710.10.30:
+    name: Technische Konformitäts-Validierung
+    description: |
+      Validierung gegen Auslieferungsspezifikationen einschließlich
+      Format, Bildrate, Lautstärke und Signalkonformität.
+  BC-3710.20:
+    name: Metadaten-Katalogisierung
+    description: |
+      Erstellung und Kuratierung von beschreibenden, technischen
+      und Rechte-Metadaten, die Medienobjekte auffindbar und
+      nutzbar machen.
+  BC-3710.20.10:
+    name: Deskriptive Metadaten-Erstellung
+    description: |
+      Katalogisierung von Titeln, Synopsen, Mitwirkenden und
+      redaktionellen Attributen gegen ein kontrolliertes Schema.
+  BC-3710.20.20:
+    name: Technische Metadaten-Erfassung
+    description: |
+      Extraktion und Speicherung von Essence-, Container- und
+      Signaleben-technischen Metadaten.
+  BC-3710.20.30:
+    name: Rechte-Metadaten-Verknüpfung
+    description: |
+      Verknüpfung von Medienobjekt-Datensätzen mit Rechte-Datensätzen
+      zu Territorien-, Fenster- und Plattformeinschränkungen.
+  BC-3710.20.40:
+    name: Taxonomie- und Kontrolliertes-Vokabular-Management
+    description: |
+      Pflege von Taxonomien, Genres und kontrollierten Vokabularen
+      über den Katalog hinweg.
+  BC-3710.30:
+    name: Medienobjekt-Speicherung und Tiering
+    description: |
+      Gestufte Speicherung von Medienobjekten über Online-, Nearline-
+      und Archiv-Tiers zur Aufteilung von Zugriffslatenz und Kosten.
+  BC-3710.30.10:
+    name: Online-Medienobjekt-Speicherung
+    description: |
+      Hochleistungs-Speicherung für aktiv in Produktion und
+      Distribution genutzte Medienobjekte.
+  BC-3710.30.20:
+    name: Nearline- und Archiv-Tier-Management
+    description: |
+      Lebenszyklusmigration von Medienobjekten zu Nearline- und
+      Archiv-Tiers mit Recall-Dienstgüteniveaus.
+  BC-3710.30.30:
+    name: Speicherkosten-Optimierung
+    description: |
+      Optimierung von Speicher-Tier-Richtlinien, Deduplizierung
+      und Footprint-Reduzierung über den Medienobjekt-Bestand.
+  BC-3710.40:
+    name: Transcodierung und Formatkonvertierung
+    description: |
+      Erstellung von Intermediate- und Distributions-Renditions
+      durch Transcodierungs- und Packaging-Pipelines.
+  BC-3710.40.10:
+    name: Mezzanine-Erzeugung
+    description: |
+      Erstellung hochwertiger Mezzanine-Master als Intermediate
+      für nachgelagerte Distributions-Encodierungen.
+  BC-3710.40.20:
+    name: Distributions-Format-Encodierung
+    description: |
+      Encodierung von Distributions-Renditions nach Broadcast-,
+      OTT- und Partner-Auslieferungsspezifikationen.
+  BC-3710.40.30:
+    name: Adaptive-Bitrate-Packaging
+    description: |
+      Packaging adaptiver Bitraten-Leitern für HLS-, MPEG-DASH-
+      und CMAF-Streaming-Auslieferung.
+  BC-3710.50:
+    name: Langzeit-Archiv und Bestandserhaltung
+    description: |
+      Langfristige Erhaltung von Master- und historischen
+      Medienobjekten einschließlich Restaurierung von
+      Archivmaterial.
+  BC-3710.50.10:
+    name: Archiv-Katalogisierung
+    description: |
+      Katalogisierung von Langzeit-Archivbeständen einschließlich
+      Altdatenträger- und physischen Element-Aufzeichnungen.
+  BC-3710.50.20:
+    name: Bestandserhaltungs-Migration
+    description: |
+      Periodische Migration von Archivmaterial über
+      Speichergenerationen zur Minderung von Format- und
+      Medienobsoleszenz.
+  BC-3710.50.30:
+    name: Restaurierung und Remastering
+    description: |
+      Bild- und Audio-Restaurierung und Remastering von
+      Archivmaterial auf moderne Auslieferungsstandards.
+  BC-3710.60:
+    name: Content-Identifier- und Versionierungs-Management
+    description: |
+      Zuweisung und Abstammung von Content-Identifikatoren und
+      Versions-Datensätzen, die jeden Schnitt und jede Rendition
+      eindeutig beschreiben.
+  BC-3710.60.10:
+    name: Content-Identifier-Zuweisung
+    description: |
+      Zuweisung interner und Registry-Identifikatoren (EIDR, ISAN,
+      ISRC, ISWC) für Werke und Renditions.
+  BC-3710.60.20:
+    name: Versions- und Schnitt-Abstammungs-Management
+    description: |
+      Verfolgung von Schnitt-, Sprach-, regulatorischen und
+      Plattform-Versionsabstammungen gegen übergeordnete Master-Datensätze.
+  BC-3710.60.30:
+    name: Externer Identifier-Querverweiskartierung
+    description: |
+      Querverweis-Kartierung zwischen internen Identifikatoren
+      und Partner-, Händler- und Registry-Identifikatoren.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-medical-affairs-management.yaml
+++ b/catalogue/i18n/de/L1-medical-affairs-management.yaml
@@ -1,0 +1,122 @@
+locale: de
+source: L1-medical-affairs-management.yaml
+entries:
+  BC-1580:
+    name: Medical-Affairs-Management
+    description: |
+      Wissenschaftlicher Austausch mit Ärzten, KOLs, MSLs und Real-World-Evidenz.
+  BC-1580.10:
+    name: Medizinische-Strategie-Management
+    description: |
+      Medizinische Strategie, wissenschaftliche Plattform und Evidenzgenerierungsplan.
+  BC-1580.10.10:
+    name: Wissenschaftliche-Plattform-Definition
+    description: |
+      Definition der wissenschaftlichen Plattform und Kernaussagen.
+  BC-1580.10.20:
+    name: Evidenzgenerierungs-Planung
+    description: |
+      Planung der Evidenzgenerierung einschließlich IIS- und RWE-Studien.
+  BC-1580.10.30:
+    name: Medizinische-Lebenszyklus-Planung
+    description: |
+      Medizinischer Lebenszyklusplan pro Wirkstoff.
+  BC-1580.20:
+    name: KOL- und HCP-Engagement-Management
+    description: |
+      Schlüsselkommunikationsleiter- und Arzt-Engagement.
+  BC-1580.20.10:
+    name: KOL-Kartierung und -Profiling
+    description: |
+      Identifikation und Profiling von Schlüsselkommunikationsleitern.
+  BC-1580.20.20:
+    name: HCP-Beratungsausschuss-Management
+    description: |
+      Planung und Durchführung von Arzt-Beratungsausschüssen.
+  BC-1580.20.30:
+    name: Wissenschaftliches-Engagement-Verfolgung
+    description: |
+      Verfolgung wissenschaftlicher Engagements und Interaktionen.
+  BC-1580.30:
+    name: Medizinische-Information-Management
+    description: |
+      Medizinische Informationsanfragen und Antwortgenerierung.
+  BC-1580.30.10:
+    name: Medizinische-Informationsanfragen-Eingang
+    description: |
+      Mehrkanal-Eingang medizinischer Informationsanfragen.
+  BC-1580.30.20:
+    name: Standard-Antwortdokumenten-Bibliothek
+    description: |
+      Pflege der Standard-Antwortdokumentenbibliothek.
+  BC-1580.30.30:
+    name: Individuelle-Medizin-Antwort-Generierung
+    description: |
+      Generierung individueller Antworten auf medizinische Anfragen.
+  BC-1580.40:
+    name: Medizinische-Kommunikations-Management
+    description: |
+      Publikationen, Kongress-Strategie und wissenschaftliche Kommunikationen.
+  BC-1580.40.10:
+    name: Publikationsplanung
+    description: |
+      Publikationsplanung gemäß GPP3 und ICMJE.
+  BC-1580.40.20:
+    name: Wissenschaftliche-Manuskript-Erstellung
+    description: |
+      Erstellung und Einreichung wissenschaftlicher Manuskripte.
+  BC-1580.40.30:
+    name: Kongress- und Symposiums-Management
+    description: |
+      Kongressstrategie, Abstracts und Symposien-Management.
+  BC-1580.50:
+    name: Investigator-Initiierte-Studien-Management
+    description: |
+      IIS-Programme und vom Prüfer initiierte Forschung.
+  BC-1580.50.10:
+    name: IIS-Programm-Governance
+    description: |
+      Governance von prüfer-initiierten Studienprogrammen.
+  BC-1580.50.20:
+    name: IIS-Vorschlags-Überprüfung
+    description: |
+      Überprüfung und Entscheidung über IIS-Vorschläge.
+  BC-1580.50.30:
+    name: IIS-Finanzierung und -Unterstützung
+    description: |
+      Finanzierung und Unterstützung von IIS-Prüfern.
+  BC-1580.60:
+    name: Medizinische-Ausbildungs-Management
+    description: |
+      Ärztliche Fortbildung, Stipendien und Programme.
+  BC-1580.60.10:
+    name: Unabhängige-Medizin-Ausbildungs-Stipendien
+    description: |
+      Vergabe von Stipendien für unabhängige medizinische Ausbildung.
+  BC-1580.60.20:
+    name: Werbliche-Medizin-Ausbildung
+    description: |
+      Werbliche medizinische Ausbildungsprogramme.
+  BC-1580.60.30:
+    name: Lehr-Inhalts-Entwicklung
+    description: |
+      Entwicklung akkreditierter Lehrinhalte.
+  BC-1580.70:
+    name: Medical-Science-Liaison-Betriebs-Management
+    description: |
+      MSL-Außendienstbetrieb, Planung und Leistung.
+  BC-1580.70.10:
+    name: MSL-Gebiet und -Zielsetzung
+    description: |
+      MSL-Gebietsdesign und KOL-Zielsetzung.
+  BC-1580.70.20:
+    name: MSL-Aktivitätsplanung
+    description: |
+      MSL-Aktivitätsplanung und Besuchsplanung.
+  BC-1580.70.30:
+    name: MSL-Leistungsverfolgung
+    description: |
+      MSL-Leistung, Erkenntniserfassung und Berichterstattung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-medical-staff-credentialing-management.yaml
+++ b/catalogue/i18n/de/L1-medical-staff-credentialing-management.yaml
@@ -1,0 +1,135 @@
+locale: de
+source: L1-medical-staff-credentialing-management.yaml
+entries:
+  BC-2890:
+    name: Ärztliche Qualifikationsprüfung und Personalverwaltung
+    description: |
+      Qualifikationsprüfung, Privilegienvergabe, Leistungs- und Peer-Review,
+      ärztliche Selbstverwaltung, Leistungserbringerregistrierung und
+      Gesundheitsprogramme für Ärzte.
+  BC-2890.10:
+    name: Ärztliche Qualifikationsprüfung
+    description: |
+      Erstmalige und fortlaufende Qualifikationsprüfung von Ärzten einschließlich
+      Primärquellenverifikation.
+  BC-2890.10.10:
+    name: Antragseingang
+    description: |
+      Eingang und Vollständigkeitsprüfung von Qualifikationsanträgen.
+  BC-2890.10.20:
+    name: Primärquellenverifikation
+    description: |
+      Primärquellenverifikation von Ausbildung, Weiterbildung, Zulassung und Referenzen.
+  BC-2890.10.30:
+    name: Qualifikationsaktenverwaltung
+    description: |
+      Pflege und Prüfung von Qualifikationsakten und Belegen.
+  BC-2890.10.40:
+    name: Rezertifizierung
+    description: |
+      Periodische Rezertifizierung aktiver Ärzte und medizinischer Fachkräfte.
+  BC-2890.20:
+    name: Privilegienverwaltung
+    description: |
+      Definition, Gewährung und Erneuerung klinischer Privilegien.
+  BC-2890.20.10:
+    name: Privilegienabgrenzung
+    description: |
+      Definition und Pflege von Privilegienabgrenzungen nach Abteilung und Fachgebiet.
+  BC-2890.20.20:
+    name: Erstprivilegienvergabe
+    description: |
+      Gewährung erster klinischer Privilegien an neue Ärzte.
+  BC-2890.20.30:
+    name: Privilegienerneuerung
+    description: |
+      Periodische Erneuerung klinischer Privilegien auf Basis von Leistungs- und Kompetenz-Daten.
+  BC-2890.20.40:
+    name: Fachspezifisches Privilegienmanagement
+    description: |
+      Management fachspezifischer, erweiterter und prozeduraler Privilegienanträge.
+  BC-2890.30:
+    name: Leistungs- und Peer-Review
+    description: |
+      Fortlaufende und fokussierte Leistungsbewertung von Ärzten und Peer-Review.
+  BC-2890.30.10:
+    name: Fortlaufende Leistungsbewertung
+    description: |
+      Fortlaufende berufliche Praxisbewertung anhand fachspezifischer Indikatoren.
+  BC-2890.30.20:
+    name: Fokussierte Leistungsbewertung
+    description: |
+      Fokussierte berufliche Praxisbewertung bei Leistungssignalen oder neuen Privilegien.
+  BC-2890.30.30:
+    name: Peer-Review-Fallüberprüfung
+    description: |
+      Strukturierte Peer-Review klinischer Fälle mit Leistungsrelevanz.
+  BC-2890.30.40:
+    name: Arzt-Leistungsberichterstattung
+    description: |
+      Berichterstattung der Arztleistung an Ärzteausschüsse und Einzelpersonen.
+  BC-2890.40:
+    name: Ärztliche Selbstverwaltung
+    description: |
+      Selbstverwaltung des medizinischen Personals einschließlich Satzung,
+      Ärztevorstand und Abteilungsbetrieb.
+  BC-2890.40.10:
+    name: Satzungspflege
+    description: |
+      Pflege und Änderung der Satzung und Geschäftsordnung des medizinischen Personals.
+  BC-2890.40.20:
+    name: Unterstützung des Ärztevorstands
+    description: |
+      Operative und analytische Unterstützung des ärztlichen Vorstands.
+  BC-2890.40.30:
+    name: Abteilungsausschuss-Betrieb
+    description: |
+      Betrieb von Abteilungs-, Fach- und ständigen Ausschüssen.
+  BC-2890.40.40:
+    name: Wahlunterstützung für Funktionsträger
+    description: |
+      Unterstützung für Nominierungen und Wahlen von Ärztefunktionsträgern.
+  BC-2890.50:
+    name: Leistungserbringer-Registrierungsmanagement
+    description: |
+      Registrierung von Leistungserbringern bei Kostenträgern und staatlichen Programmen.
+  BC-2890.50.10:
+    name: Kostenträger-Registrierung
+    description: |
+      Registrierung von Leistungserbringern in kommerziellen Kostenträger-Netzwerken.
+  BC-2890.50.20:
+    name: Zentrales Qualifikationsdatenbank-Management
+    description: |
+      Pflege zentraler Leistungserbringer-Qualifikationsdaten für Kostenträger.
+  BC-2890.50.30:
+    name: Staatliche Programmregistrierung
+    description: |
+      Registrierung von Leistungserbringern bei staatlichen Versicherungsprogrammen.
+  BC-2890.50.40:
+    name: Wiederregistrierungs-Tracking
+    description: |
+      Tracking und rechtzeitige Bearbeitung von Wiederregistrierungszyklen.
+  BC-2890.60:
+    name: Arztgesundheit und Wohlbefinden
+    description: |
+      Programme zur Unterstützung der Arztgesundheit, Burnout-Prävention und
+      vertraulicher Unterstützung.
+  BC-2890.60.10:
+    name: Management beeinträchtigter Ärzte
+    description: |
+      Identifikation, Intervention und Monitoring beeinträchtigter Ärzte.
+  BC-2890.60.20:
+    name: Wellness-Programm-Betrieb
+    description: |
+      Betrieb von Arzt-Wellness- und Resilienz-Programmen.
+  BC-2890.60.30:
+    name: Burnout-Überwachung
+    description: |
+      Überwachung von Burnout- und Wohlbefindens-Indikatoren bei Ärzten.
+  BC-2890.60.40:
+    name: Vertrauliche Unterstützungsressourcen
+    description: |
+      Vertrauliche psychische Gesundheits-, Peer-Support- und Beratungsressourcen für Ärzte.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-merchandising-management.yaml
+++ b/catalogue/i18n/de/L1-merchandising-management.yaml
@@ -1,0 +1,161 @@
+locale: de
+source: L1-merchandising-management.yaml
+entries:
+  BC-2300:
+    name: Handelsmarketing / Merchandising Management
+    description: |
+      Sortiments-, Kategorie-, Flächen-, Einkaufs-, Eigenmarken- und Abschriftentscheidungen,
+      die bestimmen, welche Produkte Verbrauchern angeboten werden, wo und mit welcher Angebotstiefe.
+  BC-2300.10:
+    name: Sortiments- & Rangplanung
+    description: |
+      Sortimentsarchitektur, Artikelanzahl und Filial-Cluster-Sortimentspläne, die die
+      Strategie in die von jedem Standort geführten Artikel übersetzen.
+    in_scope:
+      - Sortimentsarchitektur und Gut-Besser-Best-Struktur
+      - Cluster- und Kanal-Sortimentspläne
+      - Neuartikel-Einführung und Auslistungsslots
+    out_of_scope:
+      - Allgemeines Produktlebenszyklus-Management (BC-820)
+      - Bedarfsprognose (BC-520.10)
+  BC-2300.10.10:
+    name: Sortimentsarchitektur-Definition
+    description: |
+      Definition von Sortimentsarchitektur, Stufung und Gut-Besser-Best-Struktur über Kategorien.
+  BC-2300.10.20:
+    name: Filial-Cluster-Sortimentsplanung
+    description: |
+      Sortimentspläne, abgestimmt auf Filial-Cluster nach Einzugsgebiet und Einkaufsanlass.
+  BC-2300.10.30:
+    name: Artikelanzahl-Optimierung
+    description: |
+      Optimierung der Artikelanzahl pro Kategorie zum Ausgleich von Vielfalt, Komplexität und Marge.
+  BC-2300.10.40:
+    name: Neuartikel-Einführungsplanung
+    description: |
+      Platzierung und Listung neuer Artikel einschließlich Einführungsrhythmus und Ersatzentscheidungen.
+  BC-2300.10.50:
+    name: Auslistungsplanung
+    description: |
+      Sortimentsausstiegsentscheidungen, Ersatzwahl und Disposition ausgelisteter Artikel.
+  BC-2300.20:
+    name: Kategoriemanagement
+    description: |
+      Kategoriestrategie, Rollendefinition und Performance-Management, wobei jede
+      Kategorie gemäß CGF/ECR-Praxis als Geschäftseinheit behandelt wird.
+    in_scope:
+      - Kategoriestrategie und Rollendefinition
+      - Kategorie-Performance und Scorecards
+      - Kategorie-Kapitän-Zusammenarbeit mit Lieferanten
+  BC-2300.20.10:
+    name: Kategoriestrategie-Definition
+    description: |
+      Definition von Kategoriestrategie, Zielkunden und Wettbewerbspositionierung.
+  BC-2300.20.20:
+    name: Kategorierollen-Zuweisung
+    description: |
+      Zuweisung von Kategorierollen wie Destination, Standard, Convenience oder Saisonal.
+  BC-2300.20.30:
+    name: Kategorie-Performance-Analyse
+    description: |
+      Kategorie-Scorecards sowie Marktanteils-, Wachstums- und Margenanalyse.
+  BC-2300.20.40:
+    name: Kategorie-Kapitän-Engagement
+    description: |
+      Einbindung von Lieferanten-Kategorie-Kapitänen mit Informationstrennungskontrollen.
+  BC-2300.30:
+    name: Flächen- & Planogramm-Management
+    description: |
+      Flächen- und Regalraum-Allokation, Planogramme und Möblierungslayouts, die den
+      Sortimentsplan in ein physisches oder digitales Regal übersetzen.
+  BC-2300.30.10:
+    name: Planogramm-Design
+    description: |
+      Design von Planogrammen nach Kategorie, Filial-Cluster und Möblierungstyp.
+  BC-2300.30.20:
+    name: Regalflächen-Allokation
+    description: |
+      Allokation von Regalflächen über Kategorien und Marken nach Performance.
+  BC-2300.30.30:
+    name: Möblierung und Flächenlayout
+    description: |
+      Flächenlayout und Möblierungsplatzierung zur Unterstützung von Nachbarschaften und Einkäuferfluss.
+  BC-2300.30.40:
+    name: Planogramm-Compliance-Tracking
+    description: |
+      Verfolgung der Planogramm-Compliance via Filialrevisionen und Bilderkennungs-Feeds.
+  BC-2300.40:
+    name: Einkauf & Open-to-Buy Management
+    description: |
+      Open-to-Buy-Planung, Einkaufsplan-Durchführung und Filiallallokation, die
+      Sortimentspläne in Lieferanten-Kaufzusagen umwandeln.
+    in_scope:
+      - Open-to-Buy-Budgets nach Abteilung und Saison
+      - Einkaufsplan-Durchführung mit Lieferanten
+      - Allokation empfangener Waren auf Filialen
+    out_of_scope:
+      - Allgemeines Beschaffungswesen (BC-500)
+  BC-2300.40.10:
+    name: Open-to-Buy-Planung
+    description: |
+      Open-to-Buy-Budgetierung nach Abteilung, Klasse und Saison.
+  BC-2300.40.20:
+    name: Einkaufsplan-Durchführung
+    description: |
+      Durchführung von Einkaufsplänen mit Lieferanten einschließlich Stil- und Artikelauswahl.
+  BC-2300.40.30:
+    name: Filial- und Kanal-Allokation
+    description: |
+      Allokation empfangener Waren auf Filialen und Kanäle nach Attributen und Performance.
+  BC-2300.40.40:
+    name: Nachbestellungsmanagement
+    description: |
+      Nachbestellungsentscheidungen für Standard- und Dauerläufer-Artikel.
+  BC-2300.50:
+    name: Eigenmarken-Entwicklung Management
+    description: |
+      Strategie, Spezifikation, Beschaffung und Markenführung von Eigenmarken- und
+      Private-Label-Produktlinien.
+  BC-2300.50.10:
+    name: Eigenmarkenstrategie
+    description: |
+      Eigenmarken-Portfolio-Strategie und Stufung über Eigenmarken.
+  BC-2300.50.20:
+    name: Eigenmarken-Spezifikation
+    description: |
+      Produktspezifikationen, Verpackungsbriefings und Qualitätsstandards für Eigenmarken.
+  BC-2300.50.30:
+    name: Eigenmarken-Beschaffung
+    description: |
+      Beschaffung von Auftragsherstellers und Co-Packern für die Eigenmarkenproduktion.
+  BC-2300.50.40:
+    name: Eigenmarken-Markenführung
+    description: |
+      Führung von Eigenmarken-Identität, Verpackungs-Governance und Markenstärke.
+  BC-2300.60:
+    name: Abschrift- & Bestandsdisposition Management
+    description: |
+      Abschriftrhythmus, Räumungsverkaufs- und Dispositionsentscheidungen, die
+      überschüssige und auslaufende Handelsware abbauen.
+    in_scope:
+      - Abschrift-Kadenz und -Tiefe-Entscheidungen
+      - Saisonende-Räumungspläne
+      - Liquidation, Outlet, Spende und Vernichtungsdisposition
+    out_of_scope:
+      - Tägliche Preisänderungen (BC-440.20.20)
+      - Aktionsrabatte (BC-440.30)
+  BC-2300.60.10:
+    name: Abschriftstrategie
+    description: |
+      Strategie für Abschrifttiefe, -kadenz und -zeitpunkt über Kategorien.
+  BC-2300.60.20:
+    name: Saisonende-Räumungsplanung
+    description: |
+      Saisonende-Räumungspläne und Ausstiegspreis-Management.
+  BC-2300.60.30:
+    name: Bestandsdispositions-Routing
+    description: |
+      Routing von Restbeständen an Outlet, Liquidation, Spende oder Vernichtung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-mine-closure-rehabilitation-management.yaml
+++ b/catalogue/i18n/de/L1-mine-closure-rehabilitation-management.yaml
@@ -1,0 +1,124 @@
+locale: de
+source: L1-mine-closure-rehabilitation-management.yaml
+entries:
+  BC-4470:
+    name: Grubenabschluss und Bergbausanierung
+    description: |
+      Abschlussplanung, Finanzierungsvorsorge, progressive
+      Sanierung, Stilllegung und Nachsorge von Bergbauländereien
+      und Infrastruktur nach dem Betrieb.
+  BC-4470.10:
+    name: Abschlussplanung
+    description: |
+      Konzeptionelle bis detaillierte Abschlussplanentwicklung
+      mit Stakeholder-Einbindung und Regulatorgenehmigung.
+    in_scope:
+      - Konzeptionelle und lebenszyklusorientierte Abschlusspläne
+      - Detaillierte Abschlussplanrevisionen vor der Einstellung
+      - Regulatoren- und Gemeinschafts-Abschlusskonsultation
+    out_of_scope:
+      - Finanzierungsinstrumente (BC-4470.20)
+  BC-4470.10.10:
+    name: Konzeptionelle Abschlussplanentwicklung
+    description: |
+      Entwicklung konzeptioneller Abschlusspläne in frühen
+      Projektphasen.
+  BC-4470.10.20:
+    name: Detaillierte Abschlussplanentwicklung
+    description: |
+      Entwicklung detaillierter Abschlusspläne für die
+      Regulatorgenehmigung vor der Einstellung.
+  BC-4470.10.30:
+    name: Stakeholder-Abschlusseinbindung
+    description: |
+      Einbindung von Regulatoren, Gemeinschaften und
+      traditionellen Eigentümern zu Abschlussergebnissen.
+  BC-4470.20:
+    name: Abschluss-Finanzierungsvorsorge
+    description: |
+      Kostenschätzung, Management von Finanzsicherheits-
+      instrumenten und Bilanzierung von Abschlussrückstellungen.
+  BC-4470.20.10:
+    name: Abschlusskostenschätzung
+    description: |
+      Schätzung der Abschlusskosten über Sanierung,
+      Stilllegung und Nachsorgeaktivitäten hinweg.
+  BC-4470.20.20:
+    name: Finanzsicherheitsinstrument-Management
+    description: |
+      Management von Bürgschaften, Garantien und Kautionsinstrumenten,
+      die bei Regulatoren hinterlegt sind.
+  BC-4470.20.30:
+    name: Abschlussrückstellungs-Bilanzierung
+    description: |
+      Periodische Neubewertung und Erfassung von
+      Abschlussrückstellungen in den Abschlüssen.
+  BC-4470.30:
+    name: Progressive Sanierungsbetrieb
+    description: |
+      Gleichzeitige Sanierung gestörten Landes neben dem Betrieb
+      einschließlich Landformgestaltung, Begrünung und
+      Wasserläufe-Wiederherstellung.
+  BC-4470.30.10:
+    name: Landformgestaltung
+    description: |
+      Umgestaltung von Abraumhalden, Grubenwänden und
+      Tailingslandformen in stabile Abschlussprofile.
+  BC-4470.30.20:
+    name: Bodenauftrag und Begrünung
+    description: |
+      Einbringung gelagerter Bodensubstanz und Einrichtung
+      heimischer Vegetationsdecke.
+  BC-4470.30.30:
+    name: Wasserlauf-Wiederherstellung
+    description: |
+      Wiederherstellung natürlicher und gebauter Wasserläufe
+      über saniertem Land.
+  BC-4470.30.40:
+    name: Infrastruktur-Stilllegung
+    description: |
+      Progressive Stilllegung redundanter betrieblicher
+      Infrastruktur während des Betriebs.
+  BC-4470.40:
+    name: Bergbaustandort-Stilllegung
+    description: |
+      Endzeitliche Demontage, Anlagenentsorgung und
+      Geländebereinigung bei Betriebseinstellung.
+  BC-4470.40.10:
+    name: Anlagendemontage
+    description: |
+      Demontage von Prozessanlage, Bergbauinfrastruktur und
+      Oberflächengebäuden.
+  BC-4470.40.20:
+    name: Anlagenentsorgung und -verwertung
+    description: |
+      Entsorgung, Verwertung oder Übertragung von Bergbau-
+      und Aufbereitungsanlagen bei der Stilllegung.
+  BC-4470.40.30:
+    name: Geländebereinigungsbetrieb
+    description: |
+      Bereinigung kontaminierter Böden, Kohlenwasserstoffe
+      und gelagerter Materialien bei der Stilllegung.
+  BC-4470.50:
+    name: Nachsorge-Stewardship
+    description: |
+      Langfristige Überwachung, Rückgabe und Management von
+      Altlastenhaftungen nach der Betriebseinstellung.
+  BC-4470.50.10:
+    name: Langfristiger Überwachungsbetrieb
+    description: |
+      Betrieb langfristiger Wasser-, Geotechnik- und
+      Begrünungsüberwachungsprogramme.
+  BC-4470.50.20:
+    name: Rückgabe- und Übergabe-Management
+    description: |
+      Management der Landrückgabe, Pachtübergabe und
+      regulatorischen Abzeichnung.
+  BC-4470.50.30:
+    name: Altlastenhaftungs-Verfolgung
+    description: |
+      Verfolgung und Offenlegung zurückbehaltener Altlasten-
+      umwelthaftungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-mine-planning-engineering-management.yaml
+++ b/catalogue/i18n/de/L1-mine-planning-engineering-management.yaml
@@ -1,0 +1,169 @@
+locale: de
+source: L1-mine-planning-engineering-management.yaml
+entries:
+  BC-4420:
+    name: Bergbauplanung und -technik
+    description: |
+      Strategische, langfristige und kurzfristige Bergbauplanung
+      zusammen mit den zugrunde liegenden Berg-, Geotechnik- und
+      Hydrogeologiedisziplinen, die die Ressource in ausführbare
+      Produktionspläne übersetzen.
+  BC-4420.10:
+    name: Strategische Bergbauplanung
+    description: |
+      Definition der Lebensdauer-Abbaustrategie, Auswahl der
+      Abbaumethode, Grubengeometrie und Hauptprojektsequenzierung.
+    in_scope:
+      - Lebensdauer-Plan und Grubengeometrien
+      - Auswahl der Untertagabbaumethode
+      - Hauptprojektsequenzierung und Genehmigungen
+    out_of_scope:
+      - Jährliche Budgetierte Produktionsplanung (BC-4420.20)
+  BC-4420.10.10:
+    name: Lebensdauer-Planung
+    description: |
+      Definition der Lebensdauer-Abbaustrategie, Sequenzierung
+      und Kapitalrahmen.
+  BC-4420.10.20:
+    name: Grubenoptimierung
+    description: |
+      Lerchs-Grossmann- und gleichwertige Grubengeometrie-
+      Optimierung gegenüber wirtschaftlichen und geotechnischen
+      Inputs.
+  BC-4420.10.30:
+    name: Untertagabbaumethoden-Auswahl
+    description: |
+      Auswahl von Untertagabbaumethoden wie Blockbruch,
+      Sublevel-Bruch oder Stoßbau für gegebene Erzlagergeometrie.
+  BC-4420.10.40:
+    name: Hauptprojektsequenzierung
+    description: |
+      Sequenzierung größerer Hauptprojekte über den Lebensdauer-
+      Horizont.
+  BC-4420.20:
+    name: Langfristige Bergbauplanung
+    description: |
+      Jährliche und mehrjährige Produktionsplanung, Haldenstrategie
+      und Investitionsgüterplanung.
+  BC-4420.20.10:
+    name: Jährliche Produktionsplan-Definition
+    description: |
+      Definition des jährlichen Bergbauproduktionsplans und Budgets.
+  BC-4420.20.20:
+    name: Haldenstrategie-Planung
+    description: |
+      Mehrjährige Haldenaufbau-, Abbau- und Umlagerungsstrategie.
+  BC-4420.20.30:
+    name: Cutoff-Grad-Strategie
+    description: |
+      Zeitlich variable Cutoff-Grad-Strategie über die
+      Lebensdauer der Mine.
+  BC-4420.20.40:
+    name: Investitionsgüterplanung
+    description: |
+      Langfristige Planung der Bergbauflotten-Erneuerung und
+      Investitionsgüterergänzungen.
+  BC-4420.30:
+    name: Kurzfristige Bergbauplanung
+    description: |
+      Quartals-, Wochen- und Tagesbergbaupläne, die die
+      Produktionsdurchführung und Gradkontrolle steuern.
+  BC-4420.30.10:
+    name: Quartalsproduktionsplanung
+    description: |
+      Quartalsproduktionsplanungsvorbereitung gemäß dem
+      Jahresplan.
+  BC-4420.30.20:
+    name: Wöchentliche Bergbauplanung
+    description: |
+      Wöchentliche Bergbauplanung nach Sohle, Stoß und Gerät.
+  BC-4420.30.30:
+    name: Tägliche Dispositionsplanung
+    description: |
+      Tägliche und schichtweise Dispositionsplanung der
+      Bergbauflottenzuteilungen.
+  BC-4420.30.40:
+    name: Gradkontrollplanung
+    description: |
+      Planung der Gradkontrollprobenahme und Erzblock-Weiterleitung
+      für die kurzfristige Durchführung.
+  BC-4420.40:
+    name: Bergbaudesigntechnik
+    description: |
+      Ingenieurtechnisches Design von Gruben, Untertageausbrüchen,
+      Bohr- und Sprengmustern, Haulroad-Netzwerken und
+      Grubenventilationsinfrastruktur.
+  BC-4420.40.10:
+    name: Tagebauplanung
+    description: |
+      Sohlen-, Rampen- und Grubengeometrie-Ingenieurdesign für
+      Tagebaubetriebe.
+  BC-4420.40.20:
+    name: Untertagebauplanung
+    description: |
+      Stollen-, Absenk-, Schacht- und Stoßingenieurdesign für
+      Untertagebetriebe.
+  BC-4420.40.30:
+    name: Bohr- und Sprengdesign
+    description: |
+      Muster-, Lade- und Zeitgebungsdesign für die
+      Produktionssprengung.
+  BC-4420.40.40:
+    name: Haulroad-Design
+    description: |
+      Geometrisches und strukturelles Design von
+      Bergbau-Haulroad-Netzwerken.
+  BC-4420.40.50:
+    name: Ventilations- und Versorgungsdesign
+    description: |
+      Ingenieurdesign von Ventilations-, Entwässerungs-, Strom-
+      und Druckluftversorgungssystemen für Untertageminen.
+  BC-4420.50:
+    name: Geotechnische Ingenieurleistung
+    description: |
+      Geotechnische Ingenieurleistung für Böschungsstabilität,
+      Gebirgsunterstützung und Geohazard-Management in Tagebau-
+      und Untertageminen.
+  BC-4420.50.10:
+    name: Böschungsstabilitätstechnik
+    description: |
+      Böschungsstabilitätsanalyse und Grubenwandplanung für
+      Tagebaubetriebe.
+  BC-4420.50.20:
+    name: Untertagebau-Gebirgsunterstützungsdesign
+    description: |
+      Ingenieurdesign von Anker-, Matten-, Spritzbeton- und
+      Kabelunterstützung für Untertageausbrüche.
+  BC-4420.50.30:
+    name: Geotechnisches Überwachungsprogramm-Definition
+    description: |
+      Definition geotechnischer Überwachungsprogramme mit
+      Instrumentendichte, Schwellenwerten und Überprüfungszyklen.
+  BC-4420.50.40:
+    name: Geohazard-Risikobewertung
+    description: |
+      Bewertung von Steinschlag-, seismischen und
+      Senkungsgefahren über Bergbaubetriebe hinweg.
+  BC-4420.60:
+    name: Bergbau-Hydrogeologietechnik
+    description: |
+      Hydrogeologietechnik einschließlich Grundwassermodellierung,
+      Gruben-Entwässerungsdesign und Standortwasserbilanz.
+  BC-4420.60.10:
+    name: Grundwassermodellierung
+    description: |
+      Numerische Modellierung des Grundwasserverhaltens rund um
+      den Bergbaustandort.
+  BC-4420.60.20:
+    name: Gruben-Entwässerungsdesign
+    description: |
+      Ingenieurdesign von Tagebau- und
+      Untertagentwässerungssystemen.
+  BC-4420.60.30:
+    name: Wasserbilanzmodellierung
+    description: |
+      Standortweite Wasserbilanzmodellierung für Betriebs- und
+      Abschlussplanung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-mine-production-operations-management.yaml
+++ b/catalogue/i18n/de/L1-mine-production-operations-management.yaml
@@ -1,0 +1,187 @@
+locale: de
+source: L1-mine-production-operations-management.yaml
+entries:
+  BC-4430:
+    name: Bergbauförderung
+    description: |
+      Durchführung der Bergbauförderung durch Bohr-Spreng-Lade-Transport-
+      Zyklen, Untertagebaustoßbetrieb, Gradkontrolle, Gebirgsbeherrschung,
+      Grubenventilation und Entwässerung in Tagebau- und
+      Untertagebetrieben.
+  BC-4430.10:
+    name: Bohr- und Sprengbetrieb
+    description: |
+      Produktionsbohrung, Laden, Zünden und Nachsprengungsanalyse
+      für Tagebau- und Untertagebetriebe.
+    in_scope:
+      - Produktions-Sprenglochbohrung
+      - Laden und Zünden
+      - Nachsprengungsfragmentierungs- und Bewegungsanalyse
+    out_of_scope:
+      - Explorationsbohrung (BC-4400.30)
+      - Bohr- und Sprengmusterdesign (BC-4420.40.30)
+  BC-4430.10.10:
+    name: Produktionsbohrung
+    description: |
+      Bohrung von Produktions-Sprenglöchern gemäß Sprengmusterdesign.
+  BC-4430.10.20:
+    name: Sprengstoffladung
+    description: |
+      Laden von Sprengstoff und Zubehör in Sprenglöcher.
+  BC-4430.10.30:
+    name: Sprengzündung und Freigabe
+    description: |
+      Verdrahtung, Freigabe, Zündung und Nachsprengungsfreigabe
+      von Produktionssprengungen.
+  BC-4430.10.40:
+    name: Sprengungsleistungsanalyse
+    description: |
+      Fragmentierungs-, Bewegungs- und Vibrationsanalyse
+      durchgeführter Sprengungen.
+  BC-4430.20:
+    name: Lade- und Transportbetrieb
+    description: |
+      Laden, Transportieren und Disponieren von gebrochenem Gestein
+      vom Abbaustoß zur Aufbereitungsanlage oder Deponie.
+  BC-4430.20.10:
+    name: Schaufel- und Baggerbetrieb
+    description: |
+      Betrieb von Seilschaufeln, Hydraulikbaggern und
+      Frontladermaschinen.
+  BC-4430.20.20:
+    name: Fahrzeugtransportbetrieb
+    description: |
+      Betrieb von Off-Highway-Fahrzeugen und
+      Oberleitungsunterstütztem Transport.
+  BC-4430.20.30:
+    name: Flottensteuerung und Telematik
+    description: |
+      Echtzeit-Flottensteuerung, -zuteilung und telematikbasiertes
+      Produktivitätsmanagement.
+  BC-4430.20.40:
+    name: Materialbewegungs-Abgleich
+    description: |
+      Abgleich bewegter Tonnagen gegenüber Vermessung, Disposition
+      und Haldensalden.
+  BC-4430.30:
+    name: Untertageförderbetrieb
+    description: |
+      Stoßentwicklung, -förderung, Verfüllung und unterirdische
+      Materialhandhabung spezifisch für Untertagabbaumethoden.
+  BC-4430.30.10:
+    name: Stoßentwicklung
+    description: |
+      Entwicklung unterirdischer Zufahrten, Stollen und
+      Stoßinfrastruktur.
+  BC-4430.30.20:
+    name: Stoßförderung
+    description: |
+      Produktionssprengung und Geräumung aus unterirdischen Stößen.
+  BC-4430.30.30:
+    name: Verfüllungseinbau
+    description: |
+      Einbau von zementgebundenem oder Gesteins-Versatzmaterial
+      in abgebaute Stöße.
+  BC-4430.30.40:
+    name: Unterirdische Materialhandhabung
+    description: |
+      Betrieb unterirdischer Förderbänder, Erzpässe und
+      Schachtförderung.
+  BC-4430.40:
+    name: Gradkontrollbetrieb
+    description: |
+      Operativer Erz-Taubbetrieb durch Probenahme,
+      Erzblocksefinition und Weiterleitungsentscheidungen am
+      Abbaustoß.
+  BC-4430.40.10:
+    name: Gradkontrollprobenahme
+    description: |
+      Produktionsstufige Probenahme von gebrochenem Gestein und
+      Abbaustößen zur Gradbestimmung.
+  BC-4430.40.20:
+    name: Erzblocksefinition
+    description: |
+      Definition abbaufähiger Erzblöcke für die kurzfristige
+      Durchführung.
+  BC-4430.40.30:
+    name: Erz-Taub-Grenzmarkierung
+    description: |
+      Feldmarkierung von Erz-Taub-Grenzen für Schaufel- und
+      Laderfahrer.
+  BC-4430.40.40:
+    name: Roherzhalden-Zuteilung
+    description: |
+      Zuteilung abgebauten Materials zu Roherz- und
+      Gradhalden.
+  BC-4430.50:
+    name: Gebirgsbeherrschung und geotechnische Überwachung
+    description: |
+      Operative Gebirgsbeherrschung durch Überwachung und
+      Trigger-Action-Reaktion in Tagebauböschungen und
+      Untertageausbrüchen.
+  BC-4430.50.10:
+    name: Böschungsüberwachung
+    description: |
+      Echtzeit-Überwachung von Tagebauböschungen mittels Radar,
+      Prismen und Inklinometern.
+  BC-4430.50.20:
+    name: Gebirgsunterstützungseinbau
+    description: |
+      Einbau von Ankern, Matten, Spritzbeton und
+      Kabelunterstützung untertage.
+  BC-4430.50.30:
+    name: Unterirdische Seismiküberwachung
+    description: |
+      Mikroseismische Überwachung unterirdischer Ausbrüche für
+      Gebirgsschlag- und Spannungsmanagement.
+  BC-4430.50.40:
+    name: Geotechnischer Trigger-Action-Reaktion
+    description: |
+      Durchführung von Trigger-Action-Reaktionsplänen bei
+      Überschreitung von Überwachungsschwellenwerten.
+  BC-4430.60:
+    name: Grubenventilation und Atmosphärenmanagement
+    description: |
+      Betrieb von Haupt- und Hilfsventilationssystemen und
+      Überwachung der Grubenatmosphärenqualität.
+  BC-4430.60.10:
+    name: Hauptventilationsbetrieb
+    description: |
+      Betrieb primärer Oberflächen- und unterirdischer
+      Ventilationsventilatoren und -wege.
+  BC-4430.60.20:
+    name: Hilfsventilationsbetrieb
+    description: |
+      Betrieb von Hilfsventilatoren und Leitungen am Abbaustoß.
+  BC-4430.60.30:
+    name: Grubenatmosphärenüberwachung
+    description: |
+      Echtzeit- und routinemäßige Überwachung von Staub-, Gas-
+      und Sauerstoffgehalten in der Grubenatmosphäre.
+  BC-4430.60.40:
+    name: Dieselpartikelmanagement
+    description: |
+      Management der Dieselpartikelbelastung in unterirdischen
+      Arbeitsbereichen.
+  BC-4430.70:
+    name: Gruben-Entwässerungsbetrieb
+    description: |
+      Betrieb von Tagebau- und Untertagentwässerungssystemen
+      und Pumpenstation-Infrastruktur.
+  BC-4430.70.10:
+    name: Tagebau-Entwässerungsbetrieb
+    description: |
+      Betrieb von Gruben-Pumpen und Perimeter-Entwässerungsbohrungen.
+  BC-4430.70.20:
+    name: Unterirdischer Entwässerungsbetrieb
+    description: |
+      Betrieb unterirdischer Sammelbecken, Pumpen und
+      Entwässerungsverteilung.
+  BC-4430.70.30:
+    name: Pumpstationsmanagement
+    description: |
+      Betrieb und Instandhaltung fester Pumpstationen und
+      Steigleitungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-mineral-exploration-management.yaml
+++ b/catalogue/i18n/de/L1-mineral-exploration-management.yaml
@@ -1,0 +1,196 @@
+locale: de
+source: L1-mineral-exploration-management.yaml
+entries:
+  BC-4400:
+    name: Mineralexploration
+    description: |
+      Entdeckung neuer Mineralisierungen und Qualifikation von
+      Explorationsperspektiven durch geologische, geochemische und
+      geophysikalische Untersuchungen, Explorationsbohrungen und
+      Bohrkernanalysen, culminierend in Entdeckungsberichten und
+      Prospektreifungsentscheidungen.
+  BC-4400.10:
+    name: Geowissenschaftliche Untersuchungsmanagement
+    description: |
+      Erfassung, Verarbeitung und Interpretation von Luftfahrzeug-
+      und Bodengeophysik-, Geochemie- und geologischen Felddaten über
+      Explorationslizenzen.
+    in_scope:
+      - Luftgestützte magnetische und elektromagnetische Untersuchungen
+      - Bodengravitation, IP- und seismische Untersuchungen
+      - Boden-, Bachsediment- und Gesteinsgeochemie
+      - Geologische Kartierung im Maßstab 1:50.000 und Projektmaßstab
+    out_of_scope:
+      - Geologische Kernbohrprotokollierung auf Ressoursenqualität (BC-4400.30)
+      - Geologische Abgleichung in der Produktionsphase (BC-4410.60)
+  BC-4400.10.10:
+    name: Luftgestützte geophysikalische Untersuchung
+    description: |
+      Luftgestützte magnetische, elektromagnetische, radiometrische
+      und gravitative Messungen über Explorationsgebieten.
+  BC-4400.10.20:
+    name: Bodengeophysikalische Untersuchung
+    description: |
+      Bodengravitations-, Induzierte-Polarisations-, elektromagnetische
+      und seismische Messungen im Prospektmaßstab.
+  BC-4400.10.30:
+    name: Geochemische Probenahme
+    description: |
+      Boden-, Bachsediment-, biogeochemische und Gesteinsprobenahmeprogramme
+      zur Abgrenzung geochemischer Anomalien.
+  BC-4400.10.40:
+    name: Geologische Kartierung
+    description: |
+      Aufschluss- und prospektmaßstäbliche geologische Kartierung
+      zur Definition von Lithologie, Struktur und Alteration.
+  BC-4400.10.50:
+    name: Untersuchungsdateninterpretation
+    description: |
+      Integrierte Interpretation geophysikalischer und geochemischer
+      Datensätze zur Zielgenerierung.
+  BC-4400.20:
+    name: Explorationszielgenerierung
+    description: |
+      Umwandlung regionaler und Prospektdaten in priorisierte
+      Bohrziele durch Mineralsystemanalyse und Prospektivitätsmodellierung.
+    in_scope:
+      - Anwendung von Mineralsystem- und Erzlagerstättenmodellen
+      - Datengetriebene Prospektivitätsmodellierung
+      - Lead- und Zielpriorisierung
+    out_of_scope:
+      - Ressourcenschätzung für entdeckte Mineralisierung (BC-4410.20)
+  BC-4400.20.10:
+    name: Mineralsystemanalyse
+    description: |
+      Anwendung von Quell-, Transport-, Fallen- und
+      Erhaltungskriterien zur Definition mineralisierter Systeme.
+  BC-4400.20.20:
+    name: Prospektivitätsmodellierung
+    description: |
+      Wissens- und datengetriebene Prospektivitätskartierung zur
+      Vorhersage von Zielstandorten.
+  BC-4400.20.30:
+    name: Zielpriorisierung
+    description: |
+      Probabilistische Priorisierung generierter Ziele nach
+      Entdeckungswahrscheinlichkeit und potenzieller Tonnage.
+  BC-4400.20.40:
+    name: Explorations-Lead-Inventarmanagement
+    description: |
+      Pflege des priorisierten Explorations-Lead- und
+      Zielinventars und seiner Reifungsstrategie.
+  BC-4400.30:
+    name: Explorationsbohrungsbetrieb
+    description: |
+      Durchführung von Reverse-Circulation-, Diamantkern- und
+      anderen Explorationsbohrprogrammen einschließlich Bohrlochabweichung,
+      Probenprotokollierung und Bohrvertragsnehmermanagement.
+    in_scope:
+      - Reverse-Circulation- und Aircore-Bohrung
+      - Diamantkernbohrung
+      - Bohrlochneigungsvermessung
+    out_of_scope:
+      - Produktionsbohrung für Sprengstoffladung (BC-4430.10)
+      - Geotechnische Bohrung für Böschungsplanung (BC-4420.50)
+  BC-4400.30.10:
+    name: Reverse-Circulation-Bohrung
+    description: |
+      Reverse-Circulation- und Aircore-Bohrung zur
+      Explorations-Probengewinnung.
+  BC-4400.30.20:
+    name: Diamantkernbohrung
+    description: |
+      Diamantkernbohrung für orientierte und kontinuierliche
+      lithologische Probengewinnung.
+  BC-4400.30.30:
+    name: Bohrkernprotokollierung
+    description: |
+      Geologische, geotechnische und strukturelle Protokollierung
+      von Bohrsplittern und Kernen.
+  BC-4400.30.40:
+    name: Bohrlochabweichungsmanagement
+    description: |
+      Unterflurbohrabweichungsvermessung und Bohrhalsvermessungskontrolle.
+  BC-4400.30.50:
+    name: Bohrvertragsnehmermanagement
+    description: |
+      Beauftragung, Mobilisierung und Leistungsmanagement von
+      Bohrvertragsnehmern.
+  BC-4400.40:
+    name: Proben- und Analysenmanagement
+    description: |
+      Verwahrung, Aufbereitung und Analysekoordination von
+      Explorationsproben unter dokumentierten Qualitätssicherungsregimen,
+      die öffentliche Berichtsstandards erfüllen.
+    in_scope:
+      - Proben-Chain-of-Custody
+      - Laborauswahl und Durchlaufzeitmanagement
+      - Qualitätskontrolleinlagen und -überwachung
+    out_of_scope:
+      - Prozessanlageanalysen (BC-4440.60)
+      - Schmelzer-Abrechnungsanalysen (BC-4450.70)
+  BC-4400.40.10:
+    name: Probenaufbereitung
+    description: |
+      Zerkleinern, Teilen und Aufmahlen von Explorationsproben
+      für analytische Analysen.
+  BC-4400.40.20:
+    name: Laboranalysekoordination
+    description: |
+      Auswahl, Versand und Durchlaufzeitmanagement analytischer
+      Laborarbeiten.
+  BC-4400.40.30:
+    name: Qualitätssicherungsprogrammmanagement
+    description: |
+      Einlage und Überwachung von Standards, Blanks und Duplikaten
+      zur Unterstützung berichtsfähiger Analysenqualität.
+  BC-4400.40.40:
+    name: Referenzmaterialmanagement
+    description: |
+      Beschaffung, Charakterisierung und Verteilung zertifizierter
+      Referenzmaterialien.
+  BC-4400.50:
+    name: Explorationsprogrammsteuerung
+    description: |
+      Strategische Ausrichtung des Explorationsportfolios über
+      Rohstoffe, Jurisdiktionen und Risikoklassen hinweg, einschließlich
+      Investitionszuteilung und Entdeckungsleistungsverfolgung.
+  BC-4400.50.10:
+    name: Explorationsstrategie-Definition
+    description: |
+      Definition der Explorationsstrategie nach Rohstoff, Jurisdiktion
+      und Lagerstättenklasse.
+  BC-4400.50.20:
+    name: Explorationsinvestitionszuteilung
+    description: |
+      Zuteilung von Explorationskapital über regionale und
+      Prospektprogramme hinweg.
+  BC-4400.50.30:
+    name: Entdeckungsleistungsverfolgung
+    description: |
+      Verfolgung von Entdeckungskosten, Ressourcenzuwächsen und
+      Umwandlung in Reserven.
+  BC-4400.60:
+    name: Entdeckungsberichterstattung
+    description: |
+      Interne und externe Kommunikation von Explorationsergebnissen
+      einschließlich Partner- und Kapitalmarktoffenlegungen gemäß
+      öffentlichen Berichtscodes.
+  BC-4400.60.10:
+    name: Interne Entdeckungsberichterstattung
+    description: |
+      Interne Kommunikation von Explorationsergebnissen,
+      Schnittpunkten und Zielreifungsstatus.
+  BC-4400.60.20:
+    name: Öffentliche Explorationsergebnisoffenlegung
+    description: |
+      Offenlegung von Explorations-Schnittpunkten und Ergebnissen
+      gemäß JORC, NI 43-101, SAMREC und gleichwertigen Codes.
+  BC-4400.60.30:
+    name: Explorations-Joint-Venture-Berichterstattung
+    description: |
+      Berichterstattung über Explorationsfortschritt, Ausgaben und
+      Ergebnisse an Joint-Venture-Partner und Betreiber.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-mineral-processing-operations-management.yaml
+++ b/catalogue/i18n/de/L1-mineral-processing-operations-management.yaml
@@ -1,0 +1,177 @@
+locale: de
+source: L1-mineral-processing-operations-management.yaml
+entries:
+  BC-4440:
+    name: Mineralaufbereitung
+    description: |
+      Aufbereitungs- und hydrometallurgische Betriebe, die Roherz
+      durch Zerkleinerung, Anreicherung, Laugung und
+      Konzentrathandhabung in verkaufsfähige Konzentrate oder
+      Zwischenprodukte umwandeln.
+  BC-4440.10:
+    name: Roherz-Haldenverwaltung
+    description: |
+      Management von Roherz-Halden zwischen Mine und
+      Aufbereitungsanlage einschließlich Rückgewinnung, Mischung
+      und Inventarabgleich.
+    in_scope:
+      - ROM-Halden-Rückgewinnung und Mischung
+      - Haldeninventar-Abgleich
+    out_of_scope:
+      - Grubeninterne Erzblocksuzuteilung (BC-4430.40.40)
+      - Konzentrat-Haldierung (BC-4440.50.30)
+  BC-4440.10.10:
+    name: Roherz-Halden-Rückgewinnung
+    description: |
+      Rückgewinnung von Roherz-Halden zur Anlagenaufgabe über
+      Schurzenförderer oder Frontlader.
+  BC-4440.10.20:
+    name: Erzmischung
+    description: |
+      Mischung von Haldenmaterial zur Erreichung des Zielgrads
+      und metallurgischer Eigenschaften.
+  BC-4440.10.30:
+    name: Haldeninventar-Abgleich
+    description: |
+      Abgleich von Vermessungs-, Dispositions- und
+      Rückgewinnungsdaten in Haldeninventarsalden.
+  BC-4440.20:
+    name: Zerkleinerungsbetrieb
+    description: |
+      Brech-, Mahl- und Kreislaufoptimierungsbetrieb zur
+      Reduktion von Erz auf die Aufschlussgranulation.
+  BC-4440.20.10:
+    name: Brechbetrieb
+    description: |
+      Betrieb von Primär-, Sekundär- und Tertiärbrechstationen.
+  BC-4440.20.20:
+    name: Mahlmühlenbetrieb
+    description: |
+      Betrieb von SAG-, AG-, Kugel- und Stabmühlen mit
+      zugehöriger Klassierung.
+  BC-4440.20.30:
+    name: Zerkleinerungskreislauf-Optimierung
+    description: |
+      Prozessoptimierung von Zerkleinerungskreisläufen für
+      Durchsatz, P80 und Energieintensität.
+  BC-4440.30:
+    name: Anreicherungsbetrieb
+    description: |
+      Physikalische Anreicherung wertvoller Mineralien durch
+      Flotation, Schwerkraft-, Magnet- und
+      Schwermedienseparation.
+  BC-4440.30.10:
+    name: Flotationskreislaufbetrieb
+    description: |
+      Betrieb von Roh-, Scavenger- und Reinigungsflotationskreisläufen
+      mit Reagenzdosierung.
+  BC-4440.30.20:
+    name: Schwerkraftanreicherung
+    description: |
+      Betrieb von Herdapparaten, Spiralen und Zentrifugal-
+      konzentratoren für schwerkraftanreicherbare Mineralien.
+  BC-4440.30.30:
+    name: Magnetseparation
+    description: |
+      Nieder- und Hochintensitätsmagnetseparation für
+      ferromagnetische und paramagnetische Mineralien.
+  BC-4440.30.40:
+    name: Schwermedienseparation
+    description: |
+      Betrieb von Schwermedienzyklonen und -trommeln zur
+      Vorkonzentrierung.
+  BC-4440.40:
+    name: Hydrometallurgischer Betrieb
+    description: |
+      Wässrige Metallgewinnung durch Haldenlaugung, Tank- und
+      Fass-Laugung, Solventextraktion und Adsorptionskreisläufe.
+  BC-4440.40.10:
+    name: Haldenlaugungsbetrieb
+    description: |
+      Betrieb von Haldenlaugungsplätzen einschließlich
+      Aufstapelung, Bewässerung und Schwangerschaftslösungserfassung.
+  BC-4440.40.20:
+    name: Tank- und Fass-Laugungsbetrieb
+    description: |
+      Betrieb von Tank- und Fass-Laugungskreisläufen für Erz
+      und Konzentrat.
+  BC-4440.40.30:
+    name: Solventextraktionsbetrieb
+    description: |
+      Betrieb von Solventextraktionskreisläufen für selektiven
+      Metalltransfer in den Elektrolyten.
+  BC-4440.40.40:
+    name: Kohlenstoffadsorptionsbetrieb
+    description: |
+      Betrieb von Carbon-in-Pulp-, Carbon-in-Leach- und
+      Carbon-in-Column-Adsorptions-Elutions-Gewinnungskreisläufen.
+  BC-4440.50:
+    name: Konzentrathandhabung und Filtration
+    description: |
+      Eindickung, Filtration und Haldierung von Konzentraten
+      für den Versand an Schmelzer oder Verkauf.
+  BC-4440.50.10:
+    name: Eindickungsbetrieb
+    description: |
+      Betrieb von Hochraten- und Pasteneindickern für
+      Konzentrat- und Tailing-Entwässerung.
+  BC-4440.50.20:
+    name: Filtrations- und Entwässerungsbetrieb
+    description: |
+      Betrieb von Druck-, Vakuum- und Bandfiltern für
+      Konzentratentwässerung.
+  BC-4440.50.30:
+    name: Konzentrat-Haldierung
+    description: |
+      Innen- und Außenhaldierung entwässerter Konzentrate
+      vor dem Versand.
+  BC-4440.60:
+    name: Prozessanlage-Hüttenrechnung
+    description: |
+      Probenahme, Analyse und Metallbilanzen-Abgleich von
+      Aufgabegut, Produkten und Tailings.
+  BC-4440.60.10:
+    name: Anlagenprobenahme und Analyse
+    description: |
+      Querstrom-Probenahme und Analyse von Aufgabegut,
+      Konzentrat und Tailings.
+  BC-4440.60.20:
+    name: Metallurgische Bilanz
+    description: |
+      Periodischer Metallbilanz-Abgleich über das
+      Prozessanlagenfließschema.
+  BC-4440.60.30:
+    name: Gewinnungsberichterstattung
+    description: |
+      Berichterstattung über die Metallgewinnung gegenüber
+      Plan und Design.
+  BC-4440.60.40:
+    name: Konzentratqualitätsberichterstattung
+    description: |
+      Berichterstattung über Konzentratgrad, schädliche Elemente
+      und Feuchtigkeit gegenüber Spezifikation.
+  BC-4440.70:
+    name: Prozessreagenz- und Verbrauchsmaterialmanagement
+    description: |
+      Management von Prozessreagenzien und Verbrauchsmaterialien
+      einschließlich Dosierkontrolle, Inventar und Betreuung
+      gefährlicher Reagenzien.
+  BC-4440.70.10:
+    name: Reagenzdosierkontrolle
+    description: |
+      Echtzeit-Steuerung der Reagenzdosierung in Flotations-
+      und hydrometallurgischen Kreisläufen.
+  BC-4440.70.20:
+    name: Reagenzinventarmanagement
+    description: |
+      Inventar- und Verbrauchsmanagement von Massenreagenzien
+      und Mahlkörpern.
+  BC-4440.70.30:
+    name: Zyanid-Stewardship
+    description: |
+      Verantwortungsvoller Umgang mit Zyanid und anderen
+      gefährlichen Reagenzien gemäß dem Internationalen
+      Zyanid-Management-Code.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-mineral-product-marketing-management.yaml
+++ b/catalogue/i18n/de/L1-mineral-product-marketing-management.yaml
@@ -1,0 +1,150 @@
+locale: de
+source: L1-mineral-product-marketing-management.yaml
+entries:
+  BC-4480:
+    name: Mineralprodukt-Vermarktung
+    description: |
+      Verkauf, Abnahme, Verhüttungs- und Raffinationsgebühren-
+      verhandlung, vorläufige Preisabrechnung, Logistikkoordination
+      und Handelsrisikomanagement für Konzentrate, Zwischenprodukte
+      und Fertigmetallprodukte.
+  BC-4480.10:
+    name: Konzentrat- und Metallverkauf
+    description: |
+      Spot- und Terminverkaufsdurchführung und Kundenzuteilungs-
+      planung für Konzentrate und Fertigmetall.
+    in_scope:
+      - Spot-Tonnage- und Terminvertragsverkäufe
+      - Kundenzuteilungsplanung über Minen und Raffinerien
+    out_of_scope:
+      - Abrechnungen unter vorläufiger Preisgestaltung (BC-4480.40)
+  BC-4480.10.10:
+    name: Spot-Verkaufs-Durchführung
+    description: |
+      Durchführung von Spot-Verkäufen von Konzentraten und
+      Metallen an Händler und Endkunden.
+  BC-4480.10.20:
+    name: Terminvertragsmanagement
+    description: |
+      Management mehrjähriger Terminverkaufsverträge für
+      Konzentrate und Metalle.
+  BC-4480.10.30:
+    name: Kundenzuteilungsplanung
+    description: |
+      Zuteilung verfügbarer Produktion auf Kunden und Verträge.
+  BC-4480.20:
+    name: Abnahme-Vereinbarungsmanagement
+    description: |
+      Verhandlung und laufende Verwaltung von Abnahmevereinbarungen
+      einschließlich Streaming- und Royalty-Abnahmen.
+  BC-4480.20.10:
+    name: Abnahmevertrag-Verhandlung
+    description: |
+      Kommerzielle und rechtliche Verhandlung von Abnahme- und
+      Streaming-Vereinbarungen.
+  BC-4480.20.20:
+    name: Abnahmemengen-Nominierung
+    description: |
+      Nominierung von Abnahmemengen gegenüber vertraglichen
+      Ansprüchen.
+  BC-4480.20.30:
+    name: Abnahme-Leistungsüberwachung
+    description: |
+      Überwachung von Abnahmelieferung, Qualität und
+      Gegenpartei-Leistung.
+  BC-4480.30:
+    name: Verhüttungs- und Raffinationsgebühren-Verhandlung
+    description: |
+      Jährliche Benchmark- und bilaterale Verhandlung von
+      Verhüttungs- und Raffinationsgebühren sowie Konzentrat-
+      Strafkonditionen.
+  BC-4480.30.10:
+    name: Jährliche Benchmark-Verhandlung
+    description: |
+      Jährliche Benchmark-Verhandlung von Verhüttungs- und
+      Raffinationsgebühren mit Schmelzern und Kunden.
+  BC-4480.30.20:
+    name: Verhüttungsgebühren-Abrechnungsverfolgung
+    description: |
+      Verfolgung von Verhüttungs- und Raffinationsgebühren-
+      abrechnungen gegenüber Benchmark- und Vertragsbedingungen.
+  BC-4480.30.30:
+    name: Strafpflicht-Management
+    description: |
+      Management von Strafbedingungen für Arsen, Antimon,
+      Fluor und andere schädliche Elemente.
+  BC-4480.40:
+    name: Vorläufige Preisgestaltung und Abrechnung
+    description: |
+      Quotierungszeitraummanagement, vorläufige Fakturierung,
+      endgültige Abrechnungsberechnung und Hedging-Koordination
+      für preislich fixiertes Metallgehalt.
+  BC-4480.40.10:
+    name: Quotierungszeitraum-Management
+    description: |
+      Management von Quotierungszeiträumen, die die endgültige
+      Preisgestaltung von Sendungen regeln.
+  BC-4480.40.20:
+    name: Vorläufige Rechnungsausstellung
+    description: |
+      Ausstellung vorläufiger Rechnungen bei Versand basierend
+      auf angenommenen Analysen und Preisen.
+  BC-4480.40.30:
+    name: Endgültige Abrechnungsberechnung
+    description: |
+      Endgültige Abrechnung von Sendungen unter Verwendung von
+      Schiedsrichteranalysen und durchschnittlichen
+      Quotierungszeitraumspreisen.
+  BC-4480.40.40:
+    name: Hedging-Koordination
+    description: |
+      Koordination mit Treasury-Hedging-Programmen für
+      vorläufig preislich fixiertes Metallexposure.
+  BC-4480.50:
+    name: Mineralprodukt-Logistikkoordination
+    description: |
+      Massensendungs-Nominierung, Lagerschein-Management,
+      Entladungsprobenahme und Massengut-Regulierungskonformität.
+  BC-4480.50.10:
+    name: Massensendungs-Nominierung
+    description: |
+      Nominierung von Schiffen, Eisenbahnwaggons und Barken
+      für Konzentrat- und Erzsendungen.
+  BC-4480.50.20:
+    name: Lagerschein-Management
+    description: |
+      Management von LME- und anderen Börsen-Lagerscheinen
+      für Fertigmetallbestände.
+  BC-4480.50.30:
+    name: Konzentrat-Entladungsprobenahme
+    description: |
+      Koordination unabhängiger Probenahme und Analyse an
+      Entladehäfen.
+  BC-4480.50.40:
+    name: Massengut-Code-Konformität
+    description: |
+      Konformität mit dem IMO IMSBC-Code und gleichwertigen
+      Feststoff-Massengut-Vorschriften.
+  BC-4480.60:
+    name: Metallhandels-Risikomanagement
+    description: |
+      Management von Metallpreisen, Gegenpartei-Kredit- und
+      Handelsdokumentationsrisiken über das Marketingbuch hinweg.
+  BC-4480.60.10:
+    name: Preisrisikopositions-Überwachung
+    description: |
+      Überwachung preislich fixierter und unpreisierter
+      Metallpositionen über das Marketingbuch.
+  BC-4480.60.20:
+    name: Gegenpartei-Kreditmanagement
+    description: |
+      Gegenpartei-Kreditbewertung, Limits und Expositions-
+      überwachung für Handelspartner.
+  BC-4480.60.30:
+    name: Handelsbestätigung und -dokumentation
+    description: |
+      Bestätigung, Dokumentation und Aufbewahrung von
+      Handelstickets und Verträgen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-mineral-resource-reserve-management.yaml
+++ b/catalogue/i18n/de/L1-mineral-resource-reserve-management.yaml
@@ -1,0 +1,166 @@
+locale: de
+source: L1-mineral-resource-reserve-management.yaml
+entries:
+  BC-4410:
+    name: Mineralressourcen und -reserven
+    description: |
+      Geologische Modellierung, geostatistische Schätzung,
+      Klassifikation, Sachverständigen-Governance und öffentliche
+      Berichterstattung über Mineralressourcen und Erzreserven gemäß
+      CRIRSCO-konformen Codes.
+  BC-4410.10:
+    name: Geologische Modellierung
+    description: |
+      Erstellung dreidimensionaler geologischer Modelle von Lithologie,
+      Struktur, Alteration und Mineralisierungsdomänen als Input für
+      die Ressourcenschätzung.
+    in_scope:
+      - Lithologische und stratigraphische Modellierung
+      - Strukturelle und Störungsmodellierung
+      - Mineralisierungsdomänen-Wireframing
+    out_of_scope:
+      - Gruben- und Stoßentwurfs-Wireframes (BC-4420.40)
+  BC-4410.10.10:
+    name: Lithologische Modellierung
+    description: |
+      Dreidimensionale Modellierung lithologischer und
+      stratigraphischer Einheiten aus der Bohrprotokollierung.
+  BC-4410.10.20:
+    name: Strukturelle Modellierung
+    description: |
+      Modellierung von Störungen, Falten und Scherzonen, die
+      die Mineralisierungsgeometrie kontrollieren.
+  BC-4410.10.30:
+    name: Mineralisierungsdomänenmodellierung
+    description: |
+      Wireframing von Mineralisierungshüllen und Gradzonen als
+      Schätzgrenzen.
+  BC-4410.10.40:
+    name: Implizite Modellierungs-Workflows
+    description: |
+      Implizite und schnell aktualisierbare geologische
+      Modellierungs-Workflows für iterative Modellverfeinerung.
+  BC-4410.20:
+    name: Ressourcenschätzung
+    description: |
+      Geostatistische Schätzung von Grad und Tonnage in Blockmodelle
+      und Klassifikation des geschätzten Materials als Inferred,
+      Indicated oder Measured gemäß öffentlichen Berichtscodes.
+  BC-4410.20.10:
+    name: Geostatistische Schätzung
+    description: |
+      Variografie und Kriging oder simulationsbasierte Schätzung
+      von Grad in Blockmodelle.
+  BC-4410.20.20:
+    name: Blockmodellkonstruktion
+    description: |
+      Konstruktion und Befüllung regularisierter Blockmodelle für
+      die nachgelagerte Planung.
+  BC-4410.20.30:
+    name: Schätzungsvalidierung
+    description: |
+      Statistische und visuelle Validierung geschätzter Grade
+      gegenüber Kompositionsdaten.
+  BC-4410.20.40:
+    name: Ressourcenklassifikation
+    description: |
+      Klassifikation der geschätzten Mineralisierung in die
+      Kategorien Inferred, Indicated und Measured.
+  BC-4410.30:
+    name: Reservenschätzung
+    description: |
+      Anwendung von Bergbau-, metallurgischen, wirtschaftlichen und
+      anderen modifizierenden Faktoren zur Umwandlung von Indicated
+      und Measured Resources in Probable und Proved Ore Reserves.
+  BC-4410.30.10:
+    name: Modifizierende Faktoranwendung
+    description: |
+      Anwendung von Bergbau-, metallurgischen, Infrastruktur- und
+      wirtschaftlichen modifizierenden Faktoren auf Ressourcen.
+  BC-4410.30.20:
+    name: Cutoff-Grad-Bestimmung
+    description: |
+      Berechnung von Cutoff-Graden zur Unterstützung der
+      Reservendefinition unter angenommener Preisgestaltung und Kosten.
+  BC-4410.30.30:
+    name: Bergbaugewinnung und Verdünnungsmodellierung
+    description: |
+      Modellierung von Bergbaugewinnung, Verdünnung und Randeffekten
+      auf In-situ-Ressourcen.
+  BC-4410.30.40:
+    name: Erzreservenklassifikation
+    description: |
+      Klassifikation von Erzreserven in Probable und Proved
+      Kategorien.
+  BC-4410.40:
+    name: Sachverständigen-Governance
+    description: |
+      Governance qualifizierter und sachkundiger Personen, die
+      Verantwortung für Ressourcen- und Reservenaussagen gemäß
+      öffentlichen Berichtscodes übernehmen.
+  BC-4410.40.10:
+    name: Sachverständigen-Signatur
+    description: |
+      Überprüfung und Unterzeichnung von Ressourcen- und
+      Reservenaussagen durch Sachverständige oder qualifizierte
+      Personen.
+  BC-4410.40.20:
+    name: Interne Ressourcenüberprüfung
+    description: |
+      Interne Peer- und technische Ausschussüberprüfung von
+      Ressourcen- und Reservenschätzungen.
+  BC-4410.40.30:
+    name: Externe Ressourcenprüfungskoordination
+    description: |
+      Koordination unabhängiger Drittpartei-Ressourcen- und
+      Reservenprüfungen.
+  BC-4410.50:
+    name: Öffentliche Ressourcen- und Reservenberichterstattung
+    description: |
+      Vorbereitung und Offenlegung öffentlicher Aussagen über
+      Mineralressourcen und Erzreserven gemäß Wertpapierregulierungen
+      und Börsenregeln.
+  BC-4410.50.10:
+    name: Ressourcenaussagenvorbereitung
+    description: |
+      Vorbereitung öffentlicher Mineralressourcenaussagen gemäß
+      CRIRSCO-Familien-Codes.
+  BC-4410.50.20:
+    name: Reservenaussagenvorbereitung
+    description: |
+      Vorbereitung öffentlicher Erzreservenaussagen gemäß
+      CRIRSCO-Familien-Codes.
+  BC-4410.50.30:
+    name: Jährliche Reservenaussagenaktualisierung
+    description: |
+      Jährliche Aktualisierung von Ressourcen- und Reservenaussagen
+      unter Berücksichtigung von Abbau und neuen Schätzungen.
+  BC-4410.50.40:
+    name: Unabhängiger technischer Berichtskoordination
+    description: |
+      Koordination qualifizierter technischer Sachverständigenberichte
+      für Kapitalmärkte, Transaktionen und Offenlegungsereignisse.
+  BC-4410.60:
+    name: Ressourcenabgleich
+    description: |
+      Abgleich geschätzter Ressourcen und Reserven gegenüber
+      Gradekontrollen, Aufgabengut und Metallproduktion zur
+      Beurteilung der Modellleistung.
+  BC-4410.60.10:
+    name: Bergwerk-zu-Mühle-Abgleich
+    description: |
+      Abgleich geförderter Tonnagen und Grade gegenüber
+      Aufgabengut und gewonnenem Metall.
+  BC-4410.60.20:
+    name: Ressourcenabbau-Verfolgung
+    description: |
+      Verfolgung des Ressourcen- und Reservenabbaus aus
+      Bergbauaktivitäten.
+  BC-4410.60.30:
+    name: Modellleistungsanalyse
+    description: |
+      Analyse der Ressourcenmodellleistung gegenüber Istwerten
+      zur Informierung zukünftiger Schätzungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-mining-community-social-performance-management.yaml
+++ b/catalogue/i18n/de/L1-mining-community-social-performance-management.yaml
@@ -1,0 +1,171 @@
+locale: de
+source: L1-mining-community-social-performance-management.yaml
+entries:
+  BC-4500:
+    name: Soziale Verantwortung (Bergbau)
+    description: |
+      Aufrechterhaltung der sozialen Betriebslizenz durch Einbindung
+      von Gastgemeinschaften, indigenen und traditionellen Eigentümern,
+      Umsiedlung und Landzugang, Gemeinschaftsinvestitionen, lokale
+      Inhalte, Menschenrechte und Sozialleistungsberichterstattung.
+  BC-4500.10:
+    name: Gastgemeinschaft-Einbindung
+    description: |
+      Identifikation, Konsultation und Beschwerdebehandlung mit von
+      Bergbaubetrieben betroffenen Gastgemeinschaften.
+    in_scope:
+      - Stakeholder-Identifikation und -Kartierung
+      - Gemeinschaftskonsultationsprogramme
+      - Gemeinschaftsbeschwerdemechanismen
+    out_of_scope:
+      - Indigenenspezifische Einbindung (BC-4500.20)
+      - Umsiedlung (BC-4500.30)
+  BC-4500.10.10:
+    name: Gemeinschafts-Stakeholder-Kartierung
+    description: |
+      Identifikation und Kartierung von Stakeholdern im
+      Bergbaueinflussbereich.
+  BC-4500.10.20:
+    name: Gemeinschaftskonsultationsprogramm
+    description: |
+      Betrieb strukturierter Gemeinschaftskonsultationsforen
+      und Informationsoffenlegung.
+  BC-4500.10.30:
+    name: Gemeinschaftsbeschwerdebehandlung
+    description: |
+      Operativer Gemeinschaftsbeschwerdemechanismus gemäß
+      den UN-Leitprinzipien-Wirksamkeitskriterien.
+  BC-4500.20:
+    name: Indigene und traditionelle Eigentümer-Einbindung
+    description: |
+      Einbindung indigener und traditioneller Eigentümergruppen
+      einschließlich Landtitel, kulturelles Erbe und
+      Nutzenteilungsvereinbarungen.
+  BC-4500.20.10:
+    name: Landtitel- und Landrechte-Einbindung
+    description: |
+      Einbindung zu Landtiteln und gewohnheitsmäßigen Landrechten,
+      die den Bergbaubetrieb betreffen.
+  BC-4500.20.20:
+    name: Kulturgut-Management
+    description: |
+      Identifikation, Schutz und Management von Kulturgut-
+      Stätten und -Werten.
+  BC-4500.20.30:
+    name: Indigene Landnutzungsvereinbarung-Verwaltung
+    description: |
+      Verwaltung indigener Landnutzungs- und
+      Nutzenteilungsvereinbarungen.
+  BC-4500.30:
+    name: Umsiedlung und Landzugangsmanagement
+    description: |
+      Landerwerb, unfreiwillige Umsiedlung und
+      Lebensunterhalt-Wiederherstellung für projektbetroffene
+      Personen.
+  BC-4500.30.10:
+    name: Landerwerbs-Verhandlung
+    description: |
+      Verhandlung freiwilliger Landerwerbe für Bergbau und
+      zugehörige Infrastruktur.
+  BC-4500.30.20:
+    name: Unfreiwillige Umsiedlungsplanung
+    description: |
+      Planung unfreiwilliger Umsiedlungen gemäß IFC-
+      Leistungsstandards und gleichwertigen Regimen.
+  BC-4500.30.30:
+    name: Umsiedlungsaktionsplan-Umsetzung
+    description: |
+      Umsetzung von Umsiedlungsaktionsplänen für
+      projektbetroffene Haushalte.
+  BC-4500.30.40:
+    name: Lebensunterhalt-Wiederherstellungs-Programmbetrieb
+    description: |
+      Betrieb von Lebensunterhalt-Wiederherstellungsprogrammen
+      für vertriebene Haushalte und Gastgemeinschaften.
+  BC-4500.40:
+    name: Gemeinschaftsinvestition und -entwicklung
+    description: |
+      Konzeption und Durchführung von Gemeinschaftsinvestitions-
+      programmen und Co-Investitionen in lokale Infrastruktur
+      und Entwicklungsprojekte.
+  BC-4500.40.10:
+    name: Gemeinschaftsinvestitionsprogramm-Design
+    description: |
+      Design mehrjähriger Gemeinschaftsinvestitionsprogramme
+      gemäß lokalen Entwicklungsplänen.
+  BC-4500.40.20:
+    name: Lokale Infrastruktur-Co-Investition
+    description: |
+      Co-Investition in Straßen, Wasser, Energie und soziale
+      Infrastruktur, die mit Gastgemeinschaften geteilt wird.
+  BC-4500.40.30:
+    name: Gemeinschaftsentwicklungsprojekt-Durchführung
+    description: |
+      Durchführung von Gemeinschaftsentwicklungsprojekten
+      in Gesundheit, Bildung und Lebensunterhalt.
+  BC-4500.50:
+    name: Lokale Inhalte und Beschaffungsmanagement
+    description: |
+      Lokale Lieferantenentwicklung, lokale Beschäftigungs-
+      programme und Berichterstattung gegen lokale
+      Inhaltsverpflichtungen.
+  BC-4500.50.10:
+    name: Lokale Lieferantenentwicklung
+    description: |
+      Entwicklung und Kapazitätsaufbau lokaler und indigener
+      Lieferanten.
+  BC-4500.50.20:
+    name: Lokales Beschäftigungsprogramm-Management
+    description: |
+      Management lokaler Beschäftigungs-, Ausbildungs- und
+      Lehrlingsprogramme für Gastgemeinschaftsarbeiter.
+  BC-4500.50.30:
+    name: Lokaler Inhalt-Berichterstattung
+    description: |
+      Berichterstattung gegenüber staatlichen und vertraglichen
+      lokalen Inhaltsverpflichtungen.
+  BC-4500.60:
+    name: Menschenrechte und Sicherheitsmanagement
+    description: |
+      Menschenrechts-Due-Diligence, Ausrichtung auf die
+      Freiwilligen Prinzipien zu Sicherheit und Menschenrechten
+      und Aufsicht über das Verhalten von Sicherheitsdienstleistern.
+  BC-4500.60.10:
+    name: Menschenrechts-Due-Diligence
+    description: |
+      Standortbezogene Menschenrechtsfolgenabschätzung und
+      Due-Diligence gemäß UN-Leitprinzipien.
+  BC-4500.60.20:
+    name: Freiwillige Prinzipien-Compliance
+    description: |
+      Compliance mit den Freiwilligen Prinzipien zu Sicherheit
+      und Menschenrechten über Sicherheitsbetriebe hinweg.
+  BC-4500.60.30:
+    name: Sicherheitsdienstleister-Verhaltensaufsicht
+    description: |
+      Aufsicht über das Verhalten öffentlicher und privater
+      Sicherheitsdienstleister rund um Bergbaustandorte.
+  BC-4500.70:
+    name: Sozialleistungs-Berichterstattung
+    description: |
+      Verfolgung sozialer Leistungsindikatoren, soziale
+      Folgenabschätzung und externe Offenlegung der
+      Sozialleistung.
+  BC-4500.70.10:
+    name: Sozialleistungsindikator-Verfolgung
+    description: |
+      Verfolgung sozialer Leistungsindikatoren über Betriebe
+      und Investitionen hinweg.
+  BC-4500.70.20:
+    name: Soziale Folgenabschätzung
+    description: |
+      Periodische soziale Folgenabschätzung von Bergbau-
+      betrieben auf Gastgemeinschaften.
+  BC-4500.70.30:
+    name: Sozialleistung-Externe Offenlegung
+    description: |
+      Externe Offenlegung der Sozialleistung in Nachhaltigkeits-
+      und Regulierungseinreichungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-mining-tenement-royalty-management.yaml
+++ b/catalogue/i18n/de/L1-mining-tenement-royalty-management.yaml
@@ -1,0 +1,154 @@
+locale: de
+source: L1-mining-tenement-royalty-management.yaml
+entries:
+  BC-4490:
+    name: Bergbaurecht und Förderzins
+    description: |
+      Erwerb, Compliance und Portfoliomanagement von
+      Explorationslizenzen und Bergbaurechten zusammen mit
+      Berechnung, Berichterstattung und Offenlegung von
+      staatlichen, privaten und indigenen Royalty-Verpflichtungen.
+  BC-4490.10:
+    name: Bergbaurechtserwerb
+    description: |
+      Antragstellung, Ausschreibung und Erwerbsprüfung für
+      Explorationslizenzen, Bergbaurechte und andere Mineral-
+      Bergbaurechte.
+    in_scope:
+      - Grünfeld-Explorationslizenz-Antragsstellung
+      - Bergbaurechtanträge und Erneuerungen
+      - Bergbaurechts-Erwerbsprüfung
+    out_of_scope:
+      - Entdeckungsstufige Prospektreifung (BC-4400.20)
+  BC-4490.10.10:
+    name: Explorationslizenz-Antragstellung
+    description: |
+      Vorbereitung und Einreichung von Grünfeld- und
+      Brownfield-Explorationslizenz-Anträgen.
+  BC-4490.10.20:
+    name: Bergbaurecht-Antragstellung
+    description: |
+      Vorbereitung und Einreichung von Bergbaurecht-Anträgen
+      und Umwandlungen aus Explorations-Bergbaurechten.
+  BC-4490.10.30:
+    name: Bergbaurechts-Ausschreibungsteilnahme
+    description: |
+      Teilnahme an wettbewerblichen Bergbaurechts-Ausschreibungen
+      und -auktionen.
+  BC-4490.10.40:
+    name: Bergbaurechts-Erwerbsprüfung
+    description: |
+      Titel-, Belastungs- und Verpflichtungs-Due-Diligence für
+      Bergbaurechts-Erwerbe.
+  BC-4490.20:
+    name: Bergbaurechts-Compliance und -Pflege
+    description: |
+      Compliance mit jährlichen Ausgaben-, Arbeitsprogramm-,
+      Pacht- und Erneuerungsverpflichtungen von Mineral-
+      Bergbaurechten.
+  BC-4490.20.10:
+    name: Jährliche Ausgabenberichterstattung
+    description: |
+      Berichterstattung über jährliche Explorations- und
+      Entwicklungsausgaben gegenüber Bergbaurechts-Verpflichtungen.
+  BC-4490.20.20:
+    name: Arbeitsprogramm-Compliance
+    description: |
+      Nachweis der Compliance mit verpflichtenden Arbeitsprogrammen
+      auf Explorations- und Bergbau-Bergbaurechten.
+  BC-4490.20.30:
+    name: Pacht- und Gebührenzahlung
+    description: |
+      Zahlung von Jahrespachten, Gebühren und Kautions-
+      hinterlagen auf Bergbaurechten.
+  BC-4490.20.40:
+    name: Bergbaurechts-Erneuerungsmanagement
+    description: |
+      Management von Bergbaurechts-Erneuerungsanträgen und
+      Bedingungsänderungen.
+  BC-4490.30:
+    name: Bergbaurechts-Portfoliomanagement
+    description: |
+      Pflege des Bergbaurechts-Registers, Grenzenkartierung und
+      Rückgabeentscheidungen über das Portfolio hinweg.
+  BC-4490.30.10:
+    name: Bergbaurechts-Register-Management
+    description: |
+      Pflege des Unternehmens-Bergbaurechts-Registers und der
+      Quelldatenattribute.
+  BC-4490.30.20:
+    name: Bergbaurechts-Grenzkartierung
+    description: |
+      Räumliche Kartierung und Abgleich von Bergbaurechts-grenzen
+      gegenüber staatlichen Registern.
+  BC-4490.30.30:
+    name: Bergbaurechts-Rückgabeentscheidungen
+    description: |
+      Entscheidungen über teilweise und vollständige Bergbaurechts-
+      rückgabe zur Rationalisierung des Portfolios.
+  BC-4490.40:
+    name: Staatlicher Förderzins-Management
+    description: |
+      Berechnung, Einreichung und Prüfungsreaktion für
+      produktionsbasierte und ad valorem Förderzinsen, die an
+      Gaststaaten zu zahlen sind.
+  BC-4490.40.10:
+    name: Produktionsförderzins-Berechnung
+    description: |
+      Berechnung produktionsbasierter und ad valorem
+      Förderzinsen auf Mineralförderung.
+  BC-4490.40.20:
+    name: Förderzins-Erklärungseinreichung
+    description: |
+      Einreichung periodischer Förderzins-Erklärungen bei
+      staatlichen Steuerbehörden des Gastlandes.
+  BC-4490.40.30:
+    name: Förderzins-Prüfungsreaktion
+    description: |
+      Reaktion auf staatliche Förderzins-Prüfungen und
+      Veranlagungen.
+  BC-4490.50:
+    name: Privater und indigener Förderzins-Management
+    description: |
+      Verwaltung privater Royalty-Streams und indigener
+      Nutzenteilungs-Royalty-Verpflichtungen.
+  BC-4490.50.10:
+    name: Privater Royalty-Stream-Verwaltung
+    description: |
+      Verwaltung von Verkäufer-, Finanzier- und Streaming-
+      Unternehmens-Royalty-Ansprüchen.
+  BC-4490.50.20:
+    name: Indigene Nutzenteilungs-Royalty-Verwaltung
+    description: |
+      Verwaltung von Royalty-Zahlungen und Nutzenteilungs-
+      vereinbarungen mit indigenen und traditionellen
+      Eigentümergruppen.
+  BC-4490.50.30:
+    name: Förderzins-Offenlegungsberichterstattung
+    description: |
+      Offenlegung von Förderzinszahlungen gegenüber Investoren,
+      Regulatoren und betroffenen Gemeinschaften.
+  BC-4490.60:
+    name: Extraktive Transparenzberichterstattung
+    description: |
+      Zahlungen-an-Regierungen-, EITI- und wirtschaftliche
+      Eigentümerschaftsberichterstattung gemäß extraktiven
+      Transparenzregimen.
+  BC-4490.60.10:
+    name: Zahlungen-an-Regierungen-Berichterstattung
+    description: |
+      Pflichtgemäße Zahlungen-an-Regierungen-Berichterstattung
+      gemäß EU- und gleichwertigen Regimen.
+  BC-4490.60.20:
+    name: Extraktive Transparenzoffenlegung
+    description: |
+      EITI- und gleichwertige freiwillige Transparenzberichterstattung
+      über Einnahmeflüsse.
+  BC-4490.60.30:
+    name: Wirtschaftliche Eigentümerschaftsoffenlegung
+    description: |
+      Offenlegung der wirtschaftlichen Eigentümerschaft operativer
+      Einheiten gemäß EITI und gleichwertigen Regeln.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-mission-management.yaml
+++ b/catalogue/i18n/de/L1-mission-management.yaml
@@ -1,0 +1,102 @@
+locale: de
+source: L1-mission-management.yaml
+entries:
+  BC-1700:
+    name: Einsatz-Management
+    description: |
+      Einsatzplanung, Führung und Kontrolle, Durchführung und Nachbereitung.
+  BC-1700.10:
+    name: Einsatzplanungs-Management
+    description: |
+      Einsatzziele, Route, Ziel und Kräfteplanung.
+  BC-1700.10.10:
+    name: Einsatzziele-Definition
+    description: |
+      Definition von Einsatzzielen und Kommandeursabsicht.
+  BC-1700.10.20:
+    name: Kräfte- und Mittelplanung
+    description: |
+      Planung von Kräftezusammensetzung und Mittelzuweisung.
+  BC-1700.10.30:
+    name: Routen- und Zielplanung
+    description: |
+      Routenplanung und Zielauswahl.
+  BC-1700.10.40:
+    name: Einsatzrisikobewertung
+    description: |
+      Operationelle Risikobeurteilung und ROE-Bestätigung.
+  BC-1700.10.50:
+    name: Einsatzbefehl-Erstellung
+    description: |
+      Erstellung von Einsatzbefehlen und Aufgabendokumentation.
+  BC-1700.20:
+    name: Führungs- und Kontroll-Betriebs-Management
+    description: |
+      C2-Betrieb, Lagebewusstsein und Entscheidungsunterstützung.
+  BC-1700.20.10:
+    name: Gemeinsames-Lagekarten-Management
+    description: |
+      Pflege des gemeinsamen Lagebilds.
+  BC-1700.20.20:
+    name: Taktische-Entscheidungsunterstützung
+    description: |
+      Entscheidungsunterstützungswerkzeuge und Empfehlungen.
+  BC-1700.20.30:
+    name: C2-Kommunikations-Management
+    description: |
+      C2-Kommunikationsnetzwerke und taktische Nachrichtenübermittlung.
+  BC-1700.20.40:
+    name: Führungsebenen-übergreifende Koordination
+    description: |
+      Koordination über operative und taktische Führungsebenen.
+  BC-1700.30:
+    name: Einsatzdurchführungs-Management
+    description: |
+      Echtzeit-Einsatzdurchführung und taktische Steuerung.
+  BC-1700.30.10:
+    name: Taktische-Durchführungs-Koordination
+    description: |
+      Echtzeit-taktische Koordination der Einsatzelemente.
+  BC-1700.30.20:
+    name: Dynamische-Neuaufgaben-Erteilung
+    description: |
+      Dynamische Neuaufgabenerteilung und Neuplanung während der Durchführung.
+  BC-1700.30.30:
+    name: Einsatzwirkungs-Beurteilung
+    description: |
+      Echtzeit- und Kampfschadensbewertung von Einsatzwirkungen.
+  BC-1700.40:
+    name: Einsatzrehearsal- und Simulations-Management
+    description: |
+      Einsatzprobe und simulationsbasiertes Training.
+  BC-1700.40.10:
+    name: Einsatzproben-Übungsdesign
+    description: |
+      Design von Einsatzproben-Übungen.
+  BC-1700.40.20:
+    name: Live-, Virtuelle- und Konstruktive-Simulation
+    description: |
+      LVC-Simulationsumgebungsmanagement.
+  BC-1700.40.30:
+    name: Probe-Leistungsbewertung
+    description: |
+      Bewertung der Einheitenleistung während der Probe.
+  BC-1700.50:
+    name: Einsatznachbereitung- und Lernpunkte-Management
+    description: |
+      Nachbereitung, Debriefing und Erfassung von Lernpunkten.
+  BC-1700.50.10:
+    name: Einsatznachbereitung-Durchführung
+    description: |
+      Durchführung von Einsatznachbereitungen und After-Action-Reviews.
+  BC-1700.50.20:
+    name: Lernpunkte-Erfassung
+    description: |
+      Erfassung und Kodifizierung von Lernpunkten.
+  BC-1700.50.30:
+    name: Lernpunkte-Implementierungs-Verfolgung
+    description: |
+      Verfolgung der Implementierung identifizierter Verbesserungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-mobility-services-operations-management.yaml
+++ b/catalogue/i18n/de/L1-mobility-services-operations-management.yaml
@@ -1,0 +1,182 @@
+locale: de
+source: L1-mobility-services-operations-management.yaml
+entries:
+  BC-3490:
+    name: Mobilitätsdienste-Betrieb
+    description: |
+      Betrieb geteilter und bedarfsgerechter Mobilitätsdienste –
+      Ride-Hailing, Carsharing und Mikromobilität sowie
+      Mobility-as-a-Service-Aggregation – einschließlich
+      Dienstekatalog, Fahrtbetrieb, Flottenrebalancierung, Fahrer-
+      und Nutzeroperationen, dynamische Preisgestaltung,
+      Partnerintegration sowie Stadt-/Regulierungsengagement.
+  BC-3490.10:
+    name: Mobilitätsdienste-Katalog-Management
+    description: |
+      Definition von Mobilitätsdiensttypen, Preisplänen und
+      geografischen Abdeckungszonen.
+  BC-3490.10.10:
+    name: Diensttyp-Definition
+    description: |
+      Definition von Diensttypen wie Point-to-Point, Free-Floating,
+      Stationsbasiert und Poolfahrten.
+  BC-3490.10.20:
+    name: Dienstpreisplan-Konfiguration
+    description: |
+      Konfiguration von Grundpreisen, Zeit- und Streckenpreisen
+      sowie Mitgliedschaftsplänen.
+  BC-3490.10.30:
+    name: Dienst-Geofence- und Abdeckungsmanagement
+    description: |
+      Management von Betriebsgeofences, Sperrgebieten und
+      Abdeckungsbereichen.
+  BC-3490.20:
+    name: Fahrten- und Buchungsbetrieb
+    description: |
+      Erfassung, Matching, Disposition und Lebenszyklusmanagement
+      von Mobilitätsbuchungen und -fahrten.
+  BC-3490.20.10:
+    name: Fahrtbuchungs-Erfassung
+    description: |
+      Erfassung von Fahrtbuchungen über App-, Web- und
+      Partnerkanäle.
+  BC-3490.20.20:
+    name: Fahrt-Matching und -Disposition
+    description: |
+      Matching von Fahrgästen zu Fahrzeugen oder Fahrern und
+      Disposition bestätigter Fahrten.
+  BC-3490.20.30:
+    name: Fahrten-Lebenszyklusmanagement
+    description: |
+      Lebenszyklusmanagement laufender Fahrten einschließlich
+      Stornierung, Umleitung und Abschluss.
+  BC-3490.30:
+    name: Geteilter Flottenbetrieb
+    description: |
+      Operativer Betrieb der Sharing-Flotte einschließlich
+      Rebalancierung, Vor-Ort-Service und Schadenssteuerung.
+    in_scope:
+      - Fahrzeug-Rebalancierung über Zonen und Stationen
+      - Straßenreinigung, Laden und Betankung
+      - Schadens- und Verlustmanagement für Sharing-Fahrzeuge
+    out_of_scope:
+      - Generelles Unternehmens-Flottenanlage-Accounting (BC-2430)
+      - EV-Ladestation-Betrieb (BC-3480)
+  BC-3490.30.10:
+    name: Fahrzeug-Rebalancierungsbetrieb
+    description: |
+      Rebalancierung von Sharing-Fahrzeugen über Zonen, Stationen
+      und Nachfrage-Hotspots.
+  BC-3490.30.20:
+    name: Fahrzeugreinigung und Ladekoordination
+    description: |
+      Koordination von Fahrzeugreinigung, Laden und Betankung
+      im Außendienst.
+  BC-3490.30.30:
+    name: Fahrzeugschaden- und Verlustmanagement
+    description: |
+      Management von Schadensbeurteilung, Reparaturweiterleitung
+      und Verlustregress für Sharing-Fahrzeuge.
+  BC-3490.40:
+    name: Fahrer- und Anbieter-Betrieb
+    description: |
+      Onboarding, Compliance, Abwicklung und Leistungsmanagement
+      von Fahrern und sonstigen Dienstleistern.
+  BC-3490.40.10:
+    name: Fahrer-Onboarding und Compliance
+    description: |
+      Onboarding von Fahrern einschließlich Führerscheinprüfung,
+      Hintergrundüberprüfung und laufende Compliance.
+  BC-3490.40.20:
+    name: Fahrer-Verdienst und -Abwicklung
+    description: |
+      Berechnung und Auszahlung von Fahrerverdiensten, Trinkgeldern
+      und Anreizen.
+  BC-3490.40.30:
+    name: Fahrer-Leistungsmanagement
+    description: |
+      Leistungsmanagement von Fahrern einschließlich Bewertungen,
+      Coaching und Deaktivierung.
+  BC-3490.50:
+    name: Fahrgast-Betrieb
+    description: |
+      Onboarding, Support und Trust-and-Safety-Operationen für
+      Fahrgäste und Endkunden von Mobilitätsdiensten.
+  BC-3490.50.10:
+    name: Fahrgast-Onboarding und Identität
+    description: |
+      Onboarding von Fahrgästen einschließlich Identitätsverifikation,
+      Zahlungsmethode und Einwilligung.
+  BC-3490.50.20:
+    name: Fahrgast-Support-Betrieb
+    description: |
+      Unterstützung für Fahrgäste bei Vor-, Während- und
+      Nach-Fahrten-Problemen.
+  BC-3490.50.30:
+    name: Fahrgastsicherheit und Trust-Management
+    description: |
+      Trust-and-Safety-Operationen einschließlich Vorfallbehandlung,
+      Missbrauchsprävention und Sicherheitsfunktionen.
+  BC-3490.60:
+    name: Dynamische Preisgestaltung und Nachfragemanagement
+    description: |
+      Nachfrageprognose und Betrieb von dynamischer Preisgestaltung,
+      Surge- und Promotional-Engines für Mobilitätsdienste.
+  BC-3490.60.10:
+    name: Nachfrage-Prognose
+    description: |
+      Kurzfristige Nachfrageprognose nach Zone, Zeit und Diensttyp.
+  BC-3490.60.20:
+    name: Dynamische Preisgestaltungs-Engine-Betrieb
+    description: |
+      Betrieb von dynamischen Preis- und Surge-Engines einschließlich
+      Preisbegrenzungen und Auditierung.
+  BC-3490.60.30:
+    name: Promotions- und Anreiz-Betrieb
+    description: |
+      Betrieb von Fahrgast- und Fahrer-Promotions und Anreizen
+      über Kampagnen.
+  BC-3490.70:
+    name: Multimodal-Aggregation und Partnerbetrieb
+    description: |
+      MaaS-Partneraggregation, multimodale Fahrt-Komposition und
+      Inter-Operator-Abwicklung über Mobilitätspartner hinweg.
+  BC-3490.70.10:
+    name: MaaS-Partner-Onboarding
+    description: |
+      Onboarding von ÖPNV-, Ride-Hail- und Mikromobilitätspartnern
+      auf die MaaS-Plattform.
+  BC-3490.70.20:
+    name: Multimodale Fahrt-Komposition
+    description: |
+      Komposition multimodaler Fahrten aus ÖPNV und
+      On-Demand-Mobilität.
+  BC-3490.70.30:
+    name: Inter-Operator-Abwicklung
+    description: |
+      Abwicklung von Erlösen und Gebühren zwischen MaaS-Aggregatoren
+      und zugrundeliegenden Mobilitätsbetreibern.
+  BC-3490.80:
+    name: Mobilitäts-Regulierungs- und Stadtbetrieb
+    description: |
+      Engagement mit Städten und Regulatoren zu Genehmigungen,
+      Datenteilung und Bordstein-/Parkbetrieb.
+  BC-3490.80.10:
+    name: Stadtgenehmigung und Autorisierungs-Management
+    description: |
+      Management von städtischen Betriebsgenehmigungen,
+      Fahrzeugkontingenten und Autorisierungen in verschiedenen
+      Rechtsgebieten.
+  BC-3490.80.20:
+    name: Betriebsdaten-Sharing mit Städten
+    description: |
+      Teilen von Betriebsdaten mit Städten nach MDS, GBFS und
+      gleichwertigen Spezifikationen.
+  BC-3490.80.30:
+    name: Bordstein- und Parkkoordination
+    description: |
+      Koordination von Bordsteinzugang, Parkplätzen und
+      Wartezonen mit Stadtbehörden.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-omnichannel-order-fulfilment-management.yaml
+++ b/catalogue/i18n/de/L1-omnichannel-order-fulfilment-management.yaml
@@ -1,0 +1,111 @@
+locale: de
+source: L1-omnichannel-order-fulfilment-management.yaml
+entries:
+  BC-2330:
+    name: Omnikanal-Auftragserfüllung Management
+    description: |
+      Kanalübergreifende Orchestrierung von Verbraucherbestellungen — Erfassung in jedem
+      Kanal, Zusagen aus jedem Knoten und Erfüllung über Filiale, Verteilzentrum,
+      Marktplatz, Lieferanten-Direktlieferung oder Last-Mile-Partner.
+  BC-2330.10:
+    name: Kanal-Orchestrierungs-Management
+    description: |
+      Einheitliche Sicht auf Verbraucherbestellungen über Kanäle, Kanal-Mix-Routing
+      und konsistenter Status über Digital-, Filial- und Marktplatzkanäle.
+    in_scope:
+      - Kanal-Routing-Regeln und Knotenauswahl
+      - Einheitliche Bestellübersicht über Kanäle
+      - Kanal-Mix-Wirtschaftlichkeit und Erfüllungskosten-Abwägungen
+    out_of_scope:
+      - Allgemeine Auftragserfüllung (BC-520.40)
+  BC-2330.10.10:
+    name: Kanal-Routing-Regeln-Management
+    description: |
+      Definition von Routing-Regeln zur Auswahl des Erfüllungsknotens nach Kosten und Service.
+  BC-2330.10.20:
+    name: Kanalübergreifende Bestellübersicht
+    description: |
+      Einheitliche Sicht auf Bestellungen, Status und Verlauf über Kanäle.
+  BC-2330.10.30:
+    name: Kanal-Mix-Wirtschaftlichkeit
+    description: |
+      Analyse von Stückkosten nach Kanal und Erfüllungsroute.
+  BC-2330.20:
+    name: Click-and-Collect-Betriebs Management
+    description: |
+      Online-kaufen-in-Filiale-abholen-, Kerbside- und Schließfach-Abholbetrieb,
+      der digitale Bestellungen mit physischen Abholpunkten verbindet.
+  BC-2330.20.10:
+    name: Filialkommissionierungs- und Packbetrieb
+    description: |
+      Kommissionierung und Verpackung von Online-Bestellungen durch Filialmitarbeiter.
+  BC-2330.20.20:
+    name: Kundenabholübergabe
+    description: |
+      Kundenabholübergabe einschließlich Identitätsprüfung und Ausnahmebehandlung.
+  BC-2330.20.30:
+    name: Kerbside- und Schließfach-Abholung
+    description: |
+      Kerbside-Übergabe und schließfachbasierter Abholbetrieb.
+  BC-2330.30:
+    name: Verteilte Auftragserfüllung Management
+    description: |
+      Ship-from-Store-, Dark-Store- und Direktlieferungs-Erfüllung aus einem
+      verteilten Bestandspool an Verbraucherziele.
+    in_scope:
+      - Ship-from-Store-Betrieb
+      - Dark-Store- und Mikro-Fulfillment-Center-Betrieb
+      - Lieferanten-Direktlieferungs-Orchestrierung
+  BC-2330.30.10:
+    name: Ship-from-Store-Betrieb
+    description: |
+      Kommissionierung, Verpackung und Versand von Online-Bestellungen aus physischen Filialen.
+  BC-2330.30.20:
+    name: Dark-Store- und Mikro-Fulfillment-Betrieb
+    description: |
+      Betrieb von Dark Stores und Mikro-Fulfillment-Centern für digitale Bestellungen.
+  BC-2330.30.30:
+    name: Lieferanten-Direktlieferungs-Orchestrierung
+    description: |
+      Orchestrierung der Lieferanten-Direktlieferung einschließlich Bestellrouting und Tracking.
+  BC-2330.40:
+    name: Marktplatz-Verkäufer-Betriebs Management
+    description: |
+      Betrieb von Einzelhändler-als-Verkäufer-Listings auf Drittanbieter-Marktplätzen und
+      Management von Drittanbieter-Verkäufern auf einem eigenen Marktplatz.
+  BC-2330.40.10:
+    name: Marktplatz-Listing-Management
+    description: |
+      Listung von Artikeln auf Drittanbieter-Marktplätzen einschließlich Inhaltsanpassung.
+  BC-2330.40.20:
+    name: Marktplatz-Bestellerfassung
+    description: |
+      Erfassung und Übersetzung von Marktplatz-Bestellungen in die eigene Bestellpipeline.
+  BC-2330.40.30:
+    name: Drittanbieter-Verkäufer-Onboarding
+    description: |
+      Onboarding von Drittanbieter-Verkäufern auf den eigenen Marktplatz des Einzelhändlers.
+  BC-2330.40.40:
+    name: Drittanbieter-Verkäufer-Performance Management
+    description: |
+      Management der Performance und Richtlinien-Compliance von Drittanbieter-Verkäufern.
+  BC-2330.50:
+    name: Verbraucher-Lieferzeitfenster Management
+    description: |
+      Verbraucherorientierte Lieferzeitfenster-Buchung, Zeitfensterpreisgestaltung und
+      Kurierversand-Koordination für die Hauszustellung.
+  BC-2330.50.10:
+    name: Lieferzeitfenster-Buchung
+    description: |
+      Verbraucherbuchung von Lieferzeitfenstern mit Verfügbarkeits- und Kapazitätslogik.
+  BC-2330.50.20:
+    name: Zeitfenster-Preisgestaltung
+    description: |
+      Dynamische Preisgestaltung von Lieferzeitfenstern nach Nachfrage und Routendichte.
+  BC-2330.50.30:
+    name: Kurierversand-Koordination
+    description: |
+      Versandkoordination mit eigenen und Drittanbieter-Last-Mile-Kurieren.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-patient-access-management.yaml
+++ b/catalogue/i18n/de/L1-patient-access-management.yaml
@@ -1,0 +1,138 @@
+locale: de
+source: L1-patient-access-management.yaml
+entries:
+  BC-2800:
+    name: Patientenzugang-Management
+    description: |
+      Vor-Begegnungs-Aufnahme, Terminplanung, Registrierung, Leistungsanspruchsprüfung,
+      Finanzberatung, Aufnahme, Verlegungen und Entlassungen in stationären, ambulanten,
+      tagesklinischen und Notfallbereichen.
+  BC-2800.10:
+    name: Terminplanung und Terminmanagement
+    description: |
+      Anbieter- und Ressourcenplanung, Terminbuchung, Wartelistenverwaltung und
+      proaktive Erinnerungen zur Optimierung der Kapazitätsauslastung.
+  BC-2800.10.10:
+    name: Anbieterzeitplan-Optimierung
+    description: |
+      Optimierung von Anbieter-, Raum- und Geräteplänen über Vorlagen und Überlagerungen.
+  BC-2800.10.20:
+    name: Terminbuchung
+    description: |
+      Patienten- und überweiserinitiierende Terminbuchung über verschiedene Kanäle.
+  BC-2800.10.30:
+    name: Wartelisten-Management
+    description: |
+      Pflege und Priorisierung von Wartelisten für Termine und Eingriffe.
+  BC-2800.10.40:
+    name: Terminerinnerungen und Nichterscheinen-Minderung
+    description: |
+      Multi-Kanal-Erinnerungen, Bestätigungen und Nichterscheinen-Minderungsinterventionen.
+  BC-2800.20:
+    name: Patienten-Registrierungs-Management
+    description: |
+      Erfassung und Verwaltung demografischer, Identitäts- und Einwilligungsdaten
+      für die Patientenregistrierung bei einem Besuch.
+  BC-2800.20.10:
+    name: Demografiedaten-Erfassung
+    description: |
+      Erfassung demografischer Patientendaten bei der Registrierung.
+  BC-2800.20.20:
+    name: Patientenidentitäts-Verifizierung
+    description: |
+      Verifizierung der Patientenidentität mittels Dokumenten- und biometrischer Prüfungen.
+  BC-2800.20.30:
+    name: Einwilligungs- und Genehmigungserfassung
+    description: |
+      Erfassung von Behandlungs-, Finanz- und Informationsaustauschs-Einwilligungen und Genehmigungen.
+  BC-2800.20.40:
+    name: Patientenidentifikator-Management
+    description: |
+      Ausstellung und Pflege von Krankenakten-Nummern und Unternehmens-Patientenidentifikatoren.
+  BC-2800.30:
+    name: Leistungsanspruch- und Leistungs-Verifizierung
+    description: |
+      Verifizierung von Krankenversicherungsdeckung, Leistungen und Genehmigungsanforderungen
+      vor der Leistungserbringung.
+  BC-2800.30.10:
+    name: Krankenversicherungs-Deckungsverifizierung
+    description: |
+      Verifizierung aktiver Krankenversicherungsdeckung und Plandetails.
+  BC-2800.30.20:
+    name: Leistungsermittlung
+    description: |
+      Ermittlung von Patientenleistungen, Selbstbeteiligungen, Zuzahlungen und Deckungsgrenzen.
+  BC-2800.30.30:
+    name: Vorabgenehmigung-Management
+    description: |
+      Einreichung, Verfolgung und Nachverfolgung von Vorabgenehmigungsanfragen bei Kostenträgern.
+  BC-2800.30.40:
+    name: Echtzeit-Leistungsanfrage
+    description: |
+      Elektronische Echtzeit-Leistungsanspruchs- und Leistungsanfragen bei Kostenträgersystemen.
+  BC-2800.40:
+    name: Finanzberatung und Kostenschätzung
+    description: |
+      Patientenorientierte Finanzberatung, Eigenkosten-Schätzung und Einschreibung
+      in Finanzhilfeprogramme oder Selbstzahler-Regelungen.
+  BC-2800.40.10:
+    name: Patientenfinanzielle Beurteilung
+    description: |
+      Beurteilung der finanziellen Kapazität und Zahlungsoptionen des Patienten.
+  BC-2800.40.20:
+    name: Kostenschätzung
+    description: |
+      Erstellung von Eigenkosten- und Gesamtkostenschätzungen für geplante Leistungen.
+  BC-2800.40.30:
+    name: Sozialhilfe- und Finanzunterstützung
+    description: |
+      Berechtigungsermittlung und Einschreibung in Sozialhilfe- und Finanzunterstützungsprogramme.
+  BC-2800.40.40:
+    name: Selbstzahler-Einrichtung
+    description: |
+      Einrichtung von Selbstzahler-Vereinbarungen, Vorauszahlungen und Ratenplänen.
+  BC-2800.50:
+    name: Aufnahme, Verlegung und Entlassungs-Management
+    description: |
+      Operatives Management von stationären Aufnahmen, Einrichtungsüberweisungen,
+      Bettzuweisung und Entlassungsdokumentationserfassung.
+  BC-2800.50.10:
+    name: Stationäre Aufnahme
+    description: |
+      Aufnahme von Patienten in stationäre Dienste aus geplanten und ungeplanten Quellen.
+  BC-2800.50.20:
+    name: Einrichtungs-Verlegung
+    description: |
+      Koordination von Patientenverlegungen zwischen Einrichtungen und Versorgungsebenen.
+  BC-2800.50.30:
+    name: Bettzuweisung
+    description: |
+      Zuweisung und Neuzuweisung stationärer Betten basierend auf Schweregrad, Isolation und Kapazität.
+  BC-2800.50.40:
+    name: Entlassungs-Dispositionserfassung
+    description: |
+      Erfassung von Entlassungsdisposition, Nachsorgeplacierung und Überweisungsziel.
+  BC-2800.60:
+    name: Vor-Service-Bereitschafts-Management
+    description: |
+      Vor-Eingriff-Freigabe, Dokumentationsverifizierung und Patientenvorbereitungsaktivitäten
+      vor der Leistungserbringung.
+  BC-2800.60.10:
+    name: Vor-Eingriff-Freigabe
+    description: |
+      Klinische und Anästhesie-Freigabe für geplante Eingriffe.
+  BC-2800.60.20:
+    name: Erforderliche Dokumentations-Verifizierung
+    description: |
+      Verifizierung, dass Aufträge, Einwilligungen und Anamnese-Dokumentation vollständig sind.
+  BC-2800.60.30:
+    name: Vor-Besuch-Kontaktaufnahme
+    description: |
+      Vor-Besuch-Patientenkontakt für Formulare, Anamnese und Vor-Registrierung.
+  BC-2800.60.40:
+    name: Patientenvorbereitungs-Anweisungen
+    description: |
+      Übermittlung von Vor-Eingriff- und Vor-Besuch-Vorbereitungsanweisungen an Patienten.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-patient-experience-management.yaml
+++ b/catalogue/i18n/de/L1-patient-experience-management.yaml
@@ -1,0 +1,137 @@
+locale: de
+source: L1-patient-experience-management.yaml
+entries:
+  BC-2910:
+    name: Patientenerfahrungsmanagement
+    description: |
+      Patientenengagement, digitale Dienste, Zufriedenheitsmessung, Interessenvertretung
+      und Beschwerden, Patientenrechte und Ethik sowie ehrenamtliche und Hilfsdienste
+      im gesamten Versorgungskontinuum.
+  BC-2910.10:
+    name: Patientenengagement und Kommunikation
+    description: |
+      Mehrkanalige Kommunikation mit Patienten und Angehörigen einschließlich
+      Schulung und Sprachdienstleistungen.
+  BC-2910.10.10:
+    name: Mehrkanalige Patientenkommunikation
+    description: |
+      Koordinierte Patientenkommunikation über Telefon, sichere Nachrichten, Post und digitale Kanäle.
+  BC-2910.10.20:
+    name: Gesundheitsbildungsvermittlung
+    description: |
+      Vermittlung von Krankheits-, Behandlungs- und Präventionsbildung an Patienten.
+  BC-2910.10.30:
+    name: Angehörigen- und Pflegepersonen-Kommunikation
+    description: |
+      Kommunikation mit Angehörigen und autorisierten Pflegepersonen während Versorgungsepisoden.
+  BC-2910.10.40:
+    name: Sprach- und Dolmetschdienste
+    description: |
+      Bereitstellung von Sprachdolmetsch- und Übersetzungsdienstleistungen.
+  BC-2910.20:
+    name: Patientenportal und digitale Dienste
+    description: |
+      Betrieb patientenseitiger digitaler Dienste einschließlich Portale,
+      Mobile-Apps und Self-Service-Tools.
+  BC-2910.20.10:
+    name: Patientenportal-Betrieb
+    description: |
+      Betrieb von Patientenportaldiensten einschließlich Messaging und Aktenzugang.
+  BC-2910.20.20:
+    name: Mobile Gesundheitsanwendungen
+    description: |
+      Betrieb patientenseitiger mobiler Gesundheitsanwendungen.
+  BC-2910.20.30:
+    name: Patienten-Self-Service-Tools
+    description: |
+      Self-Service-Tools für Terminbuchung, Zahlung und Vorbereitungsaufgaben.
+  BC-2910.20.40:
+    name: Digitale Patientenidentitätsverwaltung
+    description: |
+      Digitale Patientenidentität, Authentifizierung und Bevollmächtigtenzugang-Management.
+  BC-2910.30:
+    name: Patientenzufriedenheitsmessung
+    description: |
+      Umfragebasierte und Echtzeit-Messung der Patientenzufriedenheit und -erfahrung.
+  BC-2910.30.10:
+    name: Stationäre Erfahrungsumfragen
+    description: |
+      Betrieb stationärer Erfahrungsumfrageprogramme und Ergebnisanalyse.
+  BC-2910.30.20:
+    name: Ambulante Erfahrungsumfragen
+    description: |
+      Betrieb ambulanter und fachspezifischer Erfahrungsumfrageprogramme.
+  BC-2910.30.30:
+    name: Echtzeit-Feedback-Erfassung
+    description: |
+      Echtzeit- und punktuelle Feedback-Erfassung von Patienten.
+  BC-2910.30.40:
+    name: Erfahrungsanalytik
+    description: |
+      Analytik zu Erfahrungstreibern, Themen und Verbesserungsmöglichkeiten.
+  BC-2910.40:
+    name: Patienteninteressenvertretung und Beschwerden
+    description: |
+      Patientenanwaltschaft, Beschwerde- und Beschwerdemanagement sowie
+      Service-Wiederherstellung.
+  BC-2910.40.10:
+    name: Patientenbeschwerde-Eingang
+    description: |
+      Eingang von Patientenbeschwerden über alle Kanäle.
+  BC-2910.40.20:
+    name: Beschwerdeuntersuchung
+    description: |
+      Formelle Untersuchung und Lösung von Patientenbeschwerden.
+  BC-2910.40.30:
+    name: Patientenanwaltschaft
+    description: |
+      Patientenanwaltschaftsdienste während Versorgungsepisoden.
+  BC-2910.40.40:
+    name: Service-Wiederherstellung
+    description: |
+      Service-Wiederherstellungsmaßnahmen bei Serviceversagensereignissen.
+  BC-2910.50:
+    name: Patientenrechte und Ethik
+    description: |
+      Überwachung von Patientenrechten, informierter Einwilligung, Patientenverfügungen
+      und Ethikkonsultation.
+  BC-2910.50.10:
+    name: Aufklärungsprozess-Überwachung
+    description: |
+      Überwachung von Aufklärungsprozessen für Behandlung und Forschung.
+  BC-2910.50.20:
+    name: Patientenverfügungs-Management
+    description: |
+      Erfassung, Speicherung und Anzeige von Patientenverfügungen und Versorgungszielen.
+  BC-2910.50.30:
+    name: Ethikkonsultation
+    description: |
+      Klinische Ethikkonsultationsdienste für Patienten, Angehörige und Kliniker.
+  BC-2910.50.40:
+    name: Patientenrechtsaufklärung
+    description: |
+      Aufklärung von Patienten über ihre Rechte und Pflichten.
+  BC-2910.60:
+    name: Ehrenamtliche und Hilfsdienste
+    description: |
+      Betrieb von Ehrenamtlichen- und Hilfsprogrammen zur Unterstützung von
+      Patienten und Angehörigen.
+  BC-2910.60.10:
+    name: Ehrenamtlichen-Onboarding
+    description: |
+      Rekrutierung, Überprüfung und Einarbeitung von Ehrenamtlichen.
+  BC-2910.60.20:
+    name: Ehrenamtliche Dienstleistungserbringung
+    description: |
+      Koordination und Erbringung ehrenamtlicher Dienste in allen Abteilungen.
+  BC-2910.60.30:
+    name: Hilfsprogramme
+    description: |
+      Betrieb von Hilfs-, philanthropischen und Gemeinschaftsprogrammen.
+  BC-2910.60.40:
+    name: Patientenunterstützungsdienste
+    description: |
+      Unterstützungsdienste wie Patientennavigation, Seelsorge und Familienbereiche.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-payments-card-management.yaml
+++ b/catalogue/i18n/de/L1-payments-card-management.yaml
@@ -1,0 +1,146 @@
+locale: de
+source: L1-payments-card-management.yaml
+entries:
+  BC-1340:
+    name: Zahlungsverkehrs- und Kartenmanagement
+    description: |
+      Zahlungsauslösung, -verarbeitung, Clearing/Abwicklung, Kartenausgabe und Kartentransaktionsverarbeitung.
+  BC-1340.10:
+    name: Zahlungsauslösungs-Management
+    description: |
+      Zahlungsauftragserfassung, -validierung und -autorisierung.
+  BC-1340.10.10:
+    name: Zahlungsauftragserfassung
+    description: |
+      Erfassung von Zahlungsaufträgen über alle Kanäle.
+  BC-1340.10.20:
+    name: Zahlungsvalidierung
+    description: |
+      Validierung von Zahlungsaufträgen und Begünstigtendaten.
+  BC-1340.10.30:
+    name: Zahlungsautorisierung
+    description: |
+      Autorisierung, Authentifizierung und starke Kundenauthentifizierung.
+  BC-1340.10.40:
+    name: Zahlungsvorankündigung
+    description: |
+      Vorankündigung von Zahlungen und Zahlungsempfängerbestätigung.
+  BC-1340.20:
+    name: Zahlungsverarbeitungs-Management
+    description: |
+      Zahlungsverarbeitung, -routing, -formatierung und ISO-20022.
+  BC-1340.20.10:
+    name: Zahlungsanreicherung und -formatierung
+    description: |
+      Anreicherung und ISO-20022-Formatierung von Zahlungsnachrichten.
+  BC-1340.20.20:
+    name: Zahlungsrouting
+    description: |
+      Routing von Zahlungen an geeignete Rails und Korrespondenzbanken.
+  BC-1340.20.30:
+    name: Zahlungssanktions-Screening
+    description: |
+      Sanktions- und Restricted-Party-Screening von Zahlungen.
+  BC-1340.20.40:
+    name: Zahlungsuntersuchungen
+    description: |
+      Untersuchung fehlgeschlagener, zurückgegebener und angefochtener Zahlungen.
+  BC-1340.30:
+    name: Clearing- und Abwicklungsmanagement
+    description: |
+      Inländisches Clearing – ACH, BACS, SEPA, FPS – und Abwicklung.
+  BC-1340.30.10:
+    name: ACH- und Massen-Clearing
+    description: |
+      Betrieb von ACH-, BACS- und Massen-Clearing-Systemen.
+  BC-1340.30.20:
+    name: SEPA-Clearing-Betrieb
+    description: |
+      SEPA-Überweisung und SEPA-Lastschrift-Betrieb.
+  BC-1340.30.30:
+    name: RTGS- und Netto-Abwicklung
+    description: |
+      RTGS-Abwicklung und verzögerte Netto-Abwicklungsvorgänge.
+  BC-1340.30.40:
+    name: Nostro- und Vostro-Abstimmung
+    description: |
+      Nostro/Vostro-Kontoabstimmung und Differenzenverwaltung.
+  BC-1340.40:
+    name: Grenzüberschreitender-Zahlungsverkehr-Management
+    description: |
+      Internationale Zahlungen, Korrespondenzbankgeschäft und Devisen.
+  BC-1340.40.10:
+    name: Korrespondenzbank-Management
+    description: |
+      Korrespondenzbankbeziehungen und RMA-Management.
+  BC-1340.40.20:
+    name: Grenzüberschreitendes-Zahlungsrouting
+    description: |
+      Routing grenzüberschreitender Zahlungen über SWIFT und alternative Rails.
+  BC-1340.40.30:
+    name: Devisenkonvertierung für Zahlungen
+    description: |
+      Devisenkonvertierung, Kursermittlung und Preisgestaltung für Zahlungen.
+  BC-1340.40.40:
+    name: SWIFT-GPI-Verfolgung
+    description: |
+      SWIFT-GPI-Statusverfolgung und Kundentransparenz.
+  BC-1340.50:
+    name: Echtzeit-Zahlungsmanagement
+    description: |
+      Echtzeit- und Sofortzahlungs-Rails.
+  BC-1340.50.10:
+    name: Sofortzahlungssystem-Betrieb
+    description: |
+      Betrieb von FPS-, SCT-Inst- und anderen Sofortzahlungssystemen.
+  BC-1340.50.20:
+    name: Request-to-Pay-Betrieb
+    description: |
+      Request-to-Pay-Nachrichtenübermittlung und Lebenszyklusmanagement.
+  BC-1340.50.30:
+    name: Echtzeit-Zahlungsliquidität
+    description: |
+      Liquiditätsmanagement für 24/7-Sofortzahlungs-Rails.
+  BC-1340.60:
+    name: Kartenausgabe-Management
+    description: |
+      Kartenproduktion, Personalisierung, Versand und Aktivierung.
+  BC-1340.60.10:
+    name: Kartenproduktion und -personalisierung
+    description: |
+      Kartenproduktion, Prägung und Personalisierungsvorgänge.
+  BC-1340.60.20:
+    name: Kartenversand und -zustellung
+    description: |
+      Versand von Plastikkarten und PIN-Zustellung.
+  BC-1340.60.30:
+    name: Kartenaktivierung
+    description: |
+      Kartenaktivierungs- und PIN-Verwaltungsworkflows.
+  BC-1340.60.40:
+    name: Digitale-Karte und Wallet-Bereitstellung
+    description: |
+      Digitale Kartenausgabe und Wallet-Bereitstellung (Tokenisierung).
+  BC-1340.70:
+    name: Kartentransaktionsverarbeitungs-Management
+    description: |
+      Switching, Autorisierung, Betrugsscreening und Chargebacks.
+  BC-1340.70.10:
+    name: Karten-Autorisierungs-Switching
+    description: |
+      Echtzeit-Autorisierungs-Switching und -Routing.
+  BC-1340.70.20:
+    name: Karten-Betrugserkennung
+    description: |
+      Echtzeit-Betrugserkennung bei Kartentransaktionen.
+  BC-1340.70.30:
+    name: Kartenabwicklung und Interbankenentgelt
+    description: |
+      Abwicklung, Interbankenentgelt und Clearing mit Kartensystemen.
+  BC-1340.70.40:
+    name: Chargeback- und Streitfall-Management
+    description: |
+      Chargeback-Bearbeitung und Kartensystem-Streitbeilegung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-permits-licences-authorisations-management.yaml
+++ b/catalogue/i18n/de/L1-permits-licences-authorisations-management.yaml
@@ -1,0 +1,131 @@
+locale: de
+source: L1-permits-licences-authorisations-management.yaml
+entries:
+  BC-3240:
+    name: Genehmigungen, Lizenzen und Zulassungen
+    description: |
+      Ausstellung, Erneuerung, Aussetzung, Widerruf und Registerpflege von
+      Genehmigungen, Lizenzen und Zulassungen, die von Behörden an Personen,
+      Unternehmen und Tätigkeiten erteilt werden, einschließlich beruflicher,
+      umweltbezogener, fachlicher und operativer Erlaubnisse.
+  BC-3240.10:
+    name: Antragseingang und Triage
+    description: |
+      Eingang, Vollständigkeitsprüfung und Triage von Anträgen auf Genehmigungen,
+      Lizenzen und Zulassungen.
+  BC-3240.10.10:
+    name: Antragseinreichung
+    description: |
+      Mehrkanalige Einreichung von Anträgen auf Genehmigungen und Lizenzen.
+  BC-3240.10.20:
+    name: Vollständigkeitsprüfung
+    description: |
+      Verifikation, dass Einreichungen vollständig sind und Dokumentationsanforderungen erfüllen.
+  BC-3240.10.30:
+    name: Antrags-Weiterleitung
+    description: |
+      Weiterleitung von Anträgen an die zuständige Genehmigungsbehörde und Prüfer.
+  BC-3240.10.40:
+    name: Gebührenberechnung und -einzug
+    description: |
+      Berechnung und Einzug gesetzlicher Antrags- und Lizenzgebühren.
+  BC-3240.20:
+    name: Berechtigungs- und Qualifikationsbewertung
+    description: |
+      Bewertung der Eignung, Qualifikationen und gesetzlichen Kriterien des Antragstellers
+      für die beantragte Erlaubnis.
+  BC-3240.20.10:
+    name: Eignungsbewertung
+    description: |
+      Bewertung der Eignung, Integrität und disqualifizierenden Vorgeschichte des Antragstellers.
+  BC-3240.20.20:
+    name: Qualifikationsverifikation
+    description: |
+      Verifikation von Qualifikationen, Kompetenzen und Voraussetzungen für die Lizenz.
+  BC-3240.20.30:
+    name: Hintergrundprüfungs-Koordination
+    description: |
+      Koordination von Hintergrund-, Vorstrafen- und Sicherheitsüberprüfungen.
+  BC-3240.20.40:
+    name: Öffentlichkeitsinteressen-Bewertung
+    description: |
+      Bewertung gesetzlicher Öffentlichkeits-, Umwelt- oder Flächennutzungskriterien.
+  BC-3240.30:
+    name: Ausstellungs- und Erneuerungsbetrieb
+    description: |
+      Entscheidung, Ausstellung und Erneuerung von Genehmigungen, Lizenzen und Zulassungen
+      einschließlich Bedingungen, Laufzeit und Anmeldedaten.
+  BC-3240.30.10:
+    name: Lizenzierungsentscheidung
+    description: |
+      Entscheidung über Erteilung, Ablehnung oder bedingte Erteilung von Genehmigungen und Lizenzen.
+  BC-3240.30.20:
+    name: Anmeldedaten-Ausstellung
+    description: |
+      Produktion und Ausstellung von physischen und digitalen Lizenzanmeldedaten.
+  BC-3240.30.30:
+    name: Erneuerungs-Bearbeitung
+    description: |
+      Bearbeitung von Erneuerungsanträgen und Dauerberechtigungsprüfungen.
+  BC-3240.30.40:
+    name: Änderungs- und Endorsement-Bearbeitung
+    description: |
+      Bearbeitung von Änderungen, Endorsements und Bedingungs-Änderungen.
+  BC-3240.40:
+    name: Inspektion und Compliance-Verifikation
+    description: |
+      Inspektion, Prüfung und Verifikation der Lizenzinhaber-Compliance mit Genehmigungsbedingungen
+      und gesetzlichen Verpflichtungen.
+  BC-3240.40.10:
+    name: Inspektionsplanung
+    description: |
+      Risikobasierte Planung und Terminierung von Compliance-Inspektionen.
+  BC-3240.40.20:
+    name: Feldinspektions-Ausführung
+    description: |
+      Ausführung von Vor-Ort-Inspektionen und Beweiserhebung.
+  BC-3240.40.30:
+    name: Compliance-Berichts-Überprüfung
+    description: |
+      Überprüfung von Pflicht-Compliance-Berichten und Selbstzertifizierungen von Lizenzinhabern.
+  BC-3240.50:
+    name: Aussetzung, Widerruf und Sanktion
+    description: |
+      Vollzugsmaßnahmen einschließlich Verwarnungen, Aussetzung, Widerruf,
+      Bußgelder und Sanktionen gegen nicht-konforme Lizenzinhaber.
+  BC-3240.50.10:
+    name: Nicht-Compliance-Untersuchung
+    description: |
+      Untersuchung mutmaßlicher Verstöße gegen Lizenzbedingungen.
+  BC-3240.50.20:
+    name: Vollzugsmaßnahmen-Entscheidung
+    description: |
+      Entscheidung über Vollzugsmaßnahmen von Verwarnungen bis zum Widerruf.
+  BC-3240.50.30:
+    name: Bußgeld-Ausstellung
+    description: |
+      Ausstellung, Aufzeichnung und Einzug von Bußgeldern.
+  BC-3240.50.40:
+    name: Aussetzung und Widerruf-Ausführung
+    description: |
+      Ausführung von Aussetzungs- und Widerrufsbeschlüssen und Einziehung von Anmeldedaten.
+  BC-3240.60:
+    name: Lizenzregister-Management
+    description: |
+      Pflege und öffentliche Offenlegung von Registern ausgestellter, ausgesetzter
+      und widerrufener Genehmigungen und Lizenzen.
+  BC-3240.60.10:
+    name: Registerpflege
+    description: |
+      Pflege autoritativer Register von Lizenzen und Genehmigungen.
+  BC-3240.60.20:
+    name: Öffentliche Registeroffenlegung
+    description: |
+      Veröffentlichung öffentlicher Register und Suchdienste.
+  BC-3240.60.30:
+    name: Register-Verifikationsdienste
+    description: |
+      Bereitstellung von Anmeldedaten-Verifikationsdiensten für Vertrauensstellen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-petroleum-joint-venture-management.yaml
+++ b/catalogue/i18n/de/L1-petroleum-joint-venture-management.yaml
@@ -1,0 +1,114 @@
+locale: de
+source: L1-petroleum-joint-venture-management.yaml
+entries:
+  BC-3110:
+    name: Gemeinschaftsunternehmen (Petroleum)
+    description: |
+      Administration von vorgelagerten Joint-Operating-Agreements, Konzessionen
+      und Produktionsteilungsverträgen - Betriebsausschüsse, AFE-Genehmigungen,
+      Joint-Interest-Abrechnung, Kapitalaufrufe, Lizenzverpflichtungen sowie
+      Berichterstattung gegenüber Partnern und Gastregierungen.
+  BC-3110.10:
+    name: Joint-Operating-Agreement-Administration
+    description: |
+      Erstellung, Administration und Governance von Joint-Operating-Agreements
+      einschließlich Betriebsausschuss-Prozessen und AFE-Genehmigungen.
+  BC-3110.10.10:
+    name: JOA-Erstellung und Neuverhandlung
+    description: |
+      Erstellung, Redlining und periodische Neuverhandlung von Joint-Operating-Agreements.
+  BC-3110.10.20:
+    name: Betriebsausschuss-Koordination
+    description: |
+      Koordination von OPCOM-, TECCOM- und Unterausschuss-Sitzungen.
+  BC-3110.10.30:
+    name: Ausgabengenehmigungsmanagement
+    description: |
+      Ausstellung, Genehmigung und Tracking von Ausgabengenehmigungen (AFEs).
+  BC-3110.10.40:
+    name: Stimmrechte und Genehmigungstracking
+    description: |
+      Tracking von Partner-Stimmrechten und JOA-Genehmigungsschwellen.
+  BC-3110.20:
+    name: Joint-Interest-Abrechnung
+    description: |
+      Erstellung, Prüfung und Streitbeilegung von Joint-Interest-Rechnungen.
+  BC-3110.20.10:
+    name: Joint-Interest-Rechnungserstellung
+    description: |
+      Erstellung monatlicher Joint-Interest-Rechnungen an Partner.
+  BC-3110.20.20:
+    name: Joint-Interest-Prüfungskoordination
+    description: |
+      Koordination partnergeführter Joint-Interest-Prüfungen.
+  BC-3110.20.30:
+    name: JIB-Streitbeilegung
+    description: |
+      Untersuchung und Beilegung von Joint-Interest-Abrechnungsstreitigkeiten.
+  BC-3110.30:
+    name: Kapitalaufrufe und Finanzierungsmanagement
+    description: |
+      Kapitalaufruf-Ausstellung, Partnerfinanzierungseingang und Ausfall-Management.
+  BC-3110.30.10:
+    name: Kapitalaufruf-Ausstellung
+    description: |
+      Ausstellung monatlicher und ergänzender Kapitalaufrufe an Partner.
+  BC-3110.30.20:
+    name: Partner-Finanzierungseingang
+    description: |
+      Eingang und Abgleich der Partner-Kapitalaufruf-Finanzierung.
+  BC-3110.30.30:
+    name: Finanzierungsausfall-Management
+    description: |
+      Management von Partnerausfall-Positionen gemäß JOA-Rechtsbehelfen.
+  BC-3110.40:
+    name: Lizenz- und Konzessionsverpflichtungsmanagement
+    description: |
+      Tracking von Arbeitsprogrammverpflichtungen, Lizenzgebühren und Lizenzaufgabeverpflichtungen.
+  BC-3110.40.10:
+    name: Arbeitsprogrammverpflichtungs-Tracking
+    description: |
+      Tracking von Mindestarbeitsverpflichtungen und Explorationsverpflichtungen.
+  BC-3110.40.20:
+    name: Konzessionslizenzgebühren-Berechnung
+    description: |
+      Berechnung von Lizenzgebühren an Gastregierungen nach Konzessionsbedingungen.
+  BC-3110.40.30:
+    name: Lizenzaufgabe-Management
+    description: |
+      Management partieller und vollständiger Lizenzaufgaben.
+  BC-3110.50:
+    name: Gastregierungs- und Partner-Berichterstattung
+    description: |
+      Berichterstattung an Gastregierungen nach PSC-Bedingungen und an Partner nach JOA-Bedingungen.
+  BC-3110.50.10:
+    name: Gastregierungs-Berichterstattung
+    description: |
+      Berichterstattung über Operationen, Kosten und Produktion an Gastregierungen.
+  BC-3110.50.20:
+    name: Produktionsteilungsvertrag-Berichterstattung
+    description: |
+      Kostenrückerstattungs-, Gewinnöl- und Abnahme-Berichterstattung nach PSC-Bedingungen.
+  BC-3110.50.30:
+    name: Partner-Leistungsberichterstattung
+    description: |
+      Periodische operative und finanzielle Berichterstattung an JV-Partner.
+  BC-3110.60:
+    name: Nicht-betriebenes Gemeinschaftsunternehmen-Management
+    description: |
+      Verwaltung von Eigenkapitalbeteiligungen an von anderen Parteien betriebenen JVs.
+  BC-3110.60.10:
+    name: Nicht-betriebene Positions-Überwachung
+    description: |
+      Monitoring von Operatoraktivitäten und JV-Leistung aus Nicht-Operator-Sicht.
+  BC-3110.60.20:
+    name: Nicht-betriebene Abstimmung
+    description: |
+      Interne Überprüfung und Abstimmung bei operator-vorgeschlagenen Arbeitsprogrammen.
+  BC-3110.60.30:
+    name: Nicht-betriebene Kostenverifikation
+    description: |
+      Verifikation operatorbelasteter Kosten gegenüber JOA-Abrechnungsverfahren.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-petroleum-process-safety-management.yaml
+++ b/catalogue/i18n/de/L1-petroleum-process-safety-management.yaml
@@ -1,0 +1,155 @@
+locale: de
+source: L1-petroleum-process-safety-management.yaml
+entries:
+  BC-3050:
+    name: Anlagensicherheit (Petroleum)
+    description: |
+      Prävention von Störfallgefahren in Kohlenwasserstoff-verarbeitenden Anlagen -
+      Prozessgefahrenanalyse, mechanische Integrität von Drucksystemen,
+      Sicherheitskritische-Element-Sicherstellung, Betriebsverfahren,
+      Leistungsberichterstattung und Notfallreaktion. Abgegrenzt von
+      branchenübergreifendem HSE-Management (BC-730), das Arbeitssicherheit,
+      Umweltschutz und persönliche Sicherheit umfasst.
+  BC-3050.10:
+    name: Prozessgefahrenanalyse
+    description: |
+      Strukturierte Identifikation und Analyse von Störfallgefahren
+      über den gesamten Anlagenlebenszyklus.
+    in_scope:
+      - HAZID, HAZOP, LOPA und Bowtie-Analyse
+      - Quantitative Risikoabschätzung
+    out_of_scope:
+      - Persönliche Sicherheitsrisikoabschätzung (BC-730)
+  BC-3050.10.10:
+    name: HAZOP-Studien
+    description: |
+      Gefährdungs- und Operabilitätsstudien für neue und geänderte Anlagen.
+  BC-3050.10.20:
+    name: HAZID-Studien
+    description: |
+      Gefährdungsidentifikationsstudien in frühen Konzept- und Entwurfsphasen.
+  BC-3050.10.30:
+    name: LOPA-Studien
+    description: |
+      Schutzschichten-Analyse zur Definition von Sicherheitsintegritätsebenen.
+  BC-3050.10.40:
+    name: Bowtie-Analyse
+    description: |
+      Bowtie-Analyse zur Kartierung von Barrieren gegen Störfallszenarien.
+  BC-3050.20:
+    name: Mechanisches Integritätsmanagement
+    description: |
+      Inspektion und Integritätsmanagement druckführender Ausrüstungen
+      und Sicherheitsdruckentlastungsvorrichtungen.
+  BC-3050.20.10:
+    name: Druckbehälterinspektion
+    description: |
+      Risikobasierte Inspektion von Druckbehältern nach API 510.
+  BC-3050.20.20:
+    name: Rohrleitung- und Pipelineintegritätsinspektion
+    description: |
+      Inspektion von Prozess-Rohrleitungen und Pipelines nach API 570 und ASME B31G.
+  BC-3050.20.30:
+    name: Lagertankinspektion
+    description: |
+      Atmosphärische und druckbeaufschlagte Lagertankinspektion nach API 653.
+  BC-3050.20.40:
+    name: Druckentlastungsvorrichtung-Management
+    description: |
+      Auslegung, Prüfung und Lebenszyklusmanagement von Sicherheitsventilen und Berstscheiben.
+  BC-3050.30:
+    name: Sicherheitskritische-Elemente-Management
+    description: |
+      Identifikation und Leistungssicherstellung sicherheitskritischer Elemente
+      und Pflege des Sicherheitsnachweises.
+  BC-3050.30.10:
+    name: Sicherheitskritische-Elemente-Identifikation
+    description: |
+      Identifikation von SCEs aus der Störfallgefahrenanalyse.
+  BC-3050.30.20:
+    name: Leistungsstandard-Definition
+    description: |
+      Definition von Leistungsstandards für jedes SCE.
+  BC-3050.30.30:
+    name: SCE-Leistungsverifikation
+    description: |
+      Verifikation der SCE-Leistung gegenüber definierten Standards.
+  BC-3050.30.40:
+    name: Sicherheitsnachweis-Pflege
+    description: |
+      Pflege von Anlagen-Sicherheitsnachweisen und Einreichung bei Behörden.
+  BC-3050.40:
+    name: Prozesssicherheits-Betriebsverfahren
+    description: |
+      Erstellung, Überprüfung und Betriebshüllendefinition für
+      prozesssicherheitskritische Verfahren.
+  BC-3050.40.10:
+    name: Betriebsverfahren-Erstellung
+    description: |
+      Erstellung prozesssicherheitskritischer Betriebsverfahren.
+  BC-3050.40.20:
+    name: Verfahrensüberprüfung und -aktualisierung
+    description: |
+      Periodische Überprüfung und Aktualisierung von Prozesssicherheitsverfahren.
+  BC-3050.40.30:
+    name: Betriebsbereich-Definition
+    description: |
+      Definition sicherer Betriebsbereiche für Prozesseinheiten.
+  BC-3050.50:
+    name: Prozesssicherheits-Änderungsmanagement
+    description: |
+      Prozesssicherheits-Governance über Anlagen-, Verfahrens- und Personaländerungen
+      einschließlich Vor-Inbetriebnahme-Sicherheitsüberprüfung.
+  BC-3050.50.10:
+    name: PSM-Änderungsanforderungs-Überprüfung
+    description: |
+      Überprüfung PSM-relevanter Änderungsanforderungen gegenüber Gefahrenstandards.
+  BC-3050.50.20:
+    name: Vor-Inbetriebnahme-Sicherheitsüberprüfung
+    description: |
+      Vor-Inbetriebnahme-Sicherheitsüberprüfungen für neue und geänderte Anlagen.
+  BC-3050.50.30:
+    name: Temporäres Änderungsmanagement
+    description: |
+      Management temporärer Prozessänderungen innerhalb ihres genehmigten Zeitfensters.
+  BC-3050.60:
+    name: Prozesssicherheits-Leistungsmanagement
+    description: |
+      Tracking und Berichterstattung vorlaufender und nachlaufender Prozesssicherheits-
+      Indikatoren nach API RP 754 und gleichwertigen Rahmenwerken.
+  BC-3050.60.10:
+    name: Tier-1- und Tier-2-Prozesssicherheitsereignis-Berichterstattung
+    description: |
+      Erfassung und Berichterstattung von Tier-1- und Tier-2-Prozesssicherheitsereignissen.
+  BC-3050.60.20:
+    name: Vorlaufende Indikator-Überwachung
+    description: |
+      Überwachung vorlaufender Tier-3- und Tier-4-Prozesssicherheitsindikatoren.
+  BC-3050.60.30:
+    name: Prozesssicherheits-KPI-Berichterstattung
+    description: |
+      Externe und interne Berichterstattung über Prozesssicherheits-KPI-Leistung.
+  BC-3050.70:
+    name: Notfallplanung und Reaktion
+    description: |
+      Notfallreaktionsplanung, Übungskoordination und Ölunfallreaktionskoordination
+      für Störfallszenarien.
+  BC-3050.70.10:
+    name: Notfallreaktionsplanung
+    description: |
+      Pflege von Anlagen- und Unternehmens-Notfallreaktionsplänen.
+  BC-3050.70.20:
+    name: Übungs- und Trainingskoordination
+    description: |
+      Koordination von Notfallübungen und Großschadensereignis-Übungen.
+  BC-3050.70.30:
+    name: Ölunfallreaktions-Koordination
+    description: |
+      Koordination von Öl- und Chemikalienunfall-Reaktionsoperationen.
+  BC-3050.70.40:
+    name: Gegenseitige Hilfe-Koordination
+    description: |
+      Koordination gegenseitiger Hilfe mit industriellen Reaktionskooperativen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-pharmaceutical-commercial-management.yaml
+++ b/catalogue/i18n/de/L1-pharmaceutical-commercial-management.yaml
@@ -1,0 +1,110 @@
+locale: de
+source: L1-pharmaceutical-commercial-management.yaml
+entries:
+  BC-1590:
+    name: Pharmazeutischer-Vertrieb-Management
+    description: |
+      HCP-Engagement, Proben, Werbematerialien, Außendienst, Marke und Patientenengagement.
+  BC-1590.10:
+    name: HCP-Engagement-Management
+    description: |
+      HCP-Engagement-Programme und Außendienstinteraktionen.
+  BC-1590.10.10:
+    name: HCP-Zielsetzung und -Segmentierung
+    description: |
+      Zielsetzung und Segmentierung von Ärzten und Gesundheitsexperten.
+  BC-1590.10.20:
+    name: HCP-Mehrkanal-Engagement
+    description: |
+      Mehrkanal-HCP-Engagement-Orchestrierung.
+  BC-1590.10.30:
+    name: HCP-Transparenz-Meldung
+    description: |
+      Sunshine-Act- und EFPIA-Transparenzberichterstattung.
+  BC-1590.20:
+    name: Proben-Management
+    description: |
+      Probenverteilung, -verantwortung und regulatorische Compliance.
+  BC-1590.20.10:
+    name: Probenanforderung und -verteilung
+    description: |
+      Probenanforderungsbearbeitung und Verteilung an Ärzte.
+  BC-1590.20.20:
+    name: Probenverantwortung und -abstimmung
+    description: |
+      PDMA-konforme Probenverantwortung und -abstimmung.
+  BC-1590.20.30:
+    name: Proben-Compliance-Auditing
+    description: |
+      Auditierung von Probenverteilungspraktiken.
+  BC-1590.30:
+    name: Werbematerialien-Management
+    description: |
+      Werbematerialentwicklung, MLR-Überprüfung und Governance.
+  BC-1590.30.10:
+    name: Werbematerial-Authoring
+    description: |
+      Erstellung von Werbematerialien und Inhalten.
+  BC-1590.30.20:
+    name: Medizinische-Rechtliche-Regulatorische Überprüfung
+    description: |
+      MLR-Überprüfungs- und Genehmigungsworkflow für Werbeinhalte.
+  BC-1590.30.30:
+    name: Werbematerial-Verteilung
+    description: |
+      Verteilung genehmigter Werbematerialien.
+  BC-1590.40:
+    name: Pharma-Außendienst-Management
+    description: |
+      Außendienstplanung, Gebiet, Zielsetzung und Einsatz.
+  BC-1590.40.10:
+    name: Außendienst-Dimensionierung
+    description: |
+      Außendienst-Dimensionierung und Strukturdesign.
+  BC-1590.40.20:
+    name: Pharma-Gebietsdesign
+    description: |
+      Pharmazeutisches Gebietsdesign und -ausrichtung.
+  BC-1590.40.30:
+    name: Außendienst-Zielsetzung
+    description: |
+      Zielsetzung und Besuchsplanung für pharmazeutische Außendienstmitarbeiter.
+  BC-1590.40.40:
+    name: Außendienst-Effektivitätsmessung
+    description: |
+      Messung und Verbesserung der Außendiensteffektivität.
+  BC-1590.50:
+    name: Pharmazeutische-Marken-Management
+    description: |
+      Markenstrategie, Positionierung und Lebenszyklus.
+  BC-1590.50.10:
+    name: Pharma-Markenstrategie
+    description: |
+      Markenstrategie und Positionierung pro Indikation.
+  BC-1590.50.20:
+    name: Marken-Forecasting
+    description: |
+      Marken-Forecasting und Nachfragesensing.
+  BC-1590.50.30:
+    name: Lebenszyklus-Markenplanung
+    description: |
+      Lebenszyklus-Markenplanung einschließlich Patentablauf.
+  BC-1590.60:
+    name: Patienten-Engagement-Management
+    description: |
+      Patientenprogramme, Unterstützungsleistungen und Advocacy.
+  BC-1590.60.10:
+    name: Patienten-Unterstützungsprogramm-Betrieb
+    description: |
+      Betrieb von Patienten-Unterstützungs- und Adhärenzprogrammen.
+  BC-1590.60.20:
+    name: Patienten-Advocacy-Engagement
+    description: |
+      Engagement mit Patientenorganisationen.
+  BC-1590.60.30:
+    name: Patienten-Erkenntniserfassung
+    description: |
+      Erfassung und Integration von Patienten-Erkenntnissen und PROs.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-pharmaceutical-manufacturing-management.yaml
+++ b/catalogue/i18n/de/L1-pharmaceutical-manufacturing-management.yaml
@@ -1,0 +1,138 @@
+locale: de
+source: L1-pharmaceutical-manufacturing-management.yaml
+entries:
+  BC-1550:
+    name: Pharmazeutische-Herstellungs-Management
+    description: |
+      GMP-konforme Herstellung von Wirkstoffen und Arzneimittelprodukten.
+  BC-1550.10:
+    name: Wirkstoff-Herstellungsmanagement
+    description: |
+      Herstellung aktiver pharmazeutischer Wirkstoffe.
+  BC-1550.10.10:
+    name: Kleinmolekül-Wirkstoffsynthese
+    description: |
+      Synthese kleiner Moleküle als aktive pharmazeutische Wirkstoffe.
+  BC-1550.10.20:
+    name: Biologika-Wirkstoff-Produktion
+    description: |
+      Zellkultur- und Fermentationsproduktion von Biologika-Wirkstoffen.
+  BC-1550.10.30:
+    name: Wirkstoff-Aufreinigung
+    description: |
+      Nachgelagerte Aufreinigung aktiver pharmazeutischer Wirkstoffe.
+  BC-1550.20:
+    name: Arzneimittelprodukt-Herstellungsmanagement
+    description: |
+      Arzneimittelproduktherstellung – Tabletten, Kapseln, Flüssigkeiten und Biologika.
+  BC-1550.20.10:
+    name: Feste-Darreichungsform-Herstellung
+    description: |
+      Herstellungsvorgänge für Tabletten und Kapseln.
+  BC-1550.20.20:
+    name: Flüssige- und Halbfeste-Darreichungsform-Herstellung
+    description: |
+      Herstellung von flüssigen, Suspensions- und halbfesten Darreichungsformen.
+  BC-1550.20.30:
+    name: Biologika-Arzneimittelprodukt-Abfüllung
+    description: |
+      Abfüllung und Fertigstellung biologischer Arzneimittelprodukte.
+  BC-1550.20.40:
+    name: Inhalations- und Spezial-Darreichungsform-Herstellung
+    description: |
+      Herstellung von Inhalations-, transdermalen und Spezial-Darreichungsformen.
+  BC-1550.30:
+    name: Sterile-Herstellungs-Management
+    description: |
+      Aseptische und Terminal-Sterilisierungs-Herstellung.
+  BC-1550.30.10:
+    name: Aseptische-Abfüllungsoperationen
+    description: |
+      Aseptische Abfüllung gemäß Annex-1-Anforderungen.
+  BC-1550.30.20:
+    name: Terminal-Sterilisierungs-Operationen
+    description: |
+      Terminal-Sterilisierungsprozesse.
+  BC-1550.30.30:
+    name: Reinraum-Operationen
+    description: |
+      Betrieb klassifizierter Reinräume und Umgebungsmonitoring.
+  BC-1550.40:
+    name: Verpackungs- und Kennzeichnungs-Management
+    description: |
+      Primär- und Sekundärverpackung sowie Kennzeichnungsvorgänge.
+  BC-1550.40.10:
+    name: Primärverpackungs-Operationen
+    description: |
+      Primärverpackung von Arzneimittelprodukten.
+  BC-1550.40.20:
+    name: Sekundärverpackungs-Operationen
+    description: |
+      Sekundärverpackung, Kartonierung und Bündelung.
+  BC-1550.40.30:
+    name: Kennzeichnungsauftrag
+    description: |
+      Aufbringen von Etiketten und Serialisierungsmarkierungen.
+  BC-1550.40.40:
+    name: Spätphasen-Anpassung
+    description: |
+      Spätphasen-Anpassung und länderspezifische Verpackung.
+  BC-1550.50:
+    name: Validierungs- und Qualifizierungs-Management
+    description: |
+      Prozess-, Ausrüstungs-, Reinigungs- und Computersystemvalidierung.
+  BC-1550.50.10:
+    name: Prozessvalidierung
+    description: |
+      Prozessvalidierung gemäß ICH Q7.
+  BC-1550.50.20:
+    name: Ausrüstungsqualifizierung
+    description: |
+      IQ-, OQ-, PQ-Qualifizierung von GMP-Ausrüstung.
+  BC-1550.50.30:
+    name: Reinigungsvalidierung
+    description: |
+      Reinigungsvalidierung bei Produktwechseln.
+  BC-1550.50.40:
+    name: Computersystem-Validierung
+    description: |
+      CSV gemäß GAMP 5 und 21 CFR Part 11.
+  BC-1550.60:
+    name: Tech-Transfer-Management
+    description: |
+      Technologietransfer zwischen Standorten und Scale-up-Aktivitäten.
+  BC-1550.60.10:
+    name: Tech-Transfer-Planung
+    description: |
+      Planung des Technologietransfers zwischen Standorten.
+  BC-1550.60.20:
+    name: Prozess-Scale-up
+    description: |
+      Scale-up vom Pilotmaßstab zum kommerziellen Produktionsmaßstab.
+  BC-1550.60.30:
+    name: Standortbereitschafts-Verifikation
+    description: |
+      Verifikation der Bereitschaft des empfangenden Standorts für den Tech-Transfer.
+  BC-1550.70:
+    name: GMP-Produktionsbetrieb-Management
+    description: |
+      Täglicher GMP-Produktionsbetrieb und Chargendokumentation.
+  BC-1550.70.10:
+    name: Chargenprotokoll-Ausführung
+    description: |
+      Ausführung von Papier- oder elektronischen Chargenprotokollen.
+  BC-1550.70.20:
+    name: In-Prozess-Kontrolle-Probenahme
+    description: |
+      In-Prozess-Kontrollprobenahme und -testing.
+  BC-1550.70.30:
+    name: Produktionslinie-Freigabe
+    description: |
+      Linienfreigabe und Produktwechselvorgänge.
+  BC-1550.70.40:
+    name: GMP-Bediener-Training
+    description: |
+      GMP-Training und -Qualifizierung von Bedienern.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-pharmaceutical-quality-management.yaml
+++ b/catalogue/i18n/de/L1-pharmaceutical-quality-management.yaml
@@ -1,0 +1,142 @@
+locale: de
+source: L1-pharmaceutical-quality-management.yaml
+entries:
+  BC-1560:
+    name: Pharmazeutische-Qualitäts-Management
+    description: |
+      GxP-Qualitätssysteme, Abweichungen/CAPA, Änderungskontrolle und Chargenfreigabe.
+  BC-1560.10:
+    name: GMP-Compliance-Management
+    description: |
+      GMP-Compliance-Rahmenwerk und regulatorische Inspektionsbereitschaft.
+  BC-1560.10.10:
+    name: GMP-Qualitätsmanagementsystem
+    description: |
+      Pflege des QMS gemäß ICH Q10.
+  BC-1560.10.20:
+    name: GMP-Inspektionsbereitschaft
+    description: |
+      Bereitschaft für FDA-, EMA- und PMDA-Inspektionen.
+  BC-1560.10.30:
+    name: GMP-Auditprogramm
+    description: |
+      Internes GMP-Auditprogramm.
+  BC-1560.20:
+    name: GxP-Qualitätskontroll-Management
+    description: |
+      QK-Labore, analytisches Testing und Stabilitätstesting.
+  BC-1560.20.10:
+    name: QK-Labor-Betrieb
+    description: |
+      Betrieb von GMP-QK-Laboratorien.
+  BC-1560.20.20:
+    name: Analytische-Methoden-Transfer
+    description: |
+      Transfer analytischer Methoden an QK-Standorte.
+  BC-1560.20.30:
+    name: Stabilitätstesting
+    description: |
+      Stabilitätstesting gemäß ICH Q1.
+  BC-1560.20.40:
+    name: Out-of-Specification-Untersuchung
+    description: |
+      Untersuchung von Out-of-Specification-Ergebnissen.
+  BC-1560.30:
+    name: GxP-Qualitätssicherungs-Management
+    description: |
+      QS-Überprüfung, Chargenprotokoll-Überprüfung und Aufsicht.
+  BC-1560.30.10:
+    name: Chargenprotokoll-Überprüfung
+    description: |
+      QS-Überprüfung ausgeführter Chargenprotokolle.
+  BC-1560.30.20:
+    name: GxP-Dokumenten-Management
+    description: |
+      Gesteuertes Dokumentenmanagement für GxP.
+  BC-1560.30.30:
+    name: QS-Aufsicht-Operationen
+    description: |
+      QS-Aufsicht im Produktionsbetrieb.
+  BC-1560.40:
+    name: Abweichungs- und CAPA-Management
+    description: |
+      Abweichungsbehandlung, CAPA und Wirksamkeitsprüfung.
+  BC-1560.40.10:
+    name: GxP-Abweichungsbehandlung
+    description: |
+      Erfassung, Untersuchung und Abschluss von GxP-Abweichungen.
+  BC-1560.40.20:
+    name: GxP-CAPA-Management
+    description: |
+      CAPA-Management mit Ursachenanalyse.
+  BC-1560.40.30:
+    name: CAPA-Wirksamkeitsverifizierung
+    description: |
+      Verifizierung der Wirksamkeit implementierter CAPAs.
+  BC-1560.50:
+    name: GxP-Änderungskontroll-Management
+    description: |
+      GxP-Änderungskontrolle und Folgenabschätzung.
+  BC-1560.50.10:
+    name: GxP-Änderungsantrags-Erfassung
+    description: |
+      Erfassung und Klassifizierung von GxP-Änderungsanträgen.
+  BC-1560.50.20:
+    name: GxP-Änderungs-Folgenabschätzung
+    description: |
+      Folgenabschätzung von GxP-Änderungen auf die Produktqualität.
+  BC-1560.50.30:
+    name: GxP-Änderungsimplementierungs-Verfolgung
+    description: |
+      Verfolgung genehmigter GxP-Änderungsimplementierungen.
+  BC-1560.60:
+    name: Pharma-Lieferanten-Qualitätsmanagement
+    description: |
+      Lieferantenqualifizierung, Audits und Qualitätsvereinbarungen.
+  BC-1560.60.10:
+    name: GMP-Lieferanten-Qualifizierung
+    description: |
+      Qualifizierung von GMP-Material- und Dienstleistungslieferanten.
+  BC-1560.60.20:
+    name: GMP-Lieferanten-Audit
+    description: |
+      GMP-Audits bei Lieferanten vor Ort.
+  BC-1560.60.30:
+    name: Qualitätsvereinbarungs-Management
+    description: |
+      Verhandlung und Pflege von Qualitätsvereinbarungen.
+  BC-1560.70:
+    name: Chargenfreigabe-Management
+    description: |
+      Qualified-Person-Freigabe und Chargenzertifizierung.
+  BC-1560.70.10:
+    name: Chargen-Dispositionsentscheidung
+    description: |
+      Dispositionsentscheidung für hergestellte Chargen.
+  BC-1560.70.20:
+    name: Qualified-Person-Zertifizierung
+    description: |
+      QP-Zertifizierung gemäß EU-Annex 16.
+  BC-1560.70.30:
+    name: Marktfreigabe-Koordination
+    description: |
+      Koordination der Freigabe für den Markt in allen Regionen.
+  BC-1560.80:
+    name: Jährliche-Produktqualitätsprüfung-Management
+    description: |
+      APQR/APR und Produktqualitäts-Trendanalyse.
+  BC-1560.80.10:
+    name: APQR-Erstellung
+    description: |
+      Erstellung von jährlichen Produktqualitätsprüfungen.
+  BC-1560.80.20:
+    name: Produktqualitäts-Trendanalyse
+    description: |
+      Trendanalyse von Produktqualitätsdaten über die Zeit.
+  BC-1560.80.30:
+    name: APQR-Maßnahmen-Verfolgung
+    description: |
+      Verfolgung von Maßnahmen aus APQR-Schlussfolgerungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-pharmaceutical-supply-chain-management.yaml
+++ b/catalogue/i18n/de/L1-pharmaceutical-supply-chain-management.yaml
@@ -1,0 +1,98 @@
+locale: de
+source: L1-pharmaceutical-supply-chain-management.yaml
+entries:
+  BC-1570:
+    name: Pharmazeutische-Lieferkette-Management
+    description: |
+      Kühlkette, Serialisierung, Vertrieb und pharmazeutische Logistik.
+  BC-1570.10:
+    name: Kühlketten-Management
+    description: |
+      Temperaturgesteuerte Lieferkette und GDP.
+  BC-1570.10.10:
+    name: Kühlketten-Design
+    description: |
+      Design und Qualifizierung von Kühlkettenlösungen.
+  BC-1570.10.20:
+    name: Temperaturüberwachung
+    description: |
+      End-to-End-Temperaturüberwachung in der Kühlkette.
+  BC-1570.10.30:
+    name: Temperaturabweichungs-Management
+    description: |
+      Untersuchung und Disposition von Temperaturabweichungen.
+  BC-1570.20:
+    name: Serialisierungs- und Track-and-Trace-Management
+    description: |
+      Serialisierung, Aggregation und Fälschungsschutz.
+  BC-1570.20.10:
+    name: Seriennummern-Management
+    description: |
+      Generierung und Zuweisung von Seriennummern pro Markt.
+  BC-1570.20.20:
+    name: Aggregations- und Hierarchie-Management
+    description: |
+      Aggregation serialisierter Einheiten zu Bündeln und Paletten.
+  BC-1570.20.30:
+    name: Regulatorische-Meldung und -Verifikation
+    description: |
+      Regulatorische Meldung (DSCSA, EU FMD) und Verifikation bei der Abgabe.
+  BC-1570.30:
+    name: Pharmazeutische-Vertriebs-Management
+    description: |
+      Vertrieb an Großhändler, Krankenhäuser und Apotheken.
+  BC-1570.30.10:
+    name: Großhändler- und Distributoren-Betrieb
+    description: |
+      Vertriebsvorgänge an Großhändler und Distributoren.
+  BC-1570.30.20:
+    name: Direktbelieferung Krankenhäuser
+    description: |
+      Direkte Krankenhausbelieferung und Direktbelieferung von Apotheken.
+  BC-1570.30.30:
+    name: Spezialvertrieb
+    description: |
+      Spezialvertrieb für Produkte mit eingeschränktem Vertrieb.
+  BC-1570.40:
+    name: Pharmazeutische-Bestandsverwaltung
+    description: |
+      Pharmazeutischer Bestand, Ablauf und Zuteilung.
+  BC-1570.40.10:
+    name: Pharmazeutische-Bestandsplanung
+    description: |
+      Bestandsplanung für pharmazeutische Produkte.
+  BC-1570.40.20:
+    name: Ablauf- und Haltbarkeits-Management
+    description: |
+      FEFO-Management und Haltbarkeitsüberwachung.
+  BC-1570.40.30:
+    name: Pharmazeutische-Zuteilung
+    description: |
+      Zuteilung begrenzter Versorgung über Märkte hinweg.
+  BC-1570.40.40:
+    name: Rückruf- und Rückzugs-Koordination
+    description: |
+      Koordination von Produktrückrufen und -rückzügen.
+  BC-1570.50:
+    name: Pharmazeutische-Logistik-Management
+    description: |
+      Transport, Lagerung und GDP-konforme Logistik.
+  BC-1570.50.10:
+    name: GDP-Konformer-Transport
+    description: |
+      GDP-konforme Transportvorgänge.
+  BC-1570.50.20:
+    name: GDP-Konforme-Lagerung
+    description: |
+      GDP-konforme Lagervorgänge.
+  BC-1570.50.30:
+    name: Pharma-Zollabwicklung
+    description: |
+      Pharmazeutische Zollabwicklung und Import-/Exportvorgänge.
+  BC-1570.50.40:
+    name: Logistikdienstleister-Management
+    description: |
+      Management von 3PL-Dienstleistern in der pharmazeutischen Lieferkette.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-pharmacovigilance-management.yaml
+++ b/catalogue/i18n/de/L1-pharmacovigilance-management.yaml
@@ -1,0 +1,98 @@
+locale: de
+source: L1-pharmacovigilance-management.yaml
+entries:
+  BC-1540:
+    name: Pharmakovigilanz-Management
+    description: |
+      Nebenwirkungsüberwachung, Signaldetektion und Sicherheitsberichterstattung.
+  BC-1540.10:
+    name: Nebenwirkungsfall-Management
+    description: |
+      ICSR-Verarbeitung und beschleunigte Meldung.
+  BC-1540.10.10:
+    name: ICSR-Eingang und -Triage
+    description: |
+      Eingang und Triage von Einzelfall-Sicherheitsberichten.
+  BC-1540.10.20:
+    name: ICSR-Fallverarbeitung
+    description: |
+      Verarbeitung, Kodierung und Narrativ-Authoring von ICSRs.
+  BC-1540.10.30:
+    name: Beschleunigte und periodische Berichterstattung
+    description: |
+      Beschleunigte Meldung gemäß ICH E2D und EU GVP.
+  BC-1540.10.40:
+    name: Medizinische-Überprüfung und Kausalitätsbewertung
+    description: |
+      Medizinische Überprüfung und Kausalitätsbewertung von Fällen.
+  BC-1540.20:
+    name: Signaldetektions- und -Management
+    description: |
+      Signaldetektion, -bewertung und -eskalation.
+  BC-1540.20.10:
+    name: Signaldetektion
+    description: |
+      Quantitative und qualitative Signaldetektion.
+  BC-1540.20.20:
+    name: Signalbewertung
+    description: |
+      Bewertung und Validierung erkannter Signale.
+  BC-1540.20.30:
+    name: Signal-Disposition und -Maßnahmen
+    description: |
+      Disposition von Signalen in Maßnahmen und Kennzeichnungsänderungen.
+  BC-1540.30:
+    name: Periodisches-Sicherheitsberichterstattungs-Management
+    description: |
+      PSURs/PBRERs, DSURs und periodische Berichte.
+  BC-1540.30.10:
+    name: PSUR/PBRER-Erstellung
+    description: |
+      Erstellung von PSURs und PBRERs.
+  BC-1540.30.20:
+    name: DSUR-Erstellung
+    description: |
+      Erstellung von Entwicklungs-Sicherheits-Aktualisierungsberichten.
+  BC-1540.30.30:
+    name: Aggregierte-Sicherheitsberichterstattung
+    description: |
+      Erstellung sonstiger aggregierter Sicherheitsberichte.
+  BC-1540.40:
+    name: Risikomanagementplan-Management
+    description: |
+      RMPs, Risikominimierungsmaßnahmen und REMS.
+  BC-1540.40.10:
+    name: Risikomanagementplan-Authoring
+    description: |
+      Erstellung von EU-RMPs und REMS-Dokumenten.
+  BC-1540.40.20:
+    name: Risikominimierungs-Implementierung
+    description: |
+      Implementierung routinemäßiger und zusätzlicher Risikominimierungsmaßnahmen.
+  BC-1540.40.30:
+    name: Risikominimierungs-Wirksamkeitsbewertung
+    description: |
+      Bewertung der Wirksamkeit von Risikominimierungsmaßnahmen.
+  BC-1540.50:
+    name: Pharmakovigilanz-Audit- und Inspektions-Management
+    description: |
+      PV-Audits, Behördeninspektionen und CAPAs.
+  BC-1540.50.10:
+    name: PV-System-Auditprogramm
+    description: |
+      Internes Auditprogramm für das PV-System.
+  BC-1540.50.20:
+    name: PV-Inspektionsbereitschaft
+    description: |
+      Bereitschaft für PV-Inspektionen der Gesundheitsbehörden.
+  BC-1540.50.30:
+    name: PV-CAPA-Management
+    description: |
+      Management von CAPAs aus Audits und Inspektionen.
+  BC-1540.50.40:
+    name: PV-System-Master-File-Pflege
+    description: |
+      Pflege des PV-System-Master-File (PSMF).
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-pharmacy-medication-management.yaml
+++ b/catalogue/i18n/de/L1-pharmacy-medication-management.yaml
@@ -1,0 +1,138 @@
+locale: de
+source: L1-pharmacy-medication-management.yaml
+entries:
+  BC-2850:
+    name: Pharmazie und Medikamentenmanagement
+    description: |
+      Apothekenbetrieb auf Anbieterseite einschließlich Arzneimittelformular, stationärer und
+      ambulanter Abgabe, Medikamentengabe und -abgleich, Betäubungsmittel-Stewardship
+      sowie klinischer Apothekendienste.
+  BC-2850.10:
+    name: Formularverwaltung
+    description: |
+      Verwaltung des Arzneimittelformulars, therapeutischer Substitutionen und
+      Reaktion auf Arzneimittelengpässe.
+  BC-2850.10.10:
+    name: Formularentscheidungsfindung
+    description: |
+      Evidenzbasierte Entscheidungen zur Aufnahme, zum Ausschluss und zur Stufenzuordnung im Formular.
+  BC-2850.10.20:
+    name: Therapeutische Substitution
+    description: |
+      Verwaltung und Umsetzung von Protokollen zur therapeutischen Substitution.
+  BC-2850.10.30:
+    name: Unterstützung des Arzneimittelausschusses
+    description: |
+      Betriebliche Unterstützung des Arzneimittel- und Therapeutischen Ausschusses.
+  BC-2850.10.40:
+    name: Arzneimittelengpassmanagement
+    description: |
+      Identifikation, Minderung und Substitutionsplanung bei Arzneimittelengpässen.
+  BC-2850.20:
+    name: Stationärer Apothekenbetrieb
+    description: |
+      Überprüfung von Verordnungen, sterile und nicht-sterile Herstellung, Abgabe
+      und intravenöse Zubereitung für den stationären Bereich.
+  BC-2850.20.10:
+    name: Verordnungsüberprüfung
+    description: |
+      Pharmazeutische Überprüfung von Medikamentenverordnungen auf Sicherheit und Angemessenheit.
+  BC-2850.20.20:
+    name: Sterile Herstellung
+    description: |
+      Sterile Herstellungsoperationen einschließlich der Herstellung gefährlicher Arzneimittel.
+  BC-2850.20.30:
+    name: Einheitsdosenabgabe
+    description: |
+      Vorbereitung und Abgabe von Einheitsdosen für die stationäre Verabreichung.
+  BC-2850.20.40:
+    name: Intravenöse Zubereitung
+    description: |
+      Herstellung intravenöser Zubereitungen, Infusionen und parenteraler Ernährung.
+  BC-2850.30:
+    name: Ambulante und Spezialapotheke
+    description: |
+      Betriebs von Einzel-, Spezial- und Versandapotheken einschließlich
+      rabattierter Arzneimittelprogramme.
+  BC-2850.30.10:
+    name: Ambulante Arzneimittelabgabe
+    description: |
+      Rezeptabgabe in Einzelhandelsapotheken für den ambulanten Bereich.
+  BC-2850.30.20:
+    name: Spezialarzneimittelverwaltung
+    description: |
+      Betrieb von Spezialapotheken für kostenintensive und begrenzt vertriebene Arzneimittel.
+  BC-2850.30.30:
+    name: Versandabwicklung
+    description: |
+      Abwicklung und Lieferung von Versandrezepten.
+  BC-2850.30.40:
+    name: Rabattarzneimittelprogramme
+    description: |
+      Betrieb gesetzlicher Arzneimittelrabattierungsprogramme und Compliance qualifizierter Einrichtungen.
+  BC-2850.40:
+    name: Medikamentengabe und -abgleich
+    description: |
+      Medikamentengabe am Krankenbett, Abgleich bei Übergängen und
+      Umgang mit patientenmitgebrachten Medikamenten.
+  BC-2850.40.10:
+    name: Medikamentengabe am Krankenbett
+    description: |
+      Barcodegestützte Medikamentengabe am Krankenbett durch Pflegepersonal.
+  BC-2850.40.20:
+    name: Medikamentenabgleich
+    description: |
+      Abgleich von Haus- und verschriebenen Medikamenten bei Aufnahme, Verlegung und Entlassung.
+  BC-2850.40.30:
+    name: Elektronische Medikamentenerfassung
+    description: |
+      Betrieb der elektronischen Medikamentenverabreichungsakte.
+  BC-2850.40.40:
+    name: Umgang mit patienteneigenen Arzneimitteln
+    description: |
+      Identifikation, Lagerung und autorisierte Verabreichung patienteneigener Arzneimittel.
+  BC-2850.50:
+    name: Betäubungsmittel-Stewardship
+    description: |
+      Compliance, Diversion-Monitoring, Bestandsverwaltung und Entsorgung
+      von Betäubungsmitteln.
+  BC-2850.50.10:
+    name: Betäubungsmittel-Compliance
+    description: |
+      Einhaltung der Betäubungsmittelvorschriften einschließlich Registrierung und Aufzeichnungspflichten.
+  BC-2850.50.20:
+    name: Diversion-Überwachung
+    description: |
+      Überwachung und Untersuchung des Verdachts auf Arzneimitteldiversion.
+  BC-2850.50.30:
+    name: Betäubungsmittelbestand
+    description: |
+      Fortlaufende Bestandsführung und Abgleich von Betäubungsmittelbeständen.
+  BC-2850.50.40:
+    name: Betäubungsmittelentsorgung
+    description: |
+      Entsorgung, protokollierte Vernichtung und Rückgabe von Betäubungsmitteln.
+  BC-2850.60:
+    name: Klinische Apothekendienste
+    description: |
+      Klinische Apothekendienste einschließlich Antikoagulationsmanagement, Antibiotika-
+      Stewardship, Medikationstherapiemanagement und therapeutischem Drug-Monitoring.
+  BC-2850.60.10:
+    name: Antikoagulationsmanagement
+    description: |
+      Pharmazeutisch geleitete Dosierung und Überwachung der Antikoagulationstherapie.
+  BC-2850.60.20:
+    name: Antibiotika-Stewardship Apotheke
+    description: |
+      Pharmazeutischer Beitrag zu Antibiotika-Stewardship-Programmen.
+  BC-2850.60.30:
+    name: Medikationstherapiemanagement
+    description: |
+      Vom Apotheker durchgeführte Medikationstherapiemanagement-Konsultationen.
+  BC-2850.60.40:
+    name: Therapeutisches Drug-Monitoring
+    description: |
+      Therapeutisches Drug-Monitoring und individuelle Dosierungsanpassungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-physical-asset-management.yaml
+++ b/catalogue/i18n/de/L1-physical-asset-management.yaml
@@ -1,0 +1,98 @@
+locale: de
+source: L1-physical-asset-management.yaml
+entries:
+  BC-1040:
+    name: Physisches Anlagenmanagement
+    description: |
+      Lebenszyklusmanagement von Werken, Anlagen, Flotten und Infrastruktur.
+  BC-1040.10:
+    name: Anlagenstrategie- und Lebenszyklusmanagement
+    description: |
+      Anlagenstrategie, Lebenszyklus und Ersatzplanung.
+  BC-1040.10.10:
+    name: Anlagenklassenstrategie
+    description: |
+      Strategie je Anlagenklasse gemäß ISO 55000.
+  BC-1040.10.20:
+    name: Anlagenlebenszyklusplanung
+    description: |
+      Gesamtlebenszyklusplanung von Anlagen durch Erwerb, Betrieb und Entsorgung.
+  BC-1040.10.30:
+    name: Anlagenersatzplanung
+    description: |
+      Ersatzplanung auf Basis von Lebenserwartung und Zustand.
+  BC-1040.10.40:
+    name: Anlagen-Investitionsplanung
+    description: |
+      Kapitalplanung für Anlageinvestitionen und -erneuerungen.
+  BC-1040.20:
+    name: Anlagenleistungsmanagement
+    description: |
+      Anlagen-KPIs, Verfügbarkeit und Auslastung.
+  BC-1040.20.10:
+    name: Anlagen-KPI-Definition
+    description: |
+      Definition von Anlagenleistungs-KPIs und Zielvorgaben.
+  BC-1040.20.20:
+    name: Anlagenverfügbarkeits-Überwachung
+    description: |
+      Überwachung von Anlagenverfügbarkeit und Betriebszeit.
+  BC-1040.20.30:
+    name: Anlagenauslastungs-Berichterstattung
+    description: |
+      Berichterstattung zu Anlagenauslastung und -leistung.
+  BC-1040.20.40:
+    name: Anlagengesundheitsindex-Management
+    description: |
+      Zusammengesetzte Gesundheitsindizes und Anlagenzustandsbewertung.
+  BC-1040.30:
+    name: Anlagenrisiko- und Kritikalitätsmanagement
+    description: |
+      Kritikalitätsklassifizierung und risikobasierte Priorisierung.
+  BC-1040.30.10:
+    name: Anlagenkritikalitäts-Klassifizierung
+    description: |
+      Kritikalitätsklassifizierung von Anlagen nach Auswirkung.
+  BC-1040.30.20:
+    name: Anlagenrisikobewertung
+    description: |
+      Risikobewertung von Anlagen einschließlich Ausfallfolgen.
+  BC-1040.30.30:
+    name: Risikobasierte Instandhaltungspriorisierung
+    description: |
+      Risikobasierte Priorisierung von Instandhaltungs- und Investitionsmaßnahmen.
+  BC-1040.40:
+    name: Anlagen-Informationsmanagement
+    description: |
+      Anlagenstammdaten und technische Dokumentation.
+  BC-1040.40.10:
+    name: Anlagenstammdaten-Management
+    description: |
+      Anlagenstammdaten, Hierarchien und Anlagenregister.
+  BC-1040.40.20:
+    name: Technische Anlagendokumentation
+    description: |
+      Technische Unterlagen, Zeichnungen und OEM-Dokumentation.
+  BC-1040.40.30:
+    name: Anlagen-Digital-Twin-Management
+    description: |
+      Digitale Zwillingsmodelle für Anlagenbetrieb und -analytik.
+  BC-1040.50:
+    name: Anlagendekommissionierungs- und Entsorgungsmanagement
+    description: |
+      Dekommissionierung, Entsorgung und Anlagenausmusterung.
+  BC-1040.50.10:
+    name: Dekommissionierungsplanung
+    description: |
+      Planung der Anlagendekommissionierung einschließlich HSE.
+  BC-1040.50.20:
+    name: Anlagenausbau-Ausführung
+    description: |
+      Physischer Ausbau und Demontage ausgemusterter Anlagen.
+  BC-1040.50.30:
+    name: Anlagenentsorgung und Wiederverkauf
+    description: |
+      Wiederverkauf, Verschrottung und Recycling ausgemusterter Anlagen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-pipeline-operations-management.yaml
+++ b/catalogue/i18n/de/L1-pipeline-operations-management.yaml
@@ -1,0 +1,118 @@
+locale: de
+source: L1-pipeline-operations-management.yaml
+entries:
+  BC-3060:
+    name: Pipelinebetrieb
+    description: |
+      Betrieb, Integrität und kaufmännisches Management von Kohlenwasserstoff-
+      Sammel- und Transportpipelines - Leitstellenbetrieb, Molchinspektionen,
+      Leckageerkennung, Zeitplanung und Nominierungen sowie Tarifverwaltung.
+  BC-3060.10:
+    name: Pipeline-Leittechnik-Betrieb
+    description: |
+      Leitstellenbetrieb und SCADA-Betrieb von Flüssigkeits- und Gas-Pipelines.
+  BC-3060.10.10:
+    name: Pipeline-Leitstelle und Betriebsführung
+    description: |
+      24/7-Leitstellenbetrieb von Pipeline-Operationen.
+  BC-3060.10.20:
+    name: SCADA-Betrieb
+    description: |
+      Betrieb von Pipeline-SCADA-Systemen und Feldtelemetrie.
+  BC-3060.10.30:
+    name: Pipeline-Hydraulikmodellierung
+    description: |
+      Echtzeit- und Offline-Hydraulikmodellierung von Pipeline-Strömungsregimen.
+  BC-3060.10.40:
+    name: Betreiberschulungs-Simulatorbetrieb
+    description: |
+      Pflege von Pipeline-Controller-Schulungssimulatoren nach behördlichen Anforderungen.
+  BC-3060.20:
+    name: Pipeline-Integritätsmanagement
+    description: |
+      Molchinspektionen, kathodischer Schutz und Defektbewertung für
+      Pipeline-Integritätssicherung.
+  BC-3060.20.10:
+    name: Molchinspektion
+    description: |
+      Smart-Molch-Inspektionskampagnen für Pipeline-Integrität.
+  BC-3060.20.20:
+    name: Kathodischer Schutz-Management
+    description: |
+      Design, Betrieb und Prüfung des kathodischen Schutzes von Pipelines.
+  BC-3060.20.30:
+    name: Pipeline-Defektbewertung
+    description: |
+      Bruchmechanische Bewertung von Metallverlusten und rissartigen Defekten.
+  BC-3060.20.40:
+    name: Trassenpatrouille
+    description: |
+      Luft- und Bodenpatrouille von Pipeline-Trassen.
+  BC-3060.30:
+    name: Leckageerkennung und Pipeline-Überwachung
+    description: |
+      Rechnergestützte und externe Leckageerkennungssysteme und Pipeline-Überwachung.
+  BC-3060.30.10:
+    name: Rechnergestützte Leckageerkennung
+    description: |
+      Echtzeit-Transientenmodell-basierte und statistische Leckageerkennungssysteme.
+  BC-3060.30.20:
+    name: Externe Leckageerkennung
+    description: |
+      Glasfaser-, Akustik- und Dampfmess-basierte externe Leckageerkennung.
+  BC-3060.30.30:
+    name: Luft- und Fußpatrouille
+    description: |
+      Routinemäßige Luft- und Fußpatrouillen von Pipeline-Korridoren.
+  BC-3060.40:
+    name: Pipeline-Zeitplanung und Nominierungen
+    description: |
+      Kapazitätsnominierungen, Chargenstaffelung und Leitungsfüllung-Management für transportierte Mengen.
+  BC-3060.40.10:
+    name: Kapazitätsnominierungs-Management
+    description: |
+      Eingang, Bestätigung und Planung von Schiffernominierungen.
+  BC-3060.40.20:
+    name: Chargenstaffelung
+    description: |
+      Staffelung von Mehrprodukt-Chargen in Flüssigkeits-Pipelines.
+  BC-3060.40.30:
+    name: Leitungsfüllung-Management
+    description: |
+      Management des Leitungsfüllungs-Eigentums und Inventars über Pipelines.
+  BC-3060.50:
+    name: Pipeline-Tarifmanagement
+    description: |
+      Einreichung und Verwaltung regulierter und vertraglicher Pipeline-
+      Tarife, Schiffer-Abrechnung und Ungleichgewichts-Abrechnung.
+  BC-3060.50.10:
+    name: Tarifeinreichung und Pflege
+    description: |
+      Einreichung und Pflege von Pipeline-Tarifen bei Regulierungsbehörden.
+  BC-3060.50.20:
+    name: Schiffer-Abrechnung
+    description: |
+      Berechnung und Ausstellung von Schiffer-Transportrechnungen.
+  BC-3060.50.30:
+    name: Ungleichgewichts-Abrechnung
+    description: |
+      Abrechnung betrieblicher Ungleichgewichte zwischen Schiffern.
+  BC-3060.60:
+    name: Pipeline-Bau und Reparaturbetrieb
+    description: |
+      In-Service-Reparaturen, Heißanzapfungsoperationen und Austauschkoordination für Transport- und Sammelpipelines.
+  BC-3060.60.10:
+    name: Pipeline-Austauschkoordination
+    description: |
+      Koordination von Pipeline-Segmentaustausch und Umleitung.
+  BC-3060.60.20:
+    name: In-Service-Reparaturbetrieb
+    description: |
+      Verbund-, Muffen- und Schweißreparaturen an in Betrieb befindlichen Pipelines.
+  BC-3060.60.30:
+    name: Heißanzapfungs-Betrieb
+    description: |
+      Heißanzapfungs- und Stopple-Operationen für Anschlüsse an druckbeaufschlagten Pipelines.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-plant-maintenance-management.yaml
+++ b/catalogue/i18n/de/L1-plant-maintenance-management.yaml
@@ -1,0 +1,130 @@
+locale: de
+source: L1-plant-maintenance-management.yaml
+entries:
+  BC-1030:
+    name: Werkinstandhaltungsmanagement
+    description: |
+      Präventive, prädiktive und korrektive Instandhaltung von Werken und Anlagen.
+  BC-1030.10:
+    name: Instandhaltungsstrategiemanagement
+    description: |
+      Instandhaltungsstrategie je Anlagenklasse und RCM.
+  BC-1030.10.10:
+    name: Reliability-Centered Maintenance-Analyse
+    description: |
+      RCM-Analyse zur Definition von Instandhaltungsstrategien je Anlagenklasse.
+  BC-1030.10.20:
+    name: Instandhaltungsplan-Definition
+    description: |
+      Definition von Instandhaltungsplänen, Aufgaben und Intervallen.
+  BC-1030.10.30:
+    name: Instandhaltungsstandards-Management
+    description: |
+      Instandhaltungsverfahren, Standards und Best Practices.
+  BC-1030.20:
+    name: Präventive Instandhaltungsmanagement
+    description: |
+      PM-Pläne, Terminierung und Ausführung.
+  BC-1030.20.10:
+    name: PM-Terminierungsmanagement
+    description: |
+      Erstellung und Verwaltung von PM-Terminplänen.
+  BC-1030.20.20:
+    name: PM-Ausführung
+    description: |
+      Durchführung von PM-Aufgaben und Abnahmeprüfung.
+  BC-1030.20.30:
+    name: PM-Compliance-Verfolgung
+    description: |
+      Verfolgung der PM-Compliance und überfälliger Aufgaben.
+  BC-1030.30:
+    name: Korrektive Instandhaltungsmanagement
+    description: |
+      Störungsbehebung und Reparaturen.
+  BC-1030.30.10:
+    name: Störungsbehebung
+    description: |
+      Ersteinsatz bei Anlagenstörungen und ungeplanten Ereignissen.
+  BC-1030.30.20:
+    name: Anlagenreparatur-Ausführung
+    description: |
+      Durchführung von Korrektivreparaturen und Verifikation.
+  BC-1030.30.30:
+    name: Fehleranalyse und -berichterstattung
+    description: |
+      Ursachenanalyse und Fehlerberichterstattung nach Korrektivarbeiten.
+  BC-1030.40:
+    name: Prädiktive Instandhaltungsmanagement
+    description: |
+      Zustandsbasierte, prädiktivanalytikgesteuerte Instandhaltung.
+  BC-1030.40.10:
+    name: Zustandsüberwachung
+    description: |
+      Schwingungs-, Thermografie-, Öl- und akustische Zustandsüberwachung.
+  BC-1030.40.20:
+    name: Prädiktive Analytik-Modellierung
+    description: |
+      Machine-Learning-basierte Ausfallvorhersage.
+  BC-1030.40.30:
+    name: Preskriptive Instandhaltungsmaßnahmen
+    description: |
+      Ableitung preskriptiver Instandhaltungsmaßnahmen aus Vorhersagen.
+  BC-1030.50:
+    name: Instandhaltungsauftrags-Management
+    description: |
+      Instandhaltungsauftrags-Lebenszyklus.
+  BC-1030.50.10:
+    name: Instandhaltungsmeldungs-Erfassung
+    description: |
+      Erfassung von Instandhaltungsmeldungen und -anforderungen.
+  BC-1030.50.20:
+    name: Instandhaltungsauftrags-Planung
+    description: |
+      Planung von Arbeitsaufträgen einschließlich Ressourcen und Teilen.
+  BC-1030.50.30:
+    name: Instandhaltungsauftrags-Ausführung
+    description: |
+      Ausführung und Rückmeldung von Instandhaltungsaufträgen.
+  BC-1030.50.40:
+    name: Instandhaltungsauftrags-Abschluss
+    description: |
+      Abschluss, Abrechnung und Archivierung von Instandhaltungsaufträgen.
+  BC-1030.60:
+    name: Instandhaltungs-Ersatzteilbestandsmanagement
+    description: |
+      MRO-Ersatzteilhaltung und -einsatz.
+  BC-1030.60.10:
+    name: MRO-Bestandsstrategie
+    description: |
+      Bestandsstrategie und Lagermengen für MRO-Teile.
+  BC-1030.60.20:
+    name: MRO-Teilebeschaffung
+    description: |
+      Beschaffung von MRO-Teilen und Verbrauchsmaterialien.
+  BC-1030.60.30:
+    name: MRO-Lager-Betrieb
+    description: |
+      Lagerbetrieb einschließlich Ausgabe und Rücknahme von MRO-Teilen.
+  BC-1030.60.40:
+    name: Kritische Ersatzteil-Management
+    description: |
+      Identifikation und Management kritischer und versicherungstechnischer Ersatzteile.
+  BC-1030.70:
+    name: Anlagenzuverlässigkeitsmanagement
+    description: |
+      Zuverlässigkeitstechnik, Fehleranalyse und MTBF/MTTR.
+  BC-1030.70.10:
+    name: Zuverlässigkeitstechnik-Analyse
+    description: |
+      Zuverlässigkeitsanalyse (FMEA, FTA, RBD) kritischer Anlagen.
+  BC-1030.70.20:
+    name: MTBF- und MTTR-Verfolgung
+    description: |
+      Verfolgung der mittleren Ausfallabstände und Reparaturzeiten.
+  BC-1030.70.30:
+    name: Zuverlässigkeitsverbesserungsprogramme
+    description: |
+      Programme zur Verbesserung der Zuverlässigkeit ausfallkritischer Anlagen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-point-of-sale-operations-management.yaml
+++ b/catalogue/i18n/de/L1-point-of-sale-operations-management.yaml
@@ -1,0 +1,151 @@
+locale: de
+source: L1-point-of-sale-operations-management.yaml
+entries:
+  BC-2320:
+    name: Kassenbetrieb / Point-of-Sale Management
+    description: |
+      Kundenorientierte Transaktionsschicht des Einzelhandels — Verkaufserfassung,
+      Zahlungsmittelannahme, Retouren und Erstattungen, Bargeldbehandlung,
+      POS-Konfiguration und Verkaufskontinuität bei Systemausfällen.
+  BC-2320.10:
+    name: Verkaufstransaktions-Management
+    description: |
+      Erfassung von Verbraucher-Verkaufstransaktionen einschließlich Warenkorbaufbau,
+      Scanning, Aktionsanwendung, Steuerbehandlung und digitaler Belege.
+    in_scope:
+      - Warenkorbaufbau und Artikelscanning
+      - Aktions- und Treuekartenanwendung an der Kasse
+      - Steuerberechnung und digitale oder Papierbelege
+    out_of_scope:
+      - Aktionsgestaltung (BC-440.30)
+      - E-Commerce-Checkout (BC-2330)
+  BC-2320.10.10:
+    name: Artikelscanning und Warenkorbaufbau
+    description: |
+      Scanning von Artikeln und Warenkorbaufbau an der Kasse einschließlich Gewichtsartikel.
+  BC-2320.10.20:
+    name: Aktions- und Treueprogramm-Anwendung
+    description: |
+      Anwendung von Aktionen, Gutscheinen und Treueeinlösungen während des Verkaufs.
+  BC-2320.10.30:
+    name: Umsatzsteuer- und MwSt-Behandlung
+    description: |
+      Berechnung von Umsatz- und Mehrwertsteuer sowie jurisdiktionsspezifischen Regeln an der Kasse.
+  BC-2320.10.40:
+    name: Beleg- und Digitalbeleg-Ausgabe
+    description: |
+      Ausgabe von Papier- und Digitalbelegen einschließlich Verbraucher-Verknüpfung.
+  BC-2320.20:
+    name: Zahlungsmittel- und Zahlungsannahme Management
+    description: |
+      Annahme von Zahlungsmitteln an der Kasse einschließlich EMV, Contactless,
+      Mobile Wallets, Geschenkkarten und alternativer Zahlungsarten mit PCI-DSS-Compliance.
+  BC-2320.20.10:
+    name: Karten- und Contactless-Zahlungsannahme
+    description: |
+      EMV-, Contactless- und Mobile-Wallet-Zahlungsannahme an Einzelhandelskassen.
+  BC-2320.20.20:
+    name: Bar- und Scheckzahlungsannahme
+    description: |
+      Bar-, Münz- und Scheckzahlungsannahme einschließlich Stückelungsbehandlung.
+  BC-2320.20.30:
+    name: Geschenkkarten- und Wertgutschein-Annahme
+    description: |
+      Annahme und Ausgabe von Geschenkkarten und gespeicherten Wertgutscheinen.
+  BC-2320.20.40:
+    name: Alternative Zahlungsarten-Annahme
+    description: |
+      Annahme von Buy-now-pay-later, QR-Code und anderen alternativen Zahlungsmitteln.
+  BC-2320.20.50:
+    name: PCI-DSS-Compliance-Betrieb
+    description: |
+      PCI-DSS-konformer Umgang mit Karteninhaberdaten am Point-of-Sale.
+  BC-2320.30:
+    name: Retouren-, Erstattungs- & Umtausch-Management
+    description: |
+      Filialinterne Verarbeitung von Verbraucherretouren, Erstattungen und Umtauschen
+      einschließlich Originalzahlungsmittel-, Filial-Gutschrift- und kanalübergreifender Fälle.
+    in_scope:
+      - Filialinterne Verbraucherretouren und Erstattungen
+      - Filial-Gutschrift- und Umtauschbearbeitung
+      - Kanalübergreifende Retouren von Online-Bestellungen in der Filiale
+    out_of_scope:
+      - Retourenlogistik zurück zum Verteilzentrum (BC-520.40.40)
+  BC-2320.30.10:
+    name: Verbraucherretouren-Annahme
+    description: |
+      Annahme von Verbraucherretouren an der Kasse gemäß Rückgaberichtlinie.
+  BC-2320.30.20:
+    name: Erstattungs- und Filial-Gutschrift-Ausgabe
+    description: |
+      Ausgabe von Erstattungen auf das Originalzahlungsmittel oder Filial-Gutschriften.
+  BC-2320.30.30:
+    name: Umtauschvorgans-Bearbeitung
+    description: |
+      Gleich- und ungleichwertige Umtauschtransaktionen einschließlich Preisabstimmung.
+  BC-2320.30.40:
+    name: Kanalübergreifende Retouren-Verarbeitung
+    description: |
+      Annahme von Online- und anderen Kanalbestellungen zur Rückgabe in der Filiale.
+  BC-2320.40:
+    name: POS-Bargeld- und Zahlungsmittel-Behandlung
+    description: |
+      Kassenschublade, Safe, Einzahlung und Tagesabschluss-Zahlungsmittel-Abstimmung
+      zum Schutz der Kasseneinnahmen.
+  BC-2320.40.10:
+    name: Kassenschubladen-Management
+    description: |
+      Öffnung, Überwachung und Abstimmung von Kassenschubladen.
+  BC-2320.40.20:
+    name: Filialsafe- und Entnahme-Betrieb
+    description: |
+      Safe-Management, Tagesentnahmen und CIT-Vorbereitung.
+  BC-2320.40.30:
+    name: Tagesabschluss-Zahlungsmittel-Abstimmung
+    description: |
+      Abstimmung aller Zahlungsmittel gegenüber POS-Verkaufsdaten am Tagesende.
+  BC-2320.40.40:
+    name: Bankeinzahlung-Vorbereitung
+    description: |
+      Vorbereitung von Bankeinzahlungen und Übergabe an den Geldtransport.
+  BC-2320.50:
+    name: POS-Konfiguration Management
+    description: |
+      Konfiguration von Zahlungsmitteln, Steuerregeln, Aktionslogik, Peripheriegeräten
+      und Kasseverhalten im gesamten Filialbestand.
+  BC-2320.50.10:
+    name: Zahlungsmittel- und Zahlungskonfiguration
+    description: |
+      Konfiguration akzeptierter Zahlungsmittel, Limits und Routing je Filiale.
+  BC-2320.50.20:
+    name: Steuerregeln-Konfiguration
+    description: |
+      Konfiguration von Steuerregeln und jurisdiktionsbezogenen Überschreibungen je Filiale.
+  BC-2320.50.30:
+    name: Aktions-Engine-Konfiguration
+    description: |
+      Konfiguration der POS-Aktions-Engine und Angebotspriorisierungsregeln.
+  BC-2320.50.40:
+    name: POS-Peripheriegeräte-Konfiguration
+    description: |
+      Konfiguration von Waagen, Scannern, Druckern und PIN-Pads an der Kasse.
+  BC-2320.60:
+    name: POS-Resilienz & Offline-Betrieb
+    description: |
+      Kontinuität des Verkaufsbetriebs bei Verbindungs- oder Systemausfällen einschließlich
+      Offline-POS, Store-and-Forward und Warteschlangen-Management.
+  BC-2320.60.10:
+    name: Offline-POS-Betrieb
+    description: |
+      Weiterbetrieb des POS bei Verbindungsverlust.
+  BC-2320.60.20:
+    name: Store-and-Forward-Transaktionsbehandlung
+    description: |
+      Speicherung und Weiterleitung von Offline-Transaktionen bei Wiederverbindung.
+  BC-2320.60.30:
+    name: Ausfall-Warteschlangen-Management
+    description: |
+      Kundenwarteschlangen-Management bei Kassenausfall-Ereignissen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-policy-administration-management.yaml
+++ b/catalogue/i18n/de/L1-policy-administration-management.yaml
@@ -1,0 +1,116 @@
+locale: de
+source: L1-policy-administration-management.yaml
+entries:
+  BC-2140:
+    name: Policen-Administration Management
+    description: |
+      Ausstellung, Endossements, unterjährige Anpassungen, Erneuerungen, Stornierungen,
+      Verfälle, Wiederinkraftsetzungen, Dokumentenverwaltung und Gruppen-/Rahmenpolice-
+      Administration laufender Versicherungsverträge.
+  BC-2140.10:
+    name: Policen-Ausstellungs-Management
+    description: |
+      Erstellung, Zusammenstellung und Aktivierung neuer Policenverträge und unterstützender Dokumente.
+  BC-2140.10.10:
+    name: Policendokument-Erstellung
+    description: |
+      Erstellung von Policendokumenten aus Produktvorlagen und gebundenen Bedingungen.
+  BC-2140.10.20:
+    name: Policen-Plan- und Formulier-Zusammenstellung
+    description: |
+      Zusammenstellung von Policenplänen, Formulierungen und Endossements zum Vertrag.
+  BC-2140.10.30:
+    name: Policen-Aktivierung
+    description: |
+      Aktivierung neuer Policen und Benachrichtigung nachgelagerter Systeme.
+  BC-2140.20:
+    name: Policen-Endossements- & Unterjährige Anpassung
+    description: |
+      Erfassung, Bepreisung, Genehmigung und Ausgabe von Endossements und unterjährigen Anpassungen.
+  BC-2140.20.10:
+    name: Endossement-Anfrage-Erfassung
+    description: |
+      Erfassung von Endossement-Anfragen von Versicherungsnehmern und Vertretern.
+  BC-2140.20.20:
+    name: Endossement-Bepreisung und Genehmigung
+    description: |
+      Bepreisung von Endossements und Underwriting-Genehmigung falls erforderlich.
+  BC-2140.20.30:
+    name: Endossement-Ausgabe und Kommunikation
+    description: |
+      Ausgabe von Endossement-Dokumenten und Kommunikation an den Versicherungsnehmer.
+  BC-2140.30:
+    name: Policen-Erneuerungs-Management
+    description: |
+      Erneuerungseignung, Neubepreisung, Angebotserstellung und Nichtererneuerungs-Behandlung.
+  BC-2140.30.10:
+    name: Erneuerungs-Eignungs-Bewertung
+    description: |
+      Bewertung der Erneuerungseignung auf Basis von Schadenerfahrung und Zeichnungsregeln.
+  BC-2140.30.20:
+    name: Erneuerungs-Neubepreisung
+    description: |
+      Neubepreisung verlängerungsfähiger Policen unter aktuellen Tarifeingaben und Erfahrung.
+  BC-2140.30.30:
+    name: Erneuerungs-Angebots-Erstellung
+    description: |
+      Erstellung und Versendung von Erneuerungsangeboten an Versicherungsnehmer.
+  BC-2140.30.40:
+    name: Nichterneuerungs-Behandlung
+    description: |
+      Behandlung von Nichterneuerungen einschließlich Fristen und regulatorischer Kommunikation.
+  BC-2140.40:
+    name: Policen-Stornierung & Verfall-Management
+    description: |
+      Stornierungsbearbeitung, Prämienanpassung, Verfall und Wiederinkraftsetzung.
+  BC-2140.40.10:
+    name: Stornierungsantrags-Bearbeitung
+    description: |
+      Bearbeitung von Stornierungsanträgen von Versicherungsnehmern, Vertretern oder dem Versicherer.
+  BC-2140.40.20:
+    name: Pro-Rata- und Kurzzeit-Berechnung
+    description: |
+      Berechnung von Pro-Rata- und Kurzzeit-Prämienanpassungen bei Stornierung.
+  BC-2140.40.30:
+    name: Verfall-Behandlung
+    description: |
+      Verfallsbearbeitung bei Nichtzahlung und Benachrichtigung des Versicherungsnehmers.
+  BC-2140.40.40:
+    name: Wiederinkraftsetzungs-Bearbeitung
+    description: |
+      Wiederinkraftsetzung verfallener oder stornierter Policen vorbehaltlich Underwriting-Prüfungen.
+  BC-2140.50:
+    name: Policendokument- & Akten-Management
+    description: |
+      Repository für Policendokumente, regulatorische Aktenaufbewahrung und Policen-Audit-Trails.
+  BC-2140.50.10:
+    name: Policendokument-Repository
+    description: |
+      Repository für Policendokumente und unterstützende Korrespondenz.
+  BC-2140.50.20:
+    name: Regulatorische Akten-Aufbewahrung
+    description: |
+      Aufbewahrung von Policenakten gemäß versicherungsregulatorischen Anforderungen.
+  BC-2140.50.30:
+    name: Policen-Audit-Trail-Pflege
+    description: |
+      Pflege unveränderlicher Audit-Trails für Policenänderungen und -entscheidungen.
+  BC-2140.60:
+    name: Gruppen- & Rahmenpolice-Administration
+    description: |
+      Gruppenpolice-Setup, Zertifikatspflege und Gruppenern-Erneuerungszyklen.
+  BC-2140.60.10:
+    name: Gruppenpolice-Setup
+    description: |
+      Setup von Gruppen- und Rahmenverträgen für Arbeitgeber- und Affinitätsprogramme.
+  BC-2140.60.20:
+    name: Mitglieder- und Zertifikats-Pflege
+    description: |
+      Pflege von Gruppenmitgliedern, Zertifikaten und Abhängigen.
+  BC-2140.60.30:
+    name: Gruppen-Erneuerungszyklus-Management
+    description: |
+      Management von Gruppen-Erneuerungszyklen, Neubepreisung und Mitglieder-Wiedereinschreibung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-population-health-management.yaml
+++ b/catalogue/i18n/de/L1-population-health-management.yaml
@@ -1,0 +1,137 @@
+locale: de
+source: L1-population-health-management.yaml
+entries:
+  BC-2880:
+    name: Bevölkerungsgesundheitsmanagement
+    description: |
+      Risikostratifizierung, Präventivversorgung, Chronisch-Krankheits-Management,
+      wertorientierter Versorgungsbetrieb, Panel- und Einschreibungsmanagement sowie
+      Populationsanalytik für zugeschriebene und risikobehaftete Bevölkerungsgruppen.
+  BC-2880.10:
+    name: Risikostratifizierung und -identifikation
+    description: |
+      Prädiktive Modellierung und Identifikation von Hochrisiko- und
+      Versorgungslücken-Populationen.
+  BC-2880.10.10:
+    name: Prädiktive Risikomodellierung
+    description: |
+      Entwicklung und Betrieb prädiktiver Risikomodelle für Kosten- und klinische Ergebnisse.
+  BC-2880.10.20:
+    name: Identifikation von Risikopatienten
+    description: |
+      Identifikation von Risikopatienten zur Frühintervention.
+  BC-2880.10.30:
+    name: Kohortendefinition
+    description: |
+      Definition und Pflege klinischer Kohorten für Bevölkerungsprogramme.
+  BC-2880.10.40:
+    name: Versorgungslücken-Identifikation
+    description: |
+      Identifikation evidenzbasierter Versorgungslücken in Bevölkerungsgruppen.
+  BC-2880.20:
+    name: Präventivversorgung und Wellness
+    description: |
+      Screening, Impfprogramme, Gesundheitsrisikobewertung und Wellness-Coaching-
+      Programme.
+  BC-2880.20.10:
+    name: Screening-Outreach
+    description: |
+      Outreach für evidenzbasierte Präventiv-Screenings.
+  BC-2880.20.20:
+    name: Impfprogramme
+    description: |
+      Durchführung von Erwachsenen- und Kinderimpfprogrammen.
+  BC-2880.20.30:
+    name: Gesundheitsrisikobewertung
+    description: |
+      Durchführung und Nachverfolgung von Gesundheitsrisikobewertungen.
+  BC-2880.20.40:
+    name: Wellness-Coaching
+    description: |
+      Durchführung von Lebensstil- und Wellness-Coaching-Programmen.
+  BC-2880.30:
+    name: Chronisch-Krankheits-Management
+    description: |
+      Krankheitsspezifische Managementprogramme für chronische Haupterkrankungen.
+  BC-2880.30.10:
+    name: Diabetesprogramme
+    description: |
+      Diabetesmanagementprogramme einschließlich Schulung und Fernmonitoring.
+  BC-2880.30.20:
+    name: Herz-Kreislauf-Erkrankungs-Programme
+    description: |
+      Herz-Kreislauf-Erkrankungs- und Hypertonie-Managementprogramme.
+  BC-2880.30.30:
+    name: Integration psychischer Gesundheitsversorgung
+    description: |
+      Integration der psychiatrischen Versorgung in Primärversorgungs- und Chronisch-Krankheits-Management.
+  BC-2880.30.40:
+    name: Atemwegserkrankungs-Programme
+    description: |
+      Asthma-, COPD- und Atemwegserkrankungs-Programme.
+  BC-2880.40:
+    name: Wertorientierter Versorgungsbetrieb
+    description: |
+      Betrieb zur Unterstützung von Accountable-Care-, Bündelbezahlungs- und wertorientierten
+      Vertragsprogrammen.
+  BC-2880.40.10:
+    name: Accountable-Care-Betrieb
+    description: |
+      Betrieb von Accountable-Care-Organisationen und Shared-Savings-Programmen.
+  BC-2880.40.20:
+    name: Bündelbezahlungs-Betrieb
+    description: |
+      Betrieb zur Unterstützung episodenbasierter Bündelbezahlungsprogramme.
+  BC-2880.40.30:
+    name: Qualitätsleistungs-Tracking
+    description: |
+      Nachverfolgung der Qualitätsleistung gegenüber wertorientierten Programmanforderungen.
+  BC-2880.40.40:
+    name: Shared-Savings-Abgleich
+    description: |
+      Abgleich von Shared-Savings- und Risikobeteiligungsabrechnungen mit Kostenträgern.
+  BC-2880.50:
+    name: Panel- und Einschreibungsmanagement
+    description: |
+      Patienteneinschreibung bei Leistungserbringern, Panel-Größenbestimmung, Kontinuitäts-
+      Tracking und Zuschreibungsabgleich.
+  BC-2880.50.10:
+    name: Patient-Arzt-Einschreibung
+    description: |
+      Zuweisung von Patienten zu Hausärzten und Versorgungsteams.
+  BC-2880.50.20:
+    name: Panel-Größenmanagement
+    description: |
+      Management von Panel-Größe, Zusammensetzung und Kapazität.
+  BC-2880.50.30:
+    name: Versorgungskontinuitäts-Tracking
+    description: |
+      Erfassung von Versorgungskontinuitätskennzahlen über Panels hinweg.
+  BC-2880.50.40:
+    name: Zuschreibungsabgleich
+    description: |
+      Abgleich von Kostenträger-Zuschreibungslisten mit internen Paneldaten.
+  BC-2880.60:
+    name: Bevölkerungsanalytik und Berichterstattung
+    description: |
+      Populationsweite Analytik zu Gesundheitsgerechtigkeit, Qualitätsprogrammleistung,
+      Kosten, Nutzung und Ergebnis-Benchmarking.
+  BC-2880.60.10:
+    name: Gesundheitsgerechtigkeitsanalytik
+    description: |
+      Analytik zu Versorgungsungleichheiten, sozialen Determinanten und Gerechtigkeitsergebnissen.
+  BC-2880.60.20:
+    name: Qualitätsprogramm-Berichterstattung
+    description: |
+      Berichterstattung gegenüber Qualitätsprogrammen wie Sternbewertungen und Qualitätskennzahlen.
+  BC-2880.60.30:
+    name: Kosten- und Nutzungsanalytik
+    description: |
+      Analytik zu Kosten, Nutzung und vermeidbaren Ausgaben.
+  BC-2880.60.40:
+    name: Ergebnis-Benchmarking
+    description: |
+      Benchmarking klinischer Ergebnisse gegenüber Peer- und nationalen Datensätzen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-power-generation-operations-management.yaml
+++ b/catalogue/i18n/de/L1-power-generation-operations-management.yaml
@@ -1,0 +1,182 @@
+locale: de
+source: L1-power-generation-operations-management.yaml
+entries:
+  BC-3800:
+    name: Stromerzeugungsbetrieb Management
+    description: |
+      Betrieb des Erzeugungsparks über thermische, nukleare, Wasser-, Wind-,
+      Solar- und Speicheranlagen – einschließlich Dispatch und Scheduling,
+      technologiespezifischen Anlagenbetrieb, Brennstoff- und Emissionshandling
+      sowie flottenweitem Leistungsmanagement.
+  BC-3800.10:
+    name: Erzeugungsdispatch und Scheduling
+    description: |
+      Kraftwerkseinsatz, Dispatchanweisungen und kurzfristige Fahrpläne
+      für den Erzeugungspark gemäß Netzbetreibernominierungen und
+      Marktpositionen.
+  BC-3800.10.10:
+    name: Kraftwerkseinsatzplanung
+    description: |
+      Day-ahead- und Intraday-Auswahl von Erzeugungseinheiten für den Betrieb.
+  BC-3800.10.20:
+    name: Wirtschaftlicher Dispatch
+    description: |
+      Echtzeit-Merit-Order-Dispatch eingesetzter Einheiten gegen die Last.
+  BC-3800.10.30:
+    name: Stillstandskoordination
+    description: |
+      Koordination geplanter und erzwungener Anlagenstillstände mit Netzbetreiber und Marktfahrplänen.
+  BC-3800.20:
+    name: Thermischer Anlagenbetrieb
+    description: |
+      Täglicher Betrieb von Kohle-, Gas- und Ölkraftwerken
+      einschließlich GuD- und KWK-Anlagen.
+    in_scope:
+      - Kessel- und Turbinenbetrieb
+      - Wärmerate- und Effizienzüberwachung
+      - Verbrennungsregelung
+    out_of_scope:
+      - Kernkraftwerksbetrieb (BC-3800.40)
+      - Erneuerbarer Anlagenbetrieb (BC-3800.50)
+  BC-3800.20.10:
+    name: Kesselbetrieb
+    description: |
+      Betrieb der Dampferzeugungsanlage und Verbrennungsregelung.
+  BC-3800.20.20:
+    name: Dampfturbinenbetrieb
+    description: |
+      Betrieb von Dampfturbinen und Kondensatspeisewassersystemen.
+  BC-3800.20.30:
+    name: Gasturbinenbetrieb
+    description: |
+      Betrieb von Gasturbinen in offener und kombinierter Zyklusausführung.
+  BC-3800.20.40:
+    name: Kraft-Wärme-Kopplungsbetrieb
+    description: |
+      Betrieb von KWK-Anlagen zur Lieferung von Strom und Prozess- bzw. Fernwärme.
+  BC-3800.30:
+    name: Wasserkraftanlagenbetrieb
+    description: |
+      Betrieb konventioneller, Pumpspeicher- und Laufwasserkraftwerke
+      einschließlich Staudamm- und Wasserwegemanagement.
+  BC-3800.30.10:
+    name: Hydro-Einheitenbetrieb
+    description: |
+      An-/Abfahrt, Regelung und Laststeuerung von Wasserkrafterzeugungseinheiten.
+  BC-3800.30.20:
+    name: Stauseepegelmanagement
+    description: |
+      Staupegel-Scheduling gegen Energie-, Hochwasser- und Umweltrestriktionen.
+  BC-3800.30.30:
+    name: Pumpspeicher-Zyklenbetrieb
+    description: |
+      Pump- und Erzeugungszyklen von Pumpspeicherkraftwerken.
+  BC-3800.30.40:
+    name: Dammüberwachung
+    description: |
+      Überwachung des strukturellen Verhaltens und der Sickerwassersituation von Staudämmen.
+  BC-3800.40:
+    name: Kernkraftanlagenbetrieb
+    description: |
+      Betrieb von Kernkraftwerken – Reaktorsteuerung, Brennstoffwechselstillstände
+      und radiologische Sicherheitsüberwachung unter Lizenzbedingungen des Nuklearregulators.
+  BC-3800.40.10:
+    name: Reaktorbetrieb
+    description: |
+      Reaktorsteuerung, Reaktivitätsmanagement und Lastfolgebetrieb.
+  BC-3800.40.20:
+    name: Brennstoffwechselstillstandsbetrieb
+    description: |
+      Planung und Durchführung von Brennstoffwechsel- und Großwartungsstillständen.
+  BC-3800.40.30:
+    name: Radiologische Überwachung
+    description: |
+      Überwachung radiologischer Freisetzungen und Personendosen gegen Grenzwerte.
+  BC-3800.40.40:
+    name: Abklingbeckenbetrieb
+    description: |
+      Betrieb und Überwachung der Abklingbeckenkühlung und des Inventars.
+  BC-3800.50:
+    name: Erneuerbare Erzeugungsbetrieb
+    description: |
+      Betrieb von Wind-, Solar-PV- und anderen variablen Erzeugungsanlagen
+      einschließlich Abregelung und Prognosedateneingabe.
+  BC-3800.50.10:
+    name: Windparkbetrieb
+    description: |
+      Onshore- und Offshore-Windparkbetrieb sowie Turbinenverfügbarkeitsmanagement.
+  BC-3800.50.20:
+    name: Solar-PV-Anlagenbetrieb
+    description: |
+      Betrieb von Utility-Scale-Solar-PV-Anlagen und String-Monitoring.
+  BC-3800.50.30:
+    name: Erneuerbare Abregelungsbetrieb
+    description: |
+      Ausführung von Abregelungsanweisungen des Netzbetreibers für variable Erneuerbare.
+  BC-3800.50.40:
+    name: Erneuerbare Erzeugungsprognose
+    description: |
+      Kurzfristprognose von Wind- und Solarerträgen als Dispatch- und Handelseingang.
+  BC-3800.60:
+    name: Energiespeicherbetrieb
+    description: |
+      Betrieb netzgekoppelter Batterie- und anderer Energiespeicheranlagen,
+      einschließlich Ladestandsmanagement und Zyklussteuerung gegen Markt-
+      und Systemdienstleistungspositionen.
+  BC-3800.60.10:
+    name: Batteriespeicherbetrieb
+    description: |
+      Betrieb und Ladestandsmanagement netzgekoppelter Batterieanlagen.
+  BC-3800.60.20:
+    name: Speicherzyklusoptimierung
+    description: |
+      Optimierung der Lade-/Entladezyklen gegen Energie- und Systemdienstleistungswertschöpfung.
+  BC-3800.60.30:
+    name: Speicherdegradationsverfolgung
+    description: |
+      Verfolgung von Rundwirkungsgrad und Kapazitätsverlust bei Batterieanlagen.
+  BC-3800.70:
+    name: Erzeugungsleistungsmanagement
+    description: |
+      Flottenweite Überwachung von Verfügbarkeit, Wärmerate, Kapazitätsfaktor
+      und Zwangsstillstandsrate über Erzeugungstechnologien hinweg.
+  BC-3800.70.10:
+    name: Verfügbarkeits- und Zuverlässigkeitsberichterstattung
+    description: |
+      GADS-konforme Berichterstattung über äquivalente Verfügbarkeit und Zwangsstillstandsstatistiken.
+  BC-3800.70.20:
+    name: Wärmerate- und Effizienzverfolgung
+    description: |
+      Verfolgung von Wärmerate und Wirkungsgrad gegen Design- und Vertragsvorgaben.
+  BC-3800.70.30:
+    name: Kapazitätsleistungsverfolgung
+    description: |
+      Verfolgung von Kapazitätsfaktor und gesicherter Leistungsbewertung.
+  BC-3800.80:
+    name: Brennstoff- und Emissionsmanagement
+    description: |
+      Brennstoffversorgung, -vorrats- und Verbrennungsnebenproduktmanagement
+      für den Erzeugungspark einschließlich Luftemissions- und CO2-Überwachung.
+  BC-3800.80.10:
+    name: Brennstoffvorratsbetrieb
+    description: |
+      Kohle-, Öl- und Biomassehof-Betrieb und Bestandskontrolle.
+  BC-3800.80.20:
+    name: Gasnominierungen
+    description: |
+      Pipeline-Gasnominierungen und -ausgleich für gasbefeuerte Erzeugung.
+  BC-3800.80.30:
+    name: Luftemissionsüberwachung
+    description: |
+      Kontinuierliche Emissionsüberwachung von NOx, SOx, Partikeln und Berichterstattung.
+  BC-3800.80.40:
+    name: CO2- und Zertifikateabrechnung
+    description: |
+      Abstimmung von CO2-Emissionen mit abgegebenen Zertifikaten im Rahmen von Cap-and-Trade-Systemen.
+  BC-3800.80.50:
+    name: Asche- und Verbrennungsrückstandsbetrieb
+    description: |
+      Handhabung und Entsorgung von Flugasche, Kesselasche und REA-Rückständen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-practice-pursuit-and-proposal-management.yaml
+++ b/catalogue/i18n/de/L1-practice-pursuit-and-proposal-management.yaml
@@ -1,0 +1,146 @@
+locale: de
+source: L1-practice-pursuit-and-proposal-management.yaml
+entries:
+  BC-4360:
+    name: Geschäftsanbahnung und Angebotswesen
+    description: |
+      Akquiseaktivitäten für professionelle Dienstleistungskanzleien —
+      Opportunitätsqualifikation, Akquisestrategie, Angebots- und
+      Pitchentwicklung, Honorarmodellierung und Gewinn-/Verlustanalyse —
+      distinct vom generischen Vertriebsmanagement.
+  BC-4360.10:
+    name: Opportunitätsqualifikationsmanagement
+    description: |
+      Qualifikation eingehender und ausgehender Akquiseopportunitäten
+      auf strategische Eignung, Durchführbarkeit und kommerzielle
+      Attraktivität.
+  BC-4360.10.10:
+    name: Opportunitätserfassung
+    description: |
+      Erfassung von Akquiseopportunitäten aus Ausschreibungen,
+      Empfehlungen und beziehungsgetriebener Eigeninitiative.
+  BC-4360.10.20:
+    name: Opportunitätsqualifikationsbewertung
+    description: |
+      Bewertung von Opportunitäten gegen strategische Eignung,
+      Fähigkeit und kommerzielle Kriterien.
+  BC-4360.10.30:
+    name: Akquise-Vorabfreigabe-Koordination
+    description: |
+      Vorabfreigabe von Opportunitäten durch indikative Unabhängigkeits-
+      und Konfliktprüfungen vor formeller Akquiseinvestition.
+  BC-4360.20:
+    name: Akquisestrategiemanagement
+    description: |
+      Definition der Akquisestrategie, des Gewinnplans,
+      der Akquiseteamzusammensetzung und der Wettbewerbspositionierung
+      für qualifizierte Opportunitäten.
+  BC-4360.20.10:
+    name: Gewinnplanentwicklung
+    description: |
+      Entwicklung des Akquise-Gewinnplans einschließlich
+      Kernbotschaften, Differenzierungsmerkmalen und
+      Stakeholder-Mapping.
+  BC-4360.20.20:
+    name: Akquiseteamzusammensetzung
+    description: |
+      Zusammensetzung des Akquiseteams einschließlich Akquiseleitung,
+      Fachexperten und Preisunterstützung.
+  BC-4360.20.30:
+    name: Wettbewerbsinformationssynthese
+    description: |
+      Synthese von Wettbewerbsinformationen über rivalisierende
+      Kanzleien, die dieselbe Opportunität verfolgen.
+  BC-4360.30:
+    name: Angebotsentwicklungsmanagement
+    description: |
+      Entwurf, Überprüfung und Einreichung schriftlicher Angebote
+      und Ausschreibungsantworten nach Mandantenspezifikationen.
+  BC-4360.30.10:
+    name: Angebotsentwurf
+    description: |
+      Entwurf von Angebotsabschnitten einschließlich Ansatz, Team
+      und einschlägiger Erfahrung.
+  BC-4360.30.20:
+    name: Angebotsbewertung und -genehmigung
+    description: |
+      Interne Überprüfung und Genehmigung von Angebotsinhalt,
+      Aussagen und kommerziellen Zusagen.
+  BC-4360.30.30:
+    name: Angebotseinreichungsmanagement
+    description: |
+      Einreichung des Angebots im vom Mandanten geforderten Format
+      und Kanal mit Einreichungsprüfpfad.
+  BC-4360.30.40:
+    name: Angebotsasset-Wiederverwendung
+    description: |
+      Wiederverwendung und Kennzeichnung von Angebotsinhalt,
+      Fallstudien und Referenzen über Akquisitionen hinweg.
+  BC-4360.40:
+    name: Pitch- und Präsentationsmanagement
+    description: |
+      Vorbereitung und Durchführung von Pitches, Beauty Parades und
+      mündlichen Präsentationen als Teil wettbewerblicher Akquisitionen.
+  BC-4360.40.10:
+    name: Pitch-Materialvorbereitung
+    description: |
+      Vorbereitung von Pitch-Decks, Demonstrationsassets und
+      Begleitmaterialien für mündliche Präsentationen.
+  BC-4360.40.20:
+    name: Pitch-Probe und Coaching
+    description: |
+      Probe des Pitch-Teams und Coaching zu Botschaften, Dynamik
+      und Q&A-Behandlung.
+  BC-4360.40.30:
+    name: Pitch-Durchführungsmanagement
+    description: |
+      Durchführung von Pitches und Beauty Parades einschließlich
+      Logistik und Folgemaaterialien.
+  BC-4360.50:
+    name: Akquise-Honorarmodellierung und -Preisgestaltung
+    description: |
+      Honorarstrukturdesign und Preismodellierung für Akquise-
+      opportunitäten einschließlich alternativer Honorarvereinbarungen
+      und Risikoanteilkonstrukte.
+    out_of_scope:
+      - Auftragsebenes Honorarmanagement (BC-4330.40)
+      - Kanzleiweite Preisstrategie (BC-290)
+  BC-4360.50.10:
+    name: Akquise-Honorarstrukturdesign
+    description: |
+      Design von Honorarstrukturen über Stunden-, Pauschal-,
+      Deckelungs-, Kontingenz- und ergebnisbasierte Optionen hinweg.
+  BC-4360.50.20:
+    name: Akquise-Profitabilitätsmodellierung
+    description: |
+      Modellierung der Akquiseprofitabilität unter verschiedenen
+      Besetzungs-, Honorar- und Risikozsenarien.
+  BC-4360.50.30:
+    name: Akquise-Preisgenehmigung
+    description: |
+      Interne Genehmigung der Akquisepreisgestaltung gegen Rabatt-,
+      Margen- und Risikoschwellen.
+  BC-4360.60:
+    name: Akquise-Gewinn-Verlust-Analyse
+    description: |
+      Strukturierte Nachbesprechung von Akquiseergebnissen,
+      Gewinnquotenanalyse und Erfassung von Erkenntnissen in die
+      Akquise- und Angebotspraxis.
+  BC-4360.60.10:
+    name: Akquiseergebnis-Nachbesprechung
+    description: |
+      Interne und mandantenseitige Nachbesprechungen von
+      Akquiseergebnissen einschließlich Wettbewerberbewertung.
+  BC-4360.60.20:
+    name: Gewinnquotenanalyse
+    description: |
+      Gewinnquotenanalyse segmentiert nach Bereich, Mandant,
+      Opportunitätstyp und Akquiseleitung.
+  BC-4360.60.30:
+    name: Akquise-Lessons-Erfassung
+    description: |
+      Erfassung von Akquiselektionen und Feedback in Akquise-
+      Playbooks und Schulungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-premium-accounting-management.yaml
+++ b/catalogue/i18n/de/L1-premium-accounting-management.yaml
@@ -1,0 +1,120 @@
+locale: de
+source: L1-premium-accounting-management.yaml
+entries:
+  BC-2150:
+    name: Prämienabrechnung Management
+    description: |
+      Prämienrechnungsstellung, Inkasso, Makler- und Provisionskontoabrechnung,
+      Prämienrückstellungs- und Verdienungsmechanik, Mahnwesen und
+      Versicherungsprämiensteuer-Buchführung.
+  BC-2150.10:
+    name: Prämien-Rechnungsstellungs-Management
+    description: |
+      Rechnungserstellung, Ratenzahlungsplanung, Abrechnungsweiterleitung und Anpassungen.
+  BC-2150.10.10:
+    name: Prämienrechnung-Erstellung
+    description: |
+      Erstellung von Prämienrechnungen und Kontoauszügen pro Abrechnungszyklus.
+  BC-2150.10.20:
+    name: Ratenzahlungsplan-Konfiguration
+    description: |
+      Konfiguration von Prämien-Ratenzahlungsplänen und Finanzierungsgebühren.
+  BC-2150.10.30:
+    name: Direktrechnungs- und Agentenrechnungs-Weiterleitung
+    description: |
+      Weiterleitung der Abrechnung zwischen Direkt- und Agentenrechnungsvereinbarungen.
+  BC-2150.10.40:
+    name: Abrechnungsanpassung und Gutschrift
+    description: |
+      Ausgabe von Abrechnungsanpassungen und Gutschriften nach Endossements und Stornierungen.
+  BC-2150.20:
+    name: Prämien-Einzugs-Management
+    description: |
+      Empfang und Anwendung von Zahlungen, Dauerzahlungsbetrieb, Rückerstattungen und Lockbox.
+  BC-2150.20.10:
+    name: Zahlungsempfang und -Anwendung
+    description: |
+      Empfang von Prämienzahlungen und Buchung auf Policenkonten.
+  BC-2150.20.20:
+    name: Lastschrift- und Dauerzahlungs-Betrieb
+    description: |
+      Betrieb von Lastschrift-, Dauerkarten- und Dauerauftragsverfahren.
+  BC-2150.20.30:
+    name: Prämienrückerstattungs-Verarbeitung
+    description: |
+      Verarbeitung von Prämienrückerstattungen nach Endossements und Stornierungen.
+  BC-2150.20.40:
+    name: Lockbox- und Barzuteilung
+    description: |
+      Lockbox-Empfang, Barzuteilung und Ausnahmebehandlung.
+  BC-2150.30:
+    name: Makler- & Vertreter-Kontoabrechnung
+    description: |
+      Vertreter-Kontoauszüge, Prämie-abzüglich-Provision-Abrechnung und Treuhandkontoabstimmung.
+  BC-2150.30.10:
+    name: Vertreter-Kontoauszug-Erstellung
+    description: |
+      Erstellung von Prämien- und Provisionskontoauszügen für Vertreter.
+  BC-2150.30.20:
+    name: Prämie-abzüglich-Provision-Abrechnung
+    description: |
+      Abrechnung der Nettoprämie von und an Vertreter.
+  BC-2150.30.30:
+    name: Vertreter-Treuhandkonto-Abstimmung
+    description: |
+      Abstimmung von Vertreter-Treuhandkonten und IBA-Salden.
+  BC-2150.40:
+    name: Prämienrückstellungs- & Verdienungs-Management
+    description: |
+      Berechnung unverdienter Prämien, Verdienungserfassung und Tracking abgegrenzter Akquisitionskosten.
+  BC-2150.40.10:
+    name: Unverdiente Prämien-Berechnung
+    description: |
+      Berechnung von Rückstellungen für unverdiente Prämien auf laufenden Policen.
+  BC-2150.40.20:
+    name: Verdiente Prämien-Erfassung
+    description: |
+      Erfassung verdienter Prämien pro Buchungsperiode.
+  BC-2150.40.30:
+    name: Abgegrenzte Akquisitionskosten-Tracking
+    description: |
+      Tracking abgegrenzter Akquisitionskosten (DAC) über Produktkohorten.
+  BC-2150.50:
+    name: Inkasso- & Mahnwesen-Management
+    description: |
+      Überwachung überfälliger Forderungen, Mahnbetrieb, Stornierung wegen Nichtzahlung und Forderungsabschreibung.
+  BC-2150.50.10:
+    name: Überfällige Forderungen-Überwachung
+    description: |
+      Überwachung überfälliger Prämienforderungen gegenüber Versicherungsnehmern und Vertretern.
+  BC-2150.50.20:
+    name: Mahnwesen- und Erinnerungs-Betrieb
+    description: |
+      Mahnbescheide, Erinnerungen und Rückstandskommunikation.
+  BC-2150.50.30:
+    name: Stornierung wegen Nichtzahlung-Behandlung
+    description: |
+      Auslösung von Stornierungsprozessen für nicht bezahlte Prämien.
+  BC-2150.50.40:
+    name: Forderungsabschreibung
+    description: |
+      Genehmigung und Buchung von Forderungsabschreibungen auf uneinbringliche Prämien.
+  BC-2150.60:
+    name: Steuer- & Abgaben-Buchführung
+    description: |
+      Versicherungsprämiensteuer-Berechnung, Stempel- und Abgabeninkasso und Prämiensteuermeldungs-Unterstützung.
+  BC-2150.60.10:
+    name: Versicherungsprämiensteuer-Berechnung
+    description: |
+      Berechnung der Versicherungsprämiensteuer über Jurisdiktionen und Produkttypen.
+  BC-2150.60.20:
+    name: Stempel- und Abgaben-Inkasso
+    description: |
+      Einzug und Abführung von Stempel- und gesetzlichen Abgaben.
+  BC-2150.60.30:
+    name: Prämiensteuermeldungs-Unterstützung
+    description: |
+      Erstellung von Grundlagendaten und Abstimmungen für Prämiensteuermeldungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-pricing-management.yaml
+++ b/catalogue/i18n/de/L1-pricing-management.yaml
@@ -1,0 +1,86 @@
+locale: de
+source: L1-pricing-management.yaml
+entries:
+  BC-440:
+    name: Preismanagement
+    description: |
+      Preisfindung, -strukturierung, Rabatte und Promotionen.
+  BC-440.10:
+    name: Preisstrategiemanagement
+    description: |
+      Preismodelle, wertbasierte Preisgestaltung und Segmentpreise.
+  BC-440.10.10:
+    name: Preismodelldefinition
+    description: |
+      Definition von Preismodellen (Kostenaufschlag, Wertbasiert, Abonnement).
+  BC-440.10.20:
+    name: Wertbasierte Preisgestaltung
+    description: |
+      Analyse von Kundenwert und Zahlungsbereitschaft zur Preisfindung.
+  BC-440.10.30:
+    name: Wettbewerbspreisbenchmarking
+    description: |
+      Benchmarking von Wettbewerberpreisen und Preispositionierung.
+  BC-440.10.40:
+    name: Segment- und Geografiepreisgestaltung
+    description: |
+      Segment-, Kanal- und geografische Preisdifferenzierung.
+  BC-440.20:
+    name: Preislisten-Management
+    description: |
+      Listenpreise, regionale Preise und Preisbuchpflege.
+  BC-440.20.10:
+    name: Preisbuchpflege
+    description: |
+      Pflege von Preisbüchern, Listenpreisen und Währungsvarianten.
+  BC-440.20.20:
+    name: Preisänderungsmanagement
+    description: |
+      Genehmigung, Kommunikation und Umsetzung von Preisänderungen.
+  BC-440.20.30:
+    name: Preisstammdatensteuerung
+    description: |
+      Steuerung der Qualität und Herkunft von Preisstammdaten.
+  BC-440.30:
+    name: Rabatt- und Promotionsmanagement
+    description: |
+      Rabattrichtlinien, Promotionsangebote und Rückvergütungen.
+  BC-440.30.10:
+    name: Rabattrichtlinienmanagement
+    description: |
+      Definition von Rabattstufen, -regeln und Genehmigungsschwellenwerten.
+  BC-440.30.20:
+    name: Promotionsplanung und -durchführung
+    description: |
+      Promotionskalender, Angebotseinrichtung und Durchführung.
+  BC-440.30.30:
+    name: Rückvergütungs- und Handelskonditionen-Management
+    description: |
+      Rückvergütungsabgrenzungen, Ansprüche und Abrechnung mit Kunden und Kanälen.
+  BC-440.30.40:
+    name: Promotionswirksamkeitsanalyse
+    description: |
+      Messung von Promotions-ROI, Uplift und Kannibalisierung.
+  BC-440.40:
+    name: Preisrealisierungs- und Compliance-Management
+    description: |
+      Preisausnahmeverwaltung und Leckageanalyse.
+  BC-440.40.10:
+    name: Preisausnahmegenehmigung
+    description: |
+      Workflow und Genehmigung richtlinienabweichender Preisausnahmen.
+  BC-440.40.20:
+    name: Taschenpreis- und Margenanalyse
+    description: |
+      Analyse des netto-realisierten Preises und der Taschenpreismarge pro Transaktion.
+  BC-440.40.30:
+    name: Preisleckageuntersuchung
+    description: |
+      Identifikation und Behebung von Preis- und Rabattleckagen.
+  BC-440.40.40:
+    name: Preis-Compliance-Monitoring
+    description: |
+      Einhaltung von Preisrichtlinien, Kartellrecht und fairen Handelsregeln.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-procurement-management.yaml
+++ b/catalogue/i18n/de/L1-procurement-management.yaml
@@ -1,0 +1,138 @@
+locale: de
+source: L1-procurement-management.yaml
+entries:
+  BC-500:
+    name: Beschaffungsmanagement
+    description: |
+      Sourcing, Vertragsabschluss, Einkauf und P2P-Betrieb.
+  BC-500.10:
+    name: Sourcing-Management
+    description: |
+      Strategisches Sourcing, RFx und Lieferantenauswahl.
+  BC-500.10.10:
+    name: Sourcing-Strategie-Definition
+    description: |
+      Definition der Sourcing-Strategie nach Kategorie und Markt.
+  BC-500.10.20:
+    name: RFx-Durchführung
+    description: |
+      Erstellung, Ausgabe und Auswertung von RFI-, RFQ- und RFP-Verfahren.
+  BC-500.10.30:
+    name: Lieferantenverhandlung
+    description: |
+      Kaufmännische und vertragliche Verhandlung mit vorselektierten Lieferanten.
+  BC-500.10.40:
+    name: Lieferantenauswahl und -vergabe
+    description: |
+      Endgültige Lieferantenauswahl, Vergabeentscheidung und -mitteilung.
+  BC-500.10.50:
+    name: Reverse-Auction-Betrieb
+    description: |
+      E-Auction-Einrichtung, Durchführung und Vergabe für wettbewerbsfähige Lose.
+  BC-500.20:
+    name: Beschaffungsvertragsmanagement
+    description: |
+      Beschaffungsverträge, Konditionen und Lebenszyklus.
+  BC-500.20.10:
+    name: Vertragsentwurf und Vorlagen
+    description: |
+      Beschaffungsvertragsvorlagen, Klauseln und Playbooks.
+  BC-500.20.20:
+    name: Vertragsgenehmigung und -ausführung
+    description: |
+      Genehmigungsworkflow, Unterzeichnung und Ausführung von Beschaffungsverträgen.
+  BC-500.20.30:
+    name: Vertrags-Compliance-Monitoring
+    description: |
+      Monitoring der Einkaufsaktivitäten gegenüber vertraglich vereinbarten Lieferanten und Preisen.
+  BC-500.20.40:
+    name: Vertragserneuerung und -nachverhandlung
+    description: |
+      Erneuerungszyklus-Management und Nachverhandlung von Beschaffungsverträgen.
+  BC-500.30:
+    name: Bestellungsmanagement
+    description: |
+      Bestellerstellung, -genehmigung und -ausführung.
+  BC-500.30.10:
+    name: Bestellungserstellung
+    description: |
+      Bestellgenerierung aus Bedarfsmeldungen, Verträgen oder Katalogen.
+  BC-500.30.20:
+    name: Bestellungsgenehmigung
+    description: |
+      Schwellenwertbasierte Genehmigungsworkflows für Bestellungen.
+  BC-500.30.30:
+    name: Bestellungsbestätigung und -änderung
+    description: |
+      Lieferantenbestätigung und Änderungsauftragsverwaltung.
+  BC-500.30.40:
+    name: Bestellungsabschluss
+    description: |
+      Wareneingangsvollendung, Rechnungsabgleich und Bestellungsabschluss.
+  BC-500.40:
+    name: Procure-to-Pay-Operations-Management
+    description: |
+      Täglicher P2P-Betrieb, Bedarfsmeldungen und Wareneingänge.
+  BC-500.40.10:
+    name: Bedarfsmeldungsmanagement
+    description: |
+      Erfassung, Genehmigung und Umwandlung von Bedarfsmeldungen.
+  BC-500.40.20:
+    name: Katalog- und Punch-Out-Management
+    description: |
+      Interne Kataloge und Lieferanten-Punch-Out für Self-Service-Einkauf.
+  BC-500.40.30:
+    name: Wareneingang und Leistungsabnahme
+    description: |
+      Erfassung von Wareneingängen und Serviceeingangsblättern.
+  BC-500.40.40:
+    name: Rechnungsabgleich und -abstimmung
+    description: |
+      Zwei-Wege- und Drei-Wege-Abgleich von Rechnungen mit Bestellung und Wareneingang.
+  BC-500.40.50:
+    name: P2P-Helpdesk und Käufer-Support
+    description: |
+      Käufer- und Lieferantenunterstützung für P2P-Transaktionen.
+  BC-500.50:
+    name: Beschaffungskategorie-Management
+    description: |
+      Kategoriestrategie und Ausgabenanalyse je Kategorie.
+  BC-500.50.10:
+    name: Kategoriestrategieentwicklung
+    description: |
+      Mehrjährige Kategoriestrategie und Beschaffungsmarktbewertung.
+  BC-500.50.20:
+    name: Kategorie-Performance-Management
+    description: |
+      KPI-Verfolgung, Einsparungen und Mehrwertlieferung je Kategorie.
+  BC-500.50.30:
+    name: Bedarfsaggregation und -standardisierung
+    description: |
+      Bedarfsbündelung und Spezifikationsstandardisierung über Geschäftsbereiche.
+  BC-500.50.40:
+    name: Kategorieinnovations-Sourcing
+    description: |
+      Identifikation von Innovation über Lieferantenmärkte.
+  BC-500.60:
+    name: Beschaffungsausgabenanalyse-Management
+    description: |
+      Ausgabentransparenz, Berichterstattung und Einsparungsverfolgung.
+  BC-500.60.10:
+    name: Ausgabendatenaggregation und -bereinigung
+    description: |
+      Aggregation, Bereinigung und Klassifizierung unternehmensweiter Ausgabendaten.
+  BC-500.60.20:
+    name: Ausgabenberichterstattung und -analytik
+    description: |
+      Ausgabenanalytik, Dashboards und Identifikation adressierbarer Ausgaben.
+  BC-500.60.30:
+    name: Einsparungsverfolgung und -validierung
+    description: |
+      Erfassung, Validierung und Berichterstattung von Beschaffungseinsparungen.
+  BC-500.60.40:
+    name: Tail-Spend-Management
+    description: |
+      Identifikation und Rationalisierung von Tail-Spend.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-product-information-management.yaml
+++ b/catalogue/i18n/de/L1-product-information-management.yaml
@@ -1,0 +1,111 @@
+locale: de
+source: L1-product-information-management.yaml
+entries:
+  BC-2370:
+    name: Produktinformations-Management
+    description: |
+      Maßgebliche Artikelattribute, Marketinginhalte und kanalfertige Produktdaten –
+      von der Artikelanlage über GS1/GDSN-Synchronisation bis hin zu Multi-Kanal-
+      Syndikation und Inhaltsbereitschaft.
+  BC-2370.10:
+    name: Artikelstammdaten-Management
+    description: |
+      Artikelstammattribute, GTINs, Hierarchien und Taxonomie, die den kanonischen
+      Produktdatensatz im gesamten Unternehmen bilden.
+    in_scope:
+      - Artikelanlage und Attributpflege
+      - GTIN-, GLN- und Verpackungsebenen-Identifikation
+      - Produkttaxonomie und -klassifikation (z. B. GS1 GPC)
+    out_of_scope:
+      - Allgemeine Stammdaten-Governance (BC-610)
+  BC-2370.10.10:
+    name: Artikelanlage und Attributierung
+    description: |
+      Anlage von Artikeldatensätzen und Erfassung von Attributwerten.
+  BC-2370.10.20:
+    name: GTIN- und Identifikator-Zuweisung
+    description: |
+      Zuweisung von GTINs und Verpackungsebenen-Identifikatoren gemäß GS1-Regeln.
+  BC-2370.10.30:
+    name: Produkthierarchie und Taxonomie
+    description: |
+      Pflege der Produkthierarchie und -taxonomie (z. B. GS1 GPC).
+  BC-2370.10.40:
+    name: Artikelstatus und Lebenszykluszustand
+    description: |
+      Verfolgung von Artikellebenszykluszuständen vom Konzept bis zur Einstellung.
+  BC-2370.20:
+    name: Produktinhalt-Erstellungsmanagement
+    description: |
+      Erstellung von Marketingtexten, Fotografie, Video und Rich Media,
+      die einen Artikeldatensatz in ein verkaufsfähiges Verbraucherprodukt verwandeln.
+  BC-2370.20.10:
+    name: Marketingtext-Erstellung
+    description: |
+      Erstellung von Titeln, Beschreibungen und Verkaufstexten je Kanal.
+  BC-2370.20.20:
+    name: Produktfotografie und Videoproduktion
+    description: |
+      Produktion von Produktfotografie, Lifestyle-Bildern und Videos.
+  BC-2370.20.30:
+    name: Rich Media und 3D-Asset-Produktion
+    description: |
+      Produktion von 360-Grad-, AR- und 3D-Produktassets.
+  BC-2370.20.40:
+    name: Übersetzung und Lokalisierung
+    description: |
+      Übersetzung und Lokalisierung von Produktinhalten für Zielmärkte.
+  BC-2370.30:
+    name: Kanal-Syndikations-Management
+    description: |
+      Veröffentlichung von Produktinhalten auf eigenen Kanälen, Händler-Feeds,
+      Marktplätzen und Handelspartnern mit kanalspezifischer Anpassung.
+  BC-2370.30.10:
+    name: Eigene Kanal-Veröffentlichung
+    description: |
+      Veröffentlichung von Inhalten auf eigenen Web-, Mobil- und Filialkanälen.
+  BC-2370.30.20:
+    name: Marktplatz-Feed-Syndikation
+    description: |
+      Syndikation von Feeds an Drittmarktplätze und Aggregatoren.
+  BC-2370.30.30:
+    name: Händler-Feed und EDI-832-Katalog
+    description: |
+      Bereitstellung von EDI-832-Produktkatalogen an Einzelhandels-Handelspartner.
+  BC-2370.40:
+    name: GS1/GDSN-Synchronisations-Management
+    description: |
+      Synchronisation von Produktstammdaten mit Handelspartnern über
+      GDSN-Datenpools, Parteiregistrierung und Empfänger-Abonnements.
+  BC-2370.40.10:
+    name: GDSN-Datenpool-Betrieb
+    description: |
+      Betrieb der GDSN-Datenpool-Beziehung und -Einreichungen.
+  BC-2370.40.20:
+    name: Partei- und Empfängerregistrierung
+    description: |
+      Registrierung von Parteien und Empfänger-Abonnements im GDSN.
+  BC-2370.40.30:
+    name: GDSN-Synchronisationsausnahme-Management
+    description: |
+      Verwaltung von GDSN-Synchronisationsausnahmen und Handelspartner-Abweichungen.
+  BC-2370.50:
+    name: Produktinhalt-Qualitätsmanagement
+    description: |
+      Inhaltsbereitschafts-Scoring, Vollständigkeitsmessung und Validierung
+      gegen kanalspezifische Qualitätsstandards.
+  BC-2370.50.10:
+    name: Inhaltsvollständigkeits-Scoring
+    description: |
+      Bewertung der Inhaltsvollständigkeit gegenüber Kanalbereitschaftsanforderungen.
+  BC-2370.50.20:
+    name: Inhaltsvalidierung und Compliance
+    description: |
+      Validierung von Inhalten gegen regulatorische und Kanalanforderungen.
+  BC-2370.50.30:
+    name: Inhaltsqualitäts-Korrektur
+    description: |
+      Korrekturworkflow für Artikel, die Inhaltsqualitätsprüfungen nicht bestehen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-product-lifecycle-management.yaml
+++ b/catalogue/i18n/de/L1-product-lifecycle-management.yaml
@@ -1,0 +1,142 @@
+locale: de
+source: L1-product-lifecycle-management.yaml
+entries:
+  BC-820:
+    name: Produktlebenszyklusmanagement
+    description: |
+      Ganzheitliches Management von Produkten vom Konzept bis zur Ausmusterung.
+  BC-820.10:
+    name: Produktkonzept-Management
+    description: |
+      Konzeptentwicklung, Ideenfindung und Marktvalidierung.
+  BC-820.10.10:
+    name: Produktideation
+    description: |
+      Entwicklung neuer Produktkonzepte auf Basis von Markt- und Kundenerkenntnissen.
+  BC-820.10.20:
+    name: Konzeptvalidierung
+    description: |
+      Validierung von Produktkonzepten durch Kunden- und Markttest.
+  BC-820.10.30:
+    name: Business-Case-Definition
+    description: |
+      Wirtschaftliche Begründung und Business Case für neue Produkte.
+  BC-820.20:
+    name: Produktdesign-Management
+    description: |
+      Produktgestaltung, Konstruktion und Design-Reviews.
+  BC-820.20.10:
+    name: Produktdesign und -konstruktion
+    description: |
+      Detailliertes Produktdesign und konstruktive Analysen.
+  BC-820.20.20:
+    name: Design-Review und -Freigabe
+    description: |
+      Formale Design-Reviews und Freigabe-Gates.
+  BC-820.20.30:
+    name: Design for X
+    description: |
+      Konstruktion für Fertigbarkeit, Nachhaltigkeit, Wartbarkeit und Kosten.
+  BC-820.20.40:
+    name: Design-Verifikation und -Validierung
+    description: |
+      Verifikation und Validierung des Designs gegenüber Anforderungen.
+  BC-820.30:
+    name: Produktspezifikations-Management
+    description: |
+      Produktspezifikationen, Anforderungen und Stücklistendefinition.
+  BC-820.30.10:
+    name: Produktanforderungsmanagement
+    description: |
+      Erfassung und Nachverfolgung von Produktanforderungen.
+  BC-820.30.20:
+    name: Produktspezifikations-Erstellung
+    description: |
+      Erstellung von Produktspezifikationen und technischen Dokumentationen.
+  BC-820.30.30:
+    name: Produkt-Stücklistendefinition
+    description: |
+      Definition von Produktstücklistenstrukturen und Revisionen.
+  BC-820.30.40:
+    name: Produktdatenmanagement
+    description: |
+      PDM für Produktdaten, Zeichnungen und CAD-Baugruppen.
+  BC-820.40:
+    name: Produktkonfigurations- und Variantenmanagement
+    description: |
+      Konfigurationen, Varianten, Optionen und Bündel.
+  BC-820.40.10:
+    name: Produktkonfigurationsmodellierung
+    description: |
+      Konfigurationsmodelle, Optionen und Regeln.
+  BC-820.40.20:
+    name: Variantenmanagement
+    description: |
+      Management von Produktvarianten und -plattformen.
+  BC-820.40.30:
+    name: Bündel- und Lösungsdefinition
+    description: |
+      Definition von Bündeln, Kits und kombinierten Lösungen.
+  BC-820.50:
+    name: Produktfreigabe- und Markteinführungsmanagement
+    description: |
+      Release-Planung, Markteinführung und Hochlauf.
+  BC-820.50.10:
+    name: Release-Planung
+    description: |
+      Planung von Releases und Definition des Inhaltsumfangs.
+  BC-820.50.20:
+    name: Markteinführungsausführung
+    description: |
+      Funktionsübergreifende Markteinführung und Bereitschaft.
+  BC-820.50.30:
+    name: Produktionshochlauf
+    description: |
+      Produktionshochlauf und Lieferkettenbereitschaft nach der Markteinführung.
+  BC-820.50.40:
+    name: Markteinführungs-Leistungsverfolgung
+    description: |
+      Verfolgung von KPIs der Markteinführung und Korrekturmaßnahmen nach dem Launch.
+  BC-820.60:
+    name: Produktleistungs- und Feedback-Management
+    description: |
+      Leistung im Betrieb, Kundenfeedback und Produktanalysen.
+  BC-820.60.10:
+    name: Produktleistungsüberwachung im Betrieb
+    description: |
+      Überwachung der Produktleistung anhand von Betriebskennzahlen.
+  BC-820.60.20:
+    name: Kundenfeedback-Synthese
+    description: |
+      Auswertung von Kundenfeedback zur Weiterentwicklung der Produkt-Roadmap.
+  BC-820.60.30:
+    name: Produkt-Roadmap-Management
+    description: |
+      Definition und Pflege von Produkt-Roadmaps.
+  BC-820.60.40:
+    name: Produktanalysen
+    description: |
+      Nutzungsanalysen, Telemetrie und Produktinstrumentierung.
+  BC-820.70:
+    name: Produkt-End-of-Life-Management
+    description: |
+      EOL-Planung, Produktabkündigung und Nachfolgestrategien.
+  BC-820.70.10:
+    name: End-of-Life-Planung
+    description: |
+      EOL-Planung, Abhängigkeiten und Zeitplanung.
+  BC-820.70.20:
+    name: Migrations- und Nachfolgestrategie
+    description: |
+      Kundenmigration zu Nachfolgeprodukten und Ersatzlösungen.
+  BC-820.70.30:
+    name: Last-Time-Buy und Versorgungssicherung
+    description: |
+      Last-Time-Buy, Ersatzteile und EOL-Versorgungsmanagement.
+  BC-820.70.40:
+    name: Kommunikation zur Produktabkündigung
+    description: |
+      Kommunikation der Produktabkündigung an Kunden und Vertriebskanäle.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-product-substance-circularity-management.yaml
+++ b/catalogue/i18n/de/L1-product-substance-circularity-management.yaml
@@ -1,0 +1,143 @@
+locale: de
+source: L1-product-substance-circularity-management.yaml
+entries:
+  BC-1980:
+    name: Produktstoff / Kreislaufwirtschaft Management
+    description: |
+      Stoffbeschränkungen, End-of-Life-Rücknahme, Reparatur, Aufarbeitung, Remanufacturing und
+      Umweltfußabdruck-Offenlegung für elektrische Produkte.
+  BC-1980.10:
+    name: Eingeschränkte Stoff-Compliance-Management
+    description: |
+      Compliance mit Stoffbeschränkungsregimen wie RoHS, REACH SVHC und Proposition 65.
+  BC-1980.10.10:
+    name: RoHS-Compliance-Verifizierung
+    description: |
+      Verifizierung von Produkten gegen RoHS-Stoffgrenzwerte.
+  BC-1980.10.20:
+    name: REACH-SVHC-Compliance
+    description: |
+      Compliance mit REACH-Verpflichtungen für besonders besorgniserregende Stoffe.
+  BC-1980.10.30:
+    name: Halogenfreiheits-Compliance
+    description: |
+      Verifizierung von halogenfreien Produktansprüchen.
+  BC-1980.10.40:
+    name: Proposition-65-Compliance
+    description: |
+      Compliance mit Warnpflichten der California Proposition 65.
+  BC-1980.20:
+    name: Stoffdeklarations-Datenverwaltung
+    description: |
+      Sammlung und Verwaltung von Stoffdeklarationsdaten über die Stückliste.
+  BC-1980.20.10:
+    name: Materialdeklarations-Sammlung
+    description: |
+      Sammlung vollständiger Materialdeklarationen von Lieferanten.
+  BC-1980.20.20:
+    name: Stoff-Compliance-Datenbank-Pflege
+    description: |
+      Pflege der Stoff-Compliance-Stammdatenbank.
+  BC-1980.20.30:
+    name: Kunden-Stoffoffenlegung
+    description: |
+      Bereitstellung von Stoffoffenlegungen an Kunden und Behörden.
+  BC-1980.30:
+    name: Konfliktmineralien-Sorgfaltspflicht
+    description: |
+      Sorgfaltspflicht bei Zinn-, Wolfram-, Tantal- und Goldquellen gemäß OECD-konformen Regimen.
+  BC-1980.30.10:
+    name: Schmelzer- & Raffinerie-Kartierung
+    description: |
+      Kartierung von Schmelzern und Raffinerien in der Lieferkette.
+  BC-1980.30.20:
+    name: Herkunftsland-Anfrage
+    description: |
+      Angemessene Herkunftslandabfragen für abgedeckte Mineralien.
+  BC-1980.30.30:
+    name: Konfliktmineralien-Berichterstattung
+    description: |
+      Gesetzliche und kundenorientierte Konfliktmineralien-Berichterstattung.
+  BC-1980.40:
+    name: Batterie- & Verpackungs-Compliance-Management
+    description: |
+      Compliance mit Batterie- und Verpackungsregimen einschließlich der EU-Batterieverordnung.
+  BC-1980.40.10:
+    name: Batterieverordnungs-Compliance
+    description: |
+      Compliance mit der EU-Batterieverordnung und gleichwertigen Regimen.
+  BC-1980.40.20:
+    name: Batteriepass-Datenverwaltung
+    description: |
+      Erstellung und Pflege von Batteriepassdaten.
+  BC-1980.40.30:
+    name: Verpackungsabfall-Compliance
+    description: |
+      Compliance mit Verpackungs- und Verpackungsabfallverpflichtungen.
+  BC-1980.50:
+    name: End-of-Life-Rücknahme-Betrieb
+    description: |
+      Rücknahme, Rückwärtslogistik und Herstellerverantwortungs-Berichterstattung für elektrische Produkte.
+  BC-1980.50.10:
+    name: WEEE-Rücknahmesystem-Betrieb
+    description: |
+      Betrieb von WEEE-Herstellerkonformitätssystem-Vereinbarungen.
+  BC-1980.50.20:
+    name: Herstellerverantwortungs-Berichterstattung
+    description: |
+      Berichterstattung über in Verkehr gebrachte und zurückgewonnene Tonnen.
+  BC-1980.50.30:
+    name: Rückwärtslogistik-Betrieb
+    description: |
+      Rückwärtslogistik für End-of-Life-Produkte und Komponenten.
+  BC-1980.60:
+    name: Reparatur- & Aufarbeitungs-Betrieb
+    description: |
+      Reparaturservicenetz und Right-to-Repair-Dokumentationsbetrieb.
+  BC-1980.60.10:
+    name: Reparaturservicenetz-Betrieb
+    description: |
+      Betrieb autorisierter Reparaturservicenetze.
+  BC-1980.60.20:
+    name: Right-to-Repair-Dokumentation
+    description: |
+      Bereitstellung von Reparaturdokumentation gemäß Right-to-Repair-Regimen.
+  BC-1980.60.30:
+    name: Aufarbeitungsprozess-Betrieb
+    description: |
+      Aufarbeitung zurückgegebener Produkte in wiederverkaufsfähigen Zustand.
+  BC-1980.70:
+    name: Remanufacturing- & Wiederverwendungs-Betrieb
+    description: |
+      Remanufacturing und Wiederverwendung von Kernen und Komponenten in Neubauten.
+  BC-1980.70.10:
+    name: Kern-Rückgewinnung & Demontage
+    description: |
+      Rückgewinnung und Demontage zurückgegebener Kerne.
+  BC-1980.70.20:
+    name: Remanufacturing-Prozess-Durchführung
+    description: |
+      Durchführung von Remanufacturing-Prozessen an zurückgewonnenen Kernen.
+  BC-1980.70.30:
+    name: Wiederverwendete Komponenten-Rückverfolgbarkeit
+    description: |
+      Rückverfolgbarkeit wiederverwendeter Komponenten in neuen Produktbauten.
+  BC-1980.80:
+    name: Produkt-Umweltfußabdruck-Berichterstattung
+    description: |
+      Erstellung und Offenlegung produktbezogener Umweltfußabdruckdaten.
+  BC-1980.80.10:
+    name: Produkt-CO2-Fußabdrucks-Berechnung
+    description: |
+      Berechnung produktbezogener CO2-Fußabdrücke.
+  BC-1980.80.20:
+    name: Umweltproduktdeklaration
+    description: |
+      Erstellung von Umweltproduktdeklarationen.
+  BC-1980.80.30:
+    name: Digitaler Produktpass-Betrieb
+    description: |
+      Betrieb digitaler Produktpässe gemäß sich entwickelnden Vorschriften.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-product-telemetry-experimentation-management.yaml
+++ b/catalogue/i18n/de/L1-product-telemetry-experimentation-management.yaml
@@ -1,0 +1,130 @@
+locale: de
+source: L1-product-telemetry-experimentation-management.yaml
+entries:
+  BC-4280:
+    name: Produkttelemetrie und Produkterprobung
+    description: |
+      Instrumentierung, Governance und Analyse von
+      Produktnutzungstelemetrie sowie Konzeption und Durchführung von
+      Feature-Experimenten, die Produktentscheidungen prägen.
+  BC-4280.10:
+    name: Produkttelemetrie-Instrumentierung
+    description: |
+      Erfassung von Produktnutzungsereignissen aus Client- und
+      Server-Laufzeitumgebungen gegen definierte Ereignisschemata.
+  BC-4280.10.10:
+    name: Ereignisschema-Definition
+    description: |
+      Definition von Produktereignisschemata einschließlich
+      erforderlicher und optionaler Eigenschaften.
+  BC-4280.10.20:
+    name: Client-Telemetrie-Instrumentierung
+    description: |
+      Instrumentierung von Client-Laufzeitumgebungen zur Ausgabe
+      von Produktereignissen.
+  BC-4280.10.30:
+    name: Server-Telemetrie-Instrumentierung
+    description: |
+      Instrumentierung von Server-Laufzeitumgebungen zur Ausgabe
+      von Produktereignissen.
+  BC-4280.20:
+    name: Telemetriequalität und -governance
+    description: |
+      Schema-Governance, Pipeline-Qualitätsüberwachung und
+      Datenschutzfilterung von Produkttelemetrie.
+  BC-4280.20.10:
+    name: Telemetrieschema-Governance
+    description: |
+      Governance von Produktereignisschemata über Produktoberflächen
+      hinweg.
+  BC-4280.20.20:
+    name: Telemetrie-Pipeline-Qualitätsüberwachung
+    description: |
+      Überwachung von Korrektheit, Vollständigkeit und Aktualität
+      der Telemetriepipeline.
+  BC-4280.20.30:
+    name: Telemetrie-Datenschutzfilterung
+    description: |
+      Filterung, Schwärzung und Minimierung von Telemetriedaten
+      gemäß Datenschutzverpflichtungen.
+  BC-4280.30:
+    name: Produktnutzungsanalyse
+    description: |
+      Analytische Ansichten zur Produktnutzung einschließlich
+      Funnels, Retentionskohorten und Feature-Engagement.
+  BC-4280.30.10:
+    name: Funnel-Analyse
+    description: |
+      Funnel-Analyse von Konversionen und Abbrüchen über
+      Produktreisen hinweg.
+  BC-4280.30.20:
+    name: Retentionskohorten-Analyse
+    description: |
+      Kohortenbasierte Analyse der Nutzerretention über die Zeit.
+  BC-4280.30.30:
+    name: Feature-Engagement-Reporting
+    description: |
+      Berichterstattung über das Engagement mit bestimmten Features
+      in der gesamten Nutzerbasis.
+  BC-4280.40:
+    name: Experimentierprogrammmanagement
+    description: |
+      Methodik, Design-Review und Entscheidung über Experimente,
+      die Produktentscheidungen leiten.
+  BC-4280.40.10:
+    name: Experimentierstandards
+    description: |
+      Standards für valide Experimentiermethodik über
+      Produktteams hinweg.
+  BC-4280.40.20:
+    name: Experiment-Design-Review
+    description: |
+      Überprüfung von Experimentdesigns gegenüber Methodik- und
+      Ethikstandards.
+  BC-4280.40.30:
+    name: Experiment-Ergebnisentscheidung
+    description: |
+      Entscheidung über Experimentergebnisse und daraus folgende
+      Produktentscheide.
+  BC-4280.50:
+    name: A/B-Test-Durchführung
+    description: |
+      Konfiguration, Targeting und Überwachung laufender A/B- und
+      multivariater Tests.
+  BC-4280.50.10:
+    name: Experiment-Konfiguration
+    description: |
+      Konfiguration von Experimentvarianten und
+      Zuweisungsregeln.
+  BC-4280.50.20:
+    name: Experiment-Targeting
+    description: |
+      Targeting von Experimentkohorten auf geeignete Zielgruppen.
+  BC-4280.50.30:
+    name: Experiment-Überwachung
+    description: |
+      Überwachung laufender Experimente auf Leitplanken und
+      vorzeitigen Abbruch.
+  BC-4280.60:
+    name: Kundenerkenntnis-Synthese
+    description: |
+      Synthese quantitativer und qualitativer Signale zu
+      Produktentscheidungen und Entscheidungsvermerken.
+  BC-4280.60.10:
+    name: Quantitative Erkenntnissynthese
+    description: |
+      Synthese quantitativer Erkenntnisse aus Telemetrie und
+      Produkterprobung.
+  BC-4280.60.20:
+    name: Qualitative Erkenntnissynthese
+    description: |
+      Synthese qualitativer Forschungsergebnisse zu
+      Produkterkenntnissen.
+  BC-4280.60.30:
+    name: Entscheidungsvermerk-Erstellung
+    description: |
+      Erstellung von Entscheidungsvermerken, die Belege, Entscheid
+      und Begründung festhalten.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-production-management.yaml
+++ b/catalogue/i18n/de/L1-production-management.yaml
@@ -1,0 +1,126 @@
+locale: de
+source: L1-production-management.yaml
+entries:
+  BC-1000:
+    name: Produktionsmanagement
+    description: |
+      Herstellung physischer Güter – Planung, Terminierung und Ausführung auf Unternehmensebene.
+  BC-1000.10:
+    name: Produktionsstrategiemanagement
+    description: |
+      Produktionsnetzwerk, Make-or-Buy und Kapazitätsstrategie.
+  BC-1000.10.10:
+    name: Fertigungsnetzwerkstrategie
+    description: |
+      Langfristige Fertigungsnetzwerk- und Standortrollendefinition.
+  BC-1000.10.20:
+    name: Make-or-Buy-Strategie
+    description: |
+      Make-or-Buy- und Outsourcing-Strategie nach Produktlinie.
+  BC-1000.10.30:
+    name: Kapazitätsstrategie
+    description: |
+      Langfristige Kapazitätsstrategie und Investitionsplanung.
+  BC-1000.10.40:
+    name: Fertigungsbetriebsmodell-Design
+    description: |
+      Design des Fertigungsbetriebsmodells und der Steuerung.
+  BC-1000.20:
+    name: Produktionsplanungsmanagement
+    description: |
+      Hauptproduktionsprogramm und mittelfristige Planung (Wochen-Monate).
+  BC-1000.20.10:
+    name: Hauptproduktionsprogramm-Erstellung
+    description: |
+      Erstellung des Hauptproduktionsprogramms über alle Werke.
+  BC-1000.20.20:
+    name: Grobkapazitätsplanung
+    description: |
+      Grobkapazitätsvalidierung gegenüber dem Hauptproduktionsprogramm.
+  BC-1000.20.30:
+    name: Mittelfristige Produktionsplanung
+    description: |
+      Wochen- und Monatsplanung der Produktion je Linie.
+  BC-1000.20.40:
+    name: Produktionsplanabgleich
+    description: |
+      Abgleich des Produktionsplans mit Angebot und Nachfrage.
+  BC-1000.30:
+    name: Produktionsterminierungsmanagement
+    description: |
+      Feinplanung und Reihenfolgeoptimierung (Stunden-Tage).
+  BC-1000.30.10:
+    name: Detaillierte Feinterminierung
+    description: |
+      Kapazitätsbeschränkte Terminierung auf Maschinen- und Linienebene.
+  BC-1000.30.20:
+    name: Reihenfolgeoptimierung
+    description: |
+      Reihenfolgeoptimierung zur Minimierung von Rüstzeiten und Verschwendung.
+  BC-1000.30.30:
+    name: Terminplantreue-Überwachung
+    description: |
+      Überwachung der Terminplantreue und Neuplanung.
+  BC-1000.30.40:
+    name: Produktionsauftrag-Freigabe
+    description: |
+      Freigabe von Produktionsaufträgen an die Fertigung.
+  BC-1000.40:
+    name: Produktionsausführungsmanagement
+    description: |
+      Ausführungssteuerung, Dispatching und Echtzeit-Kontrolle.
+  BC-1000.40.10:
+    name: Produktionsauftrags-Dispatching
+    description: |
+      Dispatching von Aufträgen an Arbeitszentren.
+  BC-1000.40.20:
+    name: Produktionsstatus-Verfolgung
+    description: |
+      Echtzeit-Verfolgung des Status von Produktionsaufträgen.
+  BC-1000.40.30:
+    name: Produktionsausnahme-Bearbeitung
+    description: |
+      Bearbeitung von Produktionsausnahmen und Eskalationen.
+  BC-1000.40.40:
+    name: Produktionsauftrag-Abschluss
+    description: |
+      Rückmeldung, Abrechnung und Abschluss von Produktionsaufträgen.
+  BC-1000.50:
+    name: Produktionsleistungsmanagement
+    description: |
+      OEE, Durchsatz, Ausbeute und Produktions-KPIs.
+  BC-1000.50.10:
+    name: OEE-Messung
+    description: |
+      Messung und Berichterstattung der Gesamtanlageneffektivität.
+  BC-1000.50.20:
+    name: Durchsatz- und Ausbeute-Analyse
+    description: |
+      Analyse von Durchsatz, Ausbeute und Erstausbeute.
+  BC-1000.50.30:
+    name: Ausfallzeit- und Verlustanalyse
+    description: |
+      Klassifikation von Ausfallzeiten und Verlustbaumanalyse.
+  BC-1000.50.40:
+    name: Produktionsleistungs-Berichterstattung
+    description: |
+      Werksleistungsberichterstattung und Benchmarking.
+  BC-1000.60:
+    name: Produktionskostenmanagement
+    description: |
+      Standardkosten, Produktionsabweichungen und Kostenanalyse.
+  BC-1000.60.10:
+    name: Standardkosten-Festlegung
+    description: |
+      Festlegung und Neubewertung von Standardkosten für produzierte Artikel.
+  BC-1000.60.20:
+    name: Produktionsabweichungsanalyse
+    description: |
+      Analyse von Material-, Lohn- und Gemeinkosten-Abweichungen.
+  BC-1000.60.30:
+    name: Produktionskosten-Berichterstattung
+    description: |
+      Periodische Produktionskostenberichterstattung und Benchmarking.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-professional-licensing-and-standards-management.yaml
+++ b/catalogue/i18n/de/L1-professional-licensing-and-standards-management.yaml
@@ -1,0 +1,146 @@
+locale: de
+source: L1-professional-licensing-and-standards-management.yaml
+entries:
+  BC-4380:
+    name: Berufszulassung und -standards
+    description: |
+      Kanzlei- und Einzellizenzierung, Berufsverbandsmeldungen,
+      berufliche Weiterbildung, Übernahme neuer Berufsstandards und
+      Untersuchung beruflichen Fehlverhaltens, die für professionelle
+      Dienstleistungskanzleien charakteristisch sind.
+  BC-4380.10:
+    name: Kanzleizulassungs- und Registrierungsmanagement
+    description: |
+      Pflege von kanzleiweiten Berufszulassungen und Registrierungen
+      bei Prüfungsaufsichtsbehörden, Anwaltskammern und gleichwertigen
+      Behörden über Jurisdiktionen hinweg.
+  BC-4380.10.10:
+    name: Kanzleiregistrierungspflege
+    description: |
+      Pflege von Kanzleiregistrierungen wie PCAOB, FRC RSB, ICAEW-
+      Kanzleiregistrierung, SRA Recognised Body und ABS-Zulassungen.
+  BC-4380.10.20:
+    name: Kanzleilizenz-Erneuerungsmanagement
+    description: |
+      Periodische Erneuerungsanmeldungen, Gebührenzahlungen und
+      unterstützende Erklärungen für Kanzleigebühren.
+  BC-4380.10.30:
+    name: Jurisdiktionsübergreifende Lizenzkoordination
+    description: |
+      Koordination der Kanzleizulassung über Mitgliedskanzlei-
+      netzwerke und Jurisdiktionen hinweg.
+  BC-4380.20:
+    name: Berufsausübungserlaubnismanagement (Einzelpersonen)
+    description: |
+      Erfassung und Pflege individueller Berufsausübungserlaubnisse,
+      Zulassungen zur Anwaltschaft, Prüfungsqualifikationen und
+      sonstiger persönlicher Lizenzen von Fachkräften.
+  BC-4380.20.10:
+    name: Berufsausübungserlaubnis-Erfassung
+    description: |
+      Erfassung und Verifizierung individueller
+      Berufsausübungserlaubnisse und Qualifikationen.
+  BC-4380.20.20:
+    name: Berufsausübungserlaubnis-Erneuerungsverfolgung
+    description: |
+      Verfolgung von Erneuerungszyklen und Voraussetzungen für
+      individuelle Berufsausübungserlaubnisse.
+  BC-4380.20.30:
+    name: Grenzübergreifende Zulassungsmanagement
+    description: |
+      Management der grenzübergreifenden Zulassung, des Status als
+      registrierter ausländischer Anwalt und von
+      Gleichwertigkeitsregelungen.
+  BC-4380.30:
+    name: Management der beruflichen Weiterbildung
+    description: |
+      Planung, Durchführung und Nachweis der von Berufsverbänden
+      und Kanzleirichtlinien geforderten Weiterbildungsstunden
+      (CPD/CPE).
+    in_scope:
+      - CPD-Lehrplanplanung
+      - CPD-Kurslieferung und -aufzeichnung
+      - CPD-Nachweis und Nachholmechanismen
+    out_of_scope:
+      - Generisches Lernen und Entwicklung (BC-300)
+  BC-4380.30.10:
+    name: CPD-Anforderungsverfolgung
+    description: |
+      Verfolgung der CPD-Stundenanforderungen pro Fachkraft,
+      Qualifikation und Jurisdiktion.
+  BC-4380.30.20:
+    name: CPD-Kurslieferung und -aufzeichnung
+    description: |
+      Lieferung akkreditierter CPD-Kurse und Aufzeichnung der
+      Teilnahme und Abschlussnachweise.
+  BC-4380.30.30:
+    name: CPD-Defizitbehebung
+    description: |
+      Identifikation und Behebung von Fachkräften, die vor
+      Meldefristen vom CPD-Defizit bedroht sind.
+  BC-4380.40:
+    name: Berufsverbandsberichterstattung
+    description: |
+      Periodische Meldungen und Benachrichtigungen an Berufsverbände,
+      Aufsichtsbehörden und Regulatoren zu Kanzlei- und
+      Einzelangelegenheiten.
+  BC-4380.40.10:
+    name: Jahresmeldevorbereitung
+    description: |
+      Vorbereitung von Jahresmeldungen und statistischen
+      Einreichungen an Berufsverbände und Aufsichtsbehörden.
+  BC-4380.40.20:
+    name: Meldepflichtige Ereignisberichterstattung
+    description: |
+      Meldung meldepflichtiger Ereignisse wie Rücktritte,
+      Führungswechsel und wesentliche Verstöße.
+  BC-4380.40.30:
+    name: Transparenzberichterstellung
+    description: |
+      Erstellung gesetzlicher oder freiwilliger Transparenzberichte,
+      die von Prüfungs- und anderen regulierten Kanzleien gefordert
+      werden.
+  BC-4380.50:
+    name: Berufsstandard-Übernahmemanagement
+    description: |
+      Übernahme neuer und überarbeiteter Berufsstandards in
+      Kanzleimethodik, Richtlinien und Auftragsdurchführung.
+  BC-4380.50.10:
+    name: Standard-Änderungs-Horizont-Scanning
+    description: |
+      Scanning bevorstehender Änderungen an Berufs- und regulatorischen
+      Standards, die für die Kanzleibereiche relevant sind.
+  BC-4380.50.20:
+    name: Standardauswirkungsbewertung
+    description: |
+      Bewertung der Methodik-, Schulungs- und Toolingauswirkungen
+      aus neuen oder überarbeiteten Standards.
+  BC-4380.50.30:
+    name: Standard-Übernahme-Einführung
+    description: |
+      Einführung von Methodik-, Richtlinien- und Tooling-Updates zur
+      Umsetzung übernommener Standards.
+  BC-4380.60:
+    name: Berufliches Fehlverhaltensuntersuchungsmanagement
+    description: |
+      Interne Untersuchung, Reaktion auf Berufsverbandsuntersuchungen
+      und Management von Berufshaftpflichtansprüchen im Zusammenhang
+      mit angeblichem beruflichen Fehlverhalten.
+  BC-4380.60.10:
+    name: Interne Verhaltensuntersuchung
+    description: |
+      Interne Untersuchung angeblicher Verstöße gegen Berufsstandards
+      oder Kanzlei-Verhaltensrichtlinien.
+  BC-4380.60.20:
+    name: Berufsverbandsuntersuchungsreaktion
+    description: |
+      Koordination der Kanzleireaktionen auf Untersuchungen durch
+      Berufsverbände und Disziplinartribunale.
+  BC-4380.60.30:
+    name: Berufshaftpflichtanspruchsmanagement
+    description: |
+      Management von Berufshaftpflichtansprüchen und
+      Versicherermeldungen aus Auftragsarbeiten.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-professional-practice-knowledge-management.yaml
+++ b/catalogue/i18n/de/L1-professional-practice-knowledge-management.yaml
@@ -1,0 +1,137 @@
+locale: de
+source: L1-professional-practice-knowledge-management.yaml
+entries:
+  BC-4370:
+    name: Praxiswissen professioneller Dienstleistungen
+    description: |
+      Pflege und Wiederverwendung von Praxispräzedenzfällen,
+      Methodikassets, Thought Leadership, Leistungsvorlagen und
+      Forschungsbibliotheken, die die Auftragsdurchführung in
+      professionellen Dienstleistungskanzleien unterstützen.
+  BC-4370.10:
+    name: Präzedenzfall- und Vorlagenmanagement
+    description: |
+      Kuration, Versionierung und Zugangskontrolle rechtlicher
+      Präzedenzfälle, Vertragsvorlagen und standardisierter
+      Arbeitsergebnisse zur Wiederverwendung.
+  BC-4370.10.10:
+    name: Präzedenzfallkuration
+    description: |
+      Auswahl, Schwärzung und Kuration hochwertiger Auftrags-
+      ergebnisse in die Kanzlei-Präzedenzfallbibliothek.
+  BC-4370.10.20:
+    name: Vorlagenpflege
+    description: |
+      Pflege und Versionskontrolle von Vertragsvorlagen, Gutachten-
+      hüllen und Standard-Leistungsvorlagen.
+  BC-4370.10.30:
+    name: Präzedenzfallzugangsgovernance
+    description: |
+      Zugangsgovernance für Präzedenzfälle zur Abwägung von
+      Wiederverwendung mit Mandantenvertraulichkeit und
+      Informationsbarrierenauflagen.
+  BC-4370.20:
+    name: Methodik- und Toolingmanagement
+    description: |
+      Definition, Weiterentwicklung und Einführung von Auftrags-
+      methodik, analytischen Frameworks und proprietären Tools.
+  BC-4370.20.10:
+    name: Methodikdefinition
+    description: |
+      Definition von Prüfungs-, Beratungs- und Rechtsmethodik
+      gemäß Berufsstandards und Kanzleirichtlinien.
+  BC-4370.20.20:
+    name: Methodikversionierung und -release
+    description: |
+      Versionierung, Release-Management und Abkündigung von
+      Methodik- und Beschleunigerkomponenten.
+  BC-4370.20.30:
+    name: Methodikeinführung und Schulung
+    description: |
+      Einführung neuer Methodikreleases einschließlich Schulungen,
+      FAQs und Adoptionsverfolgung.
+  BC-4370.30:
+    name: Praxiseinblicke und Thought-Leadership-Management
+    description: |
+      Erstellung und Verteilung von Praxisstandpunkten, Alerts,
+      Umfragen und Thought-Leadership-Publikationen.
+  BC-4370.30.10:
+    name: Einblicksthemenplanung
+    description: |
+      Planung von Einblicks- und Thought-Leadership-Themen gemäß
+      Praxisstrategie und Mandanteninteressen.
+  BC-4370.30.20:
+    name: Einblicksproduktion
+    description: |
+      Produktion von Artikeln, Alerts, Standpunkten und
+      Umfrageberichten.
+  BC-4370.30.30:
+    name: Einblicksverteilung und Engagement-Verfolgung
+    description: |
+      Verteilung von Einblicken an Mandanten- und Interessenten-
+      zielgruppen und Verfolgung des Engagements.
+  BC-4370.40:
+    name: Auftragsasset-Wiederverwendungsmanagement
+    description: |
+      Identifikation, Ernte und Kennzeichnung hochwertiger Auftrags-
+      ergebnisse als wiederverwendbare Assets, abgewogen gegen
+      Mandantenvertraulichkeit.
+  BC-4370.40.10:
+    name: Wiederverwendbares-Asset-Identifikation
+    description: |
+      Identifikation von Auftragsergebnissen mit Wiederverwendungs-
+      wert über den Ursprungsauftrag hinaus.
+  BC-4370.40.20:
+    name: Asset-Bereinigung und -Schwärzung
+    description: |
+      Bereinigung und Schwärzung von Auftragsassets zur Entfernung
+      mandantenvertraulicher Informationen vor der Wiederverwendung.
+  BC-4370.40.30:
+    name: Asset-Kennzeichnung und Auffindbarkeit
+    description: |
+      Kennzeichnung und Metadatenanreicherung wiederverwendbarer
+      Assets zur Steigerung der Auffindbarkeit über Bereiche hinweg.
+  BC-4370.50:
+    name: Praxisbibliotheksmanagement
+    description: |
+      Kuration und Lizenzierung externer Forschungsdatenbanken,
+      Rechts- und Steuerbibliotheken sowie Abonnementinhalte für
+      Fachkräfte.
+  BC-4370.50.10:
+    name: Externe Forschungsabonnementverwaltung
+    description: |
+      Beschaffung und Erneuerung von Abonnements für externe Rechts-,
+      Steuer- und Forschungsdatenbanken.
+  BC-4370.50.20:
+    name: Bibliothekskatalog und Suche
+    description: |
+      Katalog und föderierte Suche über interne und externe
+      Forschungsquellen.
+  BC-4370.50.30:
+    name: Bibliotheksnutzungsanalyse
+    description: |
+      Nutzungsanalyse von Forschungsdatenbanken zur Unterstützung
+      von Erneuerungs- und Rationalisierungsentscheidungen.
+  BC-4370.60:
+    name: Praxisgemeinschaftsmanagement
+    description: |
+      Betrieb von Praxisgruppen, Communities of Practice und
+      Fachetzwerken, die Wissen in der Kanzlei teilen.
+  BC-4370.60.10:
+    name: Praxisgruppenbetrieb
+    description: |
+      Betrieb von Praxisgruppen einschließlich Mitgliedschaft,
+      Leitung und Forumsturnus.
+  BC-4370.60.20:
+    name: Community-of-Practice-Moderation
+    description: |
+      Moderation bereichsübergreifender Communities of Practice
+      zu aufkommenden Themen und Methoden.
+  BC-4370.60.30:
+    name: Wissensbotschafter-Netzwerk
+    description: |
+      Betrieb eines Wissensbotschafter-Netzwerks, das über Bereiche
+      und Büros verteilt ist.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-professional-services-delivery-management.yaml
+++ b/catalogue/i18n/de/L1-professional-services-delivery-management.yaml
@@ -1,0 +1,182 @@
+locale: de
+source: L1-professional-services-delivery-management.yaml
+entries:
+  BC-4310:
+    name: Erbringung professioneller Dienstleistungen
+    description: |
+      Durchführung von Beratungs-, Rechts-, Prüfungs- und
+      Consulting-Aufträgen — Arbeitsplanung, Feldarbeit,
+      Leistungserstellung, interne Überprüfung und
+      Auftragsberichterstattung gemäß dem vereinbarten Auftragsumfang.
+  BC-4310.10:
+    name: Auftragsplanungsmanagement
+    description: |
+      Detaillierte Planung von Auftragsarbeiten, Meilensteinen,
+      Leistungsstruktur und risikogerechten Verfahren gemäß den
+      geltenden Berufsstandards.
+  BC-4310.10.10:
+    name: Auftrags-Arbeitsplan-Definition
+    description: |
+      Definition von Arbeitspaketen, Meilensteinen und Abhängigkeiten
+      für den Auftrag.
+  BC-4310.10.20:
+    name: Risikobasierte Verfahrensanpassung
+    description: |
+      Anpassung von Prüfungsverfahren, Beratungsanalysen oder
+      rechtlichen Schritten an das auftragsspezifische Risiko und die
+      Wesentlichkeit.
+  BC-4310.10.30:
+    name: Auftrags-Leistungsplan-Definition
+    description: |
+      Definition von Leistungsstruktur, Format und Überprüfungspunkten.
+  BC-4310.10.40:
+    name: Auftragsablaufplanung
+    description: |
+      Tägliche Ablaufplanung von Auftragsaktivitäten und
+      Ressourcenverfügbarkeit gegenüber dem Arbeitsplan.
+  BC-4310.20:
+    name: Auftragsdurchführungsmanagement
+    description: |
+      Tägliche Durchführung der Auftragsarbeiten — Feldarbeit,
+      Beratungsanalyse, Prüftests, Entwurf und Mandanteninteraktion.
+  BC-4310.20.10:
+    name: Prüfungsverfahrensdurchführung
+    description: |
+      Durchführung von Prüfungs- und Bestätigungsverfahren
+      einschließlich substanzieller Tests, Kontrollentests und
+      analytischer Verfahren.
+  BC-4310.20.20:
+    name: Beratungsanalysedurchführung
+    description: |
+      Durchführung von Consulting-Analysen, Modellierungen,
+      Benchmarkings und Empfehlungsentwicklung.
+  BC-4310.20.30:
+    name: Rechtsmandatsdurchführung
+    description: |
+      Substantielle Rechtsarbeit einschließlich Entwurf, Gutachten,
+      Gerichtsschriftsätze, transaktionelle Ausführung und Beratung.
+  BC-4310.20.40:
+    name: Mandanteninteraktionsmanagement
+    description: |
+      Tägliche Mandanteninteraktion während der Durchführung —
+      Interviews, Informationsanfragen, Statusgespräche und
+      Stakeholder-Workshops.
+  BC-4310.30:
+    name: Auftragsleistungsmanagement
+    description: |
+      Entwurf, Versionskontrolle und Abschluss von Auftragsleistungen
+      wie Prüfberichten, Gutachten, Beratungsberichten und
+      transaktionellen Unterlagen.
+  BC-4310.30.10:
+    name: Leistungsentwurf
+    description: |
+      Erstellung von Leistungsentwürfen unter Verwendung von
+      Kanzleivorlagen, Methodik und Auftragsergebnissen.
+  BC-4310.30.20:
+    name: Leistungsversionskontrolle
+    description: |
+      Versionierung, Verzweigung und Prüfpfad über Leistungsentwürfe
+      durch Überprüfungszyklen hinweg.
+  BC-4310.30.30:
+    name: Leistungsfinalisierung
+    description: |
+      Endformatierung, Unterschriftsblöcke und Freigabeverpackung
+      abgeschlossener Leistungen.
+  BC-4310.40:
+    name: Auftrags-Arbeitspapiermanagement
+    description: |
+      Erfassung, Organisation und Aufbewahrung von Auftrags-
+      arbeitspapieren und Belegen, die Leistungen und Schluss-
+      folgerungen stützen.
+    in_scope:
+      - Auftragsakte-Arbeitspapiere
+      - Belegindexierung und -querverweise
+      - Aktenzusammenstellung und -sperrung
+    out_of_scope:
+      - Wiederverwendbare Methodik- und Musterassets (BC-4370)
+  BC-4310.40.10:
+    name: Arbeitspapiererfassung
+    description: |
+      Erfassung von Belegen, Analysen und Notizen in der
+      Auftrags-Arbeitspapeierakte.
+  BC-4310.40.20:
+    name: Arbeitspapierindexierung und -querverweise
+    description: |
+      Indexierung und Querverweise von Arbeitspapieren zu
+      Leistungsaussagen und Verfahrensschritten.
+  BC-4310.40.30:
+    name: Auftragsakte-Zusammenstellung und -Sperrung
+    description: |
+      Zusammenstellung der endgültigen Auftragsakte und Sperrung
+      zur Verhinderung von Änderungen nach der Veröffentlichung
+      außerhalb genehmigter Kontrollen.
+  BC-4310.50:
+    name: Interne Auftragsüberprüfung
+    description: |
+      Überprüfungszyklen innerhalb des Auftrags durch Reviewer,
+      Manager und Partner vor der Leistungsfreigabe; getrennt von
+      der Qualitätsüberwachung auf Kanzleibene.
+    out_of_scope:
+      - Qualitätsüberwachung und EQR auf Kanzleibene (BC-4340)
+  BC-4310.50.10:
+    name: Manager-Arbeitspapierüberprüfung
+    description: |
+      Überprüfung von Arbeitspapieren und Schlussfolgerungen durch
+      den Manager vor der Partnerfreigabe.
+  BC-4310.50.20:
+    name: Partner-Überprüfung und Freigabe
+    description: |
+      Überprüfung und Freigabe von Leistungen und Gutachten durch
+      den Auftragspartner.
+  BC-4310.50.30:
+    name: Fachreferententechnische Überprüfung
+    description: |
+      Überprüfung durch Fachspezialisten (Steuer, Bewertung, IT,
+      Versicherungsmathematik) in Bereichen, die Spezialwissen
+      erfordern.
+  BC-4310.60:
+    name: Externe Spezialistenbeauftragungsmanagement
+    description: |
+      Beauftragung von Co-Anwälten, Sachverständigen,
+      Unterauftragnehmern und externen Spezialisten innerhalb
+      eines Auftrags.
+  BC-4310.60.10:
+    name: Co-Anwalts- und Unterauftragnehmerbeauftragung
+    description: |
+      Auswahl und Beauftragung von Co-Anwälten, lokalen Anwälten
+      oder Beratungs-Unterauftragnehmern.
+  BC-4310.60.20:
+    name: Sachverständigenbeauftragung
+    description: |
+      Identifikation, Beauftragung und Management von
+      Sachverständigen und externen Experten.
+  BC-4310.60.30:
+    name: Externe Spezialistenqualitätsaufsicht
+    description: |
+      Aufsicht über die Arbeitsergebnisse externer Spezialisten und
+      Abhängigkeitsbewertung für Auftragsschlussfolgerungen.
+  BC-4310.70:
+    name: Auftragsberichterstattung und Kommunikation
+    description: |
+      Statusberichterstattung, Zwischenkommunikation und
+      Abschlussberichterstattung an den Mandanten und die
+      Auftragsleitung während der Durchführung.
+  BC-4310.70.10:
+    name: Auftragsstatusberichterstattung
+    description: |
+      Periodische Statusaktualisierungen an die Auftragsleitung und
+      den Mandanten einschließlich Fortschritt, Risiken und Problemen.
+  BC-4310.70.20:
+    name: Zwischenbefundkommunikation
+    description: |
+      Zwischenkommunikation vorläufiger Erkenntnisse, Beobachtungen
+      und bedeutender Probleme an den Mandanten während der
+      Durchführung.
+  BC-4310.70.30:
+    name: Abschlussberichterstattung
+    description: |
+      Ausgabe von Abschlussberichten, Gutachten und
+      Managementbriefen als Teil des Auftragsabschlusses.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-professional-workforce-resourcing-management.yaml
+++ b/catalogue/i18n/de/L1-professional-workforce-resourcing-management.yaml
@@ -1,0 +1,158 @@
+locale: de
+source: L1-professional-workforce-resourcing-management.yaml
+entries:
+  BC-4320:
+    name: Ressourcenplanung (Professionelle Kräfte)
+    description: |
+      Zuteilung, Auslastung, Hebelwirkung und Bench-Management
+      abrechnungsfähiger Fachkräfte über das Auftragsportfolio hinweg.
+      Distinct vom generischen Human Capital Management — fokussiert auf
+      die abrechnungsfähige Belegschaft als primäre Lieferressource der
+      Kanzlei.
+  BC-4320.10:
+    name: Ressourcenbedarfsprognose
+    description: |
+      Prognose des abrechnungsfähigen Ressourcenbedarfs aus
+      Auftragspipeline, zugesagten Aufträgen und Wachstumsannahmen.
+  BC-4320.10.10:
+    name: Pipeline-gesteuerte Bedarfsprognose
+    description: |
+      Prognose des Ressourcenbedarfs aus der Akquisepipeline,
+      gewichtet nach Gewinnwahrscheinlichkeit.
+  BC-4320.10.20:
+    name: Bedarfsplanung für zugesagte Aufträge
+    description: |
+      Ressourcenbedarfsplanung aus angenommenen Aufträgen mit
+      bestätigtem Umfang und Zeitplan.
+  BC-4320.10.30:
+    name: Kompetenzspezifische Bedarfsaggregation
+    description: |
+      Aggregation des Prognosebedarfs nach Kompetenz, Spezialisierung,
+      Sprache und Sicherheitsfreigabe.
+  BC-4320.20:
+    name: Auftragsbesetzungsmanagement
+    description: |
+      Zuteilung namentlicher Fachkräfte zu Auftragsrollen unter
+      Abwägung von Auftragsanforderungen, individueller Entwicklung
+      und Auslastungszielen.
+  BC-4320.20.10:
+    name: Auftragsressourcenanfragen-Bearbeitung
+    description: |
+      Erfassung und Triage auftragsseitiger Ressourcenanfragen
+      gegenüber verfügbaren Fachkräften.
+  BC-4320.20.20:
+    name: Besetzungsentscheidungsmanagement
+    description: |
+      Besetzungsentscheidungen unter Abwägung von Auftragspassung,
+      Entwicklungsbedarf und Partnerpräferenzen.
+  BC-4320.20.30:
+    name: Besetzungsbestätigung und -benachrichtigung
+    description: |
+      Bestätigung von Besetzungsentscheidungen gegenüber der
+      Auftragsleitung und den eingesetzten Fachkräften.
+  BC-4320.30:
+    name: Kompetenz- und Spezialisierungsabgleich
+    description: |
+      Pflege von Fachkräfteprofilen und Abgleich der Profile mit
+      den Kompetenzanforderungen des Auftrags.
+  BC-4320.30.10:
+    name: Fachkräfte-Kompetenzprofil-Pflege
+    description: |
+      Erfassung und Aktualisierung von Kompetenzen, Qualifikationen,
+      Sprachen und Branchenerfahrung jeder Fachkraft.
+  BC-4320.30.20:
+    name: Auftrags-Kompetenzanforderungs-Definition
+    description: |
+      Definition von Kompetenz-, Spezialisierungs- und
+      Freigabeanforderungen je Auftragsrolle.
+  BC-4320.30.30:
+    name: Kompetenzbasierter Abgleich
+    description: |
+      Abgleich von Fachkräften mit Auftragsrollen anhand von
+      Kompetenz, Spezialisierung und Verfügbarkeit.
+  BC-4320.40:
+    name: Auslastungsmanagement
+    description: |
+      Verfolgung und Steuerung der abrechenbaren Auslastung gegenüber
+      Kanzlei- und Individualzielen einschließlich Produktivitätsanalyse.
+  BC-4320.40.10:
+    name: Auslastungsziel-Festlegung
+    description: |
+      Festlegung abrechnungsfähiger Auslastungsziele nach Stufe,
+      Bereich und Fachkraft.
+  BC-4320.40.20:
+    name: Auslastungsverfolgung
+    description: |
+      Tägliche Verfolgung abrechnungsfähiger Stunden, nicht
+      abrechnungsfähiger Stunden und Abwesenheiten.
+  BC-4320.40.30:
+    name: Auslastungsabweichungsmaßnahmen
+    description: |
+      Identifikation und Behebung von Fachkräften, die deutlich unter
+      oder über dem Auslastungsziel liegen.
+  BC-4320.50:
+    name: Bench-Management
+    description: |
+      Management nicht zugeteilter abrechnungsfähiger Kapazität
+      einschließlich Ramp-Planung, Bench-Nutzung für nicht
+      abrechnungsfähige Arbeit und proaktiver Reallokation.
+  BC-4320.50.10:
+    name: Bench-Transparenzmanagement
+    description: |
+      Sichtbarkeit verfügbarer Kapazität nach Stufe, Kompetenz
+      und Standort.
+  BC-4320.50.20:
+    name: Bench-Aktivitätszuteilung
+    description: |
+      Zuteilung von Bench-Zeit für Entwicklung, Angebotssupport,
+      Methodikarbeit oder Schulungen.
+  BC-4320.50.30:
+    name: Bench-Reduzierungsmaßnahmen
+    description: |
+      Proaktive Reallokation, Entsendung oder Kapazitätsanpassung,
+      wenn der Bench das Ziel überschreitet.
+  BC-4320.60:
+    name: Büro- und grenzübergreifende Ressourcenplanung
+    description: |
+      Koordination der Ressourcenteilung über Büros, Bereiche und
+      Grenzen hinweg einschließlich Entsendungen und Global Mobility
+      für abrechnungsfähige Fachkräfte.
+  BC-4320.60.10:
+    name: Büroübergreifende Ressourcenausleihe
+    description: |
+      Ausleihe und Verleih von Fachkräften zwischen Büros auf
+      temporärer Basis.
+  BC-4320.60.20:
+    name: Internationale Entsendungsmanagement
+    description: |
+      Längerfristige internationale Entsendungen von Fachkräften
+      zwischen Kanzleibüros oder Mitgliedskanzleijurisdiktionen.
+  BC-4320.60.30:
+    name: Büroübergreifende Verrechnung und Abrechnung
+    description: |
+      Operative Abwicklung büroübergreifender Zeit- und
+      Kostenerrechnungen bei gemeinsamen Aufträgen.
+  BC-4320.70:
+    name: Auftrags-Hebelwirkungsmanagement
+    description: |
+      Management des Partner-zu-Mitarbeiter-Verhältnisses auf
+      Aufträgen unter Abwägung von Wirtschaftlichkeit, Qualität und
+      Entwicklung.
+  BC-4320.70.10:
+    name: Auftrags-Hebelwirkungsmodellierung
+    description: |
+      Modellierung des Partner-, Manager-, Senior- und
+      Junior-Mixes pro Auftragstyp.
+  BC-4320.70.20:
+    name: Hebelwirkungsabweichungsüberwachung
+    description: |
+      Überwachung der tatsächlichen Hebelwirkung gegenüber dem Ziel
+      und Ursachenanalyse von Abweichungen.
+  BC-4320.70.30:
+    name: Stufenpyramiden-Analyse
+    description: |
+      Analyse der Stufenpyramidengesundheit, Beförderungsgeschwindigkeit
+      und des Fluktuationseinflusses auf die Hebelwirkung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-programming-scheduling-management.yaml
+++ b/catalogue/i18n/de/L1-programming-scheduling-management.yaml
@@ -1,0 +1,114 @@
+locale: de
+source: L1-programming-scheduling-management.yaml
+entries:
+  BC-3730:
+    name: Programmplanung und Sendeplanung
+    description: |
+      Lineares Kanalscheduling, EPG-Management, On-Demand-Katalog-
+      Kuratierung, Übertragungsplaylist und Continuity sowie
+      Abstimmung des Programmierungsbedarfs mit Rechts- und
+      Akquisitions-Pipelines.
+  BC-3730.10:
+    name: Lineares Kanal-Scheduling
+    description: |
+      Langfristige, taktische und Änderungs-Schedulierung linearer
+      Kanäle und Streams.
+  BC-3730.10.10:
+    name: Langfristige Sendeplanung
+    description: |
+      Multi-Quartals- und saisonale Sendepläne abgestimmt auf
+      Rechtsfenster und Publikumsstrategie.
+  BC-3730.10.20:
+    name: Taktischer Sendeplan-Aufbau
+    description: |
+      Wöchentlicher Sendeplan-Aufbau bis auf Programm- und
+      Werbeblockebene.
+  BC-3730.10.30:
+    name: Sendeplan-Änderungs-Management
+    description: |
+      Kontrollierte Bearbeitung später und Notfall-Sendeplanänderungen
+      mit nachgelagerten Benachrichtigungen.
+  BC-3730.20:
+    name: Elektronischer Programmführer-Management
+    description: |
+      Erstellung, Distribution und Aktualisierung von EPG-Daten
+      für Operatoren und Verbrauchergeräte.
+  BC-3730.20.10:
+    name: EPG-Daten-Erstellung
+    description: |
+      Erstellung von EPG-Titeln, Synopsen, Bewertungen und
+      Ereignismetadaten zur Veröffentlichung.
+  BC-3730.20.20:
+    name: EPG-Distribution an Operatoren
+    description: |
+      Distribution von EPG-Feeds an Plattformoperatoren,
+      Aggregatoren und Verbrauchergeräteplattformen.
+  BC-3730.20.30:
+    name: EPG-Echtzeit-Update-Management
+    description: |
+      Echtzeit-Updates von EPG-Daten bei Live-Überlängen,
+      Sport und Breaking News.
+  BC-3730.30:
+    name: On-Demand-Katalog-Kuratierung
+    description: |
+      Kuratierung von Titeln, Sammlungen und Personalisierungs-
+      regeln über On-Demand- und Streaming-Oberflächen hinweg.
+  BC-3730.30.10:
+    name: Titel-Auswahl und Kuratierung
+    description: |
+      Auswahl und redaktionelle Rahmung von Titeln im
+      On-Demand-Katalog einschließlich territorialer Verfügbarkeit.
+  BC-3730.30.20:
+    name: Redaktionelle Sammlungs-Management
+    description: |
+      Erstellung und Lebenszyklus von redaktionellen Sammlungen,
+      Themen und Reihen für Zuschauer.
+  BC-3730.30.30:
+    name: Personalisierungsregel-Erstellung
+    description: |
+      Erstellung von Geschäftsregeln für Personalisierung neben
+      Machine-Learning-Empfehlungen.
+  BC-3730.40:
+    name: Playlist- und Continuity-Management
+    description: |
+      Aufbau von Übertragungsplaylists und On-Air-Continuity
+      für lineare und 24/7-Streaming-Kanäle.
+  BC-3730.40.10:
+    name: Übertragungsplaylist-Aufbau
+    description: |
+      Aufbau zeitgesteuerter Übertragungsplaylists für Playout
+      einschließlich Werbeblöcken und Interstitial-Elementen.
+  BC-3730.40.20:
+    name: Continuity- und Junction-Management
+    description: |
+      Erstellung und Management von Continuity-Ankündigungen,
+      Idents und Junction-Paketen.
+  BC-3730.40.30:
+    name: Compliance-Schnitt- und Einfügungsmanagement
+    description: |
+      Anwendung von Compliance-Schnitten und Versions-Einfügungen
+      für den Zielkanal und Sendezeitslot.
+  BC-3730.50:
+    name: Programm-Akquisitionsslot-Planung
+    description: |
+      Übersetzung des Programmierungsslot-Bedarfs in
+      Akquisitions-Wunschlisten und Abstimmung erworbener
+      Rechte mit Sendebedürfnissen.
+  BC-3730.50.10:
+    name: Slot-Bedarfs-Planung
+    description: |
+      Quantifizierung des Slot-Bedarfs nach Genre, Tageszeit und
+      Zielgruppe über den Sendeplanhorizont.
+  BC-3730.50.20:
+    name: Akquisitions-Wunschlisten-Management
+    description: |
+      Wunschliste von Titeln, Formaten und Paketen priorisiert
+      für Akquisition zur Füllung identifizierter Slots.
+  BC-3730.50.30:
+    name: Programmierung-zu-Rechte-Abstimmung
+    description: |
+      Abstimmung programmierter Ausstrahlungen gegen gehaltene
+      Rechte, Ausstrahlungsanzahl und Fensterkonsumption.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-project-engineering-management.yaml
+++ b/catalogue/i18n/de/L1-project-engineering-management.yaml
@@ -1,0 +1,126 @@
+locale: de
+source: L1-project-engineering-management.yaml
+entries:
+  BC-1110:
+    name: Projektingenieurwesen-Management
+    description: |
+      Ingenieurwesen von Projekten von FEED bis zur Übergabe.
+  BC-1110.10:
+    name: Projektingenieurwesen-Planungsmanagement
+    description: |
+      Ingenieurwesen-Arbeitsstrukturplan, Liefergegenstände-Pläne und Ingenieurwesen-Terminpläne.
+  BC-1110.10.10:
+    name: Ingenieurwesen-Arbeitsstrukturplan-Definition
+    description: |
+      Ingenieurwesen-PSP und Disziplinstruktur.
+  BC-1110.10.20:
+    name: Ingenieurwesen-Liefergegenstände-Register
+    description: |
+      Liefergegenstände-Register, Verantwortliche und Zieldaten.
+  BC-1110.10.30:
+    name: Ingenieurwesen-Terminplanentwicklung
+    description: |
+      Ingenieurwesen-Terminplan mit disziplinübergreifenden Abhängigkeiten.
+  BC-1110.10.40:
+    name: Ingenieurwesen-Ressourcenauslastung
+    description: |
+      Ingenieurstundenprognose und Ressourcenauslastung.
+  BC-1110.20:
+    name: Projektingenieurwesen-Ausführungsmanagement
+    description: |
+      Multidisziplinäre Ingenieurausführungssteuerung und -berichterstattung.
+  BC-1110.20.10:
+    name: Ingenieurwesen-Fortschrittsmessung
+    description: |
+      Fortschrittsmessung von Ingenieurliefergegenständen und Earned Value.
+  BC-1110.20.20:
+    name: Ingenieurwesen-Mannstundensteuerung
+    description: |
+      Verfolgung und Prognose des Ingenieurstundenverbrauchs.
+  BC-1110.20.30:
+    name: Ingenieurwesen-Koordinationsbesprechungen
+    description: |
+      Disziplinübergreifende Ingenieurkoordination und Wochenberichterstattung.
+  BC-1110.20.40:
+    name: Ingenieurwesen-Produktivitätsverbesserung
+    description: |
+      Produktivitätsinitiativen wie Design-Automatisierung und Wiederverwendung.
+  BC-1110.30:
+    name: Ingenieurwesen-Änderungsmanagement
+    description: |
+      Änderungsanträge, technische Folgenabschätzung und Baselinesteuerung.
+  BC-1110.30.10:
+    name: Ingenieurwesen-Änderungsantrags-Erfassung
+    description: |
+      Erfassung und Klassifizierung von Ingenieurwesen-Änderungsanträgen.
+  BC-1110.30.20:
+    name: Technische Folgenabschätzung
+    description: |
+      Multidisziplinäre technische Folgenabschätzung von Änderungen.
+  BC-1110.30.30:
+    name: Ingenieurwesen-Baselinesteuerung
+    description: |
+      Steuerung von Ingenieurwesen-Baselines und Konfigurationselementen.
+  BC-1110.30.40:
+    name: Ingenieurwesen-Änderungsfreigabe und -umsetzung
+    description: |
+      Änderungsfreigabe-Gremien und Umsetzungsverfolgung.
+  BC-1110.40:
+    name: Schnittstellenmanagement
+    description: |
+      Interne und externe technische Schnittstellen und Stakeholderkoordination.
+  BC-1110.40.10:
+    name: Schnittstellen-Identifikation und -Registrierung
+    description: |
+      Identifikation und Registrierung technischer Schnittstellen.
+  BC-1110.40.20:
+    name: Schnittstellenvereinbarungs-Management
+    description: |
+      Schnittstellenvereinbarungen mit Parteien und Abnahmekriterien.
+  BC-1110.40.30:
+    name: Schnittstellenüberwachung und -abschluss
+    description: |
+      Überwachung von Schnittstellenliefergegenständen und formalem Abschluss.
+  BC-1110.50:
+    name: Projektingenieurwesen-Qualitätsmanagement
+    description: |
+      Ingenieurwesen-QS/QK, technische Sicherung, Peer-Reviews und Audits.
+  BC-1110.50.10:
+    name: Ingenieurwesen-QS-Programmmanagement
+    description: |
+      Ingenieurwesen-QS-Programm gemäß ISO 9001.
+  BC-1110.50.20:
+    name: Disziplin-Peer-Review
+    description: |
+      Disziplinärer Peer-Review von Ingenieurliefergegenständen.
+  BC-1110.50.30:
+    name: Ingenieurwesen-Technisches Audit
+    description: |
+      Unabhängige technische Audits und Qualitätssicherungs-Reviews.
+  BC-1110.50.40:
+    name: Ingenieurwesen-Lessons Learned
+    description: |
+      Erfassung und Verbreitung von Ingenieurlektionen.
+  BC-1110.60:
+    name: Projektingenieurwesen-Risiko- und Issue-Management
+    description: |
+      Technische Risiken, technische Issues und Maßnahmenverfolgung.
+  BC-1110.60.10:
+    name: Technische Risikoidentifikation
+    description: |
+      Identifikation technischer und ingenieurmäßiger Risiken.
+  BC-1110.60.20:
+    name: Technische Risikobewertung
+    description: |
+      Bewertung von Wahrscheinlichkeit und Auswirkung technischer Risiken.
+  BC-1110.60.30:
+    name: Technische Issue-Lösung
+    description: |
+      Verfolgung und Lösung technischer Issues mit Verantwortlichen.
+  BC-1110.60.40:
+    name: Technische Maßnahmenverfolgung
+    description: |
+      Verfolgung von Maßnahmen und Restrisiken.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-project-portfolio-management.yaml
+++ b/catalogue/i18n/de/L1-project-portfolio-management.yaml
@@ -1,0 +1,134 @@
+locale: de
+source: L1-project-portfolio-management.yaml
+entries:
+  BC-900:
+    name: Projektportfolio-Management
+    description: |
+      Projektdurchführung, Portfoliopriorisierung und PMO.
+  BC-900.10:
+    name: Portfoliomanagement
+    description: |
+      Portfoliogestaltung, Priorisierung und Balance.
+  BC-900.10.10:
+    name: Portfoliostruktur-Definition
+    description: |
+      Portfoliozusammensetzung nach strategischen Themen, Typen und Risiko.
+  BC-900.10.20:
+    name: Portfoliopriorisierung und -auswahl
+    description: |
+      Bewertung und Auswahl von Initiativen für die Portfolioaufnahme.
+  BC-900.10.30:
+    name: Portfolioausbalancierung
+    description: |
+      Ausbalancierung des Portfolios über Zeithorizonte, Risiko und Rendite.
+  BC-900.10.40:
+    name: Portfolio-Leistungsberichterstattung
+    description: |
+      Portfolio-Dashboards, Status und Nutzenberichterstattung.
+  BC-900.20:
+    name: Programmmanagement
+    description: |
+      Programmplanung, -ausführung und -steuerung.
+  BC-900.20.10:
+    name: Programmdefinition und -mobilisierung
+    description: |
+      Programm-Blueprint, Auftrag und Mobilisierung.
+  BC-900.20.20:
+    name: Programmplanintegration
+    description: |
+      Integration von Projektplänen, Abhängigkeiten und Meilensteinen.
+  BC-900.20.30:
+    name: Programm-Risiko- und Issue-Management
+    description: |
+      Risiko-, Issue- und Abhängigkeitsmanagement auf Programmebene.
+  BC-900.20.40:
+    name: Programmabschluss
+    description: |
+      Programmabschluss, Übergabe und Lessons Learned.
+  BC-900.30:
+    name: Projektmanagement
+    description: |
+      Projektdurchführung, Planung und Verfolgung.
+  BC-900.30.10:
+    name: Projektplanung
+    description: |
+      Projektumfang, Zeitplan, Kosten und Ressourcenplanung.
+  BC-900.30.20:
+    name: Projektdurchführung und -verfolgung
+    description: |
+      Tägliche Projektdurchführung und Fortschrittsverfolgung.
+  BC-900.30.30:
+    name: Projekt-Risiko- und Issue-Management
+    description: |
+      Risiko-, Issue- und Entscheidungsmanagement im Projekt.
+  BC-900.30.40:
+    name: Projektqualitätsmanagement
+    description: |
+      Qualität und Abnahme von Projektergebnissen.
+  BC-900.30.50:
+    name: Projektabschluss und Übergabe
+    description: |
+      Projektabschluss, Übergabe an den Betrieb und Post-Implementierungsreview.
+  BC-900.40:
+    name: Projektsteuerungs-Management
+    description: |
+      Stage-Gates, Lenkungsausschüsse und Qualitätssicherung.
+  BC-900.40.10:
+    name: Stage-Gate-Steuerung
+    description: |
+      Stage-Gate-Definitionen, Kriterien und Freigaben.
+  BC-900.40.20:
+    name: Lenkungsausschuss-Betrieb
+    description: |
+      Geschäftsordnung, Tagesordnungen und Entscheidungen des Lenkungsausschusses.
+  BC-900.40.30:
+    name: Projektqualitätssicherungs-Reviews
+    description: |
+      Unabhängige Qualitätssicherungs-Reviews und Gateway-Reviews.
+  BC-900.40.40:
+    name: Projektaudit und Lessons Learned
+    description: |
+      Post-Projekt-Audit, Lessons-Learned-Erfassung und -Verbreitung.
+  BC-900.50:
+    name: PMO-Betriebsmanagement
+    description: |
+      PMO-Dienstleistungen, Methodik und Werkzeuge.
+  BC-900.50.10:
+    name: PMO-Methodik und -Standards
+    description: |
+      Projektmethodik, Vorlagen und Standards (PRINCE2, PMI, agil).
+  BC-900.50.20:
+    name: PMO-Werkzeuge und -Berichterstattung
+    description: |
+      Projektmanagement-Werkzeuge, Dashboards und Berichterstattung.
+  BC-900.50.30:
+    name: PMO-Kompetenzentwicklung
+    description: |
+      Kompetenzaufbau und Zertifizierung von Projektmanagern.
+  BC-900.50.40:
+    name: PMO-Leistungsmanagement
+    description: |
+      PMO-Scorecard, Wertbeitrag und Leistungsverfolgung.
+  BC-900.60:
+    name: Bedarfs- und Kapazitätsmanagement
+    description: |
+      Projektbedarfsaufnahme und Ressourcenkapazitätsplanung.
+  BC-900.60.10:
+    name: Projektbedarfsaufnahme
+    description: |
+      Erfassung, Qualifizierung und Freigabe neuer Projektbedarfe.
+  BC-900.60.20:
+    name: Ressourcenkapazitätsplanung
+    description: |
+      Kapazitätsplanung über Lieferteams und Fähigkeiten hinweg.
+  BC-900.60.30:
+    name: Ressourcenzuteilung und -nivellierung
+    description: |
+      Ressourcenzuteilung über Projekte und Konfliktlösung.
+  BC-900.60.40:
+    name: Ressourcenauslastungs-Berichterstattung
+    description: |
+      Berichterstattung zu Ressourcenauslastung, abrechenbaren Stunden und Bedarfsprognosen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-property-management-operations.yaml
+++ b/catalogue/i18n/de/L1-property-management-operations.yaml
@@ -1,0 +1,222 @@
+locale: de
+source: L1-property-management-operations.yaml
+entries:
+  BC-4940:
+    name: Immobilienverwaltungsbetrieb
+    description: |
+      Vermieter- und immobilienverwaltungsseitiger Betrieb von Gewerbe-,
+      Einzelhandels- und Mehrfamilienwohngebäuden — Gebäudeservices, Anbieter-
+      und Vertragsmanagement, Auftragserteilung, Mieterservices während der
+      Nutzung, Sicherheit und Lebensschutz, Energie/Nachhaltigkeit und
+      Immobilienbuchhaltung einschließlich Nebenkostenabrechnung. Abzugrenzen
+      von Hotelbetrieb (BC-4060) und Unternehmensgebäuden (BC-700).
+    in_scope:
+      - Täglicher Gebäudebetrieb einschließlich BMS und Gemeinschaftsflächen
+      - Vorbeugende, reaktive und gesetzliche Instandhaltung
+      - Anbieter- und Servicevertragsmanagement (Reinigung, Sicherheit, Außenanlagen)
+      - Mieterein- und -auszug sowie Mieterausbaukoordination
+      - Gebäudesicherheit, Brand-/Lebensschutz und Vorfallreaktion
+      - Gebäudeenergie, Wasser, Abfall und Innenraumklima
+      - Immobilienbuchhaltung, Mieterabrechnung und Betriebsberichtswesen
+      - Nebenkosten- und Servicekostenabrechnung
+    out_of_scope:
+      - Hotel- und Resortbetrieb (BC-4060)
+      - Unternehmenseigene Gebäude für Eigenbedarf (BC-700)
+      - Geschäftspläne für stehende Assets und Investitionsausgaben-Strategie (BC-4920)
+      - Mietergewinnung und Mietvertragsabschluss (BC-4950)
+  BC-4940.10:
+    name: Gebäudebetriebsmanagement
+    description: |
+      Täglicher Betrieb von Gebäudeservices, Gebäudemanagementsystemen,
+      Gemeinschaftsflächen, Empfang und Betriebszeitplänen in Gewerbe-,
+      Einzelhandels- und Mehrfamilien-Assets.
+  BC-4940.10.10:
+    name: Gemeinschaftsflächenbetrieb
+    description: |
+      Betrieb von Gemeinschaftsflächen einschließlich Lobbys, Flure und
+      gemeinsame Einrichtungen.
+  BC-4940.10.20:
+    name: Gebäudemanagementsystem-Betrieb
+    description: |
+      Betrieb von Gebäudemanagementsystemen einschließlich HVAC,
+      Beleuchtung und Zugangskontrolle.
+  BC-4940.10.30:
+    name: Gebäudeempfang und Zugangsbetrieb
+    description: |
+      Empfangs-, Concierge- und Zugangsbetrieb für Mieter und
+      Besucher des Gebäudes.
+  BC-4940.10.40:
+    name: Betriebszeiten- und Zeitplanmanagement
+    description: |
+      Management von Betriebszeiten, Anfragen außerhalb der Betriebszeiten
+      und Feiertagszeitplänen.
+  BC-4940.20:
+    name: Immobilien-Instandhaltung und Auftragsverwaltung
+    description: |
+      Vorbeugende, reaktive und gesetzliche Instandhaltung von Gebäude-
+      systemen und mieterbezogenen Anlagen über Auftragsworkflows.
+  BC-4940.20.10:
+    name: Vorbeugende Instandhaltung
+    description: |
+      Betrieb vorbeugender Instandhaltung anhand von Zeitplan und
+      Anlagenzustandsdaten.
+  BC-4940.20.20:
+    name: Reaktive Instandhaltung und Auftragserteilung
+    description: |
+      Bearbeitung reaktiver Instandhaltung aufgrund von Mieteranfragen
+      und Inspektionsbefunden.
+  BC-4940.20.30:
+    name: Gesetzliche und Compliance-Inspektionen
+    description: |
+      Gesetzliche und Compliance-Inspektionen für Aufzüge, Brandsysteme,
+      Gas und Drucksysteme.
+  BC-4940.20.40:
+    name: Instandhaltungsberichtswesen
+    description: |
+      Berichterstattung über Instandhaltungsaktivitäten, Rückstände und
+      SLA-Leistung an Eigentümer und Mieter.
+  BC-4940.30:
+    name: Immobilien-Anbieter- und Servicevertragsmanagement
+    description: |
+      Onboarding und Management von Immobilien-Service-Anbietern und
+      -Verträgen für Reinigung, Sicherheit, Außenanlagen und
+      Energieversorgung.
+  BC-4940.30.10:
+    name: Servicevertrags-Onboarding
+    description: |
+      Onboarding von Immobilien-Service-Verträgen und Anbietern.
+  BC-4940.30.20:
+    name: Anbieterleistungsmanagement
+    description: |
+      Leistungsmanagement von Immobilienanbietern anhand von SLAs und KPIs.
+  BC-4940.30.30:
+    name: Servicespezifikation und SLA-Definition
+    description: |
+      Definition von Servicespezifikationen, Umfang und SLAs für
+      vertraglich vereinbarte Immobilien-Services.
+  BC-4940.40:
+    name: Mieterservices und Einzugskoordination
+    description: |
+      Koordination von Mieter-Onboarding, Ein- und Auszug, Mieterausbau
+      und laufende Mieterserviceanfragen im Gebäude.
+  BC-4940.40.10:
+    name: Mietereinzugskoordination
+    description: |
+      Koordination des Mietereinzugs einschließlich Zugang, Beschilderung
+      und Orientierung.
+  BC-4940.40.20:
+    name: Mieterausbaukoordination
+    description: |
+      Koordination von Mieterausbauarbeiten, Auftragnehmer-Zugang und
+      Vermieter-Genehmigungen.
+  BC-4940.40.30:
+    name: Mieterauszug und Wiederherstellung
+    description: |
+      Koordination des Mieterauszugs und Wiederherstellung der
+      gemieteten Flächen.
+  BC-4940.40.40:
+    name: Mieterserviceanfragen-Bearbeitung
+    description: |
+      Bearbeitung von Mieterserviceanfragen während der Nutzung
+      über verschiedene Kanäle.
+  BC-4940.50:
+    name: Gebäudesicherheit und Lebensschutz-Betrieb
+    description: |
+      Betrieb von Überwachung, Brand- und Lebensschutzsystemen,
+      Vorfallreaktion und Notfallevakuierung im Gebäude.
+  BC-4940.50.10:
+    name: Gebäudeüberwachungsbetrieb
+    description: |
+      Betrieb von CCTV und Überwachung in Gemeinschaftsflächen
+      und Hinterhaus-Bereichen.
+  BC-4940.50.20:
+    name: Brand- und Lebensschutzsystem-Betrieb
+    description: |
+      Betrieb von Branderkennungs-, Brandbekämpfungs- und
+      Lebensschutzsystemen einschließlich Übungen.
+  BC-4940.50.30:
+    name: Gebäudevorfallreaktion
+    description: |
+      Vorfallreaktion auf Gebäudeebene bei Sicherheits-, Diebstahl-
+      und Sicherheitsereignissen.
+  BC-4940.50.40:
+    name: Notfallevakuierungsbetrieb
+    description: |
+      Ausführung von Notfallevakuierungsplänen und Vorfallkommando
+      im Gebäude.
+  BC-4940.60:
+    name: Immobilien-Energie- und Nachhaltigkeitsbetrieb
+    description: |
+      Gebäudeseitiger Betrieb von Energie, Wasser, Abfall, Innenraumklima
+      und Mieter-Subzähler-Programmen.
+  BC-4940.60.10:
+    name: Gebäudeenergiebetrieb
+    description: |
+      Betrieb von Gebäudeenergiesystemen und Verbrauchsüberwachung
+      anhand von Zielen.
+  BC-4940.60.20:
+    name: Wasser- und Abfallbetrieb
+    description: |
+      Betrieb von Gebäudewasser-, Abwasser- und Abfalltrennungsprogrammen.
+  BC-4940.60.30:
+    name: Innenraumluftqualitätsbetrieb
+    description: |
+      Betrieb von Innenraumluftqualitäts-, Beleuchtungs- und
+      Akustikkomfort-Programmen.
+  BC-4940.60.40:
+    name: Subzähler und Mieterallokation
+    description: |
+      Betrieb von Subzählern und Mieter-Energieverbrauchsallokation.
+  BC-4940.70:
+    name: Immobilienbuchhaltung und Betriebsberichtswesen
+    description: |
+      Immobilien-Hauptbuch, Mieterabrechnung und Forderungen,
+      Verbindlichkeiten und Eigentümerberichtswesen.
+  BC-4940.70.10:
+    name: Immobilien-Hauptbuch-Betrieb
+    description: |
+      Betrieb des immobilienseitigen Hauptbuchs und Saldenbilanzen.
+  BC-4940.70.20:
+    name: Mieterabrechnung und Forderungen
+    description: |
+      Abrechnung von Miete, Erstattungen und Nebenkosten sowie
+      Einzug von Forderungen.
+  BC-4940.70.30:
+    name: Immobilien-Verbindlichkeitsbetrieb
+    description: |
+      Immobilienseitige Verbindlichkeiten für Energie, Anbieter und
+      Auftragnehmer.
+  BC-4940.70.40:
+    name: Eigentümerberichtspaket
+    description: |
+      Periodische Eigentümerberichtspakete mit Betriebsleistung
+      und Abweichungen.
+  BC-4940.80:
+    name: Nebenkosten-Abrechnung
+    description: |
+      Spezifischer Vermieter-Mieter-Abrechnungszyklus für Nebenkosten-
+      und Servicekostenbudgetierung, Erfassung, Abrechnung und
+      Mieterprüfungsreaktion.
+  BC-4940.80.10:
+    name: Nebenkosten-Budget und -Schätzung
+    description: |
+      Festlegung von Nebenkosten- und Servicekostenbudgets sowie
+      Mieter-Schätzungen für das Jahr.
+  BC-4940.80.20:
+    name: Nebenkosten-Ist-Ausgaben-Erfassung
+    description: |
+      Erfassung tatsächlicher erstattungsfähiger Ausgaben im Rahmen
+      von Nebenkosten- und Servicekostenkategorien.
+  BC-4940.80.30:
+    name: Nebenkosten-Abrechnung und -Abgleich
+    description: |
+      Abrechnung der Nebenkosten-Ist-Werte gegenüber Schätzungen und
+      Abgleich von Nachzahlungsbeträgen mit Mietern.
+  BC-4940.80.40:
+    name: Mieter-Nebenkostenprüfungsreaktion
+    description: |
+      Reaktion auf Mieter-Prüfungs- und Inspektionsanfragen zu
+      Nebenkosten- und Servicekostenrechten.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-property-operations-management.yaml
+++ b/catalogue/i18n/de/L1-property-operations-management.yaml
@@ -1,0 +1,179 @@
+locale: de
+source: L1-property-operations-management.yaml
+entries:
+  BC-4060:
+    name: Hotelbetrieb Management
+    description: |
+      Tagesbetrieb von Hotels, Resorts und Apartmenthotels –
+      Front-Office, Housekeeping, Haustechnik, Concierge,
+      Sicherheit, Nachhaltigkeit und Einhaltung von Marken- und Qualitätsstandards.
+    in_scope:
+      - Front-Office-Betrieb und Check-in/Check-out
+      - Housekeeping und Fundsachen
+      - Gebäudetechnik und Instandhaltung
+      - Concierge, Bell, Valet und Gästetransport
+      - Objektsicherheit, Brandschutz und Vorfallbehandlung
+      - Nachhaltigkeitsbetrieb auf Propertyebene
+      - Markenstandard-Audit und Qualitätskonformität
+    out_of_scope:
+      - Food & Beverage Betrieb (BC-4070)
+      - Gruppenblock- und Veranstaltungsausführung (BC-4110)
+      - Unternehmensweite Nachhaltigkeitsstrategie (BC-740)
+  BC-4060.10:
+    name: Front-Office-Betrieb
+    description: |
+      Betrieb des Front-Office einschließlich Ankunftsvorbereitung,
+      Check-in, Zimmerzuweisung, Check-out, Folioabrechnung und Schlüsselausgabe.
+  BC-4060.10.10:
+    name: Ankunftsvorbereitung
+    description: |
+      Vorbereitungsmaßnahmen vor der Ankunft einschließlich Ankunftsberichte,
+      Zimmerzuweisungen und Amenity-Vorbereitung.
+  BC-4060.10.20:
+    name: Check-in-Betrieb
+    description: |
+      Gäste-Check-in-Betrieb über Rezeption, Mobil- und Kiosksysteme.
+  BC-4060.10.30:
+    name: Zimmerzuweisung und Upgrade
+    description: |
+      Zimmerzuweisung und Upgrade-Entscheidungen einschließlich kostenpflichtiger und kostenloser Upgrades.
+  BC-4060.10.40:
+    name: Check-out und Folioabrechnung
+    description: |
+      Gäste-Check-out-Betrieb und Abrechnung des Property-Folios.
+  BC-4060.10.50:
+    name: Schlüssel- und Zugangsdatenausgabe
+    description: |
+      Ausgabe und Widerruf physischer und digitaler Zimmerschlüssel und Zugangsdaten.
+  BC-4060.20:
+    name: Housekeeping-Betrieb
+    description: |
+      Betrieb der Gästezimmerreinigung, Abend-Turn-down-Service,
+      Grundreinigung und Fundsachen.
+  BC-4060.20.10:
+    name: Täglicher Reinigungsbetrieb
+    description: |
+      Tägliche Reinigung von Bleib- und Abreisezimmern nach Propertystandards.
+  BC-4060.20.20:
+    name: Turn-down- und Bleibeservice
+    description: |
+      Turn-down- und Bleibeservice für anwesende Gäste.
+  BC-4060.20.30:
+    name: Grundreinigungs- und Außerbetriebnahme-Betrieb
+    description: |
+      Betrieb von Grundreinigungszyklen und Management außer Betrieb genommener Zimmer.
+  BC-4060.20.40:
+    name: Fundsachenregistrierung
+    description: |
+      Objekt-Fundsachenprotokollierung, -lagerung und Rückgabe an Gäste.
+  BC-4060.30:
+    name: Gebäudetechnik und Instandhaltung
+    description: |
+      Betriebs- und Instandhaltungsmaßnahmen einschließlich vorbeugender, reaktiver
+      Instandhaltung, Modernisierungsarbeiten und Konformitätsinspektionen.
+  BC-4060.30.10:
+    name: Vorbeugende Instandhaltung
+    description: |
+      Durchführung vorbeugender Instandhaltung nach Zeitplan und Zustandsdaten.
+  BC-4060.30.20:
+    name: Reaktive Instandhaltung
+    description: |
+      Durchführung reaktiver Instandhaltung aus Gästemeldungen und Inspektionsbefunden.
+  BC-4060.30.30:
+    name: Anlagenersatz und Modernisierung
+    description: |
+      Ersatz und Modernisierung von Propertyanlage in Zimmern, Publikumsbereichen und Back-of-House.
+  BC-4060.30.40:
+    name: Technikinspektionen
+    description: |
+      Konformitätsinspektionen für Brandschutzanlagen, Lebensrettungssysteme, Aufzüge und Drucksysteme.
+  BC-4060.40:
+    name: Concierge- und Gastdienste
+    description: |
+      Concierge-, Bell-, Valet- und Gästetransportdienste über die Gastereise hinweg.
+  BC-4060.40.10:
+    name: Concierge-Informations- und Buchungsdienste
+    description: |
+      Concierge-Dienste für Zielinformationen, Gastronomie- und Aktivitätsbuchungen.
+  BC-4060.40.20:
+    name: Bell- und Gepäckbetrieb
+    description: |
+      Bell- und Gepäckhandhabung einschließlich Lagerung und Lieferung.
+  BC-4060.40.30:
+    name: Valet-Parkplatzbetrieb
+    description: |
+      Valet-Parkdienste und Fahrzeughandhabung an Propertyeingängen.
+  BC-4060.40.40:
+    name: Gästetransportkoordination
+    description: |
+      Koordination des Gästebodentransports einschließlich Hotel-Shuttle und Fahrzeugbestellung.
+  BC-4060.50:
+    name: Objektsicherheits- und Sicherheitsbetrieb
+    description: |
+      Betrieb von Objektüberwachung, Brandschutz, Evakuierung
+      und Vorfallbehandlung vor Ort.
+  BC-4060.50.10:
+    name: Objektüberwachungsbetrieb
+    description: |
+      Überwachung öffentlicher und betrieblicher Räume einschließlich Monitoring und Überprüfung.
+  BC-4060.50.20:
+    name: Brand- und Lebensrettungssystembetrieb
+    description: |
+      Betrieb von Brand- und Lebensrettungssystemen einschließlich Übungen und Ausrüstungsbereitschaft.
+  BC-4060.50.30:
+    name: Notfallevakuierungsbetrieb
+    description: |
+      Ausführung von Notfallevakuierungen und Vorfallkommandooperationen vor Ort.
+  BC-4060.50.40:
+    name: Gastvorfallbehandlung
+    description: |
+      Behandlung von Gästesicherheits-, Diebstahl- und Sicherheitsvorfällen vor Ort.
+  BC-4060.60:
+    name: Objekt-Nachhaltigkeitsbetrieb
+    description: |
+      Propertyweiter Betrieb von Energie-, Wasser-, Abfall- und Wäscherwiederverwend-Programmen.
+    in_scope:
+      - Property-Messung und Verbrauchsüberwachung
+      - Propertyweite Wiederverwend- und Abfallprogramme
+    out_of_scope:
+      - Unternehmensweite Nachhaltigkeitsstrategie (BC-740)
+  BC-4060.60.10:
+    name: Property-Energiebetrieb
+    description: |
+      Betrieb von Property-Energiesystemen und Verbrauchsüberwachung gegen Ziele.
+  BC-4060.60.20:
+    name: Wasserstewardship-Betrieb
+    description: |
+      Stewardship des Property-Wasserverbrauchs einschließlich Leckerkennung und Wiederverwendungsmaßnahmen.
+  BC-4060.60.30:
+    name: Abfall- und Recyclingbetrieb
+    description: |
+      Betrieb von Property-Abfallsortierung, Recycling und Lebensmittelabfallprogrammen.
+  BC-4060.60.40:
+    name: Wäsche- und Handtuch-Wiederverwendungsprogramme
+    description: |
+      Betrieb von Wäsche- und Handtuch-Wiederverwendungsprogrammen und Gäste-Opt-in-Mechanismen.
+  BC-4060.70:
+    name: Objektqualitätsaudit und Markenstandards
+    description: |
+      Audit der Propertykonformität mit Marken- und Betriebsstandards,
+      Mystery-Guest-Programme und Serviceverbesserungsbetrieb.
+  BC-4060.70.10:
+    name: Markenstandard-Auditbetrieb
+    description: |
+      Audit der Propertykonformität mit Marken- und Betriebsstandards.
+  BC-4060.70.20:
+    name: Mystery-Guest-Programmbetrieb
+    description: |
+      Betrieb von Mystery-Guest-Programmen zur Bewertung der Gästeerfahrung.
+  BC-4060.70.30:
+    name: Serviceverbesserungsprotokollierung
+    description: |
+      Protokollierung von Serviceverbesserungsmaßnahmen einschließlich Kompensation und Nachverfolgung.
+  BC-4060.70.40:
+    name: Qualitätsverbesserungs-Abschluss
+    description: |
+      Abschluss von Audit- und Rückmeldbefunden gegen Qualitätsverbesserungspläne.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-public-benefits-entitlements-management.yaml
+++ b/catalogue/i18n/de/L1-public-benefits-entitlements-management.yaml
@@ -1,0 +1,144 @@
+locale: de
+source: L1-public-benefits-entitlements-management.yaml
+entries:
+  BC-3230:
+    name: Öffentliche Leistungen und Sozialleistungen
+    description: |
+      Design, Anspruchsbestimmung, Berechnung, Auszahlung, Monitoring und
+      Rückforderung sozialer Schutzleistungen und gesetzlicher Ansprüche
+      einschließlich Renten, Arbeitslosigkeit, Behinderung, Familie und Nahrungsmittelhilfe.
+  BC-3230.10:
+    name: Leistungsprogramm-Design und Konfiguration
+    description: |
+      Konfiguration gesetzlicher Leistungsprogramme einschließlich Anspruchsregeln,
+      Leistungsformeln und betrieblicher Parameter.
+    in_scope:
+      - Konfiguration von Anspruchsregeln
+      - Leistungsformel- und Satzfestlegung
+      - Programmparameter- und Indexierungsmanagement
+    out_of_scope:
+      - Ausarbeitung von Ermächtigungsgesetzen (durch Gesetzgebungs- und Regulierungsausarbeitungsmanagement abgedeckt)
+  BC-3230.10.10:
+    name: Anspruchsregeln-Konfiguration
+    description: |
+      Kodifizierung gesetzlicher Anspruchsregeln in maschinenausführbarer Form.
+  BC-3230.10.20:
+    name: Leistungsformel- und Satzkonfiguration
+    description: |
+      Konfiguration von Leistungsberechnungsformeln, Sätzen und Höchstgrenzen.
+  BC-3230.10.30:
+    name: Programmparameter-Indexierung
+    description: |
+      Periodische Indexierung und Anpassung von Programmparametern an Inflations- oder Lohnänderungen.
+  BC-3230.20:
+    name: Anspruchsbestimmung
+    description: |
+      Bestimmung der Antragstellerberichtigung für Leistungen einschließlich Bedürftigkeitsprüfung,
+      kategorischer Berechtigung und Haushaltszusammensetzung.
+  BC-3230.20.10:
+    name: Antragseingang
+    description: |
+      Eingang von Leistungsanträgen über Kanäle einschließlich digital, persönlich und unterstützt.
+  BC-3230.20.20:
+    name: Bedürftigkeitsprüfung
+    description: |
+      Einkommens-, Vermögens- und Haushaltsprüfung gegenüber Programmschwellen.
+  BC-3230.20.30:
+    name: Kategorische Anspruchsverifikation
+    description: |
+      Verifikation kategorischer Berechtigung wie Alter, Behinderung oder Familienstatus.
+  BC-3230.20.40:
+    name: Anspruchsentscheidung und Benachrichtigung
+    description: |
+      Entscheidungsaufzeichnung und Antragsteller-Benachrichtigung über Anspruchsergebnisse.
+  BC-3230.30:
+    name: Leistungsberechnung und Festsetzung
+    description: |
+      Berechnung von Festsetzungsbeträgen, Beitragsnachweisbeurteilung und
+      Ausstellung von Leistungsfeststellungen.
+  BC-3230.30.10:
+    name: Beitragsnachweis-Beurteilung
+    description: |
+      Beurteilung von Beitragsnachweisen für beitragsfinanzierte Leistungen wie Renten und Arbeitslosengeld.
+  BC-3230.30.20:
+    name: Festsetzungsberechnung
+    description: |
+      Berechnung von Festsetzungsbeträgen einschließlich Zuschläge, Abzüge und Auslaufzonen.
+  BC-3230.30.30:
+    name: Festsetzungsausstellung
+    description: |
+      Ausstellung und Aufzeichnung von Leistungsfeststellungen und Feststellungsbescheiden.
+  BC-3230.40:
+    name: Leistungsauszahlungsbetrieb
+    description: |
+      Periodische Auszahlung von Leistungszahlungen über Zahlungskanäle und
+      Abgleich gegenüber Festsetzungen.
+  BC-3230.40.10:
+    name: Zahlungsplan-Management
+    description: |
+      Pflege von Zahlungsplänen, -häufigkeiten und Laufkalendern.
+  BC-3230.40.20:
+    name: Zahlungsausführung
+    description: |
+      Ausführung von Zahlungsläufen über Bank-, Prepaid-Karten-, Scheck- und Sachleistungskanäle.
+  BC-3230.40.30:
+    name: Zahlungsabgleich
+    description: |
+      Abgleich von Auszahlungen gegenüber Festsetzungen und Bankbestätigungen.
+  BC-3230.40.40:
+    name: Sachleistungsverteilung
+    description: |
+      Verteilung von Sachleistungen wie Nahrungsmittelhilfegutscheinen und elektronischen Leistungsüberweisungen.
+  BC-3230.50:
+    name: Empfänger-Monitoring und Daueranspruch
+    description: |
+      Laufendes Monitoring der Empfängerumstände und periodische
+      Neubestimmung des Daueranspruchs.
+  BC-3230.50.10:
+    name: Umstandsänderungs-Erfassung
+    description: |
+      Erfassung und Verarbeitung vom Empfänger gemeldeter und erkannter Umstandsänderungen.
+  BC-3230.50.20:
+    name: Periodische Neubestimmung
+    description: |
+      Periodische Neubestimmung von Berechtigung und Festsetzungshöhe.
+  BC-3230.50.30:
+    name: Konditionalitäts- und Compliance-Monitoring
+    description: |
+      Monitoring der Empfänger-Compliance mit Konditionalität wie Jobsuche oder Schulungsanforderungen.
+  BC-3230.60:
+    name: Überzahlungs- und Rückforderungsmanagement
+    description: |
+      Erkennung, Berechnung und Rückforderung von Leistungsüberzahlungen und
+      unberechtigen Zahlungen.
+  BC-3230.60.10:
+    name: Überzahlungs-Erkennung
+    description: |
+      Erkennung von Überzahlungen durch Abgleich, Datenabgleich und Überprüfungen.
+  BC-3230.60.20:
+    name: Rückzahlungsplan-Einrichtung
+    description: |
+      Einrichtung von Rückzahlungsplänen einschließlich Raten, Abzüge und Abschreibungen.
+  BC-3230.60.30:
+    name: Schuldeninkasso-Betrieb
+    description: |
+      Einziehung rückforderbarer Schulden durch Abzüge, zivilrechtliche Maßnahmen und Verrechnungen.
+  BC-3230.70:
+    name: Leistungsbetrugs-Untersuchung
+    description: |
+      Erkennung, Untersuchung und Behandlung von Leistungsbetrugsfällen.
+  BC-3230.70.10:
+    name: Betrugrisiko-Erkennung
+    description: |
+      Risikobasierte Erkennung mutmaßlichen Betrugs durch Analytik und Nachrichtendienste.
+  BC-3230.70.20:
+    name: Betrugsfall-Untersuchung
+    description: |
+      Untersuchung mutmaßlicher Betrugsfälle einschließlich Beweiserhebung und Interviews.
+  BC-3230.70.30:
+    name: Betrugs-Sanktionierung und Überweisung
+    description: |
+      Sanktionierung bestätigten Betrugs und Überweisung zur Strafverfolgung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-public-finance-budget-management.yaml
+++ b/catalogue/i18n/de/L1-public-finance-budget-management.yaml
@@ -1,0 +1,140 @@
+locale: de
+source: L1-public-finance-budget-management.yaml
+entries:
+  BC-3280:
+    name: Öffentliche Finanzen und Haushalt
+    description: |
+      Öffentliche Haushaltsaufstellung, Mittelausführung, staatliche Fondsbuchhaltung,
+      Staatsverschuldungsmanagement, Schatzamt-Operationen und IPSAS-konforme
+      fiskalische Berichterstattung und Offenlegung.
+  BC-3280.10:
+    name: Haushaltsaufstellung
+    description: |
+      Erstellung jährlicher und mehrjähriger Haushalte einschließlich Obergrenzen,
+      Programmhaushaltsaufstellung und Einreichung bei der gesetzgebenden Körperschaft.
+    in_scope:
+      - Makrofiskalische Prognose
+      - Programmhaushaltsaufstellung und Null-Basis-Budgetierung
+      - Haushaltseinreichung bei der Gesetzgebung
+    out_of_scope:
+      - Unternehmens-FP&A und Management Accounting (durch Finanzplanung und Analyse abgedeckt)
+  BC-3280.10.10:
+    name: Makrofiskalische Prognose
+    description: |
+      Prognose von Einnahmen- und Ausgaben-Aggregaten und makrofiskalischen Szenarien.
+  BC-3280.10.20:
+    name: Haushaltsobergrenzen-Festlegung
+    description: |
+      Festlegung von Behörden- und Programm-Haushaltsobergrenzen innerhalb des Fiskalrahmens.
+  BC-3280.10.30:
+    name: Programmhaushalt-Vorbereitung
+    description: |
+      Vorbereitung von Programm- und Leistungshaushalten durch Ausgabenbehörden.
+  BC-3280.10.40:
+    name: Haushaltseinreichung an Gesetzgebung
+    description: |
+      Zusammenstellung und Einreichung des Exekutivhaushalts an die Gesetzgebung.
+  BC-3280.20:
+    name: Mittelausführung
+    description: |
+      Zuteilung, Aufteilung, Bindung, Verpflichtung und Auszahlung
+      bewilligter Mittel gemäß Haushaltsrecht.
+  BC-3280.20.10:
+    name: Mittelzuteilung und Aufteilung
+    description: |
+      Aufteilung und Zuteilung von Mitteln an Ausgabenbehörden.
+  BC-3280.20.20:
+    name: Mittelbindung und Verpflichtungserfassung
+    description: |
+      Erfassung von Mittelbindungen und Verpflichtungen gegen Bewilligungen.
+  BC-3280.20.30:
+    name: Ausgaben- und Auszahlungsverarbeitung
+    description: |
+      Verarbeitung von Ausgaben und Auszahlungen gegen verpflichtete Mittel.
+  BC-3280.20.40:
+    name: Umschichtung und Übertragungsbefugnis
+    description: |
+      Verwaltung von Umschichtungen, Übertragungen und gesetzlichen Befugnisanpassungen.
+  BC-3280.30:
+    name: Staatliche Fondsbuchhaltung
+    description: |
+      Buchhaltung für staatliche Fonds einschließlich Allgemeiner Fonds, Sonderfonds,
+      Treuhandfonds und Revolving Funds nach IPSAS oder nationalen Äquivalenten.
+  BC-3280.30.10:
+    name: Fondsstruktur-Pflege
+    description: |
+      Pflege staatlicher Fondsstrukturen und Kontenrahmen.
+  BC-3280.30.20:
+    name: Fonds-Buchhaltung
+    description: |
+      Buchung und Abgleich von Transaktionen über Allgemeine, Sonder-, Treuhand- und Revolving Funds.
+  BC-3280.30.30:
+    name: Behördenübergreifende Abrechnung
+    description: |
+      Abrechnung und Abgleich behördenübergreifender Transfers und erstattungsfähiger Vereinbarungen.
+  BC-3280.40:
+    name: Staatsverschuldungsmanagement
+    description: |
+      Ausgabe, Bedienung und Risikomanagement staatlicher und substaatlicher
+      Schuldinstrumente.
+  BC-3280.40.10:
+    name: Schuldenstrategie und Ausgabeplanung
+    description: |
+      Festlegung der Schuldenstrategie und Ausgabekalender über Instrumente und Laufzeiten.
+  BC-3280.40.20:
+    name: Schuldenausgabe-Operationen
+    description: |
+      Auktion, Syndizierung und Direktausgabe staatlicher Schuldinstrumente.
+  BC-3280.40.30:
+    name: Schuldendienst
+    description: |
+      Kupon-, Zins- und Tilgungsrückzahlungen an Schuldner.
+  BC-3280.40.40:
+    name: Schuldenportfolio-Risikomanagement
+    description: |
+      Management von Währungs-, Zinssatz- und Refinanzierungsrisiken im Schuldenportfolio.
+  BC-3280.50:
+    name: Kassenhaltung und Schatzamt-Operationen
+    description: |
+      Staatliche Kassenverwaltung, Einheitskassenbetrieb und
+      Zahlungs- und Einnahmenverarbeitung für Behörden.
+  BC-3280.50.10:
+    name: Kassenprognose
+    description: |
+      Tägliche und rollende Prognose staatlicher Kassenströme.
+  BC-3280.50.20:
+    name: Einheitskasse-Betrieb
+    description: |
+      Betrieb von Einheitskasse und konsolidierten Bankarrangements.
+  BC-3280.50.30:
+    name: Staatliche Zahlungs-Operationen
+    description: |
+      Auszahlung staatlicher Zahlungen im Namen von Ausgabenbehörden.
+  BC-3280.50.40:
+    name: Staatliche Einnahmen-Verarbeitung
+    description: |
+      Verarbeitung eingehender staatlicher Einnahmen und Gutschriften an Behörden.
+  BC-3280.60:
+    name: Fiskalische Berichterstattung und Offenlegung
+    description: |
+      Unterjährige und Jahresend-Fiskalberichte, IPSAS-Abschlüsse und
+      COFOG/GFSM-Statistikberichterstattung.
+  BC-3280.60.10:
+    name: Unterjährige Fiskalberichterstattung
+    description: |
+      Erstellung monatlicher und quartalsweiser Fiskalberichte gegenüber dem Haushalt.
+  BC-3280.60.20:
+    name: IPSAS-Abschlusserstellung
+    description: |
+      Erstellung gesamtstaatlicher und Einzel-IPSAS-Abschlüsse.
+  BC-3280.60.30:
+    name: GFSM- und COFOG-Statistikberichterstattung
+    description: |
+      Zusammenstellung fiskalischer Statistiken nach IWF-GFSM- und COFOG-Klassifikationen.
+  BC-3280.60.40:
+    name: Open-Spending-Offenlegung
+    description: |
+      Open-Data-Veröffentlichung von Ausgaben, Transaktionen und Haushaltsausführung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-public-policy-management.yaml
+++ b/catalogue/i18n/de/L1-public-policy-management.yaml
@@ -1,0 +1,136 @@
+locale: de
+source: L1-public-policy-management.yaml
+entries:
+  BC-3200:
+    name: Öffentliche Politik und Staatliche Richtlinien
+    description: |
+      Formulierung, Analyse, Entscheidungsunterstützung, Implementierungskoordination und
+      Evaluierung öffentlicher Politik über den Politikzyklus hinweg, verankert in Evidenz,
+      Stakeholder-Konsultation und Folgenabschätzung.
+  BC-3200.10:
+    name: Politische Agenda-Festlegung
+    description: |
+      Identifikation, Priorisierung und Mandatseingang von Politikthemen,
+      die staatliche Aufmerksamkeit erfordern.
+    in_scope:
+      - Themenidentifikation und Zukunftsscanning
+      - Ministerielle und politische Mandatsaufnahme
+      - Politikpriorisierung und Agenda-Management
+    out_of_scope:
+      - Erstellung von Gesetzen oder Verordnungen (durch Gesetzgebungs- und Regulierungsausarbeitungsmanagement abgedeckt)
+      - Kabinetsentscheidungsausführung (durch Politikentscheidungsunterstützung abgedeckt)
+  BC-3200.10.10:
+    name: Politikthemen-Identifikation
+    description: |
+      Identifikation aufkommender Themen und Politikprobleme durch Zukunftsscanning und Stakeholder-Signale.
+  BC-3200.10.20:
+    name: Politisches Mandatsaufnahme
+    description: |
+      Erfassung und Strukturierung politischer und ministerieller Mandate in Politikarbeitsprogramme.
+  BC-3200.10.30:
+    name: Politikpriorisierung
+    description: |
+      Priorisierung konkurrierender Politikthemen nach Kapazität, Dringlichkeit und Regierungsverpflichtungen.
+  BC-3200.20:
+    name: Politikoptionsanalyse
+    description: |
+      Evidenzüberprüfung, Modellierung und vergleichende Analyse von Politikoptionen
+      einschließlich Kosten, Auswirkungen und Machbarkeit.
+    in_scope:
+      - Evidenz- und Literaturüberprüfung
+      - Kosten-Nutzen- und Wirtschaftsmodellierung
+      - Vergleichende Optionsbewertung
+      - Verteilungs- und Gleichstellungsanalyse
+    out_of_scope:
+      - Regulierungsfolgenabschätzung für Entwurfsinstrumente (durch Gesetzgebungs- und Regulierungsausarbeitungsmanagement abgedeckt)
+  BC-3200.20.10:
+    name: Evidenz- und Literaturüberprüfung
+    description: |
+      Systematische Sammlung und Synthese von Evidenz zur Information von Politikoptionen.
+  BC-3200.20.20:
+    name: Politikmodellierung und Prognose
+    description: |
+      Quantitative Modellierung, Mikrosimulation und Prognose von Politikergebnissen.
+  BC-3200.20.30:
+    name: Optionsbewertung
+    description: |
+      Vergleichende Bewertung von Politikoptionen gegenüber Zielen und Einschränkungen.
+  BC-3200.20.40:
+    name: Verteilungs- und Gleichstellungsanalyse
+    description: |
+      Analyse von Verteilungseffekten und Gleichstellungsauswirkungen über Bevölkerungsgruppen.
+  BC-3200.30:
+    name: Stakeholder- und Öffentlichkeitsbeteiligung
+    description: |
+      Design, Durchführung und Analyse von Konsultationen mit Stakeholdern, der
+      Öffentlichkeit und zwischenstaatlichen Partnern zu Politikvorschlägen.
+  BC-3200.30.10:
+    name: Konsultations-Design
+    description: |
+      Design von Konsultationsstrategien, -instrumenten und Reichweitenplänen.
+  BC-3200.30.20:
+    name: Konsultations-Durchführung
+    description: |
+      Betrieb von Konsultationskanälen einschließlich Online-Portale, Anhörungen und Workshops.
+  BC-3200.30.30:
+    name: Konsultationsantwort-Analyse
+    description: |
+      Kodierung, Analyse und Synthese von Konsultationsantworten.
+  BC-3200.30.40:
+    name: Zwischenstaatliche Koordination
+    description: |
+      Koordination mit subnationalen und internationalen Partnern zu gemeinsamer Politik.
+  BC-3200.40:
+    name: Politikentscheidungsunterstützung
+    description: |
+      Erstellung von Kabinetts-, Ministeriums- und Exekutiv-Entscheidungsartefakten
+      einschließlich Briefings, Entscheidungsvorlagen und Empfehlungen.
+  BC-3200.40.10:
+    name: Briefing-Vorbereitung
+    description: |
+      Vorbereitung ministerieller und exekutiver Briefings zu Politikfragen.
+  BC-3200.40.20:
+    name: Kabinettsvorlage-Management
+    description: |
+      Entwurf und Koordination von Kabinetts-, Exekutiv- oder Ratsvorlagen.
+  BC-3200.40.30:
+    name: Entscheidungsaufzeichnung und Kommunikation
+    description: |
+      Aufzeichnung von Entscheidungen, Weitergabe von Ergebnissen und Beauftragung umsetzender Stellen.
+  BC-3200.50:
+    name: Politikimplementierungs-Koordination
+    description: |
+      Koordination behördenübergreifender Politikimplementierung einschließlich Programmdesign,
+      Sequenzierung und Umsetzungsaufsicht.
+  BC-3200.50.10:
+    name: Implementierungsplanung
+    description: |
+      Umwandlung von Politikentscheidungen in Implementierungspläne, Meilensteine und Verantwortlichkeiten.
+  BC-3200.50.20:
+    name: Behördenübergreifende Koordination
+    description: |
+      Koordination umsetzender Behörden und gemeinsamer Liefervereinbarungen.
+  BC-3200.50.30:
+    name: Implementierungs-Tracking
+    description: |
+      Tracking des Politikimplementierungsfortschritts gegenüber Verpflichtungen und Fristen.
+  BC-3200.60:
+    name: Politikevaluierung und Überprüfung
+    description: |
+      Ex-post-Evaluierung, Sunset- und Nachimplementierungsüberprüfungen sowie
+      Rückkopplung in den Politikzyklus.
+  BC-3200.60.10:
+    name: Ergebnis- und Wirkungsevaluierung
+    description: |
+      Evaluierung von Politikergebnissen und -wirkungen gegenüber beabsichtigten Zielen.
+  BC-3200.60.20:
+    name: Sunset- und Nachimplementierungsüberprüfung
+    description: |
+      Gesetzliche und diskretionäre Überprüfungen von Politiken und Instrumenten in definierten Abständen.
+  BC-3200.60.30:
+    name: Lektionen-Erfassung
+    description: |
+      Erfassung und Verbreitung gewonnener Erkenntnisse für künftige Politikzyklen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-public-procurement-contracting-management.yaml
+++ b/catalogue/i18n/de/L1-public-procurement-contracting-management.yaml
@@ -1,0 +1,170 @@
+locale: de
+source: L1-public-procurement-contracting-management.yaml
+entries:
+  BC-3270:
+    name: Öffentliche Beschaffung und Auftragsvergabe
+    description: |
+      Öffentliche Beschaffung und Auftragsvergabe nach FAR/DFARS- und EU-Vergaberichtlinien-Regimen
+      einschließlich Beschaffungsplanung, Ausschreibung, Quellenauswahl, Vertragsabschluss und
+      -administration, Lieferantenleistung, Einsprüche und sozio-ökonomische Programme.
+  BC-3270.10:
+    name: Beschaffungsplanung
+    description: |
+      Beschaffungsstrategie-Formulierung, Marktforschung und Planung
+      öffentlicher Beschaffungen.
+    in_scope:
+      - Marktforschung und Bedarfskonsolidierung
+      - Beschaffungsstrategie und Methodenauswahl
+      - Unabhängige staatliche Kostenschätzung
+    out_of_scope:
+      - Branchenübergreifende Einkaufsstrategie für nicht-staatliche Beschaffung (durch Beschaffungsmanagement abgedeckt)
+  BC-3270.10.10:
+    name: Marktforschung
+    description: |
+      Marktforschung zu Lieferantenbasis, Kapazität und Preisgestaltung für den Bedarf.
+  BC-3270.10.20:
+    name: Beschaffungsstrategie
+    description: |
+      Auswahl von Vertragsart, Instrument und Wettbewerbsansatz.
+  BC-3270.10.30:
+    name: Unabhängige Kostenschätzung
+    description: |
+      Erstellung unabhängiger staatlicher Kostenschätzungen und Budgetreservierungen.
+  BC-3270.10.40:
+    name: Spezifikations- und Leistungsbeschreibungs-Entwicklung
+    description: |
+      Entwicklung von Spezifikationen, Leistungsbeschreibungen und Performance-Work-Statements.
+  BC-3270.20:
+    name: Ausschreibungsmanagement
+    description: |
+      Ausstellung von Ausschreibungen einschließlich Aufforderungs-, Angebotsanforderungs- und
+      Preisanfrageunterlagen, Änderungen und Bieterfragen.
+  BC-3270.20.10:
+    name: Ausschreibungsausarbeitung
+    description: |
+      Ausarbeitung von Aufforderungs-, Angebotsanforderungs- und Preisanfrageunterlagen.
+  BC-3270.20.20:
+    name: Ausschreibungsveröffentlichung
+    description: |
+      Veröffentlichung von Ausschreibungen auf amtlichen Bekanntmachungssystemen und OJEU/SAM.gov-Äquivalenten.
+  BC-3270.20.30:
+    name: Bieter-Fragenbearbeitung
+    description: |
+      Bearbeitung von Bieterfragen, Änderungen und Klarstellungen während der Ausschreibung.
+  BC-3270.20.40:
+    name: Vorvergabe-Konferenz
+    description: |
+      Durchführung von Vorvergabe-Konferenzen und Ortsbegehungen.
+  BC-3270.30:
+    name: Quellenauswahl und Bewertung
+    description: |
+      Eingang, Bewertung und Auswahl von Angeboten und Vorschlägen gegenüber
+      veröffentlichten Kriterien.
+  BC-3270.30.10:
+    name: Angebots- und Vorschlagseingang
+    description: |
+      Eingang, Registrierung und Sicherung von Angeboten und Vorschlägen.
+  BC-3270.30.20:
+    name: Technische Bewertung
+    description: |
+      Technische Bewertung von Vorschlägen gegenüber angegebenen Kriterien.
+  BC-3270.30.30:
+    name: Preis- und Kostenanalyse
+    description: |
+      Preisangemessenheits- und Kostrealismusanalyse von Angeboten.
+  BC-3270.30.40:
+    name: Zuverlässigkeitsbestimmung
+    description: |
+      Bestimmung der Auftragnehmer-Zuverlässigkeit, Finanzkraft und Integrität.
+  BC-3270.40:
+    name: Vertragsabschluss und Vertragsbildung
+    description: |
+      Auswahlentscheidung, Vergabe-Benachrichtigung, Nachbesprechung und
+      Vertragsbildung einschließlich Unterzeichnung.
+  BC-3270.40.10:
+    name: Auswahlentscheidung
+    description: |
+      Vergabeentscheidung und Quellenauswahl-Entscheidungsdokumentation.
+  BC-3270.40.20:
+    name: Vergabe-Bekanntmachung und Nachbesprechung
+    description: |
+      Vergabe-Bekanntmachung, Unterlegenen-Benachrichtigung und Nachbesprechung.
+  BC-3270.40.30:
+    name: Vertragsunterzeichnung und Mittelbindung
+    description: |
+      Ausführung von Vertragsunterlagen und Mittelbindung.
+  BC-3270.50:
+    name: Vertragsadministration und Vertragsänderungen
+    description: |
+      Tägliche Vertragsadministration einschließlich Änderungen, Ansprüche
+      und Vergabeoffizier-Aufsicht.
+  BC-3270.50.10:
+    name: Leistungsabnahme
+    description: |
+      Inspektion und Abnahme von Leistungen gegenüber Vertragsanforderungen.
+  BC-3270.50.20:
+    name: Vertragsänderung
+    description: |
+      Ausstellung von Vertragsänderungen, Änderungsaufträgen und Optionsausübungen.
+  BC-3270.50.30:
+    name: Vertragsanspruchs-Bearbeitung
+    description: |
+      Eingang und Entscheidung über Auftragnehmer-Ansprüche und angemessene Anpassungen.
+  BC-3270.50.40:
+    name: Vertragsabschluss
+    description: |
+      Endabnahme, Mittelfreigabe und physischer sowie administrativer Abschluss.
+  BC-3270.60:
+    name: Lieferanten-Leistungsmanagement
+    description: |
+      Vergabe-Leistungserfassung, Ausschluss und Sperrung sowie Auftragnehmer-
+      Zuverlässigkeits-Tracking.
+  BC-3270.60.10:
+    name: Vergabe-Leistungserfassung
+    description: |
+      Aufzeichnung von Auftragnehmer-Vergabe-Leistungsbewertungen in staatliche Datenbanken.
+  BC-3270.60.20:
+    name: Sperrung und Ausschluss-Verwaltung
+    description: |
+      Verwaltung von Sperrungs- und Ausschlussverfahren gegen Auftragnehmer.
+  BC-3270.60.30:
+    name: Auftragnehmer-Zuverlässigkeits-Monitoring
+    description: |
+      Laufendes Monitoring der Auftragnehmer-Zuverlässigkeit und Finanzkraft.
+  BC-3270.70:
+    name: Einspruchs- und Streitbearbeitung
+    description: |
+      Eingang und Bearbeitung von Angebotseinsprüchen und Vertragsstreitigkeiten
+      über verwaltungs- und rechtliche Kanäle.
+  BC-3270.70.10:
+    name: Angebotseinspruchs-Bearbeitung
+    description: |
+      Bearbeitung von Vor- und Nachvergabe-Angebotseinsprüchen.
+  BC-3270.70.20:
+    name: Vertragsstreitbeilegung
+    description: |
+      Verwaltungs- und gerichtliche Beilegung von Vertragsstreitigkeiten.
+  BC-3270.70.30:
+    name: Alternative Streitbeilegung
+    description: |
+      Mediation, Schiedsverfahren und ADR für Vertragsstreitigkeiten.
+  BC-3270.80:
+    name: Vergabevorbehalt und Sozio-ökonomische Programmverwaltung
+    description: |
+      Verwaltung von Kleinunternehmen-, Minderheits-, Frauen- und anderen
+      sozio-ökonomischen Beschaffungspräferenzen und -zielen.
+  BC-3270.80.10:
+    name: Vergabevorbehalt-Bestimmung
+    description: |
+      Bestimmung der Anwendbarkeit von Kleinunternehmen- und sozio-ökonomischen Vergabevorbehalten.
+  BC-3270.80.20:
+    name: Unterauftrag-Plan-Aufsicht
+    description: |
+      Aufsicht über Kleinunternehmen-Unterauftrag-Pläne und -Berichte.
+  BC-3270.80.30:
+    name: Sozio-ökonomische Ziel-Berichterstattung
+    description: |
+      Tracking und Berichterstattung über sozio-ökonomische Beschaffungsziele und Errungenschaften.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-public-safety-emergency-operations-management.yaml
+++ b/catalogue/i18n/de/L1-public-safety-emergency-operations-management.yaml
@@ -1,0 +1,161 @@
+locale: de
+source: L1-public-safety-emergency-operations-management.yaml
+entries:
+  BC-3310:
+    name: Öffentliche Sicherheit und Notfallbetrieb
+    description: |
+      Öffentliche Sicherheit und Notfallbetrieb einschließlich Notfallkommunikation
+      und -leitstelle, Polizei-, Feuerwehr- und Rettungsdienst-Feldeinsatz,
+      NIMS-konforme Einsatzleitung, Katastrophenvorsorge und -bewältigung,
+      Ermittlungen der öffentlichen Sicherheit und Gegenseitigkeitshilfe.
+  BC-3310.10:
+    name: Notfallkommunikation und Leitstelle
+    description: |
+      Entgegennahme von Notrufen, computergestützte Einsatzleitung und
+      Funkkommunikation für Polizei-, Feuerwehr- und Rettungsdienst-Einsatzkräfte.
+    in_scope:
+      - 911/112/999-Notrufannahme
+      - Computergestützte Einsatzleitung
+      - Behördenfunk-Betrieb
+    out_of_scope:
+      - Telekommunikations-Universaldienstpflicht-Regime (durch Telekommunikations-Regulierungscompliance abgedeckt)
+  BC-3310.10.10:
+    name: Notrufannahme
+    description: |
+      Entgegennahme und Triage von Notrufen und Notfall-SMS-Nachrichten.
+  BC-3310.10.20:
+    name: Computergestützte Einsatzleitung
+    description: |
+      CAD-basierte Alarmierung von Polizei-, Feuerwehr- und Rettungsdiensteinheiten zu Einsätzen.
+  BC-3310.10.30:
+    name: Behördenfunk-Betrieb
+    description: |
+      Betrieb von Behördenfunk-Mobilfunknetzen und FirstNet-äquivalentem Breitband.
+  BC-3310.10.40:
+    name: Öffentliche Warn- und Alarmierung
+    description: |
+      Ausgabe öffentlicher Warnungen über WEA, Cell Broadcast, EAS, Sirenen und andere Kanäle.
+  BC-3310.20:
+    name: Feldeinsatz-Betrieb
+    description: |
+      Tägliche Feldeinsätze von Polizei-, Feuerwehr- und Rettungsdienst-Ersthelfern.
+  BC-3310.20.10:
+    name: Strafverfolgungsstreife
+    description: |
+      Routinemäßiger und proaktiver Polizeistreifendienst und Einsatzreaktion.
+  BC-3310.20.20:
+    name: Brandbekämpfung und Rettung
+    description: |
+      Brandbekämpfung, Rettungsoperationen und Gefahrstoff-Einsätze.
+  BC-3310.20.30:
+    name: Rettungsdienst-Einsatzreaktion
+    description: |
+      Prähospitale Notfallbewertung, Behandlung und Krankentransport.
+  BC-3310.20.40:
+    name: Spezialisierter Taktischer Einsatz
+    description: |
+      Spezialisierte taktische, Bombenentschärfungs- und Gefahrstoff-Einsatzoperationen.
+  BC-3310.30:
+    name: Einsatzleitung und -koordination
+    description: |
+      NIMS/ICS-konforme Einsatzleitung, behördenübergreifende Koordination
+      und Betrieb von Notfallzentralen.
+  BC-3310.30.10:
+    name: Einsatzleitung-Einrichtung
+    description: |
+      Einrichtung von Einsatzleitung, gemeinsamer Einsatzleitung und ICS-Strukturen.
+  BC-3310.30.20:
+    name: Behördenübergreifende Koordination
+    description: |
+      Koordination über reagierende Behörden und Gebietskörperschaften während Einsätzen.
+  BC-3310.30.30:
+    name: Notfallzentrale-Betrieb
+    description: |
+      Betrieb von Notfallzentralen auf lokaler, Landes- und nationaler Ebene während Notlagen.
+  BC-3310.30.40:
+    name: Gemeinsames Lagebild-Pflege
+    description: |
+      Pflege eines gemeinsamen behördenübergreifenden Lagebildes.
+  BC-3310.40:
+    name: Katastrophenvorsorge und Schadensbegrenzung
+    description: |
+      Gefahrenanalyse, Planung, Übungen, Ausbildung und Schadensbegrenzungsmaßnahmen
+      zur Katastrophenvorsorge nach dem Sendai-Rahmen.
+  BC-3310.40.10:
+    name: Gefahren- und Risikoanalyse
+    description: |
+      Identifikation und Bewertung natürlicher und durch Menschen verursachter Gefahren und Risiken.
+  BC-3310.40.20:
+    name: Notfallplanung
+    description: |
+      Erstellung von Notfalleinsatzplänen, gefahrenspezifischen Plänen und Kontinuitätsregelungen.
+  BC-3310.40.30:
+    name: Übungen und Ausbildung
+    description: |
+      Stabsrahmenübungen, Funktionsübungen und Vollschutzübungen sowie Einsatzkräfte-Ausbildungsprogramme.
+  BC-3310.40.40:
+    name: Schadensbegrenzungsprogramm-Verwaltung
+    description: |
+      Verwaltung baulicher und nichtbaulicher Katastrophen-Schadensbegrenzungsprogramme.
+  BC-3310.50:
+    name: Katastrophenbewältigung und Wiederaufbau
+    description: |
+      Katastrophenerklärung, Einsatzoperationen, Einzel- und Gemeinschaftshilfe
+      sowie langfristige Wiederaufbaukoordination.
+  BC-3310.50.10:
+    name: Katastrophenerklärung und Aktivierung
+    description: |
+      Ausrufung des Notstands und Aktivierung von Einsatzbefugnissen.
+  BC-3310.50.20:
+    name: Einzelhilfe-Verwaltung
+    description: |
+      Verwaltung von Katastrophenhilfe für betroffene Einzelpersonen und Haushalte.
+  BC-3310.50.30:
+    name: Öffentliche Hilfe-Verwaltung
+    description: |
+      Verwaltung öffentlicher Hilfsmittel für Trümmerbeseitigung, Infrastruktur und Soforthilfemaßnahmen.
+  BC-3310.50.40:
+    name: Langfristige Wiederaufbaukoordination
+    description: |
+      Koordination des langfristigen Wiederaufbaus und nachhaltiger Aufbaumaßnahmen.
+  BC-3310.60:
+    name: Ermittlungen der Öffentlichen Sicherheit
+    description: |
+      Kriminal- und Sicherheitsermittlungen einschließlich Beweismittelverwaltung,
+      Nachrichtendienstarbeit und Strafverfolgungsvorbereitung.
+  BC-3310.60.10:
+    name: Tatort-Untersuchung
+    description: |
+      Tatortbegehung und forensische Beweissicherung.
+  BC-3310.60.20:
+    name: Ermittlungsfall-Management
+    description: |
+      Ermittlungsfall-Management, Tatverdächtigen-Tracking und Strafverfolgungsvorbereitung.
+  BC-3310.60.30:
+    name: Polizeilicher Nachrichtendienst-Betrieb
+    description: |
+      Erfassung, Analyse und Weitergabe polizeilicher Nachrichtendienstinformationen im Rahmen des Erkenntnisorientierten Polizierens.
+  BC-3310.60.40:
+    name: Beweismittel- und Asservaten-Verwaltung
+    description: |
+      Verwahrung, Beweismittelkette und Entsorgung sichergestellter Beweismittel und Vermögenswerte.
+  BC-3310.70:
+    name: Notfallressourcen- und Gegenseitigkeitshilfe-Verwaltung
+    description: |
+      Typisierung, Einsatz und Verwaltung von Gegenseitigkeitshilfevereinbarungen
+      für Notfallressourcen über Gebietskörperschaften.
+  BC-3310.70.10:
+    name: Ressourcentypisierung und Inventar
+    description: |
+      NIMS-konforme Typisierung und Bestandsführung von Notfallressourcen.
+  BC-3310.70.20:
+    name: Gegenseitigkeitshilfevereinbarungs-Verwaltung
+    description: |
+      Verwaltung intra- und interjurisdiktioneller Gegenseitigkeitshilfevereinbarungen.
+  BC-3310.70.30:
+    name: Ressourceneinsatz und Demobilisierung
+    description: |
+      Einsatz, Tracking und Demobilisierung von Notfallressourcen bei Einsätzen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-quality-management.yaml
+++ b/catalogue/i18n/de/L1-quality-management.yaml
@@ -1,0 +1,130 @@
+locale: de
+source: L1-quality-management.yaml
+entries:
+  BC-720:
+    name: Qualitätsmanagement
+    description: |
+      Qualitätsstrategie, -sicherung und -kontrolle über alle Unternehmensleistungen.
+  BC-720.10:
+    name: Qualitätsstrategie- und Richtlinienmanagement
+    description: |
+      Qualitätsrichtlinie, Standards und Rahmenwerk.
+  BC-720.10.10:
+    name: Qualitätsrichtlinien- und Handbuchmanagement
+    description: |
+      Qualitätshandbuch und Richtlinien im Einklang mit ISO 9001 und Branchenstandards.
+  BC-720.10.20:
+    name: Qualitätszielsetzung
+    description: |
+      Definition von Qualitätszielen, KPIs und Sollwerten.
+  BC-720.10.30:
+    name: Qualitätsmanagementsystem-Steuerung
+    description: |
+      Steuerung von QMS-Umfang, -Struktur und -Verantwortlichkeiten.
+  BC-720.10.40:
+    name: Qualitätsrisikomanagement
+    description: |
+      Qualitätsrisikoidentifikation, -bewertung und -behandlung.
+  BC-720.20:
+    name: Qualitätssicherungsmanagement
+    description: |
+      Qualitätssysteme, Audits und Zertifizierung (ISO 9001 usw.).
+  BC-720.20.10:
+    name: Interne Qualitätsaudits
+    description: |
+      Planung und Durchführung interner Qualitätsaudits.
+  BC-720.20.20:
+    name: Externe Zertifizierungsverwaltung
+    description: |
+      Verwaltung von ISO-9001- und anderen Zertifizierungen und Überwachungsaudits.
+  BC-720.20.30:
+    name: Prozessvalidierung und -qualifizierung
+    description: |
+      Validierung und Qualifizierung von Prozessen und Anlagen.
+  BC-720.20.40:
+    name: Dokument- und Aufzeichnungslenkung
+    description: |
+      Lenkung von Dokumenten, Aufzeichnungen und Qualitätsarchiv.
+  BC-720.30:
+    name: Qualitätskontrollmanagement
+    description: |
+      Inspektionen, Prüfungen und Annahmekriterien.
+  BC-720.30.10:
+    name: Inspektionsplanung
+    description: |
+      Inspektionspläne, Stichprobennahme und Annahmekriterien.
+  BC-720.30.20:
+    name: Prozessbegleitende Qualitätskontrolle
+    description: |
+      Prozessbegleitende Kontrolle, Messung und statistische Prozesskontrolle.
+  BC-720.30.30:
+    name: Abschlussprüfung und Freigabe
+    description: |
+      Abschlussprüfung, Chargenfreigabe und Zertifikatausstellung.
+  BC-720.30.40:
+    name: Kalibrierungsmanagement
+    description: |
+      Kalibrierung von Mess- und Prüfmitteln.
+  BC-720.40:
+    name: Nichtkonformitätsmanagement
+    description: |
+      Nichtkonformitätsberichte, Abweichungen und CAPA.
+  BC-720.40.10:
+    name: Nichtkonformitätsberichterstattung
+    description: |
+      Erfassung und Klassifizierung von Nichtkonformitäten und Abweichungen.
+  BC-720.40.20:
+    name: Entscheidung und Eindämmung
+    description: |
+      Entscheidung über nichtkonformes Material und Eindämmungsmaßnahmen.
+  BC-720.40.30:
+    name: Korrektur- und Vorbeugungsmaßnahmen
+    description: |
+      CAPA-Prozess einschließlich Ursachenanalyse und Wirksamkeitsprüfungen.
+  BC-720.40.40:
+    name: Änderungskontrolle
+    description: |
+      Änderungskontrolle über qualitätsrelevante Änderungen.
+  BC-720.50:
+    name: Kontinuierliches Verbesserungsmanagement
+    description: |
+      Lean, Six Sigma, Kaizen und Verbesserungsprogramme.
+  BC-720.50.10:
+    name: Verbesserungsideen-Management
+    description: |
+      Erfassung, Bewertung und Priorisierung von Verbesserungsideen.
+  BC-720.50.20:
+    name: Lean- und Six-Sigma-Projektdurchführung
+    description: |
+      Lean- und Six-Sigma-Projektmethodik und -durchführung.
+  BC-720.50.30:
+    name: Kontinuierliches Verbesserungscoaching
+    description: |
+      Coaching und Kompetenzaufbau in KVP-Methoden.
+  BC-720.50.40:
+    name: Nutzenverfolgung
+    description: |
+      Nachverfolgung und Überprüfung des Nutzens von KVP-Projekten.
+  BC-720.60:
+    name: Kundenqualitätsmanagement
+    description: |
+      Kundenbeschwerden zu Qualität, Retouren und Feldqualität.
+  BC-720.60.10:
+    name: Kunden-Qualitätsbeschwerdebearbeitung
+    description: |
+      Erfassung, Untersuchung und Reaktion auf Kunden-Qualitätsbeschwerden.
+  BC-720.60.20:
+    name: Feldausfallanalyse
+    description: |
+      Analyse von Feldausfällen und Garantierücksendungen.
+  BC-720.60.30:
+    name: Rückruf und Kundenbenachrichtigung
+    description: |
+      Koordination von Produktrückrufen und Kundenbenachrichtigungen.
+  BC-720.60.40:
+    name: Kundenqualitätsberichterstattung
+    description: |
+      Kundenseitige Qualitätsberichte und Scorecards.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-real-estate-acquisition-disposition-management.yaml
+++ b/catalogue/i18n/de/L1-real-estate-acquisition-disposition-management.yaml
@@ -1,0 +1,186 @@
+locale: de
+source: L1-real-estate-acquisition-disposition-management.yaml
+entries:
+  BC-4930:
+    name: Immobilienerwerb und -veräußerungsmanagement
+    description: |
+      Transaktionsdisziplin für Beschaffung, Underwriting, Due Diligence,
+      Strukturierung, Verhandlung, Abschluss und Post-Closing-Onboarding
+      für Immobilienerwerbe und -veräußerungen bei direkten, Portfolio-
+      und Unternehmenstransaktionen.
+    in_scope:
+      - Akquisitions-Lead-Beschaffung und Maklermanagement
+      - Underwriting (DCF, Vergleichswerte, Sensitivität, Szenario)
+      - Physische, Umwelt-, Titel-, Miet- und finanzielle Due Diligence
+      - Angebotstrategie, LOI, Kauf- und Verkaufsvertrag und Steuer-/Vehikelstrukturierung
+      - Treuhand, Abschluss, Abrechnungserklärung und Registrierung
+      - Veräußerungsstrategie, Verkaufsmarketing, Käuferauswahl
+      - Post-Akquisitions-Daten- und Vertrags-Onboarding
+    out_of_scope:
+      - Investment-Committee-Steuerung und Fondsmandate (BC-4910)
+      - Geschäftspläne für stehende Assets (BC-4920)
+      - Bauauszahlungen und Darlehenscovenants-Überwachung (BC-4980)
+      - Maklergeschäft als Servicelinie (BC-4960)
+  BC-4930.10:
+    name: Akquisitionsbeschaffung und -screening
+    description: |
+      Beschaffung von Akquisitionsmöglichkeiten über Makler, Auftraggeber
+      und proprietäre Kanäle sowie erstes Screening anhand von Kriterien.
+  BC-4930.10.10:
+    name: Akquisitions-Lead-Beschaffung
+    description: |
+      Beschaffung von Akquisitions-Leads über direkte, Makler- und
+      Off-Market-Kanäle.
+  BC-4930.10.20:
+    name: Makler- und Vermittlermanagement
+    description: |
+      Management von Makler- und Vermittlerbeziehungen, die Akquisitions-
+      möglichkeiten liefern.
+  BC-4930.10.30:
+    name: Erstscreening und Angebotsentscheidungen
+    description: |
+      Erstscreening von Möglichkeiten und Entscheidungen über Gebot
+      oder Ablehnung.
+  BC-4930.20:
+    name: Akquisitions-Underwriting
+    description: |
+      Finanzielle, marktbezogene und risikobezogene Bewertung von
+      Zielobjekten zur Ableitung von Gebotspreisen und Renditerwartungen.
+  BC-4930.20.10:
+    name: Cashflow- und DCF-Underwriting
+    description: |
+      Erstellung von Asset-Cashflow- und Discounted-Cashflow-
+      Underwriting-Modellen.
+  BC-4930.20.20:
+    name: Vergleichsverkäufe und Cap-Rate-Analyse
+    description: |
+      Analyse von Vergleichsverkäufen und vorherrschenden Cap-Rates
+      zur Wertkalibrierung.
+  BC-4930.20.30:
+    name: Sensitivitäts- und Szenariomodellierung
+    description: |
+      Sensitivitäts- und Szenariomodellierung von Renditen bei
+      variierenden Miet-, Leerstand- und Exit-Annahmen.
+  BC-4930.30:
+    name: Due-Diligence-Management
+    description: |
+      Koordination und Ausführung multidisziplinärer Due Diligence
+      bei Zielakquisitionen einschließlich physischer, Umwelt-, rechtlicher,
+      Miet- und finanzieller Arbeitsstränge.
+  BC-4930.30.10:
+    name: Physische und technische Due Diligence
+    description: |
+      Physische Zustandsbewertungen und technische Due Diligence
+      bei Zielobjekten.
+  BC-4930.30.20:
+    name: Umwelt-Due-Diligence (Phase I/II)
+    description: |
+      Umwelt-Due-Diligence einschließlich ASTM Phase-I- und
+      Phase-II-Bewertungen.
+  BC-4930.30.30:
+    name: Titel-, Vermessung- und Zonierungsdiligence
+    description: |
+      Diligence zu Eigentumsrechten, Vermessung, Dienstbarkeiten und
+      Zonierungskonformität.
+  BC-4930.30.40:
+    name: Miet- und Mieter-Diligence
+    description: |
+      Mietvertragszusammenfassungs-Überprüfung, Estoppel-Zertifikatserfassung
+      und Mieterinterviews.
+  BC-4930.30.50:
+    name: Finanzielle und steuerliche Diligence
+    description: |
+      Finanzielle und steuerliche Diligence zu Betriebsabrechnungen,
+      Betriebskosten und historischen Steuerbescheiden.
+  BC-4930.40:
+    name: Transaktionsstrukturierung und -verhandlung
+    description: |
+      Angebotstrategie, Deal-Strukturierung und Verhandlung bindender
+      Transaktionsdokumente.
+  BC-4930.40.10:
+    name: Angebots- und Bietstrategie
+    description: |
+      Definition von Angebots- und Bietstrategie einschließlich
+      Preisgestaltung und Deal-Konditionen-Positionierung.
+  BC-4930.40.20:
+    name: Absichtserklärungsverhandlung
+    description: |
+      Verhandlung von Absichtserklärungen und Exklusivitätszeiträumen.
+  BC-4930.40.30:
+    name: Kauf- und Verkaufsvertragsverhandlung
+    description: |
+      Verhandlung und Abschluss von Kauf- und Verkaufsverträgen
+      einschließlich Zusicherungen und Gewährleistungen.
+  BC-4930.40.40:
+    name: Steuer- und Vehikelstrukturierung
+    description: |
+      Strukturierung von Akquisitionsvehikeln für Steuereffizienz
+      einschließlich 1031-Austausche und Gesellschaftsstrukturen.
+  BC-4930.50:
+    name: Abschluss- und Abrechnungsmanagement
+    description: |
+      Management von Treuhand, Abschlussbedingungen, Abschlussfinanzierung
+      und Registrierung für abgeschlossene Transaktionen.
+  BC-4930.50.10:
+    name: Treuhand und Abschlussbedingungen
+    description: |
+      Management von Treuhandkonten und Nachverfolgung der Erfüllung
+      von Abschlussbedingungen.
+  BC-4930.50.20:
+    name: Abschlussfinanzierung und Abrechnungserklärung
+    description: |
+      Koordination der Abschlussfinanzierung und Abstimmung mit der
+      Abrechnungserklärung.
+  BC-4930.50.30:
+    name: Eigentumsversicherung und Registrierung
+    description: |
+      Ausstellung der Eigentumsversicherung und Registrierung von
+      Eigentumsurkunden und Hypotheken.
+  BC-4930.60:
+    name: Veräußerungs- und Exit-Management
+    description: |
+      Verkaufsseitige Disziplin für Veräußerungspreisgestaltung,
+      Marketing, Käuferauswahl und Post-Closing-Verpflichtungen.
+  BC-4930.60.10:
+    name: Veräußerungsstrategie und -preisgestaltung
+    description: |
+      Definition von Veräußerungsstrategie, Preisgestaltung und
+      Zielkäuferpools.
+  BC-4930.60.20:
+    name: Verkaufsmarketing und Käufertour
+    description: |
+      Verkaufsseitiges Marketing einschließlich Angebotsmemorandum,
+      Datenraum und Käufertouren.
+  BC-4930.60.30:
+    name: Käuferauswahl und Bietverfahren
+    description: |
+      Auswahl des Käufers über Angebotsaufforderung, Best-and-Final-
+      oder strukturierte Auktionsverfahren.
+  BC-4930.60.40:
+    name: Post-Closing-Verpflichtungen
+    description: |
+      Nachverfolgung von Post-Closing-Verpflichtungen einschließlich
+      Einbehalte, Earn-outs und Freistellungsansprüche.
+  BC-4930.70:
+    name: Post-Akquisitions-Onboarding
+    description: |
+      Übergabe neu erworbener Assets vom Transaktionsteam an Asset-
+      und Immobilienverwaltung einschließlich Daten- und Vertrags-Onboarding.
+  BC-4930.70.10:
+    name: Asset-Datenmigration
+    description: |
+      Migration von Asset-Daten, Zeichnungen und Betriebsunterlagen
+      in Eigentümersysteme.
+  BC-4930.70.20:
+    name: Mietvertrag- und Mieterdaten-Onboarding
+    description: |
+      Onboarding von Mietvertragszusammenfassungen und Mieterdaten in
+      Vermieterssysteme.
+  BC-4930.70.30:
+    name: Lieferantenvertrags-Novation
+    description: |
+      Novation oder Ersetzung bestehender Lieferanten- und Serviceverträge
+      auf den neuen Eigentümer.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-real-estate-asset-management.yaml
+++ b/catalogue/i18n/de/L1-real-estate-asset-management.yaml
@@ -1,0 +1,194 @@
+locale: de
+source: L1-real-estate-asset-management.yaml
+entries:
+  BC-4920:
+    name: Immobilien-Asset-Management
+    description: |
+      Eigentümerseitige Verwaltung stehender Immobilienvermögenswerte über
+      die Haltedauer — Geschäftsplanausführung, Leistungsüberwachung,
+      Investitionsausgaben-Priorisierung, Repositionierung, Nachhaltigkeitspfad,
+      Asset-Risiko und Grundsteuer-/Betriebskostenoptimierung. Verbindet die
+      Investorenperspektive (BC-4910) mit dem operativen Immobilienbetrieb (BC-4940).
+    in_scope:
+      - Asset-Geschäftsplan und Halte-/Verkaufsentscheidungen
+      - Finanzielle, vermietungsbezogene und operative Leistungsüberwachung auf Asset-Ebene
+      - Investitionsausgaben-Programmplanung, Priorisierung und Ausführungsaufsicht
+      - Repositionierung, Umwandlung und Value-Add-Ausführung
+      - Asset-Dekarbonisierungspfad und ESG-Zertifizierung
+      - Asset-Risikoüberwachung (physisch, Klima, Markt, Mieterkredit)
+      - Grundsteuer-Einsprüche, Betriebskostenbewertung und Nebenkostenabrechnung
+    out_of_scope:
+      - Fonds-/Investorenportfoliokonstruktion (BC-4910)
+      - Täglicher Immobilienbetrieb und Auftragserteilung (BC-4940)
+      - Erwerbs- oder Veräußerungstransaktionen (BC-4930)
+      - Mietvertragszusammenfassung und Mietindexierung (BC-4950)
+  BC-4920.10:
+    name: Asset-Geschäftsplanmanagement
+    description: |
+      Definition und Aktualisierung von Asset-Geschäftsplänen im Einklang
+      mit Fondsmandat, Haltehorizont und Wertschöpfungsthesis.
+  BC-4920.10.10:
+    name: Asset-Geschäftsplan-Definition
+    description: |
+      Definition von Asset-Geschäftsplänen mit Thesis, Werttreibern und
+      Haltehorizont.
+  BC-4920.10.20:
+    name: Halte-/Verkaufsanalyse
+    description: |
+      Analyse der Halte-versus-Verkauf-Ökonomie und Empfehlung an das
+      Investment-Committee.
+  BC-4920.10.30:
+    name: Jährliche Planaktualisierung
+    description: |
+      Jährliche Aktualisierung der Asset-Geschäftspläne anhand von
+      Ist-Werten und revidiertem Marktausblick.
+  BC-4920.20:
+    name: Asset-Leistungsüberwachung
+    description: |
+      Überwachung finanzieller, vermietungsbezogener und operativer Leistung
+      auf Asset-Ebene gegenüber dem Geschäftsplan.
+  BC-4920.20.10:
+    name: Asset-Finanzleistungsnachverfolgung
+    description: |
+      Nachverfolgung von NOI, Cashflow und Rendite gegenüber Budget und
+      Geschäftsplan.
+  BC-4920.20.20:
+    name: Vermietungs- und Belegungsleistungsnachverfolgung
+    description: |
+      Nachverfolgung von Belegung, Vermietungsquote, gewichteter
+      Mietlaufzeit und Miete gegenüber dem Markt.
+  BC-4920.20.30:
+    name: Operative KPI-Nachverfolgung
+    description: |
+      Nachverfolgung operativer KPIs zu Betriebszeit, Beschwerden,
+      Energieintensität und Besucherzahlen.
+  BC-4920.20.40:
+    name: Abweichungsanalyse und Prognoseaktualisierung
+    description: |
+      Abweichungsanalyse von Ist-Werten zum Plan und Aktualisierung
+      der Prognose und Exit-Annahmen.
+  BC-4920.30:
+    name: Investitionsausgaben-Programmmanagement
+    description: |
+      Planung, Priorisierung und Ausführungsaufsicht von Asset- und
+      Portfolio-Investitionsausgaben-Programmen.
+  BC-4920.30.10:
+    name: Investitionsausgaben-Programmplanung
+    description: |
+      Mehrjährige Investitionsausgaben-Programmplanung nach Asset und
+      Portfolio.
+  BC-4920.30.20:
+    name: Investitionsausgaben-Priorisierung und -Genehmigung
+    description: |
+      Priorisierung und Genehmigung von Investitionsausgaben-Projekten
+      anhand von ROI- und Risikokriterien.
+  BC-4920.30.30:
+    name: Investitionsausgaben-Ausführungsaufsicht
+    description: |
+      Aufsicht über die Ausführung von Investitionsausgaben-Projekten
+      einschließlich Auszahlungen und Meilensteinlieferung.
+  BC-4920.30.40:
+    name: Investitionsausgaben-Leistungsabstimmung
+    description: |
+      Abstimmung der Investitionsausgaben-Leistung mit dem unter-
+      schriebenen Wertzuwachs und NOI-Verbesserung.
+  BC-4920.40:
+    name: Asset-Repositionierung und Value-Add-Management
+    description: |
+      Definition und Ausführung von Repositionierungs-, Umwandlungs- und
+      Mietermix-Strategien, die Nutzung oder Ertragsprofil eines Assets
+      verändern.
+  BC-4920.40.10:
+    name: Repositionierungsstrategie-Definition
+    description: |
+      Definition der Repositionierungsstrategie einschließlich Zielmarkt
+      und Wertversprechen.
+  BC-4920.40.20:
+    name: Umwandlungs- und Umnutzungsprogramme
+    description: |
+      Programme zur Umwandlung von Assets zwischen Nutzungen (Büro zu
+      Wohnen, Einzelhandel zu Mischnutzung).
+  BC-4920.40.30:
+    name: Mietermix- und Merchandising-Strategie
+    description: |
+      Definition und Ausführung von Mietermix- und Merchandising-Strategie
+      für Einzelhandels- und Mischnutzungs-Assets.
+  BC-4920.50:
+    name: Asset-Nachhaltigkeits- und ESG-Management
+    description: |
+      Asset-Dekarbonisierungspfad, Energieintensitätsmanagement,
+      Zertifizierungen und GRESB-Einreichung auf Asset-Ebene.
+  BC-4920.50.10:
+    name: Asset-Dekarbonisierungspfad
+    description: |
+      Definition des Asset-Dekarbonisierungspfades im Einklang mit
+      CRREM- und SBTi-Gebäudeleitlinien.
+  BC-4920.50.20:
+    name: Energie- und Wasserintensitätsmanagement
+    description: |
+      Management der Asset-Energie- und Wasserintensität anhand
+      der Ziele.
+  BC-4920.50.30:
+    name: Asset-ESG-Zertifizierung (LEED/BREEAM/WELL)
+    description: |
+      Einholung und Pflege von Asset-Zertifizierungen einschließlich
+      LEED, BREEAM, WELL und Fitwel.
+  BC-4920.50.40:
+    name: GRESB-Asset-Einreichung
+    description: |
+      Vorbereitung und Einreichung von Asset-Daten bei der
+      GRESB-Bewertung.
+  BC-4920.60:
+    name: Asset-Risikomanagement
+    description: |
+      Überwachung physischer, klimabezogener, marktbezogener und
+      Mieterkredit-Risiken sowie Versicherungsadäquanz auf Asset-Ebene.
+  BC-4920.60.10:
+    name: Physische und klimabezogene Risikobewertung
+    description: |
+      Bewertung physischer und klimabezogener Risiken am Asset
+      einschließlich Überschwemmung, Waldbrand und Hitzebelastung.
+  BC-4920.60.20:
+    name: Mieterkredit-Risikoüberwachung
+    description: |
+      Überwachung von Mieterkreditrisiko und Mieterfassungsrisiko nach
+      Asset und Portfolio.
+  BC-4920.60.30:
+    name: Marktrisiko-Überwachung
+    description: |
+      Überwachung von Marktrisikotr eibern einschließlich Cap-Rate-
+      Bewegungen, Angebotspipeline und Miettrends.
+  BC-4920.60.40:
+    name: Versicherungsadäquanz-Überprüfung
+    description: |
+      Periodische Überprüfung der Gebäude- und Haftpflichtversicherungs-
+      adäquanz gegenüber Asset-Wert und Exponierung.
+  BC-4920.70:
+    name: Grundsteuer- und Betriebskostenoptimierung
+    description: |
+      Management von Grundsteuerbescheiden, Betriebskostenbewertungen,
+      Nebenkostenabrechnung und Energietarifoptimierung spezifisch für
+      Immobilienvermögenswerte.
+  BC-4920.70.10:
+    name: Grundsteuerbescheid und -einspruch
+    description: |
+      Überprüfung und Einspruch gegen Grundsteuerbescheide anhand von
+      Vergleichsnachweisen.
+  BC-4920.70.20:
+    name: Betriebskostenüberprüfung
+    description: |
+      Periodische Überprüfung der Betriebskosten für Benchmarking und
+      Einsparmöglichkeiten.
+  BC-4920.70.30:
+    name: Nebenkostenabrechnung
+    description: |
+      Prüfung der Nebenkosten-Rückerstattung von Mietern gegenüber
+      Mietansprüchen.
+  BC-4920.70.40:
+    name: Energietarifoptimierung
+    description: |
+      Optimierung von Energiebeschaffung, Tarifen und Nachfragebeiträgen
+      über das Portfolio hinweg.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-real-estate-brokerage-management.yaml
+++ b/catalogue/i18n/de/L1-real-estate-brokerage-management.yaml
@@ -1,0 +1,217 @@
+locale: de
+source: L1-real-estate-brokerage-management.yaml
+entries:
+  BC-4960:
+    name: Immobilienmaklergeschäftsmanagement
+    description: |
+      Makler- und Agenturvermittlung als Servicelinie für Gewerbe- und
+      Wohnimmobilien — Listing-Akquisition, Käufer-/Mieterrepräsentation,
+      MLS-Datenverwaltung, Vergleichsanalyse, Besichtigungsbetrieb,
+      Angebotsverhandlung, Transaktionsabschlusskoordination, Provisions-
+      und Makler-Abrechnungen sowie Agenten-Produktivitäts-/Rosterbrmanagement.
+    in_scope:
+      - Verkäufer-/Vermieter-Listing-Akquisition und -Repräsentation
+      - Käufer-/Mieter-Engagement und -Repräsentation
+      - MLS-Listing-Erfassung, Syndizierung und Compliance
+      - Vergleichbare Marktanalyse und Maklerwerteinschätzung
+      - Besichtigungen, Tag der offenen Tür und Schlüsselkasten-/Digitalzugangsbetrieb
+      - Angebotsentwurf, Gegenangebot und Mehrfachangebots-Behandlung
+      - Abschlusskoordination und Bedingungsnachverfolgung
+      - Provisions-, Kooperationsmakler- und Empfehlungsgebührenabrechnung
+      - Agentenlizensierung, Sponsoring, Leistung und Provisionspläne
+    out_of_scope:
+      - Vermieterseitiger Mietbetrieb bei eigenen Assets (BC-4950)
+      - Erwerbs-/Veräußerungsausführung durch Auftraggeber (BC-4930)
+      - Immobilienbewertungsaufträge (BC-4970)
+      - Makler-/Agenten-Lizenzierungs-Regulatory (BC-4990)
+  BC-4960.10:
+    name: Listing-Akquisition und Repräsentation
+    description: |
+      Akquisition und Konvertierung von Verkäufer-/Vermieter-Listing-
+      Mandaten und Ausführung des im Listing-Vertrag zugesagten
+      Marketingplans.
+  BC-4960.10.10:
+    name: Listing-Pitch und -Gewinn
+    description: |
+      Präsentation für Listing-Mandate einschließlich CMA, Marketingvorschlag
+      und Präsentation.
+  BC-4960.10.20:
+    name: Listing-Vertragsmanagement
+    description: |
+      Management von Listing-Verträgen einschließlich Exklusivität,
+      Laufzeit und Provisionskonditionen.
+  BC-4960.10.30:
+    name: Listing-Marketingplan
+    description: |
+      Definition und Ausführung des im Listing-Vertrag zugesagten
+      Marketingplans.
+  BC-4960.20:
+    name: Käufer- und Mieterrepräsentation
+    description: |
+      Engagement und Ausführung von Kauf- und Mieterseitenrepräsentations-
+      mandaten einschließlich Suche und Vorauswahl.
+  BC-4960.20.10:
+    name: Käufer-/Mieter-Engagement
+    description: |
+      Engagement von Käufer- und Mieterkunden einschließlich
+      Agenturverträgen und Offenlegungen.
+  BC-4960.20.20:
+    name: Anforderungsdefinition und Briefing
+    description: |
+      Definition des Kundenanforderungs-Briefings mit Nutzung, Größe,
+      Lage und Budget.
+  BC-4960.20.30:
+    name: Immobiliensuche und Vorauswahl
+    description: |
+      Suche, Vorauswahl und Präsentation von Kandidatenimmobilien
+      an Kunden.
+  BC-4960.30:
+    name: Listing-Daten und MLS-Management
+    description: |
+      Management von MLS- und Portal-Listing-Daten einschließlich
+      Erfassung, Medien, Syndizierung und Compliance mit RESO-Datenstandards.
+  BC-4960.30.10:
+    name: MLS-Listing-Erfassung
+    description: |
+      Erfassung von MLS-Listings gemäß RESO-Datenwörterbuch-Feldern
+      und -Regeln.
+  BC-4960.30.20:
+    name: Listing-Medien und Fotografie
+    description: |
+      Produktion und Management von Listing-Medien einschließlich
+      Fotografie, Video und 3D-Touren.
+  BC-4960.30.30:
+    name: Syndizierung und Portal-Distribution
+    description: |
+      Distribution von Listings an Portale, Partner-Sites und Aggregatoren.
+  BC-4960.30.40:
+    name: Listing-Compliance und -Rücknahme
+    description: |
+      Compliance-Management von Listing-Genauigkeit, Statusänderungen
+      und Rücknahmen.
+  BC-4960.40:
+    name: Vergleichbare Marktanalyse
+    description: |
+      Erstellung vergleichbarer Marktanalysen, Maklerwerteinschätzungen
+      und Preispositionierung für Listing- und Käufer-Engagements.
+  BC-4960.40.10:
+    name: Vergleichsverkaufskuratierung
+    description: |
+      Kuratierung von Vergleichsverkaufsnachweisen aus MLS und
+      öffentlichen Registern.
+  BC-4960.40.20:
+    name: CMA-Berichterstellung
+    description: |
+      Erstellung von Vergleichsmarktanalyseberichten für Kundenpräsentation.
+  BC-4960.40.30:
+    name: Maklerwerteinschätzung
+    description: |
+      Ausstellung von Maklerwerteinschätzungen für Kunden und
+      institutionelle Auftraggeber.
+  BC-4960.50:
+    name: Besichtigungs- und Tag-der-offenen-Tür-Betrieb
+    description: |
+      Betrieb von Besichtigungsterminen, Tagen der offenen Tür und
+      physischen und digitalen Zugangsmöglichkeiten für Interessenten
+      und Kooperationsmakler.
+  BC-4960.50.10:
+    name: Besichtigungsterminmanagement
+    description: |
+      Management von Besichtigungsterminen und Zugriffsanfragen
+      von Kooperationsmaklern.
+  BC-4960.50.20:
+    name: Tag-der-offenen-Tür-Betrieb
+    description: |
+      Betrieb von Tag-der-offenen-Tür-Veranstaltungen einschließlich
+      Registrierung und Nachverfolgung.
+  BC-4960.50.30:
+    name: Schlüsselkasten und Zugangskontrolle
+    description: |
+      Management von Schlüsselkasten- und digitalen Zugangsdaten
+      für gelistete Objekte.
+  BC-4960.60:
+    name: Angebots- und Verhandlungsmanagement
+    description: |
+      Entwurf und Verhandlung von Angeboten, Gegenangeboten und
+      Mehrfachangebotsszenarien im Namen der vertretenen Partei.
+  BC-4960.60.10:
+    name: Angebotsentwurf
+    description: |
+      Entwurf von Angeboten und Anhängen im Namen der vertretenen
+      Partei.
+  BC-4960.60.20:
+    name: Gegenangebots- und Mehrfachangebotsmanagement
+    description: |
+      Management von Gegenangeboten und Mehrfachangebotsverfahren
+      einschließlich Best-and-Final-Aufrufe.
+  BC-4960.60.30:
+    name: Annahme und bindende Bestätigung
+    description: |
+      Bestätigung der Angebotsannahme und bindenden Vertragsformierung.
+  BC-4960.70:
+    name: Makler-Transaktionsabschlusskoordination
+    description: |
+      Koordination von Bedingungen, Treuhand und Übertragung bis zum
+      Abschluss bei vermittelten Transaktionen.
+  BC-4960.70.10:
+    name: Bedingungsnachverfolgung
+    description: |
+      Nachverfolgung von Inspektions-, Finanzierungs- und anderen
+      Bedingungen bis zur Erfüllung oder Verzicht.
+  BC-4960.70.20:
+    name: Treuhand-/Übertragungskoordination
+    description: |
+      Koordination mit Treuhand- und Übertragungsparteien zu
+      Abschlussdokumenten und Mitteln.
+  BC-4960.70.30:
+    name: Abschlusstag-Koordination
+    description: |
+      Koordination von Unterzeichnung, Schlüsselübergabe und
+      Abschlustagslogistik.
+  BC-4960.80:
+    name: Provisions- und Kooperationsmakler-Management
+    description: |
+      Erfassung von Provisionskonditionen und Abrechnung von
+      Kooperationsmaklerprovisionen und Empfehlungsgebühren.
+  BC-4960.80.10:
+    name: Provisionsvertragserfassung
+    description: |
+      Erfassung von Provisionsverträgen einschließlich Aufteilungen
+      und Bedingungen.
+  BC-4960.80.20:
+    name: Kooperationsmakler-Abrechnung
+    description: |
+      Abrechnung von Provisionen für Kooperationsmakler bei
+      abgeschlossenen Transaktionen.
+  BC-4960.80.30:
+    name: Provisionsauszahlung
+    description: |
+      Auszahlung von Provisionen an Maklerei und Agenten nach
+      Abzügen.
+  BC-4960.80.40:
+    name: Empfehlungsgebührenmanagement
+    description: |
+      Management von Empfehlungsgebührenvereinbarungen mit
+      vermittelnden Maklern und Partnern.
+  BC-4960.90:
+    name: Agenten-Produktivität und Roster-Management
+    description: |
+      Management von Agenten-Lizenzsponsor, Leistung und
+      Provisionsplanadministration im Maklerei-Roster.
+  BC-4960.90.10:
+    name: Agenten-Lizenzierung und Sponsoring-Nachverfolgung
+    description: |
+      Nachverfolgung von Agenten-Lizenzstatus und Maklerei-
+      Sponsoring-Vereinbarungen.
+  BC-4960.90.20:
+    name: Agenten-Leistungsmanagement
+    description: |
+      Leistungsmanagement von Agenten anhand von Produktionszielen
+      und Standards.
+  BC-4960.90.30:
+    name: Agenten-Provisionsplan-Administration
+    description: |
+      Administration von Agenten-Provisionsplänen, Aufteilungen und Obergrenzen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-real-estate-capital-markets-management.yaml
+++ b/catalogue/i18n/de/L1-real-estate-capital-markets-management.yaml
@@ -1,0 +1,189 @@
+locale: de
+source: L1-real-estate-capital-markets-management.yaml
+entries:
+  BC-4980:
+    name: Immobilien-Kapitalmärkte-Management
+    description: |
+      Immobilienspezifische Schulden- und Eigenkapitalmärkte-Disziplin —
+      Origination von Senior-, Mezzanine-, Bau- und Brückenschulden;
+      Darlehensverwaltung und Asset-Management; CMBS- und CRE-CLO-Strukturierung;
+      JV-Eigenkapitalprogramme; REIT-Kapitalaufnahme; Refinanzierung und
+      Rekapitalisierung; und CRE-Darlehensportfolio-Risikomanagement. Abzugrenzen
+      von allgemeinem Bankkreditgeschäft (BC-1320) und Unternehmens-Treasury (BC-210).
+    in_scope:
+      - Senior-, Mezzanine-, Bau- und Brückendarlehen-Origination
+      - Darlehenseinführung, Covenant-Überwachung, Änderung und Sonderservicing
+      - CMBS- und CRE-CLO-Pooling, Strukturierung und IRP-Berichtswesen
+      - JV-Eigenkapitalbeschaffung, Gewinnbeteiligung und Wasserfall-Strukturierung, Partnerberichtswesen
+      - REIT-öffentliches/-privates Eigenkapital, Schulden, ATM-Programme und Dividendenpolitik
+      - Refinanzierungs- und Rekapitalisierungsausführung
+      - CRE-Darlehensportfolio-Konzentration, Stresstests und Rückstellung
+    out_of_scope:
+      - Allgemeines Bankkreditgeschäft (BC-1320)
+      - Allgemeiner Kapitalmarkthandel (BC-1370)
+      - Fondsgründung und LP-Kapitalaufnahme (BC-4910)
+      - Akquisitionstransaktionsausführung (BC-4930)
+  BC-4980.10:
+    name: Immobilien-Schulden-Origination
+    description: |
+      Origination von Senior-, Mezzanine-, Bau- und Brücken-Immobilienschulden
+      anhand von Asset- und Sponsor-Underwriting.
+  BC-4980.10.10:
+    name: Senior-Hypotheken-Origination
+    description: |
+      Origination von Senior-Hypothekendarlehen auf stehenden Vermögenswerten.
+  BC-4980.10.20:
+    name: Bau- und Brückendarlehen-Origination
+    description: |
+      Origination von Bau- und Brückendarlehen für Entwicklungs- und
+      Übergangs-Assets.
+  BC-4980.10.30:
+    name: Mezzanine- und Vorzugskapital-Origination
+    description: |
+      Origination von Mezzanine-Schulden und Vorzugskapital im
+      Kapitalstapel.
+  BC-4980.10.40:
+    name: Term-Sheet- und Commitmentverhandlung
+    description: |
+      Verhandlung von Term-Sheets und Commitment-Schreiben mit
+      Kreditnehmern und Sponsoren.
+  BC-4980.20:
+    name: Immobilien-Schuldenverwaltung und Asset-Management
+    description: |
+      Einführung und Verwaltung von CRE-Darlehen sowie proaktive
+      Überwachung, Änderung und Workout wo erforderlich.
+  BC-4980.20.10:
+    name: Darlehenseinführung und Verwaltungs-Setup
+    description: |
+      Einführung neuer CRE-Darlehen in die Verwaltungsplattform und
+      Einrichtung von Zahlungs- und Berichtsabläufen.
+  BC-4980.20.20:
+    name: Covenant- und DSCR-Überwachung
+    description: |
+      Laufende Überwachung von Darlehenscovenants, DSCR und LTV
+      gegenüber Darlehensvertrags-Auslösern.
+  BC-4980.20.30:
+    name: Darlehensänderung und Workout
+    description: |
+      Verhandlung von Darlehensänderungen und Workouts bei belasteten
+      Assets.
+  BC-4980.20.40:
+    name: Sonderservicing-Koordination
+    description: |
+      Koordination mit Sonderservicern bei ausgefallenen und nahezu
+      ausgefallenen Darlehen in Verbriefungen.
+  BC-4980.30:
+    name: CMBS und Verbriefungsmanagement
+    description: |
+      Aggregation von Darlehenspools, Strukturierung von CMBS- und
+      CRE-CLO-Transaktionen sowie laufendes IRP-Berichtswesen an Investoren.
+  BC-4980.30.10:
+    name: Darlehenspoolaggregation
+    description: |
+      Aggregation von Darlehenspools, die für die Verbriefung geeignet sind.
+  BC-4980.30.20:
+    name: Verbriefungsstrukturierung
+    description: |
+      Strukturierung von CMBS- und CRE-CLO-Transaktionen einschließlich
+      Tranchen und Ratings.
+  BC-4980.30.30:
+    name: IRP-Investorenberichtswesen
+    description: |
+      Investorenberichtswesen nach dem CREFC Investor Reporting Package.
+  BC-4980.30.40:
+    name: Treuhänder- und Servicer-Koordination
+    description: |
+      Koordination mit Treuhändern, Master-Servicern und Ratingagenturen
+      bei ausstehenden Deals.
+  BC-4980.40:
+    name: Joint-Venture- und Eigenkapitalpartnermanagement
+    description: |
+      Beschaffung von JV-Eigenkapital, Strukturierung von Gewinnbeteiligungs-
+      und Wasserfall-Vereinbarungen sowie laufendes Berichtswesen und
+      Ausschüttungen an Partner.
+  BC-4980.40.10:
+    name: JV-Eigenkapitalbeschaffung
+    description: |
+      Beschaffung von Joint-Venture-Eigenkapital von institutionellen
+      und HNW-Partnern.
+  BC-4980.40.20:
+    name: Gewinnbeteiligungs- und Wasserfallstrukturierung
+    description: |
+      Strukturierung von Gewinnbeteiligungs-, Hürden- und Wasserfall-
+      Konditionen in JV-Partnerschaftsverträgen.
+  BC-4980.40.30:
+    name: JV-Partner-Berichtswesen und Ausschüttungen
+    description: |
+      Berichtswesen an JV-Partner und Ausführung vertraglicher Ausschüttungen.
+  BC-4980.50:
+    name: REIT-Kapitalmärkte-Management
+    description: |
+      Öffentliche und private REIT-Eigenkapital- und Schuldausstellungen,
+      ATM-Programme und Dividendenpolitikmanagement.
+  BC-4980.50.10:
+    name: Öffentliche REIT-Eigenkapitalausstellung
+    description: |
+      Ausstellung von REIT-Eigenkapital durch Folgeemissionen und
+      Privatplatzierungen.
+  BC-4980.50.20:
+    name: REIT-Schulden- und Anleiheausstellung
+    description: |
+      Ausstellung von REIT-ungesicherten Schulden, Anleihen und
+      wandelbaren Schuldverschreibungen.
+  BC-4980.50.30:
+    name: ATM-Programmmanagement
+    description: |
+      Management von At-the-Market-Eigenkapitalprogrammen einschließlich
+      Pacing und Offenlegung.
+  BC-4980.50.40:
+    name: Dividendenpolitikmanagement
+    description: |
+      Management der REIT-Dividendenpolitik im Einklang mit REIT-
+      Ausschüttungsanforderungen und AFFO.
+  BC-4980.60:
+    name: Refinanzierungs- und Rekapitalisierungsmanagement
+    description: |
+      Proaktive Refinanzierung und Rekapitalisierung von Kapitalstapeln
+      stehender Assets über die Haltedauer.
+  BC-4980.60.10:
+    name: Refinanzierungsstrategie und Pacing
+    description: |
+      Definition der Refinanzierungsstrategie und Fälligkeits-Pacing
+      über das Portfolio.
+  BC-4980.60.20:
+    name: Refinanzierungsausführung
+    description: |
+      Ausführung von Refinanzierungstransaktionen bei einzelnen Assets
+      und Pools.
+  BC-4980.60.30:
+    name: Rekapitalisierungsrestrukturierung
+    description: |
+      Restrukturierung von Kapitalstapeln durch Partner-Recap oder
+      Eigenkapitalspritzen.
+  BC-4980.70:
+    name: Immobilien-Darlehensportfolio-Risikomanagement
+    description: |
+      Konzentrationsüberwachung, Stresstests, Verlustvorsorge und
+      Watchlist-Management für CRE-Darlehensportfolios.
+  BC-4980.70.10:
+    name: LTV-/DSCR-Konzentrationsüberwachung
+    description: |
+      Überwachung von LTV- und DSCR-Konzentration im CRE-Darlehensportfolio.
+  BC-4980.70.20:
+    name: CRE-Darlehen-Stresstests
+    description: |
+      Stresstests des CRE-Darlehensportfolios bei Zins-, Leerstand-
+      und Wertschocks.
+  BC-4980.70.30:
+    name: CECL-/IFRS-9-Verlustvorsorge (CRE)
+    description: |
+      Verlustvorsorge für CRE-Portfolio unter CECL- und IFRS-9-
+      Expected-Credit-Loss-Rahmen.
+  BC-4980.70.40:
+    name: Watchlist und Ausfall-Nachverfolgung
+    description: |
+      Pflege der Watchlist und Nachverfolgung ausgefallener Darlehen
+      im Portfolio.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-real-estate-compliance-regulatory-management.yaml
+++ b/catalogue/i18n/de/L1-real-estate-compliance-regulatory-management.yaml
@@ -1,0 +1,228 @@
+locale: de
+source: L1-real-estate-compliance-regulatory-management.yaml
+entries:
+  BC-4990:
+    name: Immobilienkonformität und Regulatorik
+    description: |
+      Compliance-Disziplin für immobilienspezifische Regulierungsregimes,
+      die das allgemeine Unternehmens-Compliance überlagern — Makler-/
+      Agenten-Lizenzierung, faire Wohnungs- und Antidiskriminierungsregimes,
+      Immobilien-AML und wirtschaftliches Eigentum, Abrechnungs- und
+      Hypothekenoffenlegung (RESPA/TRID), Gebäudeenergieleistung,
+      Miet- und Mietpreisregulierung, Wohnungseigentümer-/HOA-/Strata-
+      Regulierung sowie Fonds-/Berater-Regulierung.
+    in_scope:
+      - Maklerei- und Agenten-Lizenzmaintenance
+      - Fair-Housing-Act-, Equality-Act-, ECOA-Konformität
+      - Immobilien-AML, wirtschaftliches Eigentum, Sanktionen und SAR-Berichtswesen
+      - RESPA, TRID und Section-8-verbundene Geschäftsoffenlegung
+      - Gebäudeenergieleistungs-Offenlegung und MEES-Compliance
+      - Mietpreisbindung, Räumungskündigung, Kautionshandhabung, STR-Registrierung
+      - Wohnungseigentümer-/HOA-/Strata-Sponsor- und Rücklagenoffenlegungen
+      - AIFMD-, ELTIF- und Investment-Advisers-Act-Fonds-/Berater-Compliance
+    out_of_scope:
+      - Unternehmens-Compliance-Management (BC-130)
+      - Cybersicherheits- und Datenschutzregimes (BC-620)
+      - Allgemeines Finanzdelikts-AML außerhalb Immobilien (BC-1400)
+      - Steuerverwaltung (BC-220)
+  BC-4990.10:
+    name: Makler- und Agenten-Lizenz-Compliance
+    description: |
+      Compliance mit Makler- und Agenten-Lizenzierungsregimes einschließlich
+      Firmenlizenz-Maintenance, Weiterbildung und designierter Makler-Aufsicht.
+  BC-4990.10.10:
+    name: Firmenlizenz-Maintenance
+    description: |
+      Pflege von Maklerfirmenlizenzen in allen Tätigkeitsregionen.
+  BC-4990.10.20:
+    name: Agenten-Lizenzierung und Weiterbildung
+    description: |
+      Nachverfolgung individueller Agenten-Lizenzen und Weiterbildungs-
+      anforderungen.
+  BC-4990.10.30:
+    name: Designierter Makler-Aufsicht
+    description: |
+      Designierter-Makler-Aufsicht über regulierte Tätigkeiten in der Firma.
+  BC-4990.10.40:
+    name: Lizenzerneuerung und Prüfungsreaktion
+    description: |
+      Erneuerung von Lizenzen und Reaktion auf Regulatoren-Prüfungen
+      und Inspektionen.
+  BC-4990.20:
+    name: Faire Wohnungs- und Antidiskriminierungs-Compliance
+    description: |
+      Konformität mit Fair-Housing-Act, Equality-Act, ECOA und
+      gleichwertigen Antidiskriminierungsregimes bei Vermietung, Verkauf
+      und Kreditvergabe-Touchpoints.
+  BC-4990.20.10:
+    name: Faire Wohnungspolitik-Maintenance
+    description: |
+      Pflege von fairen Wohnungspolitiken und Standardbetriebsverfahren.
+  BC-4990.20.20:
+    name: Werbe- und Finanzierungsquellen-Screening
+    description: |
+      Screening von Werbeinhalten und Finanzierungsquellen-Regeln auf
+      Compliance mit Schutzklassen-Beschränkungen.
+  BC-4990.20.30:
+    name: Diskriminierungsbeschwerdebearbeitung
+    description: |
+      Bearbeitung von Wohnungsdiskriminierungsbeschwerden und
+      Regulatoren-Anfragen.
+  BC-4990.20.40:
+    name: Faire Wohnungsschulung und Bestätigung
+    description: |
+      Schulung und Bestätigung von Agenten und Personal zu fairen
+      Wohnungsverpflichtungen.
+  BC-4990.30:
+    name: Immobilien-AML und Sanktions-Compliance
+    description: |
+      Compliance mit immobilienspezifischen AML-Regeln einschließlich
+      FinCEN-GTOs, FinCEN-Wohnimmobilien-Regel, AMLD-5/6-Verpflichtungen
+      für nicht-finanzielle Unternehmen und wirtschaftliche Eigentümers-
+      Berichtswesen.
+  BC-4990.30.10:
+    name: Wirtschaftliches Eigentum-Erfassung
+    description: |
+      Erfassung und Verifizierung des wirtschaftlichen Eigentums für
+      Immobilientransaktionsparteien.
+  BC-4990.30.20:
+    name: Sanktions- und PEP-Screening (Immobilien)
+    description: |
+      Screening von Transaktionsparteien gegen Sanktions-, PEP- und
+      negative Medienlisten.
+  BC-4990.30.30:
+    name: Verdachtsmeldungen (Immobilien)
+    description: |
+      Einreichung von Verdachtsmeldungen für im Anwendungsbereich
+      liegende Immobilientransaktionen.
+  BC-4990.30.40:
+    name: AML-Prüfung und Regulatoren-Inspektion
+    description: |
+      Reaktion auf AML-Prüfungen und Regulatoren-Inspektionen bei
+      Immobilien-AML-Programmen.
+  BC-4990.40:
+    name: Abrechnungs- und Hypothekenoffenlegungs-Compliance
+    description: |
+      Compliance mit US-RESPA und TRID Abrechnungs- und Hypotheken-
+      offenlegungsregeln und gleichwertigen regionalen Regimes.
+  BC-4990.40.10:
+    name: Darlehensschätzung und Abschlussoffenlegungsproduktion
+    description: |
+      Erstellung von TRID-Darlehensschätzung und Abschlussoffenlegungs-
+      dokumenten innerhalb der Fristen.
+  BC-4990.40.20:
+    name: Verbundene Geschäftsvereinbarungsoffenlegung
+    description: |
+      Offenlegung verbundener Geschäftsvereinbarungen an den erforderlichen
+      Transaktionspunkten.
+  BC-4990.40.30:
+    name: Abrechnungsdienstleister-Compliance
+    description: |
+      Compliance mit Regeln zu Abrechnungsdienstleister-Empfehlungen
+      und Section-8-Verboten.
+  BC-4990.40.40:
+    name: RESPA-Prüfungsreaktion
+    description: |
+      Reaktion auf CFPB- und staatliche Regulatoren-Inspektionen zur
+      RESPA-Compliance.
+  BC-4990.50:
+    name: Gebäudeenergieleistungs-Compliance
+    description: |
+      Compliance mit EPC, MEES, Gebäudeperformance-Standards und
+      Benchmarking-Gesetzen (z. B. Local Law 97, EPBD-Überarbeitungen).
+  BC-4990.50.10:
+    name: EPC-/Gebäudeenergiebewertungs-Compliance
+    description: |
+      Beschaffung und Registrierung von Energieausweisen und Äquivalenten.
+  BC-4990.50.20:
+    name: Mindestenergieffizienz-Compliance (MEES)
+    description: |
+      Compliance mit Mindestenergieffizienznormen für vermietete und
+      verkaufte Objekte.
+  BC-4990.50.30:
+    name: Energie-Benchmarking-Offenlegung (LL97/BPS)
+    description: |
+      Offenlegung nach städtischen Energie-Benchmarking-Vorschriften und
+      Gebäudeperformance-Standards.
+  BC-4990.50.40:
+    name: EU-EPBD-Berichtswesen-Compliance
+    description: |
+      Compliance mit der EU-Gebäudeenergieeffizienz-Richtlinie für
+      Berichtswesen und Zertifizierung.
+  BC-4990.60:
+    name: Miet- und Mietpreisregulierungs-Compliance
+    description: |
+      Compliance mit Mietpreisbindung/-stabilisierung, Räumungskündigung,
+      gesetzlicher Kautionshandhabung und Kurzzeitmiet-Registrierungsregimes.
+  BC-4990.60.10:
+    name: Mietpreiskontrolle und -stabilisierungscompliance
+    description: |
+      Compliance mit Mietpreiskontroll- und Mietpreisbindungsregimes
+      für regulierte Einheiten.
+  BC-4990.60.20:
+    name: Räumungskündigung und Verfahrens-Compliance
+    description: |
+      Compliance mit gesetzlichen Räumungskündigungs- und Verfahrens-
+      anforderungen.
+  BC-4990.60.30:
+    name: Kautions-Gesetzliche Handhabung
+    description: |
+      Gesetzliche Handhabung von Kautionen einschließlich Treuhand,
+      Zinsen und Rückgaberegeln.
+  BC-4990.60.40:
+    name: Kurzzeitmiet-/STR-Registrierungs-Compliance
+    description: |
+      Compliance mit Kurzzeitmiet-Registrierungs- und Betriebsregeln
+      in regulierten Städten.
+  BC-4990.70:
+    name: Wohnungseigentümer-, HOA- und Strata-Regulierungs-Compliance
+    description: |
+      Compliance mit Wohnungseigentümer-, HOA-, Eigentümergemeinschafts-
+      und Strata-Regulierungsregimes einschließlich Sponsor-Offenlegungen
+      und Rücklagenfondsregeln.
+  BC-4990.70.10:
+    name: Wohnungseigentümer-/Strata-Sponsor-Offenlegung
+    description: |
+      Sponsor-Offenlegungsverpflichtungen nach Wohnungseigentümer- und
+      Strata-Regulierung.
+  BC-4990.70.20:
+    name: HOA-/Eigentümergemeinschaft-Registrierung
+    description: |
+      Registrierung und laufende Einreichungen für HOA- und
+      Eigentümergemeinschafts-Entitäten.
+  BC-4990.70.30:
+    name: Rücklagenoffenlegungs-Compliance
+    description: |
+      Compliance mit Rücklagenfonds-Studie und Offenlegungsanforderungen.
+  BC-4990.70.40:
+    name: Weiterverkaufszertifikats-Compliance
+    description: |
+      Ausstellung von Weiterverkaufszertifikaten und zugehörigen
+      Offenlegungen beim Wohnungseigentümer-/HOA-Einheitenverkauf.
+  BC-4990.80:
+    name: Immobilien-Fonds- und Berater-Compliance
+    description: |
+      Compliance mit AIFMD, ELTIF, US-Investment-Advisers-Act und
+      gleichwertigen Fonds- und Berater-Regimes für Immobilienfonds-Manager.
+  BC-4990.80.10:
+    name: Fonds-Berater-Registrierung
+    description: |
+      Pflege von Fonds-Berater- und Manager-Registrierungen und
+      Genehmigungen.
+  BC-4990.80.20:
+    name: AIFMD-/ELTIF-Berichtswesen-Compliance
+    description: |
+      Compliance mit AIFMD-Anhang-IV- und ELTIF-Berichtspflichten.
+  BC-4990.80.30:
+    name: Marketing und grenzüberschreitende Notifizierung
+    description: |
+      Compliance mit grenzüberschreitenden Marketing-Notifizierungs-
+      regimes für Fonds.
+  BC-4990.80.40:
+    name: Fonds-Prüfung und Inspektionsreaktion
+    description: |
+      Reaktion auf Fonds-Regulatoren-Prüfungen und Inspektionen über
+      Jurisdiktionen hinweg.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-real-estate-development-management.yaml
+++ b/catalogue/i18n/de/L1-real-estate-development-management.yaml
@@ -1,0 +1,233 @@
+locale: de
+source: L1-real-estate-development-management.yaml
+entries:
+  BC-4900:
+    name: Immobilienentwicklungsmanagement
+    description: |
+      Initiierung, Machbarkeitsanalyse, Baugenehmigung, Finanzierung und
+      Lieferungsaufsicht für Neubauten und große Sanierungsprojekte in
+      Gewerbe- und Wohnsektoren. Eigentümerseitige Disziplin, die die allgemeine
+      Bauausführung mit vorgelagerter (Grundstück, Genehmigung, Programm,
+      Entwicklungsfinanzierung) und nachgelagerter (Vermietungsanlauf, Stabilisierung)
+      Arbeit spezifisch für Immobilienentwicklung verbindet.
+    in_scope:
+      - Grundstücksbeschaffung, Marktanalyse und Pipeline-Tracking
+      - Optimale Nutzungsanalyse und Pro-forma-Machbarkeitsstudie
+      - Zonierung, Genehmigungen, Baugenehmigungen
+      - Masterplanung und Konzeptdesign-Aufsicht
+      - Strukturierung der Entwicklungsfinanzierung einschließlich JV-Eigenkapital und Baudarlehen
+      - Eigentümerseitige Bauüberwachung, Nachtragsmanagement und Lieferungsaufsicht
+      - Vorvermietung, Eröffnung und Vermietungsanlauf bis zur stabilisierten Belegung
+    out_of_scope:
+      - Bauausführung durch Generalunternehmer und Gewerke (BC-1150)
+      - Erwerb stehender Vermögenswerte (BC-4930)
+      - Geschäftspläne für stehende Vermögenswerte und Investitionsausgaben (BC-4920)
+      - Firmeneigene Entwicklung für den Eigenbedarf (BC-710)
+  BC-4900.10:
+    name: Entwicklungs-Pipeline und Grundstücksbeschaffung
+    description: |
+      Initiierung von Entwicklungsmöglichkeiten durch Marktscreenings,
+      direkte Grundstücksbeschaffung, Off-Market-Lead-Generierung und
+      Pipeline-Tracking anhand von Investitionskriterien.
+  BC-4900.10.10:
+    name: Markt- und Teilmarktanalyse
+    description: |
+      Analyse von Metropol-, Teilmarkt- und Mikrolagedynamiken zur
+      Ausrichtung der Entwicklungstätigkeit.
+  BC-4900.10.20:
+    name: Grundstücksidentifizierung und -beschaffung
+    description: |
+      Identifizierung von Entwicklungsgrundstücken über Listing-Kanäle,
+      Maklernetzwerke und Parzellendaten-Screening.
+  BC-4900.10.30:
+    name: Off-Market-Akquisition
+    description: |
+      Erschließung von Off-Market-Möglichkeiten durch Grundeigentümer-
+      Ansprache und proprietäre Netzwerke.
+  BC-4900.10.40:
+    name: Pipeline-Tracking
+    description: |
+      Nachverfolgung von Entwicklungsmöglichkeiten durch Stufentore und
+      Investitionskriterien-Filter.
+  BC-4900.20:
+    name: Entwicklungsmachbarkeitsanalyse
+    description: |
+      Machbarkeitsbewertung von Entwicklungsmöglichkeiten über
+      Grundstücks-, Programm- und Finanzdimensionen.
+  BC-4900.20.10:
+    name: Optimale Nutzungsanalyse
+    description: |
+      Analyse rechtlich zulässiger, physisch möglicher und finanziell
+      tragfähiger Nutzungen für ein Kandidatengrundstück.
+  BC-4900.20.20:
+    name: Programm- und Baumassenstudien
+    description: |
+      Studien zu Programmnutzungsmix und Baumassen zur Prüfung von
+      Entwicklungshülle und Ertrag.
+  BC-4900.20.30:
+    name: Entwicklungs-Pro-forma-Modellierung
+    description: |
+      Erstellung einer Entwicklungs-Pro-forma mit Kosten, Erlösen sowie
+      ungehebelten und gehebelten Renditen.
+  BC-4900.20.40:
+    name: Grundstückerwerb-Underwriting
+    description: |
+      Underwriting von Grundstückserwerbspreisen und -strukturen anhand
+      der Machbarkeitsergebnisse.
+  BC-4900.30:
+    name: Bodennutzungsrechte und Genehmigungen
+    description: |
+      Sicherung von Bodennutzungsrechten, Baugenehmigungen, Umwelt-
+      genehmigungen und für den Bau erforderlichen Betriebsgenehmigungen.
+  BC-4900.30.10:
+    name: Zonierungsstrategie und Bodennutzung
+    description: |
+      Strategie und Ausführung für Zonenänderungen, Bodennutzungsplan-
+      änderungen und Dichteboni.
+  BC-4900.30.20:
+    name: Baugenehmigung und Ausnahmen
+    description: |
+      Einholung von Baugenehmigungen, Abweichungen und Sondernutzungs-
+      genehmigungen vor Planungsbehörden.
+  BC-4900.30.30:
+    name: Umweltprüfung (NEPA/UVP)
+    description: |
+      Umweltprüfung nach NEPA, UVP oder gleichwertigen regionalen Regimes
+      einschließlich Umweltverträglichkeitsprüfung und Minderungsmaßnahmen.
+  BC-4900.30.40:
+    name: Baugenehmigungen und behördliche Zulassungen
+    description: |
+      Einreichung und Einholung von Baugenehmigungen und Zulassungen
+      für den Baubeginn.
+  BC-4900.30.50:
+    name: Gemeinschafts- und Stakeholder-Engagement
+    description: |
+      Engagement mit Gemeindeausschüssen, Nachbarn und politischen
+      Stakeholdern zur Unterstützung des Genehmigungsverfahrens.
+  BC-4900.40:
+    name: Entwicklungsprogrammmanagement
+    description: |
+      Programmebene Steuerung von Entwicklungszeitplan, Budget, Risiko
+      und Stakeholder-Berichtswesen über den Entwicklungslebenszyklus.
+  BC-4900.40.10:
+    name: Entwicklungszeitplanmanagement
+    description: |
+      Definition und Nachverfolgung des Entwicklungs-Gesamtzeitplans
+      vom Grundstückserwerb bis zur Stabilisierung.
+  BC-4900.40.20:
+    name: Entwicklungsbudgetkontrolle
+    description: |
+      Kontrolle des Gesamtentwicklungskostenbudgets einschließlich Bau-,
+      Weich-, Finanzierungs- und Risikovorsorgekomponenten.
+  BC-4900.40.30:
+    name: Entwicklungsrisiko- und Risikovorsorgmanagement
+    description: |
+      Identifizierung, Quantifizierung und Management von Programmrisiken
+      und Risikovorsorgebezügen.
+  BC-4900.40.40:
+    name: Stakeholder-Berichtswesen
+    description: |
+      Berichterstattung über Entwicklungsfortschritt an Investoren,
+      Darlehensgeber und interne Governance-Organe.
+  BC-4900.50:
+    name: Masterplanung und Konzeptdesignmanagement
+    description: |
+      Definition langfristiger Masterpläne und Aufsicht über Konzept- und
+      schematische Designphasen gemäß Entwicklerabsicht.
+  BC-4900.50.10:
+    name: Masterplan-Definition
+    description: |
+      Definition von Masterplänen für mehrphasige oder mehrparzellen-
+      basierte Entwicklungen einschließlich Phasierung.
+  BC-4900.50.20:
+    name: Konzept- und schematische Designaufsicht
+    description: |
+      Eigentümerseitige Aufsicht über Architekt-Konzept- und schematische
+      Designlieferables anhand des Briefings.
+  BC-4900.50.30:
+    name: Designstandard-Verwaltung
+    description: |
+      Verwaltung von Entwickler-Designstandards und Markenstandards
+      über Beraterteams hinweg.
+  BC-4900.50.40:
+    name: Nachhaltigkeits-Brief-Definition
+    description: |
+      Definition von Nachhaltigkeits- und Zertifizierungsbriefings (LEED,
+      BREEAM, WELL, NABERS) für die Entwicklung.
+  BC-4900.60:
+    name: Entwicklungsfinanzierungsstrukturierung
+    description: |
+      Strukturierung von Eigenkapital, Fremdkapital und Anreizkapital für
+      die Finanzierung der Entwicklung bis zur Fertigstellung.
+  BC-4900.60.10:
+    name: Eigenkapitalisierung
+    description: |
+      Beschaffung und Schließung von Sponsor- und Limited-Partner-Eigenkapital
+      für das Entwicklungsprojekt.
+  BC-4900.60.20:
+    name: Baudarlehen-Origination
+    description: |
+      Origination von Bau- und Brückendarlehen anhand der Entwicklungs-Pro-forma.
+  BC-4900.60.30:
+    name: Öffentliche Anreize und Steuergutschriften
+    description: |
+      Einholung öffentlicher Anreize wie TIF, PILOT, LIHTC und Programme
+      für historische Steuergutschriften.
+  BC-4900.60.40:
+    name: Joint-Venture-Strukturierung
+    description: |
+      Strukturierung von Joint-Venture-Vehikeln, Gewinnbeteiligungen und
+      Wasserfall-Konditionen für Entwicklungspartner.
+  BC-4900.70:
+    name: Baulieferungsaufsicht
+    description: |
+      Eigentümerseitige Aufsicht über die Baulieferung durch General-
+      unternehmer und Gewerke, wobei die Ausführung bei der Baukapazität
+      (BC-1150) verbleibt.
+  BC-4900.70.10:
+    name: Auftragnehmerauswahl und -vergabe
+    description: |
+      Auswahl und Vergabe von Generalunternehmern und wichtigen Gewerke-
+      verträgen für die Entwicklung.
+  BC-4900.70.20:
+    name: Eigentümerseitige Bauüberwachung
+    description: |
+      Eigentümerseitige Überwachung von Baufortschritt, Auszahlungen und
+      Qualität während der Ausführung.
+  BC-4900.70.30:
+    name: Nachtragssteuerung
+    description: |
+      Steuerung von Nachtragsaufträgen, Umfangsänderungen und Risiko-
+      vorsorgebezügen anhand des Budgets.
+  BC-4900.70.40:
+    name: Qualitäts- und Sicherheitsaufsicht
+    description: |
+      Aufsicht über Bauqualität und Sicherheitsleistung gemäß Entwickler-
+      erwartungen und Vorschriften.
+  BC-4900.80:
+    name: Vermietungsanlauf und Stabilisierungsmanagement
+    description: |
+      Vorvermietung, Eröffnungskoordination und Hochlauf des fertiggestellten
+      Vermögenswerts auf stabilisierte Belegung und Leistung.
+  BC-4900.80.10:
+    name: Vorvermietungskoordination
+    description: |
+      Koordination von Vorvermietungskampagnen vor Gebäudefertigstellung.
+  BC-4900.80.20:
+    name: Eröffnungs- und Einzugskoordination
+    description: |
+      Koordination von Gebäudeeröffnung, ersten Einzügen und operativer
+      Übergabe.
+  BC-4900.80.30:
+    name: Stabilisierungsleistungsnachverfolgung
+    description: |
+      Nachverfolgung der Vermietungsanlauf-Geschwindigkeit und operativen
+      Leistung anhand der Stabilisierungs-Pro-forma.
+  BC-4900.80.40:
+    name: Mängellisten und Mängelbeseitigung
+    description: |
+      Abarbeitung von Mängellisten, latenten Mängeln und
+      Auftragnehmergewährleistungsansprüchen nach Übergabe.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-real-estate-investment-management.yaml
+++ b/catalogue/i18n/de/L1-real-estate-investment-management.yaml
@@ -1,0 +1,188 @@
+locale: de
+source: L1-real-estate-investment-management.yaml
+entries:
+  BC-4910:
+    name: Immobilieninvestitionsmanagement
+    description: |
+      Investmenthaus- und fondsseitige Disziplin für Strategie, Kapitalaufnahme,
+      Pipeline, Entscheidungssteuerung, Portfoliokonstruktion, Investor Relations
+      und Fondsleistung für Immobilieninvestitionsvehikel einschließlich REITs,
+      nicht börsennotierter Fonds, Einzelmandate und Joint-Venture-Programme.
+    in_scope:
+      - Fonds-/Mandatsdefinition und Anlagepolitik
+      - Kapitalaufnahme, Fondsgründung und Zeichnung
+      - Investitions-Pipeline und Deal-Sourcing über direkte und indirekte Kanäle
+      - Investment-Committee-Steuerung und Genehmigungsbedingungen
+      - Portfoliokonstruktion, Allokation und Rebalancing
+      - LP-Berichtswesen, Kapitalabrufe, Ausschüttungen und INREV/NCREIF/EPRA-Einreichung
+      - NAV-Berechnung, Leistungsattribution und Wasserfall-Berechnungen
+    out_of_scope:
+      - Asset-Geschäftspläne und Investitionsausgaben (BC-4920)
+      - Transaktionsausführung für Erwerb und Veräußerung (BC-4930)
+      - Schulden- und Eigenkapitalmärkte-Ausführung (BC-4980)
+      - Allgemeines Treasury und Investor Relations (BC-210, BC-240)
+  BC-4910.10:
+    name: Anlagestrategie und Mandatsmanagement
+    description: |
+      Definition und Verwaltung von Anlagestrategie, Fondsmandaten,
+      Sektor-/geografischer Ausrichtung und Risiko-Rendite-Zielen
+      für verwaltete Vehikel.
+  BC-4910.10.10:
+    name: Fonds-/Mandatsdefinition
+    description: |
+      Definition von Fonds- oder Einzelmandaten einschließlich Sektor,
+      Geografie, Stil und Beschränkungen.
+  BC-4910.10.20:
+    name: Sektoren- und geografische Allokation
+    description: |
+      Festlegung und Anpassung von Sektor- und geografischen Allokations-
+      zielen über Vehikel hinweg.
+  BC-4910.10.30:
+    name: Risiko-Rendite-Ausrichtung
+    description: |
+      Ausrichtung von Risiko-Rendite-Profilen nach Stilbox (Core,
+      Core-Plus, Value-Add, Opportunistisch) und Benchmark.
+  BC-4910.10.40:
+    name: Anlagepolitikpflege
+    description: |
+      Pflege von Anlagepolitikerklärungen, Ausnahmen und
+      Investorenzustimmungen.
+  BC-4910.20:
+    name: Kapitalaufnahme und Fondsgründung
+    description: |
+      Gründung von Investitionsvehikeln und Aufnahme von Investorenkapital
+      einschließlich Strukturierung, Marketing und Abschluss.
+  BC-4910.20.10:
+    name: Fondsstrukturierung und Vehikel-Setup
+    description: |
+      Strukturierung und Einrichtung von Fondsvehikeln, Feedern, Blockern
+      und steuereffizienten Holdingstrukturen.
+  BC-4910.20.20:
+    name: Investorenansprache und -zeichnung
+    description: |
+      Ansprache von Investorensegmenten, Due-Diligence-Reaktion und
+      Zeichnungsverarbeitung.
+  BC-4910.20.30:
+    name: Fondsabschlussmanagement
+    description: |
+      Management von Erst-, Zwischen- und Endabschlüssen einschließlich
+      Gleichstellung später Investoren.
+  BC-4910.20.40:
+    name: Co-Investment und Sidecar-Management
+    description: |
+      Initiierung und Management von Co-Investment-Angeboten und
+      Sidecar-Vehikeln.
+  BC-4910.30:
+    name: Investitions-Pipeline und Deal-Sourcing
+    description: |
+      Initiierung und Priorisierung von Investitionsmöglichkeiten über direkte
+      Akquisitionen, indirekte Beteiligungen und JV-Kanäle für die Fonds.
+  BC-4910.30.10:
+    name: Direkte Deal-Akquisition
+    description: |
+      Akquisition direkter Asset- und Portfolio-Investitionsmöglichkeiten
+      im Einklang mit Mandaten.
+  BC-4910.30.20:
+    name: Indirekte und Co-Investment-Beschaffung
+    description: |
+      Beschaffung indirekter Beteiligungen einschließlich Secondaries,
+      Fondsbeteiligungen und Co-Investments.
+  BC-4910.30.30:
+    name: Pipeline-Pacing und Allokation
+    description: |
+      Pacing der Pipeline gegen Fonds-Einsatzpläne und Allokation
+      über Vehikel hinweg.
+  BC-4910.40:
+    name: Investitionsentscheidung und Genehmigungsmanagement
+    description: |
+      Investment-Committee-Steuerung, Genehmigungsworkflows und Nachverfolgung
+      von Genehmigungsbedingungen für neue Investitionen.
+  BC-4910.40.10:
+    name: Investitionsmemorandum-Erstellung
+    description: |
+      Erstellung von Investitionsmemorandum für Committee-Prüfung mit
+      Thesis, Konditionen und Risiken.
+  BC-4910.40.20:
+    name: Investment-Committee-Steuerung
+    description: |
+      Steuerung des Investment-Committee-Prozesses, Quorum und
+      Entscheidungsprotokollierung.
+  BC-4910.40.30:
+    name: Genehmigungsbedingungsnachverfolgung
+    description: |
+      Nachverfolgung von Auflösungsbedingungen und nachträglichen
+      Bedingungen, die an Investitionsgenehmigungen geknüpft sind.
+  BC-4910.50:
+    name: Portfoliokonstruktion und Allokation
+    description: |
+      Konstruktion und laufendes Rebalancing von Fondsportfolios anhand
+      von Mandat-, Hebelwirkungs- und Risikozielen.
+  BC-4910.50.10:
+    name: Portfoliomodellierung
+    description: |
+      Modellierung der Portfoliozusammensetzung, Vintage-Diversifikation
+      und projizierter Leistung.
+  BC-4910.50.20:
+    name: Sektor- und Geografie-Rebalancing
+    description: |
+      Rebalancing der Portfolio-Sektor- und geografischen Mischung durch
+      Akquisitionen und Veräußerungen.
+  BC-4910.50.30:
+    name: Hebelwirkungs- und Absicherungsausrichtung
+    description: |
+      Ausrichtung und Überwachung von Portfolio-Hebelwirkung und
+      FX-/Zins-Absicherungsrichtlinien.
+  BC-4910.60:
+    name: Investor Relations und Berichtswesen
+    description: |
+      Kommunikation mit Limited Partners und börsennotierten Investoren,
+      Ausführung von Kapitalabrufen und Ausschüttungen sowie Einreichung
+      bei Branchenindizes.
+  BC-4910.60.10:
+    name: Kapitalabrufe und Ausschüttungen
+    description: |
+      Ausgabe von Kapitalabrufen und Ausführung von Ausschüttungen
+      einschließlich Kapitalrückgabe.
+  BC-4910.60.20:
+    name: LP-Berichtswesen und Offenlegungen
+    description: |
+      Quartals- und Jahresberichtswesen an Limited Partners über
+      Leistung, NAV und Offenlegungen.
+  BC-4910.60.30:
+    name: Index- und Benchmark-Einreichung
+    description: |
+      Einreichung bei NCREIF, INREV, EPRA und regionalen Benchmarks
+      für Leistungsvergleichbarkeit.
+  BC-4910.60.40:
+    name: Jährliche Investorentreffen
+    description: |
+      Ausrichtung jährlicher Investorentreffen, Beiratssitzungen und
+      Investorentage.
+  BC-4910.70:
+    name: Fondsleistung und NAV-Management
+    description: |
+      Berechnung des Fonds-NAV, Leistungsattribution und Management-/
+      Leistungsgebühren-Wasserfälle einschließlich Carry-Kristallisierung.
+  BC-4910.70.10:
+    name: NAV und Anteilspreisgestaltung
+    description: |
+      Berechnung des Fonds-NAV und der Anteilspreise im periodischen
+      Bewertungszyklus.
+  BC-4910.70.20:
+    name: Leistungsattribution
+    description: |
+      Attribution der Fondsleistung über Asset-, Sektor-, Geografie-
+      und Währungsbeiträge.
+  BC-4910.70.30:
+    name: Gebühren- und Carry-Berechnung
+    description: |
+      Berechnung von Verwaltungsgebühren und Carried Interest gemäß
+      den wirtschaftlichen LPA-Konditionen.
+  BC-4910.70.40:
+    name: Hürden- und Wasserfallberechnung
+    description: |
+      Berechnung von Vorzugsrendite-Hürden und Ausschüttungswasserfällen
+      für jedes Vehikel.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-real-estate-leasing-management.yaml
+++ b/catalogue/i18n/de/L1-real-estate-leasing-management.yaml
@@ -1,0 +1,208 @@
+locale: de
+source: L1-real-estate-leasing-management.yaml
+entries:
+  BC-4950:
+    name: Immobilienvermietungs- und Verpachtungsmanagement
+    description: |
+      Vermieterseitige Vermietung von Gewerbe-, Einzelhandels- und
+      Wohnflächen über den Mietlebenszyklus — Preisgestaltung, Marketing,
+      Interessentenbearbeitung, Bewerbungsscreening, Vertragsverhandlung
+      und -abschluss, Mietverwaltung, Erneuerung und Bindung sowie
+      Mietende. Abzugrenzen von firmeneigener Mietabwicklung (BC-710)
+      und Maklergeschäft als Servicelinie (BC-4960).
+    in_scope:
+      - Angefragte Miete und Konzessionsstrategie
+      - Leerstandsmarketing, Listings und Besichtigungen
+      - Eingehende Interessentenbearbeitung und -qualifizierung
+      - Mieterbewerbungserfassung, Screening und faire Wohnungsrecht-konforme Ablehnungsbearbeitung
+      - Mietvertrags-Term-Sheet, Entwurf, Unterzeichnung und Sicherheitsleistungshandhabung
+      - Vermieterseitige Mietvertragszusammenfassung, Indexierung und Optionsnachverfolgung
+      - Erneuerungsanbahnungen und Bindungsprogramme
+      - Auszug, Schäden und Mietende-Abrechnung
+    out_of_scope:
+      - Unternehmensseitige Mietverwaltung auf Mieterseite (BC-710)
+      - Maklerrepräsentation als Servicelinie (BC-4960)
+      - Immobilienbetrieb während der Nutzung (BC-4940)
+      - Mietregulierung und Mietrechtscompliance (BC-4990)
+  BC-4950.10:
+    name: Vermietungsstrategie und Preisgestaltung
+    description: |
+      Definition der Angefragten-Miete-Strategie, Konzessionspakete,
+      Ziel-Mietermix und Benchmarking der Asset-Miete gegenüber dem Markt.
+  BC-4950.10.10:
+    name: Angefragte Miete und Konzessionsstrategie
+    description: |
+      Definition von Angefragten-Mietniveaus und Konzessionspaketen
+      nach Asset- und Einheitentyp.
+  BC-4950.10.20:
+    name: Ziel-Mietermix-Strategie
+    description: |
+      Definition des Ziel-Mietermixes und der Kreditqualität für
+      das Asset.
+  BC-4950.10.30:
+    name: Marktmiet-Benchmarking
+    description: |
+      Periodisches Benchmarking von Bestandsmieten und Angefragten
+      Mieten gegenüber Marktnachweisen.
+  BC-4950.20:
+    name: Leerstandsmarketing und Listing
+    description: |
+      Marketing verfügbarer Flächen über Listing-Inhalte, Kanal-
+      Syndizierung und Vor-Ort-Besichtigungen.
+  BC-4950.20.10:
+    name: Listing-Inhaltsproduktion
+    description: |
+      Produktion von Listing-Inhalten einschließlich Fotografie,
+      Grundrisse und virtuelle Touren.
+  BC-4950.20.20:
+    name: Listing-Kanal und Syndizierungsmanagement
+    description: |
+      Management der Listing-Distribution an Portale, MLSs und
+      Partnerkanäle.
+  BC-4950.20.30:
+    name: Leerstandsbesichtigung und Besichtigungsbetrieb
+    description: |
+      Betrieb von Leerstandseinheiten-Besichtigungen und
+      Selbstbesichtigungen im Gebäude.
+  BC-4950.30:
+    name: Interessenten- und Anfragenmanagement
+    description: |
+      Erfassung, Qualifizierung und Nachverfolgung eingehender
+      Vermietungsanfragen und Interessenten.
+  BC-4950.30.10:
+    name: Anfragenerfassung und -weiterleitung
+    description: |
+      Erfassung von Vermietungsanfragen über Kanäle und Weiterleitung
+      an das richtige Asset-Team.
+  BC-4950.30.20:
+    name: Interessentenqualifizierung
+    description: |
+      Qualifizierung von Interessenten anhand von Zielnutzung,
+      Kreditwürdigkeit und Einheiteneignung.
+  BC-4950.30.30:
+    name: Besichtigungsplanung und Nachverfolgung
+    description: |
+      Planung von Besichtigungen und Nachverfolgung nach Besichtigungen
+      mit Interessenten.
+  BC-4950.40:
+    name: Mieterbewerbung und Screening
+    description: |
+      Erfassung von Mieterbewerbungen und Durchführung von Kredit-,
+      Identitäts- und Referenzprüfungen konform mit Wohnungsrecht-Regeln.
+  BC-4950.40.10:
+    name: Bewerbungserfassung
+    description: |
+      Erfassung von Mieterbewerbungen und Begleitdokumenten.
+  BC-4950.40.20:
+    name: Kredit- und Referenzprüfungen
+    description: |
+      Durchführung von Kreditprüfungen und Vermieter-/Arbeitgeberreferenzen
+      für Bewerbende.
+  BC-4950.40.30:
+    name: Identitäts- und Aufenthaltsrechtsprüfung
+    description: |
+      Prüfung von Identität und Miet-/Nutzungsrecht gemäß
+      jurisdiktionaler Anforderungen.
+  BC-4950.40.40:
+    name: Faire Wohnungsrecht konforme Ablehnungsbearbeitung
+    description: |
+      Bearbeitung nachteiliger Bewerbungsentscheidungen konform mit
+      Wohnungsrecht und Ablehnungsmitteilungsregeln.
+  BC-4950.50:
+    name: Mietvertragsverhandlung und -abschluss
+    description: |
+      Verhandlung von Mietvertrags-Term-Sheets, Entwurf, Redline-Management,
+      Abschluss und Erfassung von Sicherheitsleistungen und Bürgschaften.
+  BC-4950.50.10:
+    name: Term-Sheet-Verhandlung
+    description: |
+      Verhandlung von Mietvertrags-Term-Sheets mit Miete, Laufzeit,
+      Optionen und Anreizen.
+  BC-4950.50.20:
+    name: Mietvertragsentwurf und Redline-Management
+    description: |
+      Entwurf von Mietvertragsdokumenten und Management von Redline-
+      Zyklen mit Mieteranwälten.
+  BC-4950.50.30:
+    name: Mietvertragsunterzeichnung und -abschluss
+    description: |
+      Unterzeichnung und Abschluss des Mietvertrags und zugehöriger
+      Dokumente.
+  BC-4950.50.40:
+    name: Sicherheitsleistung und Bürgschaftserfassung
+    description: |
+      Erfassung von Sicherheitsleistungen, Akkreditiven und persönlichen
+      oder Unternehmensbürgschaften.
+  BC-4950.60:
+    name: Mietverwaltung (Vermieterseite)
+    description: |
+      Vermieterseitige Verwaltung von Mietvertragszusammenfassungen,
+      Mietindexierung, Optionsnachverfolgung und Mietvertrags-Compliance-
+      Überwachung während der Laufzeit.
+  BC-4950.60.10:
+    name: Mietvertragszusammenfassung
+    description: |
+      Zusammenfassung abgeschlossener Mietverträge in strukturierte
+      Schlüsselbegriffs-Aufzeichnungen.
+  BC-4950.60.20:
+    name: Mietindexierung und Eskalationsnachverfolgung
+    description: |
+      Nachverfolgung und Auslösung von Mieteskalationen einschließlich
+      Index- und Stufenklauseln.
+  BC-4950.60.30:
+    name: Options-, Kündigungs- und Erneuerungsnachverfolgung
+    description: |
+      Nachverfolgung von Mieter- und Vermieteroptionen, Kündigungsterminen
+      und Erneuerungsfenstern.
+  BC-4950.60.40:
+    name: Mietvertrags-Compliance-Überwachung
+    description: |
+      Überwachung der Mieter-Compliance mit Mietvertragsvereinbarungen
+      einschließlich Nutzung, Umbau und Berichterstattung.
+  BC-4950.70:
+    name: Erneuerungs- und Bindungsmanagement
+    description: |
+      Proaktives Management der Erneuerungspipeline, Konditionsverhandlung
+      und Bindungsprogramme für Bestandsmieter.
+  BC-4950.70.10:
+    name: Erneuerungspipeline-Management
+    description: |
+      Management der Erneuerungspipeline anhand des Ablaufkalenders
+      und der Bindungsziele.
+  BC-4950.70.20:
+    name: Erneuerungskonditionen-Verhandlung
+    description: |
+      Verhandlung von Erneuerungskonditionen einschließlich Miete,
+      Laufzeit und Anreizen.
+  BC-4950.70.30:
+    name: Bindungsprogrammbetrieb
+    description: |
+      Betrieb von Bindungsprogrammen einschließlich Mieteransprache
+      und Anreizangeboten.
+  BC-4950.80:
+    name: Auszugs- und Mietvertragsbeendigungsmanagement
+    description: |
+      Management von Mieterkündigung, Rückgabe, Schäden, Wiederherstellung,
+      Sicherheitsleistungsrückgabe und Abschlussabrechnung bei Mietende.
+  BC-4950.80.10:
+    name: Kündigungs- und Rückgabeverarbeitung
+    description: |
+      Verarbeitung von Kündigungsmitteilungen und Rückgabe der Mieträume.
+  BC-4950.80.20:
+    name: Schadensbewertung und Wiederherstellungsbewertung
+    description: |
+      Bewertung von Schäden und Mieter-Wiederherstellungsverpflichtungen
+      gemäß Mietvertrag.
+  BC-4950.80.30:
+    name: Sicherheitsleistungsrückgabe
+    description: |
+      Rückgabe von Sicherheitsleistungen unter Berücksichtigung von
+      Abzügen gemäß Gesetz und Mietvertrag.
+  BC-4950.80.40:
+    name: Mietende-Abschlussabrechnung
+    description: |
+      Abschlussabrechnung von Miete, Erstattungen und Gutschriften
+      bei Mietende.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-real-estate-valuation-appraisal-management.yaml
+++ b/catalogue/i18n/de/L1-real-estate-valuation-appraisal-management.yaml
@@ -1,0 +1,168 @@
+locale: de
+source: L1-real-estate-valuation-appraisal-management.yaml
+entries:
+  BC-4970:
+    name: Immobilienbewertung und Wertermittlungsmanagement
+    description: |
+      Bewertungs- und Wertermittlungsdisziplin für Immobilienvermögenswerte
+      und -portfolios — Auftragserfassung, Besichtigung, Vergleichsdatenkuratierung,
+      Anwendung von Vergleichs-/Ertrags-/Kostenansätzen, Berichterstattung
+      und Freigabe, wiederkehrende Portfolio-Marktbewertung und Qualitätssicherung
+      konform mit USPAP, RICS Red Book und IVS.
+    in_scope:
+      - Auftragserfassung, Abgrenzung, Interessenkonfliktskontrollen und Honorarschreiben
+      - Besichtigung und IPMS-konforme Gebäudevermessung
+      - Vergleichstransaktionen und Rendite-Benchmark-Kuratierung
+      - Vergleichsverkaufs-, Ertragskapitalisierungs-, DCF- und Kostenansätze
+      - Red-Book-/USPAP-konforme Berichtsentwurf und Freigabe
+      - Wiederkehrende Portfolio-Marktbewertung und Darlehenssicherheiten-Neubewertung
+      - Interne QA-Stichproben, Peer-Review und Prüfungsreaktion
+    out_of_scope:
+      - Akquisitions-Underwriting durch Auftraggeber (BC-4930)
+      - NAV-Berechnung auf Fondsebene (BC-4910)
+      - Grundsteuereinsprüche (BC-4920)
+      - Maklerwerteinschätzung als Maklerprodukt (BC-4960)
+  BC-4970.10:
+    name: Bewertungsauftragsmanagement
+    description: |
+      Erfassung, Abgrenzung, Interessenkonfliktskontrollen und Honorarschreiben
+      für eingehende Bewertungsaufträge von Kunden und Darlehensgebern.
+  BC-4970.10.10:
+    name: Auftragserfassung und -abgrenzung
+    description: |
+      Erfassung von Bewertungsaufträgen und Definition des Umfangs und
+      Zwecks der Bewertung.
+  BC-4970.10.20:
+    name: Auftrags-Interessenkonflikt und Unabhängigkeitscheck
+    description: |
+      Prüfung auf Interessenkonflikte und Bewerterunabhängigkeit bei
+      neuen Aufträgen.
+  BC-4970.10.30:
+    name: Auftragshonorar und Honorarschreibenausstellung
+    description: |
+      Definition und Ausstellung von Auftragshonoraren und Honorar-
+      schreiben an Kunden.
+  BC-4970.20:
+    name: Objektbesichtigung und Datenerfassung
+    description: |
+      Besichtigungsbesuche, IPMS-konforme Gebäudevermessung und
+      Erfassung von Zustandsdaten und Mängeln bei Bewertungsobjekten.
+  BC-4970.20.10:
+    name: Objektbesichtigungsbetrieb
+    description: |
+      Besichtigungen von Bewertungsobjekten durch qualifizierte Bewerter.
+  BC-4970.20.20:
+    name: Gebäudevermessung (IPMS)
+    description: |
+      Vermessung von Gebäuden und Mietflächen gemäß IPMS und
+      lokalen Vermessungsstandards.
+  BC-4970.20.30:
+    name: Zustand und Mängelerfassung
+    description: |
+      Erfassung von Gebäudezustand und Mängeln während der Besichtigung.
+  BC-4970.30:
+    name: Marktdaten und Vergleichsdatenkuratierung
+    description: |
+      Beschaffung und Kuratierung von Vergleichstransaktionen, Marktindizes
+      und Rendite-Benchmarks für Bewertungsschlussfolgerungen.
+  BC-4970.30.10:
+    name: Vergleichstransaktionserfassung
+    description: |
+      Erfassung von Vergleichstransaktionen aus Marktquellen und
+      internen Datenbanken.
+  BC-4970.30.20:
+    name: Marktindizes und Rendite-Benchmarks
+    description: |
+      Pflege von Marktindizes und Rendite-Benchmarks nach Sektor
+      und Geografie.
+  BC-4970.30.30:
+    name: Vergleichskorrekturmanagement
+    description: |
+      Management von Vergleichskorrekturen für Zeit-, Lage-, Zustand-
+      und Qualitätsunterschiede.
+  BC-4970.40:
+    name: Bewertungsansatzanwendung
+    description: |
+      Anwendung der anerkannten Bewertungsansätze — Vergleichsverkauf,
+      Ertragskapitalisierung, DCF und Kosten — auf das Bewertungsobjekt.
+  BC-4970.40.10:
+    name: Vergleichsverkaufsansatz
+    description: |
+      Anwendung des Vergleichsverkaufsansatzes mit Vergleichstransaktions-
+      nachweisen.
+  BC-4970.40.20:
+    name: Ertragskapitalisierungsansatz
+    description: |
+      Anwendung des Ertragskapitalisierungsansatzes mit NOI- und
+      Rendite-Nachweisen.
+  BC-4970.40.30:
+    name: Discounted-Cashflow-Ansatz
+    description: |
+      Anwendung des Discounted-Cashflow-Ansatzes für ertragsgenerierte
+      Objekte mit mehrjährigen Prognosen.
+  BC-4970.40.40:
+    name: Kostenansatz
+    description: |
+      Anwendung des Kostenansatzes mit Wiederbeschaffungskosten und
+      Abschreibungsanalyse.
+  BC-4970.50:
+    name: Bewertungsberichterstattung und Freigabe
+    description: |
+      Entwurf, interne Überprüfung und Freigabe von Bewertungsberichten
+      konform mit USPAP, Red Book und IVS-Standards.
+  BC-4970.50.10:
+    name: Bewertungsberichtsentwurf
+    description: |
+      Entwurf von Bewertungsberichten gemäß Auftragsumfang und -zweck.
+  BC-4970.50.20:
+    name: Prüfer-Freigabe und Qualitätskontrolle
+    description: |
+      Prüfer-Freigabe und Qualitätskontrolle von Bewertungsberichten
+      vor Ausstellung.
+  BC-4970.50.30:
+    name: Berichtsausstellung und Nachausstellungsmanagement
+    description: |
+      Ausstellung von Bewertungsberichten und Management von
+      Nachausstellungen und Ergänzungen.
+  BC-4970.60:
+    name: Portfolio-Marktbewertung und Indexbewertung
+    description: |
+      Wiederkehrende Neubewertung von Portfolios für Fonds und Darlehensgeber
+      sowie Einreichung von Bewertungsdaten bei Indizes und Benchmarks.
+  BC-4970.60.10:
+    name: Periodische Portfolio-Neubewertung
+    description: |
+      Periodische Neubewertung von Fonds- und Eigentümerportfolios
+      im vertraglichen Zyklus.
+  BC-4970.60.20:
+    name: Darlehenssicherheiten-Neubewertung
+    description: |
+      Neubewertung von Darlehenssicherheiten einschließlich Covenant-
+      und Stresstestauslöser.
+  BC-4970.60.30:
+    name: Index- und Benchmark-Berichtswesen
+    description: |
+      Berichterstattung von Bewertungsdaten an NCREIF, MSCI und
+      andere Leistungsindizes.
+  BC-4970.70:
+    name: Bewertungs-Qualitätssicherung und Prüfung
+    description: |
+      Interne QA-Stichproben, Peer-Review und Reaktion auf Kunden-
+      und Regulatoren-Prüfungen ausgestellter Bewertungen.
+  BC-4970.70.10:
+    name: Interne QA-Stichproben
+    description: |
+      Stichproben ausgestellter Bewertungen für interne Qualitätssicherungs-
+      überprüfung.
+  BC-4970.70.20:
+    name: Peer-Review-Betrieb
+    description: |
+      Betrieb von Peer-Review für komplexe oder hochwertige Bewertungen.
+  BC-4970.70.30:
+    name: Regulatoren- und Kunden-Prüfungsreaktion
+    description: |
+      Reaktion auf Regulatoren- und Kunden-Prüfungsanfragen zu
+      ausgestellten Bewertungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-refining-operations-management.yaml
+++ b/catalogue/i18n/de/L1-refining-operations-management.yaml
@@ -1,0 +1,136 @@
+locale: de
+source: L1-refining-operations-management.yaml
+entries:
+  BC-3080:
+    name: Raffinerieoperationen
+    description: |
+      Betrieb von Rohöl-Raffinerien - Destillation, Umwandlung,
+      Behandlung, Mischung, Raffineriewirtschaft, Katalysatormanagement
+      und Revisions-Koordination.
+  BC-3080.10:
+    name: Rohöldestillationsbetrieb
+    description: |
+      Betrieb atmosphärischer und Vakuum-Rohöldestillationseinheiten und Rohöldiät-Wechsel.
+  BC-3080.10.10:
+    name: Atmosphärischer Destillationsbetrieb
+    description: |
+      Betrieb von Rohöl-Atmosphärendestillationskolonnen und Vorblitzzügen.
+  BC-3080.10.20:
+    name: Vakuumdestillationsbetrieb
+    description: |
+      Betrieb von Vakuumdestillationskolonnen und Kopfsystemen.
+  BC-3080.10.30:
+    name: Rohöldiät-Wechsel
+    description: |
+      Operative Verwaltung von Rohöl-Diätänderungen und Diät-Wechseln.
+  BC-3080.20:
+    name: Umwandlungseinheiten-Betrieb
+    description: |
+      Betrieb von katalytischen Crack-, Hydrocrack-, Verkokungsund Reformiereinheiten.
+  BC-3080.20.10:
+    name: Fluid-Katalytik-Cracker-Betrieb
+    description: |
+      Betrieb von Fluid-Katalytik-Cracker-Einheiten und Regeneratoren.
+  BC-3080.20.20:
+    name: Hydrocracking-Betrieb
+    description: |
+      Betrieb von ein- und zweistufigen Hydrocrackern.
+  BC-3080.20.30:
+    name: Verkokungsbetrieb
+    description: |
+      Betrieb von Delayed-Coker-, Fluid-Coker- und Flexicoker-Einheiten.
+  BC-3080.20.40:
+    name: Reformierungsbetrieb
+    description: |
+      Betrieb katalytischer Reformer zur Oktan- und Aromatenproduktion.
+  BC-3080.30:
+    name: Behandlungs- und Hydroverarbeitungsbetrieb
+    description: |
+      Betrieb von Hydrotreating-, Schwefelrückgewinnungs- und Produktentsüßungseinheiten.
+  BC-3080.30.10:
+    name: Hydrotreating-Betrieb
+    description: |
+      Betrieb von Naphtha-, Destillat- und Gasöl-Hydrotreating-Anlagen.
+  BC-3080.30.20:
+    name: Schwefelrückgewinnung und Tailgas-Betrieb
+    description: |
+      Betrieb von Schwefelrückgewinnungseinheiten und Tailgas-Behandlung.
+  BC-3080.30.30:
+    name: Entsüßungsbetrieb
+    description: |
+      Betrieb von Kaustik- und Adsorbens-basierten Produktentsüßungsanlagen.
+  BC-3080.40:
+    name: Produktmischungsbetrieb
+    description: |
+      In-Line- und Tank-Mischung von Fertigprodukten auf Spezifikation.
+  BC-3080.40.10:
+    name: Benzinmischung
+    description: |
+      Mehrkomponenten-Benzinmischung auf Qualitätsspezifikationen.
+  BC-3080.40.20:
+    name: Destillatmischung
+    description: |
+      Diesel- und Kerosinmischung einschließlich Biobrennstoff-Integration.
+  BC-3080.40.30:
+    name: Bunkerkraftstoff-Mischung
+    description: |
+      Marine-Bunkerkraftstoff-Mischung auf ISO-8217-Spezifikationen.
+  BC-3080.40.40:
+    name: Spezifikations-Compliance-Mischung
+    description: |
+      Echtzeit-Spezifikationsoptimierung und Qualitätszertifikat-Ausstellung.
+  BC-3080.50:
+    name: Raffinerieplanung und Wirtschaft
+    description: |
+      Linearprogrammbasierte Rohölauswahl, Margenoptimierung und Raffinerieausbeute-Berichterstattung.
+  BC-3080.50.10:
+    name: Linearprogramm-Modellierung
+    description: |
+      Pflege und Lauf von Raffinerien-LP-Modellen für Plan und Wirtschaft.
+  BC-3080.50.20:
+    name: Rohölauswahl-Wirtschaft
+    description: |
+      Wirtschaftliche Bewertung von Rohölkandidaten-Käufen und Diätoptionen.
+  BC-3080.50.30:
+    name: Margenoptimierung
+    description: |
+      Kurzfristige Betriebsmargenoptimierung und Neuplanung.
+  BC-3080.50.40:
+    name: Raffinerieausbeute-Berichterstattung
+    description: |
+      Berichterstattung tatsächlicher Ausbeuten gegenüber Plan und Benchmark.
+  BC-3080.60:
+    name: Katalysator- und Raffineriechemikalien-Management
+    description: |
+      Lebenszyklusmanagement von Prozesskatalysatoren und Raffineriechemikalien-Inventar.
+  BC-3080.60.10:
+    name: Katalysator-Lebenszyklusmanagement
+    description: |
+      Katalysatorladungsplanung, In-Service-Überwachung und Austausch.
+  BC-3080.60.20:
+    name: Katalysator-Regenerierungskoordination
+    description: |
+      Koordination von In-situ- und Ex-situ-Katalysatorregenerierungskampagnen.
+  BC-3080.60.30:
+    name: Raffineriechemikalien-Inventarverwaltung
+    description: |
+      Inventar- und Verbrauchsmanagement von Prozesschemikalien.
+  BC-3080.70:
+    name: Revisions- und Großwartungskoordination
+    description: |
+      Umfangs-, Zeit- und Ausführungskoordination für größere Raffinerie-Revisionen.
+  BC-3080.70.10:
+    name: Revisionsumfang-Management
+    description: |
+      Definition und Einfrierung des Revisionsumfangs einschließlich Herausforderungsprozess.
+  BC-3080.70.20:
+    name: Revisionszeitplan-Management
+    description: |
+      Detaillierte Revisionsterminplanung und Fortschrittskontrolle.
+  BC-3080.70.30:
+    name: Abschaltungs- und Wiederinbetriebnahme-Koordination
+    description: |
+      Sequenzierte Einheiten-Abschaltung, Dekontamination und Wiederinbetriebnahme-Koordination.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-refrigerant-lifecycle-management.yaml
+++ b/catalogue/i18n/de/L1-refrigerant-lifecycle-management.yaml
@@ -1,0 +1,173 @@
+locale: de
+source: L1-refrigerant-lifecycle-management.yaml
+entries:
+  BC-2040:
+    name: Kältemittel-Lebenszyklus Management
+    description: |
+      Betrieblicher Lebenszyklus von Kältemitteln über die installierte Basis — Beschaffung und Inventar,
+      Füllmengenabrechnung, Rückgewinnung und Aufbereitung, Leckagemanagement, regulatorische Berichterstattung
+      gemäß F-Gas/EPA Section 608/Kigali-Änderung, Technikerqualifikation, Phase-out-Übergänge
+      und End-of-Life-Entsorgung.
+  BC-2040.10:
+    name: Kältemittel-Beschaffung & Inventar-Management
+    description: |
+      Beschaffung, Zuteilung, Lagerung und Abstimmung von Kältemittelbeständen.
+  BC-2040.10.10:
+    name: Kältemittel-Beschaffung
+    description: |
+      Beschaffung von Kältemitteln von zugelassenen Lieferanten.
+  BC-2040.10.20:
+    name: Kontingent-Zuteilungs-Management
+    description: |
+      Zuteilung regulatorischer Kontingente über Geschäftsbereiche und Märkte.
+  BC-2040.10.30:
+    name: Kältemittel-Lagerung & -Handhabung
+    description: |
+      Lagerung und Handhabung von Kältemittelflaschen gemäß Sicherheits- und Umweltvorschriften.
+  BC-2040.10.40:
+    name: Kältemittel-Inventar-Abstimmung
+    description: |
+      Periodische Abstimmung des Kältemittelinventars über Standorte und Feldbestände.
+  BC-2040.20:
+    name: Kältemittel-Füllmengen-Abrechnung
+    description: |
+      Anlagenbasierte Abrechnung der Kältemittelfüllmenge, Nachfüllungen und Prüfbilanz.
+  BC-2040.20.10:
+    name: Füllmengen-Aufzeichnungen nach Anlage
+    description: |
+      Aufzeichnungen der installierten Kältemittelfüllmenge nach Anlage.
+  BC-2040.20.20:
+    name: Nachfüllungs- & Wiederbefüllungs-Aufzeichnung
+    description: |
+      Aufzeichnung von Nachfüllungen gegen Anlagen-Service-Ereignisse.
+  BC-2040.20.30:
+    name: Füllmengen-Genauigkeits-Audit
+    description: |
+      Audit der Füllmengen-Abrechnungsgenauigkeit über die installierte Basis.
+  BC-2040.20.40:
+    name: Massenbilanz-Abstimmung
+    description: |
+      Massenbilanz-Abstimmung für beschaffte, verwendete, zurückgewonnene und entsorgte Kältemittel.
+  BC-2040.30:
+    name: Kältemittel-Rückgewinnung & Aufbereitungs-Betrieb
+    description: |
+      Feldrückgewinnung und nachgelagerte Aufbereitung zurückgewonnener Kältemittel zur Wiederverwendung.
+  BC-2040.30.10:
+    name: Feld-Rückgewinnungs-Betrieb
+    description: |
+      Vor-Ort-Rückgewinnung von Kältemittel aus Anlagen unter Wartung.
+  BC-2040.30.20:
+    name: Kältemittel-Aufbereitung
+    description: |
+      Aufbereitungsverarbeitung zurückgewonnener Kältemittel auf Jungfrauspezifikationen.
+  BC-2040.30.30:
+    name: Aufgearbeitetes Kältemittel Qualitätsverifizierung
+    description: |
+      Verifizierung der Qualität aufgearbeiteter Kältemittel vor der Wiederverwendung.
+  BC-2040.30.40:
+    name: Zurückgewonnene Kältemittel-Bank-Management
+    description: |
+      Verwaltung von Kältemittelbanken mit aufbereitetem Produkt zur Wiederverwendung.
+  BC-2040.40:
+    name: Kältemittel-Leckage-Management
+    description: |
+      Erkennung, Reparatur und Meldung von Kältemittelleckagen über die installierte Basis.
+  BC-2040.40.10:
+    name: Leckageerkennungs-Überwachung
+    description: |
+      Kontinuierliche und periodische Leckagenerkennungsüberwachung bei Geräten.
+  BC-2040.40.20:
+    name: Leckagebehebungs-Workflow
+    description: |
+      Workflow zur Diagnose und Behebung identifizierter Leckagen.
+  BC-2040.40.30:
+    name: Leckagenraten-Berichterstattung
+    description: |
+      Berichterstattung von Leckagenraten gegen regulatorische Schwellenwerte.
+  BC-2040.40.40:
+    name: Leckagen-Hotspot-Analyse
+    description: |
+      Analyse wiederkehrender Leckagen-Hotspots zur Steuerung von Geräte- oder Prozessänderungen.
+  BC-2040.50:
+    name: Kältemittel-Regulatorische Berichterstattung
+    description: |
+      Regulatorische Berichterstattung über Kältemittelverbrauch, Leckagen, Rückgewinnung und Stoffoffenlegungen.
+  BC-2040.50.10:
+    name: F-Gas-Jahresberichterstattung
+    description: |
+      Jahresberichterstattung gemäß EU-F-Gas-Vorschriften.
+  BC-2040.50.20:
+    name: Nationale Kältemittel-Berichterstattung
+    description: |
+      Berichterstattung unter nationalen Kältemittelprogrammen (z.B. EPA-Berichterstattung in den USA).
+  BC-2040.50.30:
+    name: Kigali- & Montreal-Berichterstattung
+    description: |
+      Berichterstattung gemäß Kigali-Änderung und Montreal-Protokoll-Verpflichtungen.
+  BC-2040.50.40:
+    name: Stoffinventar-Offenlegung
+    description: |
+      Stoffinventar-Offenlegung gegenüber Regulatoren und Stakeholdern.
+  BC-2040.60:
+    name: Techniker-Kältemittel-Qualifikations-Management
+    description: |
+      Verwaltung von Techniker-Qualifikationen, Lizenzen und Kompetenz für den Kältemittelumgang.
+  BC-2040.60.10:
+    name: Techniker-Qualifikations-Aufzeichnungen
+    description: |
+      Aufzeichnungen von Techniker-Kältemittelqualifikationen.
+  BC-2040.60.20:
+    name: Qualifikationserneuerungs-Tracking
+    description: |
+      Verfolgung bevorstehender Qualifikationserneuerungen.
+  BC-2040.60.30:
+    name: Nationale Kältemittelhandhabungs-Lizenzen
+    description: |
+      Verwaltung nationaler Kältemittelhandhabungs-Lizenzen (EPA Section 608, F-Gas-Kategorien).
+  BC-2040.60.40:
+    name: Kompetenzverifizierung
+    description: |
+      Periodische Kompetenzverifizierung für Techniker im Kältemittelumgang.
+  BC-2040.70:
+    name: Kältemittel-Phase-Out & Übergangs-Management
+    description: |
+      Strategische Verwaltung von Kältemittel-Phase-outs und Kunden-Übergangs-Fahrplänen.
+  BC-2040.70.10:
+    name: Kältemittel-Substitutions-Fahrplan
+    description: |
+      Fahrplan zur Substitution auslaufender Kältemittel durch Alternativen mit niedrigerem GWP.
+  BC-2040.70.20:
+    name: Nachrüstungs-Konversions-Planung
+    description: |
+      Planung von Nachrüstungskonversionen auf alternative Kältemittel in der installierten Basis.
+  BC-2040.70.30:
+    name: Kunden-Übergangs-Kommunikation
+    description: |
+      Kundenkommunikation zu Kältemittelübergängen und Zeitplänen.
+  BC-2040.70.40:
+    name: Phase-Out-Risiko-Management
+    description: |
+      Management von Versorgungs-, Regulierungs- und Reputationsrisiken über Phase-out-Fenster.
+  BC-2040.80:
+    name: Kältemittel-End-of-Life & Entsorgung
+    description: |
+      End-of-Life-Vernichtung und zertifizierte Entsorgung von Kältemitteln, die nicht mehr für die Wiederverwendung geeignet sind.
+  BC-2040.80.10:
+    name: Vernichtungs-Koordination
+    description: |
+      Koordination mit genehmigten Vernichtungseinrichtungen.
+  BC-2040.80.20:
+    name: Zertifizierter Entsorgungsnachweis
+    description: |
+      Pflege der Audit-Spur zum Nachweis zertifizierter Entsorgung.
+  BC-2040.80.30:
+    name: End-of-Life-Anlage-Rückgewinnung
+    description: |
+      Rückgewinnung von Kältemittel aus End-of-Life-Anlagen vor der Entsorgung.
+  BC-2040.80.40:
+    name: Entsorgungslieferanten-Management
+    description: |
+      Verwaltung zugelassener Entsorgungslieferanten und Auditorprogramm.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-regulatory-affairs-management.yaml
+++ b/catalogue/i18n/de/L1-regulatory-affairs-management.yaml
@@ -1,0 +1,118 @@
+locale: de
+source: L1-regulatory-affairs-management.yaml
+entries:
+  BC-1530:
+    name: Regulatorische-Angelegenheiten-Management
+    description: |
+      Einreichungen, Zulassungen und Lebenszyklusinteraktionen mit Aufsichtsbehörden.
+  BC-1530.10:
+    name: Regulatorische-Strategie-Management
+    description: |
+      Regulatorische Strategie und Risikobeurteilung.
+  BC-1530.10.10:
+    name: Globale Regulatorische Strategie
+    description: |
+      Multiregionale regulatorische Strategie und Pfadauswahl.
+  BC-1530.10.20:
+    name: Regulatorische Risikobeurteilung
+    description: |
+      Beurteilung regulatorischer Risiken und Notfallmaßnahmen.
+  BC-1530.10.30:
+    name: Zielproduktprofil-Management
+    description: |
+      Definition und Pflege des Zielproduktprofils.
+  BC-1530.20:
+    name: Regulatorische-Einreichungs-Management
+    description: |
+      Vorbereitung und Einreichung von INDs, NDAs, MAAs und BLAs.
+  BC-1530.20.10:
+    name: Einreichungsplanung
+    description: |
+      Einreichungsplanung und Inhaltsterminierung.
+  BC-1530.20.20:
+    name: eCTD-Zusammenstellung
+    description: |
+      Zusammenstellung von eCTD-Einreichungen.
+  BC-1530.20.30:
+    name: Einreichungs-Authoring und -Überprüfung
+    description: |
+      Erstellung und Überprüfung regulatorischer Einreichungsdokumente.
+  BC-1530.20.40:
+    name: Einreichungs-Einreichung und -Verfolgung
+    description: |
+      Einreichung und Verfolgung durch die Behördenbegutachtung.
+  BC-1530.30:
+    name: Regulatorische-Intelligenz-Management
+    description: |
+      Regulatorische Intelligenz und Leitlinienüberwachung.
+  BC-1530.30.10:
+    name: Regulatorische-Leitlinien-Überwachung
+    description: |
+      Überwachung von Leitliniendokumenten und Regeländerungen.
+  BC-1530.30.20:
+    name: Wettbewerbsorientierte Regulatorische Intelligenz
+    description: |
+      Informationen über regulatorische Aktivitäten von Mitbewerbern.
+  BC-1530.30.30:
+    name: Regulatorisches-Wissensrepository
+    description: |
+      Pflege des regulatorischen Wissensrepositorys.
+  BC-1530.40:
+    name: Regulatorischer-Lebenszykluspflege-Management
+    description: |
+      Variationen, Verlängerungen und Änderungen nach Zulassung.
+  BC-1530.40.10:
+    name: Variations-Einreichungen
+    description: |
+      Einreichung von Variationsanzeigen Typ IA, IB und II.
+  BC-1530.40.20:
+    name: Verlängungs-Einreichungen
+    description: |
+      Verlängerungseinreichungen für Zulassungen.
+  BC-1530.40.30:
+    name: Zulassungsänderungs-Management
+    description: |
+      Verwaltung von CMC- und Kennzeichnungsänderungen nach Zulassung.
+  BC-1530.40.40:
+    name: Lebenszyklus-Einreichungsplanung
+    description: |
+      Planung von Lebenszyklus-Einreichungsaktivitäten pro Produkt.
+  BC-1530.50:
+    name: Behörden-Interaktions-Management
+    description: |
+      FDA/EMA/PMDA-Meetings und wissenschaftliche Beratung.
+  BC-1530.50.10:
+    name: Wissenschaftliche-Beratungs-Anfragen
+    description: |
+      Anfragen für wissenschaftliche Beratung bei Gesundheitsbehörden.
+  BC-1530.50.20:
+    name: Behörden-Meeting-Management
+    description: |
+      Vorbereitung und Durchführung von Behördenmeetings.
+  BC-1530.50.30:
+    name: Behörden-Anfragen-Beantwortung
+    description: |
+      Beantwortung von Informationsanfragen der Gesundheitsbehörden.
+  BC-1530.60:
+    name: Kennzeichnungs-Management
+    description: |
+      SmPC/USPI, Beipackzettel und Kennzeichnungsänderungen.
+  BC-1530.60.10:
+    name: Kern-Kennzeichnungs-Management
+    description: |
+      Stammdatenblatt und Kern-Kennzeichnungsmanagement.
+  BC-1530.60.20:
+    name: Lokale-Kennzeichnungs-Anpassung
+    description: |
+      Lokale SmPC/USPI-Anpassung und Übersetzung.
+  BC-1530.60.30:
+    name: Kennzeichnungsänderungs-Implementierung
+    description: |
+      Implementierung von Kennzeichnungsänderungen in allen Märkten.
+  BC-1530.60.40:
+    name: Artwork-Management
+    description: |
+      Verpackungsartwork-Management und Korrekturlesen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-reinsurance-management.yaml
+++ b/catalogue/i18n/de/L1-reinsurance-management.yaml
@@ -1,0 +1,123 @@
+locale: de
+source: L1-reinsurance-management.yaml
+entries:
+  BC-2170:
+    name: Rückversicherung Management
+    description: |
+      Abgegebene und übernommene Rückversicherung — Vertragsentwurf, fakultative Platzierungen,
+      Bordereau, Schadenrückgewinnung, Buchführung und Rückversicherungs-Gegenparteiexpositions-Management.
+  BC-2170.10:
+    name: Abgegebenes Rückversicherungsprogramm-Design
+    description: |
+      Rückversicherungsbedarfsanalyse, Programmstrukturierung und Rückversicherungsmakler-Koordination.
+  BC-2170.10.10:
+    name: Rückversicherungsbedarf-Analyse
+    description: |
+      Analyse des Rückversicherungsbedarfs basierend auf Portfolio, Risikobereitschaft und Kapitalrestriktionen.
+  BC-2170.10.20:
+    name: Vertrag- und Fakultative-Strategie
+    description: |
+      Strategie für Vertrag vs. fakultative Abgaben und proportionale vs. nicht-proportionale Strukturen.
+  BC-2170.10.30:
+    name: Programm-Strukturierung
+    description: |
+      Strukturierung von Rückversicherungsprogrammen, Schichten und Selbstbehalten.
+  BC-2170.10.40:
+    name: Rückversicherungsmakler-Koordination
+    description: |
+      Koordination mit Rückversicherungsmaklern bei Platzierung und Erneuerung.
+  BC-2170.20:
+    name: Vertrags-Rückversicherungs-Administration
+    description: |
+      Vertragsonboarding, Prämienabgabe, Bordereau-Erstellung und Vertrags-Schadenrückgewinnung.
+  BC-2170.20.10:
+    name: Vertrags-Onboarding und Erneuerung
+    description: |
+      Onboarding und Erneuerung von Rückversicherungsverträgen und Deckungseinschreibung.
+  BC-2170.20.20:
+    name: Vertrags-Prämien-Berechnung und Abgabe
+    description: |
+      Berechnung von Vertragssprämien und Abgabe an beteiligte Rückversicherer.
+  BC-2170.20.30:
+    name: Vertrags-Bordereau-Erstellung
+    description: |
+      Erstellung von Vertrags-Prämien- und Schadenbordereaux gemäß Marktpraxis.
+  BC-2170.20.40:
+    name: Vertrags-Schadenrückgewinnung
+    description: |
+      Rückgewinnung von Vertragszahlungen von Rückversicherern.
+  BC-2170.30:
+    name: Fakultative Rückversicherungs-Administration
+    description: |
+      Fakultative Einreichung, Platzierungsverfolgung und Prämien- und Schadensabrechnung.
+  BC-2170.30.10:
+    name: Fakultative Risikoeinreichung
+    description: |
+      Einreichung einzelner Risiken zur fakultativen Platzierung.
+  BC-2170.30.20:
+    name: Fakultative Platzierungs-Tracking
+    description: |
+      Verfolgung fakultativer Zeichnungsunterschriften und Anteile über Rückversicherer.
+  BC-2170.30.30:
+    name: Fakultative Prämien- und Schadenabrechnung
+    description: |
+      Abrechnung von fakultativen Prämien und Schadenrückgewinnung.
+  BC-2170.40:
+    name: Übernommene Rückversicherungs-Management
+    description: |
+      Einwärts-Zeichnung, Prämienbuchung, Schadensadjudizierung und Retrozessions-Koordination.
+  BC-2170.40.10:
+    name: Einwärts-Einreichungs-Zeichnung
+    description: |
+      Zeichnung einwärtiger Rückversicherungseinreichungen und Risikoübernahme.
+  BC-2170.40.20:
+    name: Einwärts-Prämien-Buchung
+    description: |
+      Buchung einwärtiger Rückversicherungsprämien und Anpassungen.
+  BC-2170.40.30:
+    name: Einwärts-Schadensadjudizierung
+    description: |
+      Adjudizierung einwärtiger Rückversicherungsschäden und Rückgewinnung.
+  BC-2170.40.40:
+    name: Retrozessions-Koordination
+    description: |
+      Koordination der Retrozession an zweitrangige Rückversicherer.
+  BC-2170.50:
+    name: Rückversicherungs-Buchführung & Abrechnung
+    description: |
+      Abgabe-Buchführung, Rückgewinnungs-Tracking, Kontoauszugs-Abstimmung und Gegenpartei-Sicherheiten.
+  BC-2170.50.10:
+    name: Abgabe- und Prämien-Buchführung
+    description: |
+      Buchführung für abgegebene Prämien, Provisionen und Anpassungen.
+  BC-2170.50.20:
+    name: Rückversicherungs-Rückgewinnungs-Tracking
+    description: |
+      Verfolgung von Rückversicherungsrückgewinnung auf gezahlten und ausstehenden Schäden.
+  BC-2170.50.30:
+    name: Rückversicherer-Kontoauszug-Abstimmung
+    description: |
+      Abstimmung von Rückversicherer-Kontoauszügen und Streitbeilegung.
+  BC-2170.50.40:
+    name: Gegenpartei-Sicherheiten-Management
+    description: |
+      Verwaltung von Akkreditiven, Treuhandfonds und Sicherheiten von Rückversicherern.
+  BC-2170.60:
+    name: Rückversicherungs-Gegenparteirisiko-Management
+    description: |
+      Rückversicherer-Kreditbewertung, Gegenparteilimit-Überwachung und Ausfallminderung.
+  BC-2170.60.10:
+    name: Rückversicherer-Kreditbewertung
+    description: |
+      Kredit- und Finanzkraftbewertung von Rückversicherungs-Gegenparteien.
+  BC-2170.60.20:
+    name: Konzentrations- und Gegenparteilimit-Überwachung
+    description: |
+      Überwachung von Konzentrations- und Gegenparteiexpositionslimiten.
+  BC-2170.60.30:
+    name: Rückversicherer-Ausfall-Minderung
+    description: |
+      Minderungsmaßnahmen bei Rückversicherer-Herabstufung oder Ausfall-Szenarien.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-research-development-management.yaml
+++ b/catalogue/i18n/de/L1-research-development-management.yaml
@@ -1,0 +1,106 @@
+locale: de
+source: L1-research-development-management.yaml
+entries:
+  BC-810:
+    name: Forschungs- und Entwicklungsmanagement
+    description: |
+      Forschung, angewandte Entwicklung und Experimente.
+  BC-810.10:
+    name: Forschungsmanagement
+    description: |
+      Grundlagen- und Erkundungsforschung.
+  BC-810.10.10:
+    name: Forschungsprogramm-Definition
+    description: |
+      Definition von Forschungsprogrammen und -themen.
+  BC-810.10.20:
+    name: Literatur- und Patentrecherche
+    description: |
+      Systematische Recherche wissenschaftlicher Literatur und Patentlandschaften.
+  BC-810.10.30:
+    name: Forschungsprojektdurchführung
+    description: |
+      Durchführung von Forschungsprojekten mit Meilensteinen und Überprüfungen.
+  BC-810.10.40:
+    name: Forschungsergebnis-Veröffentlichung
+    description: |
+      Publikation, Konferenzbeiträge und Verbreitung von Forschungsergebnissen.
+  BC-810.20:
+    name: Angewandtes Entwicklungsmanagement
+    description: |
+      Angewandte Entwicklung und Technologieentwicklung.
+  BC-810.20.10:
+    name: Angewandte Entwicklungsprojektdurchführung
+    description: |
+      Durchführung angewandter Entwicklungsprojekte bis zu TRL-Meilensteinen.
+  BC-810.20.20:
+    name: Technologiereifung
+    description: |
+      Reifung der Technologiebereitschaft vom Konzept bis zur Bereitstellung.
+  BC-810.20.30:
+    name: Entwicklungswerkzeuge und -methoden
+    description: |
+      Standardisierte Entwicklungswerkzeuge, Methoden und Tool-Chains.
+  BC-810.30:
+    name: Experimentier- und Prototyping-Management
+    description: |
+      Laborarbeit, Prototypen und Machbarkeitsnachweise.
+  BC-810.30.10:
+    name: Laborbetrieb
+    description: |
+      Betrieb von Forschungs- und Entwicklungslaboren.
+  BC-810.30.20:
+    name: Prototyp-Aufbau
+    description: |
+      Aufbau und Montage physischer und digitaler Prototypen.
+  BC-810.30.30:
+    name: Machbarkeitsnachweis-Durchführung
+    description: |
+      Hypothesengesteuerte Machbarkeitsnachweise und Pilotdurchführung.
+  BC-810.30.40:
+    name: Test und Validierung
+    description: |
+      Testpläne, Datenerhebung und Validierung gegenüber Annahmekriterien.
+  BC-810.40:
+    name: F&E-Portfoliomanagement
+    description: |
+      F&E-Projektportfolio, Finanzierung und Priorisierung.
+  BC-810.40.10:
+    name: F&E-Projektauswahl
+    description: |
+      Auswahl und Priorisierung von F&E-Projekten.
+  BC-810.40.20:
+    name: F&E-Ressourcenallokation
+    description: |
+      Zuweisung von Forschern, Laboren und Kapital über Projekte.
+  BC-810.40.30:
+    name: F&E-Performance-Monitoring
+    description: |
+      Portfolio-Performance-Monitoring und Stage-Gate-Entscheidungen im F&E-Bereich.
+  BC-810.40.40:
+    name: F&E-Steuergutschriften und Fördermittelmanagement
+    description: |
+      Erfassung und Substantiierung von F&E-Steuergutschriften und Fördermitteln.
+  BC-810.50:
+    name: Technologie-Roadmap-Management
+    description: |
+      Technologiescouting, Roadmaps und Technologiestrategie.
+  BC-810.50.10:
+    name: Technologiescouting
+    description: |
+      Kontinuierliches Scouting aufkommender und disruptiver Technologien.
+  BC-810.50.20:
+    name: Technologie-Roadmap-Entwicklung
+    description: |
+      Mehrjährige Roadmaps zur Verknüpfung von Technologien mit Produkten und Märkten.
+  BC-810.50.30:
+    name: Technologiestrategie-Definition
+    description: |
+      Technologiestrategie und Plattformentscheidungen.
+  BC-810.50.40:
+    name: Make-or-Buy-Technologieentscheidungen
+    description: |
+      Eigenentwicklung-, Partner- oder Akquisitionsentscheidungen für Technologien.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-research-scholarship-management.yaml
+++ b/catalogue/i18n/de/L1-research-scholarship-management.yaml
@@ -1,0 +1,156 @@
+locale: de
+source: L1-research-scholarship-management.yaml
+entries:
+  BC-4780:
+    name: Forschungs- und Stipendienwesen
+    description: |
+      Management der Hochschulforschungsmission, umfassend Portfoliostrategie,
+      Fördermittellebenszyklus, Ethik- und Integritätsaufsicht, wissenschaftliche
+      Ergebnisse, Forschungszusammenarbeit und Wirkungsbeurteilung.
+  BC-4780.10:
+    name: Forschungsportfolio und -strategie
+    description: |
+      Strategische Gestaltung des institutionellen Forschungsportfolios über
+      Themen, Zentren und Kompetenzinvestitionen hinweg.
+    in_scope:
+      - Forschungsthemen- und Zentrumsstrategie
+      - Investitionsplanung in Forschungskapazitäten
+      - Forschungsleistungsberichtswesen
+    out_of_scope:
+      - Allgemeines Projektportfoliomanagement (abgedeckt unter branchenübergreifendem Projektportfoliomanagement)
+  BC-4780.10.10:
+    name: Forschungsthemen- und Zentrumsstrategie
+    description: |
+      Strategie für Forschungsthemen, Zentren und Institute.
+  BC-4780.10.20:
+    name: Forschungskapazitätsinvestitionsplanung
+    description: |
+      Planung von Investitionen in Forschungskapazitäten einschließlich
+      Infrastruktur und Personal.
+  BC-4780.10.30:
+    name: Forschungsleistungsberichtswesen
+    description: |
+      Internes und externes Berichtswesen zur Forschungsleistung.
+  BC-4780.20:
+    name: Forschungsförderungsmanagement
+    description: |
+      Durchgängiges Management von Forschungsförderungen und -verträgen,
+      von der Möglichkeitsidentifizierung bis zur Nachförderungs-Verwaltung.
+    in_scope:
+      - Identifizierung von Förderungsmöglichkeiten
+      - Vorförderungs-Antragsstellung
+      - Nachförderungs-Förderungsverwaltung
+    out_of_scope:
+      - Allgemeines Finanzmanagement (abgedeckt unter branchenübergreifendem Finanzmanagement)
+  BC-4780.20.10:
+    name: Förderungsmöglichkeitsidentifizierung
+    description: |
+      Identifizierung von Förderungs- und Finanzierungsmöglichkeiten für
+      Forschende.
+  BC-4780.20.20:
+    name: Vorförderungs-Antragsstellung
+    description: |
+      Entwicklung von Förderungsanträgen, Kostenschätzungen und
+      Einreichungspaketen.
+  BC-4780.20.30:
+    name: Nachförderungs-Förderungsverwaltung
+    description: |
+      Nachförderungs-Verwaltung vergebener Förderungen einschließlich
+      Berichtswesen und Compliance.
+  BC-4780.30:
+    name: Forschungsethik und Integritätsaufsicht
+    description: |
+      Unabhängige Aufsicht über Forschungsethik und Integrität, einschließlich
+      Überprüfung von Humanforschung, Tierforschungsaufsicht und
+      Fehlverhaltensuntersuchungen.
+    in_scope:
+      - Humanforschungsüberprüfung (IRB/REC)
+      - Tierforschungsaufsicht (IACUC/AWERB)
+      - Forschungsfehlverhaltensuntersuchungen
+    out_of_scope:
+      - Akademische Fehlverhaltensfälle (Prüfungen) (abgedeckt unter Prüfungs- und Bewertungswesen)
+  BC-4780.30.10:
+    name: Humanforschungsüberprüfung
+    description: |
+      Unabhängige Überprüfung von Forschung mit menschlichen Probanden.
+  BC-4780.30.20:
+    name: Tierforschungsaufsicht
+    description: |
+      Aufsicht über Forschung mit tierischen Probanden.
+  BC-4780.30.30:
+    name: Forschungsfehlverhaltensuntersuchung
+    description: |
+      Untersuchung von Vorwürfen des Forschungsfehlverhaltens.
+  BC-4780.40:
+    name: Wissenschaftliche Ergebnisse und Publikationsmanagement
+    description: |
+      Nachverfolgung und Verwaltung wissenschaftlicher Ergebnisse einschließlich
+      Publikationen, Open Access und persistenten Identifikatoren.
+    in_scope:
+      - Publikationsnachverfolgung
+      - Open-Access- und Repository-Management
+      - Management persistenter Identifikatoren (ORCID, DOI)
+    out_of_scope:
+      - Kommerzialisierung geistigen Eigentums (abgedeckt unter branchenübergreifendem Intellectual-Property-Management)
+  BC-4780.40.10:
+    name: Publikationsnachverfolgung
+    description: |
+      Nachverfolgung von Forscherpublikationen und -ergebnissen.
+  BC-4780.40.20:
+    name: Open-Access und Repository-Management
+    description: |
+      Management von Open-Access-Publikationen und institutionellen Repositories.
+  BC-4780.40.30:
+    name: Management persistenter Identifikatoren
+    description: |
+      Management persistenter Identifikatoren für Forschende und Ergebnisse.
+  BC-4780.50:
+    name: Forschungszusammenarbeit und Partnerschaftsmanagement
+    description: |
+      Aufbau und Betrieb von Forschungspartnerschaften mit Akademie, Industrie
+      und internationalen Kooperationspartnern.
+    in_scope:
+      - Interinstitutionelle Forschungsvereinbarungen
+      - Industrieforschungspartnerschaften
+      - Internationale Forschungszusammenarbeit
+    out_of_scope:
+      - Kommerzielle Lieferantenbeziehungen (abgedeckt unter branchenübergreifendem Lieferantenmanagement)
+  BC-4780.50.10:
+    name: Management interinstitutioneller Forschungsvereinbarungen
+    description: |
+      Management von Forschungsvereinbarungen mit Peer-Institutionen.
+  BC-4780.50.20:
+    name: Management von Industrieforschungspartnerschaften
+    description: |
+      Management von Industrieforschungspartnerschaften und geförderter Forschung.
+  BC-4780.50.30:
+    name: Internationale Forschungszusammenarbeit
+    description: |
+      Aufbau und Betrieb internationaler Forschungskooperationen.
+  BC-4780.60:
+    name: Forschungswirkung und -beurteilung
+    description: |
+      Beurteilung der Forschungswirkung durch Fallstudien, Bibliometrie und
+      Teilnahme an nationalen Forschungsbeurteilungsübungen.
+    in_scope:
+      - Forschungswirkungs-Fallstudien
+      - Bibliometrische und altmetrische Analyse
+      - Nationale Forschungsbeurteilungseinreichung (z. B. REF)
+    out_of_scope:
+      - Akademische Akkreditierungsüberprüfungen (abgedeckt unter Akademische Qualität & Akkreditierungsmanagement)
+  BC-4780.60.10:
+    name: Forschungswirkungs-Fallstudien
+    description: |
+      Entwicklung von Forschungswirkungs-Fallstudien.
+  BC-4780.60.20:
+    name: Bibliometrische und altmetrische Analyse
+    description: |
+      Bibliometrische und altmetrische Analyse von Forschungsergebnissen und
+      -reichweite.
+  BC-4780.60.30:
+    name: Nationale Forschungsbeurteilungseinreichung
+    description: |
+      Einreichung bei nationalen Forschungsbeurteilungsübungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-reservation-booking-management.yaml
+++ b/catalogue/i18n/de/L1-reservation-booking-management.yaml
@@ -1,0 +1,198 @@
+locale: de
+source: L1-reservation-booking-management.yaml
+entries:
+  BC-4020:
+    name: Reservierung und Buchung Management
+    description: |
+      Lebenszyklus der Reservierung, des PNR und des Hotelfolios – Erfassung,
+      Änderung, Stornierung, Gruppenblöcke, Bestätigungen, Zahlungen und
+      störungsbedingte Neubuchungen – unabhängig vom Ursprungskanal.
+    in_scope:
+      - Reservierungserfassung für Einzel-, Mehrpassagier- und Mehrkomponienten-Reisepläne
+      - Buchungsänderungen, Stornierungen und Erstattungsberechtigung
+      - Gruppenblöcke, Zimmerlisten, Stichtermin und Pickup
+      - Bestätigungs-, Gutschein- und E-Ticket-Ausstellung
+      - Buchungsseitige Zahlung und BSP/ARC-Abrechnung
+      - Fahrplan-Änderungs- und IROPS-Umbuchung
+    out_of_scope:
+      - Kanal- und Paritätsmanagement (BC-4010)
+      - Preismaschinen und Yield-Entscheidungen (BC-4030)
+      - Operative Störungsentscheidungen für Flugzeug und Besatzung (BC-4080.60)
+  BC-4020.10:
+    name: Reservierungserfassung
+    description: |
+      Erfassung von Reservierungen für einfache und komplexe Reisepläne
+      aus jedem Ursprungskanal oder Agenten.
+  BC-4020.10.10:
+    name: Einzel-Reiseplan-Reservierungserfassung
+    description: |
+      Erfassung von Einzelreiseplan-Reservierungen wie Einzel-Property-Aufenthalt
+      oder Einzel-Flugbuchung.
+  BC-4020.10.20:
+    name: Mehrpassagier-Reservierungserfassung
+    description: |
+      Erfassung von Mehrpassagier- oder Mehrgeschäfts-Reservierungen mit
+      gemeinsamen Reiseplan-Segmenten.
+  BC-4020.10.30:
+    name: Mehrkomponienten-Reservierungserfassung
+    description: |
+      Erfassung von Mehrkomponienten-Reservierungen mit Flügen,
+      Hotels, Zusatzleistungen und Bodendiensten.
+  BC-4020.10.40:
+    name: Reisebürobuchungserfassung
+    description: |
+      Erfassung von Buchungen durch Einzel- und Firmereisebüros im Namen von Reisenden.
+  BC-4020.20:
+    name: Buchungsänderung und Stornierung
+    description: |
+      Freiwillige Änderung und Stornierung von Buchungen einschließlich
+      Änderungsgebühren, Erstattungsberechtigung und Neuausstellungsoperationen.
+  BC-4020.20.10:
+    name: Buchungsänderungsmanagement
+    description: |
+      Management freiwilliger Buchungsänderungen bei Datum, Produkt und Reisendedaten.
+  BC-4020.20.20:
+    name: Buchungsstornierungsmanagement
+    description: |
+      Management freiwilliger Stornierungen und Inventarrückgabe in den Pool.
+  BC-4020.20.30:
+    name: Erstattungsberechtigungs- und Berechnung
+    description: |
+      Feststellung der Erstattungsberechtigung und Berechnung erstattungsfähiger
+      Beträge einschließlich Strafen.
+  BC-4020.20.40:
+    name: Freiwillige Neuausstellungsoperationen
+    description: |
+      Durchführung freiwilliger Neuausstellung einschließlich Tarifunterschiedserhebung
+      und Dokumentenneuausstellung.
+  BC-4020.30:
+    name: Gruppenblock-Management
+    description: |
+      Management von Gruppenblöcken gegen vertraglich gebundenes Inventar –
+      Blockerstellung, Zimmerlisten, Stichtermin und Pickup-Tracking.
+    in_scope:
+      - Gruppenblock-Lebenszyklus von Vertrag bis Bereinigung und finalem Pickup
+      - Zimmerlisten-Erfassung und -Aktualisierung
+    out_of_scope:
+      - Gruppenvertriebsverträge (BC-4110.10)
+      - Veranstaltungsauftragsausführung (BC-4110.30)
+  BC-4020.30.10:
+    name: Gruppenblock-Erstellung
+    description: |
+      Erstellung von Gruppenblöcken entsprechend vertraglicch gebundenem
+      Inventar und Ratenverpflichtungen.
+  BC-4020.30.20:
+    name: Zimmerlisten-Management
+    description: |
+      Management von Zimmerlisten zur Zuordnung einzelner Reisender
+      zu Blockinventar.
+  BC-4020.30.30:
+    name: Gruppenst-Stichterminsmanagement
+    description: |
+      Management von Gruppen-Stichtermin-Daten und Freigabe ungenutzten Blockinventars.
+  BC-4020.30.40:
+    name: Gruppen-Pickup-Tracking
+    description: |
+      Tracking des Gruppen-Pickups gegen Vertrag für Erlösrechnung und Prognose.
+  BC-4020.40:
+    name: Reservierungsbestätigung und Dokumentation
+    description: |
+      Ausstellung von Buchungsbestätigungen, Gutscheinen, E-Tickets und
+      Reiseplan-Dokumenten an Reisende und Agenten.
+  BC-4020.40.10:
+    name: Buchungsbestätigungsgenerierung
+    description: |
+      Generierung und Versand von Buchungsbestätigungen über Benachrichtigungskanäle.
+  BC-4020.40.20:
+    name: Gutschein- und Dokumentenausstellung
+    description: |
+      Ausstellung von Gutscheinen und Servicedokumenten für Hotel-, Reise-
+      und Aktivitätskomponenten.
+  BC-4020.40.30:
+    name: E-Ticket-Ausstellung und Neuausstellung
+    description: |
+      Ausstellung und Neuausstellung von Airline-E-Tickets einschließlich Coupon-Statusaktualisierungen.
+  BC-4020.40.40:
+    name: Buchungs-Reiseplan-Verteilung
+    description: |
+      Verteilung von Reiseplandokumenten an Reisende, Reisebüros und
+      integrierte Reiseverwaltungssysteme.
+  BC-4020.50:
+    name: Reservierungshalten- und Wartelistenmanagement
+    description: |
+      Management vorläufiger Reservierungshalten, Wartelisten und Umwandlungen
+      bei begrenzter Verfügbarkeit oder zahlungsfristgebundenen Konditionen.
+  BC-4020.50.10:
+    name: Vorläufige Haltenmanagement
+    description: |
+      Management vorläufiger Reservierungshalten mit kontrollierten Zahlungsfristen.
+  BC-4020.50.20:
+    name: Wartelisten-Erfassung und Priorisierung
+    description: |
+      Erfassung von Wartelisten-Anfragen und Priorisierungsregeln
+      bei verfügbar werdendem Inventar.
+  BC-4020.50.30:
+    name: Wartelisten-Umwandlungsoperationen
+    description: |
+      Umwandlung von Wartelisten-Anfragen in bestätigte Buchungen
+      bei freiwerdendem Inventar.
+  BC-4020.50.40:
+    name: Halteverfalls-Management
+    description: |
+      Management des Halteverfalls und automatische Freigabe des gehaltenen Inventars.
+  BC-4020.60:
+    name: Buchungszahlung und Abrechnung
+    description: |
+      Buchungsseitige Zahlung, Anzahlung, Kostenfang und Partnerabrechnung
+      einschließlich BSP und ARC.
+  BC-4020.60.10:
+    name: Buchungsanzahlung und Vorautorisierung
+    description: |
+      Erfassung von Buchungsanzahlungen und Kartenvorautorisierungen
+      gegen Anzahlungs- und Garantierichtlinien.
+  BC-4020.60.20:
+    name: Buchungskostenfang
+    description: |
+      Kostenfang gegen buchungsseitige Zahlungsmittel an Berechtigungspunkten.
+  BC-4020.60.30:
+    name: BSP- und ARC-Abrechnungsoperationen
+    description: |
+      Abrechnung agentenbuchter Buchungen über BSP, ARC und gleichwertige Abrechnungspläne.
+  BC-4020.60.40:
+    name: Provisionsberechnung und Auszahlung
+    description: |
+      Berechnung und Auszahlung von Provisionen an Reisebüros und Vertriebspartner.
+  BC-4020.70:
+    name: Buchungsstörungs- und Umbuchungsoperationen
+    description: |
+      Unterbringung von Buchungen, die von Fahrplanänderungen, Stornierungen
+      und Massenstörungen betroffen sind, einschließlich Kommunikation und Entschädigungsberechtigung.
+    in_scope:
+      - Fahrplanänderungs-Umbuchung
+      - Massenbedrohungs-Umbuchung (IROPS, Wetter, höhere Gewalt)
+      - Entschädigungsberechtigung nach Fluggesellschafts- und Verbraucherregeln
+    out_of_scope:
+      - Operative Entscheidungen zu Flugzeug, Besatzung und Dispatch (BC-4080.60)
+      - Reiseplan-Wiederherstellung auf Toursseite (BC-4100.60)
+  BC-4020.70.10:
+    name: Fahrplanänderungs-Umbuchung
+    description: |
+      Umbuchung von Buchungen bei Fahrplanänderungen einschließlich
+      angebotener Optionen für Reisende.
+  BC-4020.70.20:
+    name: Massenbedrohungs-Umbuchung
+    description: |
+      Umbuchung großer Buchungszahlen bei Wetter-, IROPS- oder höherer-Gewalt-Ereignissen.
+  BC-4020.70.30:
+    name: Entschädigungsberechtigungs-Feststellung
+    description: |
+      Feststellung der Entschädigungsberechtigung nach Fluggesellschaftsrichtlinien
+      und anwendbaren Fahrgastrechtsregeln.
+  BC-4020.70.40:
+    name: Umbuchungskommunikation
+    description: |
+      Ausgehende Kommunikation an betroffene Reisende und Agenten
+      während Umbuchungsereignissen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-retail-loss-prevention-management.yaml
+++ b/catalogue/i18n/de/L1-retail-loss-prevention-management.yaml
@@ -1,0 +1,109 @@
+locale: de
+source: L1-retail-loss-prevention-management.yaml
+entries:
+  BC-2340:
+    name: Verlustprävention im Einzelhandel
+    description: |
+      Prävention, Erkennung, Untersuchung und Reduzierung von Warenverlusten und
+      Betrug im gesamten Einzelhandelsbereich – von Ladendiebstahl und organisierter
+      Einzelhandelskriminalität bis hin zu internem Diebstahl und Kassenmissbrauch.
+  BC-2340.10:
+    name: Schwundanalyse-Management
+    description: |
+      Messung, Ursachenanalyse und Berichterstattung über Warenschwund nach
+      Filialen, Kanälen und Warengruppen.
+    in_scope:
+      - Schwundmessung gegenüber dem Buchbestand
+      - Schwundberichte nach Filiale, Kategorie und Ursache
+      - Ursachenanalyse unbekannter Verluste
+  BC-2340.10.10:
+    name: Schwundmessung
+    description: |
+      Messung des Schwunds gegenüber dem Buchbestand und physischen Inventuren.
+  BC-2340.10.20:
+    name: Schwund-Ursachenanalyse
+    description: |
+      Ursachenanalyse des Schwunds bei bekannten und unbekannten Verlusten.
+  BC-2340.10.30:
+    name: Schwundberichterstattung und Ziele
+    description: |
+      Schwundberichte und Festlegung von Reduktionszielen nach Filiale und Kategorie.
+  BC-2340.20:
+    name: Interne Diebstahluntersuchung
+    description: |
+      Erkennung, Untersuchung und Lösung von Mitarbeiterunehrlichkeit einschließlich
+      Disziplinar- und Rückforderungsmaßnahmen.
+  BC-2340.20.10:
+    name: Erkennung von Mitarbeiterunehrlichkeit
+    description: |
+      Erkennung von Mitarbeiterunehrlichkeit über Hinweislinien, Analysen und Audits.
+  BC-2340.20.20:
+    name: Interne Untersuchungsfallbearbeitung
+    description: |
+      Fallbearbeitung interner Untersuchungen einschließlich Beweisführung.
+  BC-2340.20.30:
+    name: Rückforderungs- und Disziplinarkoordination
+    description: |
+      Koordination von Rückforderungen, Disziplinarmaßnahmen und HR-Nachverfolgung.
+  BC-2340.30:
+    name: Externer Diebstahl und ORC-Management
+    description: |
+      Prävention und Untersuchung von Ladendiebstahl und organisierter Einzelhandelskriminalität
+      einschließlich Kontakten zu Strafverfolgungsbehörden und Branchenverbänden.
+  BC-2340.30.10:
+    name: Ladendiebstahlprävention
+    description: |
+      Prävention von Ladendiebstahl durch Abschreckung, Raumgestaltung und Intervention.
+  BC-2340.30.20:
+    name: Organisierte Einzelhandelskriminalität – Ermittlung
+    description: |
+      Ermittlung gegen Netzwerke und Muster organisierter Einzelhandelskriminalität.
+  BC-2340.30.30:
+    name: Behördliche Zusammenarbeit
+    description: |
+      Zusammenarbeit mit Polizei und Branchenforen bei Einzelhandelskriminalitätsfällen.
+  BC-2340.40:
+    name: POS-Betrugsprävention
+    description: |
+      Erkennung und Prävention von Betrug am Point of Sale einschließlich
+      Erstattungsbetrug, Sweethearting und ausnahmebasierter Berichterstattung.
+    in_scope:
+      - Erkennung von Rückgabe- und Umtauschbetrug
+      - Erkennung von Sweethearting und Rabattmissbrauch
+      - Ausnahmebasierte POS-Berichterstattung
+  BC-2340.40.10:
+    name: Rückgabe- und Umtauschbetrug-Erkennung
+    description: |
+      Erkennung von Betrugsmustern bei Rückgaben und Umtausch.
+  BC-2340.40.20:
+    name: Sweethearting- und Rabattmissbrauchs-Erkennung
+    description: |
+      Erkennung von Sweethearting und unbefugter Rabattanwendung.
+  BC-2340.40.30:
+    name: Ausnahmebasierte POS-Berichterstattung
+    description: |
+      Ausnahmebasierte Berichterstattung über POS-Transaktionen zur Aufdeckung von Anomalien.
+  BC-2340.50:
+    name: Physische Sicherheit und Überwachungsmanagement
+    description: |
+      Physische Sicherheit auf Filialebene einschließlich Videoüberwachung, EAS,
+      Zugangskontrollen und Wachdiensten.
+  BC-2340.50.10:
+    name: Filial-CCTV-Betrieb
+    description: |
+      Betrieb, Überwachung und Beweissicherung der Filial-Videoüberwachung.
+  BC-2340.50.20:
+    name: Elektronische Warensicherung – Betrieb
+    description: |
+      Betrieb von EAS-Sicherungsanlagen und -etiketten einschließlich Alarmreaktion.
+  BC-2340.50.30:
+    name: Filiale – Zugangskontrolle
+    description: |
+      Physische Zugangskontrolle zu Lagerräumen, Kassenbüros und Hinterbereichen.
+  BC-2340.50.40:
+    name: Wachdienstmanagement
+    description: |
+      Einsatz und Verwaltung von filialinternen und externen Wachdiensten.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-retail-site-network-planning-management.yaml
+++ b/catalogue/i18n/de/L1-retail-site-network-planning-management.yaml
@@ -1,0 +1,109 @@
+locale: de
+source: L1-retail-site-network-planning-management.yaml
+entries:
+  BC-2350:
+    name: Standortnetzplanung (Einzelhandel)
+    description: |
+      Auswahl, Dimensionierung und Lebenszyklus des stationären Einzelhandelsnetzwerks –
+      Einzugsgebietsanalyse, Formatwahl, Identifikation unterversorgter Flächen und
+      standortbezogene Entscheidungen im Lebenszyklus.
+  BC-2350.10:
+    name: Einzugsgebiet- und Handelsgebietsanalyse
+    description: |
+      Einzugsgebietsdefinition, Fußgänger- und Demografiemikroanalyse sowie
+      Wettbewerbsdichtebeurteilung für potenzielle und bestehende Standorte.
+  BC-2350.10.10:
+    name: Einzugsgebietsdefinition
+    description: |
+      Definition von Einzugsgebieten anhand von Fahrtzeit, Bevölkerungsdichte und Barrieren.
+  BC-2350.10.20:
+    name: Demografische Mikroanalyse
+    description: |
+      Mikroebenen-Analyse von Demografie und Lebensstil der Einzugsgebiete.
+  BC-2350.10.30:
+    name: Frequenz- und Mobilitätsanalyse
+    description: |
+      Analyse von Frequenzmustern, Mobilitätsdaten und Fußgängerströmen.
+  BC-2350.10.40:
+    name: Wettbewerbsdichteanalyse
+    description: |
+      Analyse der Wettbewerbsdichte und des Handelsgebietanteils.
+  BC-2350.20:
+    name: Filialformat-Auswahl
+    description: |
+      Auswahl des geeigneten Filialformats – Hypermarkt, Supermarkt, Convenience,
+      Fachmarkt, Dunkelformat – für ein gegebenes Einzugsgebiet und die Strategie.
+    in_scope:
+      - Formatwahl je Einzugsgebiet und Kundenmission
+      - Format-Mix-Portfolio im gesamten Netzwerk
+      - Flächen- und Grundrissgestaltung je Format
+    out_of_scope:
+      - Detailliertes Ladeninterieurdesign (BC-2310.60)
+  BC-2350.20.10:
+    name: Formatwahl je Einzugsgebiet
+    description: |
+      Auswahl des Filialformats je Einzugsgebiet basierend auf der Kundenmission.
+  BC-2350.20.20:
+    name: Formatgröße und Grundriss
+    description: |
+      Dimensionierung von Verkaufsfläche, Nebenräumen und Gesamtgrundriss je Format.
+  BC-2350.20.30:
+    name: Format-Mix-Portfolioplanung
+    description: |
+      Planung des Format-Mix im Netzwerk und Migrationen zwischen Formaten.
+  BC-2350.30:
+    name: Netzwerk-Footprint-Optimierung
+    description: |
+      Optimierung des Netzwerkpräsenz durch Identifikation unterversorgter Gebiete,
+      Kannibalisierungsmodellierung und Gesamtabdeckung.
+  BC-2350.30.10:
+    name: Identifikation unterversorgter Gebiete
+    description: |
+      Identifikation unterversorgter Handelsgebiete und ungenutzter Standortpotenziale.
+  BC-2350.30.20:
+    name: Kannibalisierungsmodellierung
+    description: |
+      Modellierung des Kannibalisierungseffekts neuer Filialen auf bestehende Standorte.
+  BC-2350.30.30:
+    name: Abdeckungs- und Reichweitenoptimierung
+    description: |
+      Optimierung von Abdeckung und Reichweite im Zielmarkt.
+  BC-2350.40:
+    name: Filial-Lebenszyklus-Management
+    description: |
+      Lebenszyklusentscheidungen je Filiale – Verlagerung, Renovierung,
+      Formatverkleinerung oder Schließung auf Basis von Leistung und Einzugsgebietsentwicklung.
+  BC-2350.40.10:
+    name: Filialleistungsdiagnostik
+    description: |
+      Diagnose unterdurchschnittlicher Filialen einschließlich Einzugsgebietswandel.
+  BC-2350.40.20:
+    name: Filialverlagerung und Renovierungsentscheidung
+    description: |
+      Entscheidungen über Verlagerung oder Renovierung von Filialen im Vergleich zu Alternativen.
+  BC-2350.40.30:
+    name: Filialschließungsentscheidung
+    description: |
+      Entscheidungsfindung zur Filialschließung einschließlich Stakeholder- und Warenauswirkungen.
+  BC-2350.50:
+    name: Einzelhandels-Immobilienbrief-Management
+    description: |
+      Einzelhandelsspezifische Immobilienbriefe, die an die unternehmensweiten
+      Immobilienteams für Standortakquisition, Mietverhandlung und Exits übergeben werden.
+    in_scope:
+      - Einzelhandelsspezifische Standortbriefe
+      - Übergabe an Corporate-Real-Estate-Akquisition (BC-710.20)
+      - Einzelhandelsspezifische Exit-Briefe (z. B. Handelsbeschränkungen)
+    out_of_scope:
+      - Mietverhandlung und -verwaltung (BC-710.20, BC-710.30)
+  BC-2350.50.10:
+    name: Einzelhandels-Standortbrief-Erstellung
+    description: |
+      Erstellung einzelhandelsspezifischer Standortbriefe mit Format- und Nachbarschaftsanforderungen.
+  BC-2350.50.20:
+    name: Einzelhandels-Exit-Brief-Erstellung
+    description: |
+      Erstellung einzelhandelsspezifischer Exit-Briefe einschließlich Handelsbeschränkungsposition.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-retail-store-operations-management.yaml
+++ b/catalogue/i18n/de/L1-retail-store-operations-management.yaml
@@ -1,0 +1,134 @@
+locale: de
+source: L1-retail-store-operations-management.yaml
+entries:
+  BC-2310:
+    name: Einzelhandelsbetrieb Management
+    description: |
+      Täglicher Betrieb physischer Einzelhandelsgeschäfte — Öffnungs- und Schließroutinen,
+      Filial-Ausführung, filialbezogenes Personal, Revisionen, Einrichtungspflege und die
+      konsistente Bereitstellung des Filialformat-Erlebnisses.
+  BC-2310.10:
+    name: Filialöffnungs- & Schließbetrieb
+    description: |
+      Tägliche Filialöffnungs- und Schließroutinen einschließlich Kassenschubladenvorbereitungen,
+      Tagesabschluss-Abstimmung und Schichtübergabe.
+  BC-2310.10.10:
+    name: Filialöffnungsroutine-Durchführung
+    description: |
+      Durchführung von Filialöffnungsverfahren einschließlich Bereitschaftsprüfungen.
+  BC-2310.10.20:
+    name: Filialschließroutine-Durchführung
+    description: |
+      Tagesabschluss-Schließroutinen einschließlich Abstimmung und Sicherung.
+  BC-2310.10.30:
+    name: Schichtübergabe-Management
+    description: |
+      Schichtübergabe zwischen Teams mit Aufgaben- und Vorfalls-Weitergabe.
+  BC-2310.20:
+    name: Filialausführungs-Management
+    description: |
+      Ausführung von Merchandising-, Aktions-, Beschilderungs- und Nachfüllaufgaben
+      auf Filialebene, damit die Filiale den Zentralplan widerspiegelt.
+    in_scope:
+      - Aufgabenmanagement für Filialmitarbeiter
+      - Planogramm- und Beschilderungsausführung
+      - Filialinterne Nachfüllung aus Lagerware
+    out_of_scope:
+      - Planogramm-Design (BC-2300.30.10)
+  BC-2310.20.10:
+    name: Filialaufgaben-Management
+    description: |
+      Verteilung und Verfolgung betrieblicher Aufgaben an Filialteams.
+  BC-2310.20.20:
+    name: Planogramm- und Beschilderungs-Durchführung
+    description: |
+      Filialinterne Durchführung von Planogrammen, Beschilderung und Aktionsaufbau.
+  BC-2310.20.30:
+    name: Filialinterne Nachfüllung
+    description: |
+      Nachfüllung von Regalen aus Lager und Lagerfläche.
+  BC-2310.20.40:
+    name: Lager- und Backoffice-Betrieb
+    description: |
+      Wareneingang, Organisation und Management von Lager- und Backoffice-Beständen.
+  BC-2310.30:
+    name: Filial-Personalmanagement
+    description: |
+      Arbeitseinsatzplanung auf Filialebene, Stunden-Personalbedarfsplanung und
+      Mitarbeiter-Performance-Management.
+    in_scope:
+      - Stündliche Personalbedarfsprognosen basierend auf Frequenz und Umsatz
+      - Schichtplanung und Zeiterfassung
+      - Mitarbeiter-Performance und Coaching auf Filialebene
+    out_of_scope:
+      - Unternehmensweites Human-Capital-Management (BC-300)
+  BC-2310.30.10:
+    name: Personalbedarf-Prognose
+    description: |
+      Prognose des stündlichen Personalbedarfs nach Filiale und Abteilung.
+  BC-2310.30.20:
+    name: Filialschicht-Planung
+    description: |
+      Planung von Filialschichten unter Berücksichtigung von Fairness und Arbeitsvorschriften.
+  BC-2310.30.30:
+    name: Zeiterfassung Management
+    description: |
+      Erfassung von Arbeitsbeginn, Arbeitsende und Ausnahmenbehandlung.
+  BC-2310.30.40:
+    name: Mitarbeiter-Performance-Coaching
+    description: |
+      Coaching, Anerkennung und Performance-Management von Filialmitarbeitern.
+  BC-2310.40:
+    name: Filialrevisions- & Compliance Management
+    description: |
+      Betriebsrevisionen, Compliance-Begehungen, Mystery-Shopping und Filialeinhaltung
+      von Marken- und Betriebsstandards.
+  BC-2310.40.10:
+    name: Betriebsrevisions-Programm
+    description: |
+      Programm von Betriebsrevisionen und Begehungen gegenüber Filialstandards.
+  BC-2310.40.20:
+    name: Mystery-Shopping-Programm
+    description: |
+      Mystery-Shopper-Programm zur Bewertung des Kundenerlebnisses.
+  BC-2310.40.30:
+    name: Filialstandard-Einhaltung
+    description: |
+      Einhaltung von Marken-, Sicherheits- und Betriebsstandards nach Filiale.
+  BC-2310.50:
+    name: Filialanlage-Pflege Management
+    description: |
+      Filialinterne Pflege von Einrichtungen, Geräten, Kühlung und Sauberkeit,
+      um die Filiale verkaufsbereit zu halten.
+  BC-2310.50.10:
+    name: Einrichtungs- und Geräte-Wartung
+    description: |
+      Wartung von Filialeinrichtungen, Regalen und Geräten.
+  BC-2310.50.20:
+    name: Kühlanlagen-Verfügbarkeits-Management
+    description: |
+      Überwachung und Verfügbarkeitsmanagement von Kühlanlagen im Lebensmitteleinzelhandel.
+  BC-2310.50.30:
+    name: Filialreinigung und -Hygiene
+    description: |
+      Sauberkeits-, Reinigungsbeauftragten- und Hygiene-Routinen für die Verkaufsfläche.
+  BC-2310.60:
+    name: Filialformat- & Erlebnis-Management
+    description: |
+      Definition und Stewardship von Filialformat-Erlebnisstandards
+      einschließlich Service-Modell, Erscheinungsbild und Kundenreise.
+  BC-2310.60.10:
+    name: Filialformat-Standards
+    description: |
+      Standards für jedes Filialformat mit Layout, Service und Ambiente.
+  BC-2310.60.20:
+    name: Kundenerlebnis-Design (Filiale)
+    description: |
+      Gestaltung der filialinternen Kundenreise und Serviceinteraktionen.
+  BC-2310.60.30:
+    name: Filialkonzept-Erneuerungsplanung
+    description: |
+      Planung von Filialkonzepterneuerungen und Pilot-Rollouts.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-route-charges-management.yaml
+++ b/catalogue/i18n/de/L1-route-charges-management.yaml
@@ -1,0 +1,90 @@
+locale: de
+source: L1-route-charges-management.yaml
+entries:
+  BC-1270:
+    name: Streckengebühren-Management
+    description: |
+      Berechnung, Abrechnung und Einzug von Flugsicherungsgebühren von Luftraumnutzern.
+  BC-1270.10:
+    name: Gebührengebiets-Management
+    description: |
+      Gebührengebietsdefinitionen, Abrechnungsregeln und Einheitspreisfestsetzung.
+  BC-1270.10.10:
+    name: Gebührengebiet-Definition
+    description: |
+      Definition von Strecken- und Terminal-Gebührengebieten.
+  BC-1270.10.20:
+    name: Einheitspreis-Berechnung
+    description: |
+      Berechnung und Genehmigung von Einheitspreisen je Gebührengebiet.
+  BC-1270.10.30:
+    name: Gebührenregel-Management
+    description: |
+      Pflege der Gebührenformel und Ausnahmeregelungen.
+  BC-1270.20:
+    name: Streckengebühren-Berechnungsmanagement
+    description: |
+      Flugbasierte Streckengebührenberechnung.
+  BC-1270.20.10:
+    name: Flugdatenerfassung für die Gebührenberechnung
+    description: |
+      Erfassung von Flugdaten als Input für die Gebührenmaschine.
+  BC-1270.20.20:
+    name: Distanz- und Gewichtsberechnung
+    description: |
+      Berechnung anrechenbarer Distanz- und Gewichtsfaktoren.
+  BC-1270.20.30:
+    name: Gebührenberechnung
+    description: |
+      Anwendung des Einheitspreises zur Ableitung von Streckengebühren je Flug.
+  BC-1270.30:
+    name: Gebühreneinzugsmanagement
+    description: |
+      Rechnungsstellung, Einzug, Zahlungsabwicklung und Mahnwesen.
+  BC-1270.30.10:
+    name: Gebührenrechnungsstellung
+    description: |
+      Erstellung monatlicher Streckengebührenrechnungen.
+  BC-1270.30.20:
+    name: Zahlungsabwicklung
+    description: |
+      Eingang und Abwicklung von Zahlungen der Luftraumnutzer.
+  BC-1270.30.30:
+    name: Mahnwesen und Forderungsmanagement
+    description: |
+      Mahnwesen, Forderungsmanagement und Vollstreckung bei überfälligen Gebühren.
+  BC-1270.40:
+    name: Airline-Kontomanagement
+    description: |
+      Luftraumnutzerkonten, Abrechnungen und Streitbeilegung.
+  BC-1270.40.10:
+    name: Luftraumnutzerkonto-Pflege
+    description: |
+      Pflege der Stammdaten von Luftraumnutzerkonten.
+  BC-1270.40.20:
+    name: Abrechnungs- und Berichterstattungsbereitstellung
+    description: |
+      Bereitstellung von Abrechnungen und Kontoberichten für Nutzer.
+  BC-1270.40.30:
+    name: Gebührenstreit-Bearbeitung
+    description: |
+      Bearbeitung von Streitigkeiten und Anpassungsansprüchen.
+  BC-1270.50:
+    name: Gebührenberichterstattungs- und Abstimmungsmanagement
+    description: |
+      Berichterstattung an Regulatoren und Eurocontrol-artige Abstimmungen.
+  BC-1270.50.10:
+    name: Regulator- und Netzwerkmanager-Berichterstattung
+    description: |
+      Berichterstattung an Regulatoren und Eurocontrol-äquivalente Netzwerkmanager.
+  BC-1270.50.20:
+    name: Gebührenabstimmung
+    description: |
+      Abstimmung zwischen Flugdaten und Gebührenberechnungen.
+  BC-1270.50.30:
+    name: Kostendeckungs-Überwachung
+    description: |
+      Überwachung der Kostendeckung gegenüber der genehmigten Kostenbasis.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-saas-platform-operations-management.yaml
+++ b/catalogue/i18n/de/L1-saas-platform-operations-management.yaml
@@ -1,0 +1,145 @@
+locale: de
+source: L1-saas-platform-operations-management.yaml
+entries:
+  BC-4220:
+    name: SaaS-Plattformbetrieb Management
+    description: |
+      Site-Reliability, Observierbarkeit, On-Call-Reaktion, Kapazität,
+      Performance und Disaster-Recovery-Betrieb des mandantenfähigen
+      SaaS-Dienstes.
+  BC-4220.10:
+    name: Service-Reliability-Engineering
+    description: |
+      Definition und Pflege von Service-Level-Indikatoren, -Zielen
+      und Fehlerbudgets für den SaaS-Dienst.
+    in_scope:
+      - SLI / SLO / Fehlerbudget-Disziplin für das laufende Produkt
+    out_of_scope:
+      - Kundenseitige SLA-Verpflichtungen (abgedeckt durch SaaS-Trust- und Service-Compliance-Management)
+      - Interne IT-Service-Level (abgedeckt durch IT-Management)
+  BC-4220.10.10:
+    name: Service-Level-Indikator-Definition
+    description: |
+      Definition von Service-Level-Indikatoren, die die Kundenerfahrung
+      laufender Dienste messen.
+  BC-4220.10.20:
+    name: Service-Level-Ziel-Management
+    description: |
+      Festlegung, Überprüfung und Anpassung von Service-Level-Zielen
+      über Dienste hinweg.
+  BC-4220.10.30:
+    name: Fehlerbudget-Management
+    description: |
+      Management von Fehlerbudgets und der Policy zur Steuerung
+      ihres Verbrauchs.
+  BC-4220.20:
+    name: Observierbarkeits-Management
+    description: |
+      Logs, Metriken, Traces und synthetisches Monitoring, die den
+      laufenden Dienst in der Produktion transparent machen.
+  BC-4220.20.10:
+    name: Anwendungsprotokollierungs-Management
+    description: |
+      Pflege von Anwendungsprotokollierungskonventionen, Pipelines
+      und Aufbewahrungsregeln.
+  BC-4220.20.20:
+    name: Metriken-Pipeline-Management
+    description: |
+      Betrieb von Metriken-Ingestion, -Speicherung und
+      -Abfragepipelines.
+  BC-4220.20.30:
+    name: Verteiltes Tracing
+    description: |
+      End-to-End-verteiltes Tracing über Dienste für die
+      Produktionsuntersuchung.
+  BC-4220.20.40:
+    name: Synthetisches Monitoring
+    description: |
+      Synthetische Prüfpunkte, die kritische Nutzerreisen von
+      außerhalb des Dienstes überprüfen.
+  BC-4220.30:
+    name: Vorfallsreaktions-Management
+    description: |
+      On-Call-Reaktion, Vorfallserkennung, Koordination und
+      Kundenkommunikation bei Produktionsvorfällen.
+  BC-4220.30.10:
+    name: On-Call-Rotations-Management
+    description: |
+      Definition und Betrieb von On-Call-Rotationen über
+      Produktteams hinweg.
+  BC-4220.30.20:
+    name: Vorfallserkennung
+    description: |
+      Erkennung von Produktionsvorfällen aus Telemetrie- und
+      externen Signalen.
+  BC-4220.30.30:
+    name: Vorfallskoordination
+    description: |
+      Koordination der Vorfallsreaktion einschließlich Rollen,
+      Kommunikation und Entscheidungen während des Vorfalls.
+  BC-4220.30.40:
+    name: Kunden-Vorfallskommunikation
+    description: |
+      Kommunikation an betroffene Kunden während und nach Vorfällen.
+  BC-4220.40:
+    name: Postmortem und Zuverlässigkeitsverbesserung
+    description: |
+      Postmortem-Erstellung und Verfolgung von Zuverlässigkeits-
+      Aktionspunkten, damit Erkenntnisse sich über Zeit kumulieren.
+  BC-4220.40.10:
+    name: Postmortem-Erstellung
+    description: |
+      Schuldenfreie Postmortem-Erstellung nach Vorfällen und
+      bedeutsamen Beinaheunfällen.
+  BC-4220.40.20:
+    name: Zuverlässigkeitsmaßnahmen-Tracking
+    description: |
+      Verfolgung von Zuverlässigkeitsmaßnahmen bis zum Abschluss
+      über Teams hinweg.
+  BC-4220.40.30:
+    name: Zuverlässigkeitstrend-Analyse
+    description: |
+      Analyse von Zuverlässigkeitstrends über Dienste und
+      Zeithorizonte hinweg.
+  BC-4220.50:
+    name: Kapazitäts- und Performance-Management
+    description: |
+      Kapazitätsprognose, Auto-Scaling-Policies und Performancetests
+      des SaaS-Dienstes.
+  BC-4220.50.10:
+    name: Kapazitätsprognose
+    description: |
+      Prognose des Kapazitätsbedarfs über Dienste und
+      Regionen hinweg.
+  BC-4220.50.20:
+    name: Auto-Scaling-Policy-Management
+    description: |
+      Definition und Anpassung von Auto-Scaling-Policies für
+      Produktdienste.
+  BC-4220.50.30:
+    name: Performancetest
+    description: |
+      Last-, Stress- und Ausdauertests des laufenden Dienstes.
+  BC-4220.60:
+    name: Disaster-Recovery und Resilienz
+    description: |
+      Sicherung und Wiederherstellung, Failover-Orchestrierung und
+      Disaster-Recovery-Übungen für den SaaS-Dienst.
+  BC-4220.60.10:
+    name: Sicherung- und Wiederherstellungs-Management
+    description: |
+      Sicherungs-Policy, Ausführung und Wiederherstellungsvalidierung
+      für Service-Datenspeicher.
+  BC-4220.60.20:
+    name: Failover-Orchestrierung
+    description: |
+      Orchestrierung des Failovers zwischen Verfügbarkeitszonen
+      und Regionen.
+  BC-4220.60.30:
+    name: Disaster-Recovery-Übungs-Management
+    description: |
+      Planung und Durchführung von Disaster-Recovery-Übungen und
+      Game-Days.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-saas-tenant-management.yaml
+++ b/catalogue/i18n/de/L1-saas-tenant-management.yaml
@@ -1,0 +1,134 @@
+locale: de
+source: L1-saas-tenant-management.yaml
+entries:
+  BC-4230:
+    name: SaaS-Mandanten-Management
+    description: |
+      Bereitstellung, Konfiguration, Isolation, Regionsplatzierung,
+      Identitätsföderation und mandantenspezifischer Datenexport im
+      mandantenfähigen Dienst.
+  BC-4230.10:
+    name: Mandantenbereitstellung und -Lebenszyklus
+    description: |
+      Erstellung, Aussetzung, Stilllegung und Migration von Mandanten
+      im mandantenfähigen Verbund.
+  BC-4230.10.10:
+    name: Mandantenbereitstellung
+    description: |
+      Erstellung neuer Mandanten und Zuteilung zugehöriger Ressourcen.
+  BC-4230.10.20:
+    name: Mandantenaussetzung
+    description: |
+      Aussetzung von Mandanten bei Nichtzahlung, Missbrauch oder
+      vertraglichen Gründen.
+  BC-4230.10.30:
+    name: Mandantenstilllegung
+    description: |
+      Stilllegung von Mandanten einschließlich Datenlöschung oder
+      -rückgabe gemäß Vertrag.
+  BC-4230.10.40:
+    name: Mandantenmigration
+    description: |
+      Migration von Mandanten zwischen Clustern, Shards oder Regionen.
+  BC-4230.20:
+    name: Mandantenkonfigurations-Management
+    description: |
+      Mandantenspezifische Funktionskonfiguration, Branding und
+      Limits oberhalb des gemeinsamen Produktbasiswerts.
+  BC-4230.20.10:
+    name: Mandantenspezifische Funktionskonfiguration
+    description: |
+      Konfiguration von Funktionsoptionen auf Mandantenebene.
+  BC-4230.20.20:
+    name: Mandanten-Branding-Management
+    description: |
+      Mandantenseitiges Branding wie Logos, Farben und
+      benutzerdefinierte Domänen.
+  BC-4230.20.30:
+    name: Mandantenlimit-Management
+    description: |
+      Konfiguration mandantenspezifischer Limits wie Kontingente und
+      Rateobergrenzen.
+  BC-4230.30:
+    name: Mandantenisolations-Management
+    description: |
+      Mechanismen zur Aufrechterhaltung logischer und physischer
+      Isolation zwischen Mandanten über Daten-, Compute- und
+      Zugangspfade hinweg.
+  BC-4230.30.10:
+    name: Mandantendatenisolation
+    description: |
+      Isolation von Mandantendaten durch Partitionierung, Verschlüsselung
+      und Zugriffsbegrenzung.
+  BC-4230.30.20:
+    name: Mandanten-Compute-Isolation
+    description: |
+      Isolation von Mandantenworkloads durch dedizierte oder
+      begrenzte Compute-Grenzen.
+  BC-4230.30.30:
+    name: Mandantenübergreifende Zugangsprävention
+    description: |
+      Kontrollen und Monitoring zur Verhinderung mandantenübergreifenden
+      Daten- und Identitätsübergangs.
+  BC-4230.40:
+    name: Datenhaltungsort und Regionsplatzierung
+    description: |
+      Zuweisung von Mandanten zu Regionen, Durchsetzung von
+      Datenhaltungsverpflichtungen und Verwaltung der
+      regionsübergreifenden Replikations-Policy.
+  BC-4230.40.10:
+    name: Mandantenregions-Zuweisung
+    description: |
+      Zuweisung von Mandanten zu Regionen entsprechend Vertrag
+      und Regulierung.
+  BC-4230.40.20:
+    name: Datenhaltungsort-Durchsetzung
+    description: |
+      Durchsetzung von Datenhaltungsgrenzen zur Laufzeit.
+  BC-4230.40.30:
+    name: Regionsübergreifende Replikations-Policy
+    description: |
+      Policy zur Steuerung regionsübergreifender Replikation für
+      Resilienz und Zugang.
+  BC-4230.50:
+    name: Mandantenidentitätsföderation
+    description: |
+      Föderation mandantenspezifischer Identitätsprovider und
+      Lebenszyklus von Mandantennutzerkonten via Single Sign-On und SCIM.
+  BC-4230.50.10:
+    name: Mandanten-SSO-Konfiguration
+    description: |
+      Konfiguration von Single Sign-On zwischen mandantenseitigen
+      Identitätsprovidern und dem Dienst.
+  BC-4230.50.20:
+    name: SCIM-basierte Nutzerbereitstellung
+    description: |
+      Lebenszyklus von Mandantennutzerkonten über SCIM oder
+      gleichwertige Bereitstellungsprotokolle.
+  BC-4230.50.30:
+    name: Mandantenidentitätsprovider-Onboarding
+    description: |
+      Onboarding und Validierung mandantenseitiger Identitätsprovider.
+  BC-4230.60:
+    name: Mandantensicherung und -Export-Management
+    description: |
+      Mandantenspezifische Datenexport-, Löschungs- und
+      Wiederherstellungsfunktionen für Mandanten und Administratoren.
+  BC-4230.60.10:
+    name: Mandantendaten-Export
+    description: |
+      Export von Mandantendaten in maschinenlesbarem Format auf
+      Anfrage oder vertraglich.
+  BC-4230.60.20:
+    name: Mandantendaten-Löschung
+    description: |
+      Nachweisbare Löschung von Mandantendaten bei Kündigung
+      oder Anfrage.
+  BC-4230.60.30:
+    name: Mandantensicherungs-Wiederherstellung
+    description: |
+      Wiederherstellung von Mandantendaten aus Sicherungen auf
+      Mandanten- oder Betreiberanfrage.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-saas-trust-service-compliance-management.yaml
+++ b/catalogue/i18n/de/L1-saas-trust-service-compliance-management.yaml
@@ -1,0 +1,135 @@
+locale: de
+source: L1-saas-trust-service-compliance-management.yaml
+entries:
+  BC-4290:
+    name: SaaS-Vertrauenswürdigkeit und Servicekonformität
+    description: |
+      Servicebezogene Attestierungen, Kundensicherheitsfragebögen,
+      öffentliche Vertrauensoffenlegungen, Sub-Prozessor-Management,
+      servicebezogene Datenschutzverpflichtungen und
+      kundenseitige Service-Resilienz-Verpflichtungen für das
+      SaaS-Angebot.
+  BC-4290.10:
+    name: Service-Attestierungsmanagement
+    description: |
+      Koordination servicebezogener Attestierungen wie SOC 2,
+      ISO 27001 und FedRAMP für das SaaS-Angebot.
+    in_scope:
+      - Prüfungsbereitschaft für den Service
+      - Prüferengagement und Berichtserstellung
+    out_of_scope:
+      - Unternehmensweites Compliance-Programm (abgedeckt durch Compliance Management)
+  BC-4290.10.10:
+    name: Prüfungsbereitschaftskoordination
+    description: |
+      Koordination der Prüfungsbereitschaft über Kontrollverantwortliche
+      für den Service hinweg.
+  BC-4290.10.20:
+    name: Prüferengagement
+    description: |
+      Beauftragung externer Prüfer und Management der
+      Prüfungsdurchführung.
+  BC-4290.10.30:
+    name: Attestierungserneuerungsmanagement
+    description: |
+      Management von Attestierungserneuerungszyklen und
+      kontinuierlichen Prüfungsvereinbarungen.
+  BC-4290.20:
+    name: Kundensicherheitsfragebogen-Management
+    description: |
+      Verwaltung des Fragebogen-Repositorys, Antwortgestaltung und
+      Wissensbasis zur Beantwortung von Kundensicherheitsbewertungen.
+  BC-4290.20.10:
+    name: Fragebogen-Repository-Management
+    description: |
+      Pflege des eingehenden Fragebogen-Repositorys und Weiterleitung.
+  BC-4290.20.20:
+    name: Fragebogenantwort-Erstellung
+    description: |
+      Erstellung von Antworten auf Kundensicherheitsfragebögen.
+  BC-4290.20.30:
+    name: Fragebogen-Wissensbasis-Pflege
+    description: |
+      Pflege einer kuratierten Wissensbasis mit genehmigten Antworten
+      und Belegen.
+  BC-4290.30:
+    name: Trust-Portal und öffentliche Offenlegung
+    description: |
+      Betrieb des Kunden-Trust-Portals, öffentliche
+      Status-Offenlegungen und Dokumentenverteilungs-Workflows.
+  BC-4290.30.10:
+    name: Trust-Portal-Inhaltsverwaltung
+    description: |
+      Kuration der auf dem Kunden-Trust-Portal veröffentlichten
+      Inhalte.
+  BC-4290.30.20:
+    name: Öffentliche Statusoffenlegung
+    description: |
+      Öffentliche Offenlegung von Vorfallstatus und historischem
+      Servicestatus.
+  BC-4290.30.30:
+    name: Dokumentenverteilungs-Workflow
+    description: |
+      Kontrollierte Verteilung von Prüfberichten und
+      Vertrauensdokumenten an Kunden.
+  BC-4290.40:
+    name: Sub-Prozessor-Management
+    description: |
+      Inventar, Offenlegung und Änderungsbenachrichtigung von
+      Sub-Prozessoren, die Kundendaten verarbeiten.
+  BC-4290.40.10:
+    name: Sub-Prozessor-Inventar
+    description: |
+      Inventar der Sub-Prozessoren und der von ihnen verarbeiteten
+      Kundendatenkategorien.
+  BC-4290.40.20:
+    name: Sub-Prozessor-Offenlegung
+    description: |
+      Kundenseitige Offenlegung der aktuellen Sub-Prozessor-Liste.
+  BC-4290.40.30:
+    name: Sub-Prozessor-Änderungsbenachrichtigung
+    description: |
+      Vorherige Benachrichtigung über Hinzufügungen und Entfernungen
+      von Sub-Prozessoren gemäß Vertrag.
+  BC-4290.50:
+    name: Service-Datenschutzverpflichtungsmanagement
+    description: |
+      Verwaltung von Datenverarbeitungsverträgen, Offenlegung von
+      Kundendatenflüssen und Weiterleitung von Betroffenenanfragen.
+  BC-4290.50.10:
+    name: Datenverarbeitungsvertrag-Management
+    description: |
+      Pflege und Ausführung von Datenverarbeitungsverträgen mit
+      Kunden.
+  BC-4290.50.20:
+    name: Kundendatenfluss-Mapping
+    description: |
+      Mapping von Kundendatenflüssen für Offenlegung und Bewertung.
+  BC-4290.50.30:
+    name: Betroffenenanfragen-Weiterleitung
+    description: |
+      Weiterleitung von über Kunden eingegangenen
+      Betroffenenanfragen an die zuständigen Stellen.
+  BC-4290.60:
+    name: Service-Resilienz-Verpflichtungsmanagement
+    description: |
+      Kundenseitige Service-Level-Verpflichtungen, Verfügbarkeits-
+      offenlegung und Service-Credit-Verwaltung.
+  BC-4290.60.10:
+    name: Service-Level-Verpflichtungsmanagement
+    description: |
+      Definition und Verwaltung kundenseitiger
+      Service-Level-Verpflichtungen.
+  BC-4290.60.20:
+    name: Verfügbarkeitsoffenlegung
+    description: |
+      Offenlegung der historischen Verfügbarkeit gegenüber den
+      zugesagten Levels.
+  BC-4290.60.30:
+    name: Service-Credit-Verwaltung
+    description: |
+      Verwaltung von Service-Credits aus nicht eingehaltenen
+      Verpflichtungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-sales-management.yaml
+++ b/catalogue/i18n/de/L1-sales-management.yaml
@@ -1,0 +1,150 @@
+locale: de
+source: L1-sales-management.yaml
+entries:
+  BC-410:
+    name: Vertriebsmanagement
+    description: |
+      Lead-to-Order-Aktivitäten – Accounts, Pipeline, Abschlüsse und Angebotserstellung.
+  BC-410.10:
+    name: Vertriebsstrategiemanagement
+    description: |
+      Coverage-Modell, Segmentierung und Vertriebsplanung.
+  BC-410.10.10:
+    name: Vertriebsabdeckungsmodell-Design
+    description: |
+      Definition von Vertriebssegmenten, Territorien und Coverage-Modellen.
+  BC-410.10.20:
+    name: Gebiets- und Kontozuweisung
+    description: |
+      Gebietsdesign, Kontozuweisung und Neuausbalancierung.
+  BC-410.10.30:
+    name: Vertriebszielsetzung
+    description: |
+      Top-Down- und Bottom-Up-Vertriebsziel- und Quotenfestsetzung.
+  BC-410.10.40:
+    name: Vertriebskapazitätsplanung
+    description: |
+      Vertriebskapazität, Anlaufzeit und Kopfzahlplanung.
+  BC-410.20:
+    name: Kontoverwaltung
+    description: |
+      Strategisches und Key-Account-Management.
+  BC-410.20.10:
+    name: Kontoplanung
+    description: |
+      Strategische Kontopläne und White-Space-Analyse.
+  BC-410.20.20:
+    name: Key-Account-Steuerung
+    description: |
+      Steuerung und Executive-Sponsoring von Schlüsselkunden.
+  BC-410.20.30:
+    name: Kontobeziehungsentwicklung
+    description: |
+      Beziehungsmapping und Stakeholderengagement bei Kunden.
+  BC-410.20.40:
+    name: Kontogesundheitsmonitoring
+    description: |
+      Kontogesundheitskennzahlen, Scorecards und Erneuerungsrisiko-Monitoring.
+  BC-410.30:
+    name: Opportunity- und Pipeline-Management
+    description: |
+      Lead-, Opportunity- und Deal-Lebenszyklus.
+  BC-410.30.10:
+    name: Lead-Qualifizierung und -Übergabe
+    description: |
+      Lead-Qualifizierung, -Scoring und Übergabe vom Marketing.
+  BC-410.30.20:
+    name: Opportunity-Management
+    description: |
+      Opportunity-Erstellung, Qualifizierung und Stufenprogression.
+  BC-410.30.30:
+    name: Deal-Strategie und -Verfolgung
+    description: |
+      Strategische Deal-Verfolgung, Win-Pläne und Deal-Überprüfungen.
+  BC-410.30.40:
+    name: Pipeline-Prognose
+    description: |
+      Pipeline-Coverage, gewichtete Prognose und Commit-Calls.
+  BC-410.40:
+    name: Angebots- und Konfigurationsmanagement
+    description: |
+      CPQ – Konfigurieren, Kalkulieren, Anbieten.
+  BC-410.40.10:
+    name: Produktkonfiguration
+    description: |
+      Produkt- und Lösungskonfiguration mit Regeln und Einschränkungen.
+  BC-410.40.20:
+    name: Angebotserstellung
+    description: |
+      Erstellung kundengerechter Angebote und Vorschläge.
+  BC-410.40.30:
+    name: Angebotsgenehmigungsworkflow
+    description: |
+      Genehmigungsworkflows für Rabatte und Sonderkonditionen.
+  BC-410.40.40:
+    name: Vertrags- und Auftragskonvertierung
+    description: |
+      Umwandlung akzeptierter Angebote in Aufträge und Verträge.
+  BC-410.50:
+    name: Vertriebsoperationsmanagement
+    description: |
+      Vertriebsprozess, Tooling und Enablement.
+  BC-410.50.10:
+    name: Vertriebsprozess- und Methodiksteuerung
+    description: |
+      Definition und Pflege des Vertriebsprozesses und der Methodik.
+  BC-410.50.20:
+    name: Vertriebs-Technologie und -Tooling
+    description: |
+      CRM- und Vertriebs-Tooling-Administration und -Integration.
+  BC-410.50.30:
+    name: Vertriebsenablement
+    description: |
+      Vertriebsplaybooks, Enablement-Inhalte und Zertifizierung.
+  BC-410.50.40:
+    name: Vertriebsdaten und -hygiene
+    description: |
+      CRM-Datenqualität, -Steuerung und Datenpflegeprogramme.
+  BC-410.60:
+    name: Kanalvertriebsmanagement
+    description: |
+      Indirekte Kanäle, Distributoren und Wiederverkäufer.
+  BC-410.60.10:
+    name: Kanalpartnergewinnung
+    description: |
+      Gewinnung und Onboarding von Distributoren, Wiederverkäufern und Agenten.
+  BC-410.60.20:
+    name: Kanalpartner-Enablement
+    description: |
+      Training, Zertifizierung und Enablement von Kanalpartnern.
+  BC-410.60.30:
+    name: Kanalprogrammmanagement
+    description: |
+      Kanalprogrammstufen, Anreize und Zusammenarbeitsregeln.
+  BC-410.60.40:
+    name: Partnerleistungsmanagement
+    description: |
+      Nachverfolgung von Sell-Through, Sell-Out und Leistungskennzahlen der Partner.
+  BC-410.70:
+    name: Vertriebsleistungsmanagement
+    description: |
+      Vergütungspläne, Quotenverwaltung und Vertriebsanalytik.
+  BC-410.70.10:
+    name: Vertriebsvergütungsplan-Design
+    description: |
+      Gestaltung von variablen Vergütungsplänen, Beschleunigern und SPIFs.
+  BC-410.70.20:
+    name: Quoten- und Gutschriftungsmanagement
+    description: |
+      Quotenallokation, Gutschriftungsregeln und Übertrag.
+  BC-410.70.30:
+    name: Vertriebsprovisionsberechnung
+    description: |
+      Berechnung, Validierung und Zahlung von Vertriebsprovisionen.
+  BC-410.70.40:
+    name: Vertriebsleistungsanalytik
+    description: |
+      Win/Loss-, Produktivitäts- und Verkäufer-Performance-Analytik.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-search-rescue-coordination-management.yaml
+++ b/catalogue/i18n/de/L1-search-rescue-coordination-management.yaml
@@ -1,0 +1,70 @@
+locale: de
+source: L1-search-rescue-coordination-management.yaml
+entries:
+  BC-1260:
+    name: Such- und Rettungsdienst-Koordinationsmanagement
+    description: |
+      SAR-Alarmierung, Koordination mit Rettungsleitstellen und Notfunkbaken-Bearbeitung.
+  BC-1260.10:
+    name: SAR-Alarmierungsmanagement
+    description: |
+      Alarmphasen – Ungewissheit, Alarm, Not.
+  BC-1260.10.10:
+    name: Ungewissheitsphase-Bearbeitung
+    description: |
+      Erkennung und Bearbeitung der INCERFA-Ungewissheitsphase.
+  BC-1260.10.20:
+    name: Alarmphase-Bearbeitung
+    description: |
+      ALERFA-Alarmphase-Bearbeitung und Eskalation.
+  BC-1260.10.30:
+    name: Notphase-Bearbeitung
+    description: |
+      DETRESFA-Notphase-Bearbeitung und SAR-Einleitung.
+  BC-1260.20:
+    name: SAR-Koordinationsmanagement
+    description: |
+      Koordination mit Rettungsleitstellen (RCCs).
+  BC-1260.20.10:
+    name: RCC-Verbindung
+    description: |
+      Verbindung zu nationalen und regionalen Rettungsleitstellen.
+  BC-1260.20.20:
+    name: SAR-Einsatzkoordination
+    description: |
+      Koordination von SAR-Einsatzressourcen und -kräften.
+  BC-1260.20.30:
+    name: Grenzüberschreitende SAR-Koordination
+    description: |
+      Grenzüberschreitende Koordination von SAR-Einsätzen.
+  BC-1260.30:
+    name: SAR-Kommunikationsmanagement
+    description: |
+      SAR-Kommunikationsnetze und Koordinationskanäle.
+  BC-1260.30.10:
+    name: SAR-Sprachkommunikations-Betrieb
+    description: |
+      Betrieb von SAR-Sprachkanälen und -frequenzen.
+  BC-1260.30.20:
+    name: SAR-Datenkommunikations-Betrieb
+    description: |
+      Betrieb von SAR-Datennetzen und -nachrichten.
+  BC-1260.40:
+    name: Notfunkbaken-Management
+    description: |
+      ELT/EPIRB/PLB-Aktivierungsbearbeitung und COSPAS-SARSAT-Schnittstelle.
+  BC-1260.40.10:
+    name: ELT-Aktivierungsbearbeitung
+    description: |
+      Erkennung und Bearbeitung von ELT-Aktivierungen.
+  BC-1260.40.20:
+    name: COSPAS-SARSAT-Schnittstellenbetrieb
+    description: |
+      Schnittstelle mit COSPAS-SARSAT-Missionskontrollzentren.
+  BC-1260.40.30:
+    name: Baken-Registrierungskoordination
+    description: |
+      Koordination mit nationalen Bakenregistern.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-shipment-visibility-tracking-management.yaml
+++ b/catalogue/i18n/de/L1-shipment-visibility-tracking-management.yaml
@@ -1,0 +1,100 @@
+locale: de
+source: L1-shipment-visibility-tracking-management.yaml
+entries:
+  BC-2510:
+    name: Sendungsverfolgung
+    description: |
+      Durchgängige Sendungssichtbarkeit durch Ereigniserfassung, Statusauflösung,
+      ETA-Prognose, Ausnahmebenachrichtigung und Control-Tower-Betrieb.
+  BC-2510.10:
+    name: Ereigniserfassung und Status-Management
+    description: |
+      Erfassung von Sendungsereignissen von Carriern, IoT und Betriebssystemen
+      und Übersetzung in kanonische Status.
+    in_scope:
+      - EDI-214-, IFTSTA- und EPCIS-Ereignisverarbeitung
+      - IoT- und Telematik-Ereigniserfassung
+    out_of_scope:
+      - Telematik für den Asset-Zustand (BC-2430.40)
+  BC-2510.10.10:
+    name: Carrier-Ereignisverarbeitung
+    description: |
+      Verarbeitung von carrierseitigen Meilensteinereignissen über EDI und APIs.
+  BC-2510.10.20:
+    name: IoT- und Telematik-Ereigniserfassung
+    description: |
+      Erfassung von Fracht-IoT- und Telematikereignissen.
+  BC-2510.10.30:
+    name: Manuelle Status-Aktualisierungserfassung
+    description: |
+      Erfassung manueller Status-Aktualisierungen von Fahrern, Agenten und Partnern.
+  BC-2510.20:
+    name: Sendungs-Tracking-Management
+    description: |
+      Auflösung des Sendungsstatus über Strecken, Verkehrsträger und Partner und
+      Bereitstellung auf internen und kundenseitigen Tracking-Oberflächen.
+  BC-2510.20.10:
+    name: Sendungsstatus-Auflösung
+    description: |
+      Auflösung des kanonischen Sendungsstatus aus Rohereignissen.
+  BC-2510.20.20:
+    name: Mehrstufige Tracking-Verknüpfung
+    description: |
+      Verknüpfung mehrstufiger, multi-carrier-Reisen zu einem einheitlichen Track.
+  BC-2510.20.30:
+    name: Öffentliches Tracking-Portal-Betrieb
+    description: |
+      Betrieb öffentlicher Tracking-Portale und Kunden-APIs.
+  BC-2510.30:
+    name: ETA-Prognose-Management
+    description: |
+      Berechnung und kontinuierliche Verfeinerung der voraussichtlichen Ankunftszeit.
+  BC-2510.30.10:
+    name: ETA-Berechnung
+    description: |
+      Deterministische ETA-Berechnung aus Fahrplänen und Meilensteinen.
+  BC-2510.30.20:
+    name: Prädiktive ETA-Modellierung
+    description: |
+      Prädiktive ETA-Modellierung unter Verwendung historischer und kontextueller Daten.
+  BC-2510.30.30:
+    name: ETA-Abweichungsbenachrichtigung
+    description: |
+      Benachrichtigung bei wesentlichen ETA-Abweichungen gegenüber Zusagen.
+  BC-2510.40:
+    name: Ausnahme- und Alarm-Management
+    description: |
+      Erkennung betrieblicher Ausnahmen, Benachrichtigung von Stakeholdern und
+      Verfolgung der Ausnahmelösung.
+  BC-2510.40.10:
+    name: Ausnahmeerkennung
+    description: |
+      Regel- und modellbasierte Erkennung betrieblicher Ausnahmen.
+  BC-2510.40.20:
+    name: Stakeholder-Benachrichtigung
+    description: |
+      Benachrichtigung von Kunden, Betriebsteams und Partnern.
+  BC-2510.40.30:
+    name: Ausnahmelösungs-Verfolgung
+    description: |
+      Verfolgung von Ausnahme-Triage, Verantwortung und Abschluss.
+  BC-2510.50:
+    name: Control-Tower-Betriebsmanagement
+    description: |
+      Durchgängige Sichtbarkeit, Leistungsüberwachung und proaktive
+      Interventionskoordination über Carrier und Partner.
+  BC-2510.50.10:
+    name: Durchgängige Sichtbarkeits-Dashboards
+    description: |
+      Betrieb durchgängiger Sichtbarkeits-Dashboards über das Netzwerk.
+  BC-2510.50.20:
+    name: Carrier-übergreifende Leistungsüberwachung
+    description: |
+      Überwachung der Leistung über Carrier und Partner.
+  BC-2510.50.30:
+    name: Proaktive Interventionskoordination
+    description: |
+      Koordination proaktiver Interventionen zum Schutz von Zusagen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-smelting-refining-operations-management.yaml
+++ b/catalogue/i18n/de/L1-smelting-refining-operations-management.yaml
@@ -1,0 +1,163 @@
+locale: de
+source: L1-smelting-refining-operations-management.yaml
+entries:
+  BC-4450:
+    name: Verhüttung und Raffination
+    description: |
+      Pyrometallurgische und elektrochemische Raffination von
+      Konzentraten und Zwischenprodukten zu LME-lieferbarem oder
+      spezifikationsgerechtem Metall, einschließlich Nebenprodukt-
+      gewinnung, Abgasbehandlung und Hüttenrechnung.
+  BC-4450.10:
+    name: Konzentrat-Empfang und Mischung
+    description: |
+      Empfangsprobenahme, Aufgabemischung und Inventarmanagement
+      von Konzentraten, die in den Schmelzerkomplex eingehen.
+    in_scope:
+      - Empfangsprobenahme und Analyse
+      - Schmelzer-Aufgabemischung
+      - Konzentratdepot-Inventar
+    out_of_scope:
+      - Konzentratverkauf-Abrechnung (BC-4480.40)
+  BC-4450.10.10:
+    name: Konzentrat-Empfangsprobenahme
+    description: |
+      Probenahme und Analyse von Konzentraten aus Drittpartei-
+      und eigenen Minen beim Empfang.
+  BC-4450.10.20:
+    name: Schmelzer-Aufgabemischung
+    description: |
+      Mischung von Konzentraten zur Erfüllung der Schmelzer-
+      Aufgabegrad- und Verunreinigungsziele.
+  BC-4450.10.30:
+    name: Konzentratinventarmanagement
+    description: |
+      Depots-, Hallen- und Silo-Inventarmanagement von
+      Konzentratbeständen.
+  BC-4450.20:
+    name: Pyrometallurgischer Betrieb
+    description: |
+      Rösten, Schmelzen, Konvertieren und Schlackenhandhabung
+      von Sulfid- und Oxidkonzentraten.
+  BC-4450.20.10:
+    name: Röstbetrieb
+    description: |
+      Betrieb von Wirbelschicht- und Etagenröstern für
+      Sulfidoxidation.
+  BC-4450.20.20:
+    name: Schmelzofen-Betrieb
+    description: |
+      Betrieb von Flash-, Elektro- und Badschmelzöfen.
+  BC-4450.20.30:
+    name: Konverterbetrieb
+    description: |
+      Betrieb von Peirce-Smith-, oben geblasenen rotierenden
+      und kontinuierlichen Konvertern.
+  BC-4450.20.40:
+    name: Schlackenhandhabung
+    description: |
+      Abstechen, Granulierung, Reinigung und Entsorgung von
+      Ofen- und Konverterschlacke.
+  BC-4450.30:
+    name: Elektrolytischer Raffinationsbetrieb
+    description: |
+      Elektrogewinnungs- und Elektroraffinations-Tankhausbetrieb
+      zur Produktion von Kathodenmetall.
+  BC-4450.30.10:
+    name: Elektrogewinnungsbetrieb
+    description: |
+      Betrieb von Elektrogewinnungszellen zur Kathoden-
+      produktion aus Laugungselektrolyt.
+  BC-4450.30.20:
+    name: Elektroraffinations-Tankhausbetrieb
+    description: |
+      Betrieb von Elektroraffinations-Zellen zur Produktion
+      hochreiner Kathoden aus Anoden.
+  BC-4450.30.30:
+    name: Kathodenstripping und -handhabung
+    description: |
+      Stripping, Waschen, Wiegen und Bündeln von Kathoden
+      für Verkauf oder nachgelagerte Gießerei.
+  BC-4450.40:
+    name: Nebenprodukt-Metallgewinnung
+    description: |
+      Gewinnung von Edel- und Nebenmetallen aus Anodenschlämmen,
+      Stäuben und Nebenproduktstömen.
+  BC-4450.40.10:
+    name: Anodenschlamm-Behandlung
+    description: |
+      Behandlung von Elektroraffinations-Anodenschlämmen zur
+      Gewinnung von Edelmetallen.
+  BC-4450.40.20:
+    name: Edelmetallraffination
+    description: |
+      Raffination von Gold, Silber und Platingruppenmetallen
+      zu Barren oder Schwamm.
+  BC-4450.40.30:
+    name: Nebenprodukt-Stromgewinnung
+    description: |
+      Gewinnung von Selen, Tellur, Schwefelsäure und anderen
+      Nebenproduktstömen.
+  BC-4450.50:
+    name: Gießerei und Produktveredelung
+    description: |
+      Gießen, Kennzeichnen und Qualitätsinspektion von
+      Fertigmetallprodukten nach kommerzieller Spezifikation.
+  BC-4450.50.10:
+    name: Gießereibetrieb
+    description: |
+      Gießen von Barren, Blöcken, Knüppeln, Brammen und Formen
+      aus geschmolzenem Metall.
+  BC-4450.50.20:
+    name: Produktkennzeichnung und Branding
+    description: |
+      Kennzeichnung, Stempelung und Markenauftragung auf
+      Gießprodukte für Rückverfolgbarkeit und Börsenzulassung.
+  BC-4450.50.30:
+    name: Fertigmetall-Qualitätsinspektion
+    description: |
+      Inspektion und Zertifizierung von Fertigmetall gegen
+      Spezifikation und Börsenregistrierungsanforderungen.
+  BC-4450.60:
+    name: Schmelzer-Abgas- und Schwefelsäureanlagenbetrieb
+    description: |
+      Reinigung von Schmelzer-Abgasen, Schwefelsäureanlagen-
+      betrieb und Kaminemissionsüberwachung.
+  BC-4450.60.10:
+    name: Abgasreinigung
+    description: |
+      Betrieb elektrostatischer Abscheider, Wäscher und
+      Kühlung für Schmelzer-Abgas.
+  BC-4450.60.20:
+    name: Schwefelsäureanlagenbetrieb
+    description: |
+      Betrieb von Doppelkontakt-Doppelabsorptions-
+      Schwefelsäureanlagen am Schmelzer-Abgas.
+  BC-4450.60.30:
+    name: Kaminemissionsüberwachung
+    description: |
+      Kontinuierliche Kaminüberwachung von Schwefeldioxid-,
+      Partikel- und Metallemissionen.
+  BC-4450.70:
+    name: Schmelzer-Hüttenrechnung
+    description: |
+      Metallbilanz, Abrechnungsanalysen und Lohnschmelz-
+      abrechnung über den Schmelzerkomplex.
+  BC-4450.70.10:
+    name: Metallbilanz und Abrechnungsanalysen
+    description: |
+      Periodischer Metallbilanz-Abgleich und Abrechnungsgrad-
+      Analysen für verschiffte Produkte.
+  BC-4450.70.20:
+    name: Gewinnungs- und Verlustberichterstattung
+    description: |
+      Berichterstattung über metallurgische Gewinnung und
+      Stromverluste über Schmelzer und Raffinerie.
+  BC-4450.70.30:
+    name: Lohnschmelzabrechnung
+    description: |
+      Abrechnung für lohngeschmolzene Drittpartei-Konzentrate
+      und kundeneigenes Metall.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-software-product-engineering-management.yaml
+++ b/catalogue/i18n/de/L1-software-product-engineering-management.yaml
@@ -1,0 +1,183 @@
+locale: de
+source: L1-software-product-engineering-management.yaml
+entries:
+  BC-4200:
+    name: Software-Produktentwicklung Management
+    description: |
+      Entdeckung, Spezifikation, Design, Implementierung, Code-Review und
+      Qualitätsentwicklung von SaaS-Produkten von der Idee bis zum
+      releasefähigen Build.
+  BC-4200.10:
+    name: Produktentdeckung und Backlog-Management
+    description: |
+      Marktchancenforschung, Ideenfindung, Validierung und Backlog-Pflege,
+      die Markt- und Kundensignale in ein priorisiertes Arbeitspaket übersetzen.
+    in_scope:
+      - Nutzer- und Marktforschung
+      - Backlog-Pflege und Priorisierung
+      - Roadmap-Definition und -Aktualisierung
+    out_of_scope:
+      - Quantitative Produktanalysen (abgedeckt durch Produkttelemetrie- und Experimentierungsmanagement)
+      - Marketing-Nachfragegenerierung
+  BC-4200.10.10:
+    name: Nutzerforschung
+    description: |
+      Generative und evaluative Forschung mit Nutzern zur Aufdeckung von
+      Bedürfnissen, Reibungspunkten und Zahlungsbereitschaft.
+  BC-4200.10.20:
+    name: Backlog-Verfeinerung
+    description: |
+      Kontinuierliche Verfeinerung des Produkt-Backlogs einschließlich
+      Schätzung, Zerlegung und Neupriorisierung.
+  BC-4200.10.30:
+    name: Roadmap-Definition
+    description: |
+      Definition und regelmäßige Aktualisierung der Produkt-Roadmap und
+      thematischer Investitionsbereiche.
+  BC-4200.10.40:
+    name: Kundenfeedback-Synthese
+    description: |
+      Synthese eingehender Rückmeldungen aus Support, Customer Success,
+      Vertrieb und Community zu handlungsrelevanten Produktsignalen.
+  BC-4200.20:
+    name: Produktspezifikations-Management
+    description: |
+      Erfassung des beabsichtigten Verhaltens, der Rahmenbedingungen und
+      Abnahmekriterien, damit Entwicklungsarbeit vorhersehbar ausgeführt werden kann.
+    in_scope:
+      - Funktionale und nicht-funktionale Spezifikationen
+      - Abnahmekriterien
+    out_of_scope:
+      - Visuelles und Interaktionsdesign (abgedeckt durch Software-Design-Management)
+  BC-4200.20.10:
+    name: Funktionale Spezifikation
+    description: |
+      Spezifikation des beabsichtigten Verhaltens und nutzerrelevanter Ergebnisse
+      für Funktionen und Fähigkeiten.
+  BC-4200.20.20:
+    name: Nicht-funktionale Spezifikation
+    description: |
+      Spezifikation nicht-funktionaler Anforderungen wie Verfügbarkeit,
+      Latenz, Durchsatz und Sicherheitsprofil.
+  BC-4200.20.30:
+    name: Abnahmekriterien-Definition
+    description: |
+      Definition testbarer Abnahmekriterien, die das „Fertig" für
+      Funktionen und User Stories verankern.
+  BC-4200.30:
+    name: Software-Design-Management
+    description: |
+      User-Experience-, System- und Barrierefreiheitsdesign für
+      Softwareprodukte, verankert in gemeinsamen Design-Systemen.
+  BC-4200.30.10:
+    name: User-Experience-Design
+    description: |
+      Interaktions-, Informationsarchitektur- und visuelles Design
+      von Produktoberflächen.
+  BC-4200.30.20:
+    name: Systemdesign
+    description: |
+      Architekturdesign von Softwarekomponenten, Diensten, Datenflüssen
+      und externen Schnittstellen.
+  BC-4200.30.30:
+    name: Design-System-Pflege
+    description: |
+      Pflege des gemeinsamen Design-Systems einschließlich Komponenten,
+      Tokens und Nutzungsrichtlinien.
+  BC-4200.30.40:
+    name: Barrierefreiheitsdesign
+    description: |
+      Design-Konformität mit Barrierefreiheitsstandards über
+      Produktoberflächen hinweg.
+  BC-4200.40:
+    name: Software-Konstruktions-Management
+    description: |
+      Implementierungspraxis einschließlich Quellcodeverwaltung,
+      Code-Review und kollaborativer Programmierdisziplinen.
+  BC-4200.40.10:
+    name: Quellcode-Management
+    description: |
+      Pflege von Quellcode-Repositories, Branching-Policy und
+      Code-Eigentümerschaft.
+  BC-4200.40.20:
+    name: Code-Review-Praxis
+    description: |
+      Peer-Review von Codeänderungen gegen Entwicklungs- und
+      Sicherheitsstandards.
+  BC-4200.40.30:
+    name: Pair- und Mob-Programmierung
+    description: |
+      Kollaborative Programmierpraktiken zur Wissensverteilung und
+      Qualitätssteigerung bei ausgewählten Arbeitsgegenständen.
+  BC-4200.50:
+    name: Software-Qualitätsentwicklung
+    description: |
+      Teststrategie, automatisierte Testsuiten-Pflege und
+      Defekt-Management für Softwareprodukte.
+    in_scope:
+      - Automatisierte Unit-, Integrations- und End-to-End-Tests des Produkts
+      - Defekt-Triage und -Behebung
+    out_of_scope:
+      - Unternehmensweites Qualitätsmanagementsystem (abgedeckt durch Qualitätsmanagement)
+      - Performance- und Resilienztests des laufenden Dienstes (abgedeckt durch SaaS-Plattformbetrieb Management)
+  BC-4200.50.10:
+    name: Teststrategie-Definition
+    description: |
+      Definition der Teststrategie über Unit-, Integrations-,
+      End-to-End- und explorative Schichten.
+  BC-4200.50.20:
+    name: Automatisierte Testsuiten-Verwaltung
+    description: |
+      Pflege automatisierter Testsuiten einschließlich Abdeckung,
+      Instabilität und Laufzeit.
+  BC-4200.50.30:
+    name: Defekt-Triage und -Behebung
+    description: |
+      Triage und Behebung von Defekten, die gegen das Produkt gemeldet wurden.
+  BC-4200.50.40:
+    name: Regressions-Abdeckungs-Management
+    description: |
+      Management der Regressionsabdeckung bei Weiterentwicklung der
+      Produktoberfläche.
+  BC-4200.60:
+    name: Open-Source-Pflege
+    description: |
+      Eingehende Nutzung, ausgehende Beiträge und Lieferketten-Artefakte
+      für im Produkt eingebettete Open-Source-Software.
+  BC-4200.60.10:
+    name: Eingehende Open-Source-Compliance
+    description: |
+      Compliance mit eingehenden Open-Source-Lizenzen und Hinweispflichten.
+  BC-4200.60.20:
+    name: Ausgehende Open-Source-Beiträge
+    description: |
+      Governance ausgehender Beiträge zu und Pflege von
+      Open-Source-Projekten.
+  BC-4200.60.30:
+    name: Software-Stücklisten-Management
+    description: |
+      Generierung, Verteilung und Pflege von Software-Stücklisten
+      in Standardformaten.
+  BC-4200.70:
+    name: Entwicklerproduktivitäts-Management
+    description: |
+      Interne Entwicklerplattformen, Tooling und Messung der
+      Entwicklerleistung zur Steigerung des nachhaltigen Lieferdurchsatzes.
+  BC-4200.70.10:
+    name: Entwickler-Toolchain-Management
+    description: |
+      Auswahl und Pflege von Entwickler-Toolchains in der
+      Entwicklerorganisation.
+  BC-4200.70.20:
+    name: Interne Entwicklerplattform-Verwaltung
+    description: |
+      Betrieb interner Plattformen, die Infrastruktur und standardisierte
+      Workflows für Entwickler abstrahieren.
+  BC-4200.70.30:
+    name: Entwicklerleistungskennzahlen
+    description: |
+      Messung der Entwicklerleistung anhand von Liefer- und
+      Entwicklererfahrungskennzahlen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-software-release-deployment-management.yaml
+++ b/catalogue/i18n/de/L1-software-release-deployment-management.yaml
@@ -1,0 +1,156 @@
+locale: de
+source: L1-software-release-deployment-management.yaml
+entries:
+  BC-4210:
+    name: Software-Release- und -Bereitstellungs-Management
+    description: |
+      Kontinuierliche Integration, Umgebungsverwaltung, Release-Engineering,
+      Feature-Flags und progressive Bereitstellung von SaaS-Produkten
+      in die Produktion.
+  BC-4210.10:
+    name: Kontinuierliche Integrations-Verwaltung
+    description: |
+      Build-Pipelines, Artefaktproduktion und Pipeline-Policy-Durchsetzung,
+      die das integrierte Produkt kontinuierlich baubar halten.
+  BC-4210.10.10:
+    name: Build-Pipeline-Management
+    description: |
+      Definition und Betrieb automatisierter Build-Pipelines für
+      Produktkomponenten.
+  BC-4210.10.20:
+    name: Artefakt-Repository-Management
+    description: |
+      Speicherung, Aufbewahrung und Zugriff auf Build-Artefakte und
+      Abhängigkeitspakete.
+  BC-4210.10.30:
+    name: Pipeline-Policy-Durchsetzung
+    description: |
+      Durchsetzung erforderlicher Qualitäts-, Sicherheits- und
+      Herkunftsgates über Pipelines hinweg.
+  BC-4210.20:
+    name: Umgebungs-Management
+    description: |
+      Bereitstellung und Pflege von Nicht-Produktionsumgebungen für
+      Entwicklung, Integration und Vorproduktions-Validierung.
+  BC-4210.20.10:
+    name: Umgebungsbereitstellung
+    description: |
+      Bereitstellung von Nicht-Produktionsumgebungen entsprechend
+      Entwicklungs- und Validierungsanforderungen.
+  BC-4210.20.20:
+    name: Umgebungskonfiguration
+    description: |
+      Konfiguration von Nicht-Produktionsumgebungen zur Aufrechterhaltung
+      der Produktionsparität, wo erforderlich.
+  BC-4210.20.30:
+    name: Umgebungsdaten-Management
+    description: |
+      Bereitstellung, Maskierung und Aktualisierung von Daten in
+      Nicht-Produktionsumgebungen.
+  BC-4210.30:
+    name: Release-Engineering-Management
+    description: |
+      Kadenz, Versionierung, Branching und Release-Notes-Disziplin
+      für Software-Releases.
+  BC-4210.30.10:
+    name: Release-Kadenz-Management
+    description: |
+      Definition und Pflege der Release-Kadenz über
+      Produktbereiche hinweg.
+  BC-4210.30.20:
+    name: Versionierung und Branching
+    description: |
+      Versionierungsschema und Branching-Strategie für
+      Produkt-Releases.
+  BC-4210.30.30:
+    name: Release-Notes-Erstellung
+    description: |
+      Erstellung kunden- und betreiberseitiger Release-Notes für
+      jeden Release.
+  BC-4210.40:
+    name: Deployment-Orchestrierung
+    description: |
+      Strategien zur sicheren Bereitstellung von Softwareänderungen
+      in die Produktion mit kontrolliertem Ausbreitungsradius.
+  BC-4210.40.10:
+    name: Schrittweise Einführung
+    description: |
+      Schrittweise Einführung von Releases auf wachsende Kohorten
+      von Mandanten oder Nutzern.
+  BC-4210.40.20:
+    name: Canary-Deployment
+    description: |
+      Bereitstellung von Releases an eine kleine Canary-Population
+      mit automatisierter Zustandsbewertung.
+  BC-4210.40.30:
+    name: Blue-Green-Deployment
+    description: |
+      Parallele Umgebungsbereitstellung mit Traffic-Umschaltung für
+      nahezu ausfallsfreie Änderungen.
+  BC-4210.40.40:
+    name: Rollback-Koordination
+    description: |
+      Koordinierter Rollback von Releases bei negativen Signalen.
+  BC-4210.50:
+    name: Feature-Flag-Management
+    description: |
+      Lebenszyklus und Laufzeitsteuerung von Feature-Flags zur Entkopplung
+      von Deployment und Release sowie zur Ausrichtung auf Kohorten.
+    in_scope:
+      - Feature-Flag-Erstellung, -Deaktivierung und -Prüfung
+      - Zielgruppenregeln
+    out_of_scope:
+      - Experimentierungsmethodik und -beurteilung (abgedeckt durch Produkttelemetrie- und Experimentierungsmanagement)
+  BC-4210.50.10:
+    name: Feature-Flag-Lebenszyklus
+    description: |
+      Lebenszyklus von Feature-Flags von der Erstellung bis zur
+      Deaktivierung.
+  BC-4210.50.20:
+    name: Zielgruppenregel-Management
+    description: |
+      Definition von Zielgruppenregeln, die bestimmen, welche Subjekte
+      eine Flag-Variante erhalten.
+  BC-4210.50.30:
+    name: Flag-Hygiene-Management
+    description: |
+      Hygienepraktiken zur Deaktivierung veralteter Flags und Vermeidung
+      der Anhäufung toter Bedingungscode.
+  BC-4210.60:
+    name: Konfigurations- und Secrets-Management
+    description: |
+      Verwaltung von Laufzeitkonfigurationswerten und Secrets, die von
+      Produktdiensten verwendet werden.
+  BC-4210.60.10:
+    name: Laufzeitkonfigurations-Management
+    description: |
+      Speicherung, Verteilung und Prüfung von
+      Laufzeitkonfigurationswerten.
+  BC-4210.60.20:
+    name: Secret-Lebenszyklus-Management
+    description: |
+      Ausstellung, Rotation und Widerruf von Secrets, die von
+      Produktdiensten verwendet werden.
+  BC-4210.70:
+    name: Produktionsänderungs-Autorisierung
+    description: |
+      Vorab-Review von Deployments, Deployment-Fenster-Governance und
+      Autorisierung menschlicher Produktionszugriffe.
+  BC-4210.70.10:
+    name: Vor-Deployment-Review
+    description: |
+      Review und Genehmigung von Änderungen vor der
+      Produktionsbereitstellung.
+  BC-4210.70.20:
+    name: Deployment-Fenster-Governance
+    description: |
+      Governance zulässiger Deployment-Fenster und
+      Einfrierperioden.
+  BC-4210.70.30:
+    name: Produktionszugriffs-Autorisierung
+    description: |
+      Autorisierung, Just-in-Time-Gewährung und Prüfung menschlicher
+      Zugänge zu Produktionssystemen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-spare-parts-aftermarket-management.yaml
+++ b/catalogue/i18n/de/L1-spare-parts-aftermarket-management.yaml
@@ -1,0 +1,126 @@
+locale: de
+source: L1-spare-parts-aftermarket-management.yaml
+entries:
+  BC-1060:
+    name: Ersatzteile- und Aftersales-Management
+    description: |
+      Ersatzteilversorgung, Aftersales-Verkauf und -Services für die Installationsbasis.
+  BC-1060.10:
+    name: Ersatzteilkatalog-Management
+    description: |
+      Katalog, Identifikation und Teilenachfolge.
+  BC-1060.10.10:
+    name: Ersatzteil-Identifikation
+    description: |
+      Teileidentifikation einschließlich illustrierter Teilekataloge.
+  BC-1060.10.20:
+    name: Teilenachfolge-Management
+    description: |
+      Management von Teilenachfolgen und Gleichwertigkeiten.
+  BC-1060.10.30:
+    name: Katalogpublikation
+    description: |
+      Publikation und Vertrieb von Ersatzteilkatalogen.
+  BC-1060.20:
+    name: Ersatzteilpreismanagement
+    description: |
+      Preisstrategie, Listenpreise und kundenspezifische Preisgestaltung.
+  BC-1060.20.10:
+    name: Teilepreisstrategie
+    description: |
+      Preisstrategie und Segmentierung für Ersatzteile.
+  BC-1060.20.20:
+    name: Teilpreisfestsetzung
+    description: |
+      Festsetzung von Listenpreisen und wertbasierter Ersatzteilpreisgestaltung.
+  BC-1060.20.30:
+    name: Kundenspezifische Ersatzteilpreisgestaltung
+    description: |
+      Kundenspezifische und Vertragspreisgestaltung für Teile.
+  BC-1060.30:
+    name: Ersatzteil-Nachfrageprognosemanagement
+    description: |
+      Nachfrageprognose für Teile (Langsamdreher, sporadische Nachfrage).
+  BC-1060.30.10:
+    name: Sporadische Nachfrageprognose
+    description: |
+      Prognose von Langsamdrehern und sporadischer Teilenachfrage.
+  BC-1060.30.20:
+    name: Installationsbasisgetriebene Prognose
+    description: |
+      Nachfrageprognose auf Basis von Installationsbasisdaten.
+  BC-1060.30.30:
+    name: Teilebestandsplan
+    description: |
+      Bestandspläne über Verteilzentren für Teile.
+  BC-1060.40:
+    name: Aftersales-Vertriebsmanagement
+    description: |
+      Aftersales-Handelsverkäufe, Verlängerungen und Upselling.
+  BC-1060.40.10:
+    name: Aftersales-Leadgenerierung
+    description: |
+      Aftersales-Leadgenerierung aus Installationsbasisdaten.
+  BC-1060.40.20:
+    name: Aftersales-Auftragsmanagement
+    description: |
+      Auftragserfassung und -abwicklung im Aftersales.
+  BC-1060.40.30:
+    name: Aftersales-Cross-Selling und Upselling
+    description: |
+      Cross-Selling und Upselling von Aftersales-Produkten und -Services.
+  BC-1060.50:
+    name: Service- und Reparaturmanagement
+    description: |
+      Reparaturen, Austauscheinheiten und Überholung.
+  BC-1060.50.10:
+    name: Reparaturwerkstatt-Betrieb
+    description: |
+      Betrieb zentraler Reparaturwerkstätten.
+  BC-1060.50.20:
+    name: Austauscheinheitenpool-Management
+    description: |
+      Management von Austauscheinheiten- und Rotable-Pools.
+  BC-1060.50.30:
+    name: Überholungs-Betrieb
+    description: |
+      Überholung, Generalüberholung und Rezertifizierung zurückgegebener Teile.
+  BC-1060.60:
+    name: Gewährleistungsmanagement
+    description: |
+      Gewährleistungsansprüche, Forderungsbearbeitung und -rückforderung.
+  BC-1060.60.10:
+    name: Gewährleistungsrichtlinien-Management
+    description: |
+      Definition von Gewährleistungsbedingungen, -fristen und -ausschlüssen.
+  BC-1060.60.20:
+    name: Gewährleistungsanspruchs-Bearbeitung
+    description: |
+      Erfassung und Bearbeitung von Kunden-Gewährleistungsansprüchen.
+  BC-1060.60.30:
+    name: Gewährleistungsrückforderung von Lieferanten
+    description: |
+      Rückforderung von Gewährleistungskosten von Lieferanten.
+  BC-1060.60.40:
+    name: Gewährleistungsrückstellungs-Management
+    description: |
+      Schätzung und Bilanzierung von Gewährleistungsrückstellungen.
+  BC-1060.70:
+    name: Installationsbasis-Management
+    description: |
+      Installationsbasisdaten, Anlagenvernetzung und Lebenszykluseinblicke.
+  BC-1060.70.10:
+    name: Installationsbasisdaten-Management
+    description: |
+      Erfassung und Verwaltung von Installationsbasisdaten.
+  BC-1060.70.20:
+    name: Vernetzte Anlagen-Betrieb
+    description: |
+      Betrieb vernetzter Anlagen und IoT-Telemetrie.
+  BC-1060.70.30:
+    name: Installationsbasis-Analytik
+    description: |
+      Analytik zu Nutzung, Zustand und Lebenszyklus der Installationsbasis.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-specialty-formulation-blending-management.yaml
+++ b/catalogue/i18n/de/L1-specialty-formulation-blending-management.yaml
@@ -1,0 +1,142 @@
+locale: de
+source: L1-specialty-formulation-blending-management.yaml
+entries:
+  BC-4630:
+    name: Spezialformulierung und Mischung
+    description: |
+      Formulierung, Mischung, Compoundierung, Abfüllung und
+      Fertigstellung von Spezialchemikalienprodukten einschließlich
+      Beschichtungen, Klebstoffe, Agroformulierungen, Schmierstoffe,
+      Tenside und Feinchemikalien.
+  BC-4630.10:
+    name: Formulierungsdesign und -entwicklung
+    description: |
+      Spezifikation, Rohstoffauswahl, Laborversuche und
+      Kostenoptimierung von Spezialformulierungen.
+  BC-4630.10.10:
+    name: Formulierungsspezifikation-Entwicklung
+    description: |
+      Entwicklung von Formulierungsspezifikationen gegenüber
+      Anwendungszielen.
+  BC-4630.10.20:
+    name: Rohstoffauswahl
+    description: |
+      Auswahl von Rohstoffen nach Leistung, Kosten und HSE.
+  BC-4630.10.30:
+    name: Labormaßstab-Formulierungsversuche
+    description: |
+      Labormaßstab-Versuchsvorbereitung und Charakterisierung
+      von Kandidatenformulierungen.
+  BC-4630.10.40:
+    name: Formulierungskosten-Optimierung
+    description: |
+      Kostenoptimierung von Formulierungen unter
+      Spezifikationsbeschränkungen.
+  BC-4630.20:
+    name: Misch- und Mischbetrieb
+    description: |
+      Betrieb von Flüssig-, Feststoff-, Emulsions- und
+      Dispersions-Mischanlagen.
+  BC-4630.20.10:
+    name: Flüssigmischbetrieb
+    description: |
+      Tank- und In-line-Mischung flüssiger Chemikalienprodukte.
+  BC-4630.20.20:
+    name: Feststoffmischbetrieb
+    description: |
+      Bandschnecken-, V-Kegel- und Taumelmischung fester
+      Formulierungen.
+  BC-4630.20.30:
+    name: Emulgierungsbetrieb
+    description: |
+      Produktion von Emulsionen mittels Rotor-Stator- und
+      Hochdruckhomogenisatoren.
+  BC-4630.20.40:
+    name: Dispersions- und Mahlbetrieb
+    description: |
+      Betrieb von Kugelmühlen, Dreiwalzwerken und Dispergierern.
+  BC-4630.30:
+    name: Compoundierung und Extrusionsbetrieb
+    description: |
+      Polymer-Compoundierung, Masterbatch-Produktion und Extrusion
+      von Spezialzwischenprodukten.
+  BC-4630.30.10:
+    name: Polymer-Compoundierung
+    description: |
+      Compoundierung von Polymeren mit Füllstoffen,
+      Stabilisatoren und Additiven.
+  BC-4630.30.20:
+    name: Masterbatch-Produktion
+    description: |
+      Produktion von Farb-, Additiv- und Funktions-Masterbatches.
+  BC-4630.30.30:
+    name: Extrusionsbetrieb
+    description: |
+      Betrieb von Einzel- und Doppelschnecken-Extrusionslinien.
+  BC-4630.40:
+    name: Abfüllungs- und Verpackungsbetrieb
+    description: |
+      Abfüllung von Spezialprodukten in Bulk-, Fass-, IBC-,
+      Kleingebinde- und Druckbehälter.
+  BC-4630.40.10:
+    name: Großbehälter-Abfüllung
+    description: |
+      Abfüllung von Straßen-, Bahn- und ISO-Großbehältern.
+  BC-4630.40.20:
+    name: Fass- und IBC-Abfüllung
+    description: |
+      Abfüllung von Stahl- und Kunststofffässern sowie
+      Intermediär-Schüttgut-Behältern.
+  BC-4630.40.30:
+    name: Kleingebinde-Abfüllung
+    description: |
+      Hochgeschwindigkeits-Abfüllung von Flaschen,
+      Kanistern und Verbrauchergebinden.
+  BC-4630.40.40:
+    name: Aerosol- und Druckgebinde-Abfüllung
+    description: |
+      Abfüllung und Crimpung von Aerosoldosen und
+      Druckbehältern.
+  BC-4630.50:
+    name: Formulierungsleistungs-Prüfung
+    description: |
+      Anwendungsleistungs-, Stabilitäts- und Benchmark-Prüfung
+      von Spezialformulierungen.
+  BC-4630.50.10:
+    name: Anwendungsleistungs-Prüfung
+    description: |
+      Prüfung von Formulierungen unter simulierten
+      Endanwendungsbedingungen.
+  BC-4630.50.20:
+    name: Stabilitäts- und Haltbarkeitsprüfung
+    description: |
+      Echtzeit- und beschleunigte Stabilitäts- und
+      Haltbarkeitsprüfung.
+  BC-4630.50.30:
+    name: Vergleichendes Benchmarking
+    description: |
+      Direktvergleich von Formulierungen gegenüber
+      Wettbewerbsprodukten.
+  BC-4630.60:
+    name: Spezialrezept-Management
+    description: |
+      Masterrezept-Erstellung, Versionskontrolle und Lokalisierung
+      für mehrstandörtliche Formulierungsproduktion.
+  BC-4630.60.10:
+    name: Masterrezept-Pflege
+    description: |
+      Erstellung und Pflege von Masterrezepten gemäß
+      ISA-88-Konventionen.
+  BC-4630.60.20:
+    name: Rezept-Versionskontrolle
+    description: |
+      Versionskontrolle von Rezepten über Genehmigungs- und
+      Revisionszyklen hinweg.
+  BC-4630.60.30:
+    name: Rezept-Lokalisierung
+    description: |
+      Lokalisierung von Masterrezepten für standortspezifische
+      Ausrüstung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-spectrum-frequency-management.yaml
+++ b/catalogue/i18n/de/L1-spectrum-frequency-management.yaml
@@ -1,0 +1,93 @@
+locale: de
+source: L1-spectrum-frequency-management.yaml
+entries:
+  BC-2670:
+    name: Frequenz- und Spektrumverwaltung
+    description: |
+      Verwaltung des Spektrum-Portfolios des Betreibers – Lizenzerwerb und -erneuerung,
+      Frequenzplanung und -koordination, Interferenzmanagement und Betrieb gemeinsam
+      genutzter Spektrumzugänge.
+  BC-2670.10:
+    name: Spektrum-Portfolio-Management
+    description: |
+      Pflege des Spektrum-Bestands-Registers und Überwachung strategischer Spektrumentscheidungen.
+  BC-2670.10.10:
+    name: Spektrum-Bestandsregister
+    description: |
+      Pflege des maßgeblichen Registers der Spektrumbestände des Betreibers nach Band, Geographie und Lizenz.
+  BC-2670.10.20:
+    name: Spektrum-Bewertung
+    description: |
+      Bewertung von Spektrumbeständen für Finanz-, M&A- und Auktionsentscheidungen.
+  BC-2670.10.30:
+    name: Spektrum-Handel
+    description: |
+      Erwerb, Veräußerung und Leasing von Spektrumrechten mit anderen Betreibern, wenn Behörden es erlauben.
+  BC-2670.20:
+    name: Spektrumlizenz-Management
+    description: |
+      End-to-End-Management von Spektrumlizenzen von der Auktionsbeteiligung bis zur Erneuerung und Compliance-Berichterstattung.
+  BC-2670.20.10:
+    name: Spektrumlizenz-Erwerb
+    description: |
+      Teilnahme an Spektrumauktionen, Ausschreibungen und bilateralen Zuteilungen.
+  BC-2670.20.20:
+    name: Spektrumlizenz-Erneuerung
+    description: |
+      Erneuerungsmanagement von Spektrumlizenzen gegen Ablaufkalender.
+  BC-2670.20.30:
+    name: Lizenzcompliance-Berichterstattung
+    description: |
+      Berichterstattung gegen Spektrumlizenzkonditionen einschließlich Abdeckungs- und Rollout-Verpflichtungen.
+  BC-2670.30:
+    name: Frequenzplanung und -koordination
+    description: |
+      Zuweisung von Kanälen und Frequenzen an Netzelemente und
+      Koordination mit benachbarten Nutzern.
+  BC-2670.30.10:
+    name: Zellenfrequenz-Zuweisung
+    description: |
+      Zuweisung von Frequenzen und PCIs an einzelne Funkkzellen.
+  BC-2670.30.20:
+    name: Kanalplanung
+    description: |
+      Planung von Kanalzuweisungen über Funkzugang und Mikrowellenverbindungen.
+  BC-2670.30.30:
+    name: Nachbarzellen-Planung
+    description: |
+      Definition von Nachbarzellenbeziehungen zur Verwaltung von Übergaben und Interferenzen.
+  BC-2670.40:
+    name: Spektrum-Interferenz-Management
+    description: |
+      Erkennung, Untersuchung und Lösung schädlicher Spektruminterferenz in Koordination mit Behörden.
+  BC-2670.40.10:
+    name: Interferenz-Erkennung
+    description: |
+      Erkennung schädlicher Interferenz aus internen und externen Quellen.
+  BC-2670.40.20:
+    name: Interferenz-Lösung
+    description: |
+      Untersuchung und Lösung identifizierter Interferenzfälle.
+  BC-2670.40.30:
+    name: Behörden-Koordination
+    description: |
+      Koordination mit nationalen Behörden bei lizenzübergreifender Interferenz und Durchsetzung.
+  BC-2670.50:
+    name: Spektrum-Sharing-Management
+    description: |
+      Betrieb von dynamischem Spektrum-Sharing und gemeinsam genutzten Zugangssystemen wie CBRS.
+  BC-2670.50.10:
+    name: Dynamisches Spektrum-Sharing
+    description: |
+      Betrieb von DSS-Sharing über Funktechnologien im gleichen Band.
+  BC-2670.50.20:
+    name: Gemeinsamer Zugangssystem-Koordination
+    description: |
+      Koordination mit gemeinsamen Zugangssystemen wie SAS und AFC zur Kanal-Gewährung.
+  BC-2670.50.30:
+    name: Sekundärnutzungs-Koordination
+    description: |
+      Koordination mit Primärlizenznehmern und Altnutzern bei Sekundärnutzungssystemen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-strategic-management.yaml
+++ b/catalogue/i18n/de/L1-strategic-management.yaml
@@ -1,0 +1,110 @@
+locale: de
+source: L1-strategic-management.yaml
+entries:
+  BC-100:
+    name: Strategisches Management
+    description: |
+      Festlegung der Unternehmensausrichtung, Vision, Mission und langfristiger Ziele.
+  BC-100.10:
+    name: Strategische Planung
+    description: |
+      Vision, Mission, strategische Ziele und Formulierung des Langfristplans.
+  BC-100.10.10:
+    name: Visions- und Missionsdefinition
+    description: |
+      Ausformulierung von Unternehmensvision, Mission und Grundwerten.
+  BC-100.10.20:
+    name: Umweltanalyse
+    description: |
+      Externe und interne Analyse (PESTLE, SWOT, Wettbewerbsbeobachtung).
+  BC-100.10.30:
+    name: Strategische Alternativenwahl
+    description: |
+      Bewertung strategischer Optionen und Auswahl der strategischen Ausrichtung.
+  BC-100.10.40:
+    name: Langfristplanentwicklung
+    description: |
+      Mehrjahresplan mit strategischen Zielen, Kennzahlen und Kapitalallokation.
+  BC-100.10.50:
+    name: Szenarioplanung
+    description: |
+      Plausible Zukunftsszenarien und Notfallstrategien.
+  BC-100.20:
+    name: Strategieumsetzungsmanagement
+    description: |
+      Übersetzung der Strategie in Ziele, OKRs und Balanced Scorecards.
+  BC-100.20.10:
+    name: Strategische Zielkaskadierung
+    description: |
+      Übertragung der Unternehmensstrategie in Geschäftsbereichs- und Funktionsziele.
+  BC-100.20.20:
+    name: Performance-Scorecard-Management
+    description: |
+      Balanced Scorecard, OKRs, KPI-Definition und -Nachverfolgung.
+  BC-100.20.30:
+    name: Strategieüberprüfung und -neuausrichtung
+    description: |
+      Periodische Strategieüberprüfungszyklen und Kurskorrektur.
+  BC-100.20.40:
+    name: Strategische Initiativensteuerung
+    description: |
+      Stage-Gate-Steuerung strategischer Initiativen.
+  BC-100.30:
+    name: Unternehmensentwicklungsmanagement
+    description: |
+      M&A, Devestitionen, Joint Ventures und Partnerschaften.
+  BC-100.30.10:
+    name: Fusionen und Akquisitionen Durchführung
+    description: |
+      Zielscreening, Due Diligence, Transaktionsstrukturierung und Abschluss.
+  BC-100.30.20:
+    name: Devestitionsmanagement
+    description: |
+      Carve-outs, Trennungen sowie Vermögens- und Unternehmensveräußerungen.
+  BC-100.30.30:
+    name: Joint-Venture- und Allianzmanagement
+    description: |
+      Gründung und Steuerung von Joint Ventures, Allianzen und strategischen Partnerschaften.
+  BC-100.30.40:
+    name: Post-Merger-Integration
+    description: |
+      Integrationsplanung und Synergierealisierung nach M&A-Transaktionen.
+  BC-100.40:
+    name: Strategisches Portfoliomanagement
+    description: |
+      Portfolio strategischer Initiativen im gesamten Unternehmen.
+  BC-100.40.10:
+    name: Initiativenportfolio-Definition
+    description: |
+      Erfassung und Kategorisierung strategischer Initiativen.
+  BC-100.40.20:
+    name: Portfoliopriorisierung
+    description: |
+      Bewertung, Auswahl und Priorisierung von Initiativen im Strategieabgleich.
+  BC-100.40.30:
+    name: Investitionsallokation
+    description: |
+      Zuteilung von Kapital, Personal und Kapazitäten über das Portfolio.
+  BC-100.40.40:
+    name: Portfolio-Performance-Monitoring
+    description: |
+      Nachverfolgung der Nutzenrealisierung und des Portfoliostatus.
+  BC-100.50:
+    name: Geschäftsmodellmanagement
+    description: |
+      Definition, Weiterentwicklung und Innovation des Geschäftsmodells.
+  BC-100.50.10:
+    name: Geschäftsmodelldesign
+    description: |
+      Ausformulierung von Wertversprechen, Kundensegmenten und Erlösmodell.
+  BC-100.50.20:
+    name: Geschäftsmodellinnovation
+    description: |
+      Erforschung und Prototyping neuer oder angrenzender Geschäftsmodelle.
+  BC-100.50.30:
+    name: Geschäftsmodell-Performance-Bewertung
+    description: |
+      Bewertung von Unit Economics, Skalierbarkeit und Modelleignung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-student-enrolment-records-management.yaml
+++ b/catalogue/i18n/de/L1-student-enrolment-records-management.yaml
@@ -1,0 +1,160 @@
+locale: de
+source: L1-student-enrolment-records-management.yaml
+entries:
+  BC-4720:
+    name: Studierendeneinschreibung und Immatrikulationsregisterverwaltung
+    description: |
+      Verwaltung des aktiven Studierendenlebenszyklus von der Einschreibung und
+      Registrierung über akademische Aufzeichnungen, Transkripte, Kreditanrechnung
+      bis hin zur Graduierung sowie zugrundeliegendes Studierenden-Identitätsregistermanagement.
+  BC-4720.10:
+    name: Einschreibung und Registrierung
+    description: |
+      Semesterweise Einschreibung und Kursregistrierung zugelassener Studierender,
+      einschließlich Stundenplanänderungen und Fortsetzung zwischen Semestern.
+    in_scope:
+      - Kursregistrierung
+      - Hinzufügen/Abmelden und Stundenplanänderung
+      - Wiedereinschreibung und Fortsetzung
+    out_of_scope:
+      - Erstmalige Zulassungsentscheidungen (abgedeckt unter Studierendengewinnung & Zulassungsmanagement)
+  BC-4720.10.10:
+    name: Kursregistrierung
+    description: |
+      Registrierung von Studierenden in Kursen, Kursabschnitten und Lerneinheiten.
+  BC-4720.10.20:
+    name: Hinzufügen/Abmelden und Stundenplanänderung
+    description: |
+      Bearbeitung von Hinzufügen/Abmelden und Stundenplanänderungen innerhalb
+      veröffentlichter Fristen.
+  BC-4720.10.30:
+    name: Wiedereinschreibung und Fortsetzung
+    description: |
+      Wiedereinschreibung und Fortsetzung über akademische Semester und Studienjahre.
+  BC-4720.20:
+    name: Akademische Datenverwaltung
+    description: |
+      Pflege maßgeblicher akademischer Studierendendaten, einschließlich Noten,
+      Transkripte und Feststellungen zum akademischen Status.
+    in_scope:
+      - Noten- und Punkteerfassung
+      - Transkriptproduktion
+      - Feststellung des akademischen Status
+    out_of_scope:
+      - Der Bewertungsworkflow selbst (abgedeckt unter Prüfungs- und Bewertungswesen)
+  BC-4720.20.10:
+    name: Noten- und Punkteerfassung
+    description: |
+      Maßgebliche Erfassung von Noten und Punkten in Studierendendaten.
+  BC-4720.20.20:
+    name: Transkriptproduktion
+    description: |
+      Erstellung und Ausstellung offizieller und inoffizieller Transkripte.
+  BC-4720.20.30:
+    name: Feststellung des akademischen Status
+    description: |
+      Feststellung des akademischen Status, Auszeichnungen, Bewährung und
+      Exmatrikulation.
+  BC-4720.30:
+    name: Kursplanung und Stundenplanaufzeichnungen
+    description: |
+      Maßgebliche Aufzeichnungen von Kursabschnitt-Stundenplänen, Raumzuweisung
+      und Konfliktlösungsentscheidungen, die nachgelagert für die Einschreibung
+      genutzt werden.
+    in_scope:
+      - Stundenplanaufzeichnungen für Abschnitte und Kohorten
+      - Raum- und Anlagenzuweisungsaufzeichnungen
+      - Aufzeichnungen zur Stundenplankonfliktlösung
+    out_of_scope:
+      - Täglicher Unterrichtsbetrieb (abgedeckt unter Lehr- und Lernbetriebsmanagement)
+  BC-4720.30.10:
+    name: Stundenplanaufzeichnungen für Abschnitte und Kohorten
+    description: |
+      Maßgebliche Stundenplanaufzeichnungen nach Abschnitt und Kohorte.
+  BC-4720.30.20:
+    name: Raum- und Anlagenzuweisungsaufzeichnungen
+    description: |
+      Aufzeichnungen über Unterrichtsraum- und Anlagenzuweisungen zu geplanten
+      Sitzungen.
+  BC-4720.30.30:
+    name: Stundenplankonfliktlösungsaufzeichnungen
+    description: |
+      Aufzeichnungen identifizierter und gelöster Stundenplankonflikte.
+  BC-4720.40:
+    name: Kreditanrechnung und Anerkennung
+    description: |
+      Bewertung und Erfassung von Kreditanrechnungen von anderen Institutionen,
+      Anerkennung früherer Lernerfahrungen und Anwendung von Anrechnungsvereinbarungen.
+    in_scope:
+      - Bewertung der Kreditanrechnung
+      - Anerkennung früherer Lernerfahrungen (APL)
+      - Anwendung von Anrechnungsvereinbarungen
+    out_of_scope:
+      - Internationale Zeugnisbewertung bei der Zulassung (abgedeckt unter Studierendengewinnung & Zulassungsmanagement)
+  BC-4720.40.10:
+    name: Kreditanrechnungsbewertung
+    description: |
+      Bewertung von an anderen Institutionen erworbenen Credits im Vergleich zu
+      Heimprogrammen.
+  BC-4720.40.20:
+    name: Anerkennung früherer Lernerfahrungen
+    description: |
+      Anerkennung früherer Erfahrungs- und informeller Lernerfahrungen für Credits.
+  BC-4720.40.30:
+    name: Anwendung von Anrechnungsvereinbarungen
+    description: |
+      Anwendung interinstitutioneller Anrechnungsvereinbarungen auf Studierendendaten.
+  BC-4720.50:
+    name: Graduierung und Zeugnisausstellung
+    description: |
+      Überprüfung der Graduierungsberechtigung, Verleihung von Abschlüssen und
+      Ausstellung prüfbarer Zeugnisse, Diplome und Zertifikate.
+    in_scope:
+      - Überprüfung der Graduierungsberechtigung
+      - Abschlussverleihung
+      - Zeugnisausstellung und nachgelagerte Verifizierung
+    out_of_scope:
+      - Prüfungsergebnisverarbeitung (abgedeckt unter Prüfungs- und Bewertungswesen)
+  BC-4720.50.10:
+    name: Überprüfung der Graduierungsberechtigung
+    description: |
+      Überprüfung der Studierendendaten anhand der Graduierungsanforderungen.
+  BC-4720.50.20:
+    name: Abschlussverleihung
+    description: |
+      Formelle Verleihung von Graden und Qualifikationen.
+  BC-4720.50.30:
+    name: Zeugnisausstellung und -verifizierung
+    description: |
+      Ausstellung und Verifizierung von Papier- und digitalen Zeugnissen,
+      einschließlich verifizierbarer Zeugnisse.
+  BC-4720.60:
+    name: Studierenden-Identitäts- und Lebenszyklus-Aufzeichnungen
+    description: |
+      Pflege von Studierendenidentifikatoren, Einschreibungsstatuskennzeichen und
+      Exmatrikulations-/Beurlaubungsaufzeichnungen, die nachgelagerte administrative
+      Aktionen verankern.
+    in_scope:
+      - Lebenszyklus-Management der Studierendenidentifikatoren
+      - Pflege des Einschreibungsstatus
+      - Exmatrikulations- und Beurlaubungsaufzeichnungen
+    out_of_scope:
+      - Identitätsauthentifizierung und -zugang (abgedeckt unter branchenübergreifendem Cybersicherheitsmanagement)
+  BC-4720.60.10:
+    name: Studierenden-Identitätslebenszyklus
+    description: |
+      Lebenszyklus eindeutiger Studierendenidentifikatoren von der Ausstellung bis
+      zur Schließung.
+  BC-4720.60.20:
+    name: Pflege des Einschreibungsstatus
+    description: |
+      Pflege maßgeblicher Einschreibungsstatuskennzeichen (aktiv, beurlaubt,
+      exmatrikuliert).
+  BC-4720.60.30:
+    name: Exmatrikulations- und Beurlaubungsaufzeichnungen
+    description: |
+      Aufzeichnungen über Studierendenexmatrikulationen, Beurlaubungen und
+      Wiedereinschreibungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-student-recruitment-admissions-management.yaml
+++ b/catalogue/i18n/de/L1-student-recruitment-admissions-management.yaml
@@ -1,0 +1,155 @@
+locale: de
+source: L1-student-recruitment-admissions-management.yaml
+entries:
+  BC-4710:
+    name: Studierendengewinnung und Zulassungsmanagement
+    description: |
+      Durchgängige Gewinnung, Bewerbungsbearbeitung, Entscheidungsfindung und
+      Konvertierung von Studieninteressierten zu eingeschriebenen Lernenden,
+      einschließlich Finanzierungsangeboten und internationaler Zulassungsabwicklung.
+  BC-4710.10:
+    name: Interessentengewinnung und Rekrutierung
+    description: |
+      Gezielte Ansprache potenzieller Studierender durch Kampagnen, Veranstaltungen
+      und Maßnahmen zur Lead-Generierung.
+    in_scope:
+      - Rekrutierungskampagnen und Bearbeitung eingehender Anfragen
+      - Tage der offenen Tür, Messen und Campus-Besuche
+      - Erfassung und Pflege von Interessenten-Leads
+    out_of_scope:
+      - Allgemeines institutionelles Markenmarketing (abgedeckt unter branchenübergreifendem Marketingmanagement)
+  BC-4710.10.10:
+    name: Rekrutierungskampagnenbetrieb
+    description: |
+      Planung und Durchführung von Rekrutierungskampagnen über verschiedene Kanäle.
+  BC-4710.10.20:
+    name: Tag der offenen Tür und Campus-Besuch
+    description: |
+      Durchführung von Tagen der offenen Tür, Schnupperstudien und
+      Studieninteressierten-Besuchen.
+  BC-4710.10.30:
+    name: Interessenten-Lead-Management
+    description: |
+      Erfassung, Pflege und Qualifizierung von Studieninteressierten-Leads.
+  BC-4710.20:
+    name: Bewerbungsmanagement
+    description: |
+      Empfang und Bearbeitung von Bewerbungen potenzieller Studierender,
+      einschließlich unterstützender Unterlagen und Kommunikation mit Bewerbenden.
+    in_scope:
+      - Bewerbungseingang und -validierung
+      - Dokument- und Referenzverifizierung
+      - Bewerbungsstatuskommunikation
+    out_of_scope:
+      - Zulassungsentscheidung (abgedeckt unter Zulassungsentscheidung)
+  BC-4710.20.10:
+    name: Bewerbungseingang und -validierung
+    description: |
+      Eingang und Vollständigkeitsprüfung von Bewerbungen über alle Kanäle.
+  BC-4710.20.20:
+    name: Verifizierung von Bewerbungsunterlagen
+    description: |
+      Verifizierung von Zeugnissen, Referenzen und Bewerbungsunterlagen.
+  BC-4710.20.30:
+    name: Bewerbungsstatuskommunikation
+    description: |
+      Kommunikation des Bewerbungsfortschritts an Bewerbende.
+  BC-4710.30:
+    name: Zulassungsentscheidung
+    description: |
+      Bewertung, Scoring, Ausschussüberprüfung und Erlass von
+      Zulassungsentscheidungen gemäß veröffentlichten Zulassungskriterien.
+    in_scope:
+      - Zulassungsbewertung und Scoring
+      - Ausschussüberprüfung bei Zulassung
+      - Erlass von Zulassungsentscheidungen
+    out_of_scope:
+      - Finanzielle Förderangebote (abgedeckt unter Finanzielle Förderung & Stipendienmanagement)
+  BC-4710.30.10:
+    name: Zulassungsbewertung und Scoring
+    description: |
+      Bewertung und Scoring von Bewerbenden anhand der Zulassungskriterien.
+  BC-4710.30.20:
+    name: Zulassungsausschussüberprüfung
+    description: |
+      Ausschuss- oder Gremiumsüberprüfung grenzwertiger und wettbewerbsintensiver
+      Bewerbungen.
+  BC-4710.30.30:
+    name: Entscheidungserlass
+    description: |
+      Erlass von Zulassungen, bedingten Zulassungen, Wartelisten und Ablehnungen.
+  BC-4710.40:
+    name: Finanzielle Förderung und Stipendienmanagement
+    description: |
+      Festlegung, Vergabe und Auszahlung von Studienförderungen, Stipendien,
+      Beihilfen und Zuschüssen zur Unterstützung von Zugang und Erschwinglichkeit.
+    in_scope:
+      - Beurteilung der Förderberechtigung
+      - Stipendienvergabe und -verwaltung
+      - Auszahlung von Beihilfen und Zuschüssen
+    out_of_scope:
+      - Einhaltung der Vorschriften für öffentliche Förderung (abgedeckt unter Bildungskonformität & Regulatorisches Berichtswesen)
+  BC-4710.40.10:
+    name: Beurteilung der Förderberechtigung
+    description: |
+      Beurteilung der bedürfnis- und leistungsbasierten Förderberechtigung.
+  BC-4710.40.20:
+    name: Stipendienvergabeverwaltung
+    description: |
+      Verwaltung der Stipendienvergabe aus internen und externen Quellen.
+  BC-4710.40.30:
+    name: Auszahlung von Beihilfen und Zuschüssen
+    description: |
+      Auszahlung von Beihilfen, Zuschüssen und Studiengebührenunterstützung.
+  BC-4710.50:
+    name: Angebots- und Einschreibungskonvertierung
+    description: |
+      Umwandlung von Zulassungsangeboten in bestätigte Einschreibungen, einschließlich
+      Annahmebearbeitung, vorbereitender Einführung und Konvertierungsanalyse.
+    in_scope:
+      - Nachverfolgung von Angebotsannahmen
+      - Vorbereitende Einführungsmaßnahmen
+      - Ausbeute- und Konvertierungsanalysen
+    out_of_scope:
+      - Aktive Einschreibung und Registrierung (abgedeckt unter Studierendeneinschreibung & Immatrikulationsregister)
+  BC-4710.50.10:
+    name: Angebotserlass und Annahmenachverfolgung
+    description: |
+      Erlass von Angeboten und Nachverfolgung von Annahme, Ablehnung und Aufschub.
+  BC-4710.50.20:
+    name: Vorbereitende Studieneinführung
+    description: |
+      Einführungsaufgaben, die von zugelassenen Studierenden vor der formalen
+      Einschreibung erledigt werden.
+  BC-4710.50.30:
+    name: Ausbeute- und Konvertierungsanalyse
+    description: |
+      Analysen zu Angebotsausbeute, Abbruch und Konvertierungsleistung.
+  BC-4710.60:
+    name: Internationale Zulassungsverwaltung
+    description: |
+      Spezialisierte Bearbeitung internationaler Bewerbender einschließlich
+      Zeugnisbewertung, Sprachkenntnisnachweis und Visumsdokumentierung.
+    in_scope:
+      - Internationale Zeugnisbewertung
+      - Beurteilung von Englischsprachkenntnissen
+      - Erstellung von Visum-Sponsoring-Dokumenten
+    out_of_scope:
+      - Laufende Visumscompliance für eingeschriebene Studierende (abgedeckt unter Bildungskonformität & Regulatorisches Berichtswesen)
+  BC-4710.60.10:
+    name: Internationale Zeugnisbewertung
+    description: |
+      Bewertung ausländischer akademischer Zeugnisse im Vergleich zum
+      inländischen Äquivalent.
+  BC-4710.60.20:
+    name: Beurteilung von Englischsprachkenntnissen
+    description: |
+      Beurteilung der Englischsprachkenntnisse nicht-muttersprachlicher Bewerbender.
+  BC-4710.60.30:
+    name: Visum-Sponsoring-Dokumentation
+    description: |
+      Ausstellung von Visum-Sponsoring-Dokumenten (z. B. I-20, CAS) an
+      zugelassene Studierende.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-student-support-wellbeing-management.yaml
+++ b/catalogue/i18n/de/L1-student-support-wellbeing-management.yaml
@@ -1,0 +1,157 @@
+locale: de
+source: L1-student-support-wellbeing-management.yaml
+entries:
+  BC-4770:
+    name: Studierendenbetreuung und Wohlbefindenmanagement
+    description: |
+      Nicht-unterrichtliche Dienste zur Unterstützung des Studienerfolgs und
+      Wohlbefindens der Studierenden, einschließlich akademischer Beratung,
+      Beratungsdiensten, Barrierefreiheit und Sonderbildungsunterstützung,
+      Karrierediensten und Seelsorge.
+  BC-4770.10:
+    name: Akademische Beratung
+    description: |
+      Beratung von Studierenden zu Studiumsplanung, Kursauswahl und akademischem
+      Fortschritt einschließlich Unterstützung für gefährdete Lernende.
+    in_scope:
+      - Studiumsplanungsberatung
+      - Beratung gefährdeter Studierender
+      - Unterstützung bei akademischer Bewährung
+    out_of_scope:
+      - Karriereberatung (abgedeckt unter Karrieredienste & Placierung)
+      - Psychische Gesundheitsberatung (abgedeckt unter Beratungs- und psychische Gesundheitsdienste)
+  BC-4770.10.10:
+    name: Studiumsplanungsberatung
+    description: |
+      Beratung zu Programmstruktur, Kursauswahl und Graduierungspfaden.
+  BC-4770.10.20:
+    name: Beratung gefährdeter Studierender
+    description: |
+      Gezielte Beratung für akademisch gefährdete Studierende.
+  BC-4770.10.30:
+    name: Unterstützung bei akademischer Bewährung
+    description: |
+      Strukturierte Unterstützung für Studierende mit akademischer Bewährung.
+  BC-4770.20:
+    name: Beratungs- und psychische Gesundheitsdienste
+    description: |
+      Bereitstellung von psychischen Gesundheitsbewertungen, Beratung und
+      Krisenreaktionsdiensten für Studierende.
+    in_scope:
+      - Psychische Gesundheitsbewertung und -triage
+      - Durchführung von Beratungsgesprächen
+      - Krisenreaktionskoordination
+    out_of_scope:
+      - Klinische medizinische Versorgung jenseits von Beratung (abgedeckt unter Gesundheitsversorgungskompetenzen oder Überweisungen)
+  BC-4770.20.10:
+    name: Psychische Gesundheitsbewertung und -triage
+    description: |
+      Erstbewertung und Triage psychischer Gesundheitsbedürfnisse von Studierenden.
+  BC-4770.20.20:
+    name: Durchführung von Beratungsgesprächen
+    description: |
+      Durchführung von Einzel- und Gruppenberatungsgesprächen.
+  BC-4770.20.30:
+    name: Krisenreaktionskoordination
+    description: |
+      Koordination der Krisenreaktion und externer Überweisungen.
+  BC-4770.30:
+    name: Behindertenservices und Nachteilsausgleich
+    description: |
+      Festlegung und Bereitstellung angemessener Nachteilsausgleiche für
+      Studierende mit Behinderungen und Bereitstellung von Hilfstechnologie.
+    in_scope:
+      - Überprüfung von Behinderungsdokumentationen
+      - Bereitstellung angemessener Nachteilsausgleiche
+      - Unterstützung durch Hilfstechnologie
+    out_of_scope:
+      - Gesetzliche Sonderpädagogikprogramme für K-12 (abgedeckt unter Sonderpädagogikdienste)
+      - Bürgerrechts-Compliance-Berichtswesen (abgedeckt unter Bildungskonformität & Regulatorisches Berichtswesen)
+  BC-4770.30.10:
+    name: Überprüfung von Behinderungsdokumentationen
+    description: |
+      Überprüfung von Behinderungsdokumentationen zur Unterstützung von
+      Nachteilsausgleichanträgen.
+  BC-4770.30.20:
+    name: Bereitstellung angemessener Nachteilsausgleiche
+    description: |
+      Bereitstellung akademischer und prüfungsbezogener Nachteilsausgleiche.
+  BC-4770.30.30:
+    name: Hilfstechnologieunterstützung
+    description: |
+      Bereitstellung und Unterstützung von Hilfstechnologie für Studierende.
+  BC-4770.40:
+    name: Sonderpädagogikdienste
+    description: |
+      Gesetzliche Sonderpädagogikdienste, die vorwiegend im K-12-Kontext
+      erbracht werden, einschließlich individueller Bildungspläne und
+      zugehöriger Dienste.
+    in_scope:
+      - Entwicklung individueller Bildungsprogramme (IEP)
+      - Durchführung spezialisierter Unterweisungen
+      - Koordination zugehöriger Dienste (z. B. Sprach-, Ergotherapie, Physiotherapie)
+    out_of_scope:
+      - Hochschulnachteilsausgleiche (abgedeckt unter Behindertenservices und Nachteilsausgleich)
+  BC-4770.40.10:
+    name: Entwicklung individueller Bildungsprogramme
+    description: |
+      Entwicklung von IEPs und gleichwertigen individuellen Plänen.
+  BC-4770.40.20:
+    name: Durchführung spezialisierter Unterweisungen
+    description: |
+      Durchführung spezialisierter Unterweisungen für Studierende mit
+      identifizierten Bedarfen.
+  BC-4770.40.30:
+    name: Koordination zugehöriger Dienste
+    description: |
+      Koordination zugehöriger Dienste wie Sprach-, Ergotherapie und Physiotherapie.
+  BC-4770.50:
+    name: Karrieredienste und Placierung
+    description: |
+      Karriereberatung, Vermittlung von Praktika und Placierungen sowie
+      Arbeitgeberbeziehungsmanagement zur Unterstützung des Berufseinstiegs.
+    in_scope:
+      - Karriereberatung
+      - Vermittlung von Praktika und Placierungen
+      - Arbeitgeberbeziehungen und Campus-Recruiting
+    out_of_scope:
+      - Kreditanerkennungspflichtige Praktikumsbetreuung (abgedeckt unter Lehr- und Lernbetriebsmanagement)
+  BC-4770.50.10:
+    name: Karriereberatung
+    description: |
+      Karriereberatung und -planung für Studierende und Hochschulabsolventen.
+  BC-4770.50.20:
+    name: Praktikums- und Placierungsvermittlung
+    description: |
+      Vermittlung von Praktika und Berufserfahrungsmöglichkeiten.
+  BC-4770.50.30:
+    name: Arbeitgeberbeziehungen und Campus-Recruiting
+    description: |
+      Management von Arbeitgeberbeziehungen und Campus-Recruiting-Veranstaltungen.
+  BC-4770.60:
+    name: Studierendenwohl und Seelsorge
+    description: |
+      Seelsorge, Mentoring, Unterstützung bei Disziplinfragen und Wohlbefinden-
+      programme der Institution.
+    in_scope:
+      - Seelsorge und Mentoring
+      - Unterstützung bei Studierendenverhalten und -disziplin
+      - Betrieb von Wohlbefindensprogrammen
+    out_of_scope:
+      - Bürgerrechtsdurchsetzungsmaßnahmen (abgedeckt unter Bildungskonformität & Regulatorisches Berichtswesen)
+  BC-4770.60.10:
+    name: Seelsorge und Mentoring
+    description: |
+      Seelsorge und Mentoring von Studierenden durch Tutoren und dediziertes
+      Personal.
+  BC-4770.60.20:
+    name: Studierendenverhalten und Disziplinarunterstützung
+    description: |
+      Unterstützung für Studierendenverhalten und Disziplinarverfahren.
+  BC-4770.60.30:
+    name: Wohlbefindensprogrammbetrieb
+    description: |
+      Betrieb institutioneller Wohlbefindensprogramme und -kampagnen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-subscription-billing-revenue-management.yaml
+++ b/catalogue/i18n/de/L1-subscription-billing-revenue-management.yaml
@@ -1,0 +1,164 @@
+locale: de
+source: L1-subscription-billing-revenue-management.yaml
+entries:
+  BC-4250:
+    name: Abonnementabrechnung und -Umsatz-Management
+    description: |
+      Nutzungsmessung, Tarifierung, Rechnungsstellung, Mahnwesen,
+      Abonnementumsatzrealisierung, Abonnementsteuerbehandlung und
+      Wiederkehrumsatz-Analysen für das SaaS-Geschäftsmodell.
+  BC-4250.10:
+    name: Nutzungsmessung
+    description: |
+      Ingestion und Aggregation von Nutzungsereignissen, die
+      nachgelagerte Tarifierung und Analysen speisen.
+  BC-4250.10.10:
+    name: Nutzungsereignis-Ingestion
+    description: |
+      Ingestion von Nutzungsereignissen aus Produktdiensten in
+      die Messpipeline.
+  BC-4250.10.20:
+    name: Nutzungsaggregation
+    description: |
+      Aggregation von Nutzungsereignissen zu abrechenbaren Mengen
+      je Mandant und Messzähler.
+  BC-4250.10.30:
+    name: Gemessene Mengenabstimmung
+    description: |
+      Abstimmung gemessener Mengen gegen Quelldaten und
+      kundenseitige Zähler.
+  BC-4250.20:
+    name: Tarifierung und Abrechnung
+    description: |
+      Anwendung von Abonnement- und Nutzungstarifen, Tagessatzberechnungen
+      und Rabatten zur Berechnung von Entgelten.
+  BC-4250.20.10:
+    name: Abonnementstarifierung
+    description: |
+      Berechnung wiederkehrender Abonnemententgelte je Zyklus.
+  BC-4250.20.20:
+    name: Nutzungstarifierung
+    description: |
+      Berechnung von Nutzungsentgelten aus tarifartierten Mengen
+      und Tarifen.
+  BC-4250.20.30:
+    name: Tagessatzberechnung
+    description: |
+      Berechnung anteiliger Entgelte aus zyklusmittigen Änderungen.
+  BC-4250.20.40:
+    name: Rabattanwendung
+    description: |
+      Anwendung ausgehandelter Rabatte und Gutschriften auf
+      berechnete Entgelte.
+  BC-4250.30:
+    name: Rechnungsstellung und Kontoauszug-Management
+    description: |
+      Generierung, Lieferung und Anpassung von Rechnungen sowie
+      Bearbeitung von Kundenabrechnungsstreitigkeiten.
+  BC-4250.30.10:
+    name: Rechnungsgenerierung
+    description: |
+      Generierung von Rechnungen aus tarifartierten Entgelten
+      und Vertragsbedingungen.
+  BC-4250.30.20:
+    name: Rechnungslieferung
+    description: |
+      Lieferung von Rechnungen an Kunden über Portal-, E-Mail-
+      und Partnerkanäle.
+  BC-4250.30.30:
+    name: Rechnungsanpassung
+    description: |
+      Anpassung von Rechnungen für Gutschriften, Fehler und
+      vertragliche Abweichungen.
+  BC-4250.30.40:
+    name: Kunden-Abrechnungsstreitigkeiten-Bearbeitung
+    description: |
+      Triage und Lösung von Kunden-Abrechnungsstreitigkeiten.
+  BC-4250.40:
+    name: Zahlungseinzug und Mahnwesen
+    description: |
+      Zahlungsmittel-Management, Zahlungsautorisierung, Mahnwesen
+      und Rückgewinnung unfreiwilliger Abwanderung.
+  BC-4250.40.10:
+    name: Zahlungsmittel-Management
+    description: |
+      Erfassung und Pflege von Kundenzahlungsmitteln und -tokens.
+  BC-4250.40.20:
+    name: Zahlungsautorisierung
+    description: |
+      Autorisierung und Einzug wiederkehrender Zahlungen über
+      Zahlungsabwickler.
+  BC-4250.40.30:
+    name: Mahnworkflow
+    description: |
+      Automatisierte Mahnsequenzen bei fehlgeschlagenen Zahlungen
+      und überfälligen Salden.
+  BC-4250.40.40:
+    name: Unfreiwillige Abwanderungs-Rückgewinnung
+    description: |
+      Rückgewinnung von Abonnements, die durch abgelaufene Karten,
+      Hartzurückweisungen und ähnliche Zahlungsfehler verloren gingen.
+  BC-4250.50:
+    name: Abonnementumsatzrealisierung
+    description: |
+      Identifikation von Leistungsverpflichtungen und Verwaltung von
+      Umsatzplänen gemäß ASC 606 / IFRS 15.
+  BC-4250.50.10:
+    name: Leistungsverpflichtungs-Identifikation
+    description: |
+      Identifikation eigenständiger Leistungsverpflichtungen aus
+      Abonnementverträgen.
+  BC-4250.50.20:
+    name: Umsatzplan-Management
+    description: |
+      Generierung und Pflege von Umsatzrealisierungsplänen über
+      die Vertragslaufzeit.
+  BC-4250.50.30:
+    name: Deferred-Revenue-Abstimmung
+    description: |
+      Abstimmung abgegrenzter Umsatzsalden gegen abgerechnete und
+      realisierte Beträge.
+  BC-4250.60:
+    name: Abonnementsteuer-Management
+    description: |
+      Steuerjurisdiktionsbestimmung, Steuerberechnung und
+      Befreiungsbehandlung über wiederkehrende und nutzungsbasierte
+      Entgelte hinweg.
+  BC-4250.60.10:
+    name: Steuerjurisdiktionsbestimmung
+    description: |
+      Bestimmung anwendbarer Steuerjurisdiktionen je Kunde und
+      Entgelt.
+  BC-4250.60.20:
+    name: Abonnementsteuerberechnung
+    description: |
+      Berechnung indirekter Steuern auf Abonnement- und
+      Nutzungsentgelte.
+  BC-4250.60.30:
+    name: Steuerbefreiungsbehandlung
+    description: |
+      Erfassung und Anwendung kundenseitiger
+      Steuerbefreiungsbescheinigungen.
+  BC-4250.70:
+    name: Abonnementumsatz-Analysen
+    description: |
+      Berechnung und Analyse von Wiederkehrumsatz-Gesundheitskennzahlen
+      einschließlich ARR, MRR, NRR, GRR und Kohortansichten.
+  BC-4250.70.10:
+    name: ARR- und MRR-Berechnung
+    description: |
+      Berechnung von jährlichem und monatlichem Wiederkehrumsatz
+      aus dem Abonnementstatus.
+  BC-4250.70.20:
+    name: Netto- und Brutto-Retention-Analyse
+    description: |
+      Analyse der Netto- und Brutto-Umsatzretention über
+      Kundenkohorten.
+  BC-4250.70.30:
+    name: Kohorten-Umsatzanalyse
+    description: |
+      Kohortenbasierte Analyse der Umsatzentwicklung und
+      Retentionsdynamik.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-subscription-lifecycle-management.yaml
+++ b/catalogue/i18n/de/L1-subscription-lifecycle-management.yaml
@@ -1,0 +1,157 @@
+locale: de
+source: L1-subscription-lifecycle-management.yaml
+entries:
+  BC-4240:
+    name: Abonnement-Lebenszyklus-Management
+    description: |
+      Plan- und Berechtigungsdesign, Abonnementvertragsabschluss,
+      Bereitstellung, Änderung, Verlängerung, Kündigung und
+      Laufzeit-Berechtigungsdurchsetzung über den kommerziellen
+      SaaS-Lebenszyklus.
+  BC-4240.10:
+    name: Plan- und Berechtigungsdesign
+    description: |
+      Definition von Plänen, Funktionsberechtigungen und den Regeln,
+      die festlegen, welche Kunden für welchen Plan berechtigt sind.
+    in_scope:
+      - Plankatalog und Funktions-Gating
+      - Planberechtigungsregeln
+    out_of_scope:
+      - Preisstrategie und Preislistengovernance (abgedeckt durch Preismanagement)
+  BC-4240.10.10:
+    name: Plankatalog-Definition
+    description: |
+      Definition des Plankatalogs einschließlich Planstufen und
+      -inhalten.
+  BC-4240.10.20:
+    name: Funktionsberechtigungs-Definition
+    description: |
+      Definition von Funktionsberechtigungen, die Plänen, Add-ons
+      und benutzerdefinierten Verträgen zugeordnet sind.
+  BC-4240.10.30:
+    name: Planberechtigungsregeln
+    description: |
+      Regeln, die bestimmen, welche Kunden und Anwendungsfälle für
+      welchen Plan berechtigt sind.
+  BC-4240.20:
+    name: Abonnementvertrags-Management
+    description: |
+      Angebotsverwaltung, Bestellformulargenerierung und Erfassung
+      von Abonnementvertragsartefakten.
+  BC-4240.20.10:
+    name: Abonnementangebots-Management
+    description: |
+      Generierung und Pflege von Abonnementangeboten im
+      Vertriebsprozess.
+  BC-4240.20.20:
+    name: Bestellformular-Generierung
+    description: |
+      Generierung von Bestellformularen, die vereinbarte Bedingungen
+      für neue und bestehende Kunden widerspiegeln.
+  BC-4240.20.30:
+    name: Abonnementvertrags-Erfassung
+    description: |
+      Erfassung und Speicherung ausgeführter Abonnementvertragsartefakte
+      und wesentlicher Bedingungen.
+  BC-4240.30:
+    name: Abonnementbereitstellung
+    description: |
+      Aktivierung des Dienstes für neue Abonnements einschließlich
+      Trial-zu-Paid-Konversion und Massenplatz-Bereitstellung.
+  BC-4240.30.10:
+    name: Erstbereitstellung
+    description: |
+      Erstbereitstellung von Dienstleistungsberechtigungen zu
+      Beginn des Abonnements.
+  BC-4240.30.20:
+    name: Trial-Konversion
+    description: |
+      Konversion von Testkonten zu bezahlten Abonnements.
+  BC-4240.30.30:
+    name: Massenplatz-Bereitstellung
+    description: |
+      Massenbereitstellung von Plätzen für Unternehmensabonnements.
+  BC-4240.40:
+    name: Abonnementänderungs-Management
+    description: |
+      Änderungen an aktiven Abonnements einschließlich Upgrades,
+      Downgrades, Platzanpassungen und Add-on-Aktivierung.
+  BC-4240.40.10:
+    name: Plan-Upgrade-Management
+    description: |
+      Bearbeitung kunden- und systemseitig initiierter Plan-Upgrades.
+  BC-4240.40.20:
+    name: Plan-Downgrade-Management
+    description: |
+      Bearbeitung von Plan-Downgrades einschließlich Auswirkungen
+      auf Berechtigungen und Daten.
+  BC-4240.40.30:
+    name: Platzanpassung
+    description: |
+      Anpassung von Platzanzahlen bei aktiven Abonnements.
+  BC-4240.40.40:
+    name: Add-on-Aktivierung
+    description: |
+      Aktivierung optionaler Add-on-Berechtigungen bei aktiven
+      Abonnements.
+  BC-4240.50:
+    name: Verlängerungs-Management
+    description: |
+      Prognose, Verarbeitung und Verhandlung von Abonnementverlängerungen
+      unabhängig ob automatisch oder manuell.
+  BC-4240.50.10:
+    name: Verlängerungsprognose
+    description: |
+      Prognose bevorstehender Verlängerungen und erwarteter Ergebnisse.
+  BC-4240.50.20:
+    name: Automatische Verlängerungsverarbeitung
+    description: |
+      Verarbeitung automatischer Abonnementverlängerungen gemäß
+      Vertragsbedingungen.
+  BC-4240.50.30:
+    name: Verlängerungsverhandlungs-Unterstützung
+    description: |
+      Unterstützung bei Verlängerungsverhandlungen einschließlich
+      Daten, Preisgestaltung und Änderungspaketen.
+  BC-4240.60:
+    name: Kündigung und Vertragsbeendigung
+    description: |
+      Freiwillige Kündigung, unfreiwillige Vertragsbeendigung und
+      Dienst-Abwicklung für ausscheidende Kunden.
+  BC-4240.60.10:
+    name: Kündigungsverarbeitung
+    description: |
+      Verarbeitung kundenseitig initiierter Kündigungen.
+  BC-4240.60.20:
+    name: Unfreiwillige Vertragsbeendigung
+    description: |
+      Vertragsbeendigung bei Nichtzahlung, Vertragsbruch oder
+      vertraglichem Ende.
+  BC-4240.60.30:
+    name: Dienst-Abwicklungs-Koordination
+    description: |
+      Koordinierte Dienst-Abwicklung einschließlich Datenexport
+      und Löschungsübergabe.
+  BC-4240.70:
+    name: Berechtigungsdurchsetzung
+    description: |
+      Auflösung und Laufzeitdurchsetzung von Abonnementberechtigungen
+      mit Prüfpfad für Zugriffsentscheidungen.
+  BC-4240.70.10:
+    name: Berechtigungsauflösung
+    description: |
+      Auflösung effektiver Berechtigungen je Abonnement, Konto
+      und Nutzer.
+  BC-4240.70.20:
+    name: Berechtigungs-Gate-Durchsetzung
+    description: |
+      Laufzeit-Gating von Funktionen und Kontingenten gegen
+      aufgelöste Berechtigungen.
+  BC-4240.70.30:
+    name: Berechtigungs-Prüfpfad
+    description: |
+      Prüfungsgrade Aufzeichnung von Berechtigungsänderungen und
+      Gate-Entscheidungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-subsurface-reservoir-management.yaml
+++ b/catalogue/i18n/de/L1-subsurface-reservoir-management.yaml
@@ -1,0 +1,139 @@
+locale: de
+source: L1-subsurface-reservoir-management.yaml
+entries:
+  BC-3010:
+    name: Untertagebau und Reservoir-Management
+    description: |
+      Geowissenschaften und Reservoir-Engineering über den gesamten Lebenszyklus von
+      Produktionsanlagen - Charakterisierung, Simulation, Reserven- und Ressourcen-
+      Klassifizierung, Abbaustrategien und verbessertes Förder-Design.
+  BC-3010.10:
+    name: Untertagebau-Geowissenschaften
+    description: |
+      Statische Untergrundcharakterisierung durch geologische Modellierung,
+      Petrophysik und strukturelle Interpretation an Produktionsanlagen.
+  BC-3010.10.10:
+    name: Geologische Modellierung
+    description: |
+      Erstellung und Aktualisierung statischer geologischer und Faziesmodelle.
+  BC-3010.10.20:
+    name: Petrophysikalische Analyse
+    description: |
+      Log-Analyse, Kernintegration und petrophysikalische Bewertung von Reservoiren.
+  BC-3010.10.30:
+    name: Strukturelle Interpretation
+    description: |
+      Strukturelle und Störungsnetz-Interpretation für Produktionsanlagen.
+  BC-3010.10.40:
+    name: Geomodell-Aktualisierung
+    description: |
+      Aktualisierung von Geomodellen mit neuen Bohr-, Seismik- und Produktionsdaten.
+  BC-3010.20:
+    name: Reservoir-Engineering
+    description: |
+      Analyse des dynamischen Reservoirverhaltens durch Simulation, PVT-Analyse,
+      Massenbilanz und Drucktransienten-Methoden.
+    in_scope:
+      - Reservoir-Simulation und Geschichtsanpassung
+      - PVT- und Flüssigkeitseigenschaftsanalyse
+      - Drucktransienten- und Bohrlochtest-Analyse
+    out_of_scope:
+      - Förderabnahmeanalyse und Produktionsprognose (BC-3010.50)
+  BC-3010.20.10:
+    name: Reservoir-Charakterisierung
+    description: |
+      Integrierte statische und dynamische Charakterisierung von Reservoiren.
+  BC-3010.20.20:
+    name: Reservoir-Simulation
+    description: |
+      Numerische Reservoir-Simulation, Geschichtsanpassung und Prognosegenerierung.
+  BC-3010.20.30:
+    name: PVT- und Flüssigkeitsanalyse
+    description: |
+      PVT-Probenahme, Laboranalyse und Flüssigkeitseigenschafts-Modellierung.
+  BC-3010.20.40:
+    name: Massenbilanzanalyse
+    description: |
+      Massenbilanzanalyse zur Schätzung von in-situ-Mengen und Antriebsmechanismen.
+  BC-3010.20.50:
+    name: Drucktransienten-Analyse
+    description: |
+      Bohrlochtest-Analyse und Drucktransienten-Interpretation.
+  BC-3010.30:
+    name: Reserven- und Ressourcen-Management
+    description: |
+      Schätzung, Klassifizierung und externe Buchung von Erdölreserven und
+      Kontingentressourcen nach SPE-PRMS und SEC-Anforderungen.
+  BC-3010.30.10:
+    name: Reservenschätzung
+    description: |
+      Deterministische und probabilistische Schätzung von Erdölreserven.
+  BC-3010.30.20:
+    name: Reservenklassifizierung
+    description: |
+      Klassifizierung von Reserven und Ressourcen nach SPE-PRMS-Kategorien.
+  BC-3010.30.30:
+    name: Reservenbuchung
+    description: |
+      Jahresend-Reservenbuchung für SEC- und gleichwertige regulatorische Offenlegungen.
+  BC-3010.30.40:
+    name: Reservenprüfungskoordination
+    description: |
+      Koordination interner und externer Reservenprüfungen.
+  BC-3010.40:
+    name: Feldentwicklungsplanung
+    description: |
+      Konzeptauswahl, Abbaustrategie und Feldentwicklungsplan-Erstellung
+      von der Entdeckung bis zur Entwicklungsgenehmigung.
+  BC-3010.40.10:
+    name: Konzeptauswahl
+    description: |
+      Untergrundgestützte Konzeptauswahl und -screening für neue Feldentwicklungen.
+  BC-3010.40.20:
+    name: Feldentwicklungsplan-Erstellung
+    description: |
+      Erstellung von Feldentwicklungsplänen für regulatorische und Partnergenehmigungen.
+  BC-3010.40.30:
+    name: Abbaustrategie-Definition
+    description: |
+      Definition der Reservoir-Abbaustrategie einschließlich Drainage und Bohranzahl.
+  BC-3010.40.40:
+    name: Untertagebau-Risikobewertung
+    description: |
+      Bewertung von Untergrundrisiken und ihrer kommerziellen Auswirkung auf Entwicklungsentscheidungen.
+  BC-3010.50:
+    name: Produktionsprognose
+    description: |
+      Erstellung und Abgleich von Produktionsprognosen für Anlagen-, Geschäfts- und Reservenplanung.
+  BC-3010.50.10:
+    name: Förderabnahmeanalyse
+    description: |
+      Förderabnahmeanalyse zur Prognose von Bohr- und Feldproduktion.
+  BC-3010.50.20:
+    name: Produktionsprognoseerstellung
+    description: |
+      Erstellung von Produktionsprognosen mit Integration von Bohr-, Reservoir- und Anlagenrestriktionen.
+  BC-3010.50.30:
+    name: Prognoseabgleich
+    description: |
+      Abgleich von Untergrundprognosen mit Produktionsbuchhaltungs-Istwerten.
+  BC-3010.60:
+    name: Verbessertes Förder-Management
+    description: |
+      Design und Überwachung von Sekundär- und Tertiärförderungsschemata
+      einschließlich Wasser- und Gasinjektions- sowie EOR-Prozessen.
+  BC-3010.60.10:
+    name: Sekundärförderungs-Design
+    description: |
+      Design von Wasserflutungs- und Gasinjektions-Sekundärförderschemata.
+  BC-3010.60.20:
+    name: Tertiärförderungs-Design
+    description: |
+      Design chemischer, thermischer und mischbarer verbesserter Erdölgewinnungsverfahren.
+  BC-3010.60.30:
+    name: Injektionsstrategie-Überwachung
+    description: |
+      Überwachung und Optimierung von Injektionsmustern und Lückenersatz.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-supplier-management.yaml
+++ b/catalogue/i18n/de/L1-supplier-management.yaml
@@ -1,0 +1,106 @@
+locale: de
+source: L1-supplier-management.yaml
+entries:
+  BC-510:
+    name: Lieferantenmanagement
+    description: |
+      Lieferantenqualifizierung, -leistung, -risiko und Beziehungsmanagement.
+  BC-510.10:
+    name: Lieferanteneinführungsmanagement
+    description: |
+      Qualifizierung, Registrierung und Due Diligence.
+  BC-510.10.10:
+    name: Lieferantenregistrierung
+    description: |
+      Erfassung von Lieferantenidentifikation, Bankverbindung und Steuerinformationen.
+  BC-510.10.20:
+    name: Lieferantenqualifizierung und -vorprüfung
+    description: |
+      Fähigkeits-, Finanz- und Compliance-Qualifizierung neuer Lieferanten.
+  BC-510.10.30:
+    name: Lieferanten-Due-Diligence
+    description: |
+      Sanktions-, ABC-, ESG- und Integritäts-Due-Diligence bei Lieferanten.
+  BC-510.10.40:
+    name: Lieferantenstammdatenmanagement
+    description: |
+      Pflege von Lieferantenstammdaten und Lebenszyklusänderungen.
+  BC-510.20:
+    name: Lieferantenleistungsmanagement
+    description: |
+      Leistungsscorecards und SLA-Management.
+  BC-510.20.10:
+    name: Lieferantenscorecards und KPIs
+    description: |
+      Definition und Nachverfolgung von Lieferantenleistungsscorecards.
+  BC-510.20.20:
+    name: Service-Level-Agreement-Management
+    description: |
+      SLA-Definition, -Monitoring und Sanktionsdurchsetzung.
+  BC-510.20.30:
+    name: Lieferantenaudit und -inspektion
+    description: |
+      Vor-Ort-Lieferantenaudits und Inspektionen von Fähigkeiten und Qualität.
+  BC-510.20.40:
+    name: Lieferantenproblem- und CAPA-Management
+    description: |
+      Problemprotokollierung, Korrektur- und Vorbeugungsmaßnahmen bei Lieferanten.
+  BC-510.30:
+    name: Lieferantenrisikomanagement
+    description: |
+      Finanz-, ESG-, geopolitisches und Cyberrisiko bei Lieferanten.
+  BC-510.30.10:
+    name: Finanzrisikomonitoring bei Lieferanten
+    description: |
+      Monitoring der finanziellen Gesundheit und des Kreditrisikos von Lieferanten.
+  BC-510.30.20:
+    name: Lieferanten-ESG- und Nachhaltigkeitsrisiko
+    description: |
+      ESG-, Menschenrechts- und moderne Sklavereirisiken in der Lieferantenbasis.
+  BC-510.30.30:
+    name: Lieferanten-Cyber- und IT-Risiko
+    description: |
+      Drittpartei-Cyber- und IT-Risikobewertung und -monitoring.
+  BC-510.30.40:
+    name: Lieferanten-Geopolitik- und Konzentrationsrisiko
+    description: |
+      Geopolitisches, Länder- und Konzentrationsrisiko in der Lieferantenbasis.
+  BC-510.40:
+    name: Lieferantenentwicklungsmanagement
+    description: |
+      Kompetenzaufbau und Lieferantenverbesserungsprogramme.
+  BC-510.40.10:
+    name: Lieferantenkompetenzaufbau
+    description: |
+      Gemeinsamer Kompetenzaufbau, Training und Technologietransfer.
+  BC-510.40.20:
+    name: Lieferantendiversitätsprogramm
+    description: |
+      Identifikation und Entwicklung vielfältiger und kleinerer Lieferanten.
+  BC-510.40.30:
+    name: Lieferanteninnovationsprogramm
+    description: |
+      Programme zur Nutzung lieferantengetriebener Innovation und Co-Entwicklung.
+  BC-510.50:
+    name: Lieferantenbeziehungsmanagement
+    description: |
+      Strategische Lieferantenbeziehungen und Steuerungsforen.
+  BC-510.50.10:
+    name: Strategische Lieferantensegmentierung
+    description: |
+      Segmentierung von Lieferanten nach Kritikalität und Wert.
+  BC-510.50.20:
+    name: Executive-Lieferantenengagement
+    description: |
+      Executive-Sponsoring und Steuerung mit strategischen Lieferanten.
+  BC-510.50.30:
+    name: Gemeinsame Geschäftsplanung
+    description: |
+      Gemeinsame Geschäftsplanung und Werterstellung mit strategischen Lieferanten.
+  BC-510.50.40:
+    name: Lieferantenportal und Zusammenarbeit
+    description: |
+      Lieferantenportal, Self-Service und Kollaborationsplattformen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-supply-chain-management.yaml
+++ b/catalogue/i18n/de/L1-supply-chain-management.yaml
@@ -1,0 +1,134 @@
+locale: de
+source: L1-supply-chain-management.yaml
+entries:
+  BC-520:
+    name: Lieferkettenmanagement
+    description: |
+      End-to-End-Lieferkettenplanung, -orchestrierung und -ausführung.
+  BC-520.10:
+    name: Bedarfsplanungsmanagement
+    description: |
+      Nachfrageprognose, statistische und konsensbasierte Planung.
+  BC-520.10.10:
+    name: Statistische Nachfrageprognose
+    description: |
+      Statistische und auf maschinellem Lernen basierende Nachfrageprognosen.
+  BC-520.10.20:
+    name: Konsensbasierte Nachfrageplanung
+    description: |
+      Funktionsübergreifender Konsens zur Nachfrageplanung einschließlich Vertriebsüberlagerung.
+  BC-520.10.30:
+    name: Neuprodukt-Nachfrageplanung
+    description: |
+      Nachfrageplanung für Neuprodukteinführungen und -auslaufungen.
+  BC-520.10.40:
+    name: Nachfrageerkennung und -gestaltung
+    description: |
+      Kurzfristige Nachfrageerkennung und Nachfragegestaltungsmaßnahmen.
+  BC-520.20:
+    name: Lieferplanungsmanagement
+    description: |
+      Liefernetzwerkplanung und Quellenzuweisung.
+  BC-520.20.10:
+    name: Liefernetzwerkplanung
+    description: |
+      Mehrstufige Liefernetzwerkplanung über Werke und Distributionszentren.
+  BC-520.20.20:
+    name: Produktionsplanerstellung
+    description: |
+      Erstellung von Hauptproduktionsplänen über Lieferstandorte.
+  BC-520.20.30:
+    name: Lieferzuteilung
+    description: |
+      Zuteilung knapper Liefermengen über Regionen und Kunden.
+  BC-520.20.40:
+    name: Quellenausbalancierung
+    description: |
+      Ausbalancierung über mehrere Lieferquellen und Dual Sourcing.
+  BC-520.30:
+    name: Vertriebs- und Betriebsplanungsmanagement
+    description: |
+      S&OP/IBP und funktionsübergreifende Abstimmung.
+  BC-520.30.10:
+    name: S&OP-Zyklusmanagement
+    description: |
+      Monatliche S&OP/IBP-Zyklusorchestierung und Meeting-Rhythmus.
+  BC-520.30.20:
+    name: Bedarfsüberprüfung
+    description: |
+      Funktionsübergreifende Überprüfung des ungebundenen Nachfrageplans.
+  BC-520.30.30:
+    name: Lieferüberprüfung
+    description: |
+      Überprüfung der Lieferfähigkeit und -engpässe im S&OP-Zyklus.
+  BC-520.30.40:
+    name: Integrierte Abstimmung und Executive-S&OP
+    description: |
+      Integrierte Abstimmung und Executive-Entscheidungsmeetings.
+  BC-520.40:
+    name: Auftragserfüllungsmanagement
+    description: |
+      Auftragszusage, Zuteilung und Erfüllungsorchestierung.
+  BC-520.40.10:
+    name: Auftragszusage und Verfügbarkeitsversprechen
+    description: |
+      ATP/CTP-Auftragszusage basierend auf Lieferung und Kapazität.
+  BC-520.40.20:
+    name: Auftragsorchestrierung
+    description: |
+      Orchestrierung der Auftragserfüllung über Knoten und Kanäle.
+  BC-520.40.30:
+    name: Auftragsverfolgung und -transparenz
+    description: |
+      End-to-End-Auftragsstatus und Sendungstransparenz.
+  BC-520.40.40:
+    name: Retouren und umgekehrte Erfüllung
+    description: |
+      Retourengenehmigung, Rückwärtslogistik und Aufbereitungsrouting.
+  BC-520.50:
+    name: Logistikoperationsmanagement
+    description: |
+      Transport- und Lagerhaltungsbetrieb in der Lieferkette.
+  BC-520.50.10:
+    name: Transportplanung
+    description: |
+      Verkehrsmittelauswahl, Routenplanung und Ladeplanung.
+  BC-520.50.20:
+    name: Carrier-Management
+    description: |
+      Carrier-Auswahl, Verträge und Leistung.
+  BC-520.50.30:
+    name: Lagerhausbetrieb
+    description: |
+      Wareneingang, Einlagerung, Kommissionierung, Verpackung und Versand.
+  BC-520.50.40:
+    name: Grenzüberschreitender Betrieb und Zollabwicklung
+    description: |
+      Grenzüberschreitende Transporte, Zollabfertigung und Handelscompliance.
+  BC-520.50.50:
+    name: Letzte-Meile-Zustellungsbetrieb
+    description: |
+      Letzte-Meile-Routenplanung, Zeitfenster-Management und Zustellnachweis.
+  BC-520.60:
+    name: Lieferkettenrisikomanagement
+    description: |
+      Lieferkettenstörungen, Transparenz und Resilienz.
+  BC-520.60.10:
+    name: End-to-End-Lieferkettentransparenz
+    description: |
+      Mehrstufige Transparenz über Lieferanten, Bestände und Sendungen.
+  BC-520.60.20:
+    name: Störungserkennung und -reaktion
+    description: |
+      Erkennung von Störungen und orchestrierte Reaktionsmaßnahmen.
+  BC-520.60.30:
+    name: Lieferkettenresilienz-Design
+    description: |
+      Netzwerkdesign für Resilienz einschließlich Dual Sourcing und Puffer.
+  BC-520.60.40:
+    name: Lieferketten-Compliance
+    description: |
+      Einhaltung von Lieferketten-Sorgfaltspflicht und Handelsvorschriften.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-sustainability-management.yaml
+++ b/catalogue/i18n/de/L1-sustainability-management.yaml
@@ -1,0 +1,114 @@
+locale: de
+source: L1-sustainability-management.yaml
+entries:
+  BC-740:
+    name: Nachhaltigkeitsmanagement
+    description: |
+      ESG-Strategie, Klima, Kreislaufwirtschaft und Nachhaltigkeitsberichterstattung.
+  BC-740.10:
+    name: ESG-Strategie- und Berichterstattungsmanagement
+    description: |
+      ESG-Strategie, Wesentlichkeit und Nachhaltigkeitsberichte.
+  BC-740.10.10:
+    name: ESG-Strategieentwicklung
+    description: |
+      ESG-Strategie, Ambitionen und Integration in die Unternehmensstrategie.
+  BC-740.10.20:
+    name: Wesentlichkeitsanalyse
+    description: |
+      Einfache und doppelte Wesentlichkeitsanalysen nach ESRS/GRI.
+  BC-740.10.30:
+    name: Nachhaltigkeitsberichterstattung und -offenlegung
+    description: |
+      Erstellung von Nachhaltigkeitsberichten und Offenlegungen (CSRD, IFRS S1/S2, GRI).
+  BC-740.10.40:
+    name: ESG-Datenmanagement und -Assurance
+    description: |
+      ESG-Datenerhebung, Kontrollen und externe Prüfung.
+  BC-740.20:
+    name: Klima- und Kohlenstoffmanagement
+    description: |
+      CO2-Fußabdruck, Dekarbonisierung und Klimaoffenlegungen.
+  BC-740.20.10:
+    name: THG-Inventarmanagement
+    description: |
+      Scope-1-, -2- und -3-Treibhausgasinventar nach GHG-Protokoll.
+  BC-740.20.20:
+    name: Dekarbonisierungs-Roadmap-Management
+    description: |
+      Science-based Targets und Dekarbonisierungs-Roadmap-Planung.
+  BC-740.20.30:
+    name: Klimarisiko- und Szenarioanalyse
+    description: |
+      Physische und transitorische Klimarisiken und TCFD-konforme Szenarien.
+  BC-740.20.40:
+    name: CO2-Kredit- und Kompensationsmanagement
+    description: |
+      Beschaffung und Nutzung von CO2-Zertifikaten und Kompensationen.
+  BC-740.20.50:
+    name: Erneuerbare-Energien-Beschaffung
+    description: |
+      PPAs, RECs und Beschaffung erneuerbarer Energien.
+  BC-740.30:
+    name: Kreislaufwirtschaftsmanagement
+    description: |
+      Kreislaufwirtschaft, Abfallreduzierung und Rücknahmeprogramme.
+  BC-740.30.10:
+    name: Kreislaufgerechtes Produktdesign
+    description: |
+      Design für Reparatur, Wiederverwendung, Recycling und reduzierten Materialeinsatz.
+  BC-740.30.20:
+    name: Rücknahme- und Wiederverwendungsprogramme
+    description: |
+      Kunden-Rücknahme-, Aufbereitungs- und Wiederverkaufsprogramme.
+  BC-740.30.30:
+    name: Recycling und Materialrückgewinnung
+    description: |
+      Recyclingprogramme und Wiederverwendung rückgewonnener Materialien.
+  BC-740.30.40:
+    name: Verpackungsnachhaltigkeit
+    description: |
+      Nachhaltige Verpackungsgestaltung und EPR-Compliance.
+  BC-740.40:
+    name: Nachhaltige Beschaffungsmanagement
+    description: |
+      Nachhaltige Lieferkette und ethische Beschaffung.
+  BC-740.40.10:
+    name: Nachhaltige Lieferantenstandards
+    description: |
+      Lieferantenverhaltenskodex und Nachhaltigkeitsstandards.
+  BC-740.40.20:
+    name: Lieferanten-ESG-Bewertung
+    description: |
+      ESG-Ratings, Audits und Bewertungen von Lieferanten.
+  BC-740.40.30:
+    name: Menschenrechts-Due-Diligence
+    description: |
+      Menschenrechts- und moderne-Sklaverei-Due-Diligence in Lieferketten.
+  BC-740.40.40:
+    name: Verantwortungsvolle Rohstoffbeschaffung
+    description: |
+      Verantwortungsvolle Beschaffung von Konfliktmineralien, Holz und Rohstoffen.
+  BC-740.50:
+    name: Nachhaltigkeits-Stakeholder-Engagement
+    description: |
+      NGO-, Gemeinschafts- und ESG-Rater-Engagement.
+  BC-740.50.10:
+    name: NGO- und Zivilgesellschaftsengagement
+    description: |
+      Engagement mit NGOs und Zivilgesellschaft zu Nachhaltigkeitsthemen.
+  BC-740.50.20:
+    name: Gemeinschaftsinvestitionen
+    description: |
+      Gemeinschaftsinvestitionen, Philanthropie und soziale Wirkungsprogramme.
+  BC-740.50.30:
+    name: ESG-Rater- und Index-Engagement
+    description: |
+      Engagement mit ESG-Ratingagenturen und Nachhaltigkeitsindizes.
+  BC-740.50.40:
+    name: Öffentliche Politik und Interessenvertretung
+    description: |
+      Interessenvertretung in der Nachhaltigkeitspolitik.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-tailings-mine-waste-management.yaml
+++ b/catalogue/i18n/de/L1-tailings-mine-waste-management.yaml
@@ -1,0 +1,159 @@
+locale: de
+source: L1-tailings-mine-waste-management.yaml
+entries:
+  BC-4460:
+    name: Abraum und Bergbauabfälle
+    description: |
+      Lebenszyklusstewardship von Tailings-Speicheranlagen,
+      Abraumhalden, Grubenwasser und gefährlichen Bergbauabfällen
+      gemäß dem Globalen Industriestandard für Tailings-Management
+      und gleichwertigen regulatorischen Regimen.
+  BC-4460.10:
+    name: Tailings-Speicheranlagen-Technik
+    description: |
+      Ingenieurdesign und Lebenszyklusplanung von
+      Tailings-Speicheranlagen einschließlich Standortauswahl,
+      Dammkonstruktion und abschlussgerichtetem Design.
+    in_scope:
+      - Standortauswahl und Konzeptplanung
+      - Dammbau-Ingenieurleistung
+      - Depositionsplanung und Strandmodellierung
+    out_of_scope:
+      - Operativer Tailings-Depositionsbetrieb (BC-4460.20)
+      - Tailings-Instrumentationsüberwachung (BC-4460.30)
+  BC-4460.10.10:
+    name: Tailings-Speicheranlagen-Standortauswahl
+    description: |
+      Multikriterielle Standortauswahl und Alternativenanalyse
+      für neue und erweiterte Tailings-Anlagen.
+  BC-4460.10.20:
+    name: Dammkonstruktionstechnik
+    description: |
+      Ingenieurdesign und Konstruktionsqualitätssicherung von
+      Tailings-Dammböschungen.
+  BC-4460.10.30:
+    name: Tailings-Depositionsplanung
+    description: |
+      Planung von Depositionssequenzen, Strandentwicklung und
+      Teichstandorten.
+  BC-4460.10.40:
+    name: Abschlussgerichtetes Anlagendesign
+    description: |
+      Design von Tailings-Anlagen gemäß langfristiger Abschluss-
+      und sicherer Endlandformplanung.
+  BC-4460.20:
+    name: Tailings-Betrieb
+    description: |
+      Operative Einlagerung von Tailings in Speicheranlagen
+      einschließlich Trübe-, Paste- und Filtertailings-Handhabung
+      und Wasserrückgewinnung.
+  BC-4460.20.10:
+    name: Tailings-Trübe-Transport
+    description: |
+      Betrieb von Tailings-Pipelines, Pumpstationen und
+      Verteilungssystemen.
+  BC-4460.20.20:
+    name: Tailings-Depositionsbetrieb
+    description: |
+      Operative Deposition von Tailings in die Speicheranlage
+      gemäß Depositionsplan.
+  BC-4460.20.30:
+    name: Tailings-Wasserrückgewinnung
+    description: |
+      Rückgewinnung von Dekant- und Sickerwasser aus
+      Tailings-Anlagen zur Wiederverwendung.
+  BC-4460.20.40:
+    name: Gefilterter und Trockenstack-Tailings-Betrieb
+    description: |
+      Betrieb von Filtertailingsanlagen und Trockenstack-
+      Einlagerung.
+  BC-4460.30:
+    name: Tailings-Überwachung und Dammgicherheit
+    description: |
+      Überwachung, Governance und Notfallvorsorge von Tailings-
+      Anlagen gemäß GISTM und gleichwertigen Dammgicherheitsregimen.
+  BC-4460.30.10:
+    name: Geotechnische Instrumentationsüberwachung
+    description: |
+      Überwachung von Piezometern, Inklinometern und Vermessungs-
+      prismen an Tailings-Anlagen.
+  BC-4460.30.20:
+    name: Unabhängige Tailings-Review-Koordination
+    description: |
+      Beauftragung und Koordination unabhängiger Tailings-Review-
+      Boards und verantwortlicher Ingenieure.
+  BC-4460.30.30:
+    name: Tailings-Notfallvorsorge
+    description: |
+      Notfallvorsorge und Reaktionsplanung für Tailings-
+      Dammbruchsszenarien.
+  BC-4460.30.40:
+    name: Tailings-Standard-Konformitätsberichterstattung
+    description: |
+      Konformitätsberichterstattung gegenüber dem Globalen
+      Industriestandard für Tailings-Management und gleichwertigen
+      Regulatoren.
+  BC-4460.40:
+    name: Abraumhaldenverwaltung
+    description: |
+      Charakterisierung und operatives Management von Abraumhalden
+      einschließlich Säure- und Schwermetalldrainage-Kontrollen.
+  BC-4460.40.10:
+    name: Abraumcharakterisierung
+    description: |
+      Geochemische Charakterisierung von Abraum auf Säure- und
+      Schwermetalldrainage-Potenzial.
+  BC-4460.40.20:
+    name: Abraumhaldenbetrieb
+    description: |
+      Operative Einlagerung von Abraum in konstruierte Halden
+      und Verfüllbereiche.
+  BC-4460.40.30:
+    name: Säure- und Schwermetalldrainage-Management
+    description: |
+      Verhinderung, Erfassung und Behandlung von Säure- und
+      Schwermetalldrainage aus Abraum und Erzhalden.
+  BC-4460.50:
+    name: Grubenwassermanagement
+    description: |
+      Standortweite Grubenwasserbilanz, Behandlung und
+      Einleitungskonformität.
+  BC-4460.50.10:
+    name: Grubenwasserbilanz-Betrieb
+    description: |
+      Operatives Management standortweiter Wasserbilanzen
+      über Tagebau-, Untertagebau- und Prozesswassersysteme.
+  BC-4460.50.20:
+    name: Grubenwasserbehandlung
+    description: |
+      Betrieb von Kalk-, Umkehrosmose- und biologischen
+      Grubenwasserbehandlungsanlagen.
+  BC-4460.50.30:
+    name: Wassereinleitungskonformitätsüberwachung
+    description: |
+      Überwachung und Berichterstattung der Wassereinleitung
+      gegenüber Umweltlizenzbedingungen.
+  BC-4460.60:
+    name: Gefährliche Bergbauabfallverwaltung
+    description: |
+      Management von Prozessreagenzabfällen, zyanid-haltigen
+      Abfällen und schwermetallhaltigen Rückständen.
+  BC-4460.60.10:
+    name: Reagenzabfallentsorgung
+    description: |
+      Entsorgung verbrauchter Prozessreagenzien und kontaminierter
+      Behälter.
+  BC-4460.60.20:
+    name: Zyanidabfallmanagement
+    description: |
+      Entgiftung und Management zyanid-haltiger Tailings und
+      Prozessrückstände.
+  BC-4460.60.30:
+    name: Quecksilber- und Schwermetall-Abfallmanagement
+    description: |
+      Management von Quecksilber-, Arsen- und anderen
+      schwermetallhaltigen Rückständen aus Aufbereitung und
+      Raffination.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-talent-creative-workforce-management.yaml
+++ b/catalogue/i18n/de/L1-talent-creative-workforce-management.yaml
@@ -1,0 +1,115 @@
+locale: de
+source: L1-talent-creative-workforce-management.yaml
+entries:
+  BC-3790:
+    name: Kreativpersonal und Künstlerisches Personal
+    description: |
+      Beschaffung und Casting von On-Screen- und kreativem Talent,
+      Talent-Kontraktierung und Engagement, Residual- und
+      Lizenzgebühren-Distribution, Gewerkschafts- und
+      Tarifskonformität sowie langfristige Kreativtalent-Beziehungen.
+  BC-3790.10:
+    name: Talent-Beschaffung und Casting
+    description: |
+      Erstellung von Casting-Briefings und die Suche, Vorsprechen
+      und Selektion von On-Screen- und Sprachtalent für Produktionen.
+  BC-3790.10.10:
+    name: Casting-Brief-Management
+    description: |
+      Erstellung von Casting-Briefs und Rollenaufteilungen für
+      Casting-Direktoren und Agenten.
+  BC-3790.10.20:
+    name: Talent-Suche und Vorsprechen
+    description: |
+      Talentsuche, Self-Tape- und Live-Vorsprechen-Koordination
+      und Shortlisting-Workflows.
+  BC-3790.10.30:
+    name: Casting-Selektions-Entscheidung
+    description: |
+      Selektionsentscheidungen und Casting-Freigabe gegen
+      kreative und kommerzielle Kriterien.
+  BC-3790.20:
+    name: Talent-Kontraktierung und Engagement
+    description: |
+      Verhandlung und Vertragserstellung von Talent-Engagements
+      einschließlich Loan-out- und Service-Company-Strukturen.
+  BC-3790.20.10:
+    name: Talent-Deal-Verhandlungs-Unterstützung
+    description: |
+      Verhandlungsunterstützung für Talent-Deals einschließlich
+      Vergleichsdeal-Benchmarking und Term-Sheet-Vorbereitung.
+  BC-3790.20.20:
+    name: Loan-out- und Service-Company-Kontraktierung
+    description: |
+      Kontraktierung über Loan-out- und Service-Company-Strukturen
+      mit Steuer- und Haftungsüberlegungen.
+  BC-3790.20.30:
+    name: Engagement-Letter-Management
+    description: |
+      Erstellung und Lebenszyklus von Engagement-Letters und
+      Kurz-Deal-Memos für Talent und Crew.
+  BC-3790.30:
+    name: Residual- und Lizenzgebühren-Distribution
+    description: |
+      Berechnung und Zahlung von Residuals, Lizenzgebühren und
+      Beteiligungen für Talent und kreative Mitwirkende.
+  BC-3790.30.10:
+    name: Residual-Berechnung
+    description: |
+      Berechnung von Residuals nach Gewerkschafts-Formeln,
+      Markttypen und Wiederverwendungsfenstern.
+  BC-3790.30.20:
+    name: Lizenzgebühren-Verteilungsnachweis-Erstellung
+    description: |
+      Erstellung von Lizenzgebühren-Verteilungsnachweisen für
+      Talent und Rechteinhaber.
+  BC-3790.30.30:
+    name: Zugrundeliegende Beteiligungen-Verfolgung
+    description: |
+      Verfolgung zugrundeliegender Beteiligungen einschließlich
+      Gewinnsdefinitionen und Accounting-Stufen.
+  BC-3790.40:
+    name: Gewerkschafts- und Tarifskonformität
+    description: |
+      Anwendung von Tarifverträgen, Gewerkschafts-Berichterstattung
+      und Prüfungsunterstützung sowie Renten- und
+      Gesundheitsbeiträge.
+  BC-3790.40.10:
+    name: Tarifvertrags-Anwendung
+    description: |
+      Anwendung von Tarifvertrag-Mindestbedingungen,
+      Arbeitsregeln und Überstundenstrukturen über Produktionen hinweg.
+  BC-3790.40.20:
+    name: Gewerkschafts-Berichterstattung und Prüfungsunterstützung
+    description: |
+      Erstellung von Gewerkschaftsberichten und Unterstützung
+      von Gewerkschafts-Prüfungen über Produktionen hinweg.
+  BC-3790.40.30:
+    name: Renten- und Gesundheitsbeitrags-Management
+    description: |
+      Berechnung und Überweisung von Renten- und
+      Gesundheitsbeiträgen an Gewerkschafts-Pläne.
+  BC-3790.50:
+    name: Kreativtalent-Beziehungsmanagement
+    description: |
+      Langfristiges Beziehungsmanagement mit kreativem Talent
+      und Programme zur Förderung von Talent-Engagement
+      und -Entwicklung.
+  BC-3790.50.10:
+    name: Langfristige Talent-Beziehungsmanagement
+    description: |
+      Management langfristiger First-Look-, Overall- und
+      Pod-Deals mit kreativem Talent.
+  BC-3790.50.20:
+    name: Talent-Leistungs-Verfolgung
+    description: |
+      Verfolgung von Talent-Beiträgen und kreativer Leistung
+      über Projekte und Slates hinweg.
+  BC-3790.50.30:
+    name: Talent-Engagement-Programme
+    description: |
+      Engagement-Programme einschließlich Autorenräume,
+      Residenzen und Entwicklungsfonds für kreatives Talent.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-tax-management.yaml
+++ b/catalogue/i18n/de/L1-tax-management.yaml
@@ -1,0 +1,110 @@
+locale: de
+source: L1-tax-management.yaml
+entries:
+  BC-220:
+    name: Steuerungsmanagement
+    description: |
+      Direkte und indirekte Steuerplanung, Compliance und Berichterstattung.
+  BC-220.10:
+    name: Direkte Steuerverwaltung
+    description: |
+      Körperschaftsteuerplanung, Compliance und Steuererklärungen.
+  BC-220.10.10:
+    name: Körperschaftsteuerrückstellung
+    description: |
+      Laufende und latente Steuerberechnungen und Steuerrückstellung.
+  BC-220.10.20:
+    name: Körperschaftsteuererklärungen
+    description: |
+      Erstellung und Einreichung von Körperschaftsteuererklärungen.
+  BC-220.10.30:
+    name: Quellensteuerungsmanagement
+    description: |
+      Quellensteuerermittlung, -zahlung und -bescheinigung.
+  BC-220.10.40:
+    name: Steuerverlusts- und -guthabenmanagement
+    description: |
+      Nutzung, Monitoring und Prognose von Steuerverlusten und -gutschriften.
+  BC-220.20:
+    name: Indirekte Steuerverwaltung
+    description: |
+      Mehrwertsteuer, GST, Umsatzsteuer und Zölle.
+  BC-220.20.10:
+    name: Mehrwertsteuer- und GST-Ermittlung
+    description: |
+      Steuercode-Mapping, Leistungsortbestimmung und indirekte Steuerermittlung.
+  BC-220.20.20:
+    name: Indirekte Steuererklärungen und -einreichungen
+    description: |
+      Erstellung und Einreichung von Mehrwertsteuer-, GST- und Umsatzsteuererklärungen.
+  BC-220.20.30:
+    name: E-Rechnungsstellung und Echtzeit-Meldung
+    description: |
+      Elektronische Rechnungsstellung und Echtzeit-Meldung an Finanzbehörden.
+  BC-220.20.40:
+    name: Zoll- und Verbrauchsteuerungsmanagement
+    description: |
+      Zollbewertung, -klassifizierung und Verbrauchsteueradministration.
+  BC-220.30:
+    name: Verrechnungspreismanagement
+    description: |
+      Verrechnungspreisrichtlinien, Dokumentation und Verteidigung.
+  BC-220.30.10:
+    name: Verrechnungspreisrichtlinien-Festlegung
+    description: |
+      Definition von Verrechnungspreisrichtlinien im Einklang mit OECD-Leitlinien.
+  BC-220.30.20:
+    name: Verrechnungspreisdokumentation
+    description: |
+      Stammdokumentation, lokale Dokumentation und länderbezogene Berichterstattung.
+  BC-220.30.30:
+    name: Konzerninternetverrechnungsoperationen
+    description: |
+      Berechnung, Rechnungsstellung und Abwicklung konzerninterner Verrechnungen.
+  BC-220.30.40:
+    name: Verrechnungspreisverteidigung
+    description: |
+      Betriebsprüfungsverteidigung, APAs und Verständigungsverfahren.
+  BC-220.40:
+    name: Steuerberichterstattung und -compliance
+    description: |
+      Steuererklärungen und gesetzliche Steueroffenlegungen.
+  BC-220.40.10:
+    name: Steuerliche Rechnungslegung und Offenlegung
+    description: |
+      Steuerliche Offenlegungen im Jahresabschluss und Effektivsteuerquoten-Analyse.
+  BC-220.40.20:
+    name: Steuerabgabenkalender
+    description: |
+      Globaler Steuerabgabenkalender und Pflichtenverfolgung.
+  BC-220.40.30:
+    name: Länderbezogene Berichterstattung
+    description: |
+      OECD-BEPS-länderbezogene Berichterstattungseinreichungen.
+  BC-220.40.40:
+    name: Steuerdaten und -abstimmung
+    description: |
+      Steuerdatenextraktion, Abstimmung und Überleitung von Probebilanz zu Erklärung.
+  BC-220.50:
+    name: Steuerplanung und -beratung
+    description: |
+      Steuerliche Strukturierung, Beratung und Streitbeilegung.
+  BC-220.50.10:
+    name: Strategische Steuerplanung
+    description: |
+      Steuereffiziente Strukturierung von Betrieb, Finanzierung und Lieferketten.
+  BC-220.50.20:
+    name: Transaktionssteuerberatung
+    description: |
+      Steuerliche Due Diligence und Strukturierung für M&A und Reorganisationen.
+  BC-220.50.30:
+    name: Steuerstreitmanagement
+    description: |
+      Steuerprüfungen, Streitigkeiten und Streitbeilegung.
+  BC-220.50.40:
+    name: Steuerrisiko und -steuerung
+    description: |
+      Steuerrisiko-Rahmenwerk, Kontrollen und Offenlegungen zur Steuerstrategie.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-tax-revenue-administration-management.yaml
+++ b/catalogue/i18n/de/L1-tax-revenue-administration-management.yaml
@@ -1,0 +1,147 @@
+locale: de
+source: L1-tax-revenue-administration-management.yaml
+entries:
+  BC-3250:
+    name: Steuer- und Abgabenverwaltung
+    description: |
+      Staatliche Verwaltung von Steuer- und Nicht-Steuereinnahmen einschließlich
+      Steuerpflichtigenregistrierung, Erklärungsbearbeitung, Veranlagung, Einzug,
+      Prüfung, Vollstreckung und Erstattungsverwaltung.
+  BC-3250.10:
+    name: Steuerpflichtigenregistrierung und Identität
+    description: |
+      Registrierung von Steuerpflichtigen, Identitätsmanagement und
+      Pflege von Steuerpflichtigen-Stammdaten.
+    in_scope:
+      - Steuerpflichtigenregistrierung und Steuer-ID-Ausstellung
+      - Steuerpflichtigen-Profilpflege
+      - Wirtschaftlich Berechtigte Aufzeichnungen
+    out_of_scope:
+      - Personenstandsregistrierung (durch Personenstandsregister- und Identitätsverwaltungsmanagement abgedeckt)
+  BC-3250.10.10:
+    name: Steuerpflichtigenregistrierung
+    description: |
+      Registrierung von Einzel- und Körperschaftssteuerpflichtigen und Ausstellung von Steueridentifikationsnummern.
+  BC-3250.10.20:
+    name: Steuerpflichtigen-Profilpflege
+    description: |
+      Pflege von Steuerpflichtigen-Stammdaten, Kontaktdaten und Steuerregistern.
+  BC-3250.10.30:
+    name: Wirtschaftlich Berechtigte Aufzeichnung
+    description: |
+      Erfassung wirtschaftlich Berechtigter und Konzernstrukturen von Körperschaften.
+  BC-3250.20:
+    name: Erklärungsbearbeitung und Veranlagung
+    description: |
+      Eingang, Validierung und Veranlagung von Steuererklärungen und Anmeldungen
+      über direkte, indirekte und Quellensteuer.
+  BC-3250.20.10:
+    name: Erklärungseinreichung
+    description: |
+      Eingang und Einreichung von Steuererklärungen und Informationsanmeldungen über alle Kanäle.
+  BC-3250.20.20:
+    name: Erklärungsvalidierung
+    description: |
+      Automatisierte und manuelle Validierung von Erklärungen einschließlich Arithmetik, Vollständigkeit und Konsistenz.
+  BC-3250.20.30:
+    name: Selbstveranlagungs-Bearbeitung
+    description: |
+      Bearbeitung von Selbstveranlagungserklärungen und Aufzeichnung angemeldeter Verbindlichkeiten.
+  BC-3250.20.40:
+    name: Standard-Veranlagungs-Ausstellung
+    description: |
+      Ausstellung von Standard- und Schätzungsveranlagungen für Nichtanmelder.
+  BC-3250.30:
+    name: Steuereinnahmen-Einzugsbetrieb
+    description: |
+      Einzug freiwilliger Steuerzahlungen über elektronische, Quellen-, Raten- und Schalterkanäle.
+  BC-3250.30.10:
+    name: Zahlungskanal-Betrieb
+    description: |
+      Betrieb von Zahlungskanälen einschließlich Banküberweisung, Karte, E-Wallet und Schalter.
+  BC-3250.30.20:
+    name: Quellensteuer und Quellenabzug
+    description: |
+      Verwaltung von Quellensteuern und Quellenabzugssystemen durch zahlende Stellen.
+  BC-3250.30.30:
+    name: Ratenzahlungsplan-Verwaltung
+    description: |
+      Einrichtung und Tracking von Steuerpflichtigen-Ratenzahlungsplänen und Zahlungsaufschüben.
+  BC-3250.30.40:
+    name: Einnahmen-Abgleich
+    description: |
+      Abgleich von Steuereinnahmen zu Steuerpflichtigenkonten und Staatskasse.
+  BC-3250.40:
+    name: Steuerprüfung und Außenprüfung
+    description: |
+      Risikobasierte Prüfung, Außenprüfung und Neuveranlagung der Steuerpflichtigen-
+      Compliance.
+  BC-3250.40.10:
+    name: Prüfungsfall-Auswahl
+    description: |
+      Risikobasierte Auswahl von Prüfungsfällen mittels Analytik und Nachrichtendiensten.
+  BC-3250.40.20:
+    name: Prüfungs-Außenprüfung
+    description: |
+      Durchführung von Prüfungsaußenprüfungen, Dokumentenuntersuchung und Steuerpflichtigen-Interviews.
+  BC-3250.40.30:
+    name: Neuveranlagungs-Ausstellung
+    description: |
+      Ausstellung von Neuveranlagungen, Anpassungen und Prüfungsentscheidungsschreiben.
+  BC-3250.40.40:
+    name: Verrechnungspreise-Prüfung
+    description: |
+      Prüfung grenzüberschreitender Verrechnungspreise nach OECD-Verrechnungspreisleitlinien.
+  BC-3250.50:
+    name: Steuerschulden und Vollstreckungsmanagement
+    description: |
+      Einziehung von Steuerschulden durch gesetzliche Vollstreckungsbefugnisse einschließlich
+      Pfändung, Pfandrechte, Pfandnahme und Strafverfolgungsüberweisung.
+  BC-3250.50.10:
+    name: Steuerschuldenportfolio-Management
+    description: |
+      Segmentierung, Alterung und Priorisierung des Steuerschuldenportfolios.
+  BC-3250.50.20:
+    name: Gesetzliche Vollstreckungsmaßnahme
+    description: |
+      Ausübung gesetzlicher Vollstreckungsbefugnisse einschließlich Pfändung, Pfandrechte und Pfandnahme.
+  BC-3250.50.30:
+    name: Steuerkriminalität-Überweisung
+    description: |
+      Untersuchung und Überweisung mutmaßlicher Steuerhinterziehung und Steuerkriminalität an die Staatsanwaltschaft.
+  BC-3250.60:
+    name: Erstattungs- und Gutschrift-Verwaltung
+    description: |
+      Bearbeitung von Steuererstattungen, Gutschrift-Verrechnungen und Streitbetrags-Sperrungen.
+  BC-3250.60.10:
+    name: Erstattungsvalidierung
+    description: |
+      Validierung von Erstattungsansprüchen gegenüber Erklärungen, Zahlungen und Risikoprofilen.
+  BC-3250.60.20:
+    name: Erstattungsausstellung
+    description: |
+      Ausstellung von Erstattungen und Verrechnung gegenüber ausstehenden Verbindlichkeiten.
+  BC-3250.60.30:
+    name: Erstattungsbetrugs-Screening
+    description: |
+      Screening von Erstattungsansprüchen auf Identitätsdiebstahl- und Erstattungsbetrugs-Indikatoren.
+  BC-3250.70:
+    name: Nicht-Steuereinnahmen-Verwaltung
+    description: |
+      Verwaltung nicht-staatlicher Steuereinnahmen einschließlich Gebühren, Bußgelder,
+      Lizenzgebühren und Abgaben.
+  BC-3250.70.10:
+    name: Gebühren- und Entgelt-Verwaltung
+    description: |
+      Verwaltung gesetzlicher Gebühren, Entgelte und Nutzerbeiträge an den Staat.
+  BC-3250.70.20:
+    name: Bußgeld- und Strafeinziehung
+    description: |
+      Einziehung gerichtlicher und verwaltungsrechtlicher Bußgelder und Strafen.
+  BC-3250.70.30:
+    name: Lizenzgebühren- und Abgaben-Verwaltung
+    description: |
+      Verwaltung von Naturressourcen-Lizenzgebühren, Umweltabgaben und zweckgebundenen Entgelten.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-teaching-learning-operations-management.yaml
+++ b/catalogue/i18n/de/L1-teaching-learning-operations-management.yaml
@@ -1,0 +1,154 @@
+locale: de
+source: L1-teaching-learning-operations-management.yaml
+entries:
+  BC-4730:
+    name: Lehr- und Lernbetriebsmanagement
+    description: |
+      Tägliche Durchführung von Lehr- und Lernbetrieb, umfassend Präsenz- und
+      Online-Unterricht, Lernumgebungsplattformen, Praktikums- und Hospitationsbetrieb,
+      ergänzenden Unterricht sowie Engagement-Tracking.
+  BC-4730.10:
+    name: Unterrichts- und Lehrveranstaltungsdurchführung
+    description: |
+      Präsenzunterricht in Vorlesungs-, Seminar-, Labor-, Studio-, Workshop- und
+      Tutoriumsformaten.
+    in_scope:
+      - Vorlesungs- und Seminardurchführung
+      - Labor- und Studiodurchführung
+      - Workshop- und Tutoriumsdurchführung
+    out_of_scope:
+      - Online- und Fernunterrichtsdurchführung (abgedeckt unter Online- und Fernlernbetrieb)
+  BC-4730.10.10:
+    name: Vorlesungs- und Seminardurchführung
+    description: |
+      Durchführung von Großgruppenvorlesungen und seminarähnlichem Unterricht.
+  BC-4730.10.20:
+    name: Labor- und Studiodurchführung
+    description: |
+      Durchführung von Labor- und studiobasiertem Unterricht mit praktischen
+      Aktivitäten.
+  BC-4730.10.30:
+    name: Workshop- und Tutoriumsdurchführung
+    description: |
+      Durchführung von Kleingruppenworkshops und Tutorien.
+  BC-4730.20:
+    name: Online- und Fernlernbetrieb
+    description: |
+      Synchrone, asynchrone und hybride Unterrichtsdurchführung durch Online-
+      und Fernmodi.
+    in_scope:
+      - Synchrone Online-Unterrichtsdurchführung
+      - Asynchrone Kursdurchführung
+      - Hybrid-Lernbetrieb
+    out_of_scope:
+      - Erstellung von Online-Lernmaterialien (abgedeckt unter Lehrinhalt- und Lernressourcenmanagement)
+  BC-4730.20.10:
+    name: Synchrone Online-Unterrichtsdurchführung
+    description: |
+      Live-Onlinekurse und Tutorien mit Dozierenden.
+  BC-4730.20.20:
+    name: Asynchrone Kursdurchführung
+    description: |
+      Selbstgesteuerter asynchroner Kursunterricht mit strukturiertem Fortschritt.
+  BC-4730.20.30:
+    name: Hybrid-Lernbetrieb
+    description: |
+      Durchführung von Kursen, die Präsenz- und Online-Modi kombinieren.
+  BC-4730.30:
+    name: Lernumgebungsmanagement
+    description: |
+      Betrieb von Lernmanagementsystemen, virtuellen Unterrichtsplattformen sowie
+      Integration mit nachgelagerten Lernwerkzeugen und -analysen.
+    in_scope:
+      - Betrieb des Lernmanagementsystems (LMS)
+      - Betrieb von virtuellen Unterrichtsplattformen
+      - LTI- und Lernwerkzeugintegration
+    out_of_scope:
+      - Allgemeine IT-Infrastruktur (abgedeckt unter branchenübergreifendem Informationstechnologiemanagement)
+  BC-4730.30.10:
+    name: Betrieb des Lernmanagementsystems
+    description: |
+      Betrieb des institutionellen Lernmanagementsystems.
+  BC-4730.30.20:
+    name: Betrieb der virtuellen Unterrichtsplattform
+    description: |
+      Betrieb von virtuellen Unterrichts- und Konferenzplattformen für den Einsatz
+      in der Lehre.
+  BC-4730.30.30:
+    name: Lernwerkzeugintegration
+    description: |
+      Integration von Drittanbieter-Lernwerkzeugen über LTI und gleichwertige
+      Standards.
+  BC-4730.40:
+    name: Praktikums-, Klinischer und Feldeinsatzbetrieb
+    description: |
+      Betrieb des arbeitsintegrierten Lernens, einschließlich Koordination von
+      Praktikumsplätzen, Betreuung und Nachverfolgung erforderlicher Praktikumsstunden.
+    in_scope:
+      - Koordination der Praktikumsplätze
+      - Klinische und Praktikumsbetreuung
+      - Nachverfolgung von Praktikumsstunden und Logbüchern
+    out_of_scope:
+      - Karriereplacierung nach dem Abschluss (abgedeckt unter Studierendenbetreuung & Wohlbefindenmanagement)
+  BC-4730.40.10:
+    name: Praktikumsplatzkoordination
+    description: |
+      Koordination mit externen Praktikumsplätzen und Gastorganisationen.
+  BC-4730.40.20:
+    name: Klinische und Praktikumsbetreuung
+    description: |
+      Betreuung von Studierenden während klinischer, beruflicher und
+      Praktikumsplatzierungen.
+  BC-4730.40.30:
+    name: Nachverfolgung von Praktikumsstunden und Logbüchern
+    description: |
+      Nachverfolgung von Praktikumsstunden, Kompetenzen und Logbucheinträgen.
+  BC-4730.50:
+    name: Tutorien und ergänzender Unterricht
+    description: |
+      Tutorien, Peer-Lernen und ergänzender akademischer Unterricht, der den
+      Hauptunterricht ergänzt.
+    in_scope:
+      - Peer-Tutoriumsbetrieb
+      - Akademische Kompetenzen-Workshop-Durchführung
+      - Fachspezifischer Tutoriumsbetrieb
+    out_of_scope:
+      - Akademische Beratung zur Studiumsplanung (abgedeckt unter Studierendenbetreuung & Wohlbefindenmanagement)
+  BC-4730.50.10:
+    name: Peer-Tutoriumsbetrieb
+    description: |
+      Betrieb von peer-geleiteten Tutorien und Lernsupportprogrammen.
+  BC-4730.50.20:
+    name: Akademischer Kompetenzen-Workshop
+    description: |
+      Durchführung interdisziplinärer akademischer Kompetenz-Workshops.
+  BC-4730.50.30:
+    name: Fachspezifischer Tutoriumsbetrieb
+    description: |
+      Fachspezifische Tutorien durch Lehrende, Fachbereiche oder Spezialdienste.
+  BC-4730.60:
+    name: Anwesenheits- und Engagement-Tracking
+    description: |
+      Erfassung und Überwachung der Studierendenanwesenheit und des Lernenden-
+      Engagements mit Frühwarnsignalen für gefährdete Lernende.
+    in_scope:
+      - Anwesenheitserfassung
+      - Überwachung des Lernenden-Engagements
+      - Frühwarnung und Interventionsauslösung
+    out_of_scope:
+      - Seelsorgerliche und Beratungsintervention (abgedeckt unter Studierendenbetreuung & Wohlbefindenmanagement)
+  BC-4730.60.10:
+    name: Anwesenheitserfassung
+    description: |
+      Erfassung der Studierendenanwesenheit bei Lehrveranstaltungen.
+  BC-4730.60.20:
+    name: Überwachung des Lernenden-Engagements
+    description: |
+      Überwachung digitaler und verhaltensbezogener Engagementsignale.
+  BC-4730.60.30:
+    name: Frühwarnung und Intervention
+    description: |
+      Auslösung von Frühwarnhinweisen und Weiterleitung an Unterstützungsdienste.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-telecom-billing-revenue-management.yaml
+++ b/catalogue/i18n/de/L1-telecom-billing-revenue-management.yaml
@@ -1,0 +1,140 @@
+locale: de
+source: L1-telecom-billing-revenue-management.yaml
+entries:
+  BC-2660:
+    name: Telekommunikations-Abrechnung und Umsatz
+    description: |
+      Mediation, Abrechnung, Rating, Rechnungsstellung, Präsentation, Inkasso,
+      Revenue Assurance und telekommunikationsspezifische Steuer- und Zuschlagsverarbeitung
+      für Prepaid-, Postpaid- und Konvergenz-Dienste.
+  BC-2660.10:
+    name: Nutzungs-Mediation-Management
+    description: |
+      Erfassung, Normalisierung und Weiterleitung von Nutzungsdatensätzen von
+      Netzelementen an Abrechnungs- und Rechnungsstellungssysteme.
+  BC-2660.10.10:
+    name: CDR-Erfassung
+    description: |
+      Erfassung von Gesprächs-, Sitzungs- und Ereignis-Detaildatensätzen von
+      Netzelementen und IPDR-Quellen.
+  BC-2660.10.20:
+    name: CDR-Anreicherung
+    description: |
+      Anreicherung von CDRs mit Teilnehmer-, Tarif- und Referenzdaten für nachgelagerte Verarbeitung.
+  BC-2660.10.30:
+    name: CDR-Deduplizierung
+    description: |
+      Erkennung und Entfernung doppelter Nutzungsdatensätze.
+  BC-2660.10.40:
+    name: CDR-Format-Konvertierung
+    description: |
+      Konvertierung von CDR-Formaten zwischen Erfassungsquellen und nachgelagerten Empfängern.
+  BC-2660.20:
+    name: Abrechnung und Rating-Management
+    description: |
+      Online- und Offline-Abrechnung, Rating, Kontostandverwaltung und Aufladung
+      für Prepaid- und Postpaid-Modelle.
+  BC-2660.20.10:
+    name: Online-Abrechnung-Management
+    description: |
+      Echtzeit-Abrechnung von Sitzungen und Ereignissen gegen Teilnehmerkontostand und Policy.
+  BC-2660.20.20:
+    name: Offline-Abrechnung-Management
+    description: |
+      Offline-Rating von Nutzungs- und Ereignisdatensätzen für die Postpaid-Abrechnung.
+  BC-2660.20.30:
+    name: Kontostand-Management
+    description: |
+      Verwaltung von Teilnehmer-Hauptkontoständen, dedizierten Kontoständen, Akkumulatoren und Quoten.
+  BC-2660.20.40:
+    name: Gutschein- und Auflademanagement
+    description: |
+      Ausstellung, Verteilung und Einlösung von Gutscheinen und elektronischen Aufladungen.
+  BC-2660.30:
+    name: Abrechnungsbetrieb-Management
+    description: |
+      Durchführung von Abrechnungszyklen, Rechnungsberechnung und Verwaltung von
+      Anpassungen und Korrekturen.
+  BC-2660.30.10:
+    name: Abrechnungszyklus-Durchführung
+    description: |
+      Durchführung geplanter Abrechnungszyklen und Ad-hoc-Rechnungsläufe.
+  BC-2660.30.20:
+    name: Rechnungsberechnung
+    description: |
+      Berechnung von Entgelten, Steuern und Anpassungen über alle Kontokomponenten.
+  BC-2660.30.30:
+    name: Rechnungsanpassung
+    description: |
+      Anwendung genehmigter Anpassungen auf Rechnungen einschließlich Gutschriften und Erlassen.
+  BC-2660.30.40:
+    name: Rechnungskorrektur
+    description: |
+      Korrektur falscher Rechnungen über Neu-Rechnungsstellung oder kompensierende Anpassungen.
+  BC-2660.40:
+    name: Rechnungspräsentation und Anfragenmanagement
+    description: |
+      Multi-Format-Präsentation von Rechnungen und Lösung von Kundenanfragen und Streitigkeiten.
+  BC-2660.40.10:
+    name: Rechnungspräsentation
+    description: |
+      Erstellung und Verteilung von Rechnungen in Papier-, PDF- und Digitalformaten.
+  BC-2660.40.20:
+    name: Einzelposten-Anfrage
+    description: |
+      Bearbeitung von Einzelpostenanfragen und Streitauslösung durch Kunden.
+  BC-2660.40.30:
+    name: Rechnungserläuterung
+    description: |
+      Erläuterung und Visualisierung von Rechnungskomponenten für Kunden und Kundenservicemitarbeiter.
+  BC-2660.50:
+    name: Telekommunikations-Inkasso-Management
+    description: |
+      Telekommunikationsspezifische Mahnprozesse, Sperrung, Kündigung und Schuldeninkasso.
+  BC-2660.50.10:
+    name: Mahnprozess-Workflow
+    description: |
+      Mehrstufiger Mahnprozess-Workflow für überfällige Postpaid-Konten.
+  BC-2660.50.20:
+    name: Dienst-Sperrung und Kündigung
+    description: |
+      Weiche Sperrung, harte Kündigung und Reaktivierung von Diensten bei unbezahlten Salden.
+  BC-2660.50.30:
+    name: Schuldeninkasso-Koordination
+    description: |
+      Koordination mit internen und externen Inkassounternehmen.
+  BC-2660.60:
+    name: Revenue-Assurance-Management
+    description: |
+      Erkennung, Quantifizierung und Behebung von Umsatzverlusten in der Umsatzkette.
+  BC-2660.60.10:
+    name: Umsatzverlust-Erkennung
+    description: |
+      Erkennung von Verlusten zwischen Netznutzung, Mediation, Abrechnung, Rechnungsstellung und Buchhaltung.
+  BC-2660.60.20:
+    name: Abrechnungsgenauigkeits-Verifizierung
+    description: |
+      Stichproben- und vollständige Verifizierung der Rechnungsgenauigkeit gegen Quellereignisse.
+  BC-2660.60.30:
+    name: Netz-zu-Abrechnung-Abstimmung
+    description: |
+      End-to-End-Abstimmung netzaufgezeichneter Ereignisse mit fakturiertem Umsatz.
+  BC-2660.70:
+    name: Telekommunikations-Steuer- und Zuschlag-Management
+    description: |
+      Berechnung und Abführung telekommunikationsspezifischer Steuern, Zuschläge und Regulierungsgebühren.
+  BC-2660.70.10:
+    name: Universaldienst-Fonds-Zuschlag
+    description: |
+      Berechnung, Abrechnung und Abführung von Universaldienst-Fonds-Beiträgen.
+  BC-2660.70.20:
+    name: Telekommunikations-Verbrauchsteuer
+    description: |
+      Berechnung und Abführung telekommunikationsspezifischer Verbrauchssteuern und Kommunikationssteuern.
+  BC-2660.70.30:
+    name: Regulierungsgebühren-Rückstellung
+    description: |
+      Rückstellung und Abführung wiederkehrender Regulierungsgebühren je Teilnehmer- und Umsatzzahl.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-telecom-fraud-management.yaml
+++ b/catalogue/i18n/de/L1-telecom-fraud-management.yaml
@@ -1,0 +1,107 @@
+locale: de
+source: L1-telecom-fraud-management.yaml
+entries:
+  BC-2690:
+    name: Telekommunikationsbetrug-Management
+    description: |
+      Erkennung, Untersuchung, Prävention, Rückgewinnung und betreiber-übergreifende
+      Meldung telekommunikationsspezifischer Betrugsformen – Abonnementbetrug, IRSF,
+      Wangiri, SIM-Tausch, Bypass und Revenue-Share-Schemata – verankert in GSMA-Betrugsrichtlinien.
+  BC-2690.10:
+    name: Telekommunikationsbetrug-Erkennung
+    description: |
+      Echtzeit- und nahezu-Echtzeit-Erkennung telekommunikationsspezifischer Betrugsmuster
+      über Sprach-, Daten- und Signalisierungsverkehr.
+  BC-2690.10.10:
+    name: Abonnementbetrug-Erkennung
+    description: |
+      Erkennung betrügerischen Diensterwerbs mit gestohlenen oder gefälschten Identitäten.
+  BC-2690.10.20:
+    name: Internationale Umsatzanteil-Betrug-Erkennung
+    description: |
+      Erkennung von IRSF-Verkehrsmustern, die die Abrechnung an Premium-Ziele aufblähen.
+  BC-2690.10.30:
+    name: Wangiri-Erkennung
+    description: |
+      Erkennung von Wangiri-Rückrufbetrugsmustern und zugehörigen Nummernbereichen.
+  BC-2690.10.40:
+    name: SIM-Tausch-Erkennung
+    description: |
+      Erkennung betrügerischer SIM- und eSIM-Tauschanfragen und nachgelagerter Kontoübernahmen.
+  BC-2690.10.50:
+    name: Bypass-Betrug-Erkennung
+    description: |
+      Erkennung von SIM-Box- und anderen Bypass-Schemata, die Zusammenschaltungserlöse betrügen.
+  BC-2690.20:
+    name: Telekommunikationsbetrug-Untersuchung
+    description: |
+      Fallbearbeitung erkannter Betrugsfälle, Beweissicherung und Strafverfolgungsbehörden-Kontakt.
+  BC-2690.20.10:
+    name: Betrugsfall-Untersuchung
+    description: |
+      Strukturierte Untersuchung erkannter Betrugsfälle bis zum Ergebnis.
+  BC-2690.20.20:
+    name: Beweiserhebung
+    description: |
+      Forensische Erfassung und Sicherung von Beweisen zur Unterstützung von Betrugsuntersuchungen.
+  BC-2690.20.30:
+    name: Strafverfolgungsbehörden-Kontakt
+    description: |
+      Kontakt mit Strafverfolgungsbehörden bei überwiesenen Betrugsfällen.
+  BC-2690.30:
+    name: Telekommunikationsbetrug-Präventionskontrollen
+    description: |
+      Präventive Kontrollen – Regeln, Geschwindigkeitsgrenzen, Authentifizierungsaufrüstung
+      und Blacklists – gegen Live-Verkehr.
+  BC-2690.30.10:
+    name: Echtzeit-Betrugsregeln-Management
+    description: |
+      Erstellung und Abstimmung von Echtzeit-Regelwerken für Betrugsmanagementsysteme.
+  BC-2690.30.20:
+    name: Geschwindigkeitskontroll-Management
+    description: |
+      Geschwindigkeitsbasierte Kontrollen auf Nutzung, Aufladungen und Änderungen zur
+      Begrenzung des Betrugsrisikos.
+  BC-2690.30.30:
+    name: Authentifizierungs-Aufrüstung
+    description: |
+      Stufenweise Authentifizierung bei risikoreichen Transaktionen und Self-Service-Aktionen.
+  BC-2690.30.40:
+    name: Betrugs-Blacklist-Management
+    description: |
+      Pflege betrugsbezogener Blacklists für Nummern, Bereiche, Geräte und Identitäten.
+  BC-2690.40:
+    name: Telekommunikationsbetrug-Verlust-Rückgewinnung
+    description: |
+      Rückgewinnung betrügerischer Entgelte, Forderungsausfälle und Assets bei bestätigtem Betrug.
+  BC-2690.40.10:
+    name: Betrügerische Entgelt-Rückgewinnung
+    description: |
+      Rückgewinnung von durch bestätigte betrügerische Aktivitäten entstandenen Entgelten.
+  BC-2690.40.20:
+    name: Forderungsausfall-Rückgewinnung
+    description: |
+      Rückgewinnung von Forderungsausfällen im Zusammenhang mit Abonnement- und Kontoübernahmebetrug.
+  BC-2690.40.30:
+    name: Asset-Rückgewinnung
+    description: |
+      Rückgewinnung von Geräten, SIMs und anderen Assets im Zusammenhang mit betrügerischen Aufträgen.
+  BC-2690.50:
+    name: Betreiber-übergreifende Betrugs-Berichterstattung
+    description: |
+      Austausch von Betrugsinformationen über die Branche und Meldung an Behörden wo erforderlich.
+  BC-2690.50.10:
+    name: Branche-Betrugsinformations-Austausch
+    description: |
+      Beitrag zu und Nutzung von Branche-Betrugsinformationskanälen wie GSMA-Betrugs-Forum.
+  BC-2690.50.20:
+    name: Behörden-Betrugs-Berichterstattung
+    description: |
+      Meldung von Betrugsvorfällen und aggregierten Risiken an Behörden wo vorgeschrieben.
+  BC-2690.50.30:
+    name: Betreiber-übergreifende Betrugs-Überweisung
+    description: |
+      Überweisung verdächtiger betrügerischer Aktivitäten an Ursprungs- oder Terminierungsbetreiber für gemeinsame Maßnahmen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-telecom-network-operations-management.yaml
+++ b/catalogue/i18n/de/L1-telecom-network-operations-management.yaml
@@ -1,0 +1,188 @@
+locale: de
+source: L1-telecom-network-operations-management.yaml
+entries:
+  BC-2600:
+    name: Telekommunikations-Netzbetrieb
+    description: |
+      Täglicher Betrieb von Fest-, Mobil- und IP-Netzen über Funkzugang, Kernnetz,
+      Transport und Edge – umfasst Fehler-, Konfigurations-, Leistungs-, Inventar-,
+      Änderungs-, Sicherheitsbetrieb und Feldkoordination auf Basis von TMN FCAPS
+      und eTOM-Ressourcenverwaltung und -betrieb.
+  BC-2600.10:
+    name: Netzfehler-Management
+    description: |
+      Erkennung, Korrelation, Ticketing, Wiederherstellung und Ursachenanalyse von
+      Netzfehlern in Zugangs-, Kern- und Transportdomänen.
+  BC-2600.10.10:
+    name: Alarmkorrelation
+    description: |
+      Echtzeit-Korrelation und Deduplizierung von Netzalarmen zu handlungsrelevanten Ereignissen.
+  BC-2600.10.20:
+    name: Störungsticket-Management
+    description: |
+      Lebenszyklusverwaltung von Netzstörungstickets von der Erstellung bis zum Abschluss.
+  BC-2600.10.30:
+    name: Netzausfall-Management
+    description: |
+      Koordination von Netzausfallreaktionen, Kommunikation und Wiederherstellungsmaßnahmen.
+  BC-2600.10.40:
+    name: Ursachenanalyse
+    description: |
+      Strukturierte Untersuchung wiederkehrender oder schwerwiegender Fehler zur
+      Identifikation und Beseitigung zugrunde liegender Ursachen.
+  BC-2600.20:
+    name: Netzwerk-Konfigurationsmanagement
+    description: |
+      Definition und Durchsetzung von Netzelementkonfigurations-Standards und
+      kontrollierte Bereitstellung von Konfigurationsänderungen.
+  BC-2600.20.10:
+    name: Goldkonfigurations-Management
+    description: |
+      Definition und Pflege genehmigter Baseline-Konfigurationen je Netzelementtyp und -rolle.
+  BC-2600.20.20:
+    name: Netzparameter-Management
+    description: |
+      Lebenszyklusverwaltung einstellbarer Netzparameter und ihrer autorisierten Bereiche.
+  BC-2600.20.30:
+    name: Software-Image-Management
+    description: |
+      Verwahrung und genehmigte Versionskontrolle von Netzelement-Software-Images und Firmware.
+  BC-2600.20.40:
+    name: Automatisierte Konfigurationsbereitstellung
+    description: |
+      Werkzeuggesteuerte Bereitstellung genehmigter Konfigurationsänderungen im großen Maßstab
+      mit Verifizierung und Rollback.
+  BC-2600.30:
+    name: Netzleistungs-Management
+    description: |
+      Kontinuierliche Erfassung und Analyse von Netzleistungszählern und KPIs
+      zur Erkennung und Prävention von Leistungsabfall.
+  BC-2600.30.10:
+    name: Netz-KPI-Erfassung
+    description: |
+      Sammlung und Speicherung von Element- und Netzebenen-Leistungszählern und KPIs.
+  BC-2600.30.20:
+    name: Schwellenwertüberwachung
+    description: |
+      Überwachung von Leistungs-KPIs gegen Ingenieurs- und SLA-Schwellenwerte.
+  BC-2600.30.30:
+    name: Kapazitätsauslastungs-Überwachung
+    description: |
+      Verfolgung der Ressourcenauslastung gegenüber der Engineered Capacity zur
+      Erkennung von Sättigungszuständen.
+  BC-2600.30.40:
+    name: Kundenwirkungskorrelation
+    description: |
+      Korrelation von Netzleistungssignalen mit Kundenerfahrungs-Indikatoren zur
+      Identifikation dienstbeeinträchtigender Zustände.
+  BC-2600.40:
+    name: Netzinventar-Management
+    description: |
+      Maßgeblicher Datensatz logischer und physischer Netzressourcen und ihrer
+      Beziehungen, synchronisiert mit der Realität durch Abstimmung.
+  BC-2600.40.10:
+    name: Logisches Netzinventar
+    description: |
+      Maßgeblicher Datensatz logischer Ressourcen wie Dienste, Schaltkreise,
+      IP/VLAN-Zuweisungen und Trägerpfade.
+  BC-2600.40.20:
+    name: Physisches Netzinventar
+    description: |
+      Maßgeblicher Datensatz physischer Assets wie Knoten, Karten, Ports,
+      Glasfaser, Leerrohre und Antennen.
+  BC-2600.40.30:
+    name: Inventarabstimmung
+    description: |
+      Abstimmung von Inventardatensätzen gegen Entdeckung, Design und Felderhebungen.
+  BC-2600.40.40:
+    name: Netzressourcen-Entdeckung
+    description: |
+      Automatisierte Entdeckung eingesetzter Netzelemente und ihrer Zustände.
+  BC-2600.50:
+    name: Netzänderungs- und Release-Management
+    description: |
+      Planung, Genehmigung, Durchführung, Verifizierung und Rollback von Änderungen
+      an Live-Netzelementen und Diensten.
+  BC-2600.50.10:
+    name: Netzänderungs-Planung
+    description: |
+      Planung und Risikobewertung von Netzänderungen einschließlich Auswirkungsfenstern.
+  BC-2600.50.20:
+    name: Netzänderungs-Umsetzung
+    description: |
+      Kontrollierte Durchführung genehmigter Netzänderungen innerhalb geplanter Fenster.
+  BC-2600.50.30:
+    name: Änderungsverifizierung
+    description: |
+      Nachänderungs-Verifizierung, dass das Netz den erwarteten Zustand hat und
+      innerhalb der Toleranz funktioniert.
+  BC-2600.50.40:
+    name: Änderungs-Rollback
+    description: |
+      Rücknahme von Änderungen, die die Verifizierung nicht bestehen oder inakzeptable Auswirkungen auslösen.
+  BC-2600.60:
+    name: Netzsicherheits-Betrieb
+    description: |
+      Telekommunikations-netzspezifische Sicherheitsüberwachung und -reaktion
+      für Signalisierungs-, Transport- und Kernnetzdomänen, ergänzend zur Unternehmens-Cybersicherheit.
+  BC-2600.60.10:
+    name: Netzbedrohungs-Überwachung
+    description: |
+      Überwachung von Signalisierungs-, Transport- und Kernnetzen auf anomale
+      und böswillige Aktivitäten.
+  BC-2600.60.20:
+    name: DDoS-Schutz
+    description: |
+      Erkennung und Abwehr volumetrischer und protokollbasierter Denial-of-Service-Angriffe
+      gegen Netz- und Kundenendpunkte.
+  BC-2600.60.30:
+    name: Netzzugangs-Kontrolle
+    description: |
+      Durchsetzung von administrativen und maschinellen Zugriffskontrollen zu Netzelementen.
+  BC-2600.60.40:
+    name: Netzsicherheits-Vorfallreaktion
+    description: |
+      Eindämmung, Beseitigung und Wiederherstellung nach bestätigten Netzsicherheitsvorfällen.
+  BC-2600.70:
+    name: Feldbetrieb-Koordination
+    description: |
+      Disposition, Ausführungssteuerung und Standortzugangskoordination für
+      Netz-Feldaktivitäten.
+  BC-2600.70.10:
+    name: Feldarbeitsauftrag-Disposition
+    description: |
+      Zuweisung von Netzarbeitsaufträgen an interne und externe Feldteams.
+  BC-2600.70.20:
+    name: Verfahrens-Ausführungssteuerung
+    description: |
+      Ausführungssteuerung genehmigter Verfahren an Live-Netzelementen.
+  BC-2600.70.30:
+    name: Standortzugangs-Koordination
+    description: |
+      Koordination des physischen Zugangs zu Netzstandorten einschließlich Begleitung,
+      Genehmigungen und Sicherheitskontrollen.
+  BC-2600.80:
+    name: Netzoptimierungs-Management
+    description: |
+      Kontinuierliche Abstimmung von Netzelementen und Verkehrspfaden zur Maximierung
+      von Leistung, Kapazität und Kundenerfahrung.
+  BC-2600.80.10:
+    name: Funkzugang-Optimierung
+    description: |
+      Abstimmung von Funkzugangsparametern, Nachbarzellenbeziehungen und Antennenkonfiguration.
+  BC-2600.80.20:
+    name: Transport-Optimierung
+    description: |
+      Abstimmung von Transportnetzpfaden, Kapazitätszuweisung und Dienstqualität.
+  BC-2600.80.30:
+    name: Verkehrsengineering
+    description: |
+      Steuerung von IP- und Transportverkehr über das Netz für Leistungs-, Kosten- und Resilienz-Ziele.
+  BC-2600.80.40:
+    name: Closed-Loop-Automatisierung
+    description: |
+      Automatisierte Erkennen-Entscheiden-Handeln-Schleifen, die das Netz kontinuierlich
+      ohne manuellen Eingriff optimieren.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-telecom-network-planning-management.yaml
+++ b/catalogue/i18n/de/L1-telecom-network-planning-management.yaml
@@ -1,0 +1,119 @@
+locale: de
+source: L1-telecom-network-planning-management.yaml
+entries:
+  BC-2610:
+    name: Telekommunikations-Netzplanung
+    description: |
+      Langfristiges Design und Dimensionierung von Fest-, Mobil- und IP-Netzen –
+      Nachfragevorhersage, Abdeckungs- und Kapazitätsplanung, Technologie-Evolutionsdefinition,
+      Standortrollout-Planung und Koordination der Ablösung von Legacy-Netzen.
+  BC-2610.10:
+    name: Netzwerk-Nachfragevorhersage
+    description: |
+      Vorhersage langfristiger Teilnehmer-, Verkehrs- und Dienstnachfrage zur
+      Steuerung von Abdeckungs- und Kapazitätsentscheidungen.
+  BC-2610.10.10:
+    name: Teilnehmerwachstums-Vorhersage
+    description: |
+      Vorhersage der Teilnehmerpopulation nach Segment, Technologie und Geographie.
+  BC-2610.10.20:
+    name: Verkehrsnachfrage-Vorhersage
+    description: |
+      Vorhersage von Sprach-, Daten-, Video- und Signalisierungsverkehrsvolumen je Domäne und Zelle.
+  BC-2610.10.30:
+    name: Dienstnachfrage-Modellierung
+    description: |
+      Modellierung der Nachfrage nach neuen und sich entwickelnden Diensten zur
+      Verankerung von Kapazitäts- und Feature-Roadmaps.
+  BC-2610.20:
+    name: Netzabdeckungs-Planung
+    description: |
+      Planung geografischer Abdeckungsziele und Resilienz für Radio-, Glasfaser- und Transportnetze.
+  BC-2610.20.10:
+    name: Funkabdeckungs-Planung
+    description: |
+      Definition von Funkabdeckungszielen und Ausbreitungsmodellierung je Band und Technologie.
+  BC-2610.20.20:
+    name: Glasfaserabdeckungs-Planung
+    description: |
+      Planung des Glasfaser-Fußabdrucks, erschlossener Haushalte und Zugangsknotenpositionierung.
+  BC-2610.20.30:
+    name: Redundanz- und Resilienzplanung
+    description: |
+      Design von Routenvielfalt, geographischer Redundanz und Resilienzzielen.
+  BC-2610.30:
+    name: Netzkapazitäts-Planung
+    description: |
+      Kapazitätsdimensionierung über Funkzugangs-, Kern- und Transportdomänen
+      zur Erfüllung prognostizierter Nachfrage innerhalb von Leistungszielen.
+  BC-2610.30.10:
+    name: Funkzugangs-Kapazitätsplanung
+    description: |
+      Kapazitätsdimensionierung von Zellen, Sektoren und Carriern im Funkzugangsnetz.
+  BC-2610.30.20:
+    name: Kernnetz-Kapazitätsplanung
+    description: |
+      Kapazitätsdimensionierung von Mobil- und Festnetz-Kernnetzfunktionen und Teilnehmerdatenspeichern.
+  BC-2610.30.30:
+    name: Transport-Kapazitätsplanung
+    description: |
+      Kapazitätsdimensionierung von Fronthaul, Backhaul, Metro und Aggregationstransport.
+  BC-2610.30.40:
+    name: IP-Backbone-Kapazitätsplanung
+    description: |
+      Kapazitätsdimensionierung des IP-Backbone, Peering und Transit-Links.
+  BC-2610.40:
+    name: Netz-Technologie-Evolution-Planung
+    description: |
+      Definition der mehrjährigen Netz-Technologie-Roadmap und Architekturevolution.
+  BC-2610.40.10:
+    name: Technologie-Roadmap-Definition
+    description: |
+      Definition der mehrjährigen Evolutions-Roadmap über Radio-, Transport- und Kernnetz-Technologien.
+  BC-2610.40.20:
+    name: Netzarchitektur-Evolution
+    description: |
+      Architekturelle Transformation in Richtung Ziel-Referenzarchitekturen wie Cloud-native Kern und Open RAN.
+  BC-2610.40.30:
+    name: Anbieter-Technologie-Auswahl
+    description: |
+      Bewertung und Auswahl von Anbieter-Technologien für neue Netzdomänen und Aktualisierungszyklen.
+  BC-2610.50:
+    name: Netzstandort-Planung
+    description: |
+      Identifikation, Vermessung, Genehmigung und Rollout-Planung neuer Netzstandorte.
+  BC-2610.50.10:
+    name: Standortidentifikation
+    description: |
+      Identifikation von Kandidatenstandorten gegen Abdeckungs-, Kapazitäts- und Backhaul-Kriterien.
+  BC-2610.50.20:
+    name: HF-Standortvermessung
+    description: |
+      Vermessung von Kandidatenstandorten auf HF-Leistung, strukturelle Machbarkeit und Interferenz.
+  BC-2610.50.30:
+    name: Baugenehmigung-Koordination
+    description: |
+      Koordination interner Genehmigungen, Baugenehmigungen und Zonenrechte für neue Standorte.
+  BC-2610.50.40:
+    name: Rollout-Planung
+    description: |
+      Zeitplanung und Sequenzierung von Standortbauten gegen Capex-, Lieferanten- und Abdeckungsverpflichtungen.
+  BC-2610.60:
+    name: Netz-End-of-Life-Planung
+    description: |
+      Planung der Legacy-Netz-Abschaltung, Kundenmigration und Asset-Dekommissionierung.
+  BC-2610.60.10:
+    name: Legacy-Netz-Dekommissionierungsplanung
+    description: |
+      Planung der geordneten Dekommissionierung von Legacy-Netzelementen und zugehörigen Assets.
+  BC-2610.60.20:
+    name: Kundenmigrations-Planung
+    description: |
+      Planung der Kundenmigration von auslaufenden Technologien auf Zielplattformen.
+  BC-2610.60.30:
+    name: Technologie-Abschaltungsplanung
+    description: |
+      Definition von Technologie-Abschaltungs-Meilensteinen, Behördenbenachrichtigungen und endgültigen Abschaltereignissen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-telecom-product-catalogue-management.yaml
+++ b/catalogue/i18n/de/L1-telecom-product-catalogue-management.yaml
@@ -1,0 +1,97 @@
+locale: de
+source: L1-telecom-product-catalogue-management.yaml
+entries:
+  BC-2650:
+    name: Telekommunikations-Produktkatalog-Management
+    description: |
+      Design, Konfiguration, Lebenszyklus und Kanalveröffentlichung von Telekommunikations-
+      produkten, Tarifen, Plänen, Bundles und Promotionen für Verbraucher-, Geschäfts-
+      und Wholesale-Kunden.
+  BC-2650.10:
+    name: Produktangebots-Design
+    description: |
+      Design neuer kommerzieller Angebote einschließlich Features, Berechtigung und Preisstrukturen.
+  BC-2650.10.10:
+    name: Angebots-Spezifikation
+    description: |
+      Spezifikation von Angebotszusammensetzung, Features und kundenseitigen Konditionen.
+  BC-2650.10.20:
+    name: Technische Produktmachbarkeit
+    description: |
+      Validierung der technischen Lieferbarkeit des vorgeschlagenen Angebots über
+      Zielnetzwerke und -plattformen.
+  BC-2650.10.30:
+    name: Preisstufen-Design
+    description: |
+      Design von Preisstufen, Berechtigungsregeln und Vertragsstrukturen für das Angebot.
+  BC-2650.20:
+    name: Tarif- und Plan-Management
+    description: |
+      Definition und Lebenszyklus von Tarifen, wiederkehrenden Entgelten und
+      Fair-Use-Richtlinien für Angebote.
+  BC-2650.20.10:
+    name: Nutzungstarif-Definition
+    description: |
+      Definition von Einzelereignis- und Einheitennutzungs-Tarifen je Diensttyp und Jurisdiktion.
+  BC-2650.20.20:
+    name: Wiederkehrendes-Entgelt-Definition
+    description: |
+      Definition wiederkehrender Entgelte, monatlicher Gebühren und vertragsbezogener Entgelte.
+  BC-2650.20.30:
+    name: Fair-Use-Richtlinien-Management
+    description: |
+      Definition und Lebenszyklus von Fair-Use- und Acceptable-Use-Richtlinien bei
+      Flatrate- und Hochnutzungsplänen.
+  BC-2650.30:
+    name: Bundle- und Promotions-Management
+    description: |
+      Zusammensetzung und Regeln von Mehrprodukt-Bundles und zeitgebundenen Promotionen.
+  BC-2650.30.10:
+    name: Bundle-Komposition
+    description: |
+      Zusammensetzung von Mehrdienstbundles über Mobil, Fest, Inhalte und Gerät.
+  BC-2650.30.20:
+    name: Promotions-Berechtigungsregeln
+    description: |
+      Definition von Kunden- und Angebotsberechtigung für Promotionen.
+  BC-2650.30.30:
+    name: Rabatt-Stapelungsregeln
+    description: |
+      Regeln für die Kombination mehrerer Rabatte und Promotionen auf einem einzigen Konto.
+  BC-2650.40:
+    name: Produktkatalog-Veröffentlichung
+    description: |
+      Veröffentlichung von Katalogversionen an Kanäle und Partner mit
+      Versionskontrolle und regionalen Varianten.
+  BC-2650.40.10:
+    name: Multi-Channel-Katalog-Veröffentlichung
+    description: |
+      Veröffentlichung von Kataloginhalten an Einzelhandels-, Digital-, Contact-Center- und Partnerkanäle.
+  BC-2650.40.20:
+    name: Katalog-Versionskontrolle
+    description: |
+      Versionskontrolle von Kataloginhalten einschließlich Gültigkeitsdaten und Rollback.
+  BC-2650.40.30:
+    name: Regionale Katalogvarianten-Management
+    description: |
+      Verwaltung regionaler und markenspezifischer Katalogvarianten aus einem gemeinsamen Master.
+  BC-2650.50:
+    name: Telekommunikations-Produkt-Lebenszyklus-Management
+    description: |
+      Lebenszyklusverwaltung von Angeboten von der Markteinführung über Änderungen,
+      Abkündigung und Bestandskundenregelung.
+  BC-2650.50.10:
+    name: Angebots-Markteinführung
+    description: |
+      Koordination von Neuangebots-Markteinführungen über Systeme, Kanäle und Regionen.
+  BC-2650.50.20:
+    name: Angebots-Änderung
+    description: |
+      Kontrollierte Änderung von Marktangeboten und Migration bestehender Teilnehmer wenn zutreffend.
+  BC-2650.50.30:
+    name: Angebots-Ruhestand und Bestandskundenregelung
+    description: |
+      Einstellung von Angeboten aus dem Verkauf und Bestandskundenregelung zu Altkondtionen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-telecom-regulatory-compliance-management.yaml
+++ b/catalogue/i18n/de/L1-telecom-regulatory-compliance-management.yaml
@@ -1,0 +1,128 @@
+locale: de
+source: L1-telecom-regulatory-compliance-management.yaml
+entries:
+  BC-2700:
+    name: Regulatorische Konformität (Telekommunikation)
+    description: |
+      Telekommunikationsspezifische regulatorische Verpflichtungen – Universaldienst,
+      rechtmäßige Interception, Vorratsdatenspeicherung, Notfalldienste, Barrierefreiheit,
+      Netzneutralität und Lizenzbedingungsberichterstattung – verankert in nationalen
+      Telekommunikationsregulierungsbehörden und ETSI/3GPP-LI-Standards.
+  BC-2700.10:
+    name: Universaldienst-Verpflichtungs-Management
+    description: |
+      Bereitstellung und Berichterstattung gegen Universaldienstverpflichtungen und zugehörige Subventionen.
+  BC-2700.10.10:
+    name: USO-Gebietsplanung
+    description: |
+      Planung von Universaldienst-Abdeckung und Qualitätsverpflichtungen nach Gebiet.
+  BC-2700.10.20:
+    name: USO-Subventions-Berichterstattung
+    description: |
+      Berichterstattung über subventionierte Kundenzahlen und Diensterbringung an USO-Fonds.
+  BC-2700.10.30:
+    name: USO-Diensterbringung
+    description: |
+      Bereitstellung mandatierter USO-Dienste einschließlich subventionierter Tarife und Mindest-Servicelevel.
+  BC-2700.20:
+    name: Rechtmäßige Interception-Management
+    description: |
+      Bereitstellung und Lieferung von Rechtmäßige-Interception-Fähigkeit unter autorisierten Beschlüssen.
+  BC-2700.20.10:
+    name: Rechtmäßige Interception-Bereitstellung
+    description: |
+      Bereitstellung von LI-Zielen in Netzelementen unter autorisierten Beschlüssen.
+  BC-2700.20.20:
+    name: Rechtmäßige Interception-Übergabe-Lieferung
+    description: |
+      Lieferung abgefangener Inhalte und Metadaten an Strafverfolgungsüberwachungseinrichtungen.
+  BC-2700.20.30:
+    name: Rechtmäßige Interception-Audit und Zugangskontrolle
+    description: |
+      Zugangskontrolle und Audit von LI-Aktivitäten zur Verhinderung unbefugter Nutzung.
+  BC-2700.30:
+    name: Telekommunikations-Vorratsdatenspeicherung
+    description: |
+      Erfassung, sichere Speicherung und autorisierte Freigabe aufbewahrter
+      Kommunikationsdaten gemäß nationalen Vorratsdatenspeicherungsrahmen.
+  BC-2700.30.10:
+    name: Aufbewahrte Daten-Erfassung
+    description: |
+      Erfassung von der Vorratsdatenspeicherungspflicht unterliegenden Kommunikationsdaten.
+  BC-2700.30.20:
+    name: Aufbewahrte Daten-Zugangs-Workflow
+    description: |
+      Autorisierter Anfrage-Workflow für den Zugang zu aufbewahrten Daten durch zuständige Behörden.
+  BC-2700.30.30:
+    name: Aufbewahrte Daten-Löschung
+    description: |
+      Löschung aufbewahrter Daten nach Ablauf der Aufbewahrungsfristen.
+  BC-2700.40:
+    name: Notfalldienste-Management
+    description: |
+      Notruframping, Standortlieferung und öffentliche Warnfähigkeiten gemäß Behördenvorschriften.
+  BC-2700.40.10:
+    name: Notruf-Routing
+    description: |
+      Routing von Notrufen an geeignete Notrufzentralen.
+  BC-2700.40.20:
+    name: Anruferstandort-Lieferung
+    description: |
+      Lieferung von Anruferstandortinformationen an Notfalldienste gemäß E911-, eCall- und AML-Standards.
+  BC-2700.40.30:
+    name: Öffentliche Warn-Übertragung
+    description: |
+      Übertragung von Cell-Broadcast- und SMS-basierten öffentlichen Warnmeldungen bei autorisierter Aktivierung.
+  BC-2700.50:
+    name: Telekommunikations-Barrierefreiheits-Management
+    description: |
+      Bereitstellung von Barrierefreiheitsfunktionen und Lösung barrierefreiheitsbezogener
+      Beschwerden unter telekommunikationsspezifischen Verpflichtungen.
+  BC-2700.50.10:
+    name: Echtzeit-Text- und TTY-Unterstützung
+    description: |
+      Unterstützung von Echtzeit-Text und TTY-Diensten für gehörlose und schwerhörige Nutzer.
+  BC-2700.50.20:
+    name: Barrierefreiheits-Feature-Bereitstellung
+    description: |
+      Bereitstellung telekommunikationsspezifischer Barrierefreiheitsfunktionen wie Relay-Dienste und barrierefreie Rechnungen.
+  BC-2700.50.30:
+    name: Barrierefreiheits-Beschwerden-Behandlung
+    description: |
+      Behandlung barrierefreiheitsbezogener Beschwerden und behördenerforderlicher Berichterstattung.
+  BC-2700.60:
+    name: Netzneutralität und Verkehrsmanagement-Offenlegung
+    description: |
+      Offenlegung von Verkehrsmanagementpraktiken und Compliance mit Netzneutralitätssystemen.
+  BC-2700.60.10:
+    name: Verkehrsmanagement-Richtlinien-Offenlegung
+    description: |
+      Offenlegung von Verkehrsmanagementpraktiken an Kunden und Behörden.
+  BC-2700.60.20:
+    name: Drosselungs-Transparenz
+    description: |
+      Transparente Berichterstattung über Drosselung, Priorisierung und Zero-Rating-Praktiken.
+  BC-2700.60.30:
+    name: Netzneutralitäts-Behördeneinreichung
+    description: |
+      Einreichungen bei Behörden zu Netzneutralitätspraktiken und Beschwerden.
+  BC-2700.70:
+    name: Telekommunikations-Regulierungs-Berichterstattung
+    description: |
+      Wiederkehrende Einreichungen von KPIs, Marktdaten und Lizenzbedingungskonformität
+      an Telekommunikationsbehörden.
+  BC-2700.70.10:
+    name: Telekommunikations-KPI-Einreichungen
+    description: |
+      Einreichung obligatorischer KPIs zu Abdeckung, Qualität und Dienstleistung.
+  BC-2700.70.20:
+    name: Telekommunikations-Marktdaten-Einreichungen
+    description: |
+      Einreichung von Marktdaten zu Teilnehmern, Umsatz und Verkehr.
+  BC-2700.70.30:
+    name: Lizenzbedingungen-Berichterstattung
+    description: |
+      Berichterstattung gegen Betriebslizenzbedingungen einschließlich Abdeckungs-, Rollout- und Qualitätsverpflichtungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-telecom-service-assurance-management.yaml
+++ b/catalogue/i18n/de/L1-telecom-service-assurance-management.yaml
@@ -1,0 +1,124 @@
+locale: de
+source: L1-telecom-service-assurance-management.yaml
+entries:
+  BC-2630:
+    name: Telekommunikations-Dienstverfügbarkeit
+    description: |
+      Dienstebenen-Leistung, Qualität, Vorfallmanagement und Kundenerfahrungs-
+      management gegen vereinbarte Ziele – verankert in eTOM-Dienstverfügbarkeit,
+      ITU-T E.800 Dienstqualität und TM-Forum-SLA-Open-API.
+  BC-2630.10:
+    name: Servicelevel-Management
+    description: |
+      Definition, Überwachung, Berichterstattung und Verstosbehandlung von
+      Servicevereinbarungen mit Kunden und Partnern.
+  BC-2630.10.10:
+    name: Servicelevel-Definition
+    description: |
+      Definition von SLA-Zielen, Metriken und Messmethoden je Dienstangebot.
+  BC-2630.10.20:
+    name: Servicelevel-Überwachung
+    description: |
+      Überwachung gemessener Dienstleistung gegen SLA-Verpflichtungen.
+  BC-2630.10.30:
+    name: Servicelevel-Berichterstattung
+    description: |
+      Berichterstattung von SLA-Ergebnissen an Kunden, Partner und interne Stakeholder.
+  BC-2630.10.40:
+    name: Servicelevel-Verstoß-Management
+    description: |
+      Behandlung von SLA-Verstößen einschließlich Gutschriftberechnung und Kundenbehebung.
+  BC-2630.20:
+    name: Dienstleistungs-Leistungsüberwachung
+    description: |
+      Kontinuierliche Überwachung von End-to-End-Dienst-KPIs und Kundenerfahrungs-
+      Indikatoren zur Erkennung von Leistungsabfall.
+  BC-2630.20.10:
+    name: End-to-End-Dienst-KPI-Überwachung
+    description: |
+      Überwachung von End-to-End-Dienst-KPIs, aggregiert über zugrunde liegende Netzdomänen.
+  BC-2630.20.20:
+    name: Kundenerfahrungs-Indikatorüberwachung
+    description: |
+      Überwachung von QoE-artigen Indikatoren, die die vom Kunden wahrgenommene Dienstqualität widerspiegeln.
+  BC-2630.20.30:
+    name: Dienstverschlechterungs-Erkennung
+    description: |
+      Frühzeitige Erkennung von Dienstverschlechterungsmustern vor Kundenauswirkung.
+  BC-2630.30:
+    name: Kundenbeeinflussendes Vorfall-Management
+    description: |
+      End-to-End-Management von Vorfällen, die Kunden betreffen – Erkennung,
+      Benachrichtigung, Eskalation und Überprüfung.
+  BC-2630.30.10:
+    name: Kunden-Vorfallerkennung
+    description: |
+      Erkennung von Vorfällen, die einen oder mehrere Kunden betreffen, basierend auf Netz- und Kundensignalen.
+  BC-2630.30.20:
+    name: Kunden-Vorfallbenachrichtigung
+    description: |
+      Benachrichtigung betroffener Kunden und Kanäle mit Status, ETA und Workaround-Informationen.
+  BC-2630.30.30:
+    name: Vorfall-Eskalation
+    description: |
+      Eskalation kundenbeeinflussendes Vorfälle gemäß Schweregrad- und Dauerpolitik.
+  BC-2630.30.40:
+    name: Post-Vorfall-Überprüfung
+    description: |
+      Strukturierte Überprüfung signifikanter kundenbeeinflussendes Vorfälle zur
+      Ableitung von Korrekturmaßnahmen.
+  BC-2630.40:
+    name: Dienstqualitäts-Management
+    description: |
+      Messung, Modellierung und Berichterstattung von Dienstqualität und Kundenerfahrung
+      einschließlich Behördenberichterstattung.
+  BC-2630.40.10:
+    name: Dienstqualitäts-Messung
+    description: |
+      Messung von QoS-Parametern wie Latenz, Verlust, Jitter und Durchsatz je Dienst.
+  BC-2630.40.20:
+    name: Kundenerfahrungs-Qualitätsmodellierung
+    description: |
+      Modellierung der vom Kunden wahrgenommenen Dienstqualität aus Netz- und Verhaltenssignalen.
+  BC-2630.40.30:
+    name: Dienstqualitäts-Berichterstattung
+    description: |
+      Berichterstattung von Dienstqualitätsmetriken an interne Stakeholder und Behörden.
+  BC-2630.50:
+    name: Dienst-Wiederherstellungs-Koordination
+    description: |
+      Koordination von Wiederherstellungsaktivitäten, Workarounds und Wiederherstellungsvalidierung
+      für beeinträchtigte Dienste.
+  BC-2630.50.10:
+    name: Dienst-Wiederherstellungs-Workflow
+    description: |
+      Orchestrierung von Wiederherstellungsaufgaben über Netz- und Feldteams.
+  BC-2630.50.20:
+    name: Workaround-Koordination
+    description: |
+      Koordination temporärer Workarounds und Bypass-Routen bei verlängerten Beeinträchtigungen.
+  BC-2630.50.30:
+    name: Dienst-Wiederherstellungsvalidierung
+    description: |
+      Validierung, dass der Dienst auf Baseline-Niveau wiederhergestellt wurde und
+      Kunden nicht mehr beeinträchtigt sind.
+  BC-2630.60:
+    name: Kundenerfahrungs-Management
+    description: |
+      Messung der Kundenerfahrung bei Dienstereignissen und proaktive Kontaktaufnahme
+      zur Milderung von Unzufriedenheit.
+  BC-2630.60.10:
+    name: Dienstereigenis-NPS-Messung
+    description: |
+      Messung von Kundenzufriedenheit und NPS im Kontext dienstbeeinträchtigender Ereignisse.
+  BC-2630.60.20:
+    name: Abwanderungsrisiko-Signalisierung
+    description: |
+      Identifikation von Kunden mit erhöhtem Abwanderungsrisiko nach Dienstvorfällen.
+  BC-2630.60.30:
+    name: Proaktive Kunden-Kontaktaufnahme
+    description: |
+      Proaktive Kontaktaufnahme mit betroffenen Kunden mit Entschuldigungen, Gutschriften und Kundenbindungsangeboten.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-telecom-service-fulfilment-management.yaml
+++ b/catalogue/i18n/de/L1-telecom-service-fulfilment-management.yaml
@@ -1,0 +1,119 @@
+locale: de
+source: L1-telecom-service-fulfilment-management.yaml
+entries:
+  BC-2620:
+    name: Telekommunikations-Dienstbereitstellung
+    description: |
+      Serviceauftrags-Erfassung, Zerlegung, Bereitstellung, Aktivierung, Abnahme
+      und Endgeräte-Installation für Verbraucher-, Geschäfts- und Wholesale-Dienste –
+      verankert in eTOM-Dienstbereitstellung und TM-Forum-Open-APIs.
+  BC-2620.10:
+    name: Serviceauftrag-Erfassung
+    description: |
+      Multi-Channel-Erfassung von Serviceaufträgen mit Machbarkeits- und Kreditprüfungen
+      vor der Einreichung.
+  BC-2620.10.10:
+    name: Omnichannel-Auftragserfassung
+    description: |
+      Erfassung von Serviceaufträgen über Einzelhandels-, Digital-, Contact-Center- und Partnerkanäle.
+  BC-2620.10.20:
+    name: Dienst-Machbarkeitsprüfung
+    description: |
+      Adress-, Abdeckungs- und Ressourcenebenen-Machbarkeitsprüfungen für angeforderte Dienste.
+  BC-2620.10.30:
+    name: Kredit- und Risiko-Gating
+    description: |
+      Kreditbewertung und Betrugsrisiko-Gating vor der Auftragsannahme.
+  BC-2620.10.40:
+    name: Auftragseinreichung
+    description: |
+      Validierung, Persistenz und nachgelagerte Einreichung angenommener Serviceaufträge.
+  BC-2620.20:
+    name: Serviceauftrag-Zerlegung
+    description: |
+      Zerlegung kundenseitiger Aufträge in ressourcenseitige Aufgaben
+      und Sequenzierung von Abhängigkeiten.
+  BC-2620.20.10:
+    name: Dienst-zu-Ressource-Zerlegung
+    description: |
+      Zerlegung kundenseitiger Dienste in ressourcenseitige Dienste und Elemente.
+  BC-2620.20.20:
+    name: Arbeitsauftrag-Generierung
+    description: |
+      Generierung von Netz- und Feldarbeitsaufträgen aus zerlegten Serviceaufträgen.
+  BC-2620.20.30:
+    name: Abhängigkeits-Sequenzierung
+    description: |
+      Sequenzierung abhängiger Aufgaben über Netzdomänen zur Bereitstellung eines End-to-End-Dienstes.
+  BC-2620.30:
+    name: Dienstbereitstellung
+    description: |
+      Zuweisung von Netzressourcen und Orchestrierung von Konfigurationsänderungen
+      zur Instanziierung von Diensten.
+  BC-2620.30.10:
+    name: Netzressourcen-Zuweisung
+    description: |
+      Zuweisung von Bandbreite, Ports, IP-Adressen und anderen Ressourcen zu einer spezifischen Dienstinstanz.
+  BC-2620.30.20:
+    name: Dienst-Orchestrierung
+    description: |
+      Orchestrierte Durchführung von Bereitstellungsschritten über physische und virtualisierte Netzfunktionen.
+  BC-2620.30.30:
+    name: Konfigurationsbereitstellung
+    description: |
+      Anwendung dienstspezifischer Konfiguration auf Ziel-Netzelemente.
+  BC-2620.40:
+    name: Dienstaktivierung
+    description: |
+      Endgültige Inbetriebnahme bereitgestellter Dienste und Benachrichtigung von Kunden und nachgelagerten Systemen.
+  BC-2620.40.10:
+    name: Dienst-Inbetriebnahme
+    description: |
+      Umschaltung bereitgestellter Dienste in den Live-Zustand.
+  BC-2620.40.20:
+    name: Teilnehmer-Einschreibung
+    description: |
+      Einschreibung von Teilnehmern in Authentifizierungs-, Autorisierungs- und Policy-Systeme für den neuen Dienst.
+  BC-2620.40.30:
+    name: Abrechnungsaktivierung
+    description: |
+      Übermittlung von Aktivierungsereignissen an die Abrechnung für Abrechnungsstart und Vertragszeitbeginn.
+  BC-2620.40.40:
+    name: Kunden-Aktivierungsbenachrichtigung
+    description: |
+      Benachrichtigung von Kunden und Kanälen, dass der Dienst aktiv und nutzbar ist.
+  BC-2620.50:
+    name: Dienstabnahme-Tests
+    description: |
+      End-to-End-Tests und Baseline-Erfassung vor der formellen Übergabe neuer Dienste.
+  BC-2620.50.10:
+    name: End-to-End-Diensttest
+    description: |
+      Durchführung von End-to-End-Funktions- und Leistungstests an neu bereitgestellten Diensten.
+  BC-2620.50.20:
+    name: Dienst-Baseline-Erfassung
+    description: |
+      Erfassung von Dienstleistungs-Baselines für die nachgelagerte SLA-Überwachung.
+  BC-2620.50.30:
+    name: Abnahme-Unterzeichnung
+    description: |
+      Formelle Abnahme und Übergabe von Diensten an den Betrieb und den Kunden.
+  BC-2620.60:
+    name: Kundenstandort-Installations-Koordination
+    description: |
+      Koordination der Installation von Kundenstandortgeräten und zugehöriger Aktivitäten.
+  BC-2620.60.10:
+    name: Installations-Terminplanung
+    description: |
+      Planung von Kundenterminen für Vor-Ort-Installationen.
+  BC-2620.60.20:
+    name: Vor-Ort-Installations-Koordination
+    description: |
+      Koordination von Installationsaktivitäten, Materialien und Zugängen am Kundenstandort.
+  BC-2620.60.30:
+    name: Kundengeräte-Registrierung
+    description: |
+      Registrierung installierter Kundenstandortgeräte und Zuordnung zur Dienstinstanz.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-telecom-subscriber-management.yaml
+++ b/catalogue/i18n/de/L1-telecom-subscriber-management.yaml
@@ -1,0 +1,116 @@
+locale: de
+source: L1-telecom-subscriber-management.yaml
+entries:
+  BC-2640:
+    name: Telekommunikations-Teilnehmer-Management
+    description: |
+      Teilnehmeridentität, SIM- und eSIM-Lebenszyklus, Nummerierung, Portabilität,
+      Geräteidentität sowie Authentifizierung und Autorisierung über Mobil- und Festnetze.
+  BC-2640.10:
+    name: Teilnehmeridentitäts-Management
+    description: |
+      Lebenszyklusverwaltung von Teilnehmer-Identifikatoren und -Profilen in der
+      Teilnehmer-Datenschicht.
+  BC-2640.10.10:
+    name: IMSI-Bereitstellung
+    description: |
+      Zuweisung und Bereitstellung von IMSI und gleichwertigen Identifikatoren
+      in Teilnehmer-Datenspeichern.
+  BC-2640.10.20:
+    name: Teilnehmerprofil-Management
+    description: |
+      Verwaltung von Teilnehmerprofil-Datensätzen in HLR, HSS, UDM und äquivalenten Systemen.
+  BC-2640.10.30:
+    name: Teilnehmeridentitäts-Widerruf
+    description: |
+      Widerruf von Teilnehmeridentitäten bei Kündigung, Betrug oder Behördenanfrage.
+  BC-2640.20:
+    name: SIM- und eSIM-Lebenszyklus-Management
+    description: |
+      Lebenszyklusverwaltung von physischen SIM-Karten und eSIM-Profilen einschließlich
+      Personalisierung, Verteilung, Tausch und Ersatz.
+  BC-2640.20.10:
+    name: Physische SIM-Bereitstellung
+    description: |
+      Personalisierung und Verteilung physischer SIM-Karten.
+  BC-2640.20.20:
+    name: eSIM-Profil-Management
+    description: |
+      Verwaltung von eSIM-Profilen über SM-DP+, SM-SR und äquivalente Plattformen.
+  BC-2640.20.30:
+    name: Profiltausch und Ersatz
+    description: |
+      Tausch und Ersatz von Teilnehmer-SIM- und eSIM-Profilen einschließlich betrugssensibler Abläufe.
+  BC-2640.30:
+    name: Nummernressourcen-Management
+    description: |
+      Verwaltung von Rufnummernressourcen, die von Regulierungsbehörden gewährt werden,
+      und deren Zuweisung an Dienste.
+  BC-2640.30.10:
+    name: Nummernblock-Zuweisung
+    description: |
+      Erwerb und Zuweisung von Nummernblöcken von der Regulierungsbehörde in das interne Inventar.
+  BC-2640.30.20:
+    name: Nummerninventar-Management
+    description: |
+      Verwaltung verfügbarer, reservierter, zugewiesener und quarantinierter Nummerninventare.
+  BC-2640.30.30:
+    name: Nummernreservierung und -rückgabe
+    description: |
+      Reservierung von Nummern für Aufträge und Rückgabe ungenutzter Nummern an den Pool oder die Behörde.
+  BC-2640.40:
+    name: Nummernportierungs-Management
+    description: |
+      Eingehende und ausgehende Mobil- und Festnetz-Nummernportierung und
+      Pflege von Routing-Referenzdaten.
+  BC-2640.40.10:
+    name: Port-In-Management
+    description: |
+      Behandlung eingehender Nummernportierungsanfragen von anderen Betreibern.
+  BC-2640.40.20:
+    name: Port-Out-Management
+    description: |
+      Behandlung ausgehender Nummernportierungsanfragen an andere Betreiber.
+  BC-2640.40.30:
+    name: Portierungsrouting-Referenzpflege
+    description: |
+      Pflege von Portierungsrouting-Daten einschließlich ENUM und zentraler Referenzdatenbanken.
+  BC-2640.50:
+    name: Geräteidentitäts-Management
+    description: |
+      Registrierung und Kontrolle von Geräteidentifikatoren für Dienst-Berechtigung
+      und Gestohlene-Geräte-Blacklisting.
+  BC-2640.50.10:
+    name: IMEI-Registrierung
+    description: |
+      Registrierung von Geräte-IMEIs gegen Teilnehmer und Dienst-Berechtigungsprüfungen.
+  BC-2640.50.20:
+    name: Geräteidentitätsregister-Pflege
+    description: |
+      Pflege von EIR-Daten für auf der Whitelist, Grayliste und Blacklist befindliche Geräte.
+  BC-2640.50.30:
+    name: Gestohlene-Geräte-Blacklisting
+    description: |
+      Blacklisting gestohlener und verlorener Geräte in Zusammenarbeit mit
+      Branche und Strafverfolgungsbehörden.
+  BC-2640.60:
+    name: Teilnehmer-Authentifizierung und Autorisierung
+    description: |
+      Authentifizierung, Autorisierung und Abrechnung von Teilnehmern und Geräten
+      über verschiedene Zugangstechnologien.
+  BC-2640.60.10:
+    name: Teilnehmer-Authentifizierung
+    description: |
+      Authentifizierung von Teilnehmern über Mobil-, Fest- und WLAN-Zugänge mittels AAA-Protokollen.
+  BC-2640.60.20:
+    name: Autorisierungsrichtlinien-Management
+    description: |
+      Verwaltung von Dienstberechtigungs- und Richtlinienregeln je Teilnehmer und Gerät.
+  BC-2640.60.30:
+    name: Abrechnungsdatensatz-Management
+    description: |
+      Generierung und Verwaltung von AAA-Abrechnungsdatensätzen für nachgelagerte
+      Abrechnung und Analytik.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-terminal-yard-operations-management.yaml
+++ b/catalogue/i18n/de/L1-terminal-yard-operations-management.yaml
@@ -1,0 +1,116 @@
+locale: de
+source: L1-terminal-yard-operations-management.yaml
+entries:
+  BC-2470:
+    name: Terminal- und Hofbetrieb-Management
+    description: |
+      Betrieb von Hafen-, intermodalen, Schienen- und Luftfracht-Terminals einschließlich
+      Schiffs- und Flugzeugabfertigung, Hofverwaltung, Tor- und Terminalausrüstungsbetrieb.
+  BC-2470.10:
+    name: Schiff- und Flugzeugabfertigungs-Management
+    description: |
+      Anlegen, Rampabfertigung und Beladung oder Entladung von Schiffen und
+      Flugzeugen an Terminals.
+    in_scope:
+      - Kaisei- und rampseitige Frachtoperationen
+      - Stauplanung an der Terminal-Schnittstelle
+    out_of_scope:
+      - Bordbetrieb während des Fernverkehrs (BC-2420.20)
+  BC-2470.10.10:
+    name: Schiffsanlegen und Stauplanung
+    description: |
+      Anlegen, Festmachen und Stauplanung für Schiffe im Hafen.
+  BC-2470.10.20:
+    name: Flugzeug-Rampenabfertigung
+    description: |
+      Rampenabfertigung und Be- und Entladung von Flugzeugen.
+  BC-2470.10.30:
+    name: Frachtbe- und Entladungsbetrieb
+    description: |
+      Be- und Entladung von Containern, ULDs und Stückgut.
+  BC-2470.20:
+    name: Hof- und Stapelverwaltung
+    description: |
+      Zuweisung und Bewegung von Containern, Trailern und Eisenbahnwaggons
+      auf Terminalgeländen und Stapelflächen.
+  BC-2470.20.10:
+    name: Hofstell-Zuweisung
+    description: |
+      Zuweisung von Hofstellplätzen an eingehende und ausgehende Einheiten.
+  BC-2470.20.20:
+    name: Container-Stapelplanung
+    description: |
+      Stapelplanung zur Optimierung von Umlagerungen und Ladevorbereitungen.
+  BC-2470.20.30:
+    name: Kühlketten- und Gefahrgut-Stapelverwaltung
+    description: |
+      Spezialisierte Stapelverwaltung für Kühlcontainer-Steckdosen und Gefahrguteinheiten.
+  BC-2470.30:
+    name: Tor-Betriebsmanagement
+    description: |
+      LKW- und Bahntorbetrieb einschließlich Vortor-Terminvereinbarung, Einfahrt und Ausfahrt.
+  BC-2470.30.10:
+    name: Einfahrts-Torbetrieb
+    description: |
+      Empfang einfahrender LKW und Eisenbahnwaggons am Terminal-Tor.
+  BC-2470.30.20:
+    name: Ausfahrts-Torbetrieb
+    description: |
+      Freigabe ausfahrender LKW und Eisenbahnwaggons vom Terminal-Tor.
+  BC-2470.30.30:
+    name: Vortor- und Terminverwaltung
+    description: |
+      Vortor-Identitäts-, Dokumenten- und Zeitfensterverwaltung.
+  BC-2470.40:
+    name: Terminal-Ausrüstungs-Betriebsmanagement
+    description: |
+      Betrieb und Instandhaltung von Terminal-Umschlagsgeräten wie Kränen, RTGs,
+      Reach-Stackern und Bodenabfertigungsgeräten.
+  BC-2470.40.10:
+    name: Kran- und RTG-Betrieb
+    description: |
+      Betrieb von Schiff-zu-Land-Kränen, RTGs und Portalkränen.
+  BC-2470.40.20:
+    name: Bodenabfertigungsgeräte-Betrieb
+    description: |
+      Betrieb von GSE wie Schleppern, Dollies und Ladegestellwagen.
+  BC-2470.40.30:
+    name: Terminal-Ausrüstungs-Instandhaltung
+    description: |
+      Instandhaltung und Überholung von Terminal-Umschlagsgeräten.
+  BC-2470.50:
+    name: Intermodaler Umschlags-Management
+    description: |
+      Umschlag von Fracht und Einheiten zwischen Verkehrsträgern an intermodalen Punkten
+      wie Bahn-Straße-Umschlagplätzen und Luftfracht-Interlining-Stationen.
+  BC-2470.50.10:
+    name: Bahnanlagen-Austausch
+    description: |
+      Austausch von Eisenbahnwaggons und intermodalen Einheiten zwischen Bahnbetreibern.
+  BC-2470.50.20:
+    name: LKW-Bahn-Umschlagsbetrieb
+    description: |
+      Umschlag von Containern und Trailern zwischen LKW und Bahn.
+  BC-2470.50.30:
+    name: Luftfracht-Interlining
+    description: |
+      Interlining von Fracht zwischen Luftfahrtgesellschaften an Hub-Flughäfen.
+  BC-2470.60:
+    name: Terminal-Kapazitäts- und Leistungsmanagement
+    description: |
+      Messung und Verbesserung von Terminal-Produktivität, Verweilzeit und Durchsatz.
+  BC-2470.60.10:
+    name: Liegeplatz- und Stand-Produktivität
+    description: |
+      Produktivitätsmessung an Schiffsanlegeplätzen und Flugzeugabfertigungsständen.
+  BC-2470.60.20:
+    name: Container-Verweilzeitmanagement
+    description: |
+      Verwaltung von Container-Verweilzeiten und Demurrage-Risiko.
+  BC-2470.60.30:
+    name: Terminal-Durchsatz-Berichterstattung
+    description: |
+      Berichterstattung über Terminal-Durchsatz nach Verkehrsträger und Einheitstyp.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-time-and-engagement-billing-management.yaml
+++ b/catalogue/i18n/de/L1-time-and-engagement-billing-management.yaml
@@ -1,0 +1,173 @@
+locale: de
+source: L1-time-and-engagement-billing-management.yaml
+entries:
+  BC-4330:
+    name: Zeit- und Projektabrechnung
+    description: |
+      Zeiterfassung, Work-in-Progress, Honorarvereinbarungen,
+      Rechnungsstellung, Realisierungsquote und Wertberichtigungssteuerung
+      für abrechnungsfähige Aufträge sowie Mandantentreuhand- und
+      Retainerfondsverwaltung für die Rechtspraxis.
+  BC-4330.10:
+    name: Zeiterfassungsmanagement
+    description: |
+      Erfassung, Validierung und Einreichung von Zeitbuchungen mit
+      narrativen Details auf Auftrags- und Aufgabenebene.
+  BC-4330.10.10:
+    name: Zeitbuchungserfassung
+    description: |
+      Tägliche Buchung abrechnungsfähiger und nicht abrechnungsfähiger
+      Zeit auf Auftrags-, Aufgaben- und Aktivitätsgranularität.
+  BC-4330.10.20:
+    name: Zeitnarrativ-Qualitätsmanagement
+    description: |
+      Qualitätskontrolle bei Zeitnarrativen zur Erfüllung von
+      Mandanten-Abrechnungsrichtlinien und E-Billing-Anforderungen.
+  BC-4330.10.30:
+    name: Zeiteinreichung und Genehmigung
+    description: |
+      Einreichung, Vorgesetztengenehmigung und Sperrung von
+      Zeitaufzeichnungen.
+  BC-4330.20:
+    name: Auftragsauslagenmanagement
+    description: |
+      Erfassung und Zuteilung auftragsbezogener Auslagen wie
+      Gerichtsgebühren, Sachverständigenhonorare, Reisekosten und
+      Druckkosten zur Weiterberechnung an den Mandanten.
+  BC-4330.20.10:
+    name: Auslagenerfassung
+    description: |
+      Erfassung von Auslagen auf der Auftragsakte zur späteren
+      Wiedereinbringung.
+  BC-4330.20.20:
+    name: Auslagenerstattbarkeitsüberprüfung
+    description: |
+      Überprüfung der Auslagenerstattbarkeit gemäß Auftragsschreiben
+      und Mandanten-Abrechnungsrichtlinien.
+  BC-4330.20.30:
+    name: Auslagenweiterberechnung auf Auftrag
+    description: |
+      Zuteilung genehmigter Auslagen auf den Auftrags-WIP zur
+      weiteren Fakturierung.
+  BC-4330.30:
+    name: Work-in-Progress-Management
+    description: |
+      Verfolgung offener WIP-Salden, Alterung und Entscheidungen
+      über Wertauf- oder -abschreibung vor der Fakturierung.
+  BC-4330.30.10:
+    name: WIP-Verfolgung
+    description: |
+      Echtzeit-Verfolgung offener WIP nach Auftrag, Partner und
+      Bereich.
+  BC-4330.30.20:
+    name: WIP-Alterungsanalyse
+    description: |
+      Alterungsanalyse offener WIP und Eskalation veralteter Salden.
+  BC-4330.30.30:
+    name: WIP-Wertauf- und -abschreibungsentscheidung
+    description: |
+      Partnerseitige Entscheidung über WIP-Wertauf-, -abschreibungen
+      und Stundungen vor der Fakturierung.
+  BC-4330.40:
+    name: Honorarvereinbarungsmanagement
+    description: |
+      Pflege auftragsebener Honorarstrukturen einschließlich
+      Stundensätzen, alternativer Honorarvereinbarungen, Pauschal-,
+      Erfolgshonoraren und Retainern.
+  BC-4330.40.10:
+    name: Stundensatzpflege
+    description: |
+      Pflege von Standard-, mandanten- und auftragssspezifischen
+      Stundensatzkarten.
+  BC-4330.40.20:
+    name: Alternative Honorarvereinbarungseinrichtung
+    description: |
+      Einrichtung von Pauschal-, Deckelungs-, Erfolgs-, Kontingenz-
+      und Retainer-Honorarvereinbarungen pro Auftrag.
+  BC-4330.40.30:
+    name: Honorarrabatt- und Mengenpreismanagement
+    description: |
+      Anwendung vereinbarter Honorarrabatte und Mengenpreise über
+      das Auftragsportfolio des Mandanten hinweg.
+  BC-4330.50:
+    name: Rechnungserstellungsmanagement
+    description: |
+      Erstellung von Auftragsrechnungen, Narrativformatierung und
+      Einhaltung mandantenseitiger E-Billing-Formatanforderungen.
+  BC-4330.50.10:
+    name: Pro-Forma-Rechnungsvorbereitung
+    description: |
+      Vorbereitung und Partnerüberprüfung von Pro-Forma-Rechnungen
+      vor endgültiger Ausstellung.
+  BC-4330.50.20:
+    name: Endgültige Rechnungsausstellung
+    description: |
+      Ausstellung endgültiger Auftragsrechnungen einschließlich
+      Narrativ, Auslagen und Steuern.
+  BC-4330.50.30:
+    name: Mandanten-E-Billing-Format-Compliance
+    description: |
+      Compliance mit mandantenseitigen E-Billing-Anforderungen
+      einschließlich LEDES, UTBMS-Aufgabencodes und
+      Client-Portal-Einreichung.
+  BC-4330.50.40:
+    name: Mandanten-Abrechnungsrichtlinien-Einhaltung
+    description: |
+      Anwendung mandantenseitiger Außenberater-Abrechnungsrichtlinien
+      für Zeit, Sätze und Auslagen.
+  BC-4330.60:
+    name: Auftrags-Realisierungsmanagement
+    description: |
+      Verfolgung von Rechnungs-zu-Einzugs- und Standard-zu-Rechnungs-
+      Realisierungsquoten, Abschreibungen und Auftragsprofitabilität.
+  BC-4330.60.10:
+    name: Standard-zu-Rechnungs-Realisierungsverfolgung
+    description: |
+      Verfolgung von Standard-WIP gegenüber Rechnungsbetrag zur
+      Aufdeckung von Umsatzlecks.
+  BC-4330.60.20:
+    name: Rechnungs-zu-Einzugs-Realisierungsverfolgung
+    description: |
+      Verfolgung des Rechnungsbetrags gegenüber eingezogenem Geld
+      einschließlich Wertberichtigung für Forderungsausfälle.
+  BC-4330.60.30:
+    name: Auftragsprofitabilitätsreporting
+    description: |
+      Berichterstattung über die Profitabilität pro Auftrag, Partner
+      und Bereich unter Verwendung von Realisierungserlösen und
+      direkten Kosten.
+  BC-4330.60.40:
+    name: Abschreibungsgenehmigung und -analyse
+    description: |
+      Genehmigungsworkflow und Ursachenanalyse von WIP- und
+      Forderungsabschreibungen.
+  BC-4330.70:
+    name: Mandantentreuhand- und Retainerfondsverwaltung
+    description: |
+      Verwaltung von Mandantengeldern auf Treuhandkonten,
+      IOLTA-ähnlichen Konten und Retainer-Salden mit spezifischen
+      Segregations- und Abstimmungsanforderungen für die Rechtspraxis.
+    in_scope:
+      - Mandantentreuhandkontobetrieb
+      - Retainersaldoverfolgung
+      - Treuhandkontoabstimmung und -reporting
+    out_of_scope:
+      - Allgemeine Kanzleikasse (BC-180)
+  BC-4330.70.10:
+    name: Mandantentreuhandkontobetrieb
+    description: |
+      Betrieb segregierter Mandantentreuhandkonten einschließlich
+      Einnahmen und Ausgaben im Auftrag des Mandanten.
+  BC-4330.70.20:
+    name: Retainersaldomanagement
+    description: |
+      Verfolgung von Mandantenretainersalden und
+      Aufstockungsauslösern.
+  BC-4330.70.30:
+    name: Treuhandabstimmung und -reporting
+    description: |
+      Dreiwegeabstimmung von Treuhandbüchern und gesetzliche oder
+      berufsständische Berichterstattung über Treuhandsalden.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-tour-itinerary-operations-management.yaml
+++ b/catalogue/i18n/de/L1-tour-itinerary-operations-management.yaml
@@ -1,0 +1,173 @@
+locale: de
+source: L1-tour-itinerary-operations-management.yaml
+entries:
+  BC-4100:
+    name: Reiseveranstaltung und Reisebürobetrieb Management
+    description: |
+      Betrieb von Reiseveranstalter- und Destination-Management-Aktivitäten –
+      Produktzusammenstellung und Lieferantenverträge, Abreiseentscheidungen,
+      Reiseleiter- und Begleiterbetrieb, Zielortlogistik, Lieferantenkoordination,
+      Reiseplanwiederherstellung und Reisendedokumentation.
+    in_scope:
+      - Tourprodukt-Zusammenstellung und Lieferantenverträge
+      - Abreiselimit- und Go/No-Go-Entscheidungen
+      - Reiseleiterzuweisung, Briefing und Einsatzleistung
+      - Zielort-Transfers und Tagesausflug-Erbringung
+      - Live-Reiseplanänderung und höhere-Gewalt-Wiederherstellung
+      - Tourkunden-Dokumentation und Gutscheinausstellung
+    out_of_scope:
+      - Tourproduktmaster- und Inventarpooldefinition (BC-4000.30)
+      - Reservierungs- und Buchungslebenszyklus (BC-4020)
+      - Kreuzfahrtbetrieb (BC-4090)
+  BC-4100.10:
+    name: Tourprodukt-Zusammenstellung und Vertragsabschluss
+    description: |
+      Zusammenstellung von Tourprodukten, Lieferantenverträge, Kalkulation,
+      Routing und Produktlebenszyklusstatus über Tourmarken hinweg.
+  BC-4100.10.10:
+    name: Lieferantenverträge und Kontingentverhandlung
+    description: |
+      Vertragsabschluss mit Unterkunfts-, Transport- und Aktivitätslieferanten
+      einschließlich Kontingentverhandlung.
+  BC-4100.10.20:
+    name: Tourkalkultion und Margenaufbau
+    description: |
+      Kalkulation von Tourprodukten und Margenaufbau gegen Zielverkaufspreise.
+  BC-4100.10.30:
+    name: Reiseplankomposition und Routing
+    description: |
+      Komposition von Reiseplänen und Routing über Zielorte und Lieferantenkomponenten.
+  BC-4100.10.40:
+    name: Tourprodukt-Lebenszyklus-Status
+    description: |
+      Lebenszyklusstatus von Tourprodukten von Konzept und Pilot bis Eingestellt.
+  BC-4100.20:
+    name: Tourabreise-Management
+    description: |
+      Entscheidungen zu Tourabreisen einschließlich Mindestpassagier-Schwellen,
+      Zuteilung, Markenkonsolidierung und Stornierung oder Substitution.
+  BC-4100.20.10:
+    name: Abreiselimit- und Go/No-Go-Entscheidung
+    description: |
+      Entscheidung, ob geplante Abreisen gegen Mindestpassagier-Schwellen operiert werden.
+  BC-4100.20.20:
+    name: Abreisezuteilung und Inventarfreigabe
+    description: |
+      Sitzzuteilung und Inventarfreigabeentscheidungen über Abreisen.
+  BC-4100.20.30:
+    name: Abreisekonsolidierung über Marken
+    description: |
+      Konsolidierung marginaler Abreisen über Schwestermarken oder Partnerveranstalter.
+  BC-4100.20.40:
+    name: Abreisestornierung und Substitution
+    description: |
+      Stornierung nicht lebensfähiger Abreisen und Substitution auf alternative Abreisedaten.
+  BC-4100.30:
+    name: Reiseleiter- und Begleiterbetrieb
+    description: |
+      Zuweisung, Briefing, Leistungsmanagement und lokale Reiseleiterkoordination
+      für die Tourerbringung.
+  BC-4100.30.10:
+    name: Reiseleiter- und Tour-Direktor-Zuweisung
+    description: |
+      Zuweisung von Reiseleitern und Tour-Direktoren zu Abreisen
+      gegen Sprach- und Reiseplananforderungen.
+  BC-4100.30.20:
+    name: Vor-Tour-Briefing und Skriptmanagement
+    description: |
+      Vor-Tour-Briefing von Begleiterteams und Management von Reiseplanen-Skripten.
+  BC-4100.30.30:
+    name: Reiseleiter-Einsatzleistungsüberwachung
+    description: |
+      Überwachung der Reiseleiterleistung während der Tourerbringung.
+  BC-4100.30.40:
+    name: Lokale Reiseleiterkoordination
+    description: |
+      Koordination lokaler Reiseleiter an Zielorten gegen stadtteil- und standortspezifische Anforderungen.
+  BC-4100.40:
+    name: Zielort-Logistik und Transfers
+    description: |
+      Zielort-Logistik einschließlich Bus- und Fahrzeugdiensten,
+      Flughafen- und Hotel-Transfers, Tagesausflugserbringung und Aktivitätsticketierung.
+  BC-4100.40.10:
+    name: Bus- und Fahrzeuglogistik
+    description: |
+      Logistik für Bus- und Fahrzeugdienste über den Reiseplan.
+  BC-4100.40.20:
+    name: Flughafen- und Hotel-Transfers
+    description: |
+      Betrieb von Flughafen- und Hotel-Transfers für Tourreisende.
+  BC-4100.40.30:
+    name: Tagesausflug-Erbringungsbetrieb
+    description: |
+      Durchführung von Tagesausflügen und Exkursionen in Mehrtages-Reiseplänen.
+  BC-4100.40.40:
+    name: Aktivitäts- und Attraktionsticketierungsbetrieb
+    description: |
+      Betrieb der Aktivitäts- und Attraktionsticketierung einschließlich Zeitfensterzuteilung.
+  BC-4100.50:
+    name: Tour-Lieferantenkoordination
+    description: |
+      Koordination mit Destination-Management-Unternehmen, Unterkunfts-
+      und Aktivitätslieferanten über die operative Erbringung.
+  BC-4100.50.10:
+    name: DMC- und Lokalbetreiberkoordination
+    description: |
+      Koordination mit Destination-Management-Unternehmen und lokalen Betreibern.
+  BC-4100.50.20:
+    name: Unterkunftslieferantenkoordination
+    description: |
+      Koordination mit Unterkunftslieferanten zu Zimmerlisten, Ankunftszeiten und Sonderwünschen.
+  BC-4100.50.30:
+    name: Attraktions- und Aktivitätslieferantenkoordination
+    description: |
+      Koordination mit Attraktions- und Aktivitätslieferanten zu Zugang und Kapazität.
+  BC-4100.50.40:
+    name: Lieferantenleistungsbetrieb
+    description: |
+      Operative Leistungsverwaltung von Tourlieferanten auf Basis von Begleiterfeedback.
+  BC-4100.60:
+    name: Reiseplanänderung und Wiederherstellung
+    description: |
+      Live-Änderung von Reiseplänen und Wiederherstellung nach Störungsereignissen
+      einschließlich höherer Gewalt und reisendenseitiger Änderungen.
+  BC-4100.60.10:
+    name: Live-Reiseplanänderungsbetrieb
+    description: |
+      Live-Änderung von Reiseplänen während einer laufenden Tour durch operative Auslöser.
+  BC-4100.60.20:
+    name: Höhere-Gewalt-Reiseplanwiederherstellung
+    description: |
+      Wiederherstellung von Reiseplänen bei höherer Gewalt wie Wetter, Streiks und politische Unruhen.
+  BC-4100.60.30:
+    name: Reisendenseitige Reiseplanänderung
+    description: |
+      Bearbeitung reisendenseitiger Änderungen, die nachgelagerte Lieferantenbuchungen betreffen.
+  BC-4100.60.40:
+    name: Wiederherstellungsentschädigungsfeststellung
+    description: |
+      Feststellung von Entschädigungen nach Reiseplanänderungen einschließlich Erstattung.
+  BC-4100.70:
+    name: Tour-Kundendokumentation
+    description: |
+      Ausstellung und Neuausstellung von Abschlussdokumenten, Gutscheinen,
+      Vorabreiseinformationen und tourspezifischer Reisendekommunikation.
+  BC-4100.70.10:
+    name: Abschlussdokumentenausstellung
+    description: |
+      Ausstellung von Abschlussdokumenten einschließlich finalem Reiseplan und Notfallkontakten.
+  BC-4100.70.20:
+    name: Gutschein- und Servicedokumentenausstellung
+    description: |
+      Ausstellung von Gutscheinen und Servicedokumenten für Tourlieferanten.
+  BC-4100.70.30:
+    name: Vorabreise-Informationspaket
+    description: |
+      Zusammenstellung von Vorabreise-Informationspaketen einschließlich Gesundheits-, Visa- und Packhinweise.
+  BC-4100.70.40:
+    name: Reisedokument-Neuausstellungsbetrieb
+    description: |
+      Neuausstellung von Dokumenten nach Reiseplanänderungen und Reisendedatenänderungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-trade-finance-management.yaml
+++ b/catalogue/i18n/de/L1-trade-finance-management.yaml
@@ -1,0 +1,98 @@
+locale: de
+source: L1-trade-finance-management.yaml
+entries:
+  BC-1350:
+    name: Handelsfinanzierungs-Management
+    description: |
+      Dokumentenakkreditive, Garantien, Lieferkettenfinanzierung und Handelskredite.
+  BC-1350.10:
+    name: Dokumentenakkreditiv-Management
+    description: |
+      Akkreditive, Import-/Export-Akkreditive.
+  BC-1350.10.10:
+    name: Akkreditiv-Eröffnung
+    description: |
+      Eröffnung von Import-Akkreditiven gemäß UCP 600.
+  BC-1350.10.20:
+    name: Akkreditiv-Avisierung und -Bestätigung
+    description: |
+      Avisierung und Bestätigung von Export-Akkreditiven.
+  BC-1350.10.30:
+    name: Dokumentenprüfung und Compliance
+    description: |
+      Prüfung von Dokumenten auf UCP- und ISBP-Konformität.
+  BC-1350.10.40:
+    name: Akkreditiv-Abwicklung und -Rückerstattung
+    description: |
+      Abwicklung und Rückerstattung im Rahmen von Dokumentenakkreditiven.
+  BC-1350.20:
+    name: Garantien- und Standby-Akkreditiv-Management
+    description: |
+      Bankgarantien, Standby-Akkreditive und Erfüllungssicherheiten.
+  BC-1350.20.10:
+    name: Bankgarantie-Eröffnung
+    description: |
+      Eröffnung von Bankgarantien und Erfüllungssicherheiten.
+  BC-1350.20.20:
+    name: Standby-Akkreditiv-Eröffnung
+    description: |
+      Eröffnung von Standby-Akkreditiven gemäß ISP98.
+  BC-1350.20.30:
+    name: Garantieanspruchs-Bearbeitung
+    description: |
+      Bearbeitung von Forderungen und Ansprüchen aus Garantien.
+  BC-1350.20.40:
+    name: Garantieänderung und -kündigung
+    description: |
+      Änderungen, Verlängerungen und Kündigung von Garantien.
+  BC-1350.30:
+    name: Dokumenteninkasso-Management
+    description: |
+      D/P- und D/A-Dokumenteninkasso.
+  BC-1350.30.10:
+    name: Dokumente-gegen-Zahlung-Betrieb
+    description: |
+      D/P-Inkassobetrieb gemäß URC 522.
+  BC-1350.30.20:
+    name: Dokumente-gegen-Akzept-Betrieb
+    description: |
+      D/A-Inkassobetrieb einschließlich Wechsel.
+  BC-1350.30.30:
+    name: Inkasso-Abwicklung
+    description: |
+      Abwicklung und Überweisung im Rahmen von Dokumenteninkasso.
+  BC-1350.40:
+    name: Lieferkettenfinanzierungs-Management
+    description: |
+      Reverse Factoring, Verbindlichkeitenfinanzierung und dynamischer Skonto.
+  BC-1350.40.10:
+    name: Käufergesteuerte Verbindlichkeitenfinanzierung
+    description: |
+      Reverse-Factoring- und käufergesteuerte Verbindlichkeitenfinanzierungsprogramme.
+  BC-1350.40.20:
+    name: Forderungsfinanzierungsprogramme
+    description: |
+      Forderungsfinanzierung und Factoring für Verkäufer.
+  BC-1350.40.30:
+    name: Dynamischer-Skonto-Betrieb
+    description: |
+      Dynamische Diskontierungsplattformen und Skontberechnung.
+  BC-1350.50:
+    name: Handelskredite-Management
+    description: |
+      Vor- und Nachexport-Handelsfinanzierung.
+  BC-1350.50.10:
+    name: Vorexport-Handelsfinanzierung
+    description: |
+      Vorexportfinanzierung von Betriebskapital und Produktion.
+  BC-1350.50.20:
+    name: Nachexport-Handelsfinanzierung
+    description: |
+      Nachexport-Diskontierung und Forfaitierungsgeschäfte.
+  BC-1350.50.30:
+    name: Importhandelsfinanzierung
+    description: |
+      Importfinanzierung einschließlich Überbrückung und Verfügungsbelegen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-trade-promotion-management.yaml
+++ b/catalogue/i18n/de/L1-trade-promotion-management.yaml
@@ -1,0 +1,115 @@
+locale: de
+source: L1-trade-promotion-management.yaml
+entries:
+  BC-2360:
+    name: Handelspromotion-Management
+    description: |
+      Konsumgüterdisziplin der Handelsinvestition bei Einzelhandelskunden –
+      gemeinsame Geschäftspläne, Handelsausgaben-Budgetierung, In-Store-Aktivierungs-
+      durchführung, Abzugsverwaltung und Messung des Uplift nach Aktionen.
+  BC-2360.10:
+    name: Handelspromotion-Strategie und Planung
+    description: |
+      Jährliche Handelspromotion-Strategie, kundenbezogene Investitionsplanung und
+      gemeinsame Geschäftspläne, die mit Einzelhandelskunden verhandelt werden.
+    in_scope:
+      - Jährlicher Handelspromotion-Kalender
+      - Kundenbezogene gemeinsame Geschäftspläne
+      - Listungsgebühren-Strategie
+  BC-2360.10.10:
+    name: Jährliche Handelsplanerstellung
+    description: |
+      Entwicklung des jährlichen Handelspromotion-Plans und Aktionskalenders.
+  BC-2360.10.20:
+    name: Gemeinsame Geschäftsplanung mit Kunden
+    description: |
+      Gemeinsame Geschäftsplanung mit strategischen Einzelhandelskunden.
+  BC-2360.10.30:
+    name: Listungsgebühren-Strategie
+    description: |
+      Strategie und Verhandlung von Listungs- und Einführungsgebühren für neue Artikel.
+  BC-2360.20:
+    name: Handelsausgaben-Budgetmanagement
+    description: |
+      Budgetierung von Handelsausgaben, Rückstellungen, Kundenzuweisung und
+      finanzielle Steuerung der Handelsinvestitionen.
+  BC-2360.20.10:
+    name: Handelsausgaben-Budgetierung
+    description: |
+      Budgetierung der Handelsausgaben nach Kunde, Marke und Aktion.
+  BC-2360.20.20:
+    name: Handelsausgaben-Rückstellungsmanagement
+    description: |
+      Rückstellung von Handelsausgaben-Verbindlichkeiten nach Kunde und Aktion.
+  BC-2360.20.30:
+    name: Handelsausgaben-Zuweisung
+    description: |
+      Zuweisung von Handelsausgabenbudgets auf Kunden, Regionen und Aktionen.
+  BC-2360.20.40:
+    name: Handelsausgaben-Finanzkontrolle
+    description: |
+      Finanzielle Kontrolle der Handelsausgaben einschließlich Genehmigungsgrenzen.
+  BC-2360.30:
+    name: Promotionsaktions-Durchführungsmanagement
+    description: |
+      Durchführung von In-Store- und Online-Promotionsaktionen einschließlich
+      Perfect-Store-Audits und Außendienst-Aktivierung.
+  BC-2360.30.10:
+    name: Aktionseinrichtung beim Kunden
+    description: |
+      Einrichtung von Promotionsaktionen beim Einzelhandelskunden einschließlich Artwork und Prognosen.
+  BC-2360.30.20:
+    name: In-Store-Aktivierung und Displays
+    description: |
+      Aktivierung von In-Store-Displays, Gondeln und Zweitplatziererungen.
+  BC-2360.30.30:
+    name: Perfect-Store-Audit-Durchführung
+    description: |
+      Außendienstdurchführung von Perfect-Store-Audits und Bilderkennungsprüfungen.
+  BC-2360.30.40:
+    name: Außendienst-Aktivierung
+    description: |
+      Aktivierung von Außendienstteams zur Förderung der Aktionsdurchführung.
+  BC-2360.40:
+    name: Abzugs- und Reklamationsmanagement
+    description: |
+      Validierung, Anfechtung und Lösung von Kundenabzügen und
+      Promotionsansprüchen, die gegen Rechnungen geltend gemacht werden.
+    in_scope:
+      - Abzugserfassung und Zuordnung zu Aktionen
+      - Validierung gegen vereinbarte Konditionen
+      - Streitbeilegung und Rückforderung
+    out_of_scope:
+      - Allgemeines Forderungsmanagement (BC-200)
+  BC-2360.40.10:
+    name: Abzugserfassung und Zuordnung
+    description: |
+      Erfassung von Kundenabzügen und Zuordnung zu Promotionsaktionen.
+  BC-2360.40.20:
+    name: Abzugsvalidierung
+    description: |
+      Validierung von Abzügen gegen vereinbarte Konditionen, Mengen und Preise.
+  BC-2360.40.30:
+    name: Streitbeilegung und Rückforderung
+    description: |
+      Streitbeilegung mit dem Kunden und Rückforderung ungültiger Abzüge.
+  BC-2360.50:
+    name: Handelspromotion-Effektivitätsmessung
+    description: |
+      Nachmessung von Promotions-Uplift, Baseline-vs.-Incremental-Analyse
+      und ROI nach Aktion, Kunde und Marke.
+  BC-2360.50.10:
+    name: Baseline- und Uplift-Messung
+    description: |
+      Messung der Baseline-Umsätze und des inkrementellen Uplift durch Promotionsaktionen.
+  BC-2360.50.20:
+    name: Promotions-ROI-Analyse
+    description: |
+      ROI-Analyse von Handelspromotionen nach Aktion, Kunde und Marke.
+  BC-2360.50.30:
+    name: Kannibalisierungs- und Vorzieheffekt-Analyse
+    description: |
+      Analyse von Kannibalisierungs- und Nachfragevorzieheffekten.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-transformation-management.yaml
+++ b/catalogue/i18n/de/L1-transformation-management.yaml
@@ -1,0 +1,86 @@
+locale: de
+source: L1-transformation-management.yaml
+entries:
+  BC-920:
+    name: Transformationsmanagement
+    description: |
+      Großangelegte Unternehmenstransformationsprogramme.
+  BC-920.10:
+    name: Transformationsprogramm-Management
+    description: |
+      Durchgängige Lieferung von Transformationsprogrammen.
+  BC-920.10.10:
+    name: Transformationsvision und -design
+    description: |
+      Definition von Transformationsvision, Zielzustand und Design.
+  BC-920.10.20:
+    name: Transformations-Roadmap-Definition
+    description: |
+      Mehrjährige Transformations-Roadmap und -Wellen.
+  BC-920.10.30:
+    name: Transformations-Workstream-Lieferung
+    description: |
+      Lieferung von Transformations-Workstreams und Abhängigkeiten.
+  BC-920.10.40:
+    name: Transformationsrisikomanagement
+    description: |
+      Identifikation und Management von Risiken auf Transformationsebene.
+  BC-920.20:
+    name: Transformationssteuerungs-Management
+    description: |
+      Transformationssteuerung, Entscheidungsrechte und Eskalation.
+  BC-920.20.10:
+    name: Transformationssteuerungsgremien-Betrieb
+    description: |
+      Betrieb von Lenkungsausschuss und Designbehörde.
+  BC-920.20.20:
+    name: Transformationsentscheidungsmanagement
+    description: |
+      Entscheidungsrahmen, Entscheidungsprotokoll und Eskalationswege.
+  BC-920.20.30:
+    name: Transformationsqualitätssicherung
+    description: |
+      Unabhängige Qualitätssicherung des Transformationsgesundheitszustands.
+  BC-920.30:
+    name: Nutzenrealisierungsmanagement
+    description: |
+      Nutzendidentifikation, -verfolgung und -realisierung.
+  BC-920.30.10:
+    name: Nutzendidentifikation und -mapping
+    description: |
+      Identifikation und Nutzenkarte mit Verknüpfung zu Ergebnissen.
+  BC-920.30.20:
+    name: Nutzen-Baseline und Zielsetzung
+    description: |
+      Baseline-Messung und Definition von Nutzungszielen.
+  BC-920.30.30:
+    name: Nutzenverfolgung und -berichterstattung
+    description: |
+      Nutzenverfolgung, Realisierungsberichterstattung und Validierung.
+  BC-920.30.40:
+    name: Wertschöpfungsoptimierung
+    description: |
+      Identifikation zusätzlicher Wertschöpfungsmöglichkeiten.
+  BC-920.40:
+    name: Transformationsbüro-Betrieb
+    description: |
+      Transformationsbüro-Dienstleistungen und -betrieb.
+  BC-920.40.10:
+    name: Transformationsbüro-Aufbau
+    description: |
+      Aufbau des Transformationsbüros, Rollen und Betriebsmodell.
+  BC-920.40.20:
+    name: Transformationsberichterstattung
+    description: |
+      Berichterstattung und Dashboards zum Transformationsfortschritt.
+  BC-920.40.30:
+    name: Transformationswerkzeug-Management
+    description: |
+      Werkzeuge für Transformationsverfolgung, Abhängigkeiten und Nutzen.
+  BC-920.40.40:
+    name: Transformationskompetenzaufbau
+    description: |
+      Kompetenzaufbau und Coaching für Transformationsleiter.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-transport-network-planning-management.yaml
+++ b/catalogue/i18n/de/L1-transport-network-planning-management.yaml
@@ -1,0 +1,101 @@
+locale: de
+source: L1-transport-network-planning-management.yaml
+entries:
+  BC-2410:
+    name: Transportnetzplanung
+    description: |
+      Gestaltung von Transportnetzwerken, Strecken, Hubs, Fahrplänen und Modalitätsmix,
+      die das Dienstleistungsportfolio des Carriers oder 3PL bestimmen.
+  BC-2410.10:
+    name: Netzwerkdesign-Management
+    description: |
+      Langfristiges Design von Hubs, Gateways, Strecken und Modalitätsmix zur
+      Unterstützung des Dienstleistungsportfolios.
+    in_scope:
+      - Hub-and-Spoke- und Punkt-zu-Punkt-Strukturentscheidungen
+      - Modalitätsmix-Design über Straße, Schiene, See und Luft
+    out_of_scope:
+      - Nachfrageseitiges Netzwerkdesign durch Versender (BC-520)
+  BC-2410.10.10:
+    name: Hub- und Gateway-Design
+    description: |
+      Auswahl und Dimensionierung von Hubs, Gateways und Konsolidierungspunkten.
+  BC-2410.10.20:
+    name: Strecken- und Service-Design
+    description: |
+      Definition von Ursprungs-Ziel-Strecken und den darauf verkehrenden Services.
+  BC-2410.10.30:
+    name: Modalitätsmix-Design
+    description: |
+      Wahl des Verkehrsträgers und intermodalen Mix für jede Strecke und Servicestufe.
+  BC-2410.20:
+    name: Fahrplanplanungs-Management
+    description: |
+      Erstellung von Masterfahrplänen, Slots und Servicezeitfenstern für Schiffsfahrten,
+      Flüge, Zugpfade und LKW-Abfahrten.
+  BC-2410.20.10:
+    name: Masterfahrplan-Design
+    description: |
+      Design wiederkehrender Schiffs-, Flug-, Zug- und LKW-Fahrpläne.
+  BC-2410.20.20:
+    name: Slot- und Zeitfensterplanung
+    description: |
+      Zuweisung von Liegeplatz-, Start- und Gate-Zeitfenstern an geplante Services.
+  BC-2410.20.30:
+    name: Fahrplanveröffentlichung
+    description: |
+      Veröffentlichung von Fahrplänen an Kunden, Partner und Buchungskanäle.
+  BC-2410.30:
+    name: Servicemuster-Management
+    description: |
+      Definition von Serviceprodukten, Transitzeitkategorien und dem Katalog
+      der Kundenservices.
+  BC-2410.30.10:
+    name: Servicelevel-Definition
+    description: |
+      Definition von Express-, Standard-, Verzögerungs- und intermodalen Servicestufen
+      mit ihren Leistungsversprechen.
+  BC-2410.30.20:
+    name: Transitzeitgestaltung
+    description: |
+      Gestaltung der Ende-zu-Ende-Transitzeiten über Streckenabschnitte und Umladepunkte.
+  BC-2410.30.30:
+    name: Servicekatalog-Management
+    description: |
+      Pflege des veröffentlichten Katalogs der Transportservices.
+  BC-2410.40:
+    name: Kapazitäts-Nachfrage-Ausgleichs-Management
+    description: |
+      Abstimmung der geplanten Kapazität mit der prognostizierten Nachfrage einschließlich
+      Leercontainer-Repositionierung.
+  BC-2410.40.10:
+    name: Nachfrageprognose-Integration
+    description: |
+      Integration von Kunden- und Marktnachfrageprognosen in Netzwerkpläne.
+  BC-2410.40.20:
+    name: Kapazitätsplan-Abstimmung
+    description: |
+      Abstimmung der geplanten Kapazität gegenüber Nachfrage und Einschränkungen.
+  BC-2410.40.30:
+    name: Leerausrüstungs-Repositionierungsplanung
+    description: |
+      Planung der Repositionierung leerer Container, Trailer und ULDs.
+  BC-2410.50:
+    name: Netzwerkoptimierung und Simulation
+    description: |
+      Modellierung, Simulation und Benchmarking von Netzwerkoptionen und Störungsszenarien.
+  BC-2410.50.10:
+    name: Netzwerkmodellierung
+    description: |
+      Erstellung analytischer Modelle des Transportnetzwerks.
+  BC-2410.50.20:
+    name: Szenariosimulation
+    description: |
+      Simulation von Nachfrage-, Störungs- und Designalternativen.
+  BC-2410.50.30:
+    name: Netzwerkleistungs-Benchmarking
+    description: |
+      Benchmarking von Netzwerkkosten und Service gegenüber Wettbewerbern und früheren Konfigurationen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-transport-operations-management.yaml
+++ b/catalogue/i18n/de/L1-transport-operations-management.yaml
@@ -1,0 +1,125 @@
+locale: de
+source: L1-transport-operations-management.yaml
+entries:
+  BC-2420:
+    name: Transportbetrieb-Management
+    description: |
+      Multimodale Durchführung von Transportbewegungen von der Abholung über den
+      Fernverkehr, Nahverkehr bis zur Letzte-Meile-Zustellung, einschließlich
+      Reaktion auf betriebliche Störungen.
+  BC-2420.10:
+    name: Disposition-Management
+    description: |
+      Zuweisung von Ladungen, Fahrern, Besatzungen und Ausrüstung für geplante und
+      Ad-hoc-Transportbewegungen.
+    in_scope:
+      - Ladungs-zu-Fahrer- und Ladungs-zu-Fahrzeug-Zuweisung
+      - Ausrüstungspositionierungsanweisungen
+    out_of_scope:
+      - Fahrereinteilung vor der Disposition (BC-2440)
+      - Kapazitätszuweisung nach Vertrag (BC-2400.20)
+  BC-2420.10.10:
+    name: Ladungszuweisung
+    description: |
+      Zuweisung von Ladungen an Fahrzeuge, Schiffe, Flüge oder Zugpfade.
+  BC-2420.10.20:
+    name: Fahrer- und Besatzungsdisposition
+    description: |
+      Disposition qualifizierter Fahrer und Besatzungen für zugewiesene Ladungen.
+  BC-2420.10.30:
+    name: Ausrüstungsdisposition
+    description: |
+      Positionierung von Containern, Trailern und ULDs für zugewiesene Bewegungen.
+  BC-2420.20:
+    name: Fernverkehrs-Betriebsmanagement
+    description: |
+      Langstreckentransport von Fracht zwischen Hubs, Terminals und Gateways über verschiedene Verkehrsträger.
+  BC-2420.20.10:
+    name: Straßen-Fernverkehr-Betrieb
+    description: |
+      Langstrecken-LKW-Transport zwischen Hubs und Terminals.
+  BC-2420.20.20:
+    name: Schienen-Fernverkehr-Betrieb
+    description: |
+      Betrieb von Güterzügen und Blockzug-Services.
+  BC-2420.20.30:
+    name: Seefernverkehr-Betrieb
+    description: |
+      Fahrtbetrieb zwischen Häfen einschließlich Umladestrecken.
+  BC-2420.20.40:
+    name: Luftfernverkehr-Betrieb
+    description: |
+      Betrieb von Frachtflügen und Freighter-Services zwischen Flughäfen.
+  BC-2420.30:
+    name: Abholung und Nahverkehr-Betriebsmanagement
+    description: |
+      Erstmeilenabholungen bei Versendern und Kurzstrecken-Nahverkehr zwischen Terminals,
+      Höfen und Binnenpunkten.
+  BC-2420.30.10:
+    name: Abholungsbetrieb
+    description: |
+      Abholung von Fracht bei Versendern und Konsolidatoren.
+  BC-2420.30.20:
+    name: Container-Nahverkehr-Betrieb
+    description: |
+      Container-Nahverkehr zwischen Hafenterminals, Bahnanlagen und Binnenlagern.
+  BC-2420.30.30:
+    name: Leerausrüstungsbewegung
+    description: |
+      Bewegung leerer Container, Trailer und ULDs zwischen Lagern.
+  BC-2420.40:
+    name: Letzte-Meile-Zustellungs-Betriebsmanagement
+    description: |
+      Letzte-Leg-Zustellung an Empfänger einschließlich Routenplanung, Durchführung und
+      Zustellnachweis.
+  BC-2420.40.10:
+    name: Letzte-Meile-Routenplanung
+    description: |
+      Routenplanung und Sequenzierung von Zustellpunkten und Zeitfenstern.
+  BC-2420.40.20:
+    name: Kundenzustellungsdurchführung
+    description: |
+      Vor-Ort-Zustellung, Unterschriftserfassung und Übergabe an Empfänger.
+  BC-2420.40.30:
+    name: Zustellnachweis
+    description: |
+      Erfassung und Speicherung von Zustellnachweisen.
+  BC-2420.40.40:
+    name: Zustellausnahme-Behandlung
+    description: |
+      Behandlung von Annahmeverweigerungen, Fehlzustellungen und Wiederzustellversuchen.
+  BC-2420.50:
+    name: Betriebsstörungs-Management
+    description: |
+      Erkennung laufender betrieblicher Störungen und Orchestrierung von Wiederherstellungsmaßnahmen.
+  BC-2420.50.10:
+    name: Betriebsvorfall-Erkennung
+    description: |
+      Erkennung von Pannen, Wetterbedingungen, Hafenverzögerungen und anderen Störungen.
+  BC-2420.50.20:
+    name: Umleitung und Wiederherstellung
+    description: |
+      Umleitung von Fracht und Wiederherstellung gestörter Services.
+  BC-2420.50.30:
+    name: Dienstwiederherstellung
+    description: |
+      Wiederherstellung normaler Fahrpläne und Kundenzusagen.
+  BC-2420.60:
+    name: Betriebsleistungs-Management
+    description: |
+      Betriebliche Messung von Pünktlichkeit, Transitzeiten und Servicelevel-Einhaltung.
+  BC-2420.60.10:
+    name: Pünktlichkeits-Tracking
+    description: |
+      Verfolgung pünktlicher Abholung, Abfahrt, Ankunft und Zustellung.
+  BC-2420.60.20:
+    name: Transitzeitüberwachung
+    description: |
+      Überwachung tatsächlicher versus zugesagter Transitzeiten.
+  BC-2420.60.30:
+    name: Betriebs-KPI-Berichterstattung
+    description: |
+      Berichterstattung über Betriebs-KPIs an interne und externe Stakeholder.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-travel-distribution-channel-management.yaml
+++ b/catalogue/i18n/de/L1-travel-distribution-channel-management.yaml
@@ -1,0 +1,171 @@
+locale: de
+source: L1-travel-distribution-channel-management.yaml
+entries:
+  BC-4010:
+    name: Reisedistributionskanal Management
+    description: |
+      Management der Vertriebswege und des Merchandisings von Reiseprodukten über
+      Direkt-, GDS-, OTA-, Großhandels- und Metasuchkanäle – einschließlich
+      Kanalanbindung, Inhalts-Syndizierung und Raten-/Verfügbarkeitsparität.
+    in_scope:
+      - Direkt-, GDS-, OTA-, Großhandels- und Metasuchkanalbetrieb
+      - Kanalmanager-Hub-Betrieb und Inhalts-Syndizierung
+      - Raten- und Verfügbarkeitsparitätspolitik und -durchsetzung
+    out_of_scope:
+      - Produktmaster- und Inventarpooldefinition (BC-4000)
+      - Reservierungslebenszyklus (BC-4020)
+      - Preis- und Yield-Entscheidungen (BC-4030)
+  BC-4010.10:
+    name: Direktkanal-Vertriebsmanagement
+    description: |
+      Vertrieb von Reiseprodukten über unternehmensinterne Direktkanäle
+      einschließlich Web, Mobil, Telefon und Self-Service-Kiosken.
+  BC-4010.10.10:
+    name: Markenwebsite-Vertriebsmanagement
+    description: |
+      Betrieb der Markenwebsite als direkter Einkaufs- und Buchungskanal
+      für Reiseprodukte.
+  BC-4010.10.20:
+    name: Mobile-App-Vertriebsmanagement
+    description: |
+      Betrieb nativer mobiler Anwendungen als direkter Vertriebs- und Servicekanal.
+  BC-4010.10.30:
+    name: Telefon- und Callcenter-Vertrieb
+    description: |
+      Telefon- und Callcenter-Vertrieb einschließlich agentenunterstützter Buchung.
+  BC-4010.10.40:
+    name: Kiosk- und Self-Service-Vertrieb
+    description: |
+      Self-Service-Vertrieb über Kioske an Flughäfen, Hotels und Partnerstandorten.
+  BC-4010.20:
+    name: GDS-Vertriebsmanagement
+    description: |
+      Vertrieb über globale Vertriebssysteme einschließlich Inhaltssynchronisation,
+      Buchungsklassen-Mapping und Kostenmanagement.
+  BC-4010.20.10:
+    name: GDS-Konnektivitätsbetrieb
+    description: |
+      Betrieb der Konnektivität zu GDS-Anbietern über Angebots-, Buchungs- und Ticketprozesse.
+  BC-4010.20.20:
+    name: GDS-Inhaltspush und Synchronisation
+    description: |
+      Push und Synchronisation von Inhalten, Raten und Verfügbarkeiten an GDS-Anbieter.
+  BC-4010.20.30:
+    name: GDS-Buchungsklassen-Mapping
+    description: |
+      Zuordnung interner Produktklassen zu GDS-Buchungsklassen und Ratencodes.
+  BC-4010.20.40:
+    name: GDS-Kosten- und Aufschlagsmanagement
+    description: |
+      Management von GDS-Buchungsgebühren, Aufschlägen und Vertriebskostenzuordnung.
+  BC-4010.30:
+    name: OTA- und Großhandelsvertriebsmanagement
+    description: |
+      Vertrieb über Online-Reisebüros, Bettenbörsen und B2B-Großhändler
+      einschließlich kommerzieller Konditionen und Inhalts-Overrides.
+  BC-4010.30.10:
+    name: OTA-Konnektivitätsbetrieb
+    description: |
+      Betrieb der Konnektivität zu OTAs für Angebots-, Buchungs- und Nachbuchungsprozesse.
+  BC-4010.30.20:
+    name: Großhandels- und Bettenbörsen-Konnektivität
+    description: |
+      Betrieb der Konnektivität zu Großhändlern und Bettenbörsen für B2B-Weitervertrieb.
+  BC-4010.30.30:
+    name: OTA-Konditionenmanagement
+    description: |
+      Management von OTA-Konditionen einschließlich Provision, Aufschlag und Nettopreismodellen.
+  BC-4010.30.40:
+    name: OTA-Inhalts-Override-Management
+    description: |
+      Management kanalspezifischer Inhalts-Overrides für OTAs unter Wahrung der Markenkonsistenz.
+  BC-4010.40:
+    name: Metasuche-Vertriebsmanagement
+    description: |
+      Vertrieb und Gebotsabgabe auf Metasuchplattformen einschließlich Feed-Betrieb
+      und Konversions-Tracking.
+  BC-4010.40.10:
+    name: Metasuche-Feed-Betrieb
+    description: |
+      Betrieb von Preis- und Verfügbarkeits-Feeds an Metasuche-Anbieter.
+  BC-4010.40.20:
+    name: Metasuche-Gebotsbetrieb
+    description: |
+      Betrieb von Gebotsstrategien auf Metasuche-Platzierungen über Märkte und Geräte.
+  BC-4010.40.30:
+    name: Metasuche-Konversions-Tracking
+    description: |
+      Tracking der Konversionszuordnung und Gebotseffektivität im Metasuche-Traffic.
+  BC-4010.40.40:
+    name: Markengebots-Konfliktmanagement
+    description: |
+      Management von Gebotskonkurrenzen zwischen Eigenmarken- und OTA-Geboten
+      auf Metasuche und Paid Search.
+  BC-4010.50:
+    name: Kanalmanager-Betrieb
+    description: |
+      Betrieb des Kanalmanager-Hubs zur Synchronisation von Inventar,
+      Raten und Restriktionen über alle Vertriebskanäle.
+  BC-4010.50.10:
+    name: Kanal-Mapping-Konfiguration
+    description: |
+      Konfiguration von Zuordnungen zwischen internen Produkten und kanalspezifischen Katalogen.
+  BC-4010.50.20:
+    name: Inventarpush-Betrieb
+    description: |
+      Betrieb von Inventar-Updates vom zentralen Pool zu allen verbundenen Kanälen.
+  BC-4010.50.30:
+    name: Ratenpush-Betrieb
+    description: |
+      Betrieb von Raten-Updates von Preismaschinen zu allen verbundenen Kanälen.
+  BC-4010.50.40:
+    name: Restriktionspush-Betrieb
+    description: |
+      Betrieb von Restriktions-Updates wie Mindestaufenthalt, Ankunftssperrung
+      und Verkaufsstopp über alle Kanäle.
+  BC-4010.60:
+    name: Raten- und Verfügbarkeitsparitätsmanagement
+    description: |
+      Definition, Überwachung und Durchsetzung der Raten- und Verfügbarkeitsparität
+      über direkte und indirekte Kanäle hinweg.
+  BC-4010.60.10:
+    name: Paritätspolitikdefinition
+    description: |
+      Definition der Raten- und Verfügbarkeitsparitätspolitik über Kanaltypen und Partnersegmente.
+  BC-4010.60.20:
+    name: Paritätsüberwachung und Prüfung
+    description: |
+      Überwachung der Kanäle auf Paritätsverstöße und routinemäßige Prüfung im Kanalmix.
+  BC-4010.60.30:
+    name: Paritätsverletzungsbehebung
+    description: |
+      Behebung identifizierter Paritätsverletzungen mit Kanälen und Partnern.
+  BC-4010.60.40:
+    name: Last-Room-Availability-Management
+    description: |
+      Management von Last-Room-Availability-Verpflichtungen gegenüber
+      Firmen- und Kanalpartnern.
+  BC-4010.70:
+    name: Verteilungsinhaltssyndizierung
+    description: |
+      Syndizierung von Produktinhalten an Vertriebspartner mit
+      Kontrollen für Format, Aktualität und Fallback.
+  BC-4010.70.10:
+    name: Inhaltsfeed-Formatmanagement
+    description: |
+      Management kanalspezifischer Inhaltsfeed-Formate und Schemata.
+  BC-4010.70.20:
+    name: Inhaltsaktualitätsüberwachung
+    description: |
+      Überwachung der Inhaltsaktualität auf Vertriebspartner-Oberflächen gegen Veröffentlichungs-SLAs.
+  BC-4010.70.30:
+    name: Kanal-Inhalts-Fallback-Regeln
+    description: |
+      Fallback-Regeln bei fehlenden oder veralteten partnerspezifischen Inhalten.
+  BC-4010.70.40:
+    name: Inhalts-Override-Abstimmung
+    description: |
+      Abstimmung von Partner-Inhalts-Overrides gegen den Masterinhaltsdatensatz.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-travel-loyalty-programme-management.yaml
+++ b/catalogue/i18n/de/L1-travel-loyalty-programme-management.yaml
@@ -1,0 +1,147 @@
+locale: de
+source: L1-travel-loyalty-programme-management.yaml
+entries:
+  BC-4050:
+    name: Reisetreueprogramm Management
+    description: |
+      Gestaltung und Betrieb von Reisenden-Treueprogrammen – Tier-Architektur,
+      Punkte-Earn- und Burn-Engines, Partneransammlung, Statusmanagement
+      und Mitgliederkommunikation, unabhängig von Gastdatensatz und Kanalplattformen.
+    in_scope:
+      - Programmtier-Architektur und Leistungskatalog
+      - Earn- und Burn-Engines einschließlich Partneransammlung
+      - Tier-Qualifikation, Bindung und Soft-Landing
+      - Mitgliederkommunikations- und Meilensteineerkennungsbetrieb
+    out_of_scope:
+      - Gastprofil und Identität (BC-4040)
+      - Vor-Ort-Erkennungslieferung (BC-4040.40)
+      - Marketingkanalausführung (BC-410)
+  BC-4050.10:
+    name: Treueprogrammgestaltung
+    description: |
+      Gestaltung der Programmarchitektur einschließlich Tier-Struktur,
+      Leistungskatalog, Sammelratenparameter und Programmregeln.
+  BC-4050.10.10:
+    name: Programmtier-Architektur
+    description: |
+      Architektur der Treuetiers einschließlich Schwellen, Leistungen und Aufstiegsregeln.
+  BC-4050.10.20:
+    name: Mitglieder-Leistungskatalog
+    description: |
+      Katalog der Mitgliederleistungen über Produkt- und Partneroberflächen.
+  BC-4050.10.30:
+    name: Sammelrate- und Multiplikatordefinition
+    description: |
+      Definition von Basissammelraten und Tier- und Produktmultiplikatoren.
+  BC-4050.10.40:
+    name: Programmbedingungen-Management
+    description: |
+      Management von Programmbedingungen einschließlich Rechtsvarianten.
+  BC-4050.20:
+    name: Treuepunkte-Earn-Engine-Betrieb
+    description: |
+      Betrieb der Earn-Engine für Aufenthalte, Flüge, Partnerausgaben,
+      Aktionsboni und fehlende Aktivitätsansprüche.
+  BC-4050.20.10:
+    name: Aufenthalts- und Flugpunktverarbeitung
+    description: |
+      Verarbeitung von Sammelereignissen aus Aufenthalten, Flügen und Reiseabschlüssen.
+  BC-4050.20.20:
+    name: Partnerausgabenansammlung
+    description: |
+      Verarbeitung von Sammelereignissen aus Co-Branding-Karten- und Partnereinzelhandelsausgaben.
+  BC-4050.20.30:
+    name: Aktionsbonusansammlung
+    description: |
+      Ansammlung von Aktionsboni gemäß Kampagnenregeln.
+  BC-4050.20.40:
+    name: Fehlaktivitätsanspruchsbearbeitung
+    description: |
+      Bearbeitung von Fehlaktivitätsansprüchen und rückwirkenden Sammelanpassungen.
+  BC-4050.30:
+    name: Treuepunkte-Burn- und Einlösungsbetrieb
+    description: |
+      Betrieb von Einlösungsflüssen einschließlich Prämien-Verfügbarkeit,
+      gemischter Bargeld-und-Punkte-Einlösung und Inventarabrechnung.
+  BC-4050.30.10:
+    name: Prämien-Verfügbarkeitsberechnung
+    description: |
+      Berechnung der Prämien-Verfügbarkeit gegen Umsatzinventar und Schutzregeln.
+  BC-4050.30.20:
+    name: Prämieneinlösungsbuchung
+    description: |
+      Buchung von Prämieneinlösungen über Eigenbrand- und Partnerinventar.
+  BC-4050.30.30:
+    name: Gemischte Bargeld-und-Punkte-Einlösung
+    description: |
+      Einlösungsflüsse mit Kombination von Bargeld und Punkten für eine Buchung.
+  BC-4050.30.40:
+    name: Einlösungsinventar-Abrechnung
+    description: |
+      Abrechnung des Einlösungsinventarverbrauchs zwischen Marken- und Partnerkonten.
+  BC-4050.40:
+    name: Tierstatus-Management
+    description: |
+      Betrieb von Tier-Qualifikation, Beförderung, Herabstufung,
+      Status-Match-Programmen und Soft-Landing-Regeln.
+  BC-4050.40.10:
+    name: Tier-Qualifikationsverfolgung
+    description: |
+      Verfolgung qualifizierender Aktivitäten gegen Tier-Schwellen über das Programmjahr.
+  BC-4050.40.20:
+    name: Tier-Beförderungs- und Herabstufungsoperationen
+    description: |
+      Operationen zur Tier-Beförderung, -Herabstufung und -Neuqualifikation an Periodenenden.
+  BC-4050.40.30:
+    name: Status-Match- und Challenge-Programme
+    description: |
+      Betrieb von Status-Match- und Tier-Challenge-Programmen für gezielte Gewinnung.
+  BC-4050.40.40:
+    name: Soft-Landing-Bindungsregeln
+    description: |
+      Bindungsregeln zur Abschwächung des Tier-Verlusts für hochwertige Mitglieder.
+  BC-4050.50:
+    name: Treuepartner-Programmmanagement
+    description: |
+      Management von Treuepartnern einschließlich Kreditkarten-, Einzel- und
+      Airline-Hotel-Partnern über Onboarding, Konfiguration und Abrechnung.
+  BC-4050.50.10:
+    name: Partner-Onboarding und Vertragsabschluss
+    description: |
+      Onboarding und Vertragsabschluss neuer Treuepartner einschließlich Due Diligence und Integration.
+  BC-4050.50.20:
+    name: Partner-Sammelratenkonfiguration
+    description: |
+      Konfiguration von Sammelraten und Bonusstrukturen für jeden Treuepartner.
+  BC-4050.50.30:
+    name: Partner-Abrechnung und Abstimmung
+    description: |
+      Abrechnung und Abstimmung partnerausgegebener Punkte und Sammelgebühren.
+  BC-4050.50.40:
+    name: Partnerleistungsmanagement
+    description: |
+      Leistungsmanagement von Treuepartnern gegen vertragliche KPIs.
+  BC-4050.60:
+    name: Treue-Kommunikations- und Erkennungsbetrieb
+    description: |
+      Betrieb von Mitgliederkommunikation, Meilensteinerkennung und
+      Überraschungs-und-Begeisterungsgesten über den Treuelebenszyklus.
+  BC-4050.60.10:
+    name: Mitglieder-Lebenszykluswommunikation
+    description: |
+      Lebenszykluskommunikation an Mitglieder über Onboarding-, aktive und Reaktivierungsphasen.
+  BC-4050.60.20:
+    name: Meilenstein- und Jubiläumserkennung
+    description: |
+      Erkennung von Mitglieder-Meilensteinen, Zugehörigkeitsjubiläen und Tier-Beförderungen.
+  BC-4050.60.30:
+    name: Überraschungs-und-Begeisterungsbetrieb
+    description: |
+      Betrieb von Überraschungs-und-Begeisterungsgesten durch Mitgliederverhalten oder Serviceereignisse.
+  BC-4050.60.40:
+    name: Mitgliedskontoauszugsgenerierung
+    description: |
+      Generierung von Mitgliedskontoauszügen mit Kontostand, Aktivität und Tier-Fortschritt.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-travel-product-inventory-management.yaml
+++ b/catalogue/i18n/de/L1-travel-product-inventory-management.yaml
@@ -1,0 +1,188 @@
+locale: de
+source: L1-travel-product-inventory-management.yaml
+entries:
+  BC-4000:
+    name: Reiseprodukt und Reiseinventar Management
+    description: |
+      Masterdefinition, Struktur und Inventarkontrolle buchbarer Reiseprodukte –
+      Zimmer, Tarife, Pakete, Zusatzleistungen, Attraktionen sowie Taxonomie
+      und Inhaltsdaten, unabhängig von den Vertriebskanälen.
+    in_scope:
+      - Unterkunfts-Zimmertypen, Ratenpläne und Paketcodes
+      - Luftfahrt-Tarifgruppen, Markenleistungstarife und Tarifregeln
+      - Verpackte Reisepläne (statisch und dynamisch) und Zusatzleistungskataloge
+      - Inventarpools, Kontingente und Überbuchungspuffer
+      - Produktstammdaten, Inhalte und Bildmaterial
+    out_of_scope:
+      - Kanalspezifische Vertriebsverkabelung (BC-4010)
+      - Reservierungslebenszyklus und Buchungen (BC-4020)
+      - Preisstrategie und Yield-Entscheidungen (BC-4030)
+  BC-4000.10:
+    name: Unterkunftsproduktmanagement
+    description: |
+      Definition von Unterkunftsprodukten einschließlich Zimmertypen, Ratenplänen,
+      Paketcodes und Unterkunftstaxonomie für das gesamte Unternehmen.
+  BC-4000.10.10:
+    name: Zimmertyp- und Inventarklassendefinition
+    description: |
+      Definition von Zimmertypen, Suitenkategorien und Inventarklassen
+      als Grundlage des Unterkunftsprodukts.
+  BC-4000.10.20:
+    name: Ratenplan- und Ratencodegestaltung
+    description: |
+      Definition von Ratenplänen, Ratencodes und Ratenplanattributen
+      zu Erstattungsfähigkeit, Vorauszahlung und Inklusivleistungen.
+  BC-4000.10.30:
+    name: Unterkunftsprodukt-Lebenszyklus-Status
+    description: |
+      Lebenszyklus-Statusmanagement für Unterkunftsprodukte von der Entwicklung
+      bis Aktiv, Gesperrt und Eingestellt.
+  BC-4000.10.40:
+    name: Unterkunftsprodukt-Bündelung
+    description: |
+      Erstellung von Unterkunftsbundles mit Frühstück, Parkplatz und weiteren Inklusivleistungen.
+  BC-4000.20:
+    name: Flugproduktmanagement
+    description: |
+      Definition von Airline-Tarifgruppen, Markenleistungsattributen,
+      Tarifregeln und Codeshare-/Interline-Produktzuordnungen.
+  BC-4000.20.10:
+    name: Tarifgruppendefinition
+    description: |
+      Definition von Tarifgruppen, Kabinen und Tarifeimern für
+      Angebot und Inventarsteuerung.
+  BC-4000.20.20:
+    name: Markenleistungsattribut-Management
+    description: |
+      Management von Markenleistungsattributen wie Freigepäck,
+      Sitzplatzwahl und Lounge-Zugang.
+  BC-4000.20.30:
+    name: Tarifregelerfassung
+    description: |
+      Erfassung von Tarifregeln zu Vorausbuchungsfrist, Mindestaufenthalt,
+      Kombinierbarkeit und Änderungsgebühren.
+  BC-4000.20.40:
+    name: Codeshare- und Interline-Produktzuordnung
+    description: |
+      Zuordnung von Partnerfluggesellschaftsprodukten zu eigenen Tarifgruppen
+      für Codeshare- und Interline-Vertrieb.
+  BC-4000.30:
+    name: Reise- und Paketproduktmanagement
+    description: |
+      Definition von Pauschalreiseplänen, Mehrstreckenprodukten und
+      Dynamikpaketierskomponentenzuordnungen.
+  BC-4000.30.10:
+    name: Statisches Paketprodukt-Definition
+    description: |
+      Definition von Festpaketen mit fixen Komponenten als einzelnes verkäufliches Produkt.
+  BC-4000.30.20:
+    name: Dynamikpaketierungs-Komponentenzuordnung
+    description: |
+      Zuordnung von Komponenten für Dynamikpaketiering, bei der der Reisende
+      Flug, Hotel und Zusatzleistungen beim Buchungsvorgang zusammenstellt.
+  BC-4000.30.30:
+    name: Paketprodukt-Versionierung
+    description: |
+      Versionierung von Paketprodukten über Saisonen, Katalogszyklen und Funktionsveröffentlichungen.
+  BC-4000.30.40:
+    name: Paketabreisekalender
+    description: |
+      Definition von Paketabreisekalendern, Sperrfristen und Saison-Fenstern.
+  BC-4000.40:
+    name: Zusatzleistungs- und Optionsproduktmanagement
+    description: |
+      Definition von Zusatzleistungen wie Mahlzeiten, Gepäck, Transfers,
+      Attraktionen, Spa und Bodendiensten.
+  BC-4000.40.10:
+    name: Zusatzleistungskatalogdefinition
+    description: |
+      Definition des Zusatzleistungskatalogs einschließlich Kategorien,
+      Varianten und Anwendungsbedingungen.
+  BC-4000.40.20:
+    name: Zusatzleistungs-Bündelungsregeln
+    description: |
+      Regeln zur Bündelung von Zusatzleistungen mit Hauptreiseprodukten
+      und anderen Zusatzleistungen.
+  BC-4000.40.30:
+    name: Cross-Selling-Zulässigkeitsregeln
+    description: |
+      Zulässigkeitsregeln für den Cross-Sell von Zusatzleistungen
+      mit Hauptprodukten in bestimmten Kanälen.
+  BC-4000.40.40:
+    name: Zusatzleistungs-Lebenszyklusmanagement
+    description: |
+      Lebenszyklusmanagement von Zusatzleistungen von der Einführung bis zur Einstellung.
+  BC-4000.50:
+    name: Reiseinventarzuteilung
+    description: |
+      Definition und Kontrolle von Inventarpools, Kontingenten und
+      Rückhalteregeln für Reiseprodukte.
+  BC-4000.50.10:
+    name: Inventarpooldefinition
+    description: |
+      Definition von Inventarpools auf Unterkunfts-, Flotten- oder
+      Produktebene als Grundlage der Zuteilung.
+  BC-4000.50.20:
+    name: Kontingent- und Blockvergabe
+    description: |
+      Zuteilung von Kontingenten und Blöcken an Kanäle, Partner und Reiseveranstalter.
+  BC-4000.50.30:
+    name: Rückhalte- und Schutzklassenregeln
+    description: |
+      Regeln zum Schutz von Inventar für bestimmte Segmente, Kanäle oder Treueprogrammmitglieder.
+  BC-4000.50.40:
+    name: Überbuchungspufferkonfiguration
+    description: |
+      Konfiguration von Überbuchungspuffern entsprechend erwarteter No-Show-
+      und Stornierungsraten.
+  BC-4000.60:
+    name: Reiseprodukt-Stammdaten-Governance
+    description: |
+      Stewardship von Produkttaxonomie, Klassifizierungen, Attributstandards
+      und Kennungsintegrität im Reiseprodukt-Master.
+  BC-4000.60.10:
+    name: Produktattributstandards
+    description: |
+      Standards für Produktattribute zur Sicherstellung konsistenter Semantik
+      über Systeme und Kanäle hinweg.
+  BC-4000.60.20:
+    name: Produktklassifizierung und Tagging
+    description: |
+      Klassifizierung und Tagging von Produkten gegen Taxonomien für
+      Suche, Merchandising und Berichterstattung.
+  BC-4000.60.30:
+    name: Produktmaster-Lebenszyklus-Status
+    description: |
+      Master-Lebenszyklusstatus für Produkte über Sub-Produkttypen hinweg
+      mit Ausrichtung von Kindstatusänderungen.
+  BC-4000.60.40:
+    name: Produktkennungs-Stewardship
+    description: |
+      Stewardship kanonischer Produktkennungen und Auflösung von
+      Kennungskollisionen und Duplikaten.
+  BC-4000.70:
+    name: Reiseinhalts- und Bildmaterialmanagement
+    description: |
+      Erstellung und Verwaltung beschreibender Inhalte, Bildmaterial, Multimedia-Assets
+      und Bewertungs-/Zertifizierungsnachweise für Reiseprodukte.
+  BC-4000.70.10:
+    name: Beschreibende Inhaltserstellung
+    description: |
+      Erstellung von Lang- und Kurzformat-Beschreibungen für Reiseprodukte.
+  BC-4000.70.20:
+    name: Bild- und Multimedia-Asset-Management
+    description: |
+      Verwaltung von Foto-, Video- und 360-Grad-Multimedia-Assets
+      zu Reiseprodukten.
+  BC-4000.70.30:
+    name: Sternebewertungs- und Zertifizierungsunterlagen
+    description: |
+      Pflege von Sternebewertungen, Drittanbieterzertifizierungen und
+      Qualitätssiegeln für Reiseprodukte.
+  BC-4000.70.40:
+    name: Inhaltslokalisierung
+    description: |
+      Lokalisierung von Produktinhalten für unterstützte Märkte und Sprachen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-travel-revenue-yield-management.yaml
+++ b/catalogue/i18n/de/L1-travel-revenue-yield-management.yaml
@@ -1,0 +1,154 @@
+locale: de
+source: L1-travel-revenue-yield-management.yaml
+entries:
+  BC-4030:
+    name: Reiseumsatz und Revenue Management
+    description: |
+      Nachfrageprognose, dynamische Preisgestaltung, Inventarkontrollen und
+      Yield-Entscheidungen zur Umsatzmaximierung über Reiseprodukte hinweg –
+      getrennt von Produktmaster, Vertriebsverkabelung und Reservierungslebenszyklus.
+    in_scope:
+      - Unkonditionierte Nachfrage- und Pickup-Tempo-Prognose
+      - Preis- und Ratenstrategie-Management (BAR, Tarifklasse, Saison)
+      - Buchungslimite, Aufenthaltsdauer-Restriktionen, Überbuchung, Nesting
+      - Wettbewerbsfähige Ratenanalyse und Marktpositionierung
+      - Aktions- und Rabattmechanismen
+      - Erlösleistungsberichterstattung (RevPAR, RevPAX, ADR, Yield)
+    out_of_scope:
+      - Produktmaster-Definition (BC-4000)
+      - Kanalspezifische Gebotsabgabe auf Metasuche (BC-4010.40.20)
+      - Gruppenvertriebsverträge (BC-4110.10)
+  BC-4030.10:
+    name: Reisennachfrageprognose
+    description: |
+      Prognose unkonditionierter Nachfrage, Buchungstempo, Gruppennachfrage
+      und No-Show- oder Stornierungsverhalten für Reiseprodukte.
+  BC-4030.10.10:
+    name: Unkonditionierte Nachfrageprognose
+    description: |
+      Prognose der Nachfrage ohne Kapazitäts- und Preisgrenzen.
+  BC-4030.10.20:
+    name: Buchungstempo- und Pickup-Prognose
+    description: |
+      Prognose von Tempo- und Pickup-Kurven gegen historische und gebuchte Muster.
+  BC-4030.10.30:
+    name: Gruppennachfrageprognose
+    description: |
+      Prognose der Gruppennachfrage einschließlich Verdrängungseffekten
+      auf transientes Inventar.
+  BC-4030.10.40:
+    name: No-Show- und Stornierungsprognose
+    description: |
+      Prognose von No-Show- und Stornierungsverhalten als Eingang
+      für Überbuchungs- und Inventarkontrollen.
+  BC-4030.20:
+    name: Preis- und Ratenstrategiemanagement
+    description: |
+      Definition und Anpassung der Ratenstrategie über BAR-Ebenen,
+      Tarifklassen, Saisonfenster und Paketpreise.
+  BC-4030.20.10:
+    name: Best-Available-Rate-Festlegung
+    description: |
+      Festlegung von BAR-Leisten nach Datum und Segment.
+  BC-4030.20.20:
+    name: Tarifklassen- und Eimer-Strategie
+    description: |
+      Strategie für Tarifklassen und Inventareimer einschließlich
+      Öffnungen, Schließungen und Neujustierung.
+  BC-4030.20.30:
+    name: Saison- und Tagestyp-Preisgestaltung
+    description: |
+      Preisvariation über Saisonen, Wochentagsmuster und Ereignisfenster.
+  BC-4030.20.40:
+    name: Paket- und Bundle-Preisgestaltung
+    description: |
+      Preisgestaltung für Paketprodukte und Bundles einschließlich Komponentenzuordnung.
+  BC-4030.30:
+    name: Inventar- und Kapazitätskontrollen
+    description: |
+      Inventarkontrollen einschließlich Buchungslimite, Aufenthaltsdauer-Restriktionen,
+      Überbuchungsstrategie und Bid-Price-Nesting.
+  BC-4030.30.10:
+    name: Buchungslimit- und Autorisierungsfestsetzung
+    description: |
+      Festlegung von Buchungslimiten und Autorisierungsniveaus nach Klasse, Kanal und Segment.
+  BC-4030.30.20:
+    name: Aufenthaltsdauer-Restriktionsmanagement
+    description: |
+      Management von Aufenthaltsdauer-Restriktionen einschließlich Mindest-, Maximal-
+      und Anreise-Tag-Regeln.
+  BC-4030.30.30:
+    name: Überbuchungsstrategiemanagement
+    description: |
+      Strategisches Management von Überbuchungsniveaus nach Datum und Segment
+      gegen Kosten für verweigerter Dienst kalibriert.
+  BC-4030.30.40:
+    name: Nesting- und Bid-Price-Management
+    description: |
+      Management von Inventar-Nesting und Bid-Price-Schwellenwerten in Erlösoptimierungsmodellen.
+  BC-4030.40:
+    name: Wettbewerbsfähige Ratenanalyse
+    description: |
+      Wettbewerbsfähiges Raten-Shopping, Marktanteilsanalyse und
+      Ratenpositionierungsempfehlungen.
+  BC-4030.40.10:
+    name: Wettbewerbsfähiges Raten-Shopping
+    description: |
+      Routinemäßiges Shopping von Wettbewerbsraten über ausgewählte Kanäle und Anreisedaten.
+  BC-4030.40.20:
+    name: Marktanteils- und Penetrationsanalyse
+    description: |
+      Analyse von Marktanteil, Belegungsindex und Ratenindex gegen den Wettbewerbsset.
+  BC-4030.40.30:
+    name: Ratenpositionierungsempfehlungen
+    description: |
+      Generierung von Ratenpositionierungsempfehlungen gegen den Wettbewerbsset und Nachfragezustand.
+  BC-4030.40.40:
+    name: Wettbewerbsset-Definition und Pflege
+    description: |
+      Definition und laufende Pflege der für Benchmarking verwendeten Wettbewerbssets.
+  BC-4030.50:
+    name: Aktions- und Rabattmanagement
+    description: |
+      Definition und Betrieb von Aktionen, Rabattcodes, intransparenten
+      und Geschlossene-Nutzergruppen-Preisen für Reiseprodukte.
+  BC-4030.50.10:
+    name: Aktionskalendermanagement
+    description: |
+      Kalenderbasiertes Management von Aktionen über Saisonen und wesentliche Buchungsfenster.
+  BC-4030.50.20:
+    name: Aktionsberechtigungsregeln
+    description: |
+      Berechtigungsregeln für die Aktionseinlösung nach Segment, Kanal und Aufenthaltsfenster.
+  BC-4030.50.30:
+    name: Rabattcode- und Gutscheinmanagement
+    description: |
+      Management von Rabattcodes, Gutscheinen und Geschenkkarten-ähnlichen Tokens.
+  BC-4030.50.40:
+    name: Intransparente und Geschlossene-Nutzergruppen-Preisgestaltung
+    description: |
+      Betrieb intransparenter Kanal- und Geschlossene-Nutzergruppen-Preismechanismen.
+  BC-4030.60:
+    name: Erlösleistungsanalyse
+    description: |
+      Berichterstattung und Analyse der Erlösleistung einschließlich RevPAR,
+      RevPAX, ADR, Yield und Prognoseabweichung.
+  BC-4030.60.10:
+    name: Erlös-KPI-Berichterstattung
+    description: |
+      Berichterstattung über Haupterlös-KPIs gegen Budget und Vorjahresperiode.
+  BC-4030.60.20:
+    name: Yield-Abweichungsanalyse
+    description: |
+      Analyse der Yield-Abweichung mit Zurechnung von Änderungen auf Mix-, Raten- und Belegungseffekte.
+  BC-4030.60.30:
+    name: Kanalerlösbeitragsanalyse
+    description: |
+      Analyse des Erlösbeitrags nach Kanal, Segment und Ratencode.
+  BC-4030.60.40:
+    name: Erlösprognose-Ist-Analyse
+    description: |
+      Analyse von Prognose- versus Ist-Erlös mit Zurechnung auf Prognosefehlquellen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-treasury-asset-liability-management.yaml
+++ b/catalogue/i18n/de/L1-treasury-asset-liability-management.yaml
@@ -1,0 +1,102 @@
+locale: de
+source: L1-treasury-asset-liability-management.yaml
+entries:
+  BC-1360:
+    name: Treasury und Aktiv-Passiv-Steuerung
+    description: |
+      Bank-Treasury, ALM, Funds-Transfer-Pricing, Liquidität und Zinsrisiko im Bankbuch.
+  BC-1360.10:
+    name: Bank-Liquiditätsmanagement
+    description: |
+      Bankliquidität, Intraday-Liquidität, LCR/NSFR.
+  BC-1360.10.10:
+    name: Liquidity-Coverage-Ratio-Management
+    description: |
+      LCR-Berechnung, -Überwachung und -Meldung gemäß Basel III.
+  BC-1360.10.20:
+    name: Net-Stable-Funding-Ratio-Management
+    description: |
+      NSFR-Berechnung und strukturelles Funding-Management.
+  BC-1360.10.30:
+    name: Intraday-Liquiditätsmanagement
+    description: |
+      Intraday-Liquiditätsüberwachung in Zahlungssystemen.
+  BC-1360.10.40:
+    name: Hochliquide-Aktiva-Management
+    description: |
+      Verwaltung und Steuerung des HQLA-Portfolios.
+  BC-1360.20:
+    name: Aktiv-Passiv-Steuerung
+    description: |
+      ALM, Bilanzverwaltung und Gap-Analyse.
+  BC-1360.20.10:
+    name: Bilanzverwaltung
+    description: |
+      Strategische Bilanzverwaltung und -optimierung.
+  BC-1360.20.20:
+    name: Gap-Analyse
+    description: |
+      Repricing- und Liquiditäts-Gap-Analyse der gesamten Bilanz.
+  BC-1360.20.30:
+    name: Verhaltensmodellierung
+    description: |
+      Verhaltensmodellierung von Nicht-Fälligkeits-Einlagen und Vorauszahlungen.
+  BC-1360.20.40:
+    name: ALM-Stresstesting
+    description: |
+      Stresstesting von Aktiv-Passiv-Inkongruenzen.
+  BC-1360.30:
+    name: Funds-Transfer-Pricing-Management
+    description: |
+      FTP und Preisgestaltung interner Mittel.
+  BC-1360.30.10:
+    name: FTP-Methodik-Management
+    description: |
+      Pflege der FTP-Methodik und Kurvengestaltung.
+  BC-1360.30.20:
+    name: FTP-Satz-Anwendung
+    description: |
+      Anwendung von FTP-Sätzen auf Produkte und Verträge.
+  BC-1360.30.30:
+    name: FTP-Berichterstattung und Analyse
+    description: |
+      FTP-Berichterstattung und Auswirkungsanalyse auf die Rentabilität.
+  BC-1360.40:
+    name: Bank-Funding-Management
+    description: |
+      Wholesale-Funding, Einlagengewinnung und Kapitalmarktfinanzierung.
+  BC-1360.40.10:
+    name: Wholesale-Funding-Management
+    description: |
+      Unbesichertes und besichertes Wholesale-Funding-Management.
+  BC-1360.40.20:
+    name: Kapitalmarktfinanzierung
+    description: |
+      Anleiheemissionen, MTNs, Pfandbriefe und Verbriefungen.
+  BC-1360.40.30:
+    name: Zentralbank-Fazilitäten-Betrieb
+    description: |
+      Nutzung von Zentralbankfazilitäten und Sicherheitenmanagement.
+  BC-1360.40.40:
+    name: Fundingplan-Management
+    description: |
+      Jahresfundingplan und Durchführung gegenüber dem Plan.
+  BC-1360.50:
+    name: Bankbuch-Zinsrisikomanagement
+    description: |
+      IRRBB und Zinsexposure im Bankbuch.
+  BC-1360.50.10:
+    name: IRRBB-Messung
+    description: |
+      Messung von EVE- und NII-Sensitivitäten für IRRBB.
+  BC-1360.50.20:
+    name: IRRBB-Hedging
+    description: |
+      Absicherung des Bankbuch-Zinsrisikos.
+  BC-1360.50.30:
+    name: IRRBB-Berichterstattung
+    description: |
+      Regulatorische und interne IRRBB-Berichterstattung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-treasury-management.yaml
+++ b/catalogue/i18n/de/L1-treasury-management.yaml
@@ -1,0 +1,126 @@
+locale: de
+source: L1-treasury-management.yaml
+entries:
+  BC-210:
+    name: Treasury-Management
+    description: |
+      Management von Liquidität, Finanzierung und finanziellen Marktrisiken.
+  BC-210.10:
+    name: Cash-Management
+    description: |
+      Cash-Positionierung, Pooling und konzerninterne Finanzierung.
+  BC-210.10.10:
+    name: Cash-Positionsmonitoring
+    description: |
+      Tägliche Überwachung der Cash-Positionen über Rechtsträgern und Währungen.
+  BC-210.10.20:
+    name: Cash-Pooling-Betrieb
+    description: |
+      Notionales und physisches Cash-Pooling im Konzern.
+  BC-210.10.30:
+    name: Konzerninterne Finanzierung
+    description: |
+      Konzerninterne Darlehen, In-House-Bank und konzerninterne Abwicklung.
+  BC-210.10.40:
+    name: Kurzfristige Anlageverwaltung
+    description: |
+      Geldmarkt- und kurzfristige Cash-Anlageaktivitäten.
+  BC-210.20:
+    name: Liquiditätsmanagement
+    description: |
+      Liquiditätsprognose, Stresstests und Finanzierungspläne.
+  BC-210.20.10:
+    name: Cashflow-Prognose
+    description: |
+      Kurz-, mittel- und langfristige Cashflow-Prognosen.
+  BC-210.20.20:
+    name: Liquiditätsrisikomonitoring
+    description: |
+      Liquiditätskennzahlen, Puffer und Frühwarnindikatoren.
+  BC-210.20.30:
+    name: Liquiditätsstresstest
+    description: |
+      Stresstests zur Liquiditätsadäquanz unter negativen Szenarien.
+  BC-210.20.40:
+    name: Notfallfinanzierungsplanung
+    description: |
+      Notfallfinanzierungspläne und zugesagte Liquiditätsfazilitäten.
+  BC-210.30:
+    name: Fremdkapital- und Schuldenmanagement
+    description: |
+      Schuldenbegebung, Fazilitätsverwaltung und Covenants.
+  BC-210.30.10:
+    name: Schuldenbegebung
+    description: |
+      Emission von Anleihen, Commercial Paper und Privatplatzierungen.
+  BC-210.30.20:
+    name: Bankkredit- und Fazilitätsverwaltung
+    description: |
+      Verhandlung und Administration von Kreditfazilitäten und bilateralen Darlehen.
+  BC-210.30.30:
+    name: Schuldendienst
+    description: |
+      Terminplanung und Ausführung von Zins-, Tilgungs- und Gebührenzahlungen.
+  BC-210.30.40:
+    name: Covenant- und Ratingmanagement
+    description: |
+      Covenant-Monitoring und Beziehungen zu Ratingagenturen.
+  BC-210.40:
+    name: Fremdwährungsmanagement
+    description: |
+      Währungsexposure, Absicherung und Abwicklung.
+  BC-210.40.10:
+    name: Währungsexposure-Identifikation
+    description: |
+      Identifikation und Quantifizierung von Währungsexposures über Rechtsträgern.
+  BC-210.40.20:
+    name: Währungsabsicherungsdurchführung
+    description: |
+      Ausführung von Devisentermingeschäften, -swaps und -optionen.
+  BC-210.40.30:
+    name: Währungsabwicklung und -bestätigung
+    description: |
+      Abwicklung, Bestätigung und Abstimmung von Devisengeschäften.
+  BC-210.40.40:
+    name: Translationsexposure-Management
+    description: |
+      Absicherung von Nettoinvestitionen und Translationsexposures.
+  BC-210.50:
+    name: Zinsrisikomanagement
+    description: |
+      Zinsexposure und Absicherungsstrategien.
+  BC-210.50.10:
+    name: Zinsexposure-Messung
+    description: |
+      Messung der Zinssensitivität über die Bilanz.
+  BC-210.50.20:
+    name: Zinsabsicherung
+    description: |
+      Ausführung von Zinsswaps, Caps und anderen Derivaten.
+  BC-210.50.30:
+    name: Hedge Accounting
+    description: |
+      Hedge-Designation, Wirksamkeitsprüfung und Bilanzierung nach IFRS 9.
+  BC-210.60:
+    name: Bankbeziehungsmanagement
+    description: |
+      Bankkontolstruktur und Verwaltung der Bankpartner.
+  BC-210.60.10:
+    name: Bankkontolebenszyklusmanagement
+    description: |
+      Eröffnung, Änderung und Schließung von Bankkonten.
+  BC-210.60.20:
+    name: Bankvollmachts- und Zeichnungsberechtigungsmanagement
+    description: |
+      Zeichnungsberechtigtenlisten, Bankvollmachten und Vollmachtsänderungen.
+  BC-210.60.30:
+    name: Bankdienstleistungsbeschaffung
+    description: |
+      Auswahl und Vertragsabschluss mit Bankpartnern und Dienstleistern.
+  BC-210.60.40:
+    name: Bankgebühren- und Servicequälitätsmanagement
+    description: |
+      Monitoring von Bankgebühren, Servicequalität und Analysen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-utility-customer-metering-management.yaml
+++ b/catalogue/i18n/de/L1-utility-customer-metering-management.yaml
@@ -1,0 +1,141 @@
+locale: de
+source: L1-utility-customer-metering-management.yaml
+entries:
+  BC-3910:
+    name: Versorgungskunden und Messwesen Management
+    description: |
+      Versorgungsspezifischer Kunden- und Messbetrieb vom Übergabepunkt
+      bis zum Rechnungseingang – Versorgungskundenkonten, Zählerinventar,
+      AMI/Intelligente-Zähler-Datenerfassung, Zählerablesung und -validierung,
+      Zähler-zu-Kasse-Eingaben, Anschluss-/Trenndienste sowie Schutz
+      schutzbedürftiger Kunden.
+  BC-3910.10:
+    name: Versorgungskundenkontoführung
+    description: |
+      Versorgungsspezifischer Kundenkontenlebenszyklus einschließlich
+      Übergabepunktkennnummern, Nutzerwechsel und Tarifzuweisung.
+  BC-3910.10.10:
+    name: Übergabepunktregistrierung
+    description: |
+      Registrierung und Pflege von Übergabepunktkennnummern (MPAN, MPRN, SPID).
+  BC-3910.10.20:
+    name: Nutzerwechselbetrieb
+    description: |
+      Einzug, Auszug und Mieterwechselverarbeitung für Versorgungsübergabepunkte.
+  BC-3910.10.30:
+    name: Kundentarifzuweisung
+    description: |
+      Zuweisung von Kunden zu anwendbaren Tarifplänen und Produktoptionen.
+  BC-3910.20:
+    name: Zählerbestandsmanagement
+    description: |
+      Lebenszyklusmanagement physischer Zähler- und Kommunikationsanlagen
+      einschließlich Lagerbestand, Einbau, Tausch und Rückgabe.
+  BC-3910.20.10:
+    name: Zählerbestandsbetrieb
+    description: |
+      Bestandsmanagement, Inbetriebnahme und Außerbetriebnahme von Zähleranlagen.
+  BC-3910.20.20:
+    name: Zählereinbaubetrieb
+    description: |
+      Feldeinbau von Neu- und Austauschzählern.
+  BC-3910.20.30:
+    name: Zählerrücknahme und Entsorgung
+    description: |
+      Rücknahme, Aufbereitung und Lebensendentsorgung von Zähleranlagen.
+  BC-3910.30:
+    name: AMI-Datenerfassungsbetrieb
+    description: |
+      Erfassung von Advanced-Metering-Infrastructure-Daten über Head-End-
+      Systeme, Kommunikationsnetze und Zählerdatenmanagement.
+    in_scope:
+      - Intelligenter Zähler Head-End-Betrieb
+      - Kommunikationsnetz- und Konzentrator-Überwachung
+      - Zählerdatenmanagement-Ingestion
+    out_of_scope:
+      - Physischer Zählereinbau (BC-3910.20.20)
+      - Handelsseitige aggregierte Nachfrage (BC-3850.30.10)
+  BC-3910.30.10:
+    name: Head-End-Systembetrieb
+    description: |
+      Betrieb von Intelligenten-Zähler-Head-End-Systemen und Zählerbefehlserteilung.
+  BC-3910.30.20:
+    name: AMI-Kommunikationsnetzbetrieb
+    description: |
+      Betrieb von HF-, PLC- und Mobilfunk-AMI-Kommunikationsnetzen und Konzentratoren.
+  BC-3910.30.30:
+    name: Zählerdatenmanagement-Ingestion
+    description: |
+      Ingestion von Intervall- und Registerablesungen in das Zählerdatenmanagementsystem.
+  BC-3910.40:
+    name: Zählerablesung und Validierung
+    description: |
+      Zyklische und ereignisgesteuerte Zählerablesung sowie Validierung,
+      Schätzung und Bearbeitung von Verbrauchsdaten.
+  BC-3910.40.10:
+    name: Manuelle Ablesung und Fahrtzählerablesung
+    description: |
+      Lauf-, Fahr- und AMR-Ablesebetrieb für Nicht-AMI-Zähler.
+  BC-3910.40.20:
+    name: Validierung, Schätzung und Bearbeitung
+    description: |
+      VEE-Verarbeitung von Register- und Intervallesungen zur Rechnungsqualitätsdatenerzeugung.
+  BC-3910.40.30:
+    name: Verbrauchsaggregation
+    description: |
+      Aggregation von Verbräuchen für Abrechnungsperioden und Vergleichsprofile.
+  BC-3910.50:
+    name: Zähler-zu-Kasse-Betrieb
+    description: |
+      Versorgungsspezifischer Betrieb zur Aufbereitung von Verbrauchsdaten für die
+      Abrechnung und Einnahmensicherung einschließlich Rechnungsausnahmenbearbeitung
+      und Erleckserkennnung.
+  BC-3910.50.10:
+    name: Rechnungsgrundlagenvorbereitung
+    description: |
+      Aufbereitung von Rechnungsgrundlagen – Verbrauch, Leistung und Blindenergie – für Abrechnungssysteme.
+  BC-3910.50.20:
+    name: Rechnungsausnahmenbearbeitung
+    description: |
+      Untersuchung und Klärung von Rechnungsausnahmen und Zählerdatenanomalien.
+  BC-3910.50.30:
+    name: Einnahmensicherungsbetrieb
+    description: |
+      Erkennung und Felduntersuchung von Zählermanipulationen und Strom- oder Wasserdiebstahl.
+  BC-3910.60:
+    name: Anschluss- und Trenndienste
+    description: |
+      Aktivierung, Deaktivierung und Vorauszahlungsmodenbetrieb von
+      Versorgungsanschlüssen an der Kundenschnittstelle.
+  BC-3910.60.10:
+    name: Anschlussaktivierungsbetrieb
+    description: |
+      Aktivierung neuer und reaktivierter Anschlüsse einschließlich Ferneinschaltung.
+  BC-3910.60.20:
+    name: Sperrung wegen Nichtzahlung
+    description: |
+      Sperrvorgänge unter Beachtung gesetzlicher und regulatorischer Schutzbestimmungen.
+  BC-3910.60.30:
+    name: Vorauszahlungsbetrieb
+    description: |
+      Betrieb von Vorauszahlungszählern und Aufladesystemen.
+  BC-3910.70:
+    name: Schutzbedürftige Kunden Management
+    description: |
+      Identifizierung und Schutz von Kunden in schutzbedürftigen Lebenslagen
+      einschließlich Vorrangkundenregistern und Erschwinglichkeitsprogrammen.
+  BC-3910.70.10:
+    name: Vorrangkundenregisterbetrieb
+    description: |
+      Pflege des Vorrangkundenregisters und zugeschnittener Unterstützungsmarkierungen.
+  BC-3910.70.20:
+    name: Härte- und Erschwinglichkeitsprogrammbetrieb
+    description: |
+      Verwaltung von Sozialtarif- und Härtefondsregelungen für Versorgungskunden.
+  BC-3910.70.30:
+    name: Medizingerätekundenmanagement
+    description: |
+      Management von Kunden, die auf Medizin- oder Dialysegeräte angewiesen sind, für Abschaltplanung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-utility-network-asset-management.yaml
+++ b/catalogue/i18n/de/L1-utility-network-asset-management.yaml
@@ -1,0 +1,139 @@
+locale: de
+source: L1-utility-network-asset-management.yaml
+entries:
+  BC-3900:
+    name: Versorgungsnetz-Anlagen Management
+    description: |
+      Ganzheitliches Management langlebiger Versorgungsnetzinfrastruktur –
+      Strom-, Gas-, Wasser- und Abwasseranlagen – einschließlich Anlagenregisterintegrität,
+      Zustandsüberwachung, Risiko- und Kritikalitätsbewertung, RAB-bewusstem Investitionsplan,
+      Erneuerungsprogrammen, Leistungsberichterstattung und geospatialem Netzkataster.
+  BC-3900.10:
+    name: Anlagenregisterführung
+    description: |
+      Pflege des Versorgungsanlagenregisters als alleinige Wahrheitsquelle
+      für Netzanlagen und ihre hierarchischen Beziehungen.
+  BC-3900.10.10:
+    name: Anlagenstammdaten-Stewardship
+    description: |
+      Stewardship von Anlagenstammdatenattributen und Klassifizierungen.
+  BC-3900.10.20:
+    name: Anlagenhierarchiepflege
+    description: |
+      Pflege funktionaler und physischer Anlagenhierarchien für Netzanlagen.
+  BC-3900.10.30:
+    name: Anlagenregisterabstimmung
+    description: |
+      Abstimmung zwischen Anlagenregister, GIS und Betriebssystemen.
+  BC-3900.20:
+    name: Anlagenzustands- und Gesundheitsüberwachung
+    description: |
+      Inspektion, Prüfung und Online-Überwachung des Anlagenzustands
+      als Eingang für Anlagengesundheitsbewertung und Priorisierung.
+  BC-3900.20.10:
+    name: Inspektionsprogrammbetrieb
+    description: |
+      Zyklische Inspektionsprogramme für Primäranlagen und Netzanlagen.
+  BC-3900.20.20:
+    name: Online-Zustandsüberwachung
+    description: |
+      Online-Zustandsüberwachung von Transformatoren, Kabeln und rotierenden Anlagen.
+  BC-3900.20.30:
+    name: Anlagengesundheitsbewertung
+    description: |
+      Berechnung von Anlagengesundheitsindizes aus Inspektions-, Prüf- und Betriebsdaten.
+  BC-3900.30:
+    name: Anlagenrisiko- und Kritikalitätsbeurteilung
+    description: |
+      Quantitative Anlagenrisikobeurteilung, die Eintretenswahrscheinlichkeit,
+      Folgen und Kritikalität zur Priorisierung von Maßnahmen kombiniert.
+  BC-3900.30.10:
+    name: Anlagenkritikalitätsbewertung
+    description: |
+      Netz- und gesellschaftliche Folgenabschätzung zur Kritikalitätsbewertung von Versorgungsanlagen.
+  BC-3900.30.20:
+    name: Ausfallwahrscheinlichkeitsmodellierung
+    description: |
+      Statistische und zustandsbasierte Ausfallwahrscheinlichkeitsmodellierung.
+  BC-3900.30.30:
+    name: Monetarisierte Risikoberechnung
+    description: |
+      Monetarisierte Risikoberechnung im Einklang mit regulatorischen KNA-Rahmenwerken.
+  BC-3900.40:
+    name: Anlagen-Investitionsplanung
+    description: |
+      Langfristige und regulierungsperiodenausgerichtete Investitionsplanung
+      über Netzkategorien für regulierte und nicht regulierte Programme.
+    in_scope:
+      - Mehrjährige Kapital- und Totex-Planung
+      - Kosten-Nutzen-Bewertung von Netzmaßnahmen
+      - Investitionsportfoliopriorisierung
+    out_of_scope:
+      - Branchenübergreifende Projektportfolio-Governance (BC-900)
+      - Tarifseitige Erlösplanung (BC-3920.30)
+  BC-3900.40.10:
+    name: Kapitalinvestitionsplanung
+    description: |
+      Mehrjährige Netzkapitalprogrammplanung nach Anlagenkategorie.
+  BC-3900.40.20:
+    name: Kosten-Nutzen-Bewertung
+    description: |
+      Kosten-Nutzen-Bewertung von Investitionsoptionen gegen regulatorische Prüfregeln.
+  BC-3900.40.30:
+    name: Investitionsportfoliopriorisierung
+    description: |
+      Kategorieübergreifende Portfoliopriorisierung unter Kapital- und Ressourcenbeschränkungen.
+  BC-3900.50:
+    name: Anlagenerneuerungs- und Ersatzplanung
+    description: |
+      Programmplanung für Anlagenerneuerungen, Ersatzmaßnahmen und
+      Lebensendstilllegungen im Netzbestand.
+  BC-3900.50.10:
+    name: Lebensendprognose
+    description: |
+      Prognose des Lebensendes von Anlagen nach Kategorie und Kohorte.
+  BC-3900.50.20:
+    name: Erneuerungsprogrammgestaltung
+    description: |
+      Gestaltung mehrjähriger Erneuerungsprogramme nach Anlagenkategorie und Geografie.
+  BC-3900.50.30:
+    name: Netzstilllegungsplanung
+    description: |
+      Planung von Stilllegungs-, Aufgabe- und Reinigungsarbeiten.
+  BC-3900.60:
+    name: Anlagenleistungsberichterstattung
+    description: |
+      Berichterstattung über Anlagenleistung und Totex-Verwendung gegen regulatorische
+      und interne Leistungsverpflichtungen.
+  BC-3900.60.10:
+    name: Netzleistungs-KPI-Berichterstattung
+    description: |
+      Berichterstattung über SAIDI, SAIFI, Leckage und gleichwertige Netz-KPIs.
+  BC-3900.60.20:
+    name: Totex-Leistungsberichterstattung
+    description: |
+      Berichterstattung über Totex-Ausgaben im Verhältnis zur Regulierungsperiodengenehmigung.
+  BC-3900.60.30:
+    name: Anlagenausfalltrend-Analyse
+    description: |
+      Trendanalyse von Anlagenausfällen und Wirksamkeit von Maßnahmen.
+  BC-3900.70:
+    name: GIS und Netzkatasterpflege
+    description: |
+      Geospatiales Kataster von Netzanlagen – Leitungen, Rohre, Kanäle
+      und Anschlusspunkte – sowie deren Integration mit Betriebssystemen.
+  BC-3900.70.10:
+    name: GIS-Netzkatasterpflege
+    description: |
+      Pflege von GIS-Netzverbindungs- und Anlagenstandortdaten.
+  BC-3900.70.20:
+    name: Bestandsaufnahme Katasterpflege
+    description: |
+      Erfassung von Bestandsänderungen aus Bau- und Erneuerungsprojekten im GIS.
+  BC-3900.70.30:
+    name: Leitungsauskunftsbetrieb
+    description: |
+      Erdverlegte Versorgungsanlagen-Auskunftsantworten an Drittgräber.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-utility-regulatory-price-control-management.yaml
+++ b/catalogue/i18n/de/L1-utility-regulatory-price-control-management.yaml
@@ -1,0 +1,139 @@
+locale: de
+source: L1-utility-regulatory-price-control-management.yaml
+entries:
+  BC-3920:
+    name: Regulierung und Preisentgeltsteuerung Management
+    description: |
+      Zusammenarbeit mit Versorgungssektorregulatoren und Verwaltung von
+      Preiskontrollregimes – Regulierungsinteraktionen, Preiskontrolleinreichungen,
+      Tarifstrukturgestaltung, Regulierungsberichterstattung, Dienstleistungsqualitätsverpflichtungen,
+      regulatorische Kostenzuordnung sowie Universaldienst- und Erschwinglichkeitsverpflichtungen.
+  BC-3920.10:
+    name: Versorgungsregulator-Engagement
+    description: |
+      Tägliche Beziehungs- und Informationsverwaltung mit
+      Sektorregulatoren und Verbraucherschutzbehörden.
+  BC-3920.10.10:
+    name: Regulatoren-Korrespondenzmanagement
+    description: |
+      Eingehende und ausgehende Korrespondenz- und Informationsanfragenbearbeitung mit Regulatoren.
+  BC-3920.10.20:
+    name: Regulierungskonsultationsreaktion
+    description: |
+      Vorbereitung und Einreichung von Stellungnahmen zu Regulierungskonsultationen.
+  BC-3920.10.30:
+    name: Regulierungsanhörungsbeteiligung
+    description: |
+      Beteiligung an Regulierungsanhörungen, Fachkonferenzen und Stakeholderforen.
+  BC-3920.20:
+    name: Preiskontrolleinreichungsmanagement
+    description: |
+      Ende-zu-Ende-Vorbereitung, Einreichung und Verhandlung mehrjähriger
+      Preiskontroll- oder Rate-Case-Geschäftspläne.
+    in_scope:
+      - Geschäftsplanzusammenstellung (RIIO, PR, Rate-Case)
+      - Kostenvergleich und Totex-Modellierung
+      - Verhandlung genehmigter Erlöse und Outputs
+    out_of_scope:
+      - Interne Investitionsplanung (BC-3900.40)
+      - Großhandelsmarktbeteiligung (BC-3850)
+  BC-3920.20.10:
+    name: Geschäftsplanvorbereitung
+    description: |
+      Vorbereitung von Preiskontrollgeschäftsplänen (RIIO, PR, Rate-Case-Entsprechungen).
+  BC-3920.20.20:
+    name: Kostenvergleich und Totex-Modellierung
+    description: |
+      Kostenvergleich und Totex-Modellierung gegen Regulierer- und Branchendatensätze.
+  BC-3920.20.30:
+    name: Erlösverhandlung
+    description: |
+      Verhandlung genehmigter Erlöse, Outputs und Anreizparameter mit dem Regulierer.
+  BC-3920.30:
+    name: Tarifstrukturgestaltung
+    description: |
+      Gestaltung regulierter Tarifstrukturen – Energieentgelte, Netzentgelte
+      und Grundpreise – für Haus-, Gewerbe- und Industriekunden.
+  BC-3920.30.10:
+    name: Netznutzungsentgelt-Tarifgestaltung
+    description: |
+      Gestaltung von Verteilungs- und Übertragungsnutzungsentgeltstrukturen.
+  BC-3920.30.20:
+    name: Endkundentarifgestaltung
+    description: |
+      Gestaltung von Endkundentarifplänen einschließlich Zeit-variablen und Saisonalstrukturen.
+  BC-3920.30.30:
+    name: Anschlusskosten-Methodologie
+    description: |
+      Anschlusskostenmethodologie und Management der strittigen/nicht strittigen Grenzen.
+  BC-3920.40:
+    name: Regulierungsberichterstattungsbetrieb
+    description: |
+      Periodische gesetzliche Berichterstattung an Versorgungsregulatoren einschließlich
+      jährlicher Leistungsberichte, Regulierungsabschlüsse und Zwischeneinreichungen.
+  BC-3920.40.10:
+    name: Jährliche Leistungsberichterstattung
+    description: |
+      Zusammenstellung und Einreichung jährlicher Leistungsberichte an Regulatoren.
+  BC-3920.40.20:
+    name: Regulierungsabschlusserstellung
+    description: |
+      Erstellung von Regulierungsabschlüssen nach Regulierer-definierten Rechnungslegungsrichtlinien.
+  BC-3920.40.30:
+    name: Ad-hoc-Regulierungseinreichungen
+    description: |
+      Ad-hoc-Dateneinreichungen an Regulierungsportale und Informationsanfragen.
+  BC-3920.50:
+    name: Dienstleistungsqualitätsverpflichtungsmanagement
+    description: |
+      Verfolgung und Anreizverwaltung regulierer-definierter
+      Output-Erfüllungsanreize und Dienstleistungsgüteverpflichtungen.
+  BC-3920.50.10:
+    name: Output-Erfüllungsanreizverfolgung
+    description: |
+      Verfolgung von ODIs, Qualitätsverpflichtungen und Anreizerträgen.
+  BC-3920.50.20:
+    name: Garantierte Standards Administration
+    description: |
+      Verwaltung garantierter Dienstgütezahlungen an Kunden.
+  BC-3920.50.30:
+    name: Leistungspenalty-Berechnung
+    description: |
+      Berechnung regulatorischer Leistungsstrafen und -belohnungen.
+  BC-3920.60:
+    name: Regulatorische Kostenzuordnung
+    description: |
+      Zuordnung von Kosten zwischen regulierten und nicht regulierten Geschäftsbereichen
+      sowie über Preiskontrollkategorien nach Kostenzuordnungsmethodologie.
+  BC-3920.60.10:
+    name: Kostenzuordnungsmethodologie-Pflege
+    description: |
+      Pflege von Regulierer-genehmigten Kostenzuordnungsmethodologien.
+  BC-3920.60.20:
+    name: Reguliert/Nicht-reguliert Kostenteilung
+    description: |
+      Periodische Anwendung der Kostenteilungen zwischen regulierten und nicht regulierten Aktivitäten.
+  BC-3920.60.30:
+    name: Capex/Opex-Klassifizierung
+    description: |
+      Klassifizierung von Ausgaben als Capex oder Opex gemäß Reguliererdefinitionen.
+  BC-3920.70:
+    name: Universaldienst- und Erschwinglichkeitsmanagement
+    description: |
+      Programmdurchführung für Universaldienstverpflichtungen und
+      Regulierer-mandatierte Erschwinglichkeits- und Energie-/Wasserarmutsmaßnahmen.
+  BC-3920.70.10:
+    name: Universaldienstverpflichtungserfüllung
+    description: |
+      Erfüllung von Universaldienstverpflichtungsanforderungen gegenüber Endkunden.
+  BC-3920.70.20:
+    name: Energie- und Wasserarmutsprogrammbetrieb
+    description: |
+      Betrieb von Energie- und Wasserarmutsbekämpfungsprogrammen.
+  BC-3920.70.30:
+    name: Erschwinglichkeitsprogramm-Berichterstattung
+    description: |
+      Berichterstattung zur Erschwinglichkeitsprogrammerfüllung an Regulierer und Regierung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-vehicle-aftersales-warranty-management.yaml
+++ b/catalogue/i18n/de/L1-vehicle-aftersales-warranty-management.yaml
@@ -1,0 +1,176 @@
+locale: de
+source: L1-vehicle-aftersales-warranty-management.yaml
+entries:
+  BC-3450:
+    name: Fahrzeug-Aftersales und Gewährleistung
+    description: |
+      OEM-seitige Aftersales-Tätigkeiten – Garantiebetrieb und
+      Beurteilung, Rückruf- und Serviceaktionsmanagement, technische
+      Serviceinformationen, Kundendienst und Engineering-Feedbackschleife –
+      verankert in Magnuson-Moss, EU-Verbraucherkaufrecht sowie
+      NHTSA/EU-Rückrufregimes.
+  BC-3450.10:
+    name: Garantiepolitik und Anspruchs-Management
+    description: |
+      Definition von Garantiepolitiken und Beurteilung von
+      Händler-Garantieansprüchen einschließlich Lieferantenregress.
+  BC-3450.10.10:
+    name: Garantiepolitik-Definition
+    description: |
+      Definition von Garantiebedingungen, Laufzeiten, Deckungsbereichen
+      und Ausschlüssen für alle Märkte und Produktlinien.
+  BC-3450.10.20:
+    name: Garantieanspruchs-Beurteilung
+    description: |
+      Beurteilung von Händler-Garantieansprüchen einschließlich
+      Arbeitszeitstandards und Teilevalidierung.
+  BC-3450.10.30:
+    name: Kulanz- und Konzessions-Management
+    description: |
+      Management von Kulanzsreparaturen, Konzessionen und
+      Kundenbindungs-Garantieverlängerungen.
+  BC-3450.10.40:
+    name: Lieferantenregress-Management
+    description: |
+      Regressierung von Garantiekosten bei verantwortlichen
+      Lieferanten auf Basis von Garantiekostenteilungsvereinbarungen.
+  BC-3450.20:
+    name: Serviceaktions- und Rückruf-Management
+    description: |
+      End-to-End-Management von Sicherheitsrückrufen und nicht
+      sicherheitsrelevanten Serviceaktionen einschließlich
+      Benachrichtigung und Erledigungserfassung.
+  BC-3450.20.10:
+    name: Rückrufentscheidung und -Benachrichtigung
+    description: |
+      Entscheidungsfindung und gesetzliche Benachrichtigung von
+      Sicherheitsrückrufen an Behörden und Fahrzeughalter.
+  BC-3450.20.20:
+    name: Serviceaktions-Planung
+    description: |
+      Planung von Serviceaktionen einschließlich Abhilfemaßnahmen,
+      Teilebereitstellung und Händleranweisungen.
+  BC-3450.20.30:
+    name: Halterbenachrichtigungs-Management
+    description: |
+      Identifizierung und Benachrichtigung betroffener Fahrzeughalter
+      per Post, E-Mail und In-Car-Kanälen.
+  BC-3450.20.40:
+    name: Kampagnenerledigungs-Verfolgung
+    description: |
+      Verfolgung von Rückruf- und Kampagnenerledigungsquoten und
+      regulatorischen Berichtspflichten.
+  BC-3450.30:
+    name: Technisches Serviceinformations-Management
+    description: |
+      Erstellung und Verteilung von Reparaturverfahren, technischen
+      Bulletins und Diagnoseinformationen für das Händlerservicenetz.
+  BC-3450.30.10:
+    name: Reparaturverfahrens-Erstellung
+    description: |
+      Erstellung von Fahrzeugreparaturverfahren, Explosionszeichnungen
+      und Anzugs-/Klemmdaten.
+  BC-3450.30.20:
+    name: Technisches Service-Bulletin-Management
+    description: |
+      Erstellung, Freigabe und Lebenszyklusmanagement von technischen
+      Servicebulletins.
+  BC-3450.30.30:
+    name: Diagnosefehlercode-Bibliotheksmanagement
+    description: |
+      Pflege von DTC-Bibliotheken, Diagnosebäumen und zugehörigem
+      geführtem Diagnoseinhalt.
+  BC-3450.30.40:
+    name: Servicewerkzeug-Spezifikation
+    description: |
+      Spezifikation von Spezialwerkzeugen und Händlerservice-
+      ausrüstung für den Fahrzeugservice.
+  BC-3450.40:
+    name: Fahrzeugdiagnose- und Telematikservice-Betrieb
+    description: |
+      OEM-Betrieb zur Unterstützung vernetzter Diagnosen, ferngeleiteter
+      Diagnosedaten und Händler-Diagnose-Tool-Ökosysteme.
+  BC-3450.40.10:
+    name: Remote-Fahrzeugdiagnose-Betrieb
+    description: |
+      Betrieb von Remote-Fahrzeuggesundheits- und Diagnosediensten
+      zur Unterstützung des Händlerservice.
+  BC-3450.40.20:
+    name: Diagnosetool-Update-Management
+    description: |
+      Management von Händler-Diagnosetool-Software, Kalibrierungsdaten
+      und Sicherheitszugriffen.
+  BC-3450.40.30:
+    name: Servicedaten-Aggregation
+    description: |
+      Aggregation und Analyse von Serviceereignisdaten von Händlern
+      und vernetzten Fahrzeugen.
+  BC-3450.50:
+    name: Kunden-Pannendienst und Pannenhilfe-Betrieb
+    description: |
+      OEM-Marken-Kundendienste einschließlich Pannenhilfe,
+      Mobilitätsersatz und Fahrzeugrückholung.
+  BC-3450.50.10:
+    name: Pannenhilfe-Betrieb
+    description: |
+      Betrieb OEM-eigener Pannenhilfe für Pann-und Vorfallreaktionen.
+  BC-3450.50.20:
+    name: Mobilitätsersatz-Koordination
+    description: |
+      Koordination von Ersatztransport für Kunden während Reparatur
+      oder Panne.
+  BC-3450.50.30:
+    name: Fahrzeugrückholungs-Koordination
+    description: |
+      Koordination der Fahrzeugrückholung nach Unfällen im Ausland
+      oder Fernpannen.
+  BC-3450.60:
+    name: Aftersales-Teilelogistik-Koordination
+    description: |
+      Koordination mit der Ersatzteilversorgungskette zur Unterstützung
+      von Händler-Servicenachfrage und Rückrufmaßnahmen.
+    in_scope:
+      - Teile-Nachfrage- und Versorgungskoordination mit Händlern
+      - Notfall-Teile-Expediting bei Fahrzeugstillständen
+      - Rückruf-Teilezuteilung für Händlernetzwerke
+    out_of_scope:
+      - Ersatzteilkatalog und -Preisgestaltung (BC-1060 Ersatzteil- und Aftermarket-Management)
+      - Ersatzteilhaltung und physische Distributionsoperationen (BC-1060)
+  BC-3450.60.10:
+    name: Teile-Nachfragekoordination mit Händlern
+    description: |
+      Koordination von Händler-Teilenachfrage-Transparenz und
+      Nachfüllsignalen an die Teilversorgungskette.
+  BC-3450.60.20:
+    name: Kritische Teile-Expediting-Management
+    description: |
+      Priorisierung kritischer Teile bei Fahrzeugstillständen und
+      schwerwiegenden Kundenfällen.
+  BC-3450.60.30:
+    name: Rückruf-Teilezuteilung
+    description: |
+      Zuteilung knapper Rückruf-Teile an Händler und Märkte basierend
+      auf betroffener Bevölkerungspriorität.
+  BC-3450.70:
+    name: Aftersales-Leistung und Qualitäts-Feedback
+    description: |
+      Analyse von Feldausfallereignissen und Kundenfeedback sowie
+      Rückführung von Problemen ins Engineering und in die Produktion.
+  BC-3450.70.10:
+    name: Feldausfall-Trendanalyse
+    description: |
+      Analyse von Garantie- und Serviceereignisdaten zur Identifikation
+      von Feldausfalltrends und aufkommenden Problemen.
+  BC-3450.70.20:
+    name: Aftersales-Kundenstimmen-Management
+    description: |
+      Erfassung und Analyse von Aftersales-Kundenfeedback einschließlich
+      Umfragen und händlererfasstem Feedback.
+  BC-3450.70.30:
+    name: Engineering-Feedbackschleifen-Management
+    description: |
+      Weiterleitung von Feldqualitätsproblemen an das Engineering
+      zur Eindämmung, Fehlerbehebung und Lessons-Learned.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-vehicle-connected-services-management.yaml
+++ b/catalogue/i18n/de/L1-vehicle-connected-services-management.yaml
@@ -1,0 +1,161 @@
+locale: de
+source: L1-vehicle-connected-services-management.yaml
+entries:
+  BC-3460:
+    name: Vernetzte Fahrzeugdienste
+    description: |
+      Betrieb vernetzter Fahrzeugdienste – Fahrzeugkonnektivitätsplattform,
+      Over-the-Air-Software-Updates, In-Car-Apps und Abonnements,
+      Fahrzeugdatenplattform, V2X-Dienste, Fahrzeugsicherheitsbetrieb
+      und Kundensupport für vernetzte Dienste.
+  BC-3460.10:
+    name: Fahrzeugkonnektivitätsplattform-Betrieb
+    description: |
+      Betrieb der In-Car-Konnektivität, SIM-Bereitstellung und der
+      Fahrzeug-zu-Cloud-Telemetrieplattform.
+  BC-3460.10.10:
+    name: Fahrzeug-SIM- und Konnektivitäts-Bereitstellung
+    description: |
+      Bereitstellung von eingebetteter SIM-Konnektivität und
+      Carrier-Roaming für vernetzte Fahrzeuge.
+  BC-3460.10.20:
+    name: Konnektivitätsnetz-Betrieb
+    description: |
+      Betrieb des Konnektivitäts-Backbones zur Unterstützung von
+      Fahrzeugdiensten einschließlich Failover und Dienstgüte.
+  BC-3460.10.30:
+    name: Fahrzeug-zu-Cloud-Telemetrie-Betrieb
+    description: |
+      Betrieb von Fahrzeugtelemetrie-Pipelines von In-Car-Agenten
+      zu Cloud-Plattformen.
+  BC-3460.20:
+    name: Over-the-Air-Software-Update-Betrieb
+    description: |
+      Betrieb von OTA-Software-Update-Kampagnen nach UN R156 und
+      dem Software-Update-Managementsystem.
+  BC-3460.20.10:
+    name: OTA-Kampagnenplanung
+    description: |
+      Planung von OTA-Software-Update-Kampagnen einschließlich
+      Umfang, Berechtigung und Rollout-Strategie.
+  BC-3460.20.20:
+    name: OTA-Paket-Distribution
+    description: |
+      Verteilung signierter OTA-Pakete an Fahrzeuge und Orchestrierung
+      der Installation über Steuergeräte.
+  BC-3460.20.30:
+    name: OTA-Rollback- und Wiederherstellungsmanagement
+    description: |
+      Management von OTA-Rollback, Wiederherstellung und
+      Feldvorfall-Reaktion bei fehlgeschlagenen Updates.
+  BC-3460.30:
+    name: In-Car-App- und Abonnement-Management
+    description: |
+      Betrieb des In-Car-App-Stores, Abonnements-Lebenszyklus
+      und In-Car-Zahlungsdienste.
+  BC-3460.30.10:
+    name: Vernetzter-Dienste-Katalog-Management
+    description: |
+      Pflege des Katalogs vernetzter Dienste und In-Car-Apps
+      für Kunden.
+  BC-3460.30.20:
+    name: Abonnements-Lebenszyklusmanagement
+    description: |
+      Lebenszyklusmanagement von Kunden-Abonnements für vernetzte
+      und Feature-on-Demand-Dienste.
+  BC-3460.30.30:
+    name: In-Car-Zahlungsbetrieb
+    description: |
+      Betrieb von In-Car-Zahlung, Tokenisierung und
+      Transaktionsabwicklung.
+  BC-3460.40:
+    name: Fahrzeugdatenplattform-Betrieb
+    description: |
+      Betrieb der Fahrzeugdatenplattform – Aufnahme, Speicherung,
+      Teilen und Einwilligungsmanagement – zur Unterstützung von
+      Erst- und Drittanbieter-Anwendungsfällen.
+    in_scope:
+      - Fahrzeugdaten-Aufnahme und -Speicherung
+      - Fahrzeugdaten-Sharing-APIs für interne und Partnernutzer
+      - Datenschutz- und Einwilligungsmanagement für Fahrzeugdaten
+    out_of_scope:
+      - Generisches Enterprise-Datenmanagement (unter Enterprise-Daten und IT abgedeckt)
+      - Funktionaler Sicherheitsnachweis (BC-3400.80)
+  BC-3460.40.10:
+    name: Fahrzeugdaten-Aufnahme und -Speicherung
+    description: |
+      Aufnahme, Normalisierung und Speicherung von Fahrzeugtelemetrie-
+      und Ereignisdaten im Flottenmaßstab.
+  BC-3460.40.20:
+    name: Fahrzeugdaten-Sharing und API-Management
+    description: |
+      Bereitstellung von Fahrzeugdaten-APIs für interne Teams, Händler
+      und externe Partner im Rahmen von Datenteilungsvereinbarungen.
+  BC-3460.40.30:
+    name: Fahrzeugdaten-Datenschutz und Einwilligungsmanagement
+    description: |
+      Management von Kunden-Einwilligung, -Präferenzen und
+      Datenschutzeinstellungen für fahrzeugerzeugte Daten.
+  BC-3460.50:
+    name: V2X- und Kooperative Mobilitätsdienste
+    description: |
+      Betrieb von V2X-Nachrichtendiensten und kooperativen
+      Mobilitätsdiensten mit Infrastruktur und anderen Fahrzeugen.
+  BC-3460.50.10:
+    name: V2I-Dienst-Betrieb
+    description: |
+      Betrieb von Fahrzeug-zu-Infrastruktur-Diensten wie
+      Ampelphasen-Timing, Baustellen-Warnung und Mauterhebung.
+  BC-3460.50.20:
+    name: V2V-Nachrichten-Betrieb
+    description: |
+      Betrieb von Fahrzeug-zu-Fahrzeug-Nachrichtendiensten und
+      Broadcast-Kanälen nach SAE J2735 und gleichwertigen Standards.
+  BC-3460.50.30:
+    name: Kooperativer-Awareness-Dienst-Betrieb
+    description: |
+      Betrieb kooperativer Awareness-, Gefahrenwarndienste und
+      Platooning-Dienste für gemischte Flotten.
+  BC-3460.60:
+    name: Fahrzeugsicherheits-Betrieb
+    description: |
+      Operativer Sicherheitsüberwachung der vernetzten Fahrzeugflotte
+      und Reaktion auf Fahrzeug-Cyber-Vorfälle.
+  BC-3460.60.10:
+    name: Fahrzeugbedrohungs-Erkennung
+    description: |
+      Erkennung von Cyberbedrohungen und anomalem Verhalten in der
+      vernetzten Fahrzeugflotte.
+  BC-3460.60.20:
+    name: Fahrzeug-Sicherheitsvorfall-Reaktion
+    description: |
+      Reaktion auf Fahrzeug-Cybersicherheitsvorfälle einschließlich
+      Eindämmung, Behebung und Kundenbenachrichtigung.
+  BC-3460.60.30:
+    name: Fahrzeug-SOC-Betrieb
+    description: |
+      Betrieb des Fahrzeug-Sicherheitsoperationszentrums und
+      unterstützender Telemetrie-Pipelines.
+  BC-3460.70:
+    name: Vernetzter-Dienste-Kundenbetrieb
+    description: |
+      Kundenorientierter Betrieb für vernetzte Dienste, einschließlich
+      Aktivierungsunterstützung, Problemlösung und Kontoverwaltung.
+  BC-3460.70.10:
+    name: Vernetzter-Dienste-Aktivierungsunterstützung
+    description: |
+      Unterstützung für Kunden-Aktivierung, -Übertragung und
+      -Deaktivierung vernetzter Dienste.
+  BC-3460.70.20:
+    name: Vernetzter-Dienste-Problemlösung
+    description: |
+      Lösung von Kunden-gemeldeten Problemen mit vernetzten Diensten
+      über Kontaktzentrum-, Händler- und Self-Service-Kanäle.
+  BC-3460.70.30:
+    name: Vernetzter-Dienste-Kontoverwaltung
+    description: |
+      Verwaltung von Kunden-Konten, Identitäten und Berechtigungen
+      für vernetzte Dienste mit Fahrzeugverknüpfung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-vehicle-engineering-management.yaml
+++ b/catalogue/i18n/de/L1-vehicle-engineering-management.yaml
@@ -1,0 +1,273 @@
+locale: de
+source: L1-vehicle-engineering-management.yaml
+entries:
+  BC-3400:
+    name: Fahrzeugtechnik-Management
+    description: |
+      Gesamtfahrzeug-Engineering in den Bereichen Karosserie, Fahrwerk,
+      Antrieb (Verbrennungsmotor, Elektro, Brennstoffzelle), Elektrik-/
+      Elektronik-Architektur, eingebettete Software, funktionale Sicherheit,
+      Cybersicherheit und SOTIF – verankert in IATF 16949, ISO 26262,
+      ISO/SAE 21434, ISO 21448, Automotive SPICE und AUTOSAR.
+  BC-3400.10:
+    name: Fahrzeugarchitektur-Management
+    description: |
+      Gesamtfahrzeug-Architektur, Packaging, Attributziele und
+      Plattform-/Variantenzerlegung als Rahmen für alle nachgelagerten
+      Engineering-Tätigkeiten.
+    in_scope:
+      - Fahrzeugattributziele und Trade-off-Auflösung
+      - Fahrzeug-Packaging, Layout und Zonenverteilung
+      - Plattform- und Modularchitektur-Entscheidungen
+    out_of_scope:
+      - Stage-Gate-Governance des Programms (BC-3410)
+      - Detailliertes Engineering auf Komponentenebene (abgedeckt durch fachspezifische L2-Ebenen)
+  BC-3400.10.10:
+    name: Fahrzeugattribut-Zielsetzung
+    description: |
+      Definition von Fahrzeugleistungs-, Komfort-, Sicherheits-,
+      Effizienz- und Markenattributzielen sowie deren Trade-off-Auflösung.
+  BC-3400.10.20:
+    name: Fahrzeug-Packaging und Layout
+    description: |
+      Gesamtfahrzeug-Packaging, Insassen- und Gepäcklayout,
+      Festpunktdefinition und Zonenzuweisung.
+  BC-3400.10.30:
+    name: Plattformarchitektur-Definition
+    description: |
+      Definition gemeinsamer Fahrzeugplattformen, gemeinsamer Module und
+      Carry-over-Strategien über Programm hinweg.
+  BC-3400.10.40:
+    name: Modul- und Variantenarchitektur
+    description: |
+      Modulare und variantenbasierte Strategie zur Ableitung von
+      Karosserieversionen, Antrieben und Ausstattungslinien von einer
+      gemeinsamen Architektur.
+  BC-3400.20:
+    name: Antriebstechnik
+    description: |
+      Engineering von Verbrennungsmotor-, Elektro- und
+      Brennstoffzellen-Antriebssystemen einschließlich Getriebe,
+      Antriebsstrang und Energiespeichersystemen.
+  BC-3400.20.10:
+    name: Verbrennungsmotor-Antriebstechnik
+    description: |
+      Engineering von Verbrennungsmotoren, Kraftstoffsystemen,
+      Abgasnachbehandlung und zugehöriger Kalibrierung.
+  BC-3400.20.20:
+    name: Elektroantrieb-Engineering
+    description: |
+      Engineering von Elektro-Antriebseinheiten, Wechselrichtern,
+      Ladeelektronik und Integration in das Hochvoltbordnetz.
+  BC-3400.20.30:
+    name: Batteriesystem-Engineering
+    description: |
+      Engineering von Traktionsbatteriezellen, Modulen, Packs,
+      Batteriemanagementsystemen und Thermomanagementsystemen.
+  BC-3400.20.40:
+    name: Brennstoffzellen-Engineering
+    description: |
+      Engineering von Wasserstoffspeichern, Brennstoffzellenstacks,
+      Balance-of-Plant und Fahrzeugintegration.
+  BC-3400.20.50:
+    name: Getriebe- und Antriebsstrang-Engineering
+    description: |
+      Engineering von Getrieben, Achsen, Antriebswellen und
+      Torque-Vectoring-Antriebsstrangkomponenten.
+  BC-3400.30:
+    name: Fahrwerk- und Fahrdynamik-Engineering
+    description: |
+      Engineering von Fahrwerk, Lenkung, Bremsen, Rädern und Reifen
+      sowie deren integriertes Dynamikverhalten.
+  BC-3400.30.10:
+    name: Fahrwerk- und Lenkungs-Engineering
+    description: |
+      Engineering von Fahrwerksgeometrie, Dämpfern, Federn und
+      Lenksystemen einschließlich Steer-by-Wire.
+  BC-3400.30.20:
+    name: Bremssystem-Engineering
+    description: |
+      Engineering von Betriebsbremsen, regenerativer Bremskraftmischung
+      und Bremssteuersystemen.
+  BC-3400.30.30:
+    name: Fahrdynamik-Abstimmung
+    description: |
+      Abstimmung von Fahrkomfort, Handling, Stabilität und
+      Traktionskontrolle zur Erreichung der Zielfahrattribute.
+  BC-3400.30.40:
+    name: Rad- und Reifen-Engineering
+    description: |
+      Engineering und Auswahl von Rädern und Reifen einschließlich
+      RDKS sowie Leistungs-/Effizienz-Trade-offs.
+  BC-3400.40:
+    name: Karosserie- und Exterieur-Engineering
+    description: |
+      Engineering von Rohkarosserie, Anbauteilen, Verglasung,
+      Außenanbauteilen, Beleuchtung und aerodynamischen Oberflächen.
+  BC-3400.40.10:
+    name: Rohkarosserie-Engineering
+    description: |
+      Engineering der Strukturkarosserie, Fügestrategie und
+      Crashlastpfade.
+  BC-3400.40.20:
+    name: Anbauteil- und Verglasungs-Engineering
+    description: |
+      Engineering von Türen, Hauben, Heckklappen, Schiebeteilen und
+      Verglasungssystemen.
+  BC-3400.40.30:
+    name: Exterieur-Anbauteile und Beleuchtungs-Engineering
+    description: |
+      Engineering von Außenanbauteilen, Emblemen und
+      Außenbeleuchtungssystemen einschließlich Scheinwerfer- und
+      Signalarchitekturen.
+  BC-3400.40.40:
+    name: Aerodynamik-Engineering
+    description: |
+      Aerodynamische Formgebung, Widerstands- und Auftriebsbalancierung
+      sowie Unterbodenströmungsmanagement.
+  BC-3400.50:
+    name: Interieur- und Komfort-Engineering
+    description: |
+      Engineering von Sitzen, Rückhaltesystemen, Innenverkleidung,
+      HMI-Oberflächen, Klimatisierung sowie Akustik- und
+      NVH-Eigenschaften.
+  BC-3400.50.10:
+    name: Sitz- und Rückhaltesystem-Engineering
+    description: |
+      Engineering von Sitzen, Sicherheitsgurten, Airbags und sonstigen
+      Insassen-Rückhaltesystemen.
+  BC-3400.50.20:
+    name: Innenverkleidung und HMI-Engineering
+    description: |
+      Engineering von Instrumententafel, Mittelkonsole, Dachhimmel
+      sowie physischen und digitalen HMI-Oberflächen.
+  BC-3400.50.30:
+    name: Klimatisierungs-Engineering
+    description: |
+      Engineering von HVAC, Kältemittelsystemen, Wärmepumpen sowie
+      Batterie- und Innenraum-Thermomanagementsystemen.
+  BC-3400.50.40:
+    name: Akustik- und NVH-Engineering
+    description: |
+      Akustik-, Schwingungs- und Rauheitstechnik sowie Abstimmung über
+      das gesamte Fahrzeug.
+  BC-3400.60:
+    name: Elektrik-/Elektronik-Architektur-Engineering
+    description: |
+      Engineering der fahrzeugseitigen E/E-Topologie, fahrzeuginternen
+      Netzwerke, Stromverteilung und Steuergerätehardware.
+  BC-3400.60.10:
+    name: E/E-Topologie-Definition
+    description: |
+      Definition der Fahrzeug-E/E-Topologie einschließlich domänen-,
+      zonal- und zentralisierter Rechenarchitekturen.
+  BC-3400.60.20:
+    name: Fahrzeugnetz-Engineering
+    description: |
+      Engineering von CAN, CAN-FD, LIN, FlexRay, Automotive Ethernet
+      und verwandten Fahrzeugkommunikationsnetzen.
+  BC-3400.60.30:
+    name: Leitungssatz- und Stromverteiler-Engineering
+    description: |
+      Engineering von Kabelbäumen, Steckverbindern sowie Hoch- und
+      Niedervolt-Stromverteilung.
+  BC-3400.60.40:
+    name: Steuergeräte-Hardware-Engineering
+    description: |
+      Engineering von Steuergerätehardware, Halbleitern und
+      Leiterplattendesigns nach AEC-Q-Standards.
+  BC-3400.70:
+    name: Fahrzeugsoftware-Engineering
+    description: |
+      Engineering von eingebetteter Software, automobilen
+      Softwareplattformen und Fahrzeugbetriebssystemen nach AUTOSAR
+      und Automotive SPICE.
+  BC-3400.70.10:
+    name: Embedded-Software-Engineering
+    description: |
+      Engineering von eingebetteter Software auf Steuergeräteebene
+      einschließlich Gerätetreibern und Basissoftwarekomponenten.
+  BC-3400.70.20:
+    name: AUTOSAR-Plattform-Engineering
+    description: |
+      Engineering von AUTOSAR Classic- und Adaptive-Plattform-
+      Konfigurationen und deren Integration.
+  BC-3400.70.30:
+    name: Fahrzeugbetriebssystem-Engineering
+    description: |
+      Engineering von Hochleistungs-Fahrzeugbetriebssystemen,
+      Hypervisoren und Middleware für software-definierte Fahrzeuge.
+  BC-3400.70.40:
+    name: Software-Integration und Build-Management
+    description: |
+      Fahrzeugsoftware-Integration, Build- und Release-Train-Management
+      über Steuergeräte und Domänen hinweg.
+  BC-3400.80:
+    name: Funktionale Sicherheit und Cybersicherheit
+    description: |
+      Engineering-Disziplinen zur Absicherung sicherheitskritischen
+      und vernetzten Fahrzeugverhaltens – verankert in ISO 26262,
+      ISO/SAE 21434 und ISO 21448.
+    in_scope:
+      - Safety-Case-Erstellung (ISO 26262)
+      - Cybersicherheits-Engineering (ISO/SAE 21434)
+      - SOTIF-Analyse und Validierung (ISO 21448)
+      - HARA, FMEA-MSR und TARA
+    out_of_scope:
+      - Operativer Fahrzeug-SOC und Incident-Response (BC-3460.60)
+      - Typzulassungseinreichungen für UN R155/R156 (BC-3420.50)
+  BC-3400.80.10:
+    name: Funktionaler Sicherheitsnachweis
+    description: |
+      Erstellung und Pflege von ISO-26262-Sicherheitsnachweisen,
+      ASIL-Zuweisung und Sicherheitsargumentationsbelegen.
+  BC-3400.80.20:
+    name: Automobil-Cybersicherheits-Engineering
+    description: |
+      Cybersicherheits-Engineering-Aktivitäten nach ISO/SAE 21434
+      einschließlich TARA, sicheres Design und sicherer Entwicklungslebenszyklus.
+  BC-3400.80.30:
+    name: SOTIF-Engineering
+    description: |
+      Analyse und Validierung der Sicherheit der beabsichtigten
+      Funktionalität für ADAS- und automatisierte Fahrfunktionen
+      gemäß ISO 21448.
+  BC-3400.80.40:
+    name: Gefährdungs- und Risikoanalyse
+    description: |
+      HARA, FMEA-MSR und weitere systematische Gefährdungsanalysen
+      zur Ableitung von Sicherheits- und Schutzanforderungen.
+  BC-3400.90:
+    name: Fahrzeug-Verifikations- und Validierungsmanagement
+    description: |
+      Verifikation und Validierung von Fahrzeug-, Subsystem- und
+      Komponentendesigns durch virtuelle, Prüfstands- und physische
+      Testkampagnen.
+  BC-3400.90.10:
+    name: Virtuelle Validierung
+    description: |
+      CAE-, MIL-/SIL-/HIL- und Digital-Twin-basierte virtuelle
+      Verifikation von Fahrzeug- und Subsystemverhalten.
+  BC-3400.90.20:
+    name: Komponenten- und Subsystem-Prüfung
+    description: |
+      Prüfstands- und Rigtestprüfung von Komponenten und Subsystemen
+      gegen Engineeringspezifikationen.
+  BC-3400.90.30:
+    name: Fahrzeug-Integrationstests
+    description: |
+      Gesamtfahrzeug-Integrationstests auf Prüfgeländen und öffentlichen
+      Straßen unter kontrollierten Bedingungen.
+  BC-3400.90.40:
+    name: Dauerhaltbarkeits- und Zuverlässigkeitstests
+    description: |
+      Beschleunigte und kundenbezogene Dauerhaltbarkeits- und
+      Zuverlässigkeitstests an Komponenten und am Gesamtfahrzeug.
+  BC-3400.90.50:
+    name: Crash- und Insassenschutztests
+    description: |
+      Engineering von Crash- und Insassenschutztests zur Erfüllung
+      regulatorischer Anforderungen und Verbraucherbewertungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-vehicle-homologation-type-approval-management.yaml
+++ b/catalogue/i18n/de/L1-vehicle-homologation-type-approval-management.yaml
@@ -1,0 +1,184 @@
+locale: de
+source: L1-vehicle-homologation-type-approval-management.yaml
+entries:
+  BC-3420:
+    name: Fahrzeugzulassung und Typgenehmigung
+    description: |
+      Regulatorische Zertifizierung von Fahrzeugen und wesentlichen
+      Komponenten in allen Märkten – UNECE-WP.29-Typgenehmigung,
+      FMVSS-Selbstzertifizierung, regionale Zulassungen (CCC, KS, MLIT),
+      Emissionen- und Energiehomologation, Crashprogramme für
+      Verbraucherbewertungen sowie Konformitätsaudit der Produktion.
+  BC-3420.10:
+    name: Typgenehmigungsstrategie und -planung
+    description: |
+      Marktübergreifende Homologationsstrategie und -planung
+      einschließlich Behördenengagement und Homologationsplanausführung.
+  BC-3420.10.10:
+    name: Marktzulassungsstrategie
+    description: |
+      Strategie für Typgenehmigung und Zertifizierung in Zielmärkten
+      und regulatorischen Regimes.
+  BC-3420.10.20:
+    name: Homologationsplan-Management
+    description: |
+      Management von Homologationsplänen, Liefergegenständen und
+      Meilensteinen auf Programmebene.
+  BC-3420.10.30:
+    name: Behördenengagement
+    description: |
+      Zusammenarbeit mit Zulassungsbehörden und Technischen Diensten
+      in verschiedenen Rechtsgebieten.
+  BC-3420.20:
+    name: Fahrzeug-Typgenehmigungseinreichungen
+    description: |
+      Vorbereitung und Einreichung von Typgenehmigungsdossiers und
+      Selbstzertifizierungsunterlagen für UNECE, FMVSS und regionale Regimes.
+  BC-3420.20.10:
+    name: UNECE-Typgenehmigungsdossier-Management
+    description: |
+      Vorbereitung, Einreichung und Pflege von UNECE-WP.29-
+      Gesamtfahrzeug-Typgenehmigungsdossiers.
+  BC-3420.20.20:
+    name: FMVSS-Selbstzertifizierungs-Management
+    description: |
+      Management von Selbstzertifizierungsbelegen nach FMVSS/49 CFR 571
+      in den Vereinigten Staaten.
+  BC-3420.20.30:
+    name: Regionale Einreichungs-Management
+    description: |
+      Einreichungsmanagement für CCC, KS, MLIT, GCC und weitere
+      regionale Kraftfahrzeug-Zulassungsregimes.
+  BC-3420.20.40:
+    name: Genehmigungsänderungs- und Erweiterungsmanagement
+    description: |
+      Management von Genehmigungsänderungen, Erweiterungen und
+      Überarbeitungen über den Fahrzeuglebenszyklus.
+  BC-3420.30:
+    name: Emissionen- und Energiehomologation
+    description: |
+      Homologation von Fahrzeugemissionen, Energieverbrauch und
+      Elektroreichweite nach WLTP, RDE, EPA, CARB, China und
+      vergleichbaren Regimes.
+  BC-3420.30.10:
+    name: Emissionsprüfzyklus-Durchführung
+    description: |
+      Durchführung von WLTP-, FTP-75-, China- und sonstigen
+      regulatorischen Emissions- und Kraftstoffverbrauchsprüfzyklen.
+  BC-3420.30.20:
+    name: Real-Driving-Emissions-Konformität
+    description: |
+      RDE-Testkampagnen und Konformitätsnachweis für
+      In-Service-Übereinstimmung.
+  BC-3420.30.30:
+    name: CO2- und Kraftstoffverbrauchsmeldung
+    description: |
+      Regulatorische CO2- und Kraftstoffverbrauchsmeldung nach
+      EU-CO2-Flottenregeln, CAFE und gleichwertigen Regelungen.
+  BC-3420.30.40:
+    name: Elektroreichweiten- und Effizienz-Homologation
+    description: |
+      Homologation von Elektrofahrzeugreichweite, Energieverbrauch
+      und Ladekennwerten in verschiedenen Märkten.
+  BC-3420.40:
+    name: Crash- und Insassensicherheits-Homologation
+    description: |
+      Regulatorische Crash-, Insassenschutz- und
+      Fußgängerschutz-Homologation sowie Verbraucherbewertungsprogramme.
+  BC-3420.40.10:
+    name: Crashtestprogramm-Management
+    description: |
+      Planung und Durchführung regulatorischer und
+      homologationsrelevanter Crashtestkampagnen.
+  BC-3420.40.20:
+    name: Rückhaltesystem-Zulassung
+    description: |
+      Zulassung von Sicherheitsgurten, Airbags und
+      Kindersitz-Verankerungen in allen regulatorischen Regimes.
+  BC-3420.40.30:
+    name: Fußgängerschutz-Zulassung
+    description: |
+      Fußgänger- und schwächerer-Verkehrsteilnehmer-Schutzhomologation
+      nach UNECE GTR 9 und gleichwertigen Vorschriften.
+  BC-3420.40.40:
+    name: NCAP-Programm-Management
+    description: |
+      Management von Verbraucher-Crashtestbewertungsprogrammen
+      einschließlich Euro NCAP, IIHS, NHTSA NCAP und regionaler NCAPs.
+  BC-3420.50:
+    name: Funktionale und Cyberzulassung
+    description: |
+      Typgenehmigungsaktivitäten speziell für UN R155 Cybersicherheit,
+      UN R156 Software-Updates und UN R157 ALKS/ADS als Ergänzung zum
+      Engineering im Bereich Fahrzeugtechnik.
+    in_scope:
+      - CSMS-Audits und Typgenehmigung
+      - SUMS-Audits und Typgenehmigung
+      - ALKS/ADS-Regulierungseinreichungen
+    out_of_scope:
+      - Cybersicherheits-Engineering-Aktivitäten (BC-3400.80)
+      - Fahrzeug-SOC-Betrieb (BC-3460.60)
+  BC-3420.50.10:
+    name: CSMS-Typgenehmigungsmanagement
+    description: |
+      Typgenehmigung des Cybersicherheits-Managementsystems nach
+      UN R155 einschließlich Auditvorbereitung und Überwachung.
+  BC-3420.50.20:
+    name: SUMS-Typgenehmigungsmanagement
+    description: |
+      Typgenehmigung des Software-Update-Managementsystems nach
+      UN R156 einschließlich Auditvorbereitung und Überwachung.
+  BC-3420.50.30:
+    name: ALKS- und ADS-Zulassungsmanagement
+    description: |
+      Zulassungseinreichungen für automatisierte Spurhaltesysteme und
+      umfassendere automatisierte Fahrsysteme nach UN R157 und
+      aufkommenden Vorschriften.
+  BC-3420.60:
+    name: Komponenten- und System-Typgenehmigung
+    description: |
+      Typgenehmigungen auf Komponentenebene für Systeme wie Beleuchtung,
+      EMV, Reifen und Bremsen zur Unterstützung der Gesamtfahrzeug-Zulassung.
+  BC-3420.60.10:
+    name: Beleuchtungs- und Signalzulassung
+    description: |
+      Zulassung von Scheinwerfern, Signalgebern und adaptiven
+      Beleuchtungssystemen.
+  BC-3420.60.20:
+    name: EMV-Zulassung
+    description: |
+      Elektromagnetische Verträglichkeitszulassung für Fahrzeug und
+      elektronische Baugruppen nach UN R10.
+  BC-3420.60.30:
+    name: Reifen- und Radzulassung
+    description: |
+      Reifen- und Radzulassung und -kennzeichnung nach UNECE und
+      regionalen Regimes.
+  BC-3420.60.40:
+    name: Brems- und Lenk-Komponentenzulassung
+    description: |
+      Zulassung von Brems- und Lenkkomponenten nach UN R13/R13H,
+      R79 und gleichwertigen Vorschriften.
+  BC-3420.70:
+    name: Produktionskonformitäts-Management
+    description: |
+      Produktionskonformitätsaudits und laufende Produktionsmuster-
+      Verifikation gegen genehmigte Spezifikationen.
+  BC-3420.70.10:
+    name: CoP-Audit-Management
+    description: |
+      Management von Produktionskonformitätsaudits durch
+      Zulassungsbehörden und Technische Dienste.
+  BC-3420.70.20:
+    name: Produktionsmuster-Verifikation
+    description: |
+      Verifikation von Produktionsmustern gegen typgenehmigte
+      Spezifikationen und Toleranzen.
+  BC-3420.70.30:
+    name: In-Service-Konformitätsüberwachung
+    description: |
+      In-Service-Konformitätsprüfung und -überwachung zur Bestätigung
+      der fortlaufenden Konformität nach dem Marktanlauf.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-vehicle-programme-management.yaml
+++ b/catalogue/i18n/de/L1-vehicle-programme-management.yaml
@@ -1,0 +1,176 @@
+locale: de
+source: L1-vehicle-programme-management.yaml
+entries:
+  BC-3410:
+    name: Fahrzeugprogramm-Management
+    description: |
+      Mehrjährige Fahrzeugprogramm-Governance mit Konzeptdefinition,
+      Stage-Gate-Meilensteinen, Plattform- und Variantenstrategie sowie
+      programmseitiger Kosten-, Gewichts- und Terminverfolgung von
+      Produktionsanlauf bis Produktionsende.
+  BC-3410.10:
+    name: Programmdefinition und -initiierung
+    description: |
+      Konzeptdefinition, Business-Case, Programm-Charter und
+      Freigabebeschluss für neue Fahrzeug- und Ableitungsprogramme.
+    in_scope:
+      - Programm-Charter und Business-Case-Genehmigung
+      - Fahrzeugkonzept- und Positionierungsdefinition
+      - Plattform- und Carry-over-Strategieabstimmung
+    out_of_scope:
+      - Detailliertes Engineering von Fahrzeugsubsystemen (BC-3400)
+      - Unternehmensweite Projektportfolio-Governance (BC-900)
+  BC-3410.10.10:
+    name: Programm-Charter und Business-Case
+    description: |
+      Genehmigungsreifer Programm-Charter, finanzieller Business-Case
+      und Investitionsfreigabe.
+  BC-3410.10.20:
+    name: Fahrzeugkonzept-Definition
+    description: |
+      Fahrzeugkonzept, Positionierung, Kundenpaketkonfiguration und
+      übergeordnete Attributziele.
+  BC-3410.10.30:
+    name: Plattformstrategie-Abstimmung
+    description: |
+      Abstimmung der Programme mit Plattform-Roadmaps,
+      Carry-over-Entscheidungen und gemeinsamen Modulstrategien.
+  BC-3410.10.40:
+    name: Programm-Freigabe-Gating
+    description: |
+      Initiale Programmfreigabe-Gates einschließlich Budget-, Termin-
+      und Ressourcenzusagen.
+  BC-3410.20:
+    name: Programm-Stage-Gate-Governance
+    description: |
+      Betrieb des Stage-Gate-Modells mit Meilenstein-Reviews,
+      Lieferabsicherung sowie Risiko- und Problemsteuerung.
+  BC-3410.20.10:
+    name: Meilensteinplanung
+    description: |
+      Planung der Programmmeilensteine von Technischem Muster und
+      Vorserienfahrzeugen bis SOP und Produktionsende.
+  BC-3410.20.20:
+    name: Gate-Review-Durchführung
+    description: |
+      Durchführung von Stage-Gate-Reviews einschließlich
+      Lieferbeurteilung und Freigabe-/Halteentscheidungen.
+  BC-3410.20.30:
+    name: Programmrisiko- und Problemmanagement
+    description: |
+      Identifikation, Eskalation und Mitigation von Programmrisiken
+      und kritischen Problemen.
+  BC-3410.20.40:
+    name: Programmreife-Beurteilung
+    description: |
+      Beurteilung der Programmreife anhand von Engineering-,
+      Fertigungs- und Lieferantenbereitschaftskriterien.
+  BC-3410.30:
+    name: Programmkostenmanagement
+    description: |
+      Festlegung und Verfolgung von Programmkostenzielen über
+      Stückliste, Werkzeuge, Investitionen und Garantierückstellungen.
+  BC-3410.30.10:
+    name: Programmkostenzielsetzung
+    description: |
+      Festlegung von Programmkostenzielen für Stückliste,
+      Fertigungskosten und Investitionsrahmen.
+  BC-3410.30.20:
+    name: Stücklistenkosten-Verfolgung
+    description: |
+      Verfolgung der Fahrzeugstücklistenkosten, Lieferantenangebote
+      und Inhaltsänderungen.
+  BC-3410.30.30:
+    name: Variable und Fixkostenprognose
+    description: |
+      Prognose der variablen und fixen Programmkosten über Anlauf-
+      und Serienphase.
+  BC-3410.30.40:
+    name: Kostensenkungsmaßnahmen-Verfolgung
+    description: |
+      Verfolgung von Kostensenkungsinitiativen, Value-Engineering-
+      Maßnahmen und deren Realisierung gegen Zielwerte.
+  BC-3410.40:
+    name: Programmgewichts- und Attributverfolgung
+    description: |
+      Verfolgung von Fahrzeuggewicht, Leistungsattributen und
+      sonstigen Attributen gegen Programm ziele sowie Trade-off-
+      Auflösung auf Programmebene.
+  BC-3410.40.10:
+    name: Fahrzeuggewichts-Verfolgung
+    description: |
+      Verfolgung des Massenanstiegs je System und Reserve gegen
+      Programmgewichtsziele.
+  BC-3410.40.20:
+    name: Attributleistungs-Verfolgung
+    description: |
+      Verfolgung der Attributleistung auf Programmebene und Reserven
+      gegen Zielwerte.
+  BC-3410.40.30:
+    name: Zielkonformitäts-Berichterstattung
+    description: |
+      Berichterstattung des Zielkonformitätsstatus an
+      Programmleitung und Lenkungsausschüsse.
+  BC-3410.50:
+    name: Varianten- und Ableitungsplanung
+    description: |
+      Planung von Ausstattungs-, Regional- und Sondermodellvarianten
+      über den Programm-Lebenszyklus.
+  BC-3410.50.10:
+    name: Ausstattungs- und Variantenplanung
+    description: |
+      Planung von Ausstattungslinien, Optionen und Serienausstattung
+      je Markt und Segment.
+  BC-3410.50.20:
+    name: Regionale Ableitungsplanung
+    description: |
+      Planung regionaler Ableitungen einschließlich marktspezifischer
+      Karosserien, Antriebe und Funktionsinhalte.
+  BC-3410.50.30:
+    name: Sonder- und Limitiertserienplanung
+    description: |
+      Planung von Sondermodellen, limitierten Serien und
+      motorsportabgeleiteten Derivaten.
+  BC-3410.60:
+    name: SOP- und EOP-Koordination
+    description: |
+      Koordination der SOP-Bereitschaft, Produktionshochlauf und
+      EOP-Auslaufplanung über Werke und Lieferantennetzwerke.
+  BC-3410.60.10:
+    name: SOP-Bereitschaftskoordination
+    description: |
+      Koordination der Engineering-, Lieferanten-, Werks- und
+      Aftersales-Bereitschaftskriterien für den SOP.
+  BC-3410.60.20:
+    name: Produktionshochlauf-Planung
+    description: |
+      Planung von Produktionshochlaufkurven, Vorserienaufbau und
+      frühen Serienvolumenkadenz.
+  BC-3410.60.30:
+    name: EOP-Auslaufkoordination
+    description: |
+      Koordination von Produktionsendeterminen, Last-Time-Buys und
+      Auslaufplänen.
+  BC-3410.70:
+    name: Programmleistungs-Berichterstattung
+    description: |
+      Berichterstattung zu Programmstatus, Entscheidungen und
+      Post-Launch-Leistung an Lenkungsausschüsse und Geschäftsführung.
+  BC-3410.70.10:
+    name: Programmstatus-Berichterstattung
+    description: |
+      Regelmäßige Programmstatusberichte zu Kosten, Terminen,
+      Qualität und Risiken.
+  BC-3410.70.20:
+    name: Programmlenkungsausschuss-Unterstützung
+    description: |
+      Vorbereitung und Unterstützung von Programmlenkungsausschüssen
+      und Vorstandsreviews.
+  BC-3410.70.30:
+    name: Post-Launch-Programmreview
+    description: |
+      Post-Launch-Reviews zur Erfassung von Lessons-Learned und
+      Einspeisung in nachfolgende Programminitiierungen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-vehicle-sales-distribution-management.yaml
+++ b/catalogue/i18n/de/L1-vehicle-sales-distribution-management.yaml
@@ -1,0 +1,170 @@
+locale: de
+source: L1-vehicle-sales-distribution-management.yaml
+entries:
+  BC-3440:
+    name: Fahrzeugvertrieb-Management
+    description: |
+      Operativer Verkauf und Vertrieb von Neufahrzeugen –
+      Großhandelsplanung, Werkskapazitätszuweisung, Auftragsbanken,
+      Vorführ- und zertifizierte Gebrauchtfahrzeugbestände, Flotten-
+      und B2B-Verkauf sowie die Übergabe- und Zulassungsschnittstelle
+      zum Endkunden.
+  BC-3440.10:
+    name: Fahrzeugverkaufsplanung und -Zuteilung
+    description: |
+      Planung von Großhandelsvolumina nach Markt und Händler sowie
+      Zuteilung von Werksfertigungskapazitäten.
+  BC-3440.10.10:
+    name: Großhandelsvolumen-Planung
+    description: |
+      Periodische Planung von Großhandelsfahrzeugvolumina nach Markt,
+      Modell und Segment.
+  BC-3440.10.20:
+    name: Produktions-Markt-Zuteilung
+    description: |
+      Zuteilung begrenzter Werkskapazitäten auf Märkte und Kanäle
+      gemäß Nachfrage und strategischen Prioritäten.
+  BC-3440.10.30:
+    name: Produktionsslot-Management
+    description: |
+      Zuteilung, Tausch und Freigabe von Werksfertigungsslots an
+      Händler und Flottenkundschaft.
+  BC-3440.20:
+    name: Fahrzeugauftragsbank-Management
+    description: |
+      Erfassung, Konfigurationsvalidierung und Lebenszyklusmanagement
+      von Lager- und Kundenfahrzeugaufträgen.
+  BC-3440.20.10:
+    name: Lagerauftrags-Management
+    description: |
+      Management von Händlerlageraufträgen gegen Zuteilungen und
+      Lagerziele.
+  BC-3440.20.20:
+    name: Kundenauftrags-Erfassung
+    description: |
+      Erfassung von Einzelhandels- und Flottenkundenfahrzeugaufträgen
+      einschließlich Konfiguration und Preisgestaltung.
+  BC-3440.20.30:
+    name: Auftrags-Konfigurationsvalidierung
+    description: |
+      Validierung von Auftragskonfigurationen gegen Machbarkeits-,
+      Regulierungs- und Preisregeln.
+  BC-3440.20.40:
+    name: Auftrags-Statusverfolgung
+    description: |
+      End-to-End-Verfolgung des Auftragsstatus von Eingang über
+      Produktion, Versand bis zum Händlereingang.
+  BC-3440.30:
+    name: Werksauftrags- und Distributionsbetrieb
+    description: |
+      Koordination der Build-to-Order-Ausführung und der ausgehenden
+      Fahrzeuglogistik vom Werk zum Händler.
+  BC-3440.30.10:
+    name: Build-to-Order-Koordination
+    description: |
+      Koordination der Build-to-Order-Ausführung mit Fertigungsbetrieb
+      und Lieferantenabrufen.
+  BC-3440.30.20:
+    name: Fahrzeuglogistik-Koordination
+    description: |
+      Koordination der ausgehenden Fahrzeuglogistik per LKW, Bahn,
+      Schiff und interne Hofumläufe.
+  BC-3440.30.30:
+    name: Eingangshafen- und Hofbetriebs-Koordination
+    description: |
+      Koordination von Eingangshafen-, Bearbeitungszentrum- und
+      Hofbetrieb einschließlich Vorlieferungs-Zubehörinstallation.
+  BC-3440.40:
+    name: Fahrzeugbestand und Vorführwagen-Management
+    description: |
+      Management von Händlerlager-, Vorführ-, Presse- und
+      Leihfahrzeugbeständen.
+  BC-3440.40.10:
+    name: Händlerlagerbestand-Management
+    description: |
+      Transparenz und Management von Fahrzeugbeständen bei Händlern
+      und unterwegs.
+  BC-3440.40.20:
+    name: Vorführwagen-Management
+    description: |
+      Management von Vorführwagenpools bei Händlern und im
+      OEM-Außendienst.
+  BC-3440.40.30:
+    name: Presse- und Leihrfahrzeug-Management
+    description: |
+      Management von Presse-, Marketing- und Leihwagenflotten
+      einschließlich Konfigurationen und Rotation.
+  BC-3440.50:
+    name: Zertifiziertes-Gebrauchtfahrzeug-Programm-Management
+    description: |
+      Management von OEM-Programmen für zertifizierte Gebrauchtfahrzeuge
+      mit Inspektion, Berechtigung, Markenführung und Garantie.
+    in_scope:
+      - CPO-Inspektion und Berechtigungskriterien
+      - CPO-Bestand und Preisgestaltung
+      - CPO-spezifische Garantieprogramme
+    out_of_scope:
+      - Gebrauchtfahrzeug-Vermarktung von Leasingrückläufern außerhalb des CPO-Programms
+  BC-3440.50.10:
+    name: CPO-Fahrzeugberechtigung und -Inspektion
+    description: |
+      Definition und Durchführung von CPO-Berechtigungskriterien und
+      Inspektionsstandards.
+  BC-3440.50.20:
+    name: CPO-Bestandsmanagement
+    description: |
+      Management von CPO-Beständen bei Händlern und in
+      zentralen Pools.
+  BC-3440.50.30:
+    name: CPO-Garantie und Markenführung
+    description: |
+      Design und Vermarktung des Marken-CPO-Garantieprogramms.
+  BC-3440.60:
+    name: Flotten- und B2B-Verkaufsmanagement
+    description: |
+      Vertriebsbetrieb für Flotten-, Leasing-, Vermiet- und sonstige
+      B2B-Fahrzeugkäufer einschließlich Ausschreibungs- und
+      Angebotsbearbeitung.
+  BC-3440.60.10:
+    name: Flottenkonten-Management
+    description: |
+      Management von Großflottenkonten und
+      Firmenkunden-Geschäftsbeziehungen.
+  BC-3440.60.20:
+    name: Flottenausschreibungs- und Angebotsmanagement
+    description: |
+      Beantwortung von Flottenausschreibungen, RFPs und strukturierten
+      Angebotsprozessen für große Fahrzeuggeschäfte.
+  BC-3440.60.30:
+    name: Flottenfahrzeug-Spezifikationsmanagement
+    description: |
+      Management von flottenspezifischen Fahrzeugspezifikationen,
+      Optionen und Umbauten.
+  BC-3440.60.40:
+    name: Vermiet- und Leasing-Kanalmanagement
+    description: |
+      Management von OEM-Beziehungen zu Vermiet- und
+      Leasingunternehmen einschließlich Rückkaufvereinbarungen.
+  BC-3440.70:
+    name: Fahrzeugübergabe und Zulassungsunterstützung
+    description: |
+      Unterstützung für Händler bei Fahrzeugübergabe, Zulassung und
+      Eintritt in die Kundenerlebnisphase.
+  BC-3440.70.10:
+    name: Vorlieferungsinspektions-Koordination
+    description: |
+      Koordination von Vorlieferungsinspektionsstandards und
+      Abnahmen bei Händlern und Bearbeitungszentren.
+  BC-3440.70.20:
+    name: Fahrzeugzulassungs-Liaison
+    description: |
+      Kontakt zu Fahrzeugzulassungsbehörden und Bereitstellung von
+      Erstzulassungsdaten.
+  BC-3440.70.30:
+    name: Kunden-Übergabeerlebnis
+    description: |
+      Definition und Sicherung des Kunden-Übergabeerlebnisses bei
+      der Auslieferung.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-warehousing-operations-management.yaml
+++ b/catalogue/i18n/de/L1-warehousing-operations-management.yaml
@@ -1,0 +1,135 @@
+locale: de
+source: L1-warehousing-operations-management.yaml
+entries:
+  BC-2460:
+    name: Lagerbetrieb-Management
+    description: |
+      Betrieb von Drittanbieter-Lagern und Distributionszentren einschließlich
+      Wareneingang, Lagerung, Warenausgang, Mehrwertleistungen und Retouren-Logistik.
+  BC-2460.10:
+    name: Wareneingangs-Betriebsmanagement
+    description: |
+      Empfang, Inspektion und Einlagerung von Waren, die das Lager betreten.
+    in_scope:
+      - Voranmeldung und ASN-Verarbeitung
+      - Wareneingangsinspektion und Einlagerung
+    out_of_scope:
+      - Warenausgangsdisposition (BC-2460.30)
+      - Inventareigentum auf Versenderebene (BC-530)
+  BC-2460.10.10:
+    name: Voranmeldeplanung
+    description: |
+      ASN-Verarbeitung, Dockplanung und Ressourcenplanung für Wareneingänge.
+  BC-2460.10.20:
+    name: Wareneingang und Inspektion
+    description: |
+      Physischer Empfang und Inspektion eingehender Waren.
+  BC-2460.10.30:
+    name: Einlagerung und Lagerplatzzuweisung
+    description: |
+      Einlagerung empfangener Waren und Zuweisung von Lagerplätzen.
+  BC-2460.20:
+    name: Lager- und Inventarbetrieb-Management
+    description: |
+      Innerbetriebliche Lagervorgänge einschließlich Slotting, Stichprobeninventuren
+      und konditionierter Lagerung.
+  BC-2460.20.10:
+    name: Slotting und Lagerplatzverwaltung
+    description: |
+      Slotting-Entscheidungen und Lagerplatzverwaltung.
+  BC-2460.20.20:
+    name: Stichprobeninventur und Abstimmung
+    description: |
+      Stichprobeninventuren, Bestandsabstimmung und Bestandsanpassung.
+  BC-2460.20.30:
+    name: Chargen-, Serien- und Batch-Verfolgung
+    description: |
+      Verfolgung von Chargen-, Serien- und Batch-Attributen für gelagerte Waren.
+  BC-2460.20.40:
+    name: Kühlketten- und Konditioniertlagerung
+    description: |
+      Betrieb temperaturgesteuerter, gefährlicher und Zolllager.
+  BC-2460.30:
+    name: Warenausgangs-Betriebsmanagement
+    description: |
+      Kommissionierung, Verpackung, Etikettierung und Versand ausgehender Sendungen.
+  BC-2460.30.10:
+    name: Kommissionierungsbetrieb
+    description: |
+      Auftragskommissionierung mit Batch-, Wellen- und Zonen-Strategien.
+  BC-2460.30.20:
+    name: Verpackung und Etikettierung
+    description: |
+      Verpackung, Etikettierung und Versanddokumentenvorbereitung.
+  BC-2460.30.30:
+    name: Versand und Verladung
+    description: |
+      Beladung ausgehender Fahrzeuge und Versandbestätigung.
+  BC-2460.40:
+    name: Mehrwertleistungs-Management
+    description: |
+      Innerhalb des Lagers erbrachte Mehrwertleistungen wie Kitting, Co-Packing,
+      Etikettierung und Konfiguration.
+  BC-2460.40.10:
+    name: Kitting- und Montageleistungen
+    description: |
+      Kitting, Untermontage und Bündelzusammenstellung im Lager.
+  BC-2460.40.20:
+    name: Co-Packing und Umetikettierung
+    description: |
+      Co-Packing-, Umverpackungs- und Umetikettierungsleistungen.
+  BC-2460.40.30:
+    name: Postponement und Konfiguration
+    description: |
+      Spätphasen-Produktkonfiguration und Postponement.
+  BC-2460.50:
+    name: Retouren- und Reverse-Logistics-Management
+    description: |
+      Empfang, Triage und Disposition zurückgesandter Waren und Rückwärtslogistikflüsse.
+  BC-2460.50.10:
+    name: Retourenempfang und Triage
+    description: |
+      Empfang und Triage zurückgesandter Waren.
+  BC-2460.50.20:
+    name: Aufbereitung und Disposition
+    description: |
+      Aufbereitung, Umverpackung und Dispositionsentscheidungen.
+  BC-2460.50.30:
+    name: Reverse-Logistics-Entsorgung
+    description: |
+      Entsorgung, Recycling und Vernichtung nicht wiederverwendbarer Retouren.
+  BC-2460.60:
+    name: Lagerressourcen-Management
+    description: |
+      Verwaltung von Arbeitskräften, Fördertechnik und Dock- und Slot-Kapazität im Lager.
+  BC-2460.60.10:
+    name: Arbeitsplanung und Produktivität
+    description: |
+      Schichtplanung, Aufgabenzuweisung und Produktivitätsverfolgung.
+  BC-2460.60.20:
+    name: Fördertechnik-Betrieb
+    description: |
+      Betrieb, Zuweisung und Instandhaltung von Gabelstaplern, Förderbändern und AGVs.
+  BC-2460.60.30:
+    name: Dock- und Slot-Planung
+    description: |
+      Planung von Ein- und Ausgangs-Dock-Slots.
+  BC-2460.70:
+    name: Lagerleistungs-Management
+    description: |
+      Messung von Lagerservice, Genauigkeits- und Durchsatz-KPIs.
+  BC-2460.70.10:
+    name: Auftragszyklen-KPI-Verfolgung
+    description: |
+      Verfolgung von Auftragszyklen, Lieferquoten und Genauigkeits-KPIs.
+  BC-2460.70.20:
+    name: Bestandsgenauigkeits-Berichterstattung
+    description: |
+      Berichterstattung über Bestandsgenauigkeit und Schwund.
+  BC-2460.70.30:
+    name: Durchsatz- und Produktivitäts-Berichterstattung
+    description: |
+      Berichterstattung über Durchsatz, Einheiten pro Stunde und Produktivitäts-Benchmarks.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-wastewater-operations-management.yaml
+++ b/catalogue/i18n/de/L1-wastewater-operations-management.yaml
@@ -1,0 +1,144 @@
+locale: de
+source: L1-wastewater-operations-management.yaml
+entries:
+  BC-3890:
+    name: Abwasserbetrieb Management
+    description: |
+      Sammlung, Behandlung und Entsorgung von Kommunal- und Industrieabwasser –
+      Kanalnetzbetrieb, Kläranlagen-Prozessbetrieb, Verstopfungs- und
+      Überschwemmungsreaktion, Schlammwirtschaft und Biosolids-Management,
+      Regenwasserüberlaufbetrieb sowie Kläranlagenablaufqualitäts-Compliance.
+  BC-3890.10:
+    name: Kanalnetzbetrieb
+    description: |
+      Betrieb von Schmutz-, Regen- und Mischkanalnetzen
+      einschließlich Pumpstationen und Druckleitungen.
+  BC-3890.10.10:
+    name: Abwasserpumpstationsbetrieb
+    description: |
+      Betrieb und Überwachung von Abwasserpumpstationen und Druckleitungen.
+  BC-3890.10.20:
+    name: Kanalüberwachung
+    description: |
+      Telemetriebasierte Überwachung von Kanalpegelständen und Pumpstationsalarmen.
+  BC-3890.10.30:
+    name: Kanalreinigungsbetrieb
+    description: |
+      Geplante und reaktive Reinigung, Hochdruckspülung und Entschlammung von Kanälen.
+  BC-3890.20:
+    name: Kläranlagenbetrieb
+    description: |
+      Täglicher Betrieb von Kläranlagen einschließlich mechanischer,
+      biologischer und weitergehender Reinigungsstufen.
+  BC-3890.20.10:
+    name: Mechanische Reinigungsstufe Betrieb
+    description: |
+      Betrieb von Siebung, Sandfang und mechanischer Vorreinigung.
+  BC-3890.20.20:
+    name: Biologische Reinigungsstufe Betrieb
+    description: |
+      Betrieb von Belebtschlamm-, Tropfkörper- und MBR-Prozessen.
+  BC-3890.20.30:
+    name: Weitergehende Reinigungsstufe Betrieb
+    description: |
+      Betrieb von Nährstoffeliminations-, Filtrations- und Desinfektionsstufen.
+  BC-3890.20.40:
+    name: Prozessregelung und Optimierung
+    description: |
+      Prozessregelung und Energieoptimierung biologischer und Belüftungsstufen.
+  BC-3890.30:
+    name: Kanalverstopfungs- und Überflutungsreaktion
+    description: |
+      Reaktive Reaktion auf Kanalverstopfungen, interne und externe
+      Kanalüberflutungen und Umweltverschmutzungsvorfälle.
+  BC-3890.30.10:
+    name: Verstopfungsbekämpfungsbetrieb
+    description: |
+      Feldeinsatz bei Kanalverstopfungen mit Hochdruckspülung und Beseitigung.
+  BC-3890.30.20:
+    name: Interne Kanalüberflutungsreaktion
+    description: |
+      Kundengerichtete Reaktion auf interne Kanalüberflutungsvorfälle.
+  BC-3890.30.30:
+    name: Externe Kanalüberflutungsreaktion
+    description: |
+      Reaktion auf externe Kanalüberflutungen und Straßenauswirkungen.
+  BC-3890.30.40:
+    name: Umweltverschmutzungsvorfalleingrenzung
+    description: |
+      Eingrenzung und Sanierung von Abwasserverschmutzungsvorfällen in Gewässern.
+  BC-3890.40:
+    name: Industrieabwassermanagement
+    description: |
+      Genehmigung, Überwachung und Abrechnung industrieller Indirekteinleiter
+      in die öffentliche Kanalisation.
+  BC-3890.40.10:
+    name: Indirekteinleiter-Genehmigungsverwaltung
+    description: |
+      Erteilung und Änderung von Indirekteinleitergenehmigungen an Industriebetriebe.
+  BC-3890.40.20:
+    name: Indirekteinleiter-Probenahmebetrieb
+    description: |
+      Probenahme und Analyse von Indirekteinleitern gegen Genehmigungsauflagen.
+  BC-3890.40.30:
+    name: Indirekteinleiter-Abrechnung
+    description: |
+      Berechnung von Indirekteinleitergebühren nach Mogden- oder gleichwertigen Formeln.
+  BC-3890.50:
+    name: Schlamm- und Biosolids-Management
+    description: |
+      Behandlung, Verwertung und Entsorgung von Klärschlamm
+      einschließlich anaerober Vergärung und Biosolids-Verwertung auf Landwirtschaft.
+  BC-3890.50.10:
+    name: Schlammeindickung und Entwässerungsbetrieb
+    description: |
+      Betrieb von Eindickung, Entwässerung und Zentrifugensystemen für Klärschlamm.
+  BC-3890.50.20:
+    name: Anaerobe Vergärung Betrieb
+    description: |
+      Betrieb mesophiler und thermophiler Faulbehälter und Biogasanlagen.
+  BC-3890.50.30:
+    name: Biosolids-Ausbringung auf Landwirtschaft
+    description: |
+      Ausbringung von Biosolids auf landwirtschaftliche Flächen gemäß Klärschlammregimes.
+  BC-3890.50.40:
+    name: Schlammverbrennung und Entsorgungsbetrieb
+    description: |
+      Betrieb der Schlammverbrennung und alternativer Entsorgungswege.
+  BC-3890.60:
+    name: Regenwasserüberlaufbetrieb
+    description: |
+      Betrieb, Überwachung und Berichterstattung von Mischwasser- und
+      Notüberläufen einschließlich Ereignisdauerüberwachung.
+  BC-3890.60.10:
+    name: Ereignisdauerüberwachung
+    description: |
+      Betrieb von EDM-Telemetrie an Regen- und Notüberläufen.
+  BC-3890.60.20:
+    name: Regenwasserüberlauf-Berichterstattung
+    description: |
+      Meldung von Überlaufmengen und -dauern an Behörden und die Öffentlichkeit.
+  BC-3890.60.30:
+    name: Regenwassertankbetrieb
+    description: |
+      Betrieb von Regenrückhaltebecken und Ausgleichsanlagen an Kläranlagenzuläufen.
+  BC-3890.70:
+    name: Kläranlagenablaufqualitätsbetrieb
+    description: |
+      Probenahme, Analyse und behördliche Meldung der Kläranlagenablaufqualität
+      gegen Einleitungserlaubnisselbstüberwachungswerte.
+  BC-3890.70.10:
+    name: Selbstüberwachungsprobenahme
+    description: |
+      Betriebliche Selbstüberwachungsprobenahme gegen numerische Einleitungserlaubnisse.
+  BC-3890.70.20:
+    name: Ablaufqualitätsüberwachung
+    description: |
+      Online- und Laborüberwachung von BSB, Ammonium und Nährstoffparametern im Kläranlagenablauf.
+  BC-3890.70.30:
+    name: Einleitungserlaubnis-Berichterstattung
+    description: |
+      Gesetzliche Berichterstattung zur Einleitungs-Compliance an Umweltbehörden.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-water-distribution-network-operations-management.yaml
+++ b/catalogue/i18n/de/L1-water-distribution-network-operations-management.yaml
@@ -1,0 +1,141 @@
+locale: de
+source: L1-water-distribution-network-operations-management.yaml
+entries:
+  BC-3880:
+    name: Wasserverteilungsnetz-Betrieb Management
+    description: |
+      Betrieb von Haupt- und Verteilungsleitungen zur Lieferung von Reinwasser
+      an Kunden – hydraulisches Management und Drucksteuerung, Leckagebekämpfung,
+      Netzwasserqualität, Leitungsreparatur und -erneuerung sowie Kundenanschlusserbringung.
+  BC-3880.10:
+    name: Verteilungsnetzkontrolle
+    description: |
+      24/7-Leitstellenbetrieb des Wasserverteilungssystems
+      mittels Telemetrie, hydraulischen Modellen und SCADA.
+  BC-3880.10.10:
+    name: Verteiler-SCADA-Betrieb
+    description: |
+      Echtzeit-Fernwirken von Pump- und Druckanlagen im Netz.
+  BC-3880.10.20:
+    name: Hydraulisches Modellbetrieb
+    description: |
+      Betrieb von Online- und Offline-hydraulischen Modellen für Netzentscheidungen.
+  BC-3880.10.30:
+    name: Netztelemetrieüberwachung
+    description: |
+      Überwachung der Telemetrie über DMAs, Ventile und Druckpunkte.
+  BC-3880.20:
+    name: Hauptleitungs- und Pumpbetrieb
+    description: |
+      Betrieb von Hauptleitungen, Pumpstationen und Interzonen-Transfers
+      einschließlich Druckerhöhung und Druckstoßmanagement.
+  BC-3880.20.10:
+    name: Pumpstationsbetrieb
+    description: |
+      Betrieb und Energieoptimierung von Verteilungspumpstationen.
+  BC-3880.20.20:
+    name: Hauptleitungsbetrieb
+    description: |
+      Betrieb, Ventilsteuerung und Druckstoßmanagement auf Übertragungshauptleitungen.
+  BC-3880.20.30:
+    name: Interzonentransferbetrieb
+    description: |
+      Betrieb von Interzonentransfers und Massenbulkversorgungsverbindungen zwischen Ressourcenzonen.
+  BC-3880.30:
+    name: Leckagemanagement
+    description: |
+      Aktive und passive Leckagebekämpfung in Zählergebieten
+      mittels Zulaufanalyse, akustischer Detektion und Feldreparatur.
+    in_scope:
+      - DMA-Zufluss- und Mindestnachtflussanalyse
+      - Akustische Leckageortung
+      - Such- und Reparaturoperationen
+    out_of_scope:
+      - Leitungserneuerungsinvestitionsprogramme (BC-3900.50)
+      - Kundenseitige Hausanschlussleckagen (BC-3910.60)
+  BC-3880.30.10:
+    name: Zählergebietanalyse
+    description: |
+      Analyse von DMA-Zufluss und Mindestnachtflussdaten zur Lecklokalisierung.
+  BC-3880.30.20:
+    name: Akustische Leckageortung
+    description: |
+      Akustische Sondierung, Korrelation und Geräuschpegelmessungen zur Lecklokalisierung.
+  BC-3880.30.30:
+    name: Such- und Reparaturbetrieb
+    description: |
+      Feldarbeit zum Aufsuchen und Reparieren erkannter Lecks gegen Reparaturzeitziele.
+  BC-3880.30.40:
+    name: Leckagenleistungsberichterstattung
+    description: |
+      Berichterstattung über Leckagenleistung gegen regulatorische und IWA-Wasserbilanz-Kennzahlen.
+  BC-3880.40:
+    name: Druckmanagement
+    description: |
+      Optimierung des Verteilungsdrucks in druckverwalteten Zonen
+      zur Leckagereduzierung und Rohrbruchratenkontrolle.
+  BC-3880.40.10:
+    name: Druckzonenkonfiguration
+    description: |
+      Konfiguration druckverwalteter Gebiete und Druckminderventil-Sollwerte.
+  BC-3880.40.20:
+    name: Weitergehende Druckregelung
+    description: |
+      Betrieb ferngesteuerter und zeitmodulierter Druckminderventile.
+  BC-3880.40.30:
+    name: Druckstoßmanagement
+    description: |
+      Druckstoßanalyse und Transientenmitigation in Verteilungsnetzen.
+  BC-3880.50:
+    name: Netzwasserqualitätsbetrieb
+    description: |
+      Netzinterne Wasserqualitätsüberwachung – Chlorresidual,
+      Verfärbungen, Geschmacks- und Geruchsprobleme – sowie Sanierungsmaßnahmen.
+  BC-3880.50.10:
+    name: Netz-Chlorresidualüberwachung
+    description: |
+      Überwachung von Chlorresidualen im Netz und Nachcalorierung.
+  BC-3880.50.20:
+    name: Verfärbungs- und Sedimentkontrolle
+    description: |
+      Spülungs- und Ice-Pigging-Betrieb zur Beherrschung von Verfärbungsbeschwerden.
+  BC-3880.50.30:
+    name: Netzprobenahmebetrieb
+    description: |
+      Gesetzliche Probenahme an Kundenentnahmestellen und Versorgungspunkten.
+  BC-3880.60:
+    name: Leitungsreparatur- und Erneuerungsbetrieb
+    description: |
+      Reaktive Reparatur von Rohrbrüchen und Muffentsagen sowie operative
+      Erbringung von Leitungserneuerungsprogrammen.
+  BC-3880.60.10:
+    name: Rohrbruchreaktion
+    description: |
+      Reaktion, Isolierung und Reparatur von Rohrbrüchen gegen Kundenminnuten-Verlustziele.
+  BC-3880.60.20:
+    name: Hausanschlussreparaturbetrieb
+    description: |
+      Reparatur von Verbindungs- und Versorgungsleitungen zwischen Hauptleitung und Absperrhahn.
+  BC-3880.60.30:
+    name: Leitungserneuerungsfeldbetrieb
+    description: |
+      Felddurchführung von Leitungserneuerungs- und Sanierungsprogrammen einschließlich grabenlosen Verfahren.
+  BC-3880.70:
+    name: Neuanschluss Wasserversorgung Betrieb
+    description: |
+      Herstellung neuer Wasserversorgungsanschlüsse für Haus-, Gewerbe- und Projektentwicklerkunden.
+  BC-3880.70.10:
+    name: Neuantragsbeurteilung Wasseranschluss
+    description: |
+      Technische Beurteilung von Neuantragsanträgen und Entwicklerdienstleistungen.
+  BC-3880.70.20:
+    name: Anschlussinstallationsbetrieb
+    description: |
+      Installation von Verbindungsleitungen, Anbohrschellen und Kundenwasserzählern.
+  BC-3880.70.30:
+    name: Anschlussinbetriebnahme
+    description: |
+      Inbetriebnahme, Spülung und Desinfektion neuer Anschlüsse vor Inbetriebnahme.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-water-resource-management.yaml
+++ b/catalogue/i18n/de/L1-water-resource-management.yaml
@@ -1,0 +1,132 @@
+locale: de
+source: L1-water-resource-management.yaml
+entries:
+  BC-3860:
+    name: Wasserressourcen Management
+    description: |
+      Nachhaltige Bewirtschaftung von Rohwasserquellen – Einzugsgebiets- und
+      Quellenschutz, Rohwasserentnahme und -speicherung, langfristige Ressourcenplanung,
+      Trockenheits- und Bewirtschaftungsmanagement, Entnahmelizenz-Compliance
+      sowie Oberflächen- und Grundwasserüberwachungsnetze.
+  BC-3860.10:
+    name: Einzugsgebiets- und Quellenschutz
+    description: |
+      Schutz von Quellwassereinzugsgebieten durch Stakeholdereinbindung,
+      Landnutzungsmaßnahmen und Quellwasserrisikobeurteilung.
+  BC-3860.10.10:
+    name: Einzugsgebietrisikobeurteilung
+    description: |
+      Einzugsgebietrisikobeurteilung für Trinkwasserquellen nach WHO-Wasserssicherheitsplanprinzipien.
+  BC-3860.10.20:
+    name: Quellschutzzonenmanagement
+    description: |
+      Ausweisung und Bewirtschaftung von Grundwasser- und Oberflächenwasserquellschutzzonen.
+  BC-3860.10.30:
+    name: Einzugsgebiet-Stakeholdereinbindung
+    description: |
+      Einbindung von Grundeigentümern, Behörden und Landwirten zu Einzugsgebietsmaßnahmen.
+  BC-3860.20:
+    name: Rohwasserentnahmebetrieb
+    description: |
+      Täglicher Betrieb von Einlässen, Flussabgängen und Grundwasserbrunnen
+      zur Versorgung des Behandlungsparks.
+  BC-3860.20.10:
+    name: Oberflächenwassereinlassbetrieb
+    description: |
+      Betrieb von Fluss- und Talsperreneinlässen einschließlich Siebung und Pumpung.
+  BC-3860.20.20:
+    name: Grundwasserbrunnenbetrieb
+    description: |
+      Betrieb und Ergiebigkeitsmanagement von Grundwasserbrunnen und Brunnenfeldern.
+  BC-3860.20.30:
+    name: Rohwasserpumpbetrieb
+    description: |
+      Pumpung von Rohwasser zu Aufbereitungsanlagen und Aquäduktsystemen.
+  BC-3860.30:
+    name: Rohwasserspeicherbetrieb
+    description: |
+      Betrieb von Stauanlagen, Ausgleichsbecken, Talsperren und
+      Vorbehandlungsspeichern einschließlich Dammüberwachung.
+  BC-3860.30.10:
+    name: Talsperrenpegelbetrieb
+    description: |
+      Betriebskurvenmanagement für Stau- und Ausgleichstalsperren.
+  BC-3860.30.20:
+    name: Dammsicherheitsüberwachung
+    description: |
+      Überwachung und Inspektion von Staudämmen nach gesetzlichen Dammssicherheitsregimes.
+  BC-3860.30.30:
+    name: Talsperren-Wasserqualitätsbetrieb
+    description: |
+      Überwachung und Bewirtschaftung der Rohwasserqualität einschließlich Algenblüten.
+  BC-3860.40:
+    name: Wasserressourcenplanung
+    description: |
+      Langfristige Wasserressourcen- und Bedarfsplanung einschließlich Angebots-
+      Nachfrage-Bilanz, Klimaanpassung und Optionsbewertung.
+  BC-3860.40.10:
+    name: Angebots-Nachfrage-Bilanzprognose
+    description: |
+      Langfristige Prognose von Angebot und Nachfrage je Ressourcenzone.
+  BC-3860.40.20:
+    name: Ressourcenoptionsbewertung
+    description: |
+      Bewertung neuer Quellen, Transferoptionen und Nachfragemanagementmaßnahmen.
+  BC-3860.40.30:
+    name: Klimawandel-Ressourcenanpassung
+    description: |
+      Anpassung von Ressourcenerträgen und Nachfrage für Klimawandelszenarien.
+  BC-3860.50:
+    name: Trockenheits- und Bewirtschaftungsmanagement
+    description: |
+      Aktivierung von Trockenplänen und Versorgungsbeschränkungen durch
+      Trockenheitsschwellen, kundengerichtete Restriktionen und Notfall-Trockenheitsgenehmigungsanträge.
+  BC-3860.50.10:
+    name: Trockenheitsschwellenüberwachung
+    description: |
+      Überwachung von Talsperren-, Fluss- und Grundwasser-Trockenheitsschwellen.
+  BC-3860.50.20:
+    name: Trockenheitsbeschränkungsbetrieb
+    description: |
+      Einführung und Aufhebung von Wassernutzungsbeschränkungen für Kunden.
+  BC-3860.50.30:
+    name: Trockenheitsgenehmigungsmanagement
+    description: |
+      Antrag und Betrieb von Trockenheitsgenehmigungen und behördlich genehmigten Anordnungen.
+  BC-3860.60:
+    name: Entnahmelizenz-Compliance
+    description: |
+      Verwaltung von Entnahmelizenzen und Compliance-Berichterstattung
+      gegen Mengen-, Zeit- und Umweltauflagen.
+  BC-3860.60.10:
+    name: Entnahmelizenz-Administration
+    description: |
+      Pflege des Entnahmelizenzportfolios und des Auflagenregisters.
+  BC-3860.60.20:
+    name: Entnahmemengenberichterstattung
+    description: |
+      Meldung entnommener Mengen und Einhaltung von Lizenzbedingungen.
+  BC-3860.60.30:
+    name: Mindestwasser-Compliance
+    description: |
+      Überwachung von Mindestabflussbedingungen und ökologischen Durchflussauflagen.
+  BC-3860.70:
+    name: Hydrometrische Überwachung
+    description: |
+      Betrieb von Oberflächen- und Grundwasserüberwachungsnetzen
+      als Input für Ressourcenplanung und operative Entscheidungen.
+  BC-3860.70.10:
+    name: Oberflächenwasserüberwachung
+    description: |
+      Betrieb von Abfluss-, Pegelstand- und Niederschlagsüberwachungsnetzen.
+  BC-3860.70.20:
+    name: Grundwasserstandsüberwachung
+    description: |
+      Betrieb von Grundwasser-Beobachtungsbohrungsnetzen.
+  BC-3860.70.30:
+    name: Hydrometrische Datenqualitätsmanagement
+    description: |
+      Qualitätssicherung und Abflusskurvenmanagement für hydrometrische Daten.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-water-treatment-operations-management.yaml
+++ b/catalogue/i18n/de/L1-water-treatment-operations-management.yaml
@@ -1,0 +1,131 @@
+locale: de
+source: L1-water-treatment-operations-management.yaml
+entries:
+  BC-3870:
+    name: Wasseraufbereitung Management
+    description: |
+      Produktion von Trinkwasser in Aufbereitungswerken – Prozessbetrieb,
+      Trinkwasserqualitätssicherung, Behandlungschemikalienmanagement,
+      Reinwasserspeicherung und Management von Aufbereitungsrückständen
+      gemäß Trinkwasserverordnung und WHO-Wassersicherheitsplanprinzipien.
+  BC-3870.10:
+    name: Aufbereitungsanlagenbetrieb
+    description: |
+      Täglicher Betrieb von Trinkwasseraufbereitungswerken
+      zur spezifikationsgerechten und bedarfsorientierten Produktion.
+  BC-3870.10.10:
+    name: Schichtbetrieb Aufbereitungswerk
+    description: |
+      Schichtbetrieb konventioneller und Membran-Aufbereitungswerke.
+  BC-3870.10.20:
+    name: Aufbereitungsproduktionsplanung
+    description: |
+      Planung der Aufbereitungsproduktion gegen Verteilungsbedarf und Speicherzustand.
+  BC-3870.10.30:
+    name: Aufbereitungsleistungsberichterstattung
+    description: |
+      Berichterstattung über Aufbereitungswerksproduktion, Energieverbrauch und Leistungskennzahlen.
+  BC-3870.20:
+    name: Aufbereitungsprozessregelung
+    description: |
+      Prozessregelung der Aufbereitungseinzelschritte – Koagulation,
+      Filtration, Desinfektion und weitergehende Behandlung – gegen
+      Online-Qualitätsüberwachung.
+  BC-3870.20.10:
+    name: Koagulations- und Klärungsregelung
+    description: |
+      Regelung von Flockungsmitteldosierung, Flockung und Klärleistung.
+  BC-3870.20.20:
+    name: Filtrationsprozessregelung
+    description: |
+      Regelung von Schnellfilter-, Langsamfilter- und Membranfiltrationsstufen.
+  BC-3870.20.30:
+    name: Desinfektionsprozessregelung
+    description: |
+      Regelung von Chlorierung, UV-, Ozon- und weitergehenden Desinfektionsprozessen.
+  BC-3870.20.40:
+    name: Weitergehende Behandlungsprozessregelung
+    description: |
+      Regelung von GAK-, Ionenaustausch- und weitergehenden Oxidationsstufen.
+  BC-3870.30:
+    name: Trinkwasserqualitätsbetrieb
+    description: |
+      Probenahme, Laboranalyse, Online-Überwachung und regulatorische
+      Berichterstattung zur Trinkwasserqualitäts-Compliance.
+    in_scope:
+      - Gesetzliche Trinkwasserprobenahme
+      - Laboranalyse mikrobiologischer und chemischer Parameter
+      - Trinkwasserqualitätsvorfallreaktion
+    out_of_scope:
+      - Netzwasserqualität (BC-3880.50)
+      - Abwasserablaufqualität (BC-3890.70)
+  BC-3870.30.10:
+    name: Gesetzliches Probenahmeprogramm
+    description: |
+      Betrieb gesetzlicher Trinkwasserprobenahmeprogramme in Aufbereitungswerken und Übergabestellen.
+  BC-3870.30.20:
+    name: Reinwasser-Online-Überwachung
+    description: |
+      Online-Überwachung von Reinwassertrübung, Chlorresidual und anderen Parametern.
+  BC-3870.30.30:
+    name: Trinkwasservorfallreaktion
+    description: |
+      Untersuchung und Behebung von Trinkwasserqualitätsvorfällen und Grenzwertüberschreitungen.
+  BC-3870.30.40:
+    name: Trinkwasserqualitätsberichterstattung
+    description: |
+      Gesetzliche Berichterstattung an Trinkwasserbehörden (DWI, EPA, Entsprechende).
+  BC-3870.40:
+    name: Behandlungschemikalienmanagement
+    description: |
+      Beschaffungsbewusstes operatives Management von Behandlungschemikalien
+      einschließlich Bestände, Dosierung und Chemikaliensicherheit.
+  BC-3870.40.10:
+    name: Chemikalienvorratsbetrieb
+    description: |
+      Bestandsmanagement von Behandlungschemikalien im Werk.
+  BC-3870.40.20:
+    name: Chemikaliendosierbetrieb
+    description: |
+      Betrieb und Kalibrierung von Dosiersystemen für Behandlungschemikalien.
+  BC-3870.40.30:
+    name: Chemikalienhandhabungssicherheit
+    description: |
+      Sichere Handhabung, COSHH- und DSEAR-Maßnahmen für Behandlungschemikalien vor Ort.
+  BC-3870.50:
+    name: Reinwasserspeicherbetrieb
+    description: |
+      Betrieb von Hochbehältern, Kontakttanks und Wassertürmen
+      zur Einspeisung von Reinwasser ins Verteilungsnetz.
+  BC-3870.50.10:
+    name: Hochbehälterbetrieb
+    description: |
+      Betrieb, Pegelregelung und Umwälzmanagement von Hochbehältern.
+  BC-3870.50.20:
+    name: Kontakttankbetrieb
+    description: |
+      Betrieb von Desinfektionskontakttanks zur Erreichung der erforderlichen CT-Werte.
+  BC-3870.50.30:
+    name: Hochbehälterinspektion
+    description: |
+      Inneninspektion und Reinigung von Reinwasserspeicheranlagen.
+  BC-3870.60:
+    name: Aufbereitungsrückstandsmanagement
+    description: |
+      Betrieb der Abwasserströme aus der Aufbereitung – Klärschlamm,
+      Filterspülwasser und verbrauchte Medien – sowie deren Entsorgungsweg.
+  BC-3870.60.10:
+    name: Klärschlammbetrieb
+    description: |
+      Betrieb der Schlammverdickung und -entwässerung in Wasserwerken.
+  BC-3870.60.20:
+    name: Filterspülwasserrückgewinnung
+    description: |
+      Rückgewinnung und Wiederverwertung oder Entsorgung von Filterspülwasser.
+  BC-3870.60.30:
+    name: Verbrauchte Medien Entsorgung
+    description: |
+      Austausch und Entsorgung verbrauchter Filtermedien und Ionenaustauscherharze.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-wealth-management-operations-management.yaml
+++ b/catalogue/i18n/de/L1-wealth-management-operations-management.yaml
@@ -1,0 +1,98 @@
+locale: de
+source: L1-wealth-management-operations-management.yaml
+entries:
+  BC-1390:
+    name: Vermögensverwaltungs-Betriebsmanagement
+    description: |
+      Anlageberatung, diskretionäres Portfoliomanagement, Kundenberichterstattung und Geeignetheitsprüfung.
+  BC-1390.10:
+    name: Anlageberatungs-Management
+    description: |
+      Beratungsmandate und Empfehlungserstellung.
+  BC-1390.10.10:
+    name: Beratungsmandat-Onboarding
+    description: |
+      Onboarding von Beratungsmandaten und Kundenvereinbarungen.
+  BC-1390.10.20:
+    name: Anlageempfehlungs-Erstellung
+    description: |
+      Erstellung personalisierter Anlageempfehlungen.
+  BC-1390.10.30:
+    name: Anlagevorschlags-Management
+    description: |
+      Erstellung und Genehmigung von Anlagevorschlägen.
+  BC-1390.20:
+    name: Diskretionäres-Portfoliomanagement
+    description: |
+      Diskretionäre Mandate und Portfoliokonstruktion.
+  BC-1390.20.10:
+    name: Diskretionäres-Mandat-Einrichtung
+    description: |
+      Einrichtung diskretionärer Mandate und IPS-Dokumentation.
+  BC-1390.20.20:
+    name: Portfoliokonstruktion
+    description: |
+      Portfoliokonstruktion und Asset-Allokation.
+  BC-1390.20.30:
+    name: Portfolio-Rebalancing
+    description: |
+      Rebalancing diskretionärer Portfolios gegenüber dem Modellportfolio.
+  BC-1390.20.40:
+    name: Mandats-Handelsausführung
+    description: |
+      Ausführung von Handelsgeschäften im Auftrag diskretionärer Mandate.
+  BC-1390.30:
+    name: Kunden-Berichterstattungs-Management
+    description: |
+      Kundenauszüge und Leistungsberichte.
+  BC-1390.30.10:
+    name: Periodische Kundenauszüge
+    description: |
+      Erstellung periodischer Kundenauszüge und Bewertungen.
+  BC-1390.30.20:
+    name: Leistungs- und Aktivitätsberichte
+    description: |
+      Leistungs-, Aktivitäts- und Steuerberichte für Kunden.
+  BC-1390.30.30:
+    name: Regulatorische Kundenoffenlegungen
+    description: |
+      MiFID-II-Kosten- und Gebühreninformationen sowie sonstige regulatorische Offenlegungen.
+  BC-1390.40:
+    name: Leistungsmessungs-Management
+    description: |
+      Leistungszurechnung und Benchmarkvergleich.
+  BC-1390.40.10:
+    name: Portfolio-Leistungsberechnung
+    description: |
+      Berechnung von TWR, MWR und sonstigen Leistungsrenditen.
+  BC-1390.40.20:
+    name: Leistungszurechnung-Analyse
+    description: |
+      Brinson- und faktorbasierte Zurechnungsanalyse.
+  BC-1390.40.30:
+    name: Benchmark- und Peer-Vergleich
+    description: |
+      Vergleich der Portfolio-Leistung mit Benchmarks und Mitbewerbern.
+  BC-1390.50:
+    name: Geeignetheits- und Angemessenheits-Management
+    description: |
+      MiFID-/Äquivalenz-Geeignetheit und Angemessenheitsprüfungen.
+  BC-1390.50.10:
+    name: Kunden-Risikoprofilerstellung
+    description: |
+      Risikobereitschafts- und -tragfähigkeitsprofilierung für Kunden.
+  BC-1390.50.20:
+    name: Geeignetheitsbeurteilung
+    description: |
+      Geeignetheitsbeurteilung von Beratungs- und diskretionären Portfolios.
+  BC-1390.50.30:
+    name: Angemessenheitsbeurteilung
+    description: |
+      Angemessenheitsprüfungen für Ausführungsgeschäfte ohne Beratung.
+  BC-1390.50.40:
+    name: Nachhaltigkeitspräferenz-Erfassung
+    description: |
+      Erfassung und Integration von Kunden-Nachhaltigkeitspräferenzen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-weapon-systems-management.yaml
+++ b/catalogue/i18n/de/L1-weapon-systems-management.yaml
@@ -1,0 +1,114 @@
+locale: de
+source: L1-weapon-systems-management.yaml
+entries:
+  BC-1710:
+    name: Waffensysteme-Management
+    description: |
+      Lebenszyklusmanagement von Waffensystemen und Plattformen.
+  BC-1710.10:
+    name: Waffensystem-Systemtechnik-Management
+    description: |
+      Waffensystem-Systemtechnik, Anforderungen und Architektur.
+  BC-1710.10.10:
+    name: Waffensystem-Anforderungstechnik
+    description: |
+      Anforderungstechnik für Waffensysteme.
+  BC-1710.10.20:
+    name: Waffensystem-Architekturdesign
+    description: |
+      Architekturdesign und Trade-off-Analyse.
+  BC-1710.10.30:
+    name: Waffensystem-Modellierung und -Simulation
+    description: |
+      Modellierung und Simulation der Waffensystemleistung.
+  BC-1710.20:
+    name: Waffensystem-Konfigurationsmanagement
+    description: |
+      Konfigurationsbaselines und Konfigurationskontrolle.
+  BC-1710.20.10:
+    name: Konfigurationsbaseline-Management
+    description: |
+      Definition und Pflege von Systemkonfigurationsbaselines.
+  BC-1710.20.20:
+    name: Konfigurationsänderungs-Kontrolle
+    description: |
+      Kontrolle von Konfigurationsänderungen durch CCBs.
+  BC-1710.20.30:
+    name: Konfigurationsstatus-Buchführung
+    description: |
+      Konfigurationsstatus-Buchführung und -Audit.
+  BC-1710.30:
+    name: Waffensystem-Integrations-Management
+    description: |
+      Teilsystemintegration und integrierte Systementwicklung.
+  BC-1710.30.10:
+    name: Teilsystem-Integration
+    description: |
+      Integration von Teilsystemen in die Waffenplattform.
+  BC-1710.30.20:
+    name: Missionssystem-Integration
+    description: |
+      Integration von Missionssystemen und Sensoren.
+  BC-1710.30.30:
+    name: System-of-Systems-Integration
+    description: |
+      Integration mit übergeordneten System-of-Systems und C5ISR.
+  BC-1710.40:
+    name: Waffensystem-Test- und Qualifikations-Management
+    description: |
+      Testprogramme, Qualifikation und Zertifizierung.
+  BC-1710.40.10:
+    name: Testprogramm-Planung
+    description: |
+      Test- und Evaluierungsprogramm-Planung.
+  BC-1710.40.20:
+    name: Entwicklungstest-Durchführung
+    description: |
+      Durchführung von Entwicklungstests an Prototypen.
+  BC-1710.40.30:
+    name: Betriebstest-Durchführung
+    description: |
+      Durchführung von Betriebstest und -Evaluierung.
+  BC-1710.40.40:
+    name: Bauartzulassung
+    description: |
+      Militärische Lufttüchtigkeits- und Bauartzulassung.
+  BC-1710.50:
+    name: Waffensystem-Durchhaltefähigkeit-Management
+    description: |
+      Instandhaltung im Betrieb, Depot-Instandhaltung und Obsoleszenz.
+  BC-1710.50.10:
+    name: Ingenieur-Unterstützung-im-Betrieb
+    description: |
+      Ingenieurunterstützung für stationierte Systeme.
+  BC-1710.50.20:
+    name: Depot-Instandhaltung
+    description: |
+      Depot-Instandhaltung, Generalüberholung und Reset.
+  BC-1710.50.30:
+    name: Obsoleszenz- und DMSMS-Management
+    description: |
+      DMSMS- und Obsoleszenzmanagement für stationierte Systeme.
+  BC-1710.50.40:
+    name: Leistungsbasierte-Logistik-Betrieb
+    description: |
+      Betrieb leistungsbasierter Logistikvereinbarungen.
+  BC-1710.60:
+    name: Waffensystem-Modifikation- und Aufrüstungs-Management
+    description: |
+      Fähigkeitsaufrüstungen, Midlife-Updates und Nachrüstungen.
+  BC-1710.60.10:
+    name: Fähigkeitsaufrüstungs-Planung
+    description: |
+      Planung von Fähigkeitsaufrüstungen und -einführungen.
+  BC-1710.60.20:
+    name: Midlife-Update-Programm-Management
+    description: |
+      Management von Midlife-Update-Programmen.
+  BC-1710.60.30:
+    name: Nachrüstungs- und Modifikations-Durchführung
+    description: |
+      Durchführung von Nachrüstungen und Feldmodifikationen.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"

--- a/catalogue/i18n/de/L1-wholesale-interconnect-roaming-management.yaml
+++ b/catalogue/i18n/de/L1-wholesale-interconnect-roaming-management.yaml
@@ -1,0 +1,117 @@
+locale: de
+source: L1-wholesale-interconnect-roaming-management.yaml
+entries:
+  BC-2680:
+    name: Wholesale, Zusammenschaltung und Roaming
+    description: |
+      Wholesale-Telekommunikationsdienste für andere Betreiber und Partner –
+      Wholesale-Produkt und -Preisgestaltung, MVNO- und MVNE-Partnerschaften,
+      Zusammenschaltung und Peering, Roaming-Partnerbeziehungen, Betreiber-übergreifende
+      Abrechnung und Kapazitätsvereinbarungen wie IRU und Dark Fiber.
+  BC-2680.10:
+    name: Wholesale-Produkt- und Preis-Management
+    description: |
+      Definition, Preisgestaltung und kommerzielle Verhandlung von Wholesale-Angeboten
+      an Betreiber, MVNOs und große Partner.
+  BC-2680.10.10:
+    name: Wholesale-Tarif-Design
+    description: |
+      Design von Wholesale-Tarifen über Sprach-, Daten-, Messaging- und Kapazitätsprodukte.
+  BC-2680.10.20:
+    name: Wholesale-Angebots-Veröffentlichung
+    description: |
+      Veröffentlichung von Wholesale-Angeboten an partnerorientierte Kanäle und
+      behördenerforderliche Referenzangebote.
+  BC-2680.10.30:
+    name: Wholesale-Verhandlung
+    description: |
+      Bilaterale kommerzielle Verhandlung von Wholesale-Vereinbarungen und spezifischen Konditionen.
+  BC-2680.20:
+    name: MVNO- und MVNE-Partnerschaft-Management
+    description: |
+      Onboarding und laufende Verwaltung von MVNO- und MVNE-Partnern einschließlich
+      BSS-Integration und kommerzieller Governance.
+  BC-2680.20.10:
+    name: MVNO-Onboarding
+    description: |
+      Onboarding neuer MVNO- und MVNE-Partner gegen kommerzielle, regulatorische und technische Bereitschaftskriterien.
+  BC-2680.20.20:
+    name: MVNO-BSS-Integration
+    description: |
+      Integration von MVNO-Partnern mit Host-BSS für Bereitstellung, Rating und Berichterstattung.
+  BC-2680.20.30:
+    name: MVNO-Commercial-Management
+    description: |
+      Laufende kommerzielle Governance, Leistungsüberprüfungen und Exit-Management von MVNO-Partnern.
+  BC-2680.30:
+    name: Zusammenschaltungs-Vereinbarungs-Management
+    description: |
+      Verwaltung von Sprach- und IP-Zusammenschaltungsvereinbarungen einschließlich Peering und Transit.
+  BC-2680.30.10:
+    name: Peering-Vereinbarungs-Management
+    description: |
+      Verwaltung von IP-Peering-Vereinbarungen und zugehörigen kommerziellen und operativen Konditionen.
+  BC-2680.30.20:
+    name: Transit-Vereinbarungs-Management
+    description: |
+      Verwaltung von Sprach- und IP-Transit-Vereinbarungen mit Upstream-Anbietern.
+  BC-2680.30.30:
+    name: Verkehrsaustausch-Messung
+    description: |
+      Messung ausgetauschter Verkehrsvolumen mit Peers und Transit-Anbietern für Abrechnung und Engineering.
+  BC-2680.40:
+    name: Roaming-Partner-Management
+    description: |
+      Aufbau und Betrieb von Roaming-Beziehungen mit internationalen Partnernetzwerken.
+  BC-2680.40.10:
+    name: Roaming-Vereinbarungs-Management
+    description: |
+      Verhandlung und Lebenszyklusverwaltung bilateraler Roaming-Vereinbarungen.
+  BC-2680.40.20:
+    name: TAP-File-Austausch
+    description: |
+      Austausch von TAP-Files mit Roaming-Partnern für die Nutzungsabrechnung.
+  BC-2680.40.30:
+    name: Roaming-Partner-Onboarding
+    description: |
+      Technisches und kommerzielles Onboarding neuer Roaming-Partner einschließlich IREG- und TADIG-Tests.
+  BC-2680.50:
+    name: Betreiber-übergreifendes Abrechnungs-Management
+    description: |
+      Abrechnung betreiber-übergreifender Nutzung und Streitigkeiten für Roaming und Zusammenschaltung.
+  BC-2680.50.10:
+    name: TAP- und NRTRDE-Abrechnung
+    description: |
+      Abrechnung von Roaming-Nutzung auf Basis von TAP- und Nahezu-Echtzeit-NRTRDE-Datensätzen.
+  BC-2680.50.20:
+    name: Zusammenschaltungs-Abrechnung
+    description: |
+      Abrechnung von Zusammenschaltungspartnern für terminierenden, originierenden und Transit-Verkehr.
+  BC-2680.50.30:
+    name: Abrechnungsstreit-Lösung
+    description: |
+      Lösung von Streitigkeiten zu betreiber-übergreifenden Abrechnungsaufstellungen.
+  BC-2680.50.40:
+    name: Abrechnungs-Abstimmung
+    description: |
+      Abstimmung betreiber-übergreifender Abrechnungsdatensätze mit interner Buchhaltung und Treasury.
+  BC-2680.60:
+    name: Wholesale-Kapazitäts- und IRU-Management
+    description: |
+      Langfristige Wholesale-Kapazitätsvereinbarungen einschließlich unveräußerlicher Nutzungsrechte
+      und Dark-Fiber-Leasing.
+  BC-2680.60.10:
+    name: Unveräußerliche Nutzungsrechte-Management
+    description: |
+      Verkauf und Kauf unveräußerlicher Nutzungsrechte an Langstrecken- und Seekapazität.
+  BC-2680.60.20:
+    name: Dark-Fiber-Management
+    description: |
+      Leasing und Verwaltung von Dark-Fiber-Strängen zu und von Partnern.
+  BC-2680.60.30:
+    name: Kapazitätsleasing-Management
+    description: |
+      Verwaltung wiederkehrender Kapazitäts-Leasingverträge auf Metro-, Langstrecken- und Unterwasserkabelrouten.
+metadata:
+  translator: claude-ai
+  date: "2026-04-29"


### PR DESCRIPTION
## Summary
This pull request adds comprehensive German language translations for the Level 1 (L1) business capability catalogue. The translations cover all major business domains and operational areas across various industries.

## Changes Made
- Added 200+ German translation files for L1 business capabilities in `catalogue/i18n/de/` directory
- Each file contains translated names and descriptions for business capability entries
- Translations cover diverse domains including:
  - Financial management and banking operations
  - Human capital and workforce management
  - Manufacturing and production operations
  - Healthcare and clinical services
  - Energy, utilities, and infrastructure
  - Transportation and logistics
  - Telecommunications and IT services
  - Real estate and property management
  - Insurance and risk management
  - Education and academic services
  - Chemical and pharmaceutical operations
  - Agriculture and food production
  - Defense and government operations
  - Media, content, and entertainment
  - And many other business capability areas

## Implementation Details
- All translation files follow the same YAML structure as the English source files
- Each entry includes a business capability code (BC-XXXX), German name, and translated description
- Files are organized alphabetically by capability domain name
- Locale is set to "de" (German) in each file header
- Source references point to the corresponding English capability files

https://claude.ai/code/session_013vDzvdH2EWJwRyQpzzbRzi