### PR TITLE
Add Italian translations for L1 business capability models

### DIFF
--- a/catalogue/i18n/it/L1-academic-quality-accreditation-management.yaml
+++ b/catalogue/i18n/it/L1-academic-quality-accreditation-management.yaml
@@ -1,0 +1,151 @@
+# Gestione della qualità accademica e dell'accreditamento (it) — translations for L1-academic-quality-accreditation-management.yaml
+locale: it
+source: L1-academic-quality-accreditation-management.yaml
+entries:
+  BC-4750:
+    name: Gestione della qualità accademica e dell'accreditamento
+    description: |
+      Assicurazione della qualità interna ed esterna dei programmi accademici e dell'istituzione,
+      incluse revisione, accreditamento, gestione dei framework di standard, feedback degli studenti
+      e miglioramento continuo.
+  BC-4750.10:
+    name: Revisione e validazione del programma
+    description: |
+      Validazione di nuovi programmi e ri-validazione periodica rispetto agli standard
+      accademici istituzionali ed esterni.
+    in_scope:
+      - Validazione di nuovi programmi
+      - Revisione periodica del programma
+      - Ri-validazione del programma
+    out_of_scope:
+      - Gate di approvazione del programma (trattati in Gestione del curriculo e dei programmi didattici)
+  BC-4750.10.10:
+    name: Validazione di nuovi programmi
+    description: |
+      Validazione di nuovi programmi rispetto agli standard accademici e di qualità.
+  BC-4750.10.20:
+    name: Revisione periodica del programma
+    description: |
+      Revisione periodica della qualità dei programmi in corso e dei loro esiti.
+  BC-4750.10.30:
+    name: Ri-validazione del programma
+    description: |
+      Ri-validazione dei programmi al termine dei cicli di validazione.
+  BC-4750.20:
+    name: Autovalutazione istituzionale
+    description: |
+      Autovalutazione delle prestazioni istituzionali rispetto agli standard di qualità
+      e benchmarking con istituti analoghi.
+    in_scope:
+      - Produzione del rapporto di autovalutazione
+      - Benchmarking degli indicatori di qualità
+      - Pianificazione strategica della qualità
+    out_of_scope:
+      - Visite di accreditamento esterno (trattate in Coordinamento degli accreditamenti e degli audit esterni)
+  BC-4750.20.10:
+    name: Produzione del rapporto di autovalutazione
+    description: |
+      Produzione dei rapporti di autovalutazione istituzionale.
+  BC-4750.20.20:
+    name: Benchmarking degli indicatori di qualità
+    description: |
+      Benchmarking degli indicatori di qualità rispetto a istituti analoghi.
+  BC-4750.20.30:
+    name: Pianificazione strategica della qualità
+    description: |
+      Pianificazione strategica delle priorità e degli investimenti in materia di qualità accademica.
+  BC-4750.30:
+    name: Coordinamento degli accreditamenti e degli audit esterni
+    description: |
+      Coordinamento con gli organismi di accreditamento esterno e i regolatori della qualità,
+      incluse le visite in loco, le ispezioni e la risposta agli esiti.
+    in_scope:
+      - Coinvolgimento degli organismi di accreditamento
+      - Coordinamento delle visite in loco e delle ispezioni
+      - Risposta agli esiti dell'accreditamento e monitoraggio delle condizioni
+    out_of_scope:
+      - Rendicontazione normativa legale (trattata in Gestione della conformità normativa nel settore dell'istruzione)
+  BC-4750.30.10:
+    name: Coinvolgimento degli organismi di accreditamento
+    description: |
+      Gestione del coinvolgimento e delle presentazioni agli organismi di accreditamento.
+  BC-4750.30.20:
+    name: Coordinamento delle visite in loco e delle ispezioni
+    description: |
+      Coordinamento delle visite in loco degli accreditatori e della logistica delle ispezioni.
+  BC-4750.30.30:
+    name: Risposta agli esiti dell'accreditamento
+    description: |
+      Risposta agli esiti, alle condizioni e alle raccomandazioni dell'accreditamento.
+  BC-4750.40:
+    name: Gestione del framework degli standard di qualità
+    description: |
+      Adozione, mappatura e manutenzione degli standard di qualità accademica
+      e della politica di qualità istituzionale.
+    in_scope:
+      - Adozione e manutenzione degli standard (es. ESG, ABET, AACSB)
+      - Redazione della politica di qualità
+      - Mappatura degli standard di qualità nelle pratiche operative
+    out_of_scope:
+      - Operazioni di audit quotidiane (trattate in Gestione dell'audit interno)
+  BC-4750.40.10:
+    name: Adozione e manutenzione degli standard
+    description: |
+      Adozione e manutenzione degli standard di qualità esterni nell'istituzione.
+  BC-4750.40.20:
+    name: Redazione della politica di qualità
+    description: |
+      Redazione e manutenzione della politica di qualità istituzionale.
+  BC-4750.40.30:
+    name: Mappatura degli standard di qualità
+    description: |
+      Mappatura degli standard di qualità nei processi operativi e nei controlli.
+  BC-4750.50:
+    name: Feedback degli studenti e valutazione dei moduli
+    description: |
+      Raccolta, analisi e chiusura del ciclo di feedback degli studenti a livello di modulo,
+      programma e istituzione.
+    in_scope:
+      - Operazioni di sondaggio di valutazione dei moduli
+      - Sondaggi nazionali e inter-istituzionali (es. NSS, NSSE)
+      - Analisi del feedback e chiusura del ciclo
+    out_of_scope:
+      - Analisi della soddisfazione di tipo commerciale al di fuori del contesto accademico (trattata in Gestione del servizio clienti)
+  BC-4750.50.10:
+    name: Operazioni di sondaggio di valutazione dei moduli
+    description: |
+      Gestione dei sondaggi di valutazione a livello di modulo.
+  BC-4750.50.20:
+    name: Partecipazione a sondaggi nazionali e inter-istituzionali
+    description: |
+      Partecipazione a sondaggi studenteschi nazionali e inter-istituzionali.
+  BC-4750.50.30:
+    name: Analisi del feedback e chiusura del ciclo
+    description: |
+      Analisi del feedback e visibile chiusura del ciclo con gli studenti.
+  BC-4750.60:
+    name: Miglioramento continuo e monitoraggio delle azioni
+    description: |
+      Identificazione, pianificazione e monitoraggio delle azioni di miglioramento della qualità
+      derivanti da revisioni, accreditamento e feedback.
+    in_scope:
+      - Pianificazione delle azioni di miglioramento
+      - Monitoraggio dell'implementazione delle azioni
+      - Repository delle lezioni apprese
+    out_of_scope:
+      - Metodi generici di miglioramento dei processi (trattati in Gestione della qualità)
+  BC-4750.60.10:
+    name: Pianificazione delle azioni di miglioramento
+    description: |
+      Pianificazione delle azioni di miglioramento della qualità accademica.
+  BC-4750.60.20:
+    name: Monitoraggio dell'implementazione delle azioni
+    description: |
+      Monitoraggio dello stato di implementazione e dell'efficacia delle azioni di qualità.
+  BC-4750.60.30:
+    name: Repository delle lezioni apprese
+    description: |
+      Curazione delle lezioni apprese dalle revisioni della qualità e dai cicli di accreditamento.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-actuarial-management.yaml
+++ b/catalogue/i18n/it/L1-actuarial-management.yaml
@@ -1,0 +1,127 @@
+# Gestione attuariale (it) — translations for L1-actuarial-management.yaml
+locale: it
+source: L1-actuarial-management.yaml
+entries:
+  BC-2180:
+    name: Gestione attuariale
+    description: |
+      Modelli di tariffazione attuariale, costituzione delle riserve, studi di esperienza, modellizzazione del capitale e della solvibilità, supporto al reporting attuariale IFRS 17 e modellizzazione delle catastrofi.
+  BC-2180.10:
+    name: Gestione attuariale della tariffazione
+    description: |
+      Modellizzazione del loss cost, analisi dell'adeguatezza del pricing, indicazione tariffaria e supporto alla documentazione del deposito tariffario.
+  BC-2180.10.10:
+    name: Modellizzazione del loss cost
+    description: |
+      Modellizzazione del loss cost per segmento, rischio e copertura.
+  BC-2180.10.20:
+    name: Analisi dell'adeguatezza del pricing
+    description: |
+      Analisi dell'adeguatezza del pricing rispetto alle perdite attese e ai carichi per spese.
+  BC-2180.10.30:
+    name: Produzione dell'indicazione tariffaria
+    description: |
+      Produzione delle indicazioni tariffarie per i comitati di prodotto e di pricing.
+  BC-2180.10.40:
+    name: Supporto alla documentazione del deposito tariffario
+    description: |
+      Produzione di memorandum attuariali e exhibit a supporto dei depositi tariffari.
+  BC-2180.20:
+    name: Gestione attuariale della riserva
+    description: |
+      Triangolazione delle perdite, stima IBNR, costituzione delle riserve per ULAE e ALAE, e documentazione di sign-off della riserva.
+  BC-2180.20.10:
+    name: Triangolazione e sviluppo delle perdite
+    description: |
+      Costruzione dei triangoli di perdita e selezione dei fattori di sviluppo.
+  BC-2180.20.20:
+    name: Stima IBNR
+    description: |
+      Stima delle riserve IBNR su tutti i portafogli.
+  BC-2180.20.30:
+    name: Costituzione delle riserve per ULAE e ALAE
+    description: |
+      Costituzione delle riserve per le spese di liquidazione del danno non allocate e allocate (ULAE e ALAE).
+  BC-2180.20.40:
+    name: Documentazione di sign-off della riserva
+    description: |
+      Produzione della documentazione del comitato riserve e delle dichiarazioni di parere attuariale.
+  BC-2180.30:
+    name: Modellizzazione del capitale e della solvibilità
+    description: |
+      Sviluppo del modello di capitale interno, calcolo della formula standard, allocazione del capitale e supporto all'ORSA.
+  BC-2180.30.10:
+    name: Sviluppo del modello di capitale interno
+    description: |
+      Sviluppo e manutenzione dei modelli di capitale interno per solvibilità e rating.
+  BC-2180.30.20:
+    name: Calcolo della formula standard
+    description: |
+      Calcolo della formula standard Solvency II e delle metriche di capitale regolamentare equivalenti.
+  BC-2180.30.30:
+    name: Allocazione del capitale
+    description: |
+      Allocazione del capitale richiesto ai rami assicurativi e ai segmenti.
+  BC-2180.30.40:
+    name: Supporto alla modellizzazione ORSA
+    description: |
+      Supporto alla modellizzazione per i cicli di valutazione del rischio proprio e della solvibilità (ORSA).
+  BC-2180.40:
+    name: Studi di esperienza e gestione delle ipotesi
+    description: |
+      Studi di mortalità, longevità, tasso di abbandono, persistenza e morbilità, e governance delle ipotesi.
+  BC-2180.40.10:
+    name: Studi di mortalità e longevità
+    description: |
+      Studi di esperienza sulla mortalità e la longevità per portafogli vita e previdenziali.
+  BC-2180.40.20:
+    name: Studi sul tasso di abbandono e la persistenza
+    description: |
+      Studi di esperienza sul tasso di abbandono e la persistenza per coorti di prodotto.
+  BC-2180.40.30:
+    name: Studi sulla morbilità e sulla frequenza dei sinistri
+    description: |
+      Studi di esperienza sulla morbilità e sulla frequenza dei sinistri per i rami salute e protezione.
+  BC-2180.40.40:
+    name: Governance e sign-off delle ipotesi
+    description: |
+      Governance e sign-off delle ipotesi attuariali utilizzate in tariffazione, riserva e reporting.
+  BC-2180.50:
+    name: Supporto al reporting attuariale IFRS 17
+    description: |
+      CSM, RA, costruzione delle coorti e produzione delle informative IFRS 17.
+  BC-2180.50.10:
+    name: Calcolo del CSM e del RA
+    description: |
+      Calcolo del CSM (contractual service margin) e del RA (risk adjustment) ai fini IFRS 17.
+  BC-2180.50.20:
+    name: Costruzione delle coorti e dei gruppi
+    description: |
+      Costruzione dei gruppi di contratti assicurativi e delle coorti annuali.
+  BC-2180.50.30:
+    name: Produzione delle informative IFRS 17
+    description: |
+      Produzione degli input attuariali per le informative e le riconciliazioni IFRS 17.
+  BC-2180.60:
+    name: Modellizzazione delle catastrofi
+    description: |
+      Gestione dei vendor dei modelli CAT, preparazione dei dati sulle esposizioni, calcolo di PML e AAL e validazione del modello.
+  BC-2180.60.10:
+    name: Gestione dei vendor dei modelli CAT
+    description: |
+      Selezione e gestione dei vendor dei modelli CAT e dei portafogli di licenze.
+  BC-2180.60.20:
+    name: Preparazione dei dati sulle esposizioni
+    description: |
+      Preparazione e condizionamento dei dati sulle esposizioni per le elaborazioni del modello CAT.
+  BC-2180.60.30:
+    name: Calcolo di PML e AAL
+    description: |
+      Calcolo delle metriche di probable maximum loss (PML) e average annual loss (AAL).
+  BC-2180.60.40:
+    name: Validazione e aggiustamento del modello CAT
+    description: |
+      Validazione e aggiustamento della view of risk degli output del modello CAT.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-advertising-sales-operations-management.yaml
+++ b/catalogue/i18n/it/L1-advertising-sales-operations-management.yaml
@@ -1,0 +1,132 @@
+# Vendita della pubblicità (it) — translations for L1-advertising-sales-operations-management.yaml
+locale: it
+source: L1-advertising-sales-operations-management.yaml
+entries:
+  BC-3760:
+    name: Vendita della pubblicità e gestione delle operazioni
+    description: |
+      Inventario pubblicitario, vendita diretta e programmatica, trafficking e
+      decisioning degli annunci, controlli di brand safety e qualità dell'inventario,
+      e reportistica dei ricavi pubblicitari su superfici lineari, digitali e connected TV.
+  BC-3760.10:
+    name: Gestione dell'inventario pubblicitario
+    description: |
+      Previsione, allocazione e prenotazione dell'inventario pubblicitario
+      su superfici lineari e digitali.
+  BC-3760.10.10:
+    name: Previsione degli avail
+    description: |
+      Previsione delle impressioni disponibili, dei GRP e degli avail
+      con targeting sull'audience per l'orizzonte di inventario.
+  BC-3760.10.20:
+    name: Allocazione dell'inventario
+    description: |
+      Allocazione dell'inventario verso i pool diretti, programmatici
+      e house su tutte le superfici.
+  BC-3760.10.30:
+    name: Prenotazione e holdback dell'inventario
+    description: |
+      Prenotazione e holdback dell'inventario per deal garantiti,
+      sponsorizzazioni ed eventi di punta.
+  BC-3760.20:
+    name: Gestione della vendita diretta degli spazi pubblicitari
+    description: |
+      Vendita diretta dell'inventario pubblicitario tramite sponsorizzazioni,
+      upfront e ordini di inserzione.
+  BC-3760.20.10:
+    name: Vendita di sponsorizzazioni
+    description: |
+      Pipeline e contrattualizzazione di deal di sponsorizzazione e integrazione.
+  BC-3760.20.20:
+    name: Vendite upfront e scatter
+    description: |
+      Vendite sul mercato upfront e scatter di inventario lineare e digitale.
+  BC-3760.20.30:
+    name: Ordini di inserzione e vendita spot lineare
+    description: |
+      Acquisizione degli ordini di inserzione e prenotazione degli spot lineari
+      rispetto al piano degli avail.
+  BC-3760.30:
+    name: Gestione delle vendite programmatiche
+    description: |
+      Configurazione e operazione di aste programmatiche, marketplace privati
+      e integrazioni nella supply path.
+  BC-3760.30.10:
+    name: Configurazione dell'asta
+    description: |
+      Configurazione di floor d'asta, deal ID e idoneità dei bidder
+      sull'inventario.
+  BC-3760.30.20:
+    name: Gestione dei deal nel marketplace privato
+    description: |
+      Redazione e ciclo di vita di deal programmatici garantiti e di
+      marketplace privati con i buyer.
+  BC-3760.30.30:
+    name: Integrazione header bidding e SSP
+    description: |
+      Integrazione di partner header bidding e supply-side platform
+      su tutte le superfici.
+  BC-3760.40:
+    name: Trafficking e operazioni pubblicitarie
+    description: |
+      Onboarding dei creativi, decisioning e inserimento degli annunci,
+      e pianificazione degli spot nelle interruzioni lineari e digitali.
+  BC-3760.40.10:
+    name: Onboarding e QC dei creativi
+    description: |
+      Onboarding e controllo qualità dei creativi pubblicitari rispetto
+      alle specifiche tecniche e di policy.
+  BC-3760.40.20:
+    name: Decisioning e inserimento degli annunci
+    description: |
+      Decisione dell'annuncio da servire e inserimento nelle interruzioni
+      lineari, lato server o lato client.
+  BC-3760.40.30:
+    name: Pianificazione degli spot
+    description: |
+      Costruzione del piano di posizionamento degli spot lineari e
+      ottimizzazione della struttura delle interruzioni.
+  BC-3760.50:
+    name: Gestione della brand safety e della qualità dell'inventario
+    description: |
+      Classificazione dell'inventario per la brand safety, rilevamento
+      del traffico non valido e tagging di idoneità per il targeting dei buyer.
+  BC-3760.50.10:
+    name: Classificazione della brand safety
+    description: |
+      Classificazione delle superfici di contenuto rispetto ai framework
+      di brand safety e idoneità.
+  BC-3760.50.20:
+    name: Rilevamento del traffico non valido
+    description: |
+      Rilevamento ed esclusione del traffico non valido sull'inventario
+      proprietario e dei partner.
+  BC-3760.50.30:
+    name: Tagging di idoneità
+    description: |
+      Tagging delle superfici di contenuto con attributi di idoneità
+      e contestuali per il targeting dei buyer.
+  BC-3760.60:
+    name: Reportistica dei ricavi pubblicitari
+    description: |
+      Reportistica della consegna delle campagne, riconciliazione degli
+      make-good e fatturazione e liquidazione degli inserzionisti su
+      vendite lineari e digitali.
+  BC-3760.60.10:
+    name: Reportistica della consegna delle campagne
+    description: |
+      Reportistica di consegna e pacing rispetto agli obiettivi di campagna
+      su tutte le superfici e valute.
+  BC-3760.60.20:
+    name: Make-good e riconciliazione
+    description: |
+      Riconciliazione delle impressioni consegnate rispetto all'ordinato,
+      con gestione di make-good e note di credito.
+  BC-3760.60.30:
+    name: Fatturazione e liquidazione degli inserzionisti
+    description: |
+      Fatturazione degli inserzionisti e delle agenzie e liquidazione
+      rispetto a sconti e commissioni di agenzia.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-aeronautical-information-management.yaml
+++ b/catalogue/i18n/it/L1-aeronautical-information-management.yaml
@@ -1,0 +1,99 @@
+# Gestione delle informazioni aeronautiche (it) — translations for L1-aeronautical-information-management.yaml
+locale: it
+source: L1-aeronautical-information-management.yaml
+entries:
+  BC-1230:
+    name: Gestione delle informazioni aeronautiche
+    description: |
+      AIP, NOTAM, banche dati aeronautiche, cartografia, AIM digitale.
+  BC-1230.10:
+    name: Gestione della pubblicazione di informazioni aeronautiche
+    description: |
+      AIP, ciclo AIRAC, emendamenti e supplementi.
+  BC-1230.10.10:
+    name: Produzione dell'AIP
+    description: |
+      Produzione della pubblicazione di informazioni aeronautiche (AIP).
+  BC-1230.10.20:
+    name: Gestione del ciclo AIRAC
+    description: |
+      Gestione del ciclo AIRAC e delle date di entrata in vigore.
+  BC-1230.10.30:
+    name: Emissione di emendamenti e supplementi all'AIP
+    description: |
+      Emissione degli emendamenti e dei supplementi all'AIP.
+  BC-1230.20:
+    name: Gestione dei NOTAM
+    description: |
+      Originazione, pubblicazione, diffusione e scadenza dei NOTAM.
+  BC-1230.20.10:
+    name: Originazione dei NOTAM
+    description: |
+      Originazione e redazione dei NOTAM.
+  BC-1230.20.20:
+    name: Pubblicazione e diffusione dei NOTAM
+    description: |
+      Pubblicazione e diffusione tramite AFTN/AMHS.
+  BC-1230.20.30:
+    name: Gestione del ciclo di vita dei NOTAM
+    description: |
+      Gestione del ciclo di vita, incluse sostituzione e cancellazione.
+  BC-1230.30:
+    name: Gestione della banca dati aeronautica
+    description: |
+      Integrità, tracciabilità, conformità AIRAC e qualità dei dati aeronautici.
+  BC-1230.30.10:
+    name: Originazione dei dati aeronautici
+    description: |
+      Originazione e acquisizione dei dati aeronautici secondo ICAO Annex 15.
+  BC-1230.30.20:
+    name: Gestione della qualità dei dati aeronautici
+    description: |
+      Controlli di qualità, accuratezza, integrità e risoluzione dei dati.
+  BC-1230.30.30:
+    name: Distribuzione dei dati aeronautici
+    description: |
+      Distribuzione dei dati aeronautici agli utenti e agli strumenti.
+  BC-1230.30.40:
+    name: Tracciabilità e audit dei dati
+    description: |
+      Tracciabilità della provenienza dei dati aeronautici e attività di audit.
+  BC-1230.40:
+    name: Gestione della cartografia e della progettazione delle procedure
+    description: |
+      Carte aeronautiche, procedure di volo strumentale, progettazione PBN.
+  BC-1230.40.10:
+    name: Produzione delle carte aeronautiche
+    description: |
+      Produzione di carte en route, terminali e aeroportuali.
+  BC-1230.40.20:
+    name: Progettazione delle procedure di volo strumentale
+    description: |
+      Progettazione di SID, STAR e procedure di avvicinamento strumentale.
+  BC-1230.40.30:
+    name: Progettazione delle procedure di navigazione basata sulle prestazioni
+    description: |
+      Progettazione di procedure PBN, incluse RNP e RNAV.
+  BC-1230.40.40:
+    name: Validazione e approvazione delle procedure
+    description: |
+      Validazione delle procedure, ispezione in volo e approvazione regolamentare.
+  BC-1230.50:
+    name: Gestione dei servizi AIM digitali
+    description: |
+      Prodotti dati digitali, servizi SWIM, AIM leggibile dalle macchine.
+  BC-1230.50.10:
+    name: Gestione dei prodotti dati digitali
+    description: |
+      Gestione dei prodotti dati AIM digitali (basati su AIXM).
+  BC-1230.50.20:
+    name: Fornitura dei servizi SWIM
+    description: |
+      Fornitura dei servizi di System Wide Information Management (SWIM).
+  BC-1230.50.30:
+    name: Distribuzione AIM leggibile dalle macchine
+    description: |
+      Distribuzione di AIM leggibile dalle macchine agli abbonati.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-aeronautical-meteorology-management.yaml
+++ b/catalogue/i18n/it/L1-aeronautical-meteorology-management.yaml
@@ -1,0 +1,75 @@
+# Gestione della meteorologia aeronautica (it) — translations for L1-aeronautical-meteorology-management.yaml
+locale: it
+source: L1-aeronautical-meteorology-management.yaml
+entries:
+  BC-1250:
+    name: Gestione della meteorologia aeronautica
+    description: |
+      Osservazione MET, previsione, briefing, servizi meteorologici per condizioni avverse.
+  BC-1250.10:
+    name: Gestione delle osservazioni MET
+    description: |
+      METAR, osservazioni automatiche, reti di sensori, osservazioni al suolo.
+  BC-1250.10.10:
+    name: Osservazione meteorologica al suolo
+    description: |
+      Osservazione meteorologica al suolo manuale e automatizzata negli aeroporti.
+  BC-1250.10.20:
+    name: Produzione di METAR e SPECI
+    description: |
+      Produzione e diffusione dei rapporti METAR e SPECI.
+  BC-1250.10.30:
+    name: Gestione della rete di sensori MET
+    description: |
+      Operazione dei sistemi automatizzati di osservazione meteorologica e dei relativi sensori.
+  BC-1250.20:
+    name: Gestione delle previsioni MET
+    description: |
+      TAF, previsioni d'area, SIGMET, AIRMET, GAMET.
+  BC-1250.20.10:
+    name: Produzione delle previsioni aeroportuali
+    description: |
+      Produzione di TAF e previsioni di tendenza per gli aeroporti.
+  BC-1250.20.20:
+    name: Produzione delle previsioni d'area
+    description: |
+      Produzione di previsioni d'area, GAMET e previsioni di tempo significativo.
+  BC-1250.20.30:
+    name: Emissione di SIGMET e AIRMET
+    description: |
+      Emissione degli avvisi SIGMET e AIRMET.
+  BC-1250.30:
+    name: Gestione del briefing e della consulenza MET
+    description: |
+      Briefing pre-volo, servizi consultivi alle unità ATS, avvisi in volo.
+  BC-1250.30.10:
+    name: Servizio di briefing pre-volo
+    description: |
+      Fornitura di servizi di auto-briefing e briefing assistito.
+  BC-1250.30.20:
+    name: Consulenza MET alle unità ATS
+    description: |
+      Fornitura di consulenze meteorologiche alle unità ATS e ai supervisori.
+  BC-1250.30.30:
+    name: Consulenza MET in volo
+    description: |
+      Servizi di consulenza meteorologica in volo agli utenti dello spazio aereo.
+  BC-1250.40:
+    name: Gestione delle condizioni meteorologiche avverse
+    description: |
+      Avvisi per cenere vulcanica, condizioni meteorologiche severe e meteorologia spaziale.
+  BC-1250.40.10:
+    name: Servizio di avviso per cenere vulcanica
+    description: |
+      Coordinamento con i VAAC e diffusione degli avvisi per cenere vulcanica.
+  BC-1250.40.20:
+    name: Servizio di allerta per condizioni meteorologiche severe
+    description: |
+      Emissione di allerte per condizioni meteorologiche severe (CB, turbolenza, ghiacciamento).
+  BC-1250.40.30:
+    name: Servizio di avviso per meteorologia spaziale
+    description: |
+      Avvisi di meteorologia spaziale in conformità con i requisiti ICAO.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-agri-environmental-stewardship-management.yaml
+++ b/catalogue/i18n/it/L1-agri-environmental-stewardship-management.yaml
@@ -1,0 +1,137 @@
+# Gestione agro-ambientale e territoriale (it) — translations for L1-agri-environmental-stewardship-management.yaml
+locale: it
+source: L1-agri-environmental-stewardship-management.yaml
+entries:
+  BC-3600:
+    name: Gestione agro-ambientale e territoriale
+    description: |
+      Gestione ambientale in azienda — salute del suolo, gestione delle acque, biodiversità,
+      gestione dei gas serra agricoli, programmi di carbonio nel suolo,
+      pratiche rigenerative e partecipazione a misure agro-ambientali
+      a complemento della sostenibilità aziendale.
+  BC-3600.10:
+    name: Gestione della salute del suolo
+    description: |
+      Gestione della sostanza organica del suolo, coltivazione di cover crops e
+      controllo dell'erosione sui terreni a seminativo.
+  BC-3600.10.10:
+    name: Monitoraggio del carbonio organico del suolo
+    description: |
+      Monitoraggio periodico del carbonio organico del suolo nei campi.
+  BC-3600.10.20:
+    name: Programmi di cover cropping
+    description: |
+      Programmi di cover cropping per mantenere la copertura e la biologia del suolo.
+  BC-3600.10.30:
+    name: Programmi di controllo dell'erosione del suolo
+    description: |
+      Programmi di controllo dell'erosione, incluse pratiche a contorno, terrazze e fasce tampone.
+  BC-3600.20:
+    name: Gestione delle acque in azienda
+    description: |
+      Efficienza nell'uso dell'acqua, protezione riparia e gestione della qualità delle acque di drenaggio a livello aziendale.
+    in_scope:
+      - Monitoraggio dell'efficienza nell'uso dell'acqua
+      - Protezione delle zone riparie e dei corsi d'acqua
+      - Gestione della qualità delle acque di drenaggio
+    out_of_scope:
+      - Rendicontazione aziendale sull'acqua (BC-740)
+      - Programmazione dell'irrigazione (BC-3500.60.10)
+  BC-3600.20.10:
+    name: Monitoraggio dell'efficienza nell'uso dell'acqua
+    description: |
+      Monitoraggio dell'efficienza nell'uso dell'acqua per coltura e campo.
+  BC-3600.20.20:
+    name: Protezione delle zone riparie e dei corsi d'acqua
+    description: |
+      Protezione delle zone riparie e dei corsi d'acqua in azienda.
+  BC-3600.20.30:
+    name: Gestione della qualità delle acque di drenaggio
+    description: |
+      Gestione della qualità delle acque di drenaggio e delle perdite di nutrienti.
+  BC-3600.30:
+    name: Gestione della biodiversità e degli habitat
+    description: |
+      Gestione della biodiversità in azienda, incluse la mappatura degli habitat,
+      la tutela degli impollinatori e le fasce tampone sui margini dei campi.
+  BC-3600.30.10:
+    name: Mappatura degli habitat aziendali
+    description: |
+      Registrazione degli habitat e delle caratteristiche di biodiversità in azienda.
+  BC-3600.30.20:
+    name: Tutela degli impollinatori
+    description: |
+      Pratiche a favore degli impollinatori, incluse fasce fiorite e soglie IPM.
+  BC-3600.30.30:
+    name: Gestione delle fasce tampone
+    description: |
+      Gestione delle fasce tampone sui margini dei campi e lungo i corsi d'acqua.
+  BC-3600.40:
+    name: Gestione dei gas serra agricoli
+    description: |
+      Quantificazione e mitigazione dei gas serra agricoli, inclusi metano enterico, protossido di azoto e CO2 in azienda.
+  BC-3600.40.10:
+    name: Programmi di mitigazione del metano enterico
+    description: |
+      Programmi di mitigazione del metano enterico negli animali ruminanti.
+  BC-3600.40.20:
+    name: Programmi di mitigazione del protossido di azoto
+    description: |
+      Mitigazione del protossido di azoto attraverso l'efficienza nell'uso dell'azoto e la scelta del momento di applicazione.
+  BC-3600.40.30:
+    name: Inventario delle emissioni aziendali
+    description: |
+      Inventario delle emissioni di gas serra a livello aziendale a supporto delle rendicontazioni.
+  BC-3600.50:
+    name: Programmi di carbonio nel suolo e crediti di carbonio
+    description: |
+      Misurazione della baseline del carbonio nel suolo, progettazione di progetti di crediti di carbonio
+      e registrazioni di emissione nell'ambito di metodologie riconosciute.
+  BC-3600.50.10:
+    name: Misurazione della baseline del carbonio nel suolo
+    description: |
+      Campagne di misurazione della baseline del carbonio nel suolo all'iscrizione del progetto.
+  BC-3600.50.20:
+    name: Progettazione del progetto di crediti di carbonio
+    description: |
+      Progettazione del progetto secondo le metodologie Verra, Gold Standard e equivalenti.
+  BC-3600.50.30:
+    name: Registrazioni di emissione dei crediti di carbonio
+    description: |
+      Registrazioni dell'emissione, del ritiro e dell'allocazione ai beneficiari dei crediti di carbonio.
+  BC-3600.60:
+    name: Gestione delle pratiche rigenerative
+    description: |
+      Adozione e registrazione di pratiche rigenerative, incluse la riduzione delle lavorazioni, l'integrazione coltura-allevamento e l'agroforestazione.
+  BC-3600.60.10:
+    name: Programmi di semina diretta e riduzione delle lavorazioni
+    description: |
+      Adozione e monitoraggio di programmi di semina diretta e di riduzione delle lavorazioni.
+  BC-3600.60.20:
+    name: Operazioni di integrazione coltura-allevamento
+    description: |
+      Integrazione delle operazioni colturali e zootecniche per il ciclo dei nutrienti.
+  BC-3600.60.30:
+    name: Registrazioni delle pratiche agroforestali
+    description: |
+      Registrazioni degli impianti agroforestali e dei sistemi silvo-pastorali.
+  BC-3600.70:
+    name: Partecipazione a misure agro-ambientali
+    description: |
+      Partecipazione agli eco-schemi della PAC, ai programmi di conservazione NRCS
+      e ai regimi agro-ambientali equivalenti con pagamento.
+  BC-3600.70.10:
+    name: Partecipazione agli eco-schemi della PAC
+    description: |
+      Partecipazione agli eco-schemi e ai requisiti di condizionalità della PAC dell'UE.
+  BC-3600.70.20:
+    name: Partecipazione ai programmi di conservazione
+    description: |
+      Partecipazione ai programmi USDA NRCS EQIP, CSP e equivalenti.
+  BC-3600.70.30:
+    name: Riconciliazione dei pagamenti agro-ambientali
+    description: |
+      Riconciliazione dei pagamenti agro-ambientali rispetto agli impegni del regime.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-agri-food-compliance-certification-management.yaml
+++ b/catalogue/i18n/it/L1-agri-food-compliance-certification-management.yaml
@@ -1,0 +1,144 @@
+# Gestione della conformità e certificazione agroalimentare (it) — translations for L1-agri-food-compliance-certification-management.yaml
+locale: it
+source: L1-agri-food-compliance-certification-management.yaml
+entries:
+  BC-3590:
+    name: Gestione della conformità e certificazione agroalimentare
+    description: |
+      Programmi di conformità e certificazione specifici del settore — assicurazione aziendale,
+      biologico, benessere animale, indicazioni geografiche, conformità agli LMR,
+      identificazione del bestiame e registrazioni di tracciabilità pre-azienda,
+      distinti dalla gestione generica della conformità e della qualità.
+  BC-3590.10:
+    name: Gestione della certificazione di assicurazione aziendale
+    description: |
+      Gestione dei programmi di certificazione di assicurazione aziendale, inclusi
+      GlobalG.A.P., LEAF Marque e regimi nazionali equivalenti.
+    in_scope:
+      - GlobalG.A.P. e assicurazione aziendale equivalente
+      - Partecipazione al LEAF Marque
+      - Coordinamento degli audit e azioni correttive
+    out_of_scope:
+      - Gestione generica della qualità (BC-720)
+      - Programmi di sicurezza alimentare lato distribuzione al dettaglio (BC-2380.10)
+  BC-3590.10.10:
+    name: Programmi di certificazione GlobalG.A.P.
+    description: |
+      Gestione della certificazione GlobalG.A.P. IFA, Acquacoltura e Zootecnia.
+  BC-3590.10.20:
+    name: Programmi LEAF Marque e equivalenti
+    description: |
+      Partecipazione al LEAF Marque e ai regimi di assicurazione nazionali equivalenti.
+  BC-3590.10.30:
+    name: Coordinamento degli audit di assicurazione aziendale
+    description: |
+      Coordinamento degli audit di assicurazione aziendale e monitoraggio delle azioni correttive.
+  BC-3590.20:
+    name: Gestione della certificazione biologica
+    description: |
+      Gestione della certificazione biologica ai sensi dell'USDA NOP, del regolamento EU organic,
+      del JAS Organic e dei regimi equivalenti.
+  BC-3590.20.10:
+    name: Registrazioni di conformità allo standard biologico
+    description: |
+      Registrazioni di conformità allo standard biologico applicabile.
+  BC-3590.20.20:
+    name: Coordinamento delle ispezioni per la certificazione biologica
+    description: |
+      Coordinamento delle ispezioni e degli audit per la certificazione biologica.
+  BC-3590.20.30:
+    name: Autorizzazione degli input biologici
+    description: |
+      Verifica che gli input siano autorizzati ai sensi dello standard biologico applicabile.
+  BC-3590.30:
+    name: Gestione della certificazione del benessere animale
+    description: |
+      Programmi di audit sul benessere animale, registrazione degli esiti di benessere
+      e conformità agli standard di benessere settoriali e di assicurazione.
+  BC-3590.30.10:
+    name: Programmi di audit sul benessere animale
+    description: |
+      Programmi di audit sul benessere animale interni e di terze parti.
+  BC-3590.30.20:
+    name: Registrazione degli esiti di benessere
+    description: |
+      Registrazione delle misurazioni degli esiti di benessere nelle unità zootecniche.
+  BC-3590.30.30:
+    name: Conformità agli standard di benessere
+    description: |
+      Evidenze di conformità agli standard di benessere settoriali e di assicurazione.
+  BC-3590.40:
+    name: Gestione delle indicazioni geografiche e della provenienza
+    description: |
+      Registrazioni e verifiche a supporto delle denominazioni di origine protette,
+      delle indicazioni geografiche e delle dichiarazioni di provenienza.
+  BC-3590.40.10:
+    name: Registrazioni delle dichiarazioni di provenienza
+    description: |
+      Registrazioni a supporto delle dichiarazioni di origine, razza e provenienza.
+  BC-3590.40.20:
+    name: Conformità alle indicazioni geografiche
+    description: |
+      Conformità a DOP, IGP e indicazioni geografiche equivalenti.
+  BC-3590.40.30:
+    name: Verifica dell'origine
+    description: |
+      Verifica dell'origine tramite metodi documentali, isotopici e del DNA.
+  BC-3590.50:
+    name: Gestione dei residui di pesticidi e degli LMR
+    description: |
+      Campionamento dei residui, conformità agli LMR e rispetto degli intervalli di sospensione per i mercati di destinazione.
+  BC-3590.50.10:
+    name: Programmi di campionamento dei residui
+    description: |
+      Programmi di campionamento dei residui di pesticidi su colture e lotti.
+  BC-3590.50.20:
+    name: Monitoraggio della conformità agli LMR
+    description: |
+      Monitoraggio della conformità ai calendari degli LMR dei mercati di destinazione.
+  BC-3590.50.30:
+    name: Conformità agli intervalli di sospensione
+    description: |
+      Conformità agli intervalli di sospensione pre-raccolta e di eliminazione nel latte.
+  BC-3590.60:
+    name: Conformità all'identificazione e alla movimentazione del bestiame
+    description: |
+      Identificazione degli animali, permessi di movimento e certificazione sanitaria transfrontaliera per bestiame e acquacoltura.
+    in_scope:
+      - Identificazione obbligatoria degli animali
+      - Registrazione dei permessi di movimento
+      - Certificazione sanitaria transfrontaliera
+    out_of_scope:
+      - Gestione generica della conformità (BC-130)
+  BC-3590.60.10:
+    name: Applicazione dei marchi di identificazione degli animali
+    description: |
+      Applicazione obbligatoria dei marchi di identificazione degli animali, inclusi EID e marchi auricolari.
+  BC-3590.60.20:
+    name: Registrazione dei permessi di movimento
+    description: |
+      Registrazione dei permessi di movimento obbligatori e dei registri di movimentazione in azienda.
+  BC-3590.60.30:
+    name: Certificazione sanitaria transfrontaliera
+    description: |
+      Certificazione sanitaria transfrontaliera, incluse le notifiche TRACES NT.
+  BC-3590.70:
+    name: Registrazioni di tracciabilità pre-azienda
+    description: |
+      Registrazioni di tracciabilità campo-lotto, animale-carcassa e input-output
+      che ancorano le successive tracce EPCIS e di custodia della catena.
+  BC-3590.70.10:
+    name: Tracciabilità campo-lotto
+    description: |
+      Tracciabilità che collega le operazioni in campo ai lotti raccolti.
+  BC-3590.70.20:
+    name: Tracciabilità animale-carcassa
+    description: |
+      Tracciabilità che collega i singoli animali alle carcasse e ai tagli principali.
+  BC-3590.70.30:
+    name: Registrazione della traccia input-output
+    description: |
+      Registrazione che collega gli input applicati ai lotti di output risultanti.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-agricultural-inputs-management.yaml
+++ b/catalogue/i18n/it/L1-agricultural-inputs-management.yaml
@@ -1,0 +1,129 @@
+# Gestione degli input agricoli (it) — translations for L1-agricultural-inputs-management.yaml
+locale: it
+source: L1-agricultural-inputs-management.yaml
+entries:
+  BC-3550:
+    name: Gestione degli input agricoli
+    description: |
+      Gestione del ciclo di vita degli input agricoli — semente e materiale genetico,
+      fertilizzanti, prodotti fitosanitari, nutrizione animale, medicinali veterinari
+      e biologici — inclusi i requisiti specifici del settore in materia di tracciabilità, stewardship
+      e stoccaggio, distinti dall'approvvigionamento generico.
+  BC-3550.10:
+    name: Gestione della semente e del materiale genetico
+    description: |
+      Approvvigionamento di semente certificata, trattamento delle sementi, tracciabilità del pedigree e dei caratteri
+      e gestione delle scorte di semente nell'intero ciclo di semina.
+    in_scope:
+      - Approvvigionamento di semente certificata
+      - Applicazione dei trattamenti sementi
+      - Tracciabilità del pedigree e dei caratteri
+      - Inventario della semente in azienda e in deposito
+    out_of_scope:
+      - R&D nel miglioramento genetico delle piante (BC-810)
+      - Raccomandazione varietale (BC-3530.40)
+  BC-3550.10.10:
+    name: Approvvigionamento e certificazione della semente
+    description: |
+      Approvvigionamento di semente certificata secondo gli schemi sementieri OCSE e i test ISTA.
+  BC-3550.10.20:
+    name: Applicazione del trattamento semente
+    description: |
+      Applicazione di trattamenti e coatings alle sementi prima della semina.
+  BC-3550.10.30:
+    name: Tracciabilità del pedigree e dei caratteri della semente
+    description: |
+      Tracciabilità del pedigree, della combinazione di caratteri e degli obblighi di stewardship delle sementi.
+  BC-3550.10.40:
+    name: Gestione dell'inventario delle sementi
+    description: |
+      Gestione dell'inventario delle sementi nei depositi e nei magazzini aziendali.
+  BC-3550.20:
+    name: Gestione degli input fertilizzanti
+    description: |
+      Approvvigionamento, stoccaggio, movimentazione e registrazioni delle applicazioni di fertilizzanti solidi e liquidi.
+  BC-3550.20.10:
+    name: Approvvigionamento di fertilizzanti
+    description: |
+      Approvvigionamento di fertilizzanti semplici e miscelati da fornitori e importatori.
+  BC-3550.20.20:
+    name: Stoccaggio e movimentazione dei fertilizzanti
+    description: |
+      Stoccaggio e movimentazione di fertilizzanti in azienda e in deposito, incluse le vasche di contenimento.
+  BC-3550.20.30:
+    name: Registrazioni delle applicazioni di fertilizzanti
+    description: |
+      Registrazioni delle applicazioni di fertilizzanti per campo, prodotto e dose.
+  BC-3550.30:
+    name: Gestione degli input fitosanitari
+    description: |
+      Approvvigionamento, stoccaggio, registrazioni delle applicazioni e stewardship dei contenitori vuoti per i prodotti fitosanitari.
+  BC-3550.30.10:
+    name: Approvvigionamento di prodotti fitosanitari
+    description: |
+      Approvvigionamento di prodotti fitosanitari autorizzati attraverso canali abilitati.
+  BC-3550.30.20:
+    name: Stoccaggio e movimentazione dei pesticidi
+    description: |
+      Stoccaggio, segregazione e controlli sulla movimentazione da parte degli operatori.
+  BC-3550.30.30:
+    name: Registrazioni delle applicazioni di pesticidi
+    description: |
+      Registrazioni delle applicazioni di pesticidi conformi ai requisiti degli enti regolatori e dei sistemi di assicurazione qualità.
+  BC-3550.30.40:
+    name: Stewardship dei contenitori vuoti
+    description: |
+      Triplo risciacquo, restituzione e riciclo dei contenitori vuoti di pesticidi.
+  BC-3550.40:
+    name: Gestione degli input per la nutrizione animale
+    description: |
+      Approvvigionamento, stoccaggio e monitoraggio dell'utilizzo di materie prime, premiscele e additivi per mangimi per le operazioni zootecniche.
+  BC-3550.40.10:
+    name: Approvvigionamento di materie prime per mangimi
+    description: |
+      Approvvigionamento di cereali, farine proteiche e ingredienti foraggeri.
+  BC-3550.40.20:
+    name: Gestione di premiscele e additivi
+    description: |
+      Approvvigionamento e inventario di premiscele, minerali e additivi per mangimi.
+  BC-3550.40.30:
+    name: Gestione dell'inventario dei mangimi e delle razioni
+    description: |
+      Gestione dell'inventario dei mangimi in azienda e monitoraggio dell'utilizzo delle razioni.
+  BC-3550.50:
+    name: Gestione degli input di medicinali veterinari
+    description: |
+      Approvvigionamento, stoccaggio in catena del freddo e registrazione dell'utilizzo
+      dei medicinali veterinari e dei biologici in azienda.
+  BC-3550.50.10:
+    name: Approvvigionamento di medicinali veterinari
+    description: |
+      Approvvigionamento su prescrizione di medicinali veterinari e biologici.
+  BC-3550.50.20:
+    name: Stoccaggio in catena del freddo dei medicinali veterinari
+    description: |
+      Stoccaggio in catena del freddo in azienda e gestione delle escursioni termiche per i medicinali veterinari.
+  BC-3550.50.30:
+    name: Registrazione dell'utilizzo dei medicinali veterinari
+    description: |
+      Registrazione dell'utilizzo con dettagli di lotto, dose, animale e operatore.
+  BC-3550.60:
+    name: Input biologici e ammendanti del suolo
+    description: |
+      Approvvigionamento di input biologici, gestione del letame e del compost,
+      e fornitura di calce e ammendanti del suolo.
+  BC-3550.60.10:
+    name: Approvvigionamento di input biologici
+    description: |
+      Approvvigionamento di biostimolanti, biofertilizzanti e inoculanti microbici.
+  BC-3550.60.20:
+    name: Gestione del letame e del compost
+    description: |
+      Stoccaggio del letame in azienda, compostaggio e operazioni di recupero dei nutrienti.
+  BC-3550.60.30:
+    name: Approvvigionamento di calce e ammendanti del suolo
+    description: |
+      Approvvigionamento di calce agricola, gesso e altri ammendanti del suolo.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-agronomy-farm-advisory-management.yaml
+++ b/catalogue/i18n/it/L1-agronomy-farm-advisory-management.yaml
@@ -1,0 +1,120 @@
+# Gestione dell'agronomia e della consulenza agronomica (it) — translations for L1-agronomy-farm-advisory-management.yaml
+locale: it
+source: L1-agronomy-farm-advisory-management.yaml
+entries:
+  BC-3530:
+    name: Gestione dell'agronomia e della consulenza agronomica
+    description: |
+      Analisi del suolo, pianificazione della nutrizione e della difesa delle colture, gestione integrata dei parassiti,
+      raccomandazioni varietali, servizi di consulenza e gestione delle sperimentazioni in campo
+      che traducono la scienza agronomica in decisioni operative a livello di campo.
+  BC-3530.10:
+    name: Campionamento e analisi del suolo
+    description: |
+      Campionamento, analisi di laboratorio e interpretazione delle analisi del suolo
+      a supporto delle decisioni di nutrizione e ammendamento.
+  BC-3530.10.10:
+    name: Operazioni di campionamento del suolo
+    description: |
+      Campionamento del suolo in campo con metodi a griglia, per zone e compositi.
+  BC-3530.10.20:
+    name: Interpretazione dei risultati delle analisi del suolo
+    description: |
+      Interpretazione dei risultati delle analisi del suolo in relazione ai fabbisogni della coltura.
+  BC-3530.10.30:
+    name: Monitoraggio degli indicatori di salute del suolo
+    description: |
+      Monitoraggio nel tempo degli indicatori di salute del suolo nei vari campi.
+  BC-3530.20:
+    name: Pianificazione della gestione dei nutrienti
+    description: |
+      Calcolo del fabbisogno nutrizionale delle colture e generazione di prescrizioni a rateo variabile
+      in linea con la gestione sostenibile dei nutrienti secondo i principi 4R.
+    in_scope:
+      - Calcolo del fabbisogno di nutrienti
+      - Generazione di mappe prescrittive a rateo variabile
+      - Registrazione della conformità ai principi 4R
+    out_of_scope:
+      - Esecuzione dell'applicazione di fertilizzanti (BC-3500.40)
+      - Programmi di carbonio nel suolo (BC-3600.50)
+  BC-3530.20.10:
+    name: Calcolo del fabbisogno di nutrienti
+    description: |
+      Calcolo del fabbisogno di nutrienti per coltura, obiettivo di resa e campo.
+  BC-3530.20.20:
+    name: Generazione di prescrizioni a rateo variabile
+    description: |
+      Generazione di mappe prescrittive a rateo variabile per fertilizzanti e ammendanti.
+  BC-3530.20.30:
+    name: Registrazione della conformità ai principi 4R
+    description: |
+      Registrazione della fonte, del dosaggio, del momento e del luogo corretti secondo i principi 4R.
+  BC-3530.30:
+    name: Pianificazione della difesa delle colture
+    description: |
+      Valutazione del rischio, pianificazione della gestione integrata dei parassiti, progettazione dei programmi di trattamento e strategia di gestione della resistenza.
+  BC-3530.30.10:
+    name: Valutazione del rischio di parassiti e malattie
+    description: |
+      Valutazione del rischio di parassiti e malattie utilizzando previsioni e informazioni dal campo.
+  BC-3530.30.20:
+    name: Pianificazione della gestione integrata dei parassiti
+    description: |
+      Pianificazione IPM che combina misure agronomiche, biologiche e chimiche.
+  BC-3530.30.30:
+    name: Progettazione del programma di trattamenti
+    description: |
+      Progettazione del programma stagionale di trattamenti, bilanciando efficacia, residui e costi.
+  BC-3530.30.40:
+    name: Pianificazione della gestione della resistenza
+    description: |
+      Pianificazione della gestione della resistenza ai pesticidi tra i diversi meccanismi d'azione.
+  BC-3530.40:
+    name: Raccomandazione di varietà e ibridi
+    description: |
+      Analisi dei dati delle sperimentazioni varietali e formulazione di raccomandazioni di varietà e ibridi
+      adattate alle condizioni locali per i produttori.
+  BC-3530.40.10:
+    name: Analisi dei risultati delle sperimentazioni varietali
+    description: |
+      Analisi statistica dei risultati delle sperimentazioni varietali su più siti e stagioni.
+  BC-3530.40.20:
+    name: Raccomandazione varietale locale
+    description: |
+      Formulazione di raccomandazioni di varietà e ibridi per zona e destinazione d'uso.
+  BC-3530.50:
+    name: Servizi di consulenza agronomica
+    description: |
+      Visite di consulenza in campo, raccomandazioni a supporto delle decisioni e formazione
+      dei produttori erogate da professionisti agronomici.
+  BC-3530.50.10:
+    name: Erogazione di visite di consulenza in campo
+    description: |
+      Visite di consulenza in azienda e trasmissione delle raccomandazioni agronomiche.
+  BC-3530.50.20:
+    name: Raccomandazione tramite strumenti di supporto alle decisioni
+    description: |
+      Utilizzo di strumenti di supporto alle decisioni per formulare raccomandazioni agronomiche.
+  BC-3530.50.30:
+    name: Erogazione di formazione ai produttori
+    description: |
+      Organizzazione di eventi formativi e giornate dimostrative per i produttori.
+  BC-3530.60:
+    name: Gestione delle sperimentazioni in campo
+    description: |
+      Progettazione, esecuzione e analisi di sperimentazioni in campo ripetute a supporto della valutazione agronomica, varietale e di prodotto.
+  BC-3530.60.10:
+    name: Progettazione della sperimentazione
+    description: |
+      Progettazione statistica di prove ripetute e dimostrative.
+  BC-3530.60.20:
+    name: Esecuzione della sperimentazione e raccolta dati
+    description: |
+      Esecuzione in situ della sperimentazione e raccolta standardizzata dei dati.
+  BC-3530.60.30:
+    name: Analisi dei risultati della sperimentazione
+    description: |
+      Analisi statistica dei risultati della sperimentazione e rendicontazione agli sponsor.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-air-traffic-control-operations-management.yaml
+++ b/catalogue/i18n/it/L1-air-traffic-control-operations-management.yaml
@@ -1,0 +1,123 @@
+# Gestione delle operazioni di controllo del traffico aereo (it) — translations for L1-air-traffic-control-operations-management.yaml
+locale: it
+source: L1-air-traffic-control-operations-management.yaml
+entries:
+  BC-1210:
+    name: Gestione delle operazioni di controllo del traffico aereo
+    description: |
+      Servizi del traffico aereo in tempo reale — en route, avvicinamento, torre aeroportuale, oceanico.
+  BC-1210.10:
+    name: Gestione delle operazioni di controllo en route
+    description: |
+      Servizi ATC en route ad alta quota.
+  BC-1210.10.10:
+    name: Fornitura della separazione en route
+    description: |
+      Fornitura della separazione orizzontale e verticale nello spazio aereo en route.
+  BC-1210.10.20:
+    name: Rilevamento e risoluzione dei conflitti en route
+    description: |
+      Rilevamento e risoluzione dei conflitti tra voli en route.
+  BC-1210.10.30:
+    name: Coordinamento en route
+    description: |
+      Coordinamento inter-settore e inter-centro del traffico en route.
+  BC-1210.10.40:
+    name: Elaborazione dei piani di volo
+    description: |
+      Elaborazione, attivazione e aggiornamento dei piani di volo.
+  BC-1210.20:
+    name: Gestione delle operazioni di controllo di avvicinamento
+    description: |
+      Controllo di avvicinamento e partenza nell'area terminale.
+  BC-1210.20.10:
+    name: Sequenziamento e metering degli arrivi
+    description: |
+      Sequenziamento degli arrivi, AMAN e operazioni di metering.
+  BC-1210.20.20:
+    name: Gestione delle partenze
+    description: |
+      Gestione delle partenze, DMAN e rispetto delle SID.
+  BC-1210.20.30:
+    name: Vettoriamento e spaziatura in avvicinamento
+    description: |
+      Vettoriamento e spaziatura per l'avvicinamento finale.
+  BC-1210.20.40:
+    name: Coordinamento nell'area terminale
+    description: |
+      Coordinamento tra il controllo di avvicinamento e le unità adiacenti.
+  BC-1210.30:
+    name: Gestione delle operazioni della torre aeroportuale
+    description: |
+      Controllo della torre negli aeroporti, incluso il movimento a terra.
+  BC-1210.30.10:
+    name: Controllo della pista
+    description: |
+      Controllo della pista, incluse le autorizzazioni al decollo e all'atterraggio.
+  BC-1210.30.20:
+    name: Controllo del movimento a terra
+    description: |
+      Controllo del movimento di superficie di aeromobili e veicoli.
+  BC-1210.30.30:
+    name: Rilascio delle autorizzazioni
+    description: |
+      Rilascio delle autorizzazioni alla partenza e delle informazioni pre-partenza.
+  BC-1210.30.40:
+    name: Coordinamento aeroportuale
+    description: |
+      Coordinamento con le operazioni aeroportuali e i servizi di emergenza.
+  BC-1210.40:
+    name: Gestione delle operazioni di controllo oceanico
+    description: |
+      Servizi ATC procedurale e oceanico.
+  BC-1210.40.10:
+    name: Fornitura della separazione procedurale
+    description: |
+      Separazione procedurale nello spazio aereo oceanico senza radar.
+  BC-1210.40.20:
+    name: Gestione delle autorizzazioni oceaniche
+    description: |
+      Rilascio di autorizzazioni e nuove autorizzazioni oceaniche.
+  BC-1210.40.30:
+    name: Operazioni CPDLC e ADS-C
+    description: |
+      Operazioni oceaniche basate su datalink tramite CPDLC e ADS-C.
+  BC-1210.50:
+    name: Gestione dei turni di servizio ATC
+    description: |
+      Supervisione del turno, passaggio di consegne, pianificazione delle postazioni.
+  BC-1210.50.10:
+    name: Supervisione del turno
+    description: |
+      Supervisione operativa del turno e delle prestazioni del servizio.
+  BC-1210.50.20:
+    name: Gestione del passaggio di consegne
+    description: |
+      Briefing strutturati e documentazione per il passaggio di consegne tra turni.
+  BC-1210.50.30:
+    name: Pianificazione delle postazioni operative
+    description: |
+      Pianificazione delle postazioni operative e gestione della fatica dei controllori.
+  BC-1210.60:
+    name: Gestione delle operazioni di contingenza
+    description: |
+      Operazioni in modo degradato, risposta ai guasti di sistema, procedure di ripristino.
+  BC-1210.60.10:
+    name: Operazioni in modo degradato
+    description: |
+      Operazioni in modo degradato con supporto di sistema ridotto.
+  BC-1210.60.20:
+    name: Risposta ai guasti di sistema
+    description: |
+      Procedure di risposta ai guasti dei sistemi ATC.
+  BC-1210.60.30:
+    name: Ricorso ai sistemi di riserva
+    description: |
+      Commutazione verso sistemi ATC di riserva e infrastrutture di contingenza.
+  BC-1210.60.40:
+    name: Manutenzione dei piani di contingenza
+    description: |
+      Manutenzione ed esercitazione dei piani di contingenza operativa.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-air-traffic-controller-competency-management.yaml
+++ b/catalogue/i18n/it/L1-air-traffic-controller-competency-management.yaml
@@ -1,0 +1,107 @@
+# Gestione delle competenze del controllore del traffico aereo (it) — translations for L1-air-traffic-controller-competency-management.yaml
+locale: it
+source: L1-air-traffic-controller-competency-management.yaml
+entries:
+  BC-1290:
+    name: Gestione delle competenze del controllore del traffico aereo
+    description: |
+      Addestramento iniziale, d'unità e di aggiornamento; rilascio delle licenze e valutazione delle competenze dei controllori.
+  BC-1290.10:
+    name: Gestione dell'addestramento iniziale
+    description: |
+      Addestramento ab-initio, addestramento di base e per abilitazione (di norma presso un'accademia).
+  BC-1290.10.10:
+    name: Programma di addestramento ab-initio
+    description: |
+      Addestramento ab-initio per ATCO, inclusa la fase di base.
+  BC-1290.10.20:
+    name: Addestramento per abilitazione
+    description: |
+      Addestramento specifico per abilitazione (ACC, APP, ADC, OCN).
+  BC-1290.10.30:
+    name: Valutazione dell'addestramento iniziale
+    description: |
+      Esami e valutazioni durante l'addestramento iniziale.
+  BC-1290.20:
+    name: Gestione dell'addestramento d'unità
+    description: |
+      Addestramento on-the-job presso l'unità operativa.
+  BC-1290.20.10:
+    name: Definizione del piano di addestramento d'unità
+    description: |
+      Definizione dei piani di addestramento d'unità per la transizione dell'ATCO.
+  BC-1290.20.20:
+    name: Erogazione dell'addestramento on-the-job
+    description: |
+      Erogazione dell'addestramento on-the-job (OJT) con istruttori OJTI.
+  BC-1290.20.30:
+    name: Validazione dell'addestramento d'unità
+    description: |
+      Validazione dell'abilitazione d'unità al termine dell'addestramento.
+  BC-1290.30:
+    name: Gestione dell'addestramento di aggiornamento
+    description: |
+      Addestramento di aggiornamento, conversione, emergenza e situazioni insolite.
+  BC-1290.30.10:
+    name: Addestramento di aggiornamento periodico
+    description: |
+      Addestramento di aggiornamento periodico per i controllori in possesso di licenza.
+  BC-1290.30.20:
+    name: Addestramento di conversione
+    description: |
+      Addestramento di conversione per nuove procedure, sistemi o settori.
+  BC-1290.30.30:
+    name: Addestramento per emergenze e situazioni insolite
+    description: |
+      Addestramento per emergenze, situazioni anomale e insolite.
+  BC-1290.40:
+    name: Gestione della valutazione delle competenze
+    description: |
+      Valutazioni periodiche delle competenze, verifiche in linea, validazione.
+  BC-1290.40.10:
+    name: Manutenzione dello schema di valutazione delle competenze
+    description: |
+      Definizione e manutenzione dello schema di valutazione delle competenze.
+  BC-1290.40.20:
+    name: Erogazione della valutazione delle competenze
+    description: |
+      Svolgimento delle valutazioni periodiche delle competenze e delle verifiche in linea.
+  BC-1290.40.30:
+    name: Gestione dei registri delle competenze
+    description: |
+      Gestione dei registri delle valutazioni delle competenze e delle relative validità.
+  BC-1290.50:
+    name: Gestione delle licenze e delle abilitazioni
+    description: |
+      Licenze ATCO, abilitazioni, idoneità medica.
+  BC-1290.50.10:
+    name: Rilascio della licenza ATCO
+    description: |
+      Rilascio e rinnovo delle licenze e delle abilitazioni ATCO.
+  BC-1290.50.20:
+    name: Amministrazione delle abilitazioni
+    description: |
+      Amministrazione delle abilitazioni d'unità e linguistiche.
+  BC-1290.50.30:
+    name: Amministrazione dell'idoneità medica
+    description: |
+      Amministrazione dell'idoneità medica di Classe 3 per i controllori.
+  BC-1290.60:
+    name: Gestione delle operazioni dei simulatori
+    description: |
+      Simulatori ATC, progettazione di scenari, operazioni del pilota simulatore.
+  BC-1290.60.10:
+    name: Progettazione degli scenari del simulatore
+    description: |
+      Progettazione di scenari ed esercitazioni per l'addestramento al simulatore.
+  BC-1290.60.20:
+    name: Operazioni del pilota simulatore
+    description: |
+      Operazione delle postazioni del pilota simulatore durante le esercitazioni.
+  BC-1290.60.30:
+    name: Manutenzione e configurazione del simulatore
+    description: |
+      Manutenzione e configurazione dei simulatori ATC.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-air-traffic-flow-management.yaml
+++ b/catalogue/i18n/it/L1-air-traffic-flow-management.yaml
@@ -1,0 +1,95 @@
+# Gestione del flusso del traffico aereo (it) — translations for L1-air-traffic-flow-management.yaml
+locale: it
+source: L1-air-traffic-flow-management.yaml
+entries:
+  BC-1220:
+    name: Gestione del flusso del traffico aereo
+    description: |
+      Pianificazione della capacità, regolazione del flusso, allocazione degli slot, bilanciamento domanda-capacità.
+  BC-1220.10:
+    name: Gestione della pianificazione della capacità
+    description: |
+      Valutazione della capacità di settore e aeroportuale, dichiarazione della capacità.
+  BC-1220.10.10:
+    name: Valutazione della capacità di settore
+    description: |
+      Valutazione della capacità di settore mediante misurazione del carico di lavoro.
+  BC-1220.10.20:
+    name: Dichiarazione della capacità aeroportuale
+    description: |
+      Dichiarazione della capacità della pista e dell'area di parcheggio aeroportuale.
+  BC-1220.10.30:
+    name: Pianificazione strategica della capacità
+    description: |
+      Pianificazione strategica pluriennale della capacità ATC.
+  BC-1220.20:
+    name: Gestione della regolazione del flusso
+    description: |
+      Misure di flusso del traffico, regolazioni e rerouting.
+  BC-1220.20.10:
+    name: Definizione delle misure di flusso
+    description: |
+      Definizione delle misure ATFCM per settore e aeroporto.
+  BC-1220.20.20:
+    name: Gestione delle proposte di rerouting
+    description: |
+      Proposta e implementazione di rerouting e scenari alternativi.
+  BC-1220.20.30:
+    name: Adeguamento tattico del flusso
+    description: |
+      Adeguamento tattico in tempo reale delle misure di flusso.
+  BC-1220.30:
+    name: Gestione dell'allocazione degli slot
+    description: |
+      Orari di decollo calcolati (CTOT), gestione degli slot, scambio di slot.
+  BC-1220.30.10:
+    name: Emissione dell'orario di decollo calcolato
+    description: |
+      Calcolo ed emissione dei CTOT agli utenti dello spazio aereo.
+  BC-1220.30.20:
+    name: Scambio e miglioramento degli slot
+    description: |
+      Scambio di slot, miglioramento degli slot e aggiornamento degli orari obiettivo.
+  BC-1220.30.30:
+    name: Conformità agli slot di partenza
+    description: |
+      Monitoraggio del rispetto degli slot e delle esenzioni.
+  BC-1220.40:
+    name: Gestione delle prestazioni di rete
+    description: |
+      Monitoraggio delle prestazioni di rete, reportistica KPI.
+  BC-1220.40.10:
+    name: Monitoraggio dei KPI di rete
+    description: |
+      Monitoraggio dei KPI di rete (ritardo, capacità, prevedibilità).
+  BC-1220.40.20:
+    name: Reportistica sulle prestazioni
+    description: |
+      Reportistica sulle prestazioni verso la rete e i regolatori del Cielo Unico Europeo.
+  BC-1220.40.30:
+    name: Analisi post-operativa
+    description: |
+      Analisi post-operativa dei flussi e dei colli di bottiglia.
+  BC-1220.50:
+    name: Gestione del bilanciamento domanda-capacità
+    description: |
+      Bilanciamento pre-tattico e tattico della domanda e della capacità.
+  BC-1220.50.10:
+    name: Bilanciamento strategico domanda-capacità
+    description: |
+      Bilanciamento a lungo termine della domanda e della capacità sulla rete.
+  BC-1220.50.20:
+    name: Bilanciamento pre-tattico domanda-capacità
+    description: |
+      Bilanciamento pre-tattico (D-1) della domanda e della capacità.
+  BC-1220.50.30:
+    name: Bilanciamento tattico domanda-capacità
+    description: |
+      Bilanciamento tattico in tempo reale della domanda e della capacità.
+  BC-1220.50.40:
+    name: Processo decisionale collaborativo
+    description: |
+      Processo decisionale collaborativo con gli utenti dello spazio aereo e gli aeroporti.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-airline-flight-operations-management.yaml
+++ b/catalogue/i18n/it/L1-airline-flight-operations-management.yaml
@@ -1,0 +1,207 @@
+# Gestione delle operazioni di volo delle compagnie aeree (it) — translations for L1-airline-flight-operations-management.yaml
+locale: it
+source: L1-airline-flight-operations-management.yaml
+entries:
+  BC-4080:
+    name: Gestione delle operazioni di volo delle compagnie aeree
+    description: |
+      Pianificazione degli orari, instradamento degli aeromobili, pianificazione degli equipaggi,
+      dispacciamento del volo, coordinamento gate e turnaround, recupero in caso di IROPS
+      e reporting sulle performance di volo e sulla sicurezza per i vettori aerei.
+    in_scope:
+      - Pianificazione dell'orario di volo, coordinamento degli slot e connection bank
+      - Instradamento degli aeromobili, assegnazione della coda e tracciamento MEL
+      - Costruzione dei pairing degli equipaggi, rostering e conformità FTL
+      - Dispacciamento del volo e controllo operativo
+      - Allocazione dei gate e coordinamento del turnaround
+      - Decisioni operative di disruption (IROPS) su aeromobili ed equipaggi
+      - Reporting sulle performance di volo e sugli eventi di sicurezza
+    out_of_scope:
+      - Controllo del traffico aereo da parte degli ANSP (BC-1700)
+      - Flusso di risistemazione dei passeggeri a livello di prenotazione (BC-4020.70)
+      - Gestione dei voli cargo (BC-3270)
+  BC-4080.10:
+    name: Pianificazione dell'orario di volo
+    description: |
+      Costruzione e pubblicazione dell'orario di volo della compagnia aerea,
+      con riferimento alla rete, agli slot e alle connection bank.
+  BC-4080.10.10:
+    name: Definizione del piano di rete e delle rotte
+    description: |
+      Definizione del piano di rete e delle rotte rispetto
+      ai piani di domanda e di flotta.
+  BC-4080.10.20:
+    name: Coordinamento degli slot aeroportuali
+    description: |
+      Coordinamento degli slot aeroportuali e dei vincoli,
+      inclusa la programmazione allineata alle IATA WSG.
+  BC-4080.10.30:
+    name: Costruzione e pubblicazione dell'orario
+    description: |
+      Costruzione dell'orario pubblicato e pubblicazione del file SSIM
+      ai partner di distribuzione.
+  BC-4080.10.40:
+    name: Ottimizzazione delle connection bank
+    description: |
+      Ottimizzazione delle connection bank hub e dei tempi minimi
+      di connessione.
+  BC-4080.20:
+    name: Instradamento degli aeromobili e assegnazione della coda
+    description: |
+      Costruzione delle rotazioni degli aeromobili, assegnazione della coda,
+      operazioni di swap, coordinamento degli slot di manutenzione e tracciamento MEL.
+  BC-4080.20.10:
+    name: Pianificazione delle rotazioni di flotta
+    description: |
+      Pianificazione delle rotazioni di flotta sulla rete, con bilanciamento
+      delle ore di volo e dei cicli.
+  BC-4080.20.20:
+    name: Assegnazione della coda e operazioni di swap
+    description: |
+      Assegnazione di code specifiche ai voli ed esecuzione
+      di swap tattici.
+  BC-4080.20.30:
+    name: Coordinamento degli slot di manutenzione degli aeromobili
+    description: |
+      Coordinamento degli slot di manutenzione e dei voli ferry
+      rispetto all'orario.
+  BC-4080.20.40:
+    name: Tracciamento della Minimum Equipment List
+    description: |
+      Tracciamento delle deroghe MEL rispetto alla scadenza
+      e all'impatto operativo.
+  BC-4080.30:
+    name: Pianificazione e rostering degli equipaggi
+    description: |
+      Pianificazione degli equipaggi di cabina e di pilotaggio, inclusa la costruzione
+      dei pairing, il bidding, il tracciamento delle qualifiche e la conformità FTL.
+  BC-4080.30.10:
+    name: Costruzione dei pairing degli equipaggi
+    description: |
+      Costruzione dei pairing degli equipaggi sull'orario
+      nel rispetto delle regole di legittimità.
+  BC-4080.30.20:
+    name: Bidding degli equipaggi e costruzione del roster
+    description: |
+      Operazione dei processi di bidding e costruzione del roster
+      per gli equipaggi di cabina e di pilotaggio.
+  BC-4080.30.30:
+    name: Tracciamento delle qualifiche e della currency degli equipaggi
+    description: |
+      Tracciamento delle qualifiche, della recency e della currency
+      dei membri dell'equipaggio.
+  BC-4080.30.40:
+    name: Conformità ai limiti di ore di volo e di servizio
+    description: |
+      Conformità alle regole FTL e sui tempi di servizio
+      nella fase di pianificazione e di esecuzione.
+  BC-4080.40:
+    name: Dispacciamento del volo e controllo operativo
+    description: |
+      Generazione dei piani di volo operativi, decisioni sul carburante,
+      briefing su meteo e NOTAM e decision-making del centro di controllo operativo.
+  BC-4080.40.10:
+    name: Generazione del piano di volo
+    description: |
+      Generazione dei piani di volo operativi, inclusi rotta,
+      quota e tempo di percorrenza.
+  BC-4080.40.20:
+    name: Calcolo del carburante operativo
+    description: |
+      Calcolo del carburante operativo, incluse riserve, contingenza
+      e imbarco discrezionale.
+  BC-4080.40.30:
+    name: Briefing meteo e NOTAM
+    description: |
+      Compilazione e consegna dei briefing meteo e NOTAM
+      agli equipaggi e al dispacciamento.
+  BC-4080.40.40:
+    name: Decision-making del centro di controllo operativo
+    description: |
+      Decision-making dell'OCC su ritardi, dirottamenti
+      e opzioni di recupero.
+  BC-4080.50:
+    name: Operazioni gate e turnaround
+    description: |
+      Pianificazione dei gate e coordinamento in tempo reale del turnaround
+      negli aeroporti, inclusa la gestione del pushback e dei ritardi sul piazzale.
+  BC-4080.50.10:
+    name: Allocazione e sequenziamento dei gate
+    description: |
+      Allocazione dei gate e sequenziamento degli stand
+      nelle operazioni del giorno.
+  BC-4080.50.20:
+    name: Coordinamento del turnaround
+    description: |
+      Coordinamento in tempo reale delle attività di turnaround,
+      inclusi catering, rifornimento e imbarco.
+  BC-4080.50.30:
+    name: Operazioni di pushback e block-out
+    description: |
+      Coordinamento del pushback, del block-out e del rullaggio
+      allo stand.
+  BC-4080.50.40:
+    name: Gestione dei ritardi sul piazzale
+    description: |
+      Gestione dei ritardi sul piazzale nel rispetto dei limiti normativi
+      e degli obblighi di assistenza ai passeggeri.
+  BC-4080.60:
+    name: Gestione delle disruption di volo e IROPS
+    description: |
+      Decisioni operative durante gli eventi di disruption, inclusi dirottamenti,
+      cancellazioni di massa e recupero degli equipaggi, oltre al coordinamento
+      con i flussi di re-booking lato passeggeri.
+    in_scope:
+      - Decision-making su dirottamenti e cancellazioni
+      - Recupero degli equipaggi in caso di disruption e assegnazione degli standby
+      - Coordinamento con la risistemazione dei passeggeri (BC-4020.70)
+    out_of_scope:
+      - Re-booking e determinazione del risarcimento a livello passeggero (BC-4020.70)
+  BC-4080.60.10:
+    name: Operazioni di decisione sul dirottamento
+    description: |
+      Operazioni per decidere ed eseguire dirottamenti
+      in rotta e prima della partenza.
+  BC-4080.60.20:
+    name: Operazioni di recupero per cancellazioni di massa
+    description: |
+      Operazioni di recupero durante le cancellazioni di massa,
+      relative ad aeromobili, equipaggi e slot.
+  BC-4080.60.30:
+    name: Recupero degli equipaggi in caso di disruption
+    description: |
+      Recupero dei roster degli equipaggi durante la disruption,
+      inclusa l'assegnazione degli standby e delle riserve.
+  BC-4080.60.40:
+    name: Coordinamento del re-booking dei passeggeri
+    description: |
+      Coordinamento con i team di risistemazione dei passeggeri
+      sulle opzioni di recupero e la prioritizzazione.
+  BC-4080.70:
+    name: Reporting sulle performance di volo e sulla sicurezza
+    description: |
+      Reporting sulle performance di volo, sui KPI di puntualità,
+      sui rapporti di sicurezza aerea e sui feed di dati operativi sulla sicurezza.
+  BC-4080.70.10:
+    name: Reporting sulla puntualità (OTP)
+    description: |
+      Reporting sull'OTP (puntualità) e sui codici di ritardo
+      sulla rete.
+  BC-4080.70.20:
+    name: Acquisizione dei rapporti di sicurezza aerea
+    description: |
+      Acquisizione e triage dei rapporti di sicurezza aerea
+      da parte degli equipaggi e del personale operativo.
+  BC-4080.70.30:
+    name: Supporto alle indagini sulla sicurezza operativa
+    description: |
+      Supporto alle indagini sulla sicurezza operativa,
+      incluse la raccolta dei dati e le azioni di follow-up.
+  BC-4080.70.40:
+    name: Feed di analisi dei dati di volo
+    description: |
+      Feed di analisi dei dati di volo per i programmi
+      di analisi della sicurezza e delle operazioni.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-airspace-management.yaml
+++ b/catalogue/i18n/it/L1-airspace-management.yaml
@@ -1,0 +1,83 @@
+# Gestione dello spazio aereo (it) — translations for L1-airspace-management.yaml
+locale: it
+source: L1-airspace-management.yaml
+entries:
+  BC-1200:
+    name: Gestione dello spazio aereo
+    description: |
+      Progettazione dello spazio aereo, settorializzazione, aree ristrette, coordinamento civile-militare.
+  BC-1200.10:
+    name: Gestione della progettazione dello spazio aereo
+    description: |
+      Struttura dello spazio aereo, classificazione, progettazione della rete di rotte e confini dei settori.
+  BC-1200.10.10:
+    name: Progettazione della struttura dello spazio aereo
+    description: |
+      Definizione di FIR, UIR, aree di controllo e classificazione dello spazio aereo secondo ICAO Annex 11.
+  BC-1200.10.20:
+    name: Progettazione della rete di rotte ATS
+    description: |
+      Progettazione di reti di rotte ATS convenzionali e basate su PBN.
+  BC-1200.10.30:
+    name: Progettazione dei confini di settore
+    description: |
+      Definizione dei confini di settore e dei settori elementari.
+  BC-1200.10.40:
+    name: Progettazione del Free Route Airspace
+    description: |
+      Progettazione e implementazione del Free Route Airspace.
+  BC-1200.20:
+    name: Gestione della settorializzazione dello spazio aereo
+    description: |
+      Definizioni di settore, schemi di apertura, allineamento con il carico di lavoro dei controllori.
+  BC-1200.20.10:
+    name: Gestione delle configurazioni di settore
+    description: |
+      Definizione e manutenzione delle configurazioni di settore.
+  BC-1200.20.20:
+    name: Pianificazione degli schemi di apertura dei settori
+    description: |
+      Pianificazione degli schemi di apertura dei settori in base alle previsioni di traffico.
+  BC-1200.20.30:
+    name: Settorializzazione basata sul carico di lavoro
+    description: |
+      Settorializzazione allineata alla valutazione del carico di lavoro dei controllori del traffico aereo.
+  BC-1200.30:
+    name: Gestione dello spazio aereo riservato
+    description: |
+      Aree pericolose, aree ristrette, aree proibite, zone militari.
+  BC-1200.30.10:
+    name: Definizione delle aree ristrette
+    description: |
+      Definizione di aree ristrette, proibite e pericolose dello spazio aereo.
+  BC-1200.30.20:
+    name: Gestione delle aree temporaneamente riservate
+    description: |
+      Gestione delle aree temporaneamente riservate e segregate.
+  BC-1200.30.30:
+    name: Coordinamento di attivazione e rilascio
+    description: |
+      Attivazione, rilascio e notifica delle restrizioni dello spazio aereo.
+  BC-1200.40:
+    name: Gestione del coordinamento dello spazio aereo
+    description: |
+      Coordinamento civile-militare, coordinamento transfrontaliero dello spazio aereo, cooperazione FAB.
+  BC-1200.40.10:
+    name: Coordinamento civile-militare dello spazio aereo
+    description: |
+      Coordinamento civile-militare e FUA (Flexible Use of Airspace).
+  BC-1200.40.20:
+    name: Coordinamento transfrontaliero dello spazio aereo
+    description: |
+      Coordinamento dell'utilizzo dello spazio aereo oltre i confini FIR.
+  BC-1200.40.30:
+    name: Cooperazione nei blocchi funzionali di spazio aereo
+    description: |
+      Cooperazione nei blocchi funzionali di spazio aereo (FAB).
+  BC-1200.40.40:
+    name: Consultazione degli utenti dello spazio aereo
+    description: |
+      Consultazione degli utenti dello spazio aereo in merito alle modifiche progettuali.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-aquaculture-operations-management.yaml
+++ b/catalogue/i18n/it/L1-aquaculture-operations-management.yaml
@@ -1,0 +1,133 @@
+# Gestione delle operazioni di acquacoltura (it) — translations for L1-aquaculture-operations-management.yaml
+locale: it
+source: L1-aquaculture-operations-management.yaml
+entries:
+  BC-3520:
+    name: Gestione delle operazioni di acquacoltura
+    description: |
+      Produzione di specie acquatiche d'allevamento — incubatoio e stoccaggio, alimentazione, qualità dell'acqua,
+      salute degli animali, operazioni in gabbie e vasche, raccolta e conformità ambientale
+      per pesci, molluschi e crostacei e piante acquatiche.
+  BC-3520.10:
+    name: Approvvigionamento del materiale di ripopolamento e operazioni di stoccaggio
+    description: |
+      Approvvigionamento del broodstock, operazioni di incubatoio e stoccaggio dei giovanili nei sistemi di ingrasso.
+  BC-3520.10.10:
+    name: Approvvigionamento del broodstock
+    description: |
+      Approvvigionamento e quarantena del broodstock per la produzione in incubatoio.
+  BC-3520.10.20:
+    name: Operazioni di incubatoio
+    description: |
+      Incubazione delle uova, allevamento larvale e produzione di giovanili in incubatoio.
+  BC-3520.10.30:
+    name: Operazioni di stoccaggio dei giovanili
+    description: |
+      Immissione dei giovanili in gabbie, vasche e bacini di ingrasso.
+  BC-3520.20:
+    name: Operazioni di alimentazione in acquacoltura
+    description: |
+      Pianificazione, distribuzione e monitoraggio dell'indice di conversione alimentare per le specie acquatiche allevate.
+  BC-3520.20.10:
+    name: Pianificazione delle razioni alimentari
+    description: |
+      Pianificazione delle razioni alimentari per specie, stadio di vita e temperatura dell'acqua.
+  BC-3520.20.20:
+    name: Operazioni di distribuzione degli alimenti
+    description: |
+      Distribuzione manuale, meccanica e automatizzata degli alimenti in gabbie e vasche.
+  BC-3520.20.30:
+    name: Monitoraggio dell'indice di conversione alimentare
+    description: |
+      Monitoraggio dell'indice di conversione alimentare rispetto ai piani di alimentazione.
+  BC-3520.30:
+    name: Gestione della qualità dell'acqua
+    description: |
+      Monitoraggio continuo della qualità dell'acqua, ossigenazione e trattamento in sistemi ad acqua corrente e RAS.
+    in_scope:
+      - Monitoraggio dell'ossigeno disciolto e della temperatura
+      - Operazioni di aerazione e ossigenazione
+      - Trattamento e ricircolo dell'acqua
+  BC-3520.30.10:
+    name: Monitoraggio della qualità dell'acqua
+    description: |
+      Monitoraggio in tempo reale di ossigeno disciolto, temperatura, salinità e pH.
+  BC-3520.30.20:
+    name: Operazioni di aerazione e ossigenazione
+    description: |
+      Gestione degli impianti di aerazione e iniezione di ossigeno.
+  BC-3520.30.30:
+    name: Trattamento e ricircolo dell'acqua
+    description: |
+      Trattamento meccanico, biologico e UV dell'acqua nei sistemi a ricircolo.
+  BC-3520.40:
+    name: Gestione della salute degli animali acquatici
+    description: |
+      Sorveglianza delle malattie, trattamenti, biosicurezza e registrazione della mortalità per le specie acquatiche allevate.
+  BC-3520.40.10:
+    name: Sorveglianza delle malattie acquatiche
+    description: |
+      Sorveglianza di agenti patogeni, parassiti e malattie acquatiche soggette a denuncia obbligatoria.
+  BC-3520.40.20:
+    name: Operazioni di trattamento in acquacoltura
+    description: |
+      Operazioni di trattamento in acqua e in bagno, incluso il controllo dei parassiti (sea lice).
+  BC-3520.40.30:
+    name: Operazioni di biosicurezza in acquacoltura
+    description: |
+      Biosicurezza del sito, disinfezione delle attrezzature e controlli sui movimenti.
+  BC-3520.40.40:
+    name: Registrazione della mortalità
+    description: |
+      Registrazione giornaliera della mortalità, classificazione e gestione dello smaltimento.
+  BC-3520.50:
+    name: Operazioni in gabbie e vasche
+    description: |
+      Gestione quotidiana e integrità delle gabbie, delle vasche e dei bacini di ingrasso, incluso il controllo dei predatori e l'antivegetativa.
+  BC-3520.50.10:
+    name: Ispezione di reti e gabbie
+    description: |
+      Ispezione di routine di reti, gabbie e ormeggi per verificarne l'integrità.
+  BC-3520.50.20:
+    name: Prevenzione dei predatori e delle fughe
+    description: |
+      Operazioni di deterrenza dei predatori e prevenzione delle fughe degli animali.
+  BC-3520.50.30:
+    name: Operazioni antivegetativa
+    description: |
+      Pulizia delle reti e operazioni antivegetativa sulle infrastrutture sommerse.
+  BC-3520.60:
+    name: Operazioni di raccolta in acquacoltura
+    description: |
+      Campionamento pre-raccolta, esecuzione della raccolta e mantenimento in vita per la trasformazione o la spedizione al mercato del vivo.
+  BC-3520.60.10:
+    name: Campionamento pre-raccolta
+    description: |
+      Campionamento pre-raccolta di taglia, qualità e residui.
+  BC-3520.60.20:
+    name: Esecuzione della raccolta
+    description: |
+      Concentrazione, pompaggio, stordimento ed esecuzione della raccolta.
+  BC-3520.60.30:
+    name: Mantenimento in vita e trasferimento
+    description: |
+      Mantenimento in vita e trasferimento tramite well-boat o autobotte al trasformatore o al mercato.
+  BC-3520.70:
+    name: Conformità ambientale in acquacoltura
+    description: |
+      Monitoraggio ambientale a livello di sito e rendicontazione richiesti dalle licenze di acquacoltura e dai regimi di certificazione.
+  BC-3520.70.10:
+    name: Monitoraggio ambientale del sito
+    description: |
+      Monitoraggio ambientale a livello di sito rispetto alle condizioni della licenza.
+  BC-3520.70.20:
+    name: Rendicontazione degli effluenti
+    description: |
+      Rendicontazione agli enti regolatori degli scarichi di nutrienti e degli effluenti.
+  BC-3520.70.30:
+    name: Valutazione dell'impatto sul benthos
+    description: |
+      Campionamenti dell'impatto sul benthos e monitoraggio delle attività di ripristino sotto i siti a gabbia.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-assessment-examinations-management.yaml
+++ b/catalogue/i18n/it/L1-assessment-examinations-management.yaml
@@ -1,0 +1,150 @@
+# Gestione della valutazione e degli esami (it) — translations for L1-assessment-examinations-management.yaml
+locale: it
+source: L1-assessment-examinations-management.yaml
+entries:
+  BC-4740:
+    name: Gestione della valutazione e degli esami
+    description: |
+      Progettazione, somministrazione, correzione, moderazione e conferimento delle valutazioni
+      e degli esami che attestano l'apprendimento degli studenti, inclusa la supervisione dell'integrità accademica.
+  BC-4740.10:
+    name: Progettazione della valutazione e gestione delle banche di domande
+    description: |
+      Progettazione degli strumenti di valutazione e manutenzione di banche di domande calibrate
+      a supporto di una valutazione coerente e affidabile.
+    in_scope:
+      - Definizione del piano di valutazione
+      - Redazione e calibrazione degli item
+      - Manutenzione della banca di domande
+    out_of_scope:
+      - Progettazione del programma del corso (trattata in Gestione del curriculo e dei programmi didattici)
+  BC-4740.10.10:
+    name: Definizione del piano di valutazione
+    description: |
+      Definizione dei piani di valutazione e della ponderazione rispetto ai risultati di apprendimento.
+  BC-4740.10.20:
+    name: Redazione e calibrazione degli item
+    description: |
+      Redazione e calibrazione statistica degli item di valutazione.
+  BC-4740.10.30:
+    name: Manutenzione della banca di domande
+    description: |
+      Manutenzione delle banche di domande sicure tra versioni e cicli di utilizzo.
+  BC-4740.20:
+    name: Operazioni degli esami
+    description: |
+      Erogazione operativa degli esami in presenza e online, inclusa
+      la pianificazione degli esami, la sorveglianza e i servizi di sorveglianza a distanza.
+    in_scope:
+      - Pianificazione degli esami
+      - Sede d'esame e sorveglianza
+      - Sorveglianza online e a distanza
+    out_of_scope:
+      - Valutazione quotidiana in aula (trattata in Gestione delle operazioni didattiche e di apprendimento)
+  BC-4740.20.10:
+    name: Pianificazione degli esami
+    description: |
+      Pianificazione degli esami tra coorti, sedi e modalità.
+  BC-4740.20.20:
+    name: Sede d'esame e sorveglianza
+    description: |
+      Allestimento della sede e sorveglianza degli esami in presenza.
+  BC-4740.20.30:
+    name: Sorveglianza online e a distanza
+    description: |
+      Gestione della sorveglianza online e a distanza per gli esami online.
+  BC-4740.30:
+    name: Operazioni di correzione e attribuzione del voto
+    description: |
+      Correzione degli elaborati degli studenti e calcolo dei voti, inclusa la doppia correzione
+      anonima e le regole di aggregazione dei voti.
+    in_scope:
+      - Applicazione degli schemi di correzione
+      - Doppia correzione e correzione anonima
+      - Aggregazione e calcolo dei voti
+    out_of_scope:
+      - Manutenzione ufficiale del registro dei voti (trattata in Gestione delle iscrizioni e dei registri degli studenti)
+  BC-4740.30.10:
+    name: Applicazione degli schemi di correzione
+    description: |
+      Applicazione degli schemi di correzione e delle rubriche agli elaborati degli studenti.
+  BC-4740.30.20:
+    name: Doppia correzione e correzione anonima
+    description: |
+      Gestione dei workflow di doppia correzione e di correzione anonima.
+  BC-4740.30.30:
+    name: Aggregazione e calcolo dei voti
+    description: |
+      Aggregazione e calcolo dei punteggi parziali per ottenere i voti finali.
+  BC-4740.40:
+    name: Moderazione e commissioni d'esame
+    description: |
+      Moderazione interna, coinvolgimento degli esaminatori esterni e processo decisionale
+      delle commissioni d'esame sui titoli e sulla progressione.
+    in_scope:
+      - Moderazione interna
+      - Coordinamento degli esaminatori esterni
+      - Processo decisionale della commissione d'esame
+    out_of_scope:
+      - Revisione a livello di programma (trattata in Gestione della qualità accademica e dell'accreditamento)
+  BC-4740.40.10:
+    name: Moderazione interna
+    description: |
+      Moderazione interna delle decisioni di correzione tra i correttori e le coorti.
+  BC-4740.40.20:
+    name: Coordinamento degli esaminatori esterni
+    description: |
+      Coordinamento degli esaminatori esterni e dei loro cicli di rendicontazione.
+  BC-4740.40.30:
+    name: Processo decisionale della commissione d'esame
+    description: |
+      Processo decisionale della commissione d'esame su risultati, progressione e titoli.
+  BC-4740.50:
+    name: Emissione dei titoli e delle qualifiche
+    description: |
+      Pubblicazione dei risultati ed emissione dei titoli e delle qualifiche,
+      inclusa la gestione dei ricorsi sui risultati.
+    in_scope:
+      - Pubblicazione dei risultati
+      - Emissione di certificati e diplomi
+      - Gestione dei ricorsi sui risultati
+    out_of_scope:
+      - Credenziali digitali verificabili (trattate in Gestione delle iscrizioni e dei registri degli studenti)
+  BC-4740.50.10:
+    name: Pubblicazione dei risultati
+    description: |
+      Pubblicazione dei risultati provvisori e ratificati agli studenti.
+  BC-4740.50.20:
+    name: Emissione di certificati e diplomi
+    description: |
+      Emissione di certificati e diplomi che attestano i titoli conseguiti.
+  BC-4740.50.30:
+    name: Gestione dei ricorsi sui risultati
+    description: |
+      Gestione dei ricorsi degli studenti contro gli esiti della valutazione.
+  BC-4740.60:
+    name: Gestione dell'integrità accademica
+    description: |
+      Rilevazione, indagine e rimediazione delle violazioni dell'integrità accademica,
+      inclusi il plagio e il contracting delle valutazioni.
+    in_scope:
+      - Rilevazione del plagio
+      - Indagine sulle violazioni
+      - Applicazione di sanzioni e rimediazione
+    out_of_scope:
+      - Violazioni dell'integrità nella ricerca (trattate in Gestione della ricerca e delle borse di studio)
+  BC-4740.60.10:
+    name: Rilevazione del plagio
+    description: |
+      Rilevazione del plagio e del contracting delle valutazioni negli elaborati presentati.
+  BC-4740.60.20:
+    name: Indagine sulle violazioni
+    description: |
+      Indagine sui casi sospetti di violazione dell'integrità accademica.
+  BC-4740.60.30:
+    name: Applicazione di sanzioni e rimediazione
+    description: |
+      Applicazione di sanzioni e misure di rimediazione per le violazioni accertate.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-audience-measurement-insights-management.yaml
+++ b/catalogue/i18n/it/L1-audience-measurement-insights-management.yaml
@@ -1,0 +1,113 @@
+# Misurazione dell'audience e analisi degli insight (it) — translations for L1-audience-measurement-insights-management.yaml
+locale: it
+source: L1-audience-measurement-insights-management.yaml
+entries:
+  BC-3770:
+    name: Misurazione dell'audience e analisi degli insight
+    description: |
+      Acquisizione della telemetria di visione, misurazione panel e censuaria,
+      analytics delle performance dei contenuti, modellazione delle raccomandazioni
+      e ricerca sull'audience per servizi lineari, on-demand e live.
+  BC-3770.10:
+    name: Acquisizione dei dati di visione
+    description: |
+      Acquisizione dei dati di sintonizzazione lineare, telemetria di
+      riproduzione OTT e segnali censuari dei set-top box nella piattaforma analytics.
+  BC-3770.10.10:
+    name: Acquisizione dei dati di sintonizzazione lineare
+    description: |
+      Acquisizione dei dati di sintonizzazione lineare dai percorsi
+      di ritorno degli operatori e da fonti partner.
+  BC-3770.10.20:
+    name: Acquisizione della telemetria di riproduzione OTT
+    description: |
+      Acquisizione della telemetria di riproduzione OTT dai client e
+      dai servizi di origin per gli analytics.
+  BC-3770.10.30:
+    name: Acquisizione censuaria dei set-top box
+    description: |
+      Acquisizione censuaria degli eventi di visione dei set-top box
+      con controlli sulla privacy applicati.
+  BC-3770.20:
+    name: Misurazione panel e censuaria dell'audience
+    description: |
+      Calibrazione dei panel, produzione della misurazione di valuta e
+      deduplicazione dell'audience cross-piattaforma.
+  BC-3770.20.10:
+    name: Calibrazione del panel
+    description: |
+      Calibrazione della misurazione panel rispetto ai segnali censuari
+      e alle cornici demografiche.
+  BC-3770.20.20:
+    name: Produzione della misurazione di valuta
+    description: |
+      Produzione di metriche di misurazione dell'audience di livello valuta
+      per il trading e la reportistica.
+  BC-3770.20.30:
+    name: Deduplicazione dell'audience cross-piattaforma
+    description: |
+      Deduplicazione delle audience su superfici lineari, OTT e digitali
+      verso una visione cross-piattaforma unificata.
+  BC-3770.30:
+    name: Analytics delle performance dei contenuti
+    description: |
+      Analytics delle performance dei contenuti per titolo, coorte e nel
+      tempo per orientare commissioning e acquisizioni.
+  BC-3770.30.10:
+    name: Reportistica delle performance per titolo
+    description: |
+      Reportistica delle performance a livello di titolo su reach,
+      completamento e contributo.
+  BC-3770.30.20:
+    name: Analytics del funnel di engagement
+    description: |
+      Analytics del funnel su discovery, avvio, completamento e
+      comportamenti di visione successivi.
+  BC-3770.30.30:
+    name: Analytics per coorte e lifetime value
+    description: |
+      Analytics di retention per coorte e lifetime value per gli abbonati
+      direct-to-consumer.
+  BC-3770.40:
+    name: Modellazione delle raccomandazioni dei contenuti
+    description: |
+      Addestramento, test e composizione personalizzata delle raccomandazioni
+      di contenuto per le superfici degli spettatori.
+  BC-3770.40.10:
+    name: Addestramento del modello di raccomandazione
+    description: |
+      Addestramento e ciclo di vita dei modelli di raccomandazione
+      basati su segnali di visione e metadati.
+  BC-3770.40.20:
+    name: Gestione dei test A/B per le raccomandazioni
+    description: |
+      Test A/B e multi-armed bandit per le policy di raccomandazione
+      e le decisioni sulle superfici.
+  BC-3770.40.30:
+    name: Composizione dello slate personalizzato
+    description: |
+      Composizione di home, righe e shelf personalizzati per le
+      superfici degli spettatori.
+  BC-3770.50:
+    name: Gestione degli insight e della ricerca sull'audience
+    description: |
+      Ricerca personalizzata quantitativa e qualitativa sull'audience
+      e sintesi e distribuzione degli insight al business.
+  BC-3770.50.10:
+    name: Studi di ricerca personalizzati sull'audience
+    description: |
+      Progettazione e conduzione di studi personalizzati sull'audience,
+      compresi segmentazione e tracker.
+  BC-3770.50.20:
+    name: Gestione della ricerca qualitativa
+    description: |
+      Ricerca qualitativa con gli spettatori, compresi focus group
+      e interviste in profondità.
+  BC-3770.50.30:
+    name: Sintesi e distribuzione degli insight
+    description: |
+      Sintesi degli output di misurazione e ricerca in insight
+      e loro distribuzione ai destinatari nel business.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-audience-viewer-management.yaml
+++ b/catalogue/i18n/it/L1-audience-viewer-management.yaml
@@ -1,0 +1,112 @@
+# Gestione dell'audience e degli spettatori (it) — translations for L1-audience-viewer-management.yaml
+locale: it
+source: L1-audience-viewer-management.yaml
+entries:
+  BC-3750:
+    name: Gestione dell'audience e degli spettatori
+    description: |
+      Identità dello spettatore, abbonamento e diritti di accesso, autenticazione
+      multi-dispositivo, engagement e fidelizzazione, e controllo parentale per
+      servizi di contenuto direct-to-consumer su piattaforme OTT, IPTV e pay-TV.
+  BC-3750.10:
+    name: Gestione dell'identità dello spettatore
+    description: |
+      Provisioning e gestione degli account degli spettatori, dei nuclei
+      familiari e dell'identità federata tra i servizi.
+  BC-3750.10.10:
+    name: Provisioning degli account degli spettatori
+    description: |
+      Creazione e ciclo di vita degli account degli spettatori, compresi
+      la fusione e la divisione degli account.
+  BC-3750.10.20:
+    name: Gestione del nucleo familiare e dei profili
+    description: |
+      Gestione delle configurazioni di nucleo familiare e dei profili
+      individuali per spettatore all'interno degli account condivisi.
+  BC-3750.10.30:
+    name: Federazione dell'identità
+    description: |
+      Federazione dell'identità dello spettatore con operatori, retailer
+      e provider di identità di terze parti.
+  BC-3750.20:
+    name: Gestione degli abbonamenti e dei diritti di accesso
+    description: |
+      Ciclo di vita degli abbonamenti degli spettatori e dei record di
+      diritti di accesso che governano l'accesso ai servizi e ai tier di contenuto.
+  BC-3750.20.10:
+    name: Iscrizione al piano di abbonamento
+    description: |
+      Iscrizione degli spettatori a piani di abbonamento, transazionali
+      e con pubblicità.
+  BC-3750.20.20:
+    name: Concessione e revoca dei diritti di accesso
+    description: |
+      Concessione e revoca dei diritti di accesso ai contenuti in base
+      ad abbonamenti, acquisti e bundle di partner.
+  BC-3750.20.30:
+    name: Diritti di accesso per stream concorrenti
+    description: |
+      Controllo degli stream concorrenti e del numero di dispositivi per
+      account in base ai diritti di accesso.
+  BC-3750.30:
+    name: Autenticazione multi-dispositivo
+    description: |
+      Autenticazione degli spettatori su tutti i dispositivi, compresi
+      i flussi TV-Everywhere con i provider di identità degli operatori.
+  BC-3750.30.10:
+    name: Registrazione del dispositivo
+    description: |
+      Registrazione e cancellazione dei dispositivi dagli account degli spettatori.
+  BC-3750.30.20:
+    name: Gestione delle sessioni autenticate
+    description: |
+      Gestione delle sessioni di riproduzione autenticate e del ciclo di vita
+      dei token su tutti i dispositivi.
+  BC-3750.30.30:
+    name: Autenticazione TV-Everywhere
+    description: |
+      Autenticazione degli abbonati pay-TV tramite i provider di identità
+      degli operatori per l'accesso via OTT.
+  BC-3750.40:
+    name: Gestione dell'engagement e della fidelizzazione degli spettatori
+    description: |
+      Modellazione, progettazione dei percorsi e interventi per aumentare
+      l'engagement sui contenuti e ridurre l'abbandono nei servizi direct-to-consumer.
+  BC-3750.40.10:
+    name: Modellazione delle abitudini di visione
+    description: |
+      Modellazione delle abitudini degli spettatori, degli stati di visione e
+      dell'affinità con i contenuti per guidare le decisioni di engagement.
+  BC-3750.40.20:
+    name: Gestione dei programmi di win-back e fidelizzazione
+    description: |
+      Progettazione ed esecuzione di programmi di salvataggio, win-back e
+      fidelizzazione per gli spettatori a rischio e inattivi.
+  BC-3750.40.30:
+    name: Gestione del percorso di onboarding e attivazione
+    description: |
+      Percorsi per l'onboarding dei nuovi spettatori e per l'attivazione
+      alla prima visione significativa.
+  BC-3750.50:
+    name: Gestione del controllo parentale e delle restrizioni del profilo
+    description: |
+      Configurazione e applicazione delle restrizioni sui contenuti a livello
+      di profilo, blocchi PIN e limiti di tempo di visione.
+  BC-3750.50.10:
+    name: Restrizione dei contenuti a livello di profilo
+    description: |
+      Restrizione per profilo dei contenuti in base alla classificazione per
+      età, categoria e liste di blocco personalizzate.
+  BC-3750.50.20:
+    name: Gestione di PIN e blocchi
+    description: |
+      Gestione di PIN, blocco del profilo e blocco degli acquisti su
+      dispositivi e superfici.
+  BC-3750.50.30:
+    name: Configurazione dei limiti di visione
+    description: |
+      Configurazione dei limiti di tempo di visione, delle restrizioni
+      per fascia oraria e dei controlli sul tempo schermo.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-autonomous-driving-operations-management.yaml
+++ b/catalogue/i18n/it/L1-autonomous-driving-operations-management.yaml
@@ -1,0 +1,162 @@
+# Gestione delle operazioni di guida autonoma (it) — translations for L1-autonomous-driving-operations-management.yaml
+locale: it
+source: L1-autonomous-driving-operations-management.yaml
+entries:
+  BC-3470:
+    name: Gestione delle operazioni di guida autonoma
+    description: |
+      Gestione operativa delle flotte a guida automatizzata — governance dell'ODD,
+      librerie di scenari, safety case ADS, validazione in simulazione e su strada,
+      teleoperazione e coinvolgimento dei regolatori su permessi e segnalazione degli
+      incidenti, ancorata su ISO 21448, SAE J3016 e UN R157.
+  BC-3470.10:
+    name: Governance dell'ODD
+    description: |
+      Definizione, monitoraggio della conformità e gestione del ciclo di vita dell'ODD
+      per ciascuna funzione di guida automatizzata.
+  BC-3470.10.10:
+    name: Gestione della definizione dell'ODD
+    description: |
+      Definizione dell'ODD inclusi i confini geografici, ambientali e
+      comportamentali.
+  BC-3470.10.20:
+    name: Monitoraggio della conformità all'ODD
+    description: |
+      Monitoraggio della conformità all'ODD in servizio e rilevamento di operazioni
+      al di fuori del dominio definito.
+  BC-3470.10.30:
+    name: Gestione degli aggiornamenti dei limiti dell'ODD
+    description: |
+      Gestione delle espansioni e delle restrizioni dell'ODD lungo il ciclo di vita,
+      incluse approvazione e deployment.
+  BC-3470.20:
+    name: Gestione del catalogo di scenari di guida e test
+    description: |
+      Curazione della libreria di scenari di guida e del catalogo di test utilizzati
+      per la progettazione, la simulazione e la validazione dei sistemi di guida
+      automatizzata.
+  BC-3470.20.10:
+    name: Curazione della libreria di scenari
+    description: |
+      Curazione di librerie di scenari strutturate utilizzate per la progettazione e
+      la validazione dell'ADS.
+  BC-3470.20.20:
+    name: Acquisizione e triage dei casi limite
+    description: |
+      Acquisizione, triage e prioritizzazione dei casi limite osservati in
+      simulazione, sulle flotte di test e in servizio.
+  BC-3470.20.30:
+    name: Reportistica della copertura degli scenari
+    description: |
+      Reportistica della copertura degli scenari e dei gap residui rispetto ai
+      requisiti dell'ODD.
+  BC-3470.30:
+    name: Operazioni della flotta autonoma
+    description: |
+      Operatività quotidiana delle flotte di veicoli a guida automatizzata di test,
+      pilota e commerciali, inclusi dispatch, salute e ciclo di turnaround.
+    in_scope:
+      - Dispatch e routing dei veicoli autonomi
+      - Monitoraggio della salute della flotta e telemetria ground-truth
+      - Coordinamento di ricarica, pulizia e turnaround
+    out_of_scope:
+      - Prenotazione e pricing rivolti al passeggero per i servizi di mobilità condivisa (BC-3490)
+      - Ingegneria del veicolo e sviluppo software (BC-3400)
+  BC-3470.30.10:
+    name: Operazioni di dispatch dei veicoli autonomi
+    description: |
+      Dispatch e routing dei veicoli autonomi per missioni di test, pilota e
+      commerciali.
+  BC-3470.30.20:
+    name: Monitoraggio della salute della flotta autonoma
+    description: |
+      Monitoraggio in tempo reale della salute della flotta autonoma, inclusi
+      calibrazione dei sensori e stato del software.
+  BC-3470.30.30:
+    name: Coordinamento della ricarica e pulizia dei veicoli autonomi
+    description: |
+      Coordinamento delle attività di ricarica, pulizia e turnaround per le
+      flotte autonome nei depositi.
+  BC-3470.40:
+    name: Operazioni remote e teleassistenza
+    description: |
+      Operatività dei centri di teleassistenza che forniscono supporto remoto e
+      interventi autorizzati per le flotte a guida automatizzata.
+  BC-3470.40.10:
+    name: Operazioni del centro di teleassistenza
+    description: |
+      Operatività dei centri di teleassistenza remota, inclusa la gestione dei
+      turni e i percorsi di escalation.
+  BC-3470.40.20:
+    name: Gestione delle decisioni di intervento remoto
+    description: |
+      Framework decisionali e autorizzazione per interventi remoti che vanno dal
+      consulenziale al controllo diretto del veicolo.
+  BC-3470.40.30:
+    name: Gestione della forza lavoro dei teleoperatori
+    description: |
+      Reclutamento, formazione, certificazione e gestione delle performance della
+      forza lavoro dei teleoperatori.
+  BC-3470.50:
+    name: Gestione del safety case e dell'assurance
+    description: |
+      Manutenzione del safety case operativo dell'ADS e degli indicatori che ne
+      monitorano la validità continua.
+  BC-3470.50.10:
+    name: Redazione del safety case
+    description: |
+      Redazione del safety case strutturato dell'ADS incluse affermazioni,
+      argomentazioni e prove.
+  BC-3470.50.20:
+    name: Manutenzione dei safety argument
+    description: |
+      Manutenzione dei safety argument all'evolversi del sistema, dell'ODD e del
+      contesto operativo.
+  BC-3470.50.30:
+    name: Monitoraggio degli indicatori di performance della sicurezza
+    description: |
+      Definizione e monitoraggio degli indicatori di performance della sicurezza
+      leading e lagging per la flotta deployata.
+  BC-3470.60:
+    name: Operazioni di validazione della guida autonoma
+    description: |
+      Gestione operativa delle campagne di validazione — simulazione, circuito
+      chiuso e strada pubblica — che forniscono le prove per il safety case.
+  BC-3470.60.10:
+    name: Operazioni di validazione basate su simulazione
+    description: |
+      Operatività di farm di simulazione su larga scala e regressione degli scenari
+      per la validazione dell'ADS.
+  BC-3470.60.20:
+    name: Operazioni di validazione su circuito chiuso
+    description: |
+      Operatività dei programmi di test su circuito chiuso e delle campagne su pista
+      di prova per la validazione dell'ADS.
+  BC-3470.60.30:
+    name: Operazioni di sperimentazione su strada pubblica
+    description: |
+      Operatività delle sperimentazioni supervisionate su strada pubblica, incluse
+      la disciplina del safety driver e la gestione degli incidenti.
+  BC-3470.70:
+    name: Coinvolgimento normativo ADS
+    description: |
+      Coinvolgimento dei regolatori e del pubblico sulle autorizzazioni alla guida
+      autonoma, sulla segnalazione degli incidenti e sulla costruzione della fiducia.
+  BC-3470.70.10:
+    name: Gestione dei permessi e delle autorizzazioni ADS
+    description: |
+      Gestione dei permessi, delle esenzioni e delle autorizzazioni per il deployment
+      dell'ADS in ciascuna giurisdizione.
+  BC-3470.70.20:
+    name: Segnalazione degli incidenti ai regolatori
+    description: |
+      Segnalazione degli incidenti ADS e delle disattivazioni ai regolatori e
+      coordinamento con le indagini.
+  BC-3470.70.30:
+    name: Coinvolgimento del pubblico e degli stakeholder
+    description: |
+      Coinvolgimento di città, comunità e stakeholder sul deployment dell'ADS,
+      sulla sicurezza e sui benefici.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-aviation-safety-management.yaml
+++ b/catalogue/i18n/it/L1-aviation-safety-management.yaml
@@ -1,0 +1,115 @@
+# Gestione della sicurezza aeronautica (it) — translations for L1-aviation-safety-management.yaml
+locale: it
+source: L1-aviation-safety-management.yaml
+entries:
+  BC-1280:
+    name: Gestione della sicurezza aeronautica
+    description: |
+      Sistema di gestione della sicurezza (SMS), valutazione del rischio, cultura della sicurezza, indagine sugli eventi.
+  BC-1280.10:
+    name: Gestione del sistema di gestione della sicurezza
+    description: |
+      Framework SMS, politica della sicurezza, obiettivi di sicurezza, governance della sicurezza.
+  BC-1280.10.10:
+    name: Politica e obiettivi di sicurezza
+    description: |
+      Definizione della politica della sicurezza e degli obiettivi di sicurezza.
+  BC-1280.10.20:
+    name: Gestione del framework SMS
+    description: |
+      Manutenzione del framework SMS secondo ICAO Annex 19.
+  BC-1280.10.30:
+    name: Governance e responsabilità della sicurezza
+    description: |
+      Commissioni di revisione della sicurezza e assetti del responsabile accountable.
+  BC-1280.10.40:
+    name: Gestione delle risorse per la sicurezza
+    description: |
+      Allocazione delle risorse alla funzione di sicurezza.
+  BC-1280.20:
+    name: Gestione della valutazione del rischio per la sicurezza
+    description: |
+      Identificazione dei pericoli, valutazione e mitigazione del rischio.
+  BC-1280.20.10:
+    name: Identificazione dei pericoli
+    description: |
+      Identificazione proattiva e reattiva dei pericoli per la sicurezza.
+  BC-1280.20.20:
+    name: Valutazione del rischio per la sicurezza
+    description: |
+      Valutazione della probabilità e della gravità dei rischi per la sicurezza.
+  BC-1280.20.30:
+    name: Mitigazione del rischio per la sicurezza
+    description: |
+      Definizione e monitoraggio delle azioni di mitigazione del rischio per la sicurezza.
+  BC-1280.20.40:
+    name: Valutazione della sicurezza dei cambiamenti
+    description: |
+      Valutazione della sicurezza delle modifiche operative e tecniche.
+  BC-1280.30:
+    name: Gestione della cultura della sicurezza e della segnalazione
+    description: |
+      Segnalazione riservata, cultura della sicurezza, segnalazione volontaria degli eventi.
+  BC-1280.30.10:
+    name: Programma di cultura della sicurezza
+    description: |
+      Programma di cultura della sicurezza e tutele per i segnalatori.
+  BC-1280.30.20:
+    name: Segnalazione volontaria degli eventi
+    description: |
+      Canali di segnalazione volontaria e riservata degli eventi.
+  BC-1280.30.30:
+    name: Segnalazione obbligatoria degli eventi
+    description: |
+      Segnalazione obbligatoria degli eventi ai regolatori.
+  BC-1280.40:
+    name: Gestione delle indagini sugli eventi
+    description: |
+      Indagini interne, analisi delle cause radice, lezioni apprese.
+  BC-1280.40.10:
+    name: Indagine interna sugli eventi
+    description: |
+      Indagine interna sugli eventi di sicurezza.
+  BC-1280.40.20:
+    name: Analisi delle cause radice
+    description: |
+      Analisi delle cause radice degli eventi e dei fattori contributivi.
+  BC-1280.40.30:
+    name: Lezioni apprese dalle indagini
+    description: |
+      Raccolta e diffusione delle lezioni apprese in materia di sicurezza.
+  BC-1280.50:
+    name: Gestione del monitoraggio delle prestazioni di sicurezza
+    description: |
+      Indicatori di performance di sicurezza (SPI), obiettivi (SPT), dashboard e reportistica regolatoria.
+  BC-1280.50.10:
+    name: Gestione degli indicatori di performance di sicurezza
+    description: |
+      Definizione e monitoraggio degli SPI e degli SPT.
+  BC-1280.50.20:
+    name: Analisi delle tendenze di sicurezza
+    description: |
+      Analisi delle tendenze degli eventi e delle prestazioni degli SPI.
+  BC-1280.50.30:
+    name: Reportistica sulla sicurezza verso il regolatore
+    description: |
+      Reportistica periodica sulle prestazioni di sicurezza verso l'autorità dell'aviazione civile.
+  BC-1280.60:
+    name: Gestione della promozione della sicurezza
+    description: |
+      Programmi di cultura della sicurezza, formazione, sensibilizzazione e comunicazione.
+  BC-1280.60.10:
+    name: Programma di cultura della sicurezza
+    description: |
+      Indagini sulla cultura della sicurezza e programmi di miglioramento.
+  BC-1280.60.20:
+    name: Erogazione della formazione sulla sicurezza
+    description: |
+      Erogazione della formazione sulla sicurezza e della formazione SMS ricorrente.
+  BC-1280.60.30:
+    name: Comunicazione sulla sicurezza
+    description: |
+      Comunicazioni sulla sicurezza, bollettini e campagne di sensibilizzazione.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-banking-customer-management.yaml
+++ b/catalogue/i18n/it/L1-banking-customer-management.yaml
@@ -1,0 +1,119 @@
+# Gestione della clientela bancaria (it) — translations for L1-banking-customer-management.yaml
+locale: it
+source: L1-banking-customer-management.yaml
+entries:
+  BC-1300:
+    name: Gestione della clientela bancaria
+    description: |
+      Onboarding della clientela, KYC/CDD, servicing, accesso ai canali per i clienti bancari.
+  BC-1300.10:
+    name: Gestione dell'onboarding della clientela
+    description: |
+      Apertura del conto, verifica dell'identità, attivazione del conto.
+  BC-1300.10.10:
+    name: Raccolta delle domande di adesione
+    description: |
+      Acquisizione dei dati relativi a nuovi clienti e richieste di apertura conto.
+  BC-1300.10.20:
+    name: Verifica dell'identità
+    description: |
+      Verifica dell'identità tramite controllo dei documenti e biometria.
+  BC-1300.10.30:
+    name: Configurazione e attivazione del conto
+    description: |
+      Configurazione di conti, prodotti e attivazione dell'accesso ai canali.
+  BC-1300.10.40:
+    name: Comunicazione dello stato dell'onboarding
+    description: |
+      Comunicazione al cliente dello stato dell'onboarding della clientela e dei passi successivi.
+  BC-1300.20:
+    name: Gestione KYC e CDD (customer due diligence)
+    description: |
+      KYC, CDD, EDD (enhanced due diligence), revisione periodica, screening PEP.
+  BC-1300.20.10:
+    name: Classificazione del rischio del cliente
+    description: |
+      Classificazione del rischio dei clienti in base a fattori di rischio antiriciclaggio.
+  BC-1300.20.20:
+    name: Raccolta della documentazione KYC
+    description: |
+      Raccolta e validazione della documentazione KYC.
+  BC-1300.20.30:
+    name: Screening delle sanzioni e delle PEP
+    description: |
+      Screening delle sanzioni, PEP (persona politicamente esposta) e media avversi.
+  BC-1300.20.40:
+    name: EDD (enhanced due diligence)
+    description: |
+      EDD per clienti ad alto rischio e strutture complesse.
+  BC-1300.20.50:
+    name: Revisione periodica del KYC
+    description: |
+      Revisione e aggiornamento periodici delle informazioni KYC del cliente.
+  BC-1300.30:
+    name: Gestione del servicing alla clientela
+    description: |
+      Richieste di servizio quotidiane e manutenzione del conto.
+  BC-1300.30.10:
+    name: Manutenzione del conto
+    description: |
+      Manutenzione del conto, compresi limiti, firmatari e indirizzi.
+  BC-1300.30.20:
+    name: Gestione delle richieste di servizio
+    description: |
+      Gestione delle richieste di servizio e delle istruzioni dei clienti.
+  BC-1300.30.30:
+    name: Fornitura di estratti conto e documenti
+    description: |
+      Fornitura di estratti conto, certificati e documenti ai clienti.
+  BC-1300.30.40:
+    name: Gestione della chiusura del rapporto con il cliente
+    description: |
+      Offboarding della clientela e chiusura dei rapporti con i clienti.
+  BC-1300.40:
+    name: Gestione delle informazioni sulla clientela
+    description: |
+      Dati del cliente, consensi, preferenze, golden record.
+  BC-1300.40.10:
+    name: Manutenzione del profilo del cliente
+    description: |
+      Manutenzione del profilo del cliente e dei dati anagrafici.
+  BC-1300.40.20:
+    name: Gestione della titolarità effettiva
+    description: |
+      Raccolta e manutenzione delle informazioni sulla titolarità effettiva.
+  BC-1300.40.30:
+    name: Gestione del consenso del cliente
+    description: |
+      Raccolta e applicazione dei consensi per marketing e condivisione dei dati.
+  BC-1300.40.40:
+    name: Gestione del golden record del cliente
+    description: |
+      Manutenzione del golden record del cliente su tutti i sistemi.
+  BC-1300.50:
+    name: Gestione dei canali bancari
+    description: |
+      Operatività di filiale, ATM, canali online, mobile e telefonia.
+  BC-1300.50.10:
+    name: Operatività del canale filiale
+    description: |
+      Gestione del canale fisico di filiale e dei servizi di sportello.
+  BC-1300.50.20:
+    name: Operatività ATM e self-service
+    description: |
+      Gestione del parco ATM, chioschi e dispositivi self-service.
+  BC-1300.50.30:
+    name: Operatività del canale digitale
+    description: |
+      Gestione dei canali di banca digitale online e mobile.
+  BC-1300.50.40:
+    name: Operatività del canale telefonico
+    description: |
+      Gestione dei canali di telefonia bancaria e autenticazione vocale.
+  BC-1300.50.50:
+    name: Operatività del canale open banking e API
+    description: |
+      Gestione delle API di open banking e dell'accesso di terze parti.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-banking-product-management.yaml
+++ b/catalogue/i18n/it/L1-banking-product-management.yaml
@@ -1,0 +1,99 @@
+# Gestione dei prodotti bancari (it) — translations for L1-banking-product-management.yaml
+locale: it
+source: L1-banking-product-management.yaml
+entries:
+  BC-1310:
+    name: Gestione dei prodotti bancari
+    description: |
+      Product factory bancaria — catalogo prodotti, parametri, tariffazione e ciclo di vita.
+  BC-1310.10:
+    name: Gestione del catalogo prodotti bancari
+    description: |
+      Catalogo prodotti bancari e anagrafica prodotti.
+  BC-1310.10.10:
+    name: Gestione dei dati anagrafici di prodotto
+    description: |
+      Manutenzione dei dati anagrafici di prodotto e delle gerarchie di prodotto.
+  BC-1310.10.20:
+    name: Pubblicazione del catalogo prodotti
+    description: |
+      Pubblicazione del catalogo prodotti bancari su canali e partner.
+  BC-1310.10.30:
+    name: Gestione della documentazione di prodotto
+    description: |
+      Produzione e manutenzione dei documenti informativi di prodotto.
+  BC-1310.20:
+    name: Gestione dei parametri e della configurazione di prodotto
+    description: |
+      Tassi, commissioni, limiti, regole di eleggibilità e parametri di prodotto.
+  BC-1310.20.10:
+    name: Configurazione del tasso di prodotto
+    description: |
+      Configurazione dei tassi di interesse e dei listini tassi.
+  BC-1310.20.20:
+    name: Configurazione delle commissioni di prodotto
+    description: |
+      Configurazione delle commissioni di prodotto e delle esenzioni.
+  BC-1310.20.30:
+    name: Configurazione dei limiti di prodotto
+    description: |
+      Configurazione dei limiti di transazione e di prodotto.
+  BC-1310.20.40:
+    name: Configurazione delle regole di eleggibilità del prodotto
+    description: |
+      Configurazione delle regole di eleggibilità e qualificazione.
+  BC-1310.30:
+    name: Gestione della tariffazione bancaria dei prodotti
+    description: |
+      Tariffazione bancaria dei prodotti, promozioni e prezzi specifici per cliente.
+  BC-1310.30.10:
+    name: Tariffazione standard dei prodotti
+    description: |
+      Tariffazione bancaria standard di prodotti e servizi.
+  BC-1310.30.20:
+    name: Tariffazione promozionale
+    description: |
+      Campagne di tariffazione promozionale e offerte a tempo limitato.
+  BC-1310.30.30:
+    name: Tariffazione personalizzata e per relazione
+    description: |
+      Tariffazione specifica per cliente e basata sulla relazione bancaria.
+  BC-1310.40:
+    name: Gestione del pacchetto prodotti
+    description: |
+      Pacchetti prodotti, bundle e tariffazione di relazione.
+  BC-1310.40.10:
+    name: Definizione del pacchetto prodotti
+    description: |
+      Definizione di bundle, pacchetti di prodotti e relative regole.
+  BC-1310.40.20:
+    name: Gestione dell'eleggibilità al pacchetto
+    description: |
+      Regole di eleggibilità e criteri di qualificazione per i pacchetti prodotti.
+  BC-1310.40.30:
+    name: Monitoraggio delle performance del pacchetto
+    description: |
+      Monitoraggio dell'adozione e dell'economicità dei pacchetti prodotti.
+  BC-1310.50:
+    name: Gestione del ciclo di vita del prodotto bancario
+    description: |
+      Introduzione di nuovi prodotti, ritiro e cessazione.
+  BC-1310.50.10:
+    name: Approvazione di nuovi prodotti
+    description: |
+      Processo di approvazione di nuovi prodotti e governance del comitato prodotti.
+  BC-1310.50.20:
+    name: Lancio del prodotto
+    description: |
+      Esecuzione del lancio del prodotto e preparazione dei canali.
+  BC-1310.50.30:
+    name: Revisione delle performance del prodotto
+    description: |
+      Revisioni periodiche delle performance del prodotto e del rapporto qualità-prezzo.
+  BC-1310.50.40:
+    name: Ritiro del prodotto e migrazione della clientela
+    description: |
+      Ritiro del prodotto e migrazione dei clienti verso prodotti successori.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-banking-risk-management.yaml
+++ b/catalogue/i18n/it/L1-banking-risk-management.yaml
@@ -1,0 +1,127 @@
+# Gestione del rischio bancario (it) — translations for L1-banking-risk-management.yaml
+locale: it
+source: L1-banking-risk-management.yaml
+entries:
+  BC-1410:
+    name: Gestione del rischio bancario
+    description: |
+      Tipologie di rischio specifiche del settore bancario — rischio di credito, di mercato, di liquidità, di modello e rischio di credito di controparte.
+  BC-1410.10:
+    name: Gestione del rischio di credito bancario
+    description: |
+      Framework di rischio di credito, RWA e stress test.
+  BC-1410.10.10:
+    name: Framework del rischio di credito
+    description: |
+      Definizione del framework e delle politiche di rischio di credito.
+  BC-1410.10.20:
+    name: Calcolo e segnalazione degli RWA
+    description: |
+      Calcolo e segnalazione degli RWA con approccio standardizzato e IRB.
+  BC-1410.10.30:
+    name: Stress test del rischio di credito
+    description: |
+      Stress test del rischio di credito e analisi degli scenari.
+  BC-1410.10.40:
+    name: Gestione del rischio di concentrazione
+    description: |
+      Gestione del rischio di concentrazione per singolo nome, settore e paese.
+  BC-1410.20:
+    name: Gestione del rischio di mercato
+    description: |
+      VaR, sensibilità, limiti di rischio di mercato e FRTB.
+  BC-1410.20.10:
+    name: Misurazione del rischio di mercato
+    description: |
+      Misurazione di VaR, expected shortfall (ES) e sensibilità del trading book.
+  BC-1410.20.20:
+    name: Gestione dei limiti di rischio di mercato
+    description: |
+      Definizione e monitoraggio dei limiti di rischio di mercato.
+  BC-1410.20.30:
+    name: Stress test del rischio di mercato
+    description: |
+      Stress test e analisi degli scenari di rischio di mercato.
+  BC-1410.20.40:
+    name: Gestione dell'implementazione del FRTB
+    description: |
+      Implementazione e gestione del FRTB con approccio standardizzato (SA) e modelli interni (IMA).
+  BC-1410.30:
+    name: Gestione del rischio operativo bancario
+    description: |
+      Framework di rischio operativo, RCSA e dati sugli eventi di perdita.
+  BC-1410.30.10:
+    name: Framework del rischio operativo
+    description: |
+      Framework, tassonomia e politiche del rischio operativo.
+  BC-1410.30.20:
+    name: Risk and control self-assessment (RCSA)
+    description: |
+      Esecuzione del RCSA e aggiornamento del profilo di rischio.
+  BC-1410.30.30:
+    name: Acquisizione degli eventi di perdita operativa
+    description: |
+      Acquisizione e classificazione degli eventi di perdita da rischio operativo.
+  BC-1410.30.40:
+    name: Gestione degli indicatori chiave di rischio operativo
+    description: |
+      Definizione, soglie e monitoraggio dei KRI del rischio operativo.
+  BC-1410.40:
+    name: Gestione del rischio di liquidità
+    description: |
+      Framework di rischio di liquidità, stress test e piano di finanziamento di emergenza.
+  BC-1410.40.10:
+    name: Framework del rischio di liquidità
+    description: |
+      Framework, propensione al rischio e politiche di rischio di liquidità.
+  BC-1410.40.20:
+    name: Stress test del rischio di liquidità
+    description: |
+      Stress test specifici sulla liquidità e stress test inversi.
+  BC-1410.40.30:
+    name: Gestione del piano di finanziamento di emergenza
+    description: |
+      Manutenzione e verifica del piano di finanziamento di emergenza.
+  BC-1410.50:
+    name: Gestione del rischio di modello
+    description: |
+      Validazione dei modelli, governance dei modelli e inventario dei modelli.
+  BC-1410.50.10:
+    name: Gestione dell'inventario dei modelli
+    description: |
+      Manutenzione dell'inventario dei modelli a livello aziendale.
+  BC-1410.50.20:
+    name: Classificazione del rischio dei modelli
+    description: |
+      Classificazione dei modelli per livello di rischio ai fini della governance.
+  BC-1410.50.30:
+    name: Validazione indipendente dei modelli
+    description: |
+      Validazione indipendente dei modelli in conformità a SR 11-7/TRIM.
+  BC-1410.50.40:
+    name: Monitoraggio delle performance dei modelli
+    description: |
+      Monitoraggio continuativo delle performance e ricalibrazione dei modelli.
+  BC-1410.60:
+    name: Gestione del rischio di credito di controparte
+    description: |
+      CCR (rischio di credito di controparte), CVA ed esposizione su derivati.
+  BC-1410.60.10:
+    name: Misurazione dell'esposizione di controparte
+    description: |
+      Misurazione dell'esposizione di controparte (PFE, EEPE).
+  BC-1410.60.20:
+    name: Gestione di CVA e XVA
+    description: |
+      Gestione di CVA, DVA, FVA e altri aggiustamenti di valutazione (XVA).
+  BC-1410.60.30:
+    name: Gestione dei limiti di controparte
+    description: |
+      Definizione e monitoraggio dei limiti di controparte.
+  BC-1410.60.40:
+    name: Gestione del rischio di correlazione sfavorevole
+    description: |
+      Identificazione e gestione del rischio di correlazione sfavorevole specifico e generale.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-border-immigration-management.yaml
+++ b/catalogue/i18n/it/L1-border-immigration-management.yaml
@@ -1,0 +1,133 @@
+# Gestione delle frontiere e dell'immigrazione (it) — translations for L1-border-immigration-management.yaml
+locale: it
+source: L1-border-immigration-management.yaml
+entries:
+  BC-3300:
+    name: Gestione delle frontiere e dell'immigrazione
+    description: |
+      Controllo delle frontiere per le persone, visti e autorizzazioni di viaggio, determinazione dello status di rifugiato e di asilo, gestione dello status di soggiorno, naturalizzazione e operazioni di rimpatrio.
+  BC-3300.10:
+    name: Gestione di visti e autorizzazioni di viaggio
+    description: |
+      Elaborazione delle domande, adozione delle decisioni e rilascio di visti e autorizzazioni di viaggio, incluso il pre-clearance di tipo ETA.
+    in_scope:
+      - Elaborazione e decisione sulle domande di visto
+      - Autorizzazione di viaggio elettronica
+      - Screening delle frodi sui visti
+    out_of_scope:
+      - Dogana delle merci e conformità commerciale (coperta dalla Gestione della conformità doganale e commerciale)
+  BC-3300.10.10:
+    name: Elaborazione delle domande di visto
+    description: |
+      Ricezione, validazione ed elaborazione delle domande di visto per tutte le categorie.
+  BC-3300.10.20:
+    name: Decisione sul visto
+    description: |
+      Adozione delle decisioni sulle domande di visto, inclusi il diniego e le condizioni.
+  BC-3300.10.30:
+    name: Autorizzazione di viaggio elettronica
+    description: |
+      Rilascio e revoca di autorizzazioni di viaggio anticipate di tipo ETA.
+  BC-3300.10.40:
+    name: Screening delle frodi sui visti
+    description: |
+      Screening delle domande per frodi, falsificazione di documenti e anomalie nei documenti di identità.
+  BC-3300.20:
+    name: Ispezione e ammissione alla frontiera
+    description: |
+      Ispezione e ammissione dei viaggiatori ai valichi di frontiera, incluse le ispezioni primarie e secondarie.
+  BC-3300.20.10:
+    name: Elaborazione dei dati anticipati sui passeggeri
+    description: |
+      Elaborazione dei dati API e PNR prima dell'arrivo del viaggiatore.
+  BC-3300.20.20:
+    name: Ispezione primaria
+    description: |
+      Ispezione di primo livello ai valichi di frontiera, inclusa la verifica biometrica.
+  BC-3300.20.30:
+    name: Ispezione secondaria
+    description: |
+      Ispezione secondaria dei viaggiatori che richiedono un ulteriore esame.
+  BC-3300.20.40:
+    name: Decisione di ammissione o diniego
+    description: |
+      Adozione delle decisioni di ammissione, diniego e condizioni di ingresso.
+  BC-3300.30:
+    name: Determinazione dello status di asilo e di rifugiato
+    description: |
+      Ricezione, esame e determinazione delle domande di asilo ai sensi della Convenzione sui rifugiati del 1951 e dei regimi nazionali di protezione.
+  BC-3300.30.10:
+    name: Ricezione delle domande di asilo
+    description: |
+      Ricezione e registrazione delle domande di asilo alle frontiere e nel territorio nazionale.
+  BC-3300.30.20:
+    name: Determinazione dello status di rifugiato
+    description: |
+      Esame dello status di rifugiato ai sensi della Convenzione del 1951 e della protezione complementare.
+  BC-3300.30.30:
+    name: Coordinamento dell'accoglienza e del supporto ai richiedenti asilo
+    description: |
+      Coordinamento dell'accoglienza, dell'alloggio e del supporto di base per i richiedenti asilo.
+  BC-3300.30.40:
+    name: Reinsediamento e percorsi umanitari
+    description: |
+      Gestione dei programmi di reinsediamento e di ammissione per motivi umanitari.
+  BC-3300.40:
+    name: Gestione dello status di soggiorno e residenza
+    description: |
+      Gestione dello status migratorio nel territorio nazionale, inclusi permessi di soggiorno, autorizzazioni al lavoro e casi di ricongiungimento familiare.
+  BC-3300.40.10:
+    name: Gestione dei permessi di soggiorno
+    description: |
+      Rilascio e rinnovo dei permessi di soggiorno e dei titoli di soggiorno biometrici.
+  BC-3300.40.20:
+    name: Gestione delle autorizzazioni al lavoro
+    description: |
+      Gestione dei permessi di lavoro, delle licenze di sponsorizzazione e dei test del mercato del lavoro.
+  BC-3300.40.30:
+    name: Elaborazione del ricongiungimento familiare
+    description: |
+      Elaborazione delle domande di ricongiungimento familiare e per persone a carico.
+  BC-3300.40.40:
+    name: Monitoraggio della conformità allo status
+    description: |
+      Monitoraggio della conformità alle condizioni migratorie e ai cambiamenti di status.
+  BC-3300.50:
+    name: Gestione della naturalizzazione e della cittadinanza
+    description: |
+      Esame delle domande di naturalizzazione, cittadinanza per discendenza o registrazione e casi di revoca della cittadinanza.
+  BC-3300.50.10:
+    name: Elaborazione delle domande di naturalizzazione
+    description: |
+      Elaborazione delle domande di naturalizzazione e valutazione dei requisiti di buona condotta.
+  BC-3300.50.20:
+    name: Cittadinanza per discendenza e per registrazione
+    description: |
+      Determinazione della cittadinanza per discendenza, registrazione e adozione.
+  BC-3300.50.30:
+    name: Gestione delle cerimonie di cittadinanza e del giuramento
+    description: |
+      Organizzazione delle cerimonie di cittadinanza e prestazione del giuramento di fedeltà.
+  BC-3300.50.40:
+    name: Gestione della revoca della cittadinanza
+    description: |
+      Esame dei casi di revoca, rinuncia e annullamento della cittadinanza.
+  BC-3300.60:
+    name: Gestione del rimpatrio e della detenzione
+    description: |
+      Operazioni di detenzione, rimpatrio e ritorno volontario di persone prive di status migratorio regolare.
+  BC-3300.60.10:
+    name: Operazioni di detenzione ai fini migratori
+    description: |
+      Gestione dei centri di detenzione per immigrati e degli standard di benessere.
+  BC-3300.60.20:
+    name: Esecuzione degli ordini di rimpatrio
+    description: |
+      Esecuzione degli ordini di rimpatrio ed espulsione, inclusi i rimpatri con scorta.
+  BC-3300.60.30:
+    name: Operazioni del programma di ritorno volontario
+    description: |
+      Coordinamento dei programmi di rimpatrio volontario assistito e di reintegrazione.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-building-automation-system-engineering-management.yaml
+++ b/catalogue/i18n/it/L1-building-automation-system-engineering-management.yaml
@@ -1,0 +1,208 @@
+# Gestione dell'ingegneria del sistema di automazione degli edifici (it) — translations for L1-building-automation-system-engineering-management.yaml
+locale: it
+source: L1-building-automation-system-engineering-management.yaml
+entries:
+  BC-2010:
+    name: Gestione dell'ingegneria del sistema di automazione degli edifici
+    description: |
+      Ingegneria di prodotto dei controllori BAS, dei dispositivi di campo, del software supervisor,
+      delle librerie di sequenze di controllo riutilizzabili, degli stack di protocollo di
+      comunicazione, dei modelli semantici dei dati e della cybersicurezza BAS — basata su
+      ISO 16484 / ASHRAE 135 (BACnet) e ASHRAE Guideline 36.
+    in_scope:
+      - Ingegneria di prodotto del controllore BAS specifico per applicazione e dei dispositivi di campo
+      - Ingegneria software del server supervisor, degli allarmi e dello storico dei trend
+      - Librerie riutilizzabili di sequenze operative (Guideline 36 e controllo avanzato)
+      - Stack di protocollo BACnet, KNX, LonWorks, Modbus, DALI, OPC UA, MQTT
+      - Modellazione semantica dei dati con Brick/Haystack
+      - Controllori BAS sicuri per progettazione e cybersicurezza della rete BAS
+    out_of_scope:
+      - Ingegneria generica di prodotti elettronici coperta da BC-1900
+      - Liste punti e personalizzazione delle sequenze a livello di progetto (BC-2020)
+      - Ingegneria delle apparecchiature meccaniche HVAC (BC-2000)
+      - Messa in servizio e operazioni di assistenza sul sito (BC-2050, BC-2060)
+
+  BC-2010.10:
+    name: Ingegneria del prodotto controllore BAS
+    description: |
+      Ingegneria di prodotti controllori per edifici specifici per applicazione — controllori
+      di zona, UTA, impianto, programmabili e gateway edge.
+
+  BC-2010.10.10:
+    name: Ingegneria del controllore di zona
+    description: Ingegneria dei controllori di zona per il controllo VAV, fan coil e unitario.
+
+  BC-2010.10.20:
+    name: Ingegneria del controllore UTA
+    description: Ingegneria dei controllori per unità di trattamento aria con supporto integrato delle sequenze.
+
+  BC-2010.10.30:
+    name: Ingegneria del controllore d'impianto
+    description: Ingegneria dei controllori per impianti centrali di chiller e caldaie.
+
+  BC-2010.10.40:
+    name: Ingegneria del controllore programmabile
+    description: Ingegneria dei controllori BAS liberamente programmabili.
+
+  BC-2010.10.50:
+    name: Ingegneria del gateway edge
+    description: Ingegneria dei gateway edge per la traduzione tra BAS e piattaforme IoT/cloud.
+
+  BC-2010.20:
+    name: Ingegneria dei dispositivi di campo BAS
+    description: |
+      Ingegneria di sensori, valvole, serrande e dispositivi di campo wireless che
+      confluiscono nel BAS.
+
+  BC-2010.20.10:
+    name: Ingegneria del prodotto sensore
+    description: Ingegneria di sensori di temperatura, umidità, pressione, CO2 e qualità dell'aria come dispositivi BAS.
+
+  BC-2010.20.20:
+    name: Ingegneria di valvole e attuatori
+    description: Ingegneria di valvole di regolazione e attuatori per sistemi idronici.
+
+  BC-2010.20.30:
+    name: Ingegneria dell'attuatore di serranda
+    description: Ingegneria degli attuatori di serranda per il controllo lato aria del BAS.
+
+  BC-2010.20.40:
+    name: Ingegneria dei dispositivi di campo wireless
+    description: Ingegneria di sensori e attuatori wireless per applicazioni di retrofit e IoT.
+
+  BC-2010.30:
+    name: Ingegneria del software supervisor BAS
+    description: |
+      Ingegneria di server supervisor, interfacce operatore, motori di allarme e storici.
+
+  BC-2010.30.10:
+    name: Ingegneria del server supervisor
+    description: Ingegneria dei server supervisor head-end per la gestione delle reti di controllori.
+
+  BC-2010.30.20:
+    name: Ingegneria dell'interfaccia operatore
+    description: Ingegneria delle interfacce operatore grafiche e delle dashboard.
+
+  BC-2010.30.30:
+    name: Ingegneria del motore allarmi ed eventi
+    description: Ingegneria dei motori di elaborazione, prioritizzazione e notifica degli allarmi.
+
+  BC-2010.30.40:
+    name: Ingegneria dei trend e dello storico
+    description: Ingegneria dei sottosistemi di registrazione dei trend e dello storico di serie temporali.
+
+  BC-2010.40:
+    name: Ingegneria della libreria di sequenze di controllo
+    description: |
+      Ingegneria di librerie riutilizzabili e indipendenti dal fornitore di sequenze operative
+      per i sottosistemi HVAC.
+
+  BC-2010.40.10:
+    name: Libreria di sequenze VAV
+    description: Sequenze riutilizzabili per il controllo di zone a volume d'aria variabile.
+
+  BC-2010.40.20:
+    name: Libreria di sequenze UTA
+    description: Sequenze riutilizzabili per il controllo delle unità di trattamento aria.
+
+  BC-2010.40.30:
+    name: Libreria di sequenze per impianti centrali
+    description: Sequenze riutilizzabili per il controllo degli impianti di chiller e caldaie.
+
+  BC-2010.40.40:
+    name: Libreria di sequenze di controllo avanzato
+    description: Sequenze riutilizzabili per il controllo predittivo e basato sull'ottimizzazione.
+
+  BC-2010.50:
+    name: Ingegneria del protocollo di comunicazione BAS
+    description: |
+      Ingegneria degli stack di protocollo di comunicazione per l'automazione degli edifici e dei driver.
+
+  BC-2010.50.10:
+    name: Ingegneria dello stack BACnet
+    description: Ingegneria degli stack di protocollo BACnet/IP e BACnet/MSTP.
+
+  BC-2010.50.20:
+    name: Ingegneria dello stack KNX e LonWorks
+    description: Ingegneria degli stack di protocollo KNX e LonWorks.
+
+  BC-2010.50.30:
+    name: Ingegneria dei driver Modbus e DALI
+    description: Ingegneria dei driver Modbus e DALI per l'integrazione HVAC e illuminotecnica.
+
+  BC-2010.50.40:
+    name: Ingegneria del server OPC UA
+    description: Ingegneria dei server OPC UA per l'interoperabilità BAS di livello industriale.
+
+  BC-2010.50.50:
+    name: Ingegneria della messaggistica MQTT e IoT
+    description: Ingegneria delle interfacce di messaggistica MQTT e IoT per la connettività cloud.
+
+  BC-2010.60:
+    name: Ingegneria del modello semantico dei dati dell'edificio
+    description: |
+      Ingegneria di modelli semantici, ontologie e convenzioni di denominazione per rendere
+      interpretabili dai sistemi i dati BAS.
+
+  BC-2010.60.10:
+    name: Modellazione con schema Brick
+    description: Ingegneria dei modelli Brick Schema che descrivono la topologia dell'edificio e le apparecchiature.
+
+  BC-2010.60.20:
+    name: Ingegneria della libreria di tag Haystack
+    description: Ingegneria delle librerie di tag Haystack e delle convenzioni di tagging.
+
+  BC-2010.60.30:
+    name: Libreria di punti e convenzioni di denominazione
+    description: Manutenzione delle librerie di convenzioni di denominazione dei punti e dei tag.
+
+  BC-2010.60.40:
+    name: Ingegneria dell'ontologia delle risorse
+    description: Ingegneria delle ontologie delle risorse che collegano i dati BAS alle apparecchiature e alle ubicazioni.
+
+  BC-2010.70:
+    name: Ingegneria della cybersicurezza BAS
+    description: |
+      Ingegneria sicura per progettazione di prodotti BAS, reti e controlli d'identità.
+
+  BC-2010.70.10:
+    name: Architettura del controllore sicuro
+    description: Avvio sicuro, aggiornamento sicuro e architettura del controllore con hardening.
+
+  BC-2010.70.20:
+    name: Progettazione della segmentazione della rete BAS
+    description: Schemi di segmentazione e zonizzazione delle reti BAS.
+
+  BC-2010.70.30:
+    name: Ingegneria dell'autenticazione e dell'identità
+    description: Ingegneria dell'identità di dispositivi, utenti e servizi per il BAS.
+
+  BC-2010.70.40:
+    name: Ingegneria della gestione delle vulnerabilità BAS
+    description: Ingegneria del triage delle vulnerabilità dei prodotti, delle patch e della divulgazione per i prodotti BAS.
+
+  BC-2010.80:
+    name: Verifica del prodotto BAS e conformità
+    description: |
+      Verifica dei prodotti BAS per la conformità ai protocolli, l'interoperabilità
+      e la disponibilità per la certificazione.
+
+  BC-2010.80.10:
+    name: Test di conformità al protocollo
+    description: Test dei prodotti rispetto alle suite di conformità BACnet, LonMark, KNX e altri protocolli.
+
+  BC-2010.80.20:
+    name: Test di interoperabilità in laboratorio
+    description: Test di interoperabilità multi-fornitore in laboratori dedicati.
+
+  BC-2010.80.30:
+    name: Test di regressione del protocollo
+    description: Test di regressione degli stack di protocollo tra le revisioni del firmware.
+
+  BC-2010.80.40:
+    name: Documentazione di conformità
+    description: Redazione di PICS, BIBB e documentazione di conformità equivalente.
+
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-building-performance-management.yaml
+++ b/catalogue/i18n/it/L1-building-performance-management.yaml
@@ -1,0 +1,202 @@
+# Gestione della performance degli edifici (it) — translations for L1-building-performance-management.yaml
+locale: it
+source: L1-building-performance-management.yaml
+entries:
+  BC-2070:
+    name: Gestione della performance degli edifici
+    description: |
+      Ottimizzazione continua e basata sui dati della performance degli edifici — misurazione e
+      verifica dell'energia (IPMVP / ASHRAE Guideline 14), FDD (Fault Detection and Diagnostics),
+      analisi dell'energia e della qualità dell'aria interna (IAQ), risposta alla domanda e
+      interazione con la rete elettrica, tracciamento del carbonio e della sostenibilità, e
+      reporting periodico delle prestazioni ai proprietari degli edifici.
+    in_scope:
+      - Baseline M&V dell'energia, calcolo dei risparmi e aggiustamenti
+      - Librerie di regole FDD e triage continuativo dei guasti
+      - Benchmarking energetico dell'edificio, attribuzione, rilevamento delle anomalie e previsione
+      - Analisi della qualità ambientale interna per risultati termici, aerei, acustici e di illuminazione
+      - Risposta alla domanda e operazioni dell'edificio grid-interactive
+      - Carbonio operativo, allocazione delle rinnovabili e metriche ESG a livello di edificio
+      - Dashboard per il proprietario, reporting periodico e briefing agli stakeholder
+    out_of_scope:
+      - Cx e FPT durante il commissioning di progetto (BC-2050)
+      - Esecuzione dell'assistenza sul campo (BC-2060)
+      - Strategia di sostenibilità aziendale e reporting (BC-740)
+      - Progettazione delle apparecchiature HVAC (BC-2000) e ingegneria del prodotto BAS (BC-2010)
+
+  BC-2070.10:
+    name: Misurazione e verifica dell'energia
+    description: |
+      Baseline, calcolo dei risparmi e aggiustamento della prestazione energetica ai sensi
+      di IPMVP / ASHRAE Guideline 14.
+
+  BC-2070.10.10:
+    name: Modellazione della baseline
+    description: Modellazione delle baseline energetiche rispetto alle quali vengono misurati i risparmi.
+
+  BC-2070.10.20:
+    name: Redazione del piano M&V
+    description: Redazione dei piani di misurazione e verifica allineati ai protocolli riconosciuti.
+
+  BC-2070.10.30:
+    name: Calcolo dei risparmi
+    description: Calcolo dei risparmi energetici rispetto alla baseline.
+
+  BC-2070.10.40:
+    name: Aggiustamento e normalizzazione
+    description: Aggiustamento e normalizzazione degli output M&V per clima e occupazione.
+
+  BC-2070.20:
+    name: Operazioni di FDD (Fault Detection and Diagnostics)
+    description: |
+      Gestione delle librerie di regole FDD e triage continuativo dei guasti rilevati.
+
+  BC-2070.20.10:
+    name: Gestione della libreria di regole FDD
+    description: Manutenzione delle librerie di regole di FDD (Fault Detection and Diagnostics).
+
+  BC-2070.20.20:
+    name: Triage e prioritizzazione dei guasti
+    description: Triage e prioritizzazione dei guasti rilevati per impatto.
+
+  BC-2070.20.30:
+    name: Analisi diagnostica della causa profonda
+    description: Analisi diagnostica per identificare le cause profonde dei guasti rilevati.
+
+  BC-2070.20.40:
+    name: Ottimizzazione dei falsi positivi FDD
+    description: Ottimizzazione delle regole FDD per ridurre i tassi di allarme falso positivo.
+
+  BC-2070.30:
+    name: Analisi delle prestazioni energetiche
+    description: |
+      Analisi del consumo energetico nell'intero portafoglio edilizio.
+
+  BC-2070.30.10:
+    name: Benchmarking e confronto tra pari
+    description: Benchmarking delle prestazioni energetiche dell'edificio rispetto ai pari.
+
+  BC-2070.30.20:
+    name: Attribuzione del consumo energetico
+    description: Attribuzione del consumo energetico tra sistemi, zone e carichi.
+
+  BC-2070.30.30:
+    name: Rilevamento delle anomalie energetiche
+    description: Rilevamento delle anomalie nei pattern di consumo energetico.
+
+  BC-2070.30.40:
+    name: Previsione e targeting
+    description: Previsione del consumo energetico futuro e targeting rispetto agli obiettivi di miglioramento.
+
+  BC-2070.40:
+    name: Analisi della qualità ambientale interna
+    description: |
+      Analisi dei risultati della qualità ambientale interna, incluse metriche di comfort,
+      aria, acustica e illuminazione.
+
+  BC-2070.40.10:
+    name: Analisi del comfort termico
+    description: Analisi del comfort termico rispetto ai criteri ASHRAE 55 ed equivalenti.
+
+  BC-2070.40.20:
+    name: Analisi della qualità dell'aria
+    description: Analisi della qualità dell'aria interna (IAQ) rispetto ai criteri ASHRAE 62.1 ed equivalenti.
+
+  BC-2070.40.30:
+    name: Analisi acustica e dell'illuminazione
+    description: Analisi delle prestazioni acustiche e di illuminazione per i risultati degli occupanti.
+
+  BC-2070.40.40:
+    name: Correlazione del feedback degli occupanti
+    description: Correlazione del feedback degli occupanti con i dati ambientali misurati.
+
+  BC-2070.50:
+    name: Gestione della risposta alla domanda e dell'interazione con la rete elettrica
+    description: |
+      Gestione del comportamento dell'edificio grid-interactive e partecipazione ai programmi
+      di risposta alla domanda.
+
+  BC-2070.50.10:
+    name: Iscrizione ai programmi di risposta alla domanda
+    description: Iscrizione degli edifici ai programmi di risposta alla domanda.
+
+  BC-2070.50.20:
+    name: Esecuzione della riduzione del carico
+    description: Esecuzione degli eventi di riduzione del carico rispetto agli obblighi contrattuali.
+
+  BC-2070.50.30:
+    name: Operazioni dell'edificio grid-interactive
+    description: Operazioni degli edifici efficienti grid-interactive.
+
+  BC-2070.50.40:
+    name: Risposta tariffaria e ai prezzi
+    description: Risposta delle operazioni dell'edificio alle tariffe a fascia oraria e dinamiche.
+
+  BC-2070.60:
+    name: Tracciamento delle prestazioni di carbonio e sostenibilità
+    description: |
+      Contabilità del carbonio operativo a livello di edificio e tracciamento dei risultati
+      di sostenibilità.
+
+  BC-2070.60.10:
+    name: Contabilità del carbonio operativo
+    description: Contabilità delle emissioni di carbonio operativo a livello di edificio.
+
+  BC-2070.60.20:
+    name: Allocazione dell'energia rinnovabile
+    description: Allocazione dell'energia rinnovabile in loco e contrattuale agli edifici.
+
+  BC-2070.60.30:
+    name: Metriche ESG a livello di edificio
+    description: Calcolo delle metriche ESG a livello di edificio per il reporting di portafoglio.
+
+  BC-2070.60.40:
+    name: Tracciamento delle prestazioni per la certificazione di sostenibilità
+    description: Tracciamento delle prestazioni rispetto ai criteri di certificazione degli edifici verdi.
+
+  BC-2070.70:
+    name: Gestione delle raccomandazioni di miglioramento delle prestazioni
+    description: |
+      Identificazione e gestione delle opportunità di miglioramento delle prestazioni e dei
+      casi di risparmio.
+
+  BC-2070.70.10:
+    name: Identificazione delle opportunità
+    description: Identificazione delle opportunità di miglioramento delle prestazioni dall'analisi.
+
+  BC-2070.70.20:
+    name: Business case dei risparmi
+    description: Sviluppo dei business case a supporto dei miglioramenti raccomandati.
+
+  BC-2070.70.30:
+    name: Prioritizzazione delle raccomandazioni
+    description: Prioritizzazione delle raccomandazioni nell'intero portafoglio.
+
+  BC-2070.70.40:
+    name: Tracciamento dell'attuazione
+    description: Tracciamento dell'attuazione delle raccomandazioni accettate.
+
+  BC-2070.80:
+    name: Reporting delle prestazioni e operazioni della dashboard
+    description: |
+      Dashboard per il proprietario, report periodici e reporting normativo delle prestazioni.
+
+  BC-2070.80.10:
+    name: Operazioni della dashboard del proprietario
+    description: Gestione delle dashboard di prestazione per il proprietario.
+
+  BC-2070.80.20:
+    name: Reporting periodico delle prestazioni
+    description: Produzione di report periodici delle prestazioni per i clienti.
+
+  BC-2070.80.30:
+    name: Reporting normativo delle prestazioni
+    description: Reporting delle prestazioni dell'edificio ai programmi normativi (ad es. benchmarking obbligatorio).
+
+  BC-2070.80.40:
+    name: Briefing sulle prestazioni per gli stakeholder
+    description: Briefing agli occupanti, agli investitori e agli stakeholder sulle prestazioni dell'edificio.
+
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-building-systems-commissioning-management.yaml
+++ b/catalogue/i18n/it/L1-building-systems-commissioning-management.yaml
@@ -1,0 +1,196 @@
+# Gestione della messa in servizio degli impianti degli edifici (it) — translations for L1-building-systems-commissioning-management.yaml
+locale: it
+source: L1-building-systems-commissioning-management.yaml
+entries:
+  BC-2050:
+    name: Gestione della messa in servizio degli impianti degli edifici
+    description: |
+      Messa in servizio degli impianti HVAC e BAS come servizio erogabile — messa in servizio
+      iniziale, retro-commissioning, ri-commissioning e commissioning basato sul monitoraggio.
+      Basato sul processo di commissioning totale dell'edificio secondo ASHRAE Guideline 0 /
+      Guideline 1.1.
+    in_scope:
+      - Revisione dei requisiti del committente e della base di progetto
+      - Verifica dell'installazione pre-funzionale e ispezione dell'avviamento
+      - Prove funzionali delle prestazioni degli impianti HVAC e BAS
+      - Verifica delle sequenze operative e prove di integrazione dei sistemi
+      - Retro-commissioning, ri-commissioning e commissioning basato sul monitoraggio
+      - Documentazione Cx, manuali di sistema e formazione del committente
+    out_of_scope:
+      - Progettazione dell'integrazione ingegneristica a livello di progetto (BC-2020)
+      - Operazioni di assistenza continuativa dopo il collaudo (BC-2060)
+      - Commissioning ingegneristico generico di impianti capitalizzati (BC-1160)
+
+  BC-2050.10:
+    name: Pianificazione e scoping della messa in servizio
+    description: |
+      Definizione del programma di commissioning, dello scope e della base di accettazione
+      per il progetto.
+
+  BC-2050.10.10:
+    name: Revisione dei requisiti del committente
+    description: Revisione dei requisiti del committente come baseline del commissioning.
+
+  BC-2050.10.20:
+    name: Revisione della base di progetto
+    description: Revisione della base di progetto rispetto ai requisiti del committente.
+
+  BC-2050.10.30:
+    name: Redazione del piano di messa in servizio
+    description: Redazione del piano di commissioning che definisce lo scope, i ruoli e l'accettazione.
+
+  BC-2050.10.40:
+    name: Registro dei rischi del commissioning
+    description: Manutenzione del registro dei rischi del commissioning durante l'erogazione.
+
+  BC-2050.20:
+    name: Gestione delle ispezioni pre-funzionali
+    description: |
+      Verifica della completezza dell'installazione e della disponibilità all'avviamento prima
+      delle prove funzionali.
+
+  BC-2050.20.10:
+    name: Checklist di verifica dell'installazione
+    description: Esecuzione delle checklist di verifica dell'installazione.
+
+  BC-2050.20.20:
+    name: Ispezione di avviamento
+    description: Ispezione dell'avviamento delle apparecchiature rispetto ai requisiti del costruttore.
+
+  BC-2050.20.30:
+    name: Registrazione delle problematiche pre-funzionali
+    description: Registrazione delle problematiche pre-funzionali nel log delle problematiche del commissioning.
+
+  BC-2050.20.40:
+    name: Approvazione pre-funzionale
+    description: Approvazione del raggiungimento della disponibilità pre-funzionale.
+
+  BC-2050.30:
+    name: Prove funzionali delle prestazioni
+    description: |
+      Prove funzionali delle prestazioni dei sottosistemi HVAC e BAS rispetto ai criteri documentati.
+
+  BC-2050.30.10:
+    name: Redazione degli script di prova
+    description: Redazione degli script di prova funzionale rispetto all'intento progettuale.
+
+  BC-2050.30.20:
+    name: Esecuzione e testimonianza delle prove
+    description: Esecuzione e testimonianza delle prove funzionali sugli impianti HVAC e BAS.
+
+  BC-2050.30.30:
+    name: Risoluzione delle problematiche di prova
+    description: Risoluzione delle problematiche identificate durante le prove funzionali.
+
+  BC-2050.30.40:
+    name: Approvazione dei risultati delle prove
+    description: Approvazione dei risultati delle prove e chiusura dei casi di prova.
+
+  BC-2050.40:
+    name: Verifica delle sequenze operative
+    description: |
+      Verifica delle sequenze di controllo programmate rispetto alle sequenze operative progettuali.
+
+  BC-2050.40.10:
+    name: Walkthrough della logica di controllo
+    description: Walkthrough della logica di controllo rispetto alle sequenze redatte.
+
+  BC-2050.40.20:
+    name: Verifica dei setpoint e delle modalità operative
+    description: Verifica dei setpoint e delle modalità operative nei vari calendari.
+
+  BC-2050.40.30:
+    name: Test di override e comportamento in caso di guasto
+    description: Test dei percorsi di override e dei comportamenti in modalità di guasto.
+
+  BC-2050.40.40:
+    name: Verifica basata sui trend
+    description: Utilizzo dei dati di trend per verificare le prestazioni delle sequenze nel tempo.
+
+  BC-2050.50:
+    name: Prove di integrazione dei sistemi
+    description: |
+      Prove dei comportamenti integrati tra sistemi HVAC, antincendio e sistemi elettrici.
+
+  BC-2050.50.10:
+    name: Prova di integrazione antincendio e sicurezza vita
+    description: Prove di integrazione che coprono l'interazione HVAC con i sistemi antincendio e di sicurezza vita.
+
+  BC-2050.50.20:
+    name: Prova di controllo del fumo e pressurizzazione
+    description: Prove delle sequenze di controllo del fumo e di pressurizzazione.
+
+  BC-2050.50.30:
+    name: Prova di mancanza di alimentazione e riduzione del carico
+    description: Prove del comportamento HVAC durante i mancanza di alimentazione e gli eventi di riduzione del carico.
+
+  BC-2050.50.40:
+    name: Prova di integrazione della rete dell'edificio
+    description: Prove di integrazione tra BAS e le reti IT adiacenti dell'edificio.
+
+  BC-2050.60:
+    name: Retro-commissioning e ri-commissioning
+    description: |
+      Servizio di commissioning applicato agli edifici esistenti e come cicli periodici di ri-commissioning.
+
+  BC-2050.60.10:
+    name: Indagine sull'edificio esistente
+    description: Indagine sulle prestazioni dell'edificio esistente rispetto all'intento attuale.
+
+  BC-2050.60.20:
+    name: Analisi dei gap di prestazione
+    description: Analisi dei gap di prestazione e delle cause profonde negli edifici esistenti.
+
+  BC-2050.60.30:
+    name: Attuazione delle misure di retro-commissioning
+    description: Attuazione delle misure di retro-commissioning sui sistemi esistenti.
+
+  BC-2050.60.40:
+    name: Esecuzione del ciclo di ri-commissioning
+    description: Esecuzione dei cicli periodici di ri-commissioning per prestazioni sostenute.
+
+  BC-2050.70:
+    name: Commissioning basato sul monitoraggio
+    description: |
+      Commissioning continuo basato sui dati che utilizza strumentazione e telemetria.
+
+  BC-2050.70.10:
+    name: Piano di monitoraggio e strumentazione
+    description: Redazione dei piani di monitoraggio e selezione della strumentazione di supporto.
+
+  BC-2050.70.20:
+    name: Trend continuo delle prestazioni
+    description: Trend continuo delle prestazioni dell'edificio per informazioni sul commissioning.
+
+  BC-2050.70.30:
+    name: Indagine sulle anomalie
+    description: Indagine sulle anomalie rilevate dai trend continui.
+
+  BC-2050.70.40:
+    name: Verifica della persistenza
+    description: Verifica che le prestazioni commissionate persistano nel tempo.
+
+  BC-2050.80:
+    name: Documentazione e chiusura del commissioning
+    description: |
+      Produzione dei deliverable del commissioning e chiusura formale dello scope del commissioning.
+
+  BC-2050.80.10:
+    name: Redazione del rapporto di commissioning
+    description: Redazione del rapporto finale di commissioning.
+
+  BC-2050.80.20:
+    name: Compilazione del manuale di sistema
+    description: Compilazione del manuale di sistema per la gestione da parte del committente.
+
+  BC-2050.80.30:
+    name: Erogazione della formazione al committente
+    description: Erogazione della formazione al committente sui sistemi messi in servizio.
+
+  BC-2050.80.40:
+    name: Approvazione finale del collaudo
+    description: Approvazione finale del commissioning e passaggio di consegne alle operazioni.
+
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-business-continuity-management.yaml
+++ b/catalogue/i18n/it/L1-business-continuity-management.yaml
@@ -1,0 +1,91 @@
+# Gestione della continuità operativa (it) — translations for L1-business-continuity-management.yaml
+locale: it
+source: L1-business-continuity-management.yaml
+entries:
+  BC-160:
+    name: Gestione della continuità operativa
+    description: |
+      Pianificazione della resilienza, disaster recovery e risposta alle crisi.
+  BC-160.10:
+    name: Pianificazione della continuità operativa
+    description: |
+      Business impact analysis, sviluppo dei piani e strategie di continuità.
+  BC-160.10.10:
+    name: Analisi dell'impatto sul business
+    description: |
+      Identificazione dei processi critici, RTO, RPO e dipendenze.
+  BC-160.10.20:
+    name: Definizione della strategia di continuità
+    description: |
+      Selezione delle strategie di continuità e delle opzioni di ripristino.
+  BC-160.10.30:
+    name: Sviluppo del piano di continuità operativa
+    description: |
+      Documentazione dei piani di continuità operativa allineati alla ISO 22301.
+  BC-160.10.40:
+    name: Manutenzione e aggiornamento dei piani
+    description: |
+      Revisione e aggiornamento periodico dei piani di continuità.
+  BC-160.20:
+    name: Gestione del disaster recovery
+    description: |
+      Disaster recovery informatico e operativo.
+  BC-160.20.10:
+    name: Pianificazione del ripristino dei servizi IT
+    description: |
+      Piani di ripristino per i servizi IT critici e l'infrastruttura.
+  BC-160.20.20:
+    name: Gestione di backup e ripristino
+    description: |
+      Strategie di backup, immodificabilità e validazione del ripristino.
+  BC-160.20.30:
+    name: Operazioni di failover e ripristino del sito
+    description: |
+      Failover, attivazione del sito alternativo e ripristino operativo.
+  BC-160.20.40:
+    name: Coordinamento del ripristino operativo
+    description: |
+      Coordinamento delle operazioni aziendali durante l'attivazione del piano di ripristino.
+  BC-160.30:
+    name: Gestione delle crisi
+    description: |
+      Risposta alle crisi, struttura di comando ed escalation.
+  BC-160.30.10:
+    name: Struttura di comando per la gestione delle crisi
+    description: |
+      Team di gestione delle crisi, ruoli e struttura di command-and-control.
+  BC-160.30.20:
+    name: Comunicazione in situazioni di crisi
+    description: |
+      Comunicazioni interne ed esterne in situazioni di crisi e gestione degli stakeholder.
+  BC-160.30.30:
+    name: Escalation e attivazione degli incidenti
+    description: |
+      Classificazione della gravità, percorsi di escalation e attivazione dei piani.
+  BC-160.30.40:
+    name: Revisione post-crisi
+    description: |
+      Lezioni apprese e azioni di miglioramento a seguito delle crisi.
+  BC-160.40:
+    name: Test ed esercitazioni di resilienza
+    description: |
+      Esercitazioni, drill e validazione dei piani.
+  BC-160.40.10:
+    name: Esercitazioni tabletop e simulazioni
+    description: |
+      Esercitazioni tabletop, walkthrough e simulazioni.
+  BC-160.40.20:
+    name: Test di failover in produzione
+    description: |
+      Test di failover e ripristino in produzione rispetto ai target RTO e RPO.
+  BC-160.40.30:
+    name: Gestione del programma di esercitazioni
+    description: |
+      Calendario annuale delle esercitazioni, ambito e copertura degli stakeholder.
+  BC-160.40.40:
+    name: Monitoraggio dei risultati dei test e delle azioni di miglioramento
+    description: |
+      Raccolta dei risultati delle esercitazioni e monitoraggio delle azioni di miglioramento.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-capital-markets-operations-management.yaml
+++ b/catalogue/i18n/it/L1-capital-markets-operations-management.yaml
@@ -1,0 +1,155 @@
+# Gestione delle operazioni sui mercati dei capitali (it) — translations for L1-capital-markets-operations-management.yaml
+locale: it
+source: L1-capital-markets-operations-management.yaml
+entries:
+  BC-1380:
+    name: Gestione delle operazioni sui mercati dei capitali
+    description: |
+      Conferma delle operazioni, compensazione, regolamento, custodia, gestione del collaterale, operazioni societarie e riconciliazione.
+  BC-1380.10:
+    name: Gestione della conferma delle operazioni
+    description: |
+      Acquisizione delle operazioni, registrazione, conferma e gestione delle contestazioni.
+  BC-1380.10.10:
+    name: Acquisizione e registrazione delle operazioni
+    description: |
+      Acquisizione e registrazione delle operazioni nei sistemi di front e middle office.
+  BC-1380.10.20:
+    name: Abbinamento delle conferme di operazione
+    description: |
+      Abbinamento e affermazione delle conferme di operazione.
+  BC-1380.10.30:
+    name: Gestione delle operazioni contestate
+    description: |
+      Gestione delle contestazioni e delle operazioni non abbinate.
+  BC-1380.20:
+    name: Gestione della compensazione
+    description: |
+      Compensazione centralizzata, CCP e membership di compensazione.
+  BC-1380.20.10:
+    name: Invio delle operazioni alla CCP
+    description: |
+      Invio delle operazioni compensate alle controparti centrali (CCP).
+  BC-1380.20.20:
+    name: Gestione dei margini di compensazione
+    description: |
+      Gestione dei margini iniziali e di variazione con le CCP.
+  BC-1380.20.30:
+    name: Operatività dei membri di compensazione
+    description: |
+      Gestione dei servizi di clearing member diretto e per la clientela.
+  BC-1380.30:
+    name: Gestione del regolamento
+    description: |
+      Regolamento DvP, cicli T+1/T+2 e gestione dei mancati regolamenti.
+  BC-1380.30.10:
+    name: Generazione delle istruzioni di regolamento
+    description: |
+      Generazione delle istruzioni di regolamento per le operazioni.
+  BC-1380.30.20:
+    name: Operazioni di regolamento dei titoli
+    description: |
+      Operazioni di regolamento DvP presso CSD e ICSD.
+  BC-1380.30.30:
+    name: Gestione dei mancati regolamenti
+    description: |
+      Identificazione e risoluzione dei mancati regolamenti (CSDR).
+  BC-1380.40:
+    name: Gestione della custodia
+    description: |
+      Custodia dei titoli, reti di sub-custodia.
+  BC-1380.40.10:
+    name: Custodia dei titoli
+    description: |
+      Custodia dei titoli per conti della clientela e conti proprietari.
+  BC-1380.40.20:
+    name: Gestione della rete di sub-custodia
+    description: |
+      Gestione della rete di sub-custodia e delle banche agenti.
+  BC-1380.40.30:
+    name: Servizi fiscali di custodia
+    description: |
+      Servizi di recupero delle ritenute fiscali e di trattenuta connessi alla custodia.
+  BC-1380.50:
+    name: Gestione del collaterale
+    description: |
+      Collaterale, marginazione e ottimizzazione.
+  BC-1380.50.10:
+    name: Gestione delle margin call
+    description: |
+      Emissione e risposta alle margin call in regime bilaterale e con CCP.
+  BC-1380.50.20:
+    name: Operazioni di movimento del collaterale
+    description: |
+      Movimentazione operativa del collaterale tra controparti.
+  BC-1380.50.30:
+    name: Ottimizzazione del collaterale
+    description: |
+      Ottimizzazione dell'utilizzo del collaterale e operazioni di sostituzione.
+  BC-1380.50.40:
+    name: Gestione dell'eleggibilità del collaterale
+    description: |
+      Regole di eleggibilità del collaterale e applicazione degli haircut.
+  BC-1380.60:
+    name: Gestione delle operazioni societarie
+    description: |
+      Elaborazione delle operazioni societarie obbligatorie e volontarie.
+  BC-1380.60.10:
+    name: Notifica delle operazioni societarie
+    description: |
+      Acquisizione e notifica delle operazioni societarie alla clientela.
+  BC-1380.60.20:
+    name: Elaborazione delle operazioni societarie obbligatorie
+    description: |
+      Elaborazione di dividendi, interessi ed eventi obbligatori.
+  BC-1380.60.30:
+    name: Elaborazione delle operazioni societarie volontarie
+    description: |
+      Elaborazione delle azioni volontarie, comprese le opzioni di adesione.
+  BC-1380.60.40:
+    name: Operatività del voto per delega
+    description: |
+      Raccolta e invio dei voti per delega.
+  BC-1380.70:
+    name: Gestione della riconciliazione
+    description: |
+      Riconciliazione nostro/vostro, delle posizioni e dei conti di cassa.
+  BC-1380.70.10:
+    name: Riconciliazione dei conti di cassa
+    description: |
+      Riconciliazione dei conti di cassa, inclusi nostro/vostro.
+  BC-1380.70.20:
+    name: Riconciliazione delle posizioni in titoli
+    description: |
+      Riconciliazione delle posizioni in titoli tra sistemi e depositari.
+  BC-1380.70.30:
+    name: Riconciliazione front-to-back delle operazioni
+    description: |
+      Riconciliazione front-to-back delle operazioni tra sistemi.
+  BC-1380.70.40:
+    name: Gestione delle differenze di riconciliazione
+    description: |
+      Indagine e risoluzione delle differenze di riconciliazione.
+  BC-1380.80:
+    name: Gestione del prestito titoli
+    description: |
+      Prestito titoli, prestito titoli in prestito e gestione del collaterale.
+  BC-1380.80.10:
+    name: Origination del prestito titoli
+    description: |
+      Origination delle operazioni di prestito e di concessione in prestito di titoli.
+  BC-1380.80.20:
+    name: Operazioni sul collaterale per il prestito titoli
+    description: |
+      Operazioni sul collaterale a supporto del prestito titoli.
+  BC-1380.80.30:
+    name: Calcolo delle commissioni e dei rebate sul prestito titoli
+    description: |
+      Calcolo e regolamento di commissioni e rebate.
+  BC-1380.80.40:
+    name: Gestione del richiamo dei titoli in prestito
+    description: |
+      Richiamo dei titoli concessi in prestito e operazioni di sostituzione.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-capital-markets-trading-management.yaml
+++ b/catalogue/i18n/it/L1-capital-markets-trading-management.yaml
@@ -1,0 +1,115 @@
+# Gestione del trading sui mercati dei capitali (it) — translations for L1-capital-markets-trading-management.yaml
+locale: it
+source: L1-capital-markets-trading-management.yaml
+entries:
+  BC-1370:
+    name: Gestione del trading sui mercati dei capitali
+    description: |
+      Trading di front office, market making, gestione delle posizioni, vendite e trading.
+  BC-1370.10:
+    name: Gestione del market making
+    description: |
+      Market making su tutte le classi di attività.
+  BC-1370.10.10:
+    name: Generazione delle quotazioni
+    description: |
+      Generazione di quotazioni denaro/lettera su tutti i mercati.
+  BC-1370.10.20:
+    name: Gestione dell'inventario del market maker
+    description: |
+      Gestione dell'inventario del market maker e della posizione di rischio.
+  BC-1370.10.30:
+    name: Motore di pricing del market maker
+    description: |
+      Gestione del motore di pricing e dei relativi parametri.
+  BC-1370.20:
+    name: Gestione delle posizioni di trading
+    description: |
+      Posizioni di trading e attribuzione del P&L.
+  BC-1370.20.10:
+    name: Monitoraggio in tempo reale delle posizioni
+    description: |
+      Monitoraggio in tempo reale delle posizioni del trading book.
+  BC-1370.20.20:
+    name: Calcolo del P&L di trading
+    description: |
+      Calcolo del P&L di trading su tutti i desk.
+  BC-1370.20.30:
+    name: Analisi dell'attribuzione del P&L
+    description: |
+      Attribuzione del P&L per fattore di rischio, periodo temporale e trader.
+  BC-1370.30:
+    name: Gestione degli ordini di trading
+    description: |
+      Acquisizione degli ordini, esecuzione, smart order routing e best execution.
+  BC-1370.30.10:
+    name: Acquisizione degli ordini di trading
+    description: |
+      Acquisizione e validazione degli ordini della clientela e proprietari.
+  BC-1370.30.20:
+    name: Smart order routing
+    description: |
+      Instradamento intelligente degli ordini su più sedi di esecuzione per la best execution.
+  BC-1370.30.30:
+    name: Monitoraggio della qualità dell'esecuzione
+    description: |
+      Monitoraggio della qualità dell'esecuzione e analisi della best execution.
+  BC-1370.30.40:
+    name: Gestione del ciclo di vita degli ordini
+    description: |
+      Ciclo di vita degli ordini, incluse modifiche e cancellazioni.
+  BC-1370.40:
+    name: Gestione del trading algoritmico
+    description: |
+      Strategie algoritmiche, backtesting e conformità normativa.
+  BC-1370.40.10:
+    name: Sviluppo di strategie algoritmiche
+    description: |
+      Sviluppo e certificazione di strategie di trading algoritmico.
+  BC-1370.40.20:
+    name: Backtesting algoritmico
+    description: |
+      Backtesting e simulazione degli algoritmi di trading.
+  BC-1370.40.30:
+    name: Controlli del trading algoritmico
+    description: |
+      Controlli pre-trade e in esecuzione sul trading algoritmico.
+  BC-1370.50:
+    name: Gestione delle vendite e del trading
+    description: |
+      Desk commerciali per la clientela, trading vocale ed elettronico.
+  BC-1370.50.10:
+    name: Operatività dei desk di vendita alla clientela
+    description: |
+      Gestione dei desk di vendita vocale per la clientela istituzionale.
+  BC-1370.50.20:
+    name: Operatività del trading elettronico
+    description: |
+      Gestione delle piattaforme di trading elettronico e della connettività.
+  BC-1370.50.30:
+    name: Ricerca pre-trade e tariffazione
+    description: |
+      Ricerca pre-trade, tariffazione indicativa e supporto alla strutturazione.
+  BC-1370.60:
+    name: Gestione della conformità e della sorveglianza nel trading
+    description: |
+      Sorveglianza delle operazioni, rilevamento dell'abuso di mercato, MiFID II.
+  BC-1370.60.10:
+    name: Sorveglianza delle operazioni
+    description: |
+      Sorveglianza delle operazioni e rilevamento di pattern sospetti.
+  BC-1370.60.20:
+    name: Rilevamento dell'abuso di mercato
+    description: |
+      Rilevamento dell'abuso di mercato, inclusi insider trading e manipolazione.
+  BC-1370.60.30:
+    name: Sorveglianza delle comunicazioni
+    description: |
+      Sorveglianza delle comunicazioni dei trader, incluse le comunicazioni vocali.
+  BC-1370.60.40:
+    name: Segnalazione regolatoria delle operazioni
+    description: |
+      Segnalazione regolatoria delle operazioni e delle transazioni (MiFIR, EMIR, SFTR).
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-care-coordination-management.yaml
+++ b/catalogue/i18n/it/L1-care-coordination-management.yaml
@@ -1,0 +1,139 @@
+# Gestione del coordinamento delle cure (it) — translations for L1-care-coordination-management.yaml
+locale: it
+source: L1-care-coordination-management.yaml
+entries:
+  BC-2820:
+    name: Gestione del coordinamento delle cure
+    description: |
+      Coordinamento delle cure tra professionisti, contesti e archi temporali, incluse richieste di
+      consulenza, case management, transizioni delle cure, pianificazione della dimissione,
+      gestione dell'utilizzo e collegamento con i determinanti sociali della salute.
+  BC-2820.10:
+    name: Gestione delle richieste di consulenza
+    description: |
+      Gestione end-to-end delle richieste di consulenza, dalla registrazione dell'ordine
+      all'abbinamento con lo specialista, al monitoraggio e alla chiusura.
+  BC-2820.10.10:
+    name: Registrazione dell'ordine di consulenza
+    description: |
+      Raccolta degli ordini di consulenza da parte dei professionisti invianti con il relativo contesto clinico.
+  BC-2820.10.20:
+    name: Abbinamento con lo specialista
+    description: |
+      Abbinamento delle richieste di consulenza agli specialisti in base al bisogno clinico, alla rete e all'accessibilità.
+  BC-2820.10.30:
+    name: Monitoraggio delle richieste di consulenza
+    description: |
+      Monitoraggio dello stato delle richieste, della pianificazione e del completamento nella rete.
+  BC-2820.10.40:
+    name: Chiusura delle richieste di consulenza
+    description: |
+      Chiusura delle richieste di consulenza con restituzione del referto del consulente al professionista inviante.
+  BC-2820.20:
+    name: Case management e gestione delle cure
+    description: |
+      Identificazione, pianificazione ed esecuzione degli interventi di case management
+      per pazienti ad alto rischio e con bisogni complessi.
+  BC-2820.20.10:
+    name: Stratificazione dei casi
+    description: |
+      Stratificazione dei pazienti in livelli di case management in base al rischio clinico e sociale.
+  BC-2820.20.20:
+    name: Sviluppo del piano di cura
+    description: |
+      Sviluppo di piani di cura individualizzati con obiettivi centrati sul paziente.
+  BC-2820.20.30:
+    name: Esecuzione del piano di cura
+    description: |
+      Esecuzione e rivalutazione continua degli interventi previsti nel piano di cura.
+  BC-2820.20.40:
+    name: Assegnazione del case manager
+    description: |
+      Assegnazione e gestione del carico di lavoro dei case manager e dei navigator.
+  BC-2820.30:
+    name: Pianificazione della dimissione
+    description: |
+      Pianificazione della dimissione sicura dall'assistenza in regime di ricovero, inclusa la
+      valutazione dei bisogni, il collocamento post-acuto e l'educazione del paziente.
+  BC-2820.30.10:
+    name: Valutazione dei bisogni alla dimissione
+    description: |
+      Valutazione multidisciplinare dei bisogni clinici e sociali post-dimissione.
+  BC-2820.30.20:
+    name: Sviluppo del piano di dimissione
+    description: |
+      Sviluppo del piano di dimissione, inclusi servizi, attrezzature e follow-up.
+  BC-2820.30.30:
+    name: Collocamento post-acuto
+    description: |
+      Collocamento dei pazienti in strutture di lungodegenza, riabilitazione e assistenza domiciliare.
+  BC-2820.30.40:
+    name: Educazione alla dimissione
+    description: |
+      Educazione del paziente e del caregiver sulle istruzioni di dimissione, i farmaci e i segnali d'allarme.
+  BC-2820.40:
+    name: Transizioni delle cure
+    description: |
+      Coordinamento delle transizioni dei pazienti tra professionisti e contesti per garantire
+      continuità, sicurezza e responsabilità sui risultati.
+  BC-2820.40.10:
+    name: Comunicazione di passaggio delle consegne
+    description: |
+      Comunicazione strutturata di passaggio delle consegne tra professionisti e team di cura nelle transizioni.
+  BC-2820.40.20:
+    name: Riconciliazione farmacologica nelle transizioni
+    description: |
+      Riconciliazione dei farmaci nelle transizioni delle cure.
+  BC-2820.40.30:
+    name: Pianificazione degli appuntamenti di follow-up
+    description: |
+      Pianificazione degli appuntamenti di follow-up post-dimissione e post-incontro.
+  BC-2820.40.40:
+    name: Monitoraggio degli esiti nelle transizioni
+    description: |
+      Monitoraggio dei tassi di riammissione, delle complicanze e delle metriche di esito nelle transizioni.
+  BC-2820.50:
+    name: Gestione dell'utilizzo
+    description: |
+      Revisione e supervisione delle ammissioni, dei soggiorni prolungati e della durata della degenza
+      in base alla necessità medica e ai criteri di utilizzo.
+  BC-2820.50.10:
+    name: Revisione dell'ammissione
+    description: |
+      Revisione della necessità medica dell'ammissione e dello stato di ricovero rispetto all'osservazione.
+  BC-2820.50.20:
+    name: Revisione del proseguimento del ricovero
+    description: |
+      Revisione periodica del proseguimento del ricovero rispetto ai criteri stabiliti.
+  BC-2820.50.30:
+    name: Ottimizzazione della durata della degenza
+    description: |
+      Ottimizzazione della durata della degenza tramite identificazione e risoluzione delle barriere.
+  BC-2820.50.40:
+    name: Monitoraggio delle giornate evitabili
+    description: |
+      Rilevazione e analisi delle giornate di ricovero evitabili e delle relative cause radice.
+  BC-2820.60:
+    name: Determinanti sociali della salute e collegamento con la comunità
+    description: |
+      Identificazione dei determinanti sociali della salute e collegamento con le risorse
+      comunitarie a supporto degli esiti clinici.
+  BC-2820.60.10:
+    name: Screening dei bisogni sociali
+    description: |
+      Screening per bisogni legati all'alloggio, all'alimentazione, ai trasporti e ad altri bisogni sociali.
+  BC-2820.60.20:
+    name: Richiesta di risorse comunitarie
+    description: |
+      Richiesta di risorse comunitarie per far fronte ai bisogni sociali identificati.
+  BC-2820.60.30:
+    name: Documentazione dei determinanti sociali
+    description: |
+      Documentazione strutturata dei determinanti sociali nella cartella clinica.
+  BC-2820.60.40:
+    name: Monitoraggio in ciclo chiuso delle richieste
+    description: |
+      Monitoraggio in ciclo chiuso delle richieste comunitarie fino all'esito e alla risoluzione.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-cargo-documentation-management.yaml
+++ b/catalogue/i18n/it/L1-cargo-documentation-management.yaml
@@ -1,0 +1,105 @@
+# Gestione della documentazione delle merci (it) — translations for L1-cargo-documentation-management.yaml
+locale: it
+source: L1-cargo-documentation-management.yaml
+entries:
+  BC-2500:
+    name: Gestione della documentazione delle merci
+    description: |
+      Emissione, scambio e gestione del ciclo di vita dei documenti di trasporto, incluse
+      polizze di carico, lettere di vettura aerea, lettere di vettura stradali e ferroviarie,
+      manifesti e i loro equivalenti elettronici.
+  BC-2500.10:
+    name: Gestione della polizza di carico
+    description: |
+      Emissione, restituzione e gestione delle polizze di carico marittime e fluviali
+      in forma negoziabile e non negoziabile.
+    in_scope:
+      - Polizze di carico master e house
+      - Varianti negoziabili, nominative e seaway bill
+    out_of_scope:
+      - Gestione di lettere di credito nel finanziamento del commercio (BC-1360)
+  BC-2500.10.10:
+    name: Emissione della polizza di carico
+    description: |
+      Emissione di polizze di carico master e house.
+  BC-2500.10.20:
+    name: Restituzione e svincolo della polizza di carico
+    description: |
+      Telex release, restituzione e svincolo merci a fronte delle polizze di carico.
+  BC-2500.10.30:
+    name: Varianti negoziabili e nominative della polizza di carico
+    description: |
+      Emissione di varianti negoziabili, nominative e seaway bill.
+  BC-2500.20:
+    name: Gestione della lettera di vettura aerea (AWB)
+    description: |
+      Emissione e gestione delle lettere di vettura aerea master e house, inclusa
+      l'e-AWB.
+  BC-2500.20.10:
+    name: Emissione della lettera di vettura aerea master
+    description: |
+      Emissione delle lettere di vettura aerea master da parte dei vettori aerei.
+  BC-2500.20.20:
+    name: Emissione della lettera di vettura aerea house
+    description: |
+      Emissione delle lettere di vettura aerea house da parte degli spedizionieri e
+      dei consolidatori.
+  BC-2500.20.30:
+    name: Conversione e manutenzione dell'e-AWB
+    description: |
+      Conversione delle AWB cartacee in e-AWB e manutenzione del ciclo di vita.
+  BC-2500.30:
+    name: Gestione delle lettere di vettura stradali e ferroviarie
+    description: |
+      Emissione e gestione delle lettere di vettura stradali e ferroviarie nell'ambito
+      dei regimi CMR e CIM/SMGS.
+  BC-2500.30.10:
+    name: Emissione della lettera di vettura CMR
+    description: |
+      Emissione delle lettere di vettura CMR per il trasporto internazionale su strada.
+  BC-2500.30.20:
+    name: Emissione delle lettere di vettura CIM e SMGS
+    description: |
+      Emissione delle lettere di vettura CIM e SMGS per il trasporto ferroviario
+      internazionale.
+  BC-2500.30.30:
+    name: Emissione delle lettere di vettura nazionali
+    description: |
+      Emissione delle lettere di vettura nazionali e dei documenti di consegna.
+  BC-2500.40:
+    name: Gestione dei manifesti e delle dichiarazioni cargo
+    description: |
+      Presentazione dei manifesti cargo e delle dichiarazioni di pre-arrivo a dogane,
+      terminal e vettori partner.
+  BC-2500.40.10:
+    name: Presentazione del manifesto inbound
+    description: |
+      Presentazione dei manifesti inbound a terminal e dogana.
+  BC-2500.40.20:
+    name: Presentazione del manifesto outbound
+    description: |
+      Presentazione dei manifesti outbound a terminal e dogana.
+  BC-2500.40.30:
+    name: Segnalazione pre-arrivo delle merci
+    description: |
+      Segnalazione pre-arrivo nell'ambito di regimi quali ICS2 e CBP ACE.
+  BC-2500.50:
+    name: Gestione della documentazione elettronica
+    description: |
+      Gestione delle piattaforme di documenti di trasporto elettronici, incluse le
+      piattaforme di polizza di carico elettronica e gli scambi ONE Record.
+  BC-2500.50.10:
+    name: Operazioni di polizza di carico elettronica
+    description: |
+      Gestione delle piattaforme di polizza di carico elettronica.
+  BC-2500.50.20:
+    name: Operazioni e-AWB e ONE Record
+    description: |
+      Gestione degli scambi di dati e-AWB e ONE Record.
+  BC-2500.50.30:
+    name: Scambio e verifica dei documenti
+    description: |
+      Scambio di documenti tra le parti e verifica delle firme e dei sigilli elettronici.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-change-management.yaml
+++ b/catalogue/i18n/it/L1-change-management.yaml
@@ -1,0 +1,91 @@
+# Gestione del cambiamento (it) — translations for L1-change-management.yaml
+locale: it
+source: L1-change-management.yaml
+entries:
+  BC-910:
+    name: Gestione del cambiamento
+    description: |
+      Pianificazione ed esecuzione del cambiamento organizzativo.
+  BC-910.10:
+    name: Gestione della strategia di cambiamento
+    description: |
+      Visione, narrativa e strategia del cambiamento.
+  BC-910.10.10:
+    name: Visione e narrativa del cambiamento
+    description: |
+      Articolazione della visione del cambiamento, del caso per il cambiamento e della narrativa.
+  BC-910.10.20:
+    name: Analisi dell'impatto del cambiamento
+    description: |
+      Identificazione e valutazione degli impatti del cambiamento su persone e processi.
+  BC-910.10.30:
+    name: Valutazione della preparazione al cambiamento
+    description: |
+      Valutazione della preparazione organizzativa al cambiamento.
+  BC-910.10.40:
+    name: Sviluppo del piano di cambiamento
+    description: |
+      Sviluppo dei piani integrati di gestione del cambiamento.
+  BC-910.20:
+    name: Gestione del coinvolgimento degli stakeholder nel cambiamento
+    description: |
+      Identificazione, coinvolgimento e allineamento degli stakeholder.
+  BC-910.20.10:
+    name: Identificazione e mappatura degli stakeholder
+    description: |
+      Identificazione e mappatura degli stakeholder impattati.
+  BC-910.20.20:
+    name: Coinvolgimento degli sponsor
+    description: |
+      Definizione della coalizione degli sponsor e attività di engagement.
+  BC-910.20.30:
+    name: Gestione della rete del cambiamento
+    description: |
+      Reti di change agent e change champion.
+  BC-910.20.40:
+    name: Gestione della resistenza
+    description: |
+      Identificazione e gestione della resistenza al cambiamento.
+  BC-910.30:
+    name: Gestione delle comunicazioni e della formazione al cambiamento
+    description: |
+      Comunicazioni e formazione come parte del cambiamento.
+  BC-910.30.10:
+    name: Pianificazione delle comunicazioni di cambiamento
+    description: |
+      Piani di comunicazione per audience e canale nelle iniziative di cambiamento.
+  BC-910.30.20:
+    name: Erogazione delle comunicazioni di cambiamento
+    description: |
+      Esecuzione di campagne di comunicazione e produzione di materiali.
+  BC-910.30.30:
+    name: Progettazione della formazione al cambiamento
+    description: |
+      Progettazione della formazione e del potenziamento delle competenze per il cambiamento.
+  BC-910.30.40:
+    name: Erogazione della formazione al cambiamento
+    description: |
+      Erogazione della formazione durante l'implementazione del cambiamento.
+  BC-910.40:
+    name: Gestione dell'adozione e del consolidamento del cambiamento
+    description: |
+      Monitoraggio dell'adozione, rinforzo e consolidamento.
+  BC-910.40.10:
+    name: Misurazione dell'adozione
+    description: |
+      Misurazione dell'adozione, dell'utilizzo e del cambiamento comportamentale.
+  BC-910.40.20:
+    name: Rinforzo e consolidamento
+    description: |
+      Meccanismi di rinforzo e consolidamento dei nuovi comportamenti.
+  BC-910.40.30:
+    name: Gestione del periodo di hypercare
+    description: |
+      Supporto nel periodo di hypercare post-implementazione.
+  BC-910.40.40:
+    name: Lezioni apprese dal cambiamento
+    description: |
+      Raccolta e disseminazione delle lezioni apprese dal cambiamento.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-chemical-bulk-logistics-management.yaml
+++ b/catalogue/i18n/it/L1-chemical-bulk-logistics-management.yaml
@@ -1,0 +1,171 @@
+# Gestione della logistica dei prodotti chimici alla rinfusa (it) — translations for L1-chemical-bulk-logistics-management.yaml
+locale: it
+source: L1-chemical-bulk-logistics-management.yaml
+entries:
+  BC-4680:
+    name: Gestione della logistica dei prodotti chimici alla rinfusa
+    description: |
+      Movimentazione di prodotti chimici alla rinfusa attraverso le modalità
+      di stoccaggio in serbatoi, trasporto stradale, ferroviario, marittimo,
+      via pipeline e magazzinaggio, incluse le operazioni conformi alla
+      normativa sulle merci pericolose, la lavorazione per conto terzi
+      e la misurazione per il trasferimento di custodia.
+  BC-4680.10:
+    name: Operazioni di stoccaggio alla rinfusa e del parco serbatoi
+    description: |
+      Gestione dei serbatoi di stoccaggio alla rinfusa e del parco serbatoi,
+      inclusa l'allocazione, la pulizia e la riconciliazione delle perdite.
+  BC-4680.10.10:
+    name: Gestione delle scorte del parco serbatoi
+    description: |
+      Gestione delle scorte nei parchi serbatoi atmosferici e in pressione.
+  BC-4680.10.20:
+    name: Allocazione e instradamento dei serbatoi
+    description: |
+      Allocazione dei serbatoi ai prodotti e instradamento dei flussi
+      in entrata e in uscita.
+  BC-4680.10.30:
+    name: Coordinamento della pulizia dei serbatoi
+    description: |
+      Coordinamento della pulizia dei serbatoi tra i cambi prodotto.
+  BC-4680.10.40:
+    name: Riconciliazione delle perdite del parco serbatoi
+    description: |
+      Riconciliazione delle perdite fisiche negli inventari del parco serbatoi.
+  BC-4680.20:
+    name: Logistica delle autocisterne e delle cisterne ISO
+    description: |
+      Gestione delle flotte di autocisterne e cisterne ISO, incluse
+      le operazioni di isola di carico e la pulizia dei contenitori.
+  BC-4680.20.10:
+    name: Schedulazione delle autocisterne
+    description: |
+      Schedulazione dei movimenti delle autocisterne e assegnazione
+      degli stalli di carico.
+  BC-4680.20.20:
+    name: Gestione della flotta di cisterne ISO
+    description: |
+      Gestione delle flotte di cisterne ISO, inclusi posizionamento
+      e riutilizzo.
+  BC-4680.20.30:
+    name: Operazioni dell'isola di carico
+    description: |
+      Operazioni dell'isola di carico per la spedizione di autocisterne
+      e cisterne ISO.
+  BC-4680.20.40:
+    name: Coordinamento della pulizia dei contenitori
+    description: |
+      Coordinamento della pulizia approvata dei contenitori tra i carichi.
+  BC-4680.30:
+    name: Logistica delle cisterne ferroviarie
+    description: |
+      Allocazione, carico, scarico e coordinamento della manutenzione
+      delle cisterne ferroviarie.
+  BC-4680.30.10:
+    name: Allocazione delle cisterne ferroviarie
+    description: |
+      Allocazione delle cisterne ferroviarie a prodotti e rotte.
+  BC-4680.30.20:
+    name: Operazioni di carico e scarico ferroviario
+    description: |
+      Conduzione dei rack di carico e scarico ferroviario.
+  BC-4680.30.30:
+    name: Coordinamento della manutenzione delle cisterne ferroviarie
+    description: |
+      Coordinamento della manutenzione e della qualifica a livello
+      di flotta delle cisterne ferroviarie.
+  BC-4680.40:
+    name: Logistica marittima di prodotti chimici alla rinfusa
+    description: |
+      Logistica marittima per parcel tanker e navi cisterna chimiche,
+      inclusi noleggio, carico e stivaggio.
+  BC-4680.40.10:
+    name: Coordinamento del noleggio di navi cisterna chimiche
+    description: |
+      Coordinamento del noleggio di navi cisterna chimiche e parcel tanker.
+  BC-4680.40.20:
+    name: Operazioni di carico e scarico marittimo
+    description: |
+      Conduzione degli impianti di carico e scarico marittimo.
+  BC-4680.40.30:
+    name: Pianificazione dello stivaggio dei parcel tanker
+    description: |
+      Pianificazione dello stivaggio di carichi parziali compatibili
+      su navi cisterna chimiche.
+  BC-4680.50:
+    name: Coordinamento dei movimenti via pipeline
+    description: |
+      Gestione delle nomine, sequenziamento e coordinamento del trasferimento
+      di custodia per i movimenti di prodotti chimici alla rinfusa via pipeline.
+  BC-4680.50.10:
+    name: Gestione delle nomine di pipeline
+    description: |
+      Gestione delle nomine per i movimenti di pipeline con operatori
+      e controparti.
+  BC-4680.50.20:
+    name: Sequenziamento dei lotti in pipeline
+    description: |
+      Sequenziamento dei lotti con gestione delle interfacce.
+  BC-4680.50.30:
+    name: Coordinamento del trasferimento di custodia via pipeline
+    description: |
+      Coordinamento del trasferimento di custodia ai punti di immissione
+      e di consegna della pipeline.
+  BC-4680.60:
+    name: Operazioni di magazzinaggio per merci pericolose
+    description: |
+      Ricevimento, segregazione e stoccaggio di prodotti chimici confezionati
+      pericolosi in magazzini conformi.
+  BC-4680.60.10:
+    name: Ricevimento e stoccaggio di merci pericolose
+    description: |
+      Ricevimento e stoccaggio di prodotti chimici confezionati pericolosi.
+  BC-4680.60.20:
+    name: Gestione della conformità alla segregazione
+    description: |
+      Gestione della conformità alla segregazione chimica in magazzino.
+  BC-4680.60.30:
+    name: Operazioni di stoccaggio di fusti e IBC
+    description: |
+      Operazioni di stoccaggio per fusti e contenitori intermedi per
+      liquidi sfusi.
+  BC-4680.70:
+    name: Coordinamento della produzione in conto terzi
+    description: |
+      Coordinamento della produzione in conto lavorazione su asset
+      di terzi, inclusa la riconciliazione dei materiali lavorati.
+  BC-4680.70.10:
+    name: Selezione e qualifica del terzista
+    description: |
+      Selezione e qualifica dei partner di produzione in conto lavorazione.
+  BC-4680.70.20:
+    name: Schedulazione della produzione in conto terzi
+    description: |
+      Schedulazione delle campagne in conto lavorazione su asset di terzi.
+  BC-4680.70.30:
+    name: Riconciliazione dei materiali in conto lavorazione
+    description: |
+      Riconciliazione dei materiali in entrata e in uscita dalla produzione
+      in conto lavorazione.
+  BC-4680.80:
+    name: Misurazione per il trasferimento di custodia alla rinfusa
+    description: |
+      Misurazione di volume, massa e campionamento alle interfacce
+      di trasferimento di custodia.
+  BC-4680.80.10:
+    name: Misurazione di volume e massa
+    description: |
+      Misurazione tarata di volume e massa ai punti di custodia.
+  BC-4680.80.20:
+    name: Coordinamento del campionamento
+    description: |
+      Coordinamento del campionamento rappresentativo al trasferimento
+      di custodia.
+  BC-4680.80.30:
+    name: Documentazione del trasferimento di custodia
+    description: |
+      Emissione e conservazione della documentazione di trasferimento
+      di custodia.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-chemical-commercial-trading-management.yaml
+++ b/catalogue/i18n/it/L1-chemical-commercial-trading-management.yaml
@@ -1,0 +1,153 @@
+# Gestione del commercio e trading di prodotti chimici (it) — translations for L1-chemical-commercial-trading-management.yaml
+locale: it
+source: L1-chemical-commercial-trading-management.yaml
+entries:
+  BC-4690:
+    name: Gestione del commercio e trading di prodotti chimici
+    description: |
+      Trading di prodotti chimici di base e specialistici, gestione del
+      bilanciamento domanda-offerta, approvvigionamento di materie prime,
+      copertura dei rischi, contratti di offtake di lungo termine
+      e riferimento agli indici di prezzo.
+  BC-4690.10:
+    name: Trading di prodotti chimici di base
+    description: |
+      Trading spot e a termine di prodotti chimici di base sul mercato fisico.
+  BC-4690.10.10:
+    name: Trading di carichi spot
+    description: |
+      Trading di carichi spot ai prezzi di mercato prevalenti.
+  BC-4690.10.20:
+    name: Trading a contratto a termine
+    description: |
+      Negoziazione ed esecuzione di contratti di trading a termine.
+  BC-4690.10.30:
+    name: Vendita di carichi in eccesso
+    description: |
+      Smaltimento di carichi in eccesso e di difficile collocazione
+      attraverso i canali di trading.
+  BC-4690.20:
+    name: Gestione commerciale della chimica specialistica
+    description: |
+      Gestione degli account, distribuzione e vendita orientata alla
+      soluzione di prodotti chimici specialistici differenziati.
+  BC-4690.20.10:
+    name: Gestione degli account di chimica specialistica
+    description: |
+      Gestione degli account strategici di chimica specialistica.
+  BC-4690.20.20:
+    name: Gestione dei canali distributivi
+    description: |
+      Gestione dei canali di distribuzione indiretti.
+  BC-4690.20.30:
+    name: Vendita di applicazione a valle
+    description: |
+      Vendita orientata all'applicazione presso i formulatori
+      e i trasformatori a valle.
+  BC-4690.20.40:
+    name: Coordinamento della vendita di soluzioni integrate
+    description: |
+      Coordinamento della vendita multi-prodotto per applicazioni complesse.
+  BC-4690.30:
+    name: Approvvigionamento di materie prime petrolchimiche
+    description: |
+      Approvvigionamento di materie prime idrocarburiche, aromatiche,
+      bio e inorganiche per le operazioni chimiche.
+  BC-4690.30.10:
+    name: Approvvigionamento di nafta e materie prime olefiniche
+    description: |
+      Approvvigionamento di nafta, etano e materie prime olefiniche
+      per i cracker.
+  BC-4690.30.20:
+    name: Approvvigionamento di materie prime aromatiche
+    description: |
+      Approvvigionamento di benzene, toluene e xilene come materie prime.
+  BC-4690.30.30:
+    name: Approvvigionamento di bio-materie prime
+    description: |
+      Approvvigionamento di materie prime di origine biologica
+      nell'ambito di schemi di bilancio di massa.
+  BC-4690.30.40:
+    name: Approvvigionamento di materie prime inorganiche
+    description: |
+      Approvvigionamento di sali inorganici, minerali e minerali grezzi
+      per la lavorazione chimica.
+  BC-4690.40:
+    name: Copertura dei rischi e gestione del rischio chimico
+    description: |
+      Copertura dell'esposizione al prezzo delle materie prime, al rischio
+      valutario e al margine nel portafoglio chimico.
+  BC-4690.40.10:
+    name: Copertura del prezzo delle materie prime
+    description: |
+      Copertura dell'esposizione al prezzo delle materie prime
+      sui mercati delle commodity.
+  BC-4690.40.20:
+    name: Copertura dell'esposizione valutaria
+    description: |
+      Copertura dell'esposizione al cambio valutario sui contratti chimici.
+  BC-4690.40.30:
+    name: Strategia di copertura del margine
+    description: |
+      Definizione ed esecuzione di strategie di copertura del margine
+      di cracker e chimico.
+  BC-4690.50:
+    name: Gestione del bilanciamento domanda-offerta
+    description: |
+      Compilazione e riconciliazione di offerta, domanda e bilancio
+      sull'intera gamma di prodotti chimici.
+  BC-4690.50.10:
+    name: Compilazione delle previsioni della domanda
+    description: |
+      Compilazione delle previsioni della domanda nel breve e nel
+      medio termine.
+  BC-4690.50.20:
+    name: Compilazione della capacità di offerta
+    description: |
+      Compilazione della capacità di offerta attraverso asset propri
+      e in conto lavorazione.
+  BC-4690.50.30:
+    name: Riconciliazione del bilanciamento
+    description: |
+      Riconciliazione dei bilanci domanda-offerta e identificazione
+      dei vincoli.
+  BC-4690.60:
+    name: Gestione dei contratti di offtake di lungo termine
+    description: |
+      Negoziazione, redazione e monitoraggio delle prestazioni dei contratti
+      di offtake e fornitura a lungo termine.
+  BC-4690.60.10:
+    name: Negoziazione del term sheet di offtake
+    description: |
+      Negoziazione dei term sheet per i contratti di offtake di lungo termine.
+  BC-4690.60.20:
+    name: Redazione dei contratti di lungo termine
+    description: |
+      Redazione dei contratti definitivi di fornitura e offtake
+      di lungo termine.
+  BC-4690.60.30:
+    name: Monitoraggio delle prestazioni dell'offtake
+    description: |
+      Monitoraggio delle prestazioni dell'offtake rispetto agli obblighi
+      contrattuali.
+  BC-4690.70:
+    name: Gestione degli indici di prezzo e dei prezzi di riferimento
+    description: |
+      Gestione degli abbonamenti e degli indici di prezzo di riferimento
+      utilizzati nel pricing chimico.
+  BC-4690.70.10:
+    name: Gestione degli abbonamenti agli indici di prezzo
+    description: |
+      Gestione degli abbonamenti a ICIS, Argus, Platts e indici analoghi.
+  BC-4690.70.20:
+    name: Manutenzione delle curve di prezzo di riferimento
+    description: |
+      Manutenzione delle curve di prezzo di riferimento interne
+      per i prodotti chimici.
+  BC-4690.70.30:
+    name: Calcolo dei prezzi indicizzati
+    description: |
+      Calcolo dei prezzi ai clienti indicizzati e dei saldi contrattuali.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-chemical-manufacturing-operations-management.yaml
+++ b/catalogue/i18n/it/L1-chemical-manufacturing-operations-management.yaml
@@ -1,0 +1,185 @@
+# Gestione delle operazioni di produzione chimica (it) — translations for L1-chemical-manufacturing-operations-management.yaml
+locale: it
+source: L1-chemical-manufacturing-operations-management.yaml
+entries:
+  BC-4620:
+    name: Gestione delle operazioni di produzione chimica
+    description: |
+      Conduzione quotidiana di impianti di reazione, separazione, polimerizzazione
+      e sintesi inorganica, inclusi il monitoraggio dei catalizzatori, la schedulazione
+      della produzione e il coordinamento delle fermate di manutenzione.
+  BC-4620.10:
+    name: Operazioni unitarie di reazione
+    description: |
+      Conduzione di sistemi di reattori continui, a lotti, catalitici
+      ed elettrochimici.
+  BC-4620.10.10:
+    name: Operazioni di reattori continui
+    description: |
+      Conduzione di reattori a mescolamento continuo e a flusso a pistone.
+  BC-4620.10.20:
+    name: Operazioni di reattori a lotti
+    description: |
+      Conduzione di reattori a lotti e semi-lotti secondo le ricette approvate.
+  BC-4620.10.30:
+    name: Operazioni di reattori catalitici
+    description: |
+      Conduzione di reattori catalitici a letto fisso e a letto fluido.
+  BC-4620.10.40:
+    name: Operazioni di reattori fotochimici ed elettrochimici
+    description: |
+      Conduzione di reattori fotochimici, elettrochimici e al plasma.
+  BC-4620.20:
+    name: Operazioni unitarie di separazione
+    description: |
+      Conduzione di unità di distillazione, cristallizzazione, filtrazione,
+      essiccazione e separazione a membrana.
+  BC-4620.20.10:
+    name: Operazioni di distillazione
+    description: |
+      Conduzione di colonne di distillazione a piatti e a riempimento.
+  BC-4620.20.20:
+    name: Operazioni di cristallizzazione
+    description: |
+      Conduzione di cristallizzatori a raffreddamento, evaporativi e reattivi.
+  BC-4620.20.30:
+    name: Filtrazione e separazione solido-liquido
+    description: |
+      Conduzione di centrifughe, filtropresse e filtri rotanti a vuoto.
+  BC-4620.20.40:
+    name: Operazioni di essiccazione
+    description: |
+      Conduzione di essiccatori a letto fluido, a spruzzo e a contatto.
+  BC-4620.20.50:
+    name: Operazioni di separazione a membrana
+    description: |
+      Conduzione di membrane a osmosi inversa, ultrafiltrazione e pervaporazione.
+  BC-4620.30:
+    name: Operazioni di polimerizzazione
+    description: |
+      Conduzione di processi di polimerizzazione in massa, in soluzione,
+      in sospensione, in emulsione e compounding a valle.
+  BC-4620.30.10:
+    name: Operazioni di polimerizzazione in massa
+    description: |
+      Conduzione di reattori di polimerizzazione in massa.
+  BC-4620.30.20:
+    name: Operazioni di polimerizzazione in soluzione
+    description: |
+      Conduzione di processi di polimerizzazione in soluzione.
+  BC-4620.30.30:
+    name: Polimerizzazione in sospensione e in emulsione
+    description: |
+      Conduzione di reattori di polimerizzazione in sospensione e in emulsione.
+  BC-4620.30.40:
+    name: Operazioni di compounding di polimeri
+    description: |
+      Compounding di polimeri con additivi mediante melt-mixing.
+  BC-4620.40:
+    name: Operazioni inorganiche ed elettrochimiche
+    description: |
+      Conduzione di impianti cloro-soda, elettrolisi, calcinazione
+      e altri processi di sintesi inorganica.
+  BC-4620.40.10:
+    name: Operazioni di celle cloro-soda
+    description: |
+      Conduzione di celle cloro-soda a membrana e a diaframma senza mercurio.
+  BC-4620.40.20:
+    name: Operazioni di elettrolisi
+    description: |
+      Conduzione di celle di elettrolisi per metalli e gas.
+  BC-4620.40.30:
+    name: Operazioni di calcinazione e arrostimento
+    description: |
+      Conduzione di forni rotanti, arrostitori a letto fluido e calcinatori.
+  BC-4620.40.40:
+    name: Operazioni di sintesi inorganica
+    description: |
+      Conduzione di unità di sintesi inorganica, incluse precipitazione
+      e digestione.
+  BC-4620.50:
+    name: Gestione del ciclo di vita di catalizzatori e prodotti chimici di processo
+    description: |
+      Selezione, monitoraggio, rigenerazione e gestione delle scorte
+      di catalizzatori e prodotti chimici di processo.
+  BC-4620.50.10:
+    name: Selezione e caricamento del catalizzatore
+    description: |
+      Selezione e caricamento di catalizzatori a letto fisso e a letto fluido.
+  BC-4620.50.20:
+    name: Monitoraggio delle prestazioni del catalizzatore
+    description: |
+      Monitoraggio in servizio dell'attività e della selettività del catalizzatore.
+  BC-4620.50.30:
+    name: Coordinamento della rigenerazione del catalizzatore
+    description: |
+      Coordinamento delle campagne di rigenerazione in situ ed ex situ
+      del catalizzatore.
+  BC-4620.50.40:
+    name: Gestione delle scorte di prodotti chimici di processo
+    description: |
+      Gestione delle scorte e dei consumi di solventi, additivi
+      e prodotti chimici di processo.
+  BC-4620.60:
+    name: Controllo del processo ed esecuzione delle operazioni
+    description: |
+      Esecuzione quotidiana delle operazioni dal campo e dalla sala di controllo,
+      incluso il monitoraggio dell'inviluppo operativo.
+  BC-4620.60.10:
+    name: Esecuzione dei giri operatore
+    description: |
+      Esecuzione di giri operatore strutturati e verifiche sul campo.
+  BC-4620.60.20:
+    name: Operazioni alla consolle DCS
+    description: |
+      Operazioni alla consolle DCS, incluse la gestione degli allarmi
+      e il controllo di supervisione.
+  BC-4620.60.30:
+    name: Gestione del passaggio di consegne tra turni
+    description: |
+      Passaggio di consegne strutturato tra turni e revisione del registro operativo.
+  BC-4620.60.40:
+    name: Monitoraggio dell'inviluppo operativo
+    description: |
+      Monitoraggio in tempo reale degli inviluppi operativi di sicurezza
+      e di qualità.
+  BC-4620.70:
+    name: Coordinamento delle fermate di manutenzione
+    description: |
+      Coordinamento di scopo, pianificazione ed esecuzione delle fermate
+      di manutenzione e dei grandi interventi programmati.
+  BC-4620.70.10:
+    name: Gestione dello scopo della fermata
+    description: |
+      Definizione e congelamento dello scopo della fermata, incluso
+      il processo di contestazione.
+  BC-4620.70.20:
+    name: Gestione del programma della fermata
+    description: |
+      Schedulazione dettagliata della fermata e controllo dell'avanzamento.
+  BC-4620.70.30:
+    name: Coordinamento dello spegnimento e della riaccensione
+    description: |
+      Coordinamento sequenziale dello spegnimento, della decontaminazione
+      e della riaccensione delle unità.
+  BC-4620.80:
+    name: Schedulazione della produzione chimica
+    description: |
+      Schedulazione della produzione in modalità campagna e in continuo
+      e pianificazione dei cambi prodotto.
+  BC-4620.80.10:
+    name: Pianificazione della campagna produttiva
+    description: |
+      Pianificazione di campagne multi-prodotto su asset condivisi.
+  BC-4620.80.20:
+    name: Sequenziamento della produzione
+    description: |
+      Sequenziamento dei prodotti per minimizzare le transizioni
+      e le perdite di resa.
+  BC-4620.80.30:
+    name: Schedulazione dei cambi prodotto
+    description: |
+      Schedulazione e coordinamento dei cambi di grado e di prodotto.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-chemical-process-engineering-management.yaml
+++ b/catalogue/i18n/it/L1-chemical-process-engineering-management.yaml
@@ -1,0 +1,177 @@
+# Gestione dell'ingegneria di processo chimico (it) — translations for L1-chemical-process-engineering-management.yaml
+locale: it
+source: L1-chemical-process-engineering-management.yaml
+entries:
+  BC-4610:
+    name: Gestione dell'ingegneria di processo chimico
+    description: |
+      Progettazione del processo, ingegneria del bilancio di massa ed energia,
+      simulazione, specifica delle apparecchiature e ingegneria di base
+      per impianti chimici nuovi e revampati.
+  BC-4610.10:
+    name: Progettazione dello schema di flusso del processo
+    description: |
+      Sviluppo di diagrammi di flusso a blocchi, PFD e P&ID
+      per i processi chimici.
+  BC-4610.10.10:
+    name: Sviluppo del diagramma di flusso a blocchi
+    description: |
+      Redazione dei diagrammi di flusso a blocchi per la definizione
+      preliminare del processo.
+  BC-4610.10.20:
+    name: Sviluppo del PFD
+    description: |
+      Redazione dei PFD (Process Flow Diagram) con condizioni e proprietà
+      delle correnti.
+  BC-4610.10.30:
+    name: Sviluppo del P&ID
+    description: |
+      Redazione e revisione dei P&ID (Piping and Instrumentation Diagram)
+      per le unità di processo chimico.
+  BC-4610.10.40:
+    name: Sviluppo del diagramma di flusso delle utilities
+    description: |
+      Redazione dei diagrammi di flusso delle utilities relativi a vapore,
+      acqua di raffreddamento e gas inerti.
+  BC-4610.20:
+    name: Dimensionamento di reattori e apparecchiature di separazione
+    description: |
+      Dimensionamento di reattori e apparecchiature di separazione sulla base
+      di cinetica, termodinamica e principi delle operazioni unitarie.
+  BC-4610.20.10:
+    name: Progettazione del reattore
+    description: |
+      Dimensionamento e configurazione di reattori CSTR, PFR e a letto fisso.
+  BC-4610.20.20:
+    name: Progettazione della colonna di distillazione
+    description: |
+      Progettazione di colonne di distillazione a piatti e a riempimento,
+      inclusi gli interni.
+  BC-4610.20.30:
+    name: Progettazione della rete di scambiatori di calore
+    description: |
+      Progettazione mediante analisi di pinch e della rete di scambiatori
+      per l'integrazione energetica.
+  BC-4610.20.40:
+    name: Dimensionamento di cristallizzatori e filtri
+    description: |
+      Dimensionamento di cristallizzatori, centrifughe e apparecchiature
+      di filtrazione.
+  BC-4610.30:
+    name: Ingegneria del bilancio termico e di massa
+    description: |
+      Chiusura dei bilanci di massa ed energia complessivi e di unità
+      e stima del fabbisogno di utilities.
+  BC-4610.30.10:
+    name: Calcolo del bilancio di massa
+    description: |
+      Calcolo e riconciliazione dei bilanci di massa di impianto e di unità.
+  BC-4610.30.20:
+    name: Calcolo del bilancio energetico
+    description: |
+      Calcolo dei bilanci energetici attraverso reattori, scambiatori e utilities.
+  BC-4610.30.30:
+    name: Stima del fabbisogno di utilities
+    description: |
+      Stima del fabbisogno di vapore, energia elettrica, acqua di raffreddamento
+      e gas inerti.
+  BC-4610.40:
+    name: Gestione della simulazione di processo
+    description: |
+      Sviluppo e manutenzione di simulazioni di processo in regime stazionario
+      e dinamico a supporto di progettazione e operazioni.
+  BC-4610.40.10:
+    name: Simulazione di processo in regime stazionario
+    description: |
+      Sviluppo ed esecuzione di simulatori in regime stazionario per
+      progettazione e analisi.
+  BC-4610.40.20:
+    name: Simulazione di processo dinamica
+    description: |
+      Sviluppo ed esecuzione di simulatori dinamici per studi di controllo
+      e sicurezza.
+  BC-4610.40.30:
+    name: Validazione del modello di simulazione
+    description: |
+      Validazione dei modelli di simulazione rispetto a dati di impianto
+      o di pilota.
+  BC-4610.50:
+    name: Gestione delle specifiche delle apparecchiature
+    description: |
+      Redazione e gestione del ciclo di vita dei datasheet delle apparecchiature
+      e dei disegni dei fornitori.
+  BC-4610.50.10:
+    name: Redazione dei datasheet delle apparecchiature
+    description: |
+      Redazione dei datasheet meccanici, elettrici e strumentali.
+  BC-4610.50.20:
+    name: Manutenzione delle specifiche delle apparecchiature
+    description: |
+      Gestione della configurazione delle specifiche delle apparecchiature approvate.
+  BC-4610.50.30:
+    name: Revisione dei disegni del fornitore
+    description: |
+      Revisione dei disegni del fornitore rispetto ai datasheet e ai
+      requisiti di processo.
+  BC-4610.60:
+    name: Ingegneria del layout dell'impianto e del piano di ubicazione
+    description: |
+      Definizione dei piani di ubicazione, delle distanze di sicurezza tra
+      le apparecchiature e della classificazione delle aree pericolose
+      per gli impianti chimici.
+  BC-4610.60.10:
+    name: Sviluppo del piano di ubicazione
+    description: |
+      Sviluppo dei piani di ubicazione di unità e di sito.
+  BC-4610.60.20:
+    name: Determinazione delle distanze di sicurezza tra apparecchiature
+    description: |
+      Determinazione delle distanze di sicurezza tra apparecchiature
+      in base alla sicurezza di processo e alla costruibilità.
+  BC-4610.60.30:
+    name: Classificazione delle aree pericolose
+    description: |
+      Classificazione delle aree pericolose per il controllo delle
+      sorgenti di accensione.
+  BC-4610.70:
+    name: Sviluppo della filosofia di controllo del processo
+    description: |
+      Definizione delle strategie di controllo del processo, del controllo
+      avanzato e della base delle procedure operative per impianti nuovi
+      e modificati.
+  BC-4610.70.10:
+    name: Definizione degli anelli di regolazione
+    description: |
+      Definizione degli anelli di regolazione e dell'intento di taratura.
+  BC-4610.70.20:
+    name: Strategia di controllo avanzato del processo
+    description: |
+      Definizione di strategie di controllo predittivo avanzato.
+  BC-4610.70.30:
+    name: Sviluppo della base delle procedure operative
+    description: |
+      Sviluppo della base delle procedure operative per impianti nuovi
+      e modificati.
+  BC-4610.80:
+    name: Coordinamento dell'ingegneria di base (FEED)
+    description: |
+      Coordinamento dei pacchetti di ingegneria concettuale, di base e FEED
+      per i progetti chimici.
+  BC-4610.80.10:
+    name: Coordinamento dell'ingegneria concettuale
+    description: |
+      Coordinamento degli studi di ingegneria concettuale e dello screening
+      delle alternative.
+  BC-4610.80.20:
+    name: Produzione del pacchetto di ingegneria di base
+    description: |
+      Produzione dei pacchetti di ingegneria di base consegnati alla
+      progettazione di dettaglio.
+  BC-4610.80.30:
+    name: Verifica del FEED
+    description: |
+      Verifica dei deliverable del FEED rispetto ai requisiti di processo
+      e di progetto.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-chemical-process-safety-management.yaml
+++ b/catalogue/i18n/it/L1-chemical-process-safety-management.yaml
@@ -1,0 +1,204 @@
+# Gestione della sicurezza di processo chimico (it) — translations for L1-chemical-process-safety-management.yaml
+locale: it
+source: L1-chemical-process-safety-management.yaml
+entries:
+  BC-4640:
+    name: Gestione della sicurezza di processo chimico
+    description: |
+      Prevenzione degli incidenti rilevanti in processi chimici reattivi,
+      infiammabili e tossici: analisi dei pericoli di processo, integrità
+      meccanica, sistemi strumentali di sicurezza, pericoli reattivi e da
+      combustibili, rendicontazione delle prestazioni e risposta alle emergenze.
+  BC-4640.10:
+    name: Analisi dei pericoli di processo
+    description: |
+      Identificazione e analisi strutturata dei pericoli di incidente rilevante
+      nell'intero ciclo di vita dell'asset.
+    in_scope:
+      - HAZID, HAZOP, LOPA e analisi bow-tie
+      - Valutazione quantitativa del rischio
+    out_of_scope:
+      - Valutazione del rischio per la sicurezza individuale (BC-730)
+  BC-4640.10.10:
+    name: Studi HAZOP
+    description: |
+      Studi di pericolo e operabilità (HAZOP) su impianti nuovi e modificati.
+  BC-4640.10.20:
+    name: Studi HAZID
+    description: |
+      Studi di identificazione dei pericoli (HAZID) nelle prime fasi di
+      concetto e progettazione.
+  BC-4640.10.30:
+    name: Studi LOPA
+    description: |
+      Analisi degli strati di protezione (LOPA) per la definizione
+      dei livelli di integrità della sicurezza (SIL).
+  BC-4640.10.40:
+    name: Analisi bow-tie
+    description: |
+      Analisi bow-tie per la mappatura delle barriere rispetto agli scenari
+      di incidente rilevante.
+  BC-4640.10.50:
+    name: Valutazione quantitativa del rischio
+    description: |
+      Valutazione quantitativa del rischio degli scenari di incidente rilevante.
+  BC-4640.20:
+    name: Gestione dell'integrità meccanica
+    description: |
+      Ispezione e gestione dell'integrità delle apparecchiature in pressione
+      e dei dispositivi di sicurezza.
+  BC-4640.20.10:
+    name: Ispezione dei recipienti in pressione
+    description: |
+      Ispezione basata sul rischio dei recipienti in pressione secondo API 510.
+  BC-4640.20.20:
+    name: Ispezione dell'integrità della tubazione di processo
+    description: |
+      Ispezione della tubazione di processo secondo API 570 e ASME B31.3.
+  BC-4640.20.30:
+    name: Ispezione dei serbatoi di stoccaggio
+    description: |
+      Ispezione dei serbatoi di stoccaggio atmosferici e in pressione
+      secondo API 653.
+  BC-4640.20.40:
+    name: Gestione dei dispositivi di scarico della pressione
+    description: |
+      Dimensionamento, collaudo e gestione del ciclo di vita di valvole
+      di sicurezza e dischi di rottura.
+  BC-4640.20.50:
+    name: Integrità degli sfiati atmosferici e delle torce
+    description: |
+      Garanzia dell'integrità degli sfiati atmosferici, degli scrubber
+      e delle torce.
+  BC-4640.30:
+    name: Gestione dei sistemi strumentati di sicurezza
+    description: |
+      Gestione del ciclo di vita della sicurezza funzionale dei sistemi
+      strumentati di sicurezza secondo IEC 61511.
+  BC-4640.30.10:
+    name: Determinazione del SIL
+    description: |
+      Determinazione dei livelli di integrità della sicurezza (SIL)
+      per le funzioni di protezione.
+  BC-4640.30.20:
+    name: Verifica delle funzioni di sicurezza
+    description: |
+      Verifica che le funzioni strumentali di sicurezza (SIF) progettate
+      soddisfino il SIL richiesto.
+  BC-4640.30.30:
+    name: Collaudo periodico del SIS
+    description: |
+      Collaudo periodico dei sistemi strumentati di sicurezza.
+  BC-4640.30.40:
+    name: Valutazione della sicurezza funzionale
+    description: |
+      Valutazioni della sicurezza funzionale alle fasi di controllo
+      del ciclo di vita.
+  BC-4640.40:
+    name: Gestione dei pericoli reattivi e da combustibili
+    description: |
+      Identificazione e controllo dei rischi da chimica reattiva, reazioni
+      fuori controllo, polveri combustibili e sorgenti di accensione.
+  BC-4640.40.10:
+    name: Valutazione del rischio da chimica reattiva
+    description: |
+      Valutazione dei rischi della chimica reattiva, incluse le incompatibilità.
+  BC-4640.40.20:
+    name: Prevenzione delle reazioni fuori controllo
+    description: |
+      Prevenzione e mitigazione delle reazioni esotermiche fuori controllo.
+  BC-4640.40.30:
+    name: Controllo dei pericoli da polveri combustibili
+    description: |
+      Controllo dei pericoli da polveri combustibili secondo NFPA 654.
+  BC-4640.40.40:
+    name: Controllo dell'elettricità statica e delle sorgenti di accensione
+    description: |
+      Controllo delle sorgenti di innesco elettrostatiche e di altro tipo
+      nelle aree di processo.
+  BC-4640.50:
+    name: Gestione delle modifiche nell'ambito del PSM
+    description: |
+      Governance della sicurezza di processo sulle modifiche di impianto,
+      procedurali e del personale, inclusa la revisione di sicurezza
+      prima dell'avvio.
+  BC-4640.50.10:
+    name: Revisione delle richieste di modifica PSM
+    description: |
+      Revisione delle richieste di modifica che impattano il PSM rispetto
+      agli standard di pericolo.
+  BC-4640.50.20:
+    name: Revisione di sicurezza pre-avvio
+    description: |
+      Revisioni di sicurezza pre-avvio per impianti nuovi e modificati.
+  BC-4640.50.30:
+    name: Gestione delle modifiche temporanee
+    description: |
+      Gestione delle modifiche temporanee al processo entro la finestra
+      autorizzata.
+  BC-4640.60:
+    name: Gestione delle prestazioni di sicurezza di processo
+    description: |
+      Monitoraggio e rendicontazione degli indicatori di sicurezza di processo
+      anticipatori e ritardati secondo CCPS RBPS e framework equivalenti.
+  BC-4640.60.10:
+    name: Rendicontazione degli eventi di sicurezza di processo Tier 1 e Tier 2
+    description: |
+      Acquisizione e rendicontazione degli eventi di sicurezza di processo
+      Tier 1 e Tier 2.
+  BC-4640.60.20:
+    name: Monitoraggio degli indicatori anticipatori
+    description: |
+      Monitoraggio degli indicatori di sicurezza di processo anticipatori
+      Tier 3 e Tier 4.
+  BC-4640.60.30:
+    name: Rendicontazione dei KPI di sicurezza di processo
+    description: |
+      Rendicontazione interna ed esterna delle prestazioni dei KPI
+      di sicurezza di processo.
+  BC-4640.70:
+    name: Preparazione e risposta alle emergenze
+    description: |
+      Pianificazione della risposta alle emergenze, esecuzione di esercitazioni
+      e coordinamento della risposta al rilascio di sostanze tossiche
+      per scenari di incidente rilevante.
+  BC-4640.70.10:
+    name: Pianificazione della risposta alle emergenze
+    description: |
+      Manutenzione dei piani di risposta alle emergenze di installazione
+      e aziendali.
+  BC-4640.70.20:
+    name: Coordinamento di esercitazioni e prove
+    description: |
+      Coordinamento di esercitazioni di emergenza e prove di incidente grave.
+  BC-4640.70.30:
+    name: Coordinamento della risposta al rilascio di sostanze tossiche
+    description: |
+      Coordinamento delle operazioni di risposta al rilascio di sostanze
+      tossiche e infiammabili.
+  BC-4640.70.40:
+    name: Coordinamento del mutuo soccorso
+    description: |
+      Coordinamento del mutuo soccorso con i consorzi di risposta del settore.
+  BC-4640.80:
+    name: Procedure operative di sicurezza di processo
+    description: |
+      Redazione, revisione e definizione dell'inviluppo operativo per le
+      procedure critiche per la sicurezza di processo.
+  BC-4640.80.10:
+    name: Redazione delle procedure operative critiche per la sicurezza
+    description: |
+      Redazione delle procedure operative critiche per la sicurezza
+      di processo.
+  BC-4640.80.20:
+    name: Definizione dell'inviluppo operativo sicuro
+    description: |
+      Definizione degli inviluppi operativi sicuri per le unità di processo.
+  BC-4640.80.30:
+    name: Revisione periodica delle procedure
+    description: |
+      Revisione e aggiornamento periodici delle procedure di sicurezza
+      di processo.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-chemical-product-stewardship-management.yaml
+++ b/catalogue/i18n/it/L1-chemical-product-stewardship-management.yaml
@@ -1,0 +1,138 @@
+# Gestione responsabile dei prodotti chimici (it) — translations for L1-chemical-product-stewardship-management.yaml
+locale: it
+source: L1-chemical-product-stewardship-management.yaml
+entries:
+  BC-4650:
+    name: Gestione responsabile dei prodotti chimici
+    description: |
+      Classificazione ed etichettatura dei pericoli, redazione delle SDS,
+      scenari di esposizione, programmi per le sostanze problematiche
+      e comunicazione dei pericoli ai clienti nell'intero ciclo di vita
+      del prodotto chimico.
+  BC-4650.10:
+    name: Classificazione ed etichettatura dei pericoli
+    description: |
+      Classificazione GHS di sostanze e miscele e progettazione
+      di etichette conformi.
+  BC-4650.10.10:
+    name: Classificazione GHS
+    description: |
+      Classificazione delle sostanze secondo lo schema di pericolo UN GHS.
+  BC-4650.10.20:
+    name: Classificazione delle miscele
+    description: |
+      Classificazione delle miscele mediante principi di estrapolazione
+      e dati sperimentali.
+  BC-4650.10.30:
+    name: Progettazione di pittogrammi ed etichette di pericolo
+    description: |
+      Progettazione di pittogrammi conformi al GHS, avvertenze
+      e grafica delle etichette.
+  BC-4650.10.40:
+    name: Localizzazione multilingue delle etichette
+    description: |
+      Traduzione e localizzazione delle etichette per i mercati di destinazione.
+  BC-4650.20:
+    name: Gestione delle SDS
+    description: |
+      Redazione, revisione e distribuzione delle SDS (schede di dati di sicurezza),
+      incluse le SDS estese per gli utilizzatori a valle.
+  BC-4650.20.10:
+    name: Redazione delle SDS
+    description: |
+      Redazione delle SDS (schede di dati di sicurezza) nel formato
+      a 16 sezioni.
+  BC-4650.20.20:
+    name: Revisione e aggiornamento delle SDS
+    description: |
+      Revisione e aggiornamento delle SDS sulla base di nuovi dati
+      e modifiche normative.
+  BC-4650.20.30:
+    name: Gestione della distribuzione delle SDS
+    description: |
+      Distribuzione delle SDS ai clienti e ai partner della supply chain.
+  BC-4650.20.40:
+    name: Gestione delle SDS estese
+    description: |
+      Gestione degli allegati alle SDS estese contenenti gli scenari
+      di esposizione.
+  BC-4650.30:
+    name: Gestione degli scenari di esposizione
+    description: |
+      Sviluppo e manutenzione degli scenari di esposizione per lavoratori,
+      consumatori e ambiente per le sostanze registrate.
+  BC-4650.30.10:
+    name: Sviluppo degli scenari di esposizione dei lavoratori
+    description: |
+      Sviluppo degli scenari di esposizione dei lavoratori nelle tipiche
+      condizioni di utilizzo.
+  BC-4650.30.20:
+    name: Sviluppo degli scenari di esposizione dei consumatori
+    description: |
+      Sviluppo degli scenari di esposizione dei consumatori per gli usi
+      nei prodotti finali.
+  BC-4650.30.30:
+    name: Sviluppo degli scenari di rilascio ambientale
+    description: |
+      Sviluppo degli scenari di rilascio ambientale nell'intero ciclo di vita.
+  BC-4650.40:
+    name: Gestione delle sostanze problematiche
+    description: |
+      Identificazione, sostituzione e monitoraggio delle restrizioni relative
+      alle sostanze estremamente preoccupanti (SVHC) nel portafoglio prodotti.
+  BC-4650.40.10:
+    name: Gestione dell'inventario SVHC
+    description: |
+      Manutenzione dell'inventario della presenza di SVHC nel portafoglio prodotti.
+  BC-4650.40.20:
+    name: Gestione del programma di sostituzione delle sostanze
+    description: |
+      Gestione del programma di iniziative di sostituzione con sostanze
+      più sicure.
+  BC-4650.40.30:
+    name: Manutenzione della lista delle sostanze soggette a restrizioni
+    description: |
+      Manutenzione delle liste interne di sostanze soggette a restrizioni
+      e delle liste imposte dai clienti.
+  BC-4650.50:
+    name: Comunicazione dei pericoli ai clienti
+    description: |
+      Comunicazione in uscita delle informazioni sui pericoli ai clienti
+      e agli utilizzatori a valle.
+  BC-4650.50.10:
+    name: Notifica di gestione responsabile ai clienti
+    description: |
+      Notifica ai clienti delle modifiche rilevanti per la gestione
+      responsabile.
+  BC-4650.50.20:
+    name: Produzione di materiali di formazione sui pericoli
+    description: |
+      Produzione di materiali formativi sulla manipolazione e l'utilizzo
+      in sicurezza.
+  BC-4650.50.30:
+    name: Gestione delle richieste degli utilizzatori a valle
+    description: |
+      Gestione delle richieste di informazioni sulla gestione responsabile
+      da parte degli utilizzatori a valle.
+  BC-4650.60:
+    name: Gestione responsabile del ciclo di vita del prodotto
+    description: |
+      Gestione responsabile dei prodotti chimici nell'intero ciclo di vita,
+      incluse le considerazioni sul fine vita, la riciclabilità e il riutilizzo.
+  BC-4650.60.10:
+    name: Manutenzione del profilo di pericolo del prodotto
+    description: |
+      Manutenzione dei profili di pericolo consolidati per prodotto.
+  BC-4650.60.20:
+    name: Coordinamento della gestione responsabile a fine vita
+    description: |
+      Coordinamento degli accordi di ritiro e di gestione responsabile
+      a fine vita.
+  BC-4650.60.30:
+    name: Valutazione della riciclabilità e del riutilizzo
+    description: |
+      Valutazione del potenziale di riciclabilità e riutilizzo dei
+      prodotti chimici.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-chemical-quality-management.yaml
+++ b/catalogue/i18n/it/L1-chemical-quality-management.yaml
@@ -1,0 +1,149 @@
+# Gestione della qualità nella produzione chimica (it) — translations for L1-chemical-quality-management.yaml
+locale: it
+source: L1-chemical-quality-management.yaml
+entries:
+  BC-4670:
+    name: Gestione della qualità nella produzione chimica
+    description: |
+      Definizione delle specifiche, operazioni di laboratorio analitico,
+      rilascio dei lotti, gestione dei reclami e delle contestazioni sui
+      certificati di analisi, standard di riferimento e conformità GMP
+      specifica del settore.
+  BC-4670.10:
+    name: Gestione delle specifiche chimiche
+    description: |
+      Definizione e gestione del ciclo di vita delle specifiche di materie
+      prime, intermedi e prodotti finiti.
+  BC-4670.10.10:
+    name: Definizione delle specifiche delle materie prime
+    description: |
+      Definizione e revisione delle specifiche per le materie prime
+      in entrata.
+  BC-4670.10.20:
+    name: Definizione delle specifiche degli intermedi
+    description: |
+      Definizione delle specifiche degli intermedi lungo la catena produttiva.
+  BC-4670.10.30:
+    name: Definizione delle specifiche del prodotto finito
+    description: |
+      Definizione delle specifiche del prodotto finito e dei criteri
+      di rilascio.
+  BC-4670.10.40:
+    name: Gestione del ciclo di vita delle specifiche
+    description: |
+      Gestione del ciclo di vita delle specifiche approvate e delle
+      relative modifiche.
+  BC-4670.20:
+    name: Operazioni di laboratorio analitico
+    description: |
+      Conduzione di laboratori QC per analisi di chimica per via umida,
+      cromatografia, spettroscopia e test delle proprietà fisiche.
+  BC-4670.20.10:
+    name: Operazioni di laboratorio per la chimica per via umida
+    description: |
+      Conduzione dei flussi di lavoro analitici per la chimica per via umida.
+  BC-4670.20.20:
+    name: Operazioni di cromatografia
+    description: |
+      Conduzione di piattaforme HPLC, GC e cromatografia ionica.
+  BC-4670.20.30:
+    name: Operazioni di spettroscopia
+    description: |
+      Conduzione di piattaforme FTIR, NMR, ICP e spettrometria di massa.
+  BC-4670.20.40:
+    name: Test delle proprietà fisiche
+    description: |
+      Test delle proprietà fisiche quali viscosità, densità
+      e granulometria.
+  BC-4670.30:
+    name: Gestione del rilascio dei lotti
+    description: |
+      Decisioni di disposizione, emissione dei certificati di analisi
+      e gestione dei risultati fuori specifica per i lotti chimici.
+  BC-4670.30.10:
+    name: Decisione di disposizione del lotto
+    description: |
+      Decisione di disposizione dei lotti prodotti rispetto alle specifiche.
+  BC-4670.30.20:
+    name: Emissione del certificato di analisi
+    description: |
+      Emissione dei certificati di analisi ai clienti.
+  BC-4670.30.30:
+    name: Indagine sui risultati fuori specifica
+    description: |
+      Indagine sui risultati analitici fuori specifica (OOS/OOT).
+  BC-4670.40:
+    name: Gestione dei reclami dei clienti e delle contestazioni sui COA
+    description: |
+      Acquisizione e risoluzione dei reclami dei clienti e delle
+      contestazioni sui certificati di analisi.
+  BC-4670.40.10:
+    name: Acquisizione dei reclami dei clienti
+    description: |
+      Acquisizione e triage dei reclami dei clienti sui prodotti chimici.
+  BC-4670.40.20:
+    name: Indagine sulle contestazioni dei COA
+    description: |
+      Indagine sulle contestazioni relative ai valori riportati
+      nei certificati di analisi.
+  BC-4670.40.30:
+    name: Riesame analitico dei campioni del cliente
+    description: |
+      Riesame analitico dei campioni conservati e forniti dal cliente.
+  BC-4670.50:
+    name: Gestione dei materiali e degli standard di riferimento
+    description: |
+      Approvvigionamento, qualifica e monitoraggio della stabilità degli
+      standard e dei materiali di riferimento.
+  BC-4670.50.10:
+    name: Approvvigionamento degli standard di riferimento
+    description: |
+      Approvvigionamento di materiali di riferimento certificati da
+      fornitori accreditati.
+  BC-4670.50.20:
+    name: Qualifica degli standard di riferimento interni
+    description: |
+      Qualifica degli standard di riferimento di lavoro prodotti internamente.
+  BC-4670.50.30:
+    name: Monitoraggio della stabilità degli standard di riferimento
+    description: |
+      Monitoraggio della stabilità degli standard di riferimento in uso.
+  BC-4670.60:
+    name: Sviluppo e validazione dei metodi analitici
+    description: |
+      Sviluppo, validazione e trasferimento dei metodi analitici tra
+      i laboratori.
+  BC-4670.60.10:
+    name: Sviluppo dei metodi analitici
+    description: |
+      Sviluppo di nuovi metodi analitici a supporto delle specifiche.
+  BC-4670.60.20:
+    name: Validazione dei metodi analitici
+    description: |
+      Validazione dei metodi analitici per accuratezza, precisione
+      e robustezza.
+  BC-4670.60.30:
+    name: Trasferimento dei metodi analitici
+    description: |
+      Trasferimento dei metodi validati tra i laboratori.
+  BC-4670.70:
+    name: Conformità GMP specifica del settore
+    description: |
+      Conformità ai regimi GMP specifici del settore per i prodotti chimici
+      destinati a mercati a valle regolamentati.
+  BC-4670.70.10:
+    name: Conformità EFfCI GMP
+    description: |
+      Conformità alle GMP EFfCI per gli ingredienti cosmetici.
+  BC-4670.70.20:
+    name: Conformità IPEC GMP
+    description: |
+      Conformità alle GMP IPEC per gli eccipienti farmaceutici.
+  BC-4670.70.30:
+    name: Conformità per il contatto con alimenti
+    description: |
+      Conformità alle normative sul contatto con alimenti per i prodotti
+      chimici destinati agli imballaggi alimentari.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-chemical-regulatory-compliance-management.yaml
+++ b/catalogue/i18n/it/L1-chemical-regulatory-compliance-management.yaml
@@ -1,0 +1,161 @@
+# Gestione della conformità normativa per prodotti chimici (it) — translations for L1-chemical-regulatory-compliance-management.yaml
+locale: it
+source: L1-chemical-regulatory-compliance-management.yaml
+entries:
+  BC-4660:
+    name: Gestione della conformità normativa per prodotti chimici
+    description: |
+      Registrazione delle sostanze, dossier, autorizzazioni, restrizioni,
+      inventari e controlli sulle importazioni/esportazioni ai sensi di
+      REACH, TSCA, K-REACH, CWC e regimi equivalenti.
+  BC-4660.10:
+    name: Gestione della registrazione delle sostanze
+    description: |
+      Registrazione delle sostanze nei principali regimi mondiali
+      di inventari chimici.
+  BC-4660.10.10:
+    name: Gestione delle registrazioni REACH
+    description: |
+      Gestione delle registrazioni REACH, inclusi SIEF e presentazione
+      congiunta.
+  BC-4660.10.20:
+    name: Notifica TSCA PMN e inventario TSCA
+    description: |
+      Notifica pre-produzione e notifica all'inventario TSCA.
+  BC-4660.10.30:
+    name: Notifica K-REACH e Asia-Pacifico
+    description: |
+      Notifica ai sensi di K-REACH, Cina, Giappone e altri regimi
+      dell'Asia-Pacifico.
+  BC-4660.10.40:
+    name: Gestione delle notifiche per polimeri
+    description: |
+      Gestione delle notifiche e delle esenzioni per le sostanze polimeriche.
+  BC-4660.20:
+    name: Gestione delle autorizzazioni e delle restrizioni
+    description: |
+      Conformità con i controlli su autorizzazioni, restrizioni e sostanze
+      emergenti.
+  BC-4660.20.10:
+    name: Domanda di autorizzazione REACH
+    description: |
+      Preparazione e presentazione delle domande di autorizzazione
+      REACH Allegato XIV.
+  BC-4660.20.20:
+    name: Conformità alle restrizioni REACH
+    description: |
+      Conformità alle voci di restrizione dell'Allegato XVII REACH.
+  BC-4660.20.30:
+    name: Monitoraggio della lista candidata SVHC
+    description: |
+      Monitoraggio degli aggiornamenti della lista candidata SVHC
+      e analisi dell'impatto.
+  BC-4660.20.40:
+    name: Gestione delle restrizioni PFAS e di sostanze emergenti
+    description: |
+      Gestione delle restrizioni su PFAS, microplastiche e altre
+      sostanze emergenti.
+  BC-4660.30:
+    name: Gestione del dossier normativo
+    description: |
+      Redazione e manutenzione dei dossier normativi in formato IUCLID
+      e formati equivalenti.
+  BC-4660.30.10:
+    name: Gestione del dossier IUCLID
+    description: |
+      Redazione e manutenzione dei dossier IUCLID 6.
+  BC-4660.30.20:
+    name: Preparazione del rapporto sulla sicurezza chimica
+    description: |
+      Preparazione dei rapporti sulla sicurezza chimica ai sensi
+      dell'Allegato I REACH.
+  BC-4660.30.30:
+    name: Manutenzione del profilo di identità della sostanza
+    description: |
+      Manutenzione dei profili di identità della sostanza e delle
+      prove analitiche.
+  BC-4660.40:
+    name: Gestione degli inventari delle sostanze
+    description: |
+      Gestione della presenza delle sostanze negli inventari EINECS, CE
+      e degli inventari chimici nazionali.
+  BC-4660.40.10:
+    name: Gestione dei numeri EINECS e CE
+    description: |
+      Gestione delle assegnazioni e degli aggiornamenti dei numeri
+      EINECS e CE.
+  BC-4660.40.20:
+    name: Notifica di nuove sostanze agli inventari
+    description: |
+      Notifica di nuove sostanze agli inventari nazionali.
+  BC-4660.40.30:
+    name: Riconciliazione degli inventari nazionali
+    description: |
+      Riconciliazione del portafoglio rispetto agli inventari chimici
+      nazionali.
+  BC-4660.50:
+    name: Controllo delle importazioni ed esportazioni di prodotti chimici
+    description: |
+      Conformità ai controlli internazionali sul commercio di prodotti
+      chimici, inclusi CWC, precursori di stupefacenti, doppio uso e PIC.
+  BC-4660.50.10:
+    name: Conformità alle schedule CWC
+    description: |
+      Conformità alle dichiarazioni e alle licenze OPCW per le sostanze
+      di Schedule 1, 2 e 3.
+  BC-4660.50.20:
+    name: Controllo dei precursori di stupefacenti
+    description: |
+      Conformità ai regimi di controllo INCB e nazionali sui precursori
+      di stupefacenti.
+  BC-4660.50.30:
+    name: Licenze per l'esportazione a doppio uso
+    description: |
+      Ottenimento di licenze e conformità all'uso finale per le esportazioni
+      di prodotti chimici a doppio uso.
+  BC-4660.50.40:
+    name: Conformità al consenso informato preliminare
+    description: |
+      Conformità al regime di consenso informato preliminare della
+      Convenzione di Rotterdam.
+  BC-4660.60:
+    name: Sorveglianza e intelligence normativa
+    description: |
+      Monitoraggio e valutazione dell'impatto dell'evoluzione delle
+      normative chimiche nei diversi mercati.
+  BC-4660.60.10:
+    name: Scansione dell'orizzonte normativo
+    description: |
+      Analisi prospettica delle normative chimiche in attesa di adozione
+      ed emergenti.
+  BC-4660.60.20:
+    name: Valutazione dell'impatto delle modifiche normative
+    description: |
+      Valutazione dell'impatto delle modifiche normative sul portafoglio
+      e sulle operazioni.
+  BC-4660.60.30:
+    name: Collegamento con le associazioni di settore
+    description: |
+      Relazione con Cefic, ACC e associazioni di settore equivalenti.
+  BC-4660.70:
+    name: Confronto con le autorità e presentazione dei dossier
+    description: |
+      Interazione con le autorità di regolamentazione, incluse presentazioni,
+      richieste di informazioni e ispezioni.
+  BC-4660.70.10:
+    name: Preparazione delle presentazioni alle autorità
+    description: |
+      Preparazione delle presentazioni all'ECHA, all'EPA e ad autorità
+      equivalenti.
+  BC-4660.70.20:
+    name: Risposta alle richieste delle autorità
+    description: |
+      Risposta alle richieste di informazioni delle autorità su dossier
+      e registrazioni.
+  BC-4660.70.30:
+    name: Preparazione alle ispezioni
+    description: |
+      Manutenzione della prontezza per ispezioni e audit dei regolatori.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-chemical-research-process-development-management.yaml
+++ b/catalogue/i18n/it/L1-chemical-research-process-development-management.yaml
@@ -1,0 +1,165 @@
+# Gestione della ricerca chimica e sviluppo di processo (it) — translations for L1-chemical-research-process-development-management.yaml
+locale: it
+source: L1-chemical-research-process-development-management.yaml
+entries:
+  BC-4600:
+    name: Gestione della ricerca chimica e sviluppo di processo
+    description: |
+      Scoperta di nuove molecole e vie di sintesi, sviluppo di processo a scala da banco,
+      conduzione dell'impianto pilota e scale-up verso la produzione commerciale
+      per prodotti chimici.
+  BC-4600.10:
+    name: Scoperta di molecole e vie di sintesi
+    description: |
+      Identificazione delle molecole target e selezione delle vie di sintesi
+      percorribili per prodotti chimici nuovi e consolidati.
+  BC-4600.10.10:
+    name: Identificazione delle molecole target
+    description: |
+      Identificazione delle molecole candidate rispetto ai target applicativi.
+  BC-4600.10.20:
+    name: Analisi retrosintetica
+    description: |
+      Analisi retrosintetica assistita da computer ed eseguita da esperti
+      per le vie di sintesi.
+  BC-4600.10.30:
+    name: Screening di catalizzatori e reagenti
+    description: |
+      Screening ad alto rendimento e mirato di catalizzatori e reagenti.
+  BC-4600.10.40:
+    name: Valutazione della selezione del percorso
+    description: |
+      Valutazione multi-criterio delle vie candidate in base a resa, costo,
+      sicurezza e sostenibilità.
+  BC-4600.20:
+    name: Ricerca sulla cinetica e sulla termodinamica delle reazioni
+    description: |
+      Generazione di dati cinetici e termodinamici necessari per la modellazione
+      e la progettazione dei processi chimici.
+  BC-4600.20.10:
+    name: Misurazione della cinetica di reazione
+    description: |
+      Misurazione delle velocità di reazione e delle costanti di velocità
+      in condizioni controllate.
+  BC-4600.20.20:
+    name: Misurazione delle proprietà termodinamiche
+    description: |
+      Determinazione di entalpia, entropia e capacità termica per
+      reagenti e prodotti.
+  BC-4600.20.30:
+    name: Studi sugli equilibri di fase
+    description: |
+      Sperimentazione degli equilibri vapore-liquido, liquido-liquido
+      e solido-liquido.
+  BC-4600.20.40:
+    name: Sviluppo del modello cinetico
+    description: |
+      Adattamento e validazione di modelli cinetici rispetto ai dati misurati.
+  BC-4600.30:
+    name: Sviluppo e ottimizzazione del processo
+    description: |
+      Sviluppo e ottimizzazione a scala da banco delle finestre operative
+      del processo chimico prima delle prove in impianto pilota.
+  BC-4600.30.10:
+    name: Design of experiments a scala da banco
+    description: |
+      Design of experiments (DoE) a scala da banco per caratterizzare
+      il comportamento del processo.
+  BC-4600.30.20:
+    name: Ottimizzazione dei parametri di processo
+    description: |
+      Ottimizzazione di temperatura, pressione, tempo di residenza
+      e stechiometria.
+  BC-4600.30.30:
+    name: Miglioramento di resa e selettività
+    description: |
+      Miglioramento di resa e selettività attraverso interventi
+      di ingegneria di reazione.
+  BC-4600.30.40:
+    name: Selezione del sistema solvente
+    description: |
+      Selezione e ottimizzazione dei sistemi solvente bilanciando
+      prestazioni e requisiti HSE.
+  BC-4600.40:
+    name: Gestione delle operazioni dell'impianto pilota
+    description: |
+      Pianificazione, esecuzione e analisi di campagne produttive a scala pilota
+      per ridurre i rischi dello scale-up commerciale.
+  BC-4600.40.10:
+    name: Pianificazione della campagna pilota
+    description: |
+      Pianificazione delle campagne in impianto pilota, inclusi obiettivi
+      e bilanci di massa.
+  BC-4600.40.20:
+    name: Esecuzione dell'impianto pilota
+    description: |
+      Esecuzione delle prove pilota in condizioni di processo rappresentative.
+  BC-4600.40.30:
+    name: Analisi dei dati pilota
+    description: |
+      Analisi dei dati pilota per affinare i modelli cinetici e di resa.
+  BC-4600.40.40:
+    name: Gestione dei beni dell'impianto pilota
+    description: |
+      Gestione del ciclo di vita delle apparecchiature e della strumentazione
+      dell'impianto pilota.
+  BC-4600.50:
+    name: Gestione dello scale-up del processo
+    description: |
+      Trasformazione dei processi a scala pilota in definizioni di processo
+      commerciale validate.
+  BC-4600.50.10:
+    name: Modellazione dello scale-up
+    description: |
+      Utilizzo dell'analisi dimensionale e della CFD per modellare
+      gli effetti dello scale-up.
+  BC-4600.50.20:
+    name: Validazione a scala dimostrativa
+    description: |
+      Esercizio di impianti a scala dimostrativa per validare
+      le ipotesi dello scale-up.
+  BC-4600.50.30:
+    name: Definizione del processo commerciale
+    description: |
+      Finalizzazione della base del processo commerciale pronta per il FEED.
+  BC-4600.60:
+    name: Screening dei pericoli di sicurezza di processo
+    description: |
+      Screening in fase iniziale dei pericoli reattivi, termici e da polveri
+      durante la ricerca e lo sviluppo.
+  BC-4600.60.10:
+    name: Screening della chimica reattiva
+    description: |
+      Screening dei pericoli della chimica reattiva mediante DSC, ARC
+      e calorimetria Calvet.
+  BC-4600.60.20:
+    name: Test di stabilità termica
+    description: |
+      Determinazione delle temperature di innesco della decomposizione termica
+      e del potenziale di runaway.
+  BC-4600.60.30:
+    name: Caratterizzazione dei pericoli da polveri
+    description: |
+      Caratterizzazione dei pericoli da polveri combustibili, inclusi Kst e MIE.
+  BC-4600.70:
+    name: Gestione della conoscenza e dei dati di R&D
+    description: |
+      Acquisizione e gestione della conoscenza di R&D, dei registri degli esperimenti
+      e degli asset di dati di processo.
+  BC-4600.70.10:
+    name: Gestione del quaderno di laboratorio elettronico
+    description: |
+      Gestione dei quaderni di laboratorio elettronici per la R&D chimica.
+  BC-4600.70.20:
+    name: Gestione del repository della conoscenza di processo
+    description: |
+      Curatela della conoscenza di processo attraverso le fasi di scoperta,
+      sviluppo e scale-up.
+  BC-4600.70.30:
+    name: Curatela dei dati di R&D
+    description: |
+      Curatela, conservazione e riutilizzo dei dati strutturati degli
+      esperimenti di R&D.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-citizen-constituent-service-management.yaml
+++ b/catalogue/i18n/it/L1-citizen-constituent-service-management.yaml
@@ -1,0 +1,126 @@
+# Gestione dei servizi ai cittadini e ai costituenti (it) — translations for L1-citizen-constituent-service-management.yaml
+locale: it
+source: L1-citizen-constituent-service-management.yaml
+entries:
+  BC-3220:
+    name: Gestione dei servizi ai cittadini e ai costituenti
+    description: |
+      Erogazione multicanale di servizi pubblici a cittadini, residenti e costituenti, incluse autenticazione dell'identità, gestione dei casi, richieste di informazioni, ricorsi e partecipazione.
+  BC-3220.10:
+    name: Operazioni dei canali di servizio
+    description: |
+      Gestione dei canali fisici, telefonici, postali, digitali e mobili attraverso cui i cittadini accedono ai servizi pubblici.
+    in_scope:
+      - Centri di servizio unico e sportelli di accoglienza
+      - Canali di contact center e telefonia
+      - Portali digitali e app mobili
+      - Canali postali e basati su moduli
+    out_of_scope:
+      - Verifica dell'identità dei cittadini (coperta dalla Identità e autenticazione del cittadino)
+  BC-3220.10.10:
+    name: Operazioni dello sportello unico
+    description: |
+      Gestione dei centri di servizio fisici e degli sportelli unici tra le agenzie.
+  BC-3220.10.20:
+    name: Operazioni del contact center
+    description: |
+      Gestione dei contact center telefonici e via chat di più agenzie.
+  BC-3220.10.30:
+    name: Operazioni del portale digitale di servizio
+    description: |
+      Gestione dei portali digitali rivolti ai cittadini e delle app mobili per i servizi.
+  BC-3220.10.40:
+    name: Garanzia di accessibilità del servizio
+    description: |
+      Garanzia di accessibilità WCAG e Section 508 su tutti i canali di servizio e supporto alle tecnologie assistive.
+  BC-3220.20:
+    name: Identità e autenticazione del cittadino
+    description: |
+      Istituzione e verifica delle identità digitali dei cittadini, delle credenziali e dei livelli di garanzia per l'accesso ai servizi pubblici.
+  BC-3220.20.10:
+    name: Verifica dell'identità
+    description: |
+      Verifica dell'identità allineata ai livelli NIST 800-63 IAL o ai livelli di garanzia eIDAS.
+  BC-3220.20.20:
+    name: Emissione delle credenziali
+    description: |
+      Emissione di autenticatori e credenziali per l'accesso ai servizi pubblici.
+  BC-3220.20.30:
+    name: Operazioni di autenticazione
+    description: |
+      Autenticazione quotidiana dei cittadini nei confronti dei servizi pubblici.
+  BC-3220.20.40:
+    name: Federazione e fiducia transfrontaliera
+    description: |
+      Federazione dell'identità tra le agenzie e fiducia transfrontaliera ai sensi di eIDAS o equivalente.
+  BC-3220.30:
+    name: Gestione dei casi dei cittadini
+    description: |
+      Gestione del ciclo di vita end-to-end dei casi dei cittadini tra agenzie e programmi.
+  BC-3220.30.10:
+    name: Ricezione e triage dei casi
+    description: |
+      Ricezione, classificazione e triage dei casi dei cittadini.
+  BC-3220.30.20:
+    name: Instradamento e assegnazione dei casi
+    description: |
+      Instradamento dei casi agli operatori e alle agenzie in base alla competenza e alle regole.
+  BC-3220.30.30:
+    name: Avanzamento e risoluzione dei casi
+    description: |
+      Avanzamento dei casi attraverso i flussi di lavoro del servizio fino alla risoluzione.
+  BC-3220.30.40:
+    name: Chiusura e revisione della qualità dei casi
+    description: |
+      Chiusura, revisione della qualità e rielaborazione dei casi completati.
+  BC-3220.40:
+    name: Gestione delle richieste di servizio e delle informazioni
+    description: |
+      Gestione di richieste di informazioni, istanze, reclami e domande di accesso agli atti su tutti i canali.
+  BC-3220.40.10:
+    name: Gestione delle richieste generali
+    description: |
+      Gestione delle richieste generali e delle domande di informazioni.
+  BC-3220.40.20:
+    name: Gestione dei reclami
+    description: |
+      Ricezione, istruttoria e risoluzione dei reclami dei cittadini.
+  BC-3220.40.30:
+    name: Gestione delle richieste di accesso agli atti
+    description: |
+      Gestione delle richieste di accesso agli atti e alle informazioni in possesso della pubblica amministrazione.
+  BC-3220.50:
+    name: Gestione dei ricorsi e del Difensore civico
+    description: |
+      Revisione amministrativa indipendente delle decisioni delle agenzie, inclusi ricorsi, tribunali e indagini del Difensore civico.
+  BC-3220.50.10:
+    name: Ricezione dei ricorsi amministrativi
+    description: |
+      Ricezione e validazione dei ricorsi amministrativi avverso le decisioni delle agenzie.
+  BC-3220.50.20:
+    name: Udienza e decisione sui ricorsi
+    description: |
+      Trattazione dei ricorsi e adozione delle decisioni da parte delle autorità di revisione.
+  BC-3220.50.30:
+    name: Indagine del Difensore civico
+    description: |
+      Indagine indipendente del Difensore civico sui reclami di cattiva amministrazione.
+  BC-3220.60:
+    name: Partecipazione e coinvolgimento dei cittadini
+    description: |
+      Coinvolgimento bidirezionale con i cittadini attraverso piattaforme partecipative, petizioni e canali di feedback.
+  BC-3220.60.10:
+    name: Gestione di petizioni e iniziative civiche
+    description: |
+      Ricezione, validazione e risposta a petizioni e proposte di iniziativa civica.
+  BC-3220.60.20:
+    name: Operazioni delle piattaforme partecipative
+    description: |
+      Gestione di piattaforme di bilancio partecipativo, deliberazione e co-creazione.
+  BC-3220.60.30:
+    name: Misurazione della soddisfazione dei cittadini
+    description: |
+      Misurazione della soddisfazione, della fiducia e dell'esperienza di servizio dei cittadini.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-civil-records-identity-registration-management.yaml
+++ b/catalogue/i18n/it/L1-civil-records-identity-registration-management.yaml
@@ -1,0 +1,125 @@
+# Gestione dell'anagrafe e della registrazione dell'identità (it) — translations for L1-civil-records-identity-registration-management.yaml
+locale: it
+source: L1-civil-records-identity-registration-management.yaml
+entries:
+  BC-3290:
+    name: Gestione dell'anagrafe e della registrazione dell'identità
+    description: |
+      Registrazione e custodia di atti civili e di legge, inclusi eventi vitali, identità nazionale, registri di imprese ed enti e catasto, con controlli di autenticazione, divulgazione e privacy.
+  BC-3290.10:
+    name: Gestione dei registri dello stato civile
+    description: |
+      Registrazione degli eventi vitali, inclusi nascite, decessi, matrimoni, unioni civili e divorzi.
+    in_scope:
+      - Registrazione di nascite, decessi, matrimoni e divorzi
+      - Certificazione degli eventi vitali
+      - Estrazione delle statistiche dello stato civile
+    out_of_scope:
+      - Rilascio del codice fiscale (coperto dalla Registrazione dell'identità nazionale)
+  BC-3290.10.10:
+    name: Registrazione delle nascite
+    description: |
+      Registrazione delle nascite e rilascio dei certificati di nascita.
+  BC-3290.10.20:
+    name: Registrazione dei decessi
+    description: |
+      Registrazione dei decessi e rilascio dei certificati di morte.
+  BC-3290.10.30:
+    name: Registrazione di matrimoni e unioni civili
+    description: |
+      Registrazione dei matrimoni e delle unioni civili e rilascio dei relativi certificati.
+  BC-3290.10.40:
+    name: Registrazione di divorzi e annullamenti
+    description: |
+      Registrazione di divorzi, annullamenti e sentenze di scioglimento del matrimonio.
+  BC-3290.20:
+    name: Registrazione dell'identità nazionale
+    description: |
+      Istituzione, manutenzione e autenticazione dei registri e delle credenziali di identità nazionale.
+  BC-3290.20.10:
+    name: Iscrizione all'anagrafe
+    description: |
+      Iscrizione di cittadini e residenti nel sistema di identità nazionale.
+  BC-3290.20.20:
+    name: Acquisizione e deduplicazione dei dati biometrici
+    description: |
+      Acquisizione, deduplicazione e corrispondenza degli identificatori biometrici.
+  BC-3290.20.30:
+    name: Rilascio delle credenziali di identità
+    description: |
+      Produzione e rilascio di carte d'identità nazionali e credenziali digitali.
+  BC-3290.20.40:
+    name: Aggiornamento e ciclo di vita dell'identità
+    description: |
+      Aggiornamento degli attributi identitari, degli eventi del ciclo di vita e reemissione delle credenziali.
+  BC-3290.30:
+    name: Gestione del registro di imprese ed enti
+    description: |
+      Registrazione di società, società di persone, associazioni e altri enti giuridici e manutenzione dei dati di registro.
+  BC-3290.30.10:
+    name: Registrazione degli enti
+    description: |
+      Registrazione di società, società di persone, associazioni e altri enti.
+  BC-3290.30.20:
+    name: Elaborazione dei depositi annuali
+    description: |
+      Ricezione ed elaborazione di bilanci annuali, relazioni e depositi degli amministratori.
+  BC-3290.30.30:
+    name: Gestione del registro della titolarità effettiva
+    description: |
+      Manutenzione delle dichiarazioni di titolarità effettiva e di controllo.
+  BC-3290.30.40:
+    name: Scioglimento e cancellazione degli enti
+    description: |
+      Cancellazione, scioglimento e ripristino di enti giuridici.
+  BC-3290.40:
+    name: Gestione del catasto e del registro fondiario
+    description: |
+      Registrazione di titoli fondiari, servitù, ipoteche e particelle catastali e manutenzione dei registri fondiari.
+  BC-3290.40.10:
+    name: Registrazione dei titoli fondiari
+    description: |
+      Registrazione di titoli fondiari, trasferimenti e diritti di proprietà.
+  BC-3290.40.20:
+    name: Registrazione di oneri e ipoteche
+    description: |
+      Registrazione di ipoteche, servitù e altri oneri.
+  BC-3290.40.30:
+    name: Manutenzione delle mappe catastali
+    description: |
+      Manutenzione dei confini delle particelle catastali e dei documenti di rilievo.
+  BC-3290.50:
+    name: Autenticazione degli atti e apostille
+    description: |
+      Autenticazione di documenti pubblici per uso nazionale e internazionale, inclusi i servizi di apostille ai sensi della Convenzione dell'Aia.
+  BC-3290.50.10:
+    name: Autenticazione dei documenti
+    description: |
+      Autenticazione di documenti pubblici per uso giuridico e amministrativo.
+  BC-3290.50.20:
+    name: Rilascio dell'apostille
+    description: |
+      Rilascio di apostille ai sensi della Convenzione dell'Aia del 1961.
+  BC-3290.50.30:
+    name: Coordinamento dei servizi notarili
+    description: |
+      Coordinamento dei servizi notarili ove prestati dalla pubblica amministrazione.
+  BC-3290.60:
+    name: Divulgazione degli atti e privacy
+    description: |
+      Divulgazione controllata, oscuramento e gestione della privacy degli atti civili e di legge.
+  BC-3290.60.10:
+    name: Servizi di ricerca pubblica
+    description: |
+      Fornitura di servizi di ricerca e certificazione sui registri civili accessibili al pubblico.
+  BC-3290.60.20:
+    name: Gestione della divulgazione riservata
+    description: |
+      Gestione delle divulgazioni riservate, incluse adozione, protezione dei testimoni e cauzioni di sicurezza.
+  BC-3290.60.30:
+    name: Privacy e oscuramento degli atti
+    description: |
+      Applicazione dei controlli sulla privacy e dell'oscuramento agli atti civili prima della divulgazione.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-classified-information-security-management.yaml
+++ b/catalogue/i18n/it/L1-classified-information-security-management.yaml
@@ -1,0 +1,115 @@
+# Gestione della sicurezza delle informazioni classificate (it) — translations for L1-classified-information-security-management.yaml
+locale: it
+source: L1-classified-information-security-management.yaml
+entries:
+  BC-1810:
+    name: Gestione della sicurezza delle informazioni classificate
+    description: |
+      Nulla osta di sicurezza del personale, classificazione delle informazioni, sicurezza industriale, COMSEC e minacce interne.
+  BC-1810.10:
+    name: Gestione del nulla osta di sicurezza del personale
+    description: |
+      Domande di nulla osta, reinvestigazione periodica e debriefing.
+  BC-1810.10.10:
+    name: Trattamento delle domande di nulla osta di sicurezza
+    description: |
+      Sponsorizzazione e trattamento delle domande di nulla osta di sicurezza del personale.
+  BC-1810.10.20:
+    name: Reinvestigazione periodica del personale autorizzato
+    description: |
+      Reinvestigazione periodica e valutazione continua del personale autorizzato.
+  BC-1810.10.30:
+    name: Indottrinamento e debriefing del personale autorizzato
+    description: |
+      Indottrinamento alla sicurezza, esecuzione degli NDA e debriefing del personale.
+  BC-1810.20:
+    name: Gestione della classificazione delle informazioni
+    description: |
+      Classificazione, declassificazione e caveat di gestione delle informazioni.
+  BC-1810.20.10:
+    name: Decisioni di classificazione originale
+    description: |
+      Decisioni dell'autorità di classificazione originale (OCA).
+  BC-1810.20.20:
+    name: Classificazione derivativa delle informazioni
+    description: |
+      Classificazione derivativa di nuovi documenti da materiale esistente.
+  BC-1810.20.30:
+    name: Revisione per la declassificazione
+    description: |
+      Revisione sistematica e obbligatoria per la declassificazione.
+  BC-1810.20.40:
+    name: Caveat di gestione e marcatura delle informazioni classificate
+    description: |
+      Applicazione dei caveat di gestione, del controllo della diffusione e delle marcature di classificazione.
+  BC-1810.30:
+    name: Gestione della sicurezza fisica della difesa
+    description: |
+      Strutture autorizzate, SCIF e aree protette.
+  BC-1810.30.10:
+    name: Accreditamento delle strutture autorizzate
+    description: |
+      Accreditamento e mantenimento delle strutture autorizzate alla gestione di materiale classificato.
+  BC-1810.30.20:
+    name: Operatività dei SCIF
+    description: |
+      Gestione delle Sensitive Compartmented Information Facility (SCIF).
+  BC-1810.30.30:
+    name: Controllo degli accessi alle aree protette
+    description: |
+      Controllo degli accessi e gestione dei visitatori nelle aree protette.
+  BC-1810.40:
+    name: Gestione della sicurezza industriale
+    description: |
+      Conformità NISPOM o equivalente, FOCI e sicurezza della supply chain.
+  BC-1810.40.10:
+    name: Gestione della conformità NISPOM
+    description: |
+      Conformità al NISPOM/32 CFR 117 o alle norme nazionali equivalenti.
+  BC-1810.40.20:
+    name: Gestione della proprietà e dell'influenza straniera (FOCI)
+    description: |
+      Valutazione della FOCI e accordi di mitigazione.
+  BC-1810.40.30:
+    name: Verifica della sicurezza della supply chain
+    description: |
+      Verifica dei partner della supply chain autorizzati e allineamento con CMMC.
+  BC-1810.40.40:
+    name: Amministrazione dei contratti classificati
+    description: |
+      Amministrazione dei requisiti di sicurezza dei contratti classificati tramite DD Form 254.
+  BC-1810.50:
+    name: Gestione COMSEC
+    description: |
+      Sicurezza delle comunicazioni e gestione delle chiavi crittografiche.
+  BC-1810.50.10:
+    name: Gestione dell'account COMSEC
+    description: |
+      Gestione degli account COMSEC e responsabilità del custode.
+  BC-1810.50.20:
+    name: Gestione delle chiavi crittografiche
+    description: |
+      Gestione delle chiavi crittografiche inclusi EKMS/KMI.
+  BC-1810.50.30:
+    name: Custodia delle apparecchiature COMSEC
+    description: |
+      Custodia e responsabilità delle apparecchiature COMSEC.
+  BC-1810.60:
+    name: Gestione delle minacce interne
+    description: |
+      Programmi per le minacce interne, monitoraggio e risposta.
+  BC-1810.60.10:
+    name: Operatività del programma per le minacce interne
+    description: |
+      Operatività del programma per le minacce interne ai sensi dell'E.O. 13587.
+  BC-1810.60.20:
+    name: Monitoraggio dell'attività degli utenti
+    description: |
+      Monitoraggio dell'attività degli utenti sui sistemi informativi classificati.
+  BC-1810.60.30:
+    name: Investigazione sulle minacce interne
+    description: |
+      Investigazione sugli indicatori e sugli incidenti di minaccia interna.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-client-engagement-management.yaml
+++ b/catalogue/i18n/it/L1-client-engagement-management.yaml
@@ -1,0 +1,211 @@
+# Gestione del cliente (it) — translations for L1-client-engagement-management.yaml
+locale: it
+source: L1-client-engagement-management.yaml
+entries:
+  BC-4300:
+    name: Gestione del cliente
+    description: |
+      Ciclo di vita dell'acquisizione del cliente e della commessa, definizione dell'ambito,
+      mobilizzazione, controllo delle modifiche, chiusura e gestione continuativa delle relazioni
+      con i clienti in ambiti legale, advisory e di revisione e assurance.
+  BC-4300.10:
+    name: Gestione dell'accettazione del cliente
+    description: |
+      Accettazione di nuove relazioni con i clienti, inclusi KYC, screening AML,
+      verifiche su sanzioni e PEP e verifica della titolarità effettiva
+      prima di accettare qualsiasi incarico.
+    in_scope:
+      - KYC e clearance AML per nuovi clienti
+      - Screening su sanzioni e PEP per clienti potenziali
+      - Verifiche sulla titolarità effettiva e sull'origine dei fondi
+      - Aggiornamento periodico dei fascicoli KYC dei clienti
+    out_of_scope:
+      - Valutazione di indipendenza e conflitti di interesse (BC-4350)
+      - Accettazione del rischio specifico dell'incarico (BC-4300.20)
+  BC-4300.10.10:
+    name: Raccolta dei dati KYC del cliente
+    description: |
+      Raccolta di informazioni identificative, sulla titolarità effettiva
+      e sull'origine dei fondi per clienti potenziali ed esistenti.
+  BC-4300.10.20:
+    name: Screening del cliente su sanzioni e PEP
+    description: |
+      Screening di clienti e titolari effettivi rispetto a liste
+      di sanzioni, PEP e media avverse.
+  BC-4300.10.30:
+    name: Rating del rischio del cliente
+    description: |
+      Rating del rischio della relazione con il cliente per determinare
+      la profondità della due diligence e la cadenza di revisione.
+  BC-4300.10.40:
+    name: Aggiornamento periodico della due diligence sul cliente
+    description: |
+      Aggiornamento periodico di KYC, assetti proprietari
+      e rating di rischio del cliente.
+  BC-4300.20:
+    name: Gestione dell'accettazione dell'incarico
+    description: |
+      Workflow decisionale per accettare o declinare un incarico specifico, che tiene conto
+      della clearance su indipendenza e conflitti, della valutazione della capacità,
+      della fattibilità economica e della valutazione del rischio specifico.
+    in_scope:
+      - Valutazione del rischio dell'incarico
+      - Verifica di capacità e competenze
+      - Decisione go/no-go per l'incarico
+    out_of_scope:
+      - Verifiche sostanziali di indipendenza e conflitti (BC-4350)
+      - Attività di pursuit e proposta (BC-4360)
+  BC-4300.20.10:
+    name: Valutazione del rischio dell'incarico
+    description: |
+      Valutazione del rischio specifico dell'incarico, inclusi la complessità
+      della materia, l'integrità del cliente e la recuperabilità degli onorari.
+  BC-4300.20.20:
+    name: Verifica di capacità e competenze
+    description: |
+      Conferma che lo studio disponga della competenza tecnica
+      e della capacità di risorse per eseguire l'incarico.
+  BC-4300.20.30:
+    name: Decisione go/no-go per l'incarico
+    description: |
+      Decisione go/no-go a livello di partner che integra rischio,
+      conflitti, indipendenza, capacità e input commerciali.
+  BC-4300.30:
+    name: Gestione dell'ambito e dei termini dell'incarico
+    description: |
+      Definizione dell'ambito dell'incarico, dei deliverable, delle ipotesi,
+      dei termini economici e della lettera d'incarico o dell'accordo di retainer.
+    in_scope:
+      - Definizione dell'ambito dei servizi
+      - Bozza della struttura economica e dei termini
+      - Emissione della lettera d'incarico o dell'accordo di retainer
+    out_of_scope:
+      - Strategia di pricing a livello di studio (BC-4360.50)
+      - Proposta nella fase di pursuit (BC-4360.30)
+  BC-4300.30.10:
+    name: Definizione dell'ambito dell'incarico
+    description: |
+      Definizione di servizi, deliverable, ipotesi, esclusioni
+      e dipendenze per l'incarico.
+  BC-4300.30.20:
+    name: Bozza della lettera d'incarico
+    description: |
+      Bozza di lettere d'incarico e accordi di retainer allineati
+      ai template dello studio e agli standard professionali applicabili.
+  BC-4300.30.30:
+    name: Negoziazione dei termini dell'incarico
+    description: |
+      Negoziazione dei termini dell'incarico con il cliente, inclusi
+      massimali di responsabilità, legge applicabile e clausole di risoluzione delle controversie.
+  BC-4300.30.40:
+    name: Sottoscrizione della lettera d'incarico
+    description: |
+      Firma, controfirma e archiviazione delle lettere d'incarico firmate
+      come precondizione per la mobilizzazione dell'incarico.
+  BC-4300.40:
+    name: Gestione della mobilizzazione dell'incarico
+    description: |
+      Avvio operativo di un incarico accettato, inclusi la formazione del team,
+      il kickoff, l'accesso sicuro ai dati e la configurazione dell'infrastruttura dell'incarico.
+  BC-4300.40.10:
+    name: Formazione del team dell'incarico
+    description: |
+      Identificazione e conferma dei ruoli di partner, manager
+      e staff nel team dell'incarico.
+  BC-4300.40.20:
+    name: Gestione del kickoff dell'incarico
+    description: |
+      Riunioni di kickoff interne e rivolte al cliente, materiali di briefing
+      e conferma degli obiettivi e delle modalità di lavoro.
+  BC-4300.40.30:
+    name: Configurazione dell'accesso ai dati dell'incarico
+    description: |
+      Provisioning di data room sicure, portali clienti e credenziali di accesso
+      specifici per l'incarico.
+  BC-4300.40.40:
+    name: Configurazione dell'infrastruttura dell'incarico
+    description: |
+      Configurazione dei codici di incarico, delle strutture di fatturazione
+      e della numerazione delle pratiche nei sistemi dello studio.
+  BC-4300.50:
+    name: Gestione delle modifiche all'incarico
+    description: |
+      Controllo delle modifiche all'ambito, agli onorari, alle tempistiche
+      o alla composizione del team dopo la firma della lettera d'incarico.
+  BC-4300.50.10:
+    name: Gestione delle richieste di modifica dell'ambito
+    description: |
+      Raccolta, valutazione e definizione delle richieste di modifica dell'ambito
+      dal cliente o dal team dell'incarico.
+  BC-4300.50.20:
+    name: Approvazione delle variazioni di onorario
+    description: |
+      Workflow di approvazione per rettifiche degli onorari, retainer aggiuntivi
+      e autorizzazioni per lavori fuori ambito.
+  BC-4300.50.30:
+    name: Modifica alla lettera d'incarico
+    description: |
+      Emissione e sottoscrizione di addendum e lettere integrative
+      che recepiscono le modifiche approvate all'incarico.
+  BC-4300.60:
+    name: Gestione della chiusura dell'incarico
+    description: |
+      Conclusione degli incarichi completati, inclusi la consegna dei deliverable,
+      la conservazione dei documenti di lavoro, il trigger della fatturazione finale
+      e il debriefing post-incarico.
+  BC-4300.60.10:
+    name: Gestione della consegna dei deliverable
+    description: |
+      Consegna finale di report, pareri e prodotti di lavoro al cliente
+      con relativa trasmissione.
+  BC-4300.60.20:
+    name: Configurazione della conservazione del fascicolo
+    description: |
+      Chiusura del fascicolo dell'incarico e configurazione delle policy
+      di conservazione, recupero e distruzione.
+  BC-4300.60.30:
+    name: Debriefing e lezioni apprese dell'incarico
+    description: |
+      Revisione post-incarico con il team per raccogliere
+      le lezioni apprese e le azioni di miglioramento.
+  BC-4300.60.40:
+    name: Comunicazione di chiusura al cliente
+    description: |
+      Comunicazione di chiusura al cliente, inclusi report finale,
+      survey di soddisfazione e pianificazione del follow-up.
+  BC-4300.70:
+    name: Gestione della relazione con il cliente
+    description: |
+      Gestione continuativa delle relazioni strategiche con i clienti, inclusi
+      la responsabilità del partner di relazione, la pianificazione dell'account
+      e il coordinamento cross-practice.
+    in_scope:
+      - Assegnazione del partner di relazione
+      - Pianificazione dell'account su più incarichi
+      - Monitoraggio della soddisfazione del cliente
+    out_of_scope:
+      - Attività di pursuit e proposta (BC-4360)
+      - CRM generico (BC-3060)
+  BC-4300.70.10:
+    name: Assegnazione del partner di relazione
+    description: |
+      Assegnazione e rotazione del partner di relazione principale
+      per ogni cliente strategico.
+  BC-4300.70.20:
+    name: Pianificazione dell'account cliente
+    description: |
+      Pianificazione a livello di account sul portafoglio di incarichi con un singolo cliente,
+      inclusi share-of-wallet e obiettivi di relazione.
+  BC-4300.70.30:
+    name: Monitoraggio della soddisfazione del cliente
+    description: |
+      Raccolta del feedback del cliente, NPS o misure equivalenti
+      ed escalation dei segnali di insoddisfazione.
+  BC-4300.70.40:
+    name: Coordinamento cross-practice del cliente
+    description: |
+      Coordinamento tra gruppi di practice e aree geografiche
+      che servono un cliente comune.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-clinical-care-delivery-management.yaml
+++ b/catalogue/i18n/it/L1-clinical-care-delivery-management.yaml
@@ -1,0 +1,180 @@
+# Gestione dell'erogazione dell'assistenza clinica (it) — translations for L1-clinical-care-delivery-management.yaml
+locale: it
+source: L1-clinical-care-delivery-management.yaml
+entries:
+  BC-2810:
+    name: Gestione dell'erogazione dell'assistenza clinica
+    description: |
+      Erogazione dell'assistenza clinica diretta nei contesti di ricovero, ambulatoriale, d'emergenza,
+      chirurgico, materno, di salute mentale, riabilitativo e domiciliare.
+  BC-2810.10:
+    name: Erogazione dell'assistenza in regime di ricovero
+    description: |
+      Erogazione dell'assistenza acuta, intermedia e intensiva in regime di ricovero, incluse
+      valutazione, visite, assistenza al letto del paziente e gestione della terapia intensiva.
+  BC-2810.10.10:
+    name: Valutazione all'ammissione
+    description: |
+      Anamnesi e visita, valutazione infermieristica e screening del rischio all'ammissione.
+  BC-2810.10.20:
+    name: Visite cliniche
+    description: |
+      Visite cliniche multidisciplinari e pianificazione delle cure al letto del paziente.
+  BC-2810.10.30:
+    name: Assistenza al letto del paziente
+    description: |
+      Assistenza infermieristica e clinica diretta al letto del paziente, incluso il supporto nelle attività quotidiane.
+  BC-2810.10.40:
+    name: Operazioni di terapia intensiva
+    description: |
+      Operazioni di terapia intensiva comprendenti gestione del ventilatore, monitoraggio emodinamico e sorveglianza continua.
+  BC-2810.20:
+    name: Erogazione dell'assistenza ambulatoriale
+    description: |
+      Erogazione di servizi ambulatoriali, di telehealth e di procedure e trattamenti in regime
+      di day hospital e poliambulatorio.
+  BC-2810.20.10:
+    name: Conduzione della visita ambulatoriale
+    description: |
+      Conduzione di visite in studio e in clinica, incluse consultazioni di cure primarie e specialistiche.
+  BC-2810.20.20:
+    name: Erogazione di procedure ambulatoriali
+    description: |
+      Erogazione di procedure in regime ambulatoriale e di day surgery, inclusi interventi minori e infusioni.
+  BC-2810.20.30:
+    name: Erogazione di incontri in telehealth
+    description: |
+      Erogazione di incontri in telehealth sincroni e asincroni.
+  BC-2810.20.40:
+    name: Somministrazione di trattamenti ambulatoriali
+    description: |
+      Somministrazione di trattamenti ambulatoriali quali chemioterapia, dialisi e infusioni.
+  BC-2810.30:
+    name: Erogazione dell'assistenza d'emergenza
+    description: |
+      Erogazione del triage del pronto soccorso, stabilizzazione, risposta ai traumi e decisioni
+      di destinazione per le cure non programmate.
+  BC-2810.30.10:
+    name: Triage del pronto soccorso
+    description: |
+      Triage e assegnazione dell'acuità ai pazienti che accedono al pronto soccorso.
+  BC-2810.30.20:
+    name: Stabilizzazione d'emergenza
+    description: |
+      Valutazione iniziale, rianimazione e stabilizzazione di pazienti acutamente malati o traumatizzati.
+  BC-2810.30.30:
+    name: Risposta al trauma
+    description: |
+      Attivazione del team trauma, risposta del team e gestione damage-control per i casi di trauma maggiore.
+  BC-2810.30.40:
+    name: Destinazione dal pronto soccorso
+    description: |
+      Decisioni di destinazione dal pronto soccorso, incluse ammissione, trasferimento, osservazione e dimissione.
+  BC-2810.40:
+    name: Erogazione dell'assistenza chirurgica e procedurale
+    description: |
+      Assistenza pre-, intra- e post-operatoria per procedure chirurgiche e interventistiche
+      nelle sale operatorie e nelle sale procedurali.
+  BC-2810.40.10:
+    name: Assistenza pre-operatoria
+    description: |
+      Valutazione pre-operatoria, ottimizzazione e assistenza nell'area di attesa.
+  BC-2810.40.20:
+    name: Gestione intra-operatoria
+    description: |
+      Assistenza chirurgica, anestesiologica e del team di sala in fase intra-operatoria.
+  BC-2810.40.30:
+    name: Assistenza post-anestesia
+    description: |
+      Recupero in unità di cura post-anestesia e valutazione dell'idoneità alla dimissione.
+  BC-2810.40.40:
+    name: Endoscopia e procedure interventistiche
+    description: |
+      Erogazione di procedure endoscopiche, di radiologia interventistica e di cardiologia interventistica.
+  BC-2810.50:
+    name: Erogazione dell'assistenza materno-neonatale
+    description: |
+      Erogazione dell'assistenza antepartum, intrapartum, postpartum e neonatale nei servizi
+      di maternità e neonatologia.
+  BC-2810.50.10:
+    name: Assistenza antepartum
+    description: |
+      Valutazione prenatale, screening e ricoveri antepartum.
+  BC-2810.50.20:
+    name: Assistenza intrapartum
+    description: |
+      Gestione del travaglio e del parto, inclusi il taglio cesareo e il parto operativo.
+  BC-2810.50.30:
+    name: Assistenza postpartum
+    description: |
+      Recupero materno postpartum, supporto all'allattamento ed educazione postpartum.
+  BC-2810.50.40:
+    name: Assistenza neonatale
+    description: |
+      Assistenza al neonato sano, screening e erogazione dell'assistenza intensiva neonatale.
+  BC-2810.60:
+    name: Erogazione dell'assistenza di salute mentale
+    description: |
+      Assistenza di salute mentale attraverso valutazione psichiatrica, unità di ricovero psichiatrico,
+      terapia ambulatoriale e trattamento per disturbi da uso di sostanze.
+  BC-2810.60.10:
+    name: Valutazione psichiatrica
+    description: |
+      Valutazione psichiatrica e psicologica e intervento in crisi.
+  BC-2810.60.20:
+    name: Assistenza psichiatrica in regime di ricovero
+    description: |
+      Assistenza psichiatrica in regime di ricovero, inclusa la terapia ambientale e il trattamento farmacologico.
+  BC-2810.60.30:
+    name: Terapia comportamentale ambulatoriale
+    description: |
+      Psicoterapia ambulatoriale, terapia di gruppo e programmi di ospedalizzazione parziale.
+  BC-2810.60.40:
+    name: Assistenza per disturbi da uso di sostanze
+    description: |
+      Disintossicazione, trattamento farmacologico assistito e servizi di riabilitazione per disturbi da uso di sostanze.
+  BC-2810.70:
+    name: Servizi di riabilitazione e terapia
+    description: |
+      Servizi di riabilitazione fisica, occupazionale, logopedica e cardio-polmonare
+      nei contesti di ricovero e ambulatoriale.
+  BC-2810.70.10:
+    name: Fisioterapia
+    description: |
+      Valutazione e trattamento fisioterapico in contesti di ricovero e ambulatoriale.
+  BC-2810.70.20:
+    name: Terapia occupazionale
+    description: |
+      Valutazione e trattamento di terapia occupazionale finalizzati all'indipendenza funzionale.
+  BC-2810.70.30:
+    name: Logopedia
+    description: |
+      Servizi di terapia del linguaggio, della comunicazione e della deglutizione.
+  BC-2810.70.40:
+    name: Riabilitazione cardiaca e polmonare
+    description: |
+      Erogazione di programmi di riabilitazione cardiaca e polmonare.
+  BC-2810.80:
+    name: Erogazione dell'assistenza domiciliare e di comunità
+    description: |
+      Assistenza erogata a domicilio o nel contesto comunitario del paziente, incluse visite
+      domiciliari infermieristiche, cure palliative e monitoraggio a distanza.
+  BC-2810.80.10:
+    name: Visite di assistenza domiciliare
+    description: |
+      Visite domiciliari specialistiche, incluse assistenza infermieristica e terapia a domicilio.
+  BC-2810.80.20:
+    name: Cure palliative e hospice a domicilio
+    description: |
+      Assistenza di fine vita e cure palliative erogate a domicilio.
+  BC-2810.80.30:
+    name: Visite di salute di comunità
+    description: |
+      Visite degli operatori sanitari di comunità e programmi di outreach.
+  BC-2810.80.40:
+    name: Assistenza tramite monitoraggio remoto
+    description: |
+      Servizi di monitoraggio remoto del paziente per popolazioni con patologie croniche e post-acute.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-clinical-documentation-management.yaml
+++ b/catalogue/i18n/it/L1-clinical-documentation-management.yaml
@@ -1,0 +1,139 @@
+# Gestione della documentazione clinica (it) — translations for L1-clinical-documentation-management.yaml
+locale: it
+source: L1-clinical-documentation-management.yaml
+entries:
+  BC-2830:
+    name: Gestione della documentazione clinica
+    description: |
+      Documentazione dei clinici, CPOE, revisione dei referti, supporto decisionale clinico,
+      miglioramento della documentazione e workflow mediato dalla cartella clinica elettronica (CCE/EHR)
+      a supporto del registro attivo dell'assistenza al paziente.
+  BC-2830.10:
+    name: Documentazione delle note cliniche
+    description: |
+      Redazione di note cliniche per diversi tipi di incontro mediante modalità narrative,
+      strutturate, vocali e di acquisizione ambientale.
+  BC-2830.10.10:
+    name: Redazione delle note di evoluzione
+    description: |
+      Redazione di note di evoluzione per pazienti in regime di ricovero e ambulatoriale.
+  BC-2830.10.20:
+    name: Redazione dei referti procedurali
+    description: |
+      Redazione di referti operatori e procedurali.
+  BC-2830.10.30:
+    name: Redazione della lettera di dimissione
+    description: |
+      Redazione di lettere di dimissione e di trasferimento.
+  BC-2830.10.40:
+    name: Documentazione vocale e ambientale
+    description: |
+      Workflow di documentazione tramite dettatura vocale e acquisizione ambientale.
+  BC-2830.20:
+    name: CPOE (immissione computerizzata degli ordini)
+    description: |
+      Immissione degli ordini da parte del professionista per farmaci, diagnostica e procedure,
+      inclusi set di ordini e protocolli clinici.
+  BC-2830.20.10:
+    name: Immissione degli ordini farmacologici
+    description: |
+      Immissione da parte del professionista degli ordini farmacologici con dose, via di somministrazione e frequenza.
+  BC-2830.20.20:
+    name: Immissione degli ordini diagnostici
+    description: |
+      Immissione da parte del professionista degli ordini di laboratorio, diagnostica per immagini e altri esami.
+  BC-2830.20.30:
+    name: Immissione degli ordini procedurali
+    description: |
+      Immissione da parte del professionista degli ordini di procedure e consulenze.
+  BC-2830.20.40:
+    name: Utilizzo di set di ordini e protocolli
+    description: |
+      Utilizzo di set di ordini standardizzati, piani di potenza e protocolli clinici.
+  BC-2830.30:
+    name: Revisione e validazione dei referti
+    description: |
+      Instradamento, revisione e validazione dei referti diagnostici e gestione
+      della notifica dei valori critici.
+  BC-2830.30.10:
+    name: Notifica e instradamento dei referti
+    description: |
+      Instradamento dei referti ai professionisti ordinanti e a quelli di guardia.
+  BC-2830.30.20:
+    name: Presa in carico dei referti
+    description: |
+      Presa in carico e validazione da parte del professionista dei referti ricevuti.
+  BC-2830.30.30:
+    name: Comunicazione dei valori critici
+    description: |
+      Comunicazione entro i tempi previsti dei referti con valori critici e di panico.
+  BC-2830.30.40:
+    name: Revisione dell'andamento dei referti
+    description: |
+      Revisione dell'andamento dei referti e dei dati longitudinali all'interno della cartella clinica.
+  BC-2830.40:
+    name: Supporto decisionale clinico
+    description: |
+      Supporto decisionale clinico in tempo reale, inclusi alert, percorsi clinici,
+      calcolo di score di rischio e avvisi sulle buone pratiche cliniche.
+  BC-2830.40.10:
+    name: Alert per interazioni farmacologiche
+    description: |
+      Alert per interazioni farmaco-farmaco, farmaco-allergia e farmaco-malattia.
+  BC-2830.40.20:
+    name: Guida ai percorsi clinici
+    description: |
+      Supporto decisionale basato su percorsi e linee guida al punto di cura.
+  BC-2830.40.30:
+    name: Calcolo degli score di rischio
+    description: |
+      Visualizzazione degli score di rischio clinico, quali predittori di deterioramento e sepsi.
+  BC-2830.40.40:
+    name: Gestione degli avvisi sulle buone pratiche
+    description: |
+      Redazione, ottimizzazione e governance degli avvisi sulle buone pratiche cliniche.
+  BC-2830.50:
+    name: Miglioramento della documentazione clinica
+    description: |
+      Revisione contestuale e retrospettiva, query e programmi di formazione per migliorare
+      la completezza e la specificità della documentazione.
+  BC-2830.50.10:
+    name: Revisione contestuale della documentazione
+    description: |
+      Revisione contestuale della documentazione del ricovero per accuratezza e specificità clinica.
+  BC-2830.50.20:
+    name: Gestione delle query ai professionisti
+    description: |
+      Generazione e monitoraggio di query conformi sulla documentazione clinica.
+  BC-2830.50.30:
+    name: Audit della qualità della documentazione
+    description: |
+      Audit della qualità della documentazione clinica e dell'impatto sul case-mix index.
+  BC-2830.50.40:
+    name: Formazione dei professionisti sulla documentazione
+    description: |
+      Formazione dei professionisti sugli standard di documentazione e sulle opportunità di miglioramento.
+  BC-2830.60:
+    name: Gestione del workflow della CCE/EHR
+    description: |
+      Workflow della cartella clinica elettronica rivolto ai clinici, inclusi gestione della posta
+      in arrivo, dei compiti, della chiusura dell'incontro e delle consegne.
+  BC-2830.60.10:
+    name: Gestione della posta in arrivo e dei compiti
+    description: |
+      Gestione della posta in arrivo dei clinici, dei compiti e delle code di attività.
+  BC-2830.60.20:
+    name: Chiusura dell'incontro
+    description: |
+      Chiusura dell'incontro, inclusi codifica, fatturazione e completamento della documentazione.
+  BC-2830.60.30:
+    name: Documentazione per la copertura trasversale
+    description: |
+      Workflow di documentazione per la copertura trasversale e le guardie.
+  BC-2830.60.40:
+    name: Gestione delle liste pazienti e delle consegne
+    description: |
+      Gestione delle liste pazienti e della documentazione strutturata delle consegne tra turni.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-clinical-quality-safety-management.yaml
+++ b/catalogue/i18n/it/L1-clinical-quality-safety-management.yaml
@@ -1,0 +1,139 @@
+# Gestione della qualità clinica e della sicurezza (it) — translations for L1-clinical-quality-safety-management.yaml
+locale: it
+source: L1-clinical-quality-safety-management.yaml
+entries:
+  BC-2840:
+    name: Gestione della qualità clinica e della sicurezza
+    description: |
+      Gestione degli eventi di sicurezza del paziente, prevenzione e controllo delle infezioni,
+      misurazione degli esiti clinici, preparazione all'accreditamento, rischio clinico e
+      responsabilità civile, e programmi di miglioramento della qualità specifici per l'assistenza clinica.
+  BC-2840.10:
+    name: Gestione degli eventi di sicurezza del paziente
+    description: |
+      Rilevazione, indagine e gestione degli eventi di sicurezza del paziente,
+      inclusi eventi sentinella e quasi-incidenti.
+  BC-2840.10.10:
+    name: Segnalazione e rilevazione degli eventi
+    description: |
+      Segnalazione e rilevazione multicanale degli eventi di sicurezza del paziente e dei quasi-incidenti.
+  BC-2840.10.20:
+    name: Analisi delle cause radice
+    description: |
+      Analisi delle cause radice e delle cause apparenti degli eventi di sicurezza del paziente.
+  BC-2840.10.30:
+    name: Gestione degli eventi sentinella
+    description: |
+      Identificazione, risposta e segnalazione di eventi sentinella e never event.
+  BC-2840.10.40:
+    name: Indagine nella cultura equa
+    description: |
+      Revisione nella cultura equa dei fattori umani e delle responsabilità negli eventi di sicurezza.
+  BC-2840.20:
+    name: Prevenzione e controllo delle infezioni
+    description: |
+      Sorveglianza, prevenzione e controllo delle infezioni correlate all'assistenza sanitaria,
+      incluse la risposta alle epidemie e la stewardship antimicrobica.
+  BC-2840.20.10:
+    name: Sorveglianza delle infezioni correlate all'assistenza
+    description: |
+      Sorveglianza e segnalazione delle infezioni correlate all'assistenza sanitaria.
+  BC-2840.20.20:
+    name: Indagine sui focolai infettivi
+    description: |
+      Indagine e contenimento di cluster infettivi e focolai epidemici.
+  BC-2840.20.30:
+    name: Supervisione della sterilizzazione
+    description: |
+      Supervisione delle operazioni del reparto di sterilizzazione e della relativa conformità.
+  BC-2840.20.40:
+    name: Stewardship antimicrobica
+    description: |
+      Operazioni del programma di stewardship antimicrobica e supervisione delle prescrizioni.
+  BC-2840.30:
+    name: Misurazione degli esiti clinici
+    description: |
+      Misurazione e reportistica degli esiti clinici rispetto alle misure core, alle
+      sottomissioni ai registri e agli esiti riferiti dai pazienti.
+  BC-2840.30.10:
+    name: Reportistica delle misure core
+    description: |
+      Raccolta e sottomissione delle misure core di qualità regolatorie.
+  BC-2840.30.20:
+    name: Monitoraggio di mortalità e riammissioni
+    description: |
+      Monitoraggio della mortalità, delle riammissioni e degli esiti corretti per il rischio.
+  BC-2840.30.30:
+    name: Sottomissione ai registri di esito specialistici
+    description: |
+      Sottomissione a registri di esito specialistici quali quelli di cardiologia, chirurgia e ictus.
+  BC-2840.30.40:
+    name: Raccolta degli esiti riferiti dai pazienti
+    description: |
+      Raccolta e analisi degli esiti e delle misure di esperienza riferiti dai pazienti.
+  BC-2840.40:
+    name: Preparazione all'accreditamento e alle ispezioni
+    description: |
+      Preparazione all'accreditamento clinico, normativo e specialistico
+      e ai programmi di ispezione.
+  BC-2840.40.10:
+    name: Programmi di ispezione simulata
+    description: |
+      Operazioni di programmi di ispezione simulata e di preparazione continua.
+  BC-2840.40.20:
+    name: Metodologia del tracciante
+    description: |
+      Metodologia del tracciante paziente e di sistema per la preparazione all'accreditamento.
+  BC-2840.40.30:
+    name: Monitoraggio della conformità agli standard
+    description: |
+      Monitoraggio della conformità agli standard di accreditamento e normativi.
+  BC-2840.40.40:
+    name: Coordinamento della risposta alle ispezioni
+    description: |
+      Coordinamento delle ispezioni di accreditamento, dei rilievi e dei piani di azione correttiva.
+  BC-2840.50:
+    name: Gestione del rischio clinico e della responsabilità civile
+    description: |
+      Identificazione e mitigazione del rischio clinico e gestione del contenzioso
+      medico-legale specifico per l'assistenza clinica.
+  BC-2840.50.10:
+    name: Valutazione del rischio clinico
+    description: |
+      Identificazione e valutazione dei rischi clinici nei diversi servizi e processi.
+  BC-2840.50.20:
+    name: Supporto alla difesa legale
+    description: |
+      Supporto all'indagine e alla difesa in casi di responsabilità medico-legale.
+  BC-2840.50.30:
+    name: Processo di comunicazione e scuse
+    description: |
+      Operazioni del programma di comunicazione e scuse per gli eventi avversi.
+  BC-2840.50.40:
+    name: Pianificazione della mitigazione del rischio clinico
+    description: |
+      Pianificazione ed esecuzione delle azioni di mitigazione del rischio clinico.
+  BC-2840.60:
+    name: Programmi di miglioramento della qualità
+    description: |
+      Metodologia di miglioramento della performance, implementazione di bundle e
+      iniziative di alta affidabilità.
+  BC-2840.60.10:
+    name: Gestione del ciclo PDSA
+    description: |
+      Gestione del ciclo Plan-Do-Study-Act per il miglioramento clinico.
+  BC-2840.60.20:
+    name: Implementazione di bundle e protocolli
+    description: |
+      Implementazione di bundle basati sulle prove di efficacia e di protocolli clinici.
+  BC-2840.60.30:
+    name: Monitoraggio dei progetti di miglioramento della performance
+    description: |
+      Monitoraggio dei progetti di miglioramento della performance e dei relativi esiti.
+  BC-2840.60.40:
+    name: Iniziative di alta affidabilità
+    description: |
+      Principi delle organizzazioni ad alta affidabilità e gestione delle relative iniziative.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-clinical-trials-management.yaml
+++ b/catalogue/i18n/it/L1-clinical-trials-management.yaml
@@ -1,0 +1,143 @@
+# Gestione delle sperimentazioni cliniche (it) — translations for L1-clinical-trials-management.yaml
+locale: it
+source: L1-clinical-trials-management.yaml
+entries:
+  BC-1520:
+    name: Gestione delle sperimentazioni cliniche
+    description: |
+      Pianificazione, esecuzione e monitoraggio degli studi clinici.
+  BC-1520.10:
+    name: Gestione del disegno delle sperimentazioni cliniche
+    description: |
+      Progettazione del protocollo, metodologia statistica, endpoint.
+  BC-1520.10.10:
+    name: Redazione del protocollo clinico
+    description: |
+      Redazione dei protocolli di studi clinici.
+  BC-1520.10.20:
+    name: Definizione del piano di analisi statistica
+    description: |
+      Metodologia statistica e definizione del piano di analisi.
+  BC-1520.10.30:
+    name: Definizione di endpoint e outcome
+    description: |
+      Definizione degli endpoint primari, secondari ed esplorativi.
+  BC-1520.10.40:
+    name: Gestione del disegno adattativo
+    description: |
+      Progettazione di studi adattativi e platform trial.
+  BC-1520.20:
+    name: Gestione dei centri sperimentali
+    description: |
+      Selezione, attivazione e supervisione dei centri sperimentali.
+  BC-1520.20.10:
+    name: Identificazione e fattibilità del centro sperimentale
+    description: |
+      Identificazione e valutazione di fattibilità dei centri sperimentatori.
+  BC-1520.20.20:
+    name: Attivazione del centro sperimentale
+    description: |
+      Attivazione del centro sperimentale, inclusi aspetti etici, regolatori e contrattuali.
+  BC-1520.20.30:
+    name: Formazione dello sperimentatore e del centro sperimentale
+    description: |
+      Erogazione della formazione allo sperimentatore e al centro sperimentale.
+  BC-1520.20.40:
+    name: Gestione delle performance del centro sperimentale
+    description: |
+      Monitoraggio delle performance e attività di rimedio del centro sperimentale.
+  BC-1520.30:
+    name: Gestione dei soggetti della sperimentazione clinica
+    description: |
+      Arruolamento, screening, ritenzione e consenso informato.
+  BC-1520.30.10:
+    name: Arruolamento dei soggetti
+    description: |
+      Arruolamento dei soggetti, inclusi canali digitali.
+  BC-1520.30.20:
+    name: Gestione del consenso informato
+    description: |
+      Raccolta del consenso informato ed ICF (modulo di consenso informato) elettronico.
+  BC-1520.30.30:
+    name: Screening e arruolamento dei soggetti
+    description: |
+      Screening e arruolamento secondo i criteri di inclusione ed esclusione.
+  BC-1520.30.40:
+    name: Ritenzione dei soggetti
+    description: |
+      Strategie di ritenzione ed engagement del paziente.
+  BC-1520.40:
+    name: Gestione dei dati clinici
+    description: |
+      EDC, raccolta dati, gestione delle query, chiusura del database.
+  BC-1520.40.10:
+    name: Gestione di EDC e CRF
+    description: |
+      Sistema EDC (electronic data capture) e progettazione della CRF.
+  BC-1520.40.20:
+    name: Gestione delle query dei dati clinici
+    description: |
+      Generazione, risoluzione e pulizia dei dati.
+  BC-1520.40.30:
+    name: Standardizzazione dei dati clinici
+    description: |
+      Standardizzazione dei dati secondo CDISC SDTM/ADaM.
+  BC-1520.40.40:
+    name: Chiusura e archiviazione del database
+    description: |
+      Chiusura del database, archiviazione e preparazione del pacchetto di presentazione della domanda.
+  BC-1520.50:
+    name: Gestione del monitoraggio delle sperimentazioni cliniche
+    description: |
+      Monitoraggio in loco, monitoraggio basato sul rischio, audit.
+  BC-1520.50.10:
+    name: Monitoraggio in loco
+    description: |
+      Verifica dei dati sorgente in loco e visite di monitoraggio.
+  BC-1520.50.20:
+    name: Monitoraggio centralizzato e basato sul rischio
+    description: |
+      Programmi di monitoraggio centralizzato e basato sul rischio.
+  BC-1520.50.30:
+    name: Audit di qualità clinica
+    description: |
+      Audit GCP di studi, centri sperimentali e vendor.
+  BC-1520.60:
+    name: Gestione delle forniture per le sperimentazioni cliniche
+    description: |
+      Fornitura di IMP, distribuzione, randomizzazione, accountability del farmaco.
+  BC-1520.60.10:
+    name: Produzione e confezionamento dell'IMP
+    description: |
+      Produzione e confezionamento dei prodotti medicinali sperimentali (IMP).
+  BC-1520.60.20:
+    name: Distribuzione e operazioni di deposito dell'IMP
+    description: |
+      Operazioni di deposito e distribuzione globale dell'IMP.
+  BC-1520.60.30:
+    name: Randomizzazione e operatività IRT
+    description: |
+      Randomizzazione tramite IRT/IWRS e gestione delle forniture dello studio.
+  BC-1520.60.40:
+    name: Accountability e riconciliazione dell'IMP
+    description: |
+      Accountability dell'IMP, resi e distruzione.
+  BC-1520.70:
+    name: Gestione dell'outsourcing clinico e della CRO
+    description: |
+      Selezione, contrattualizzazione e supervisione della CRO.
+  BC-1520.70.10:
+    name: Selezione e contrattualizzazione della CRO
+    description: |
+      Selezione, scoping e contrattualizzazione della CRO.
+  BC-1520.70.20:
+    name: Supervisione delle performance della CRO
+    description: |
+      Supervisione dello sponsor sulle performance e i KPI della CRO.
+  BC-1520.70.30:
+    name: Supervisione della qualità del vendor
+    description: |
+      Supervisione della qualità dei vendor clinici e dei laboratori.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-commissioning-handover-management.yaml
+++ b/catalogue/i18n/it/L1-commissioning-handover-management.yaml
@@ -1,0 +1,103 @@
+# Gestione del commissioning e della consegna (it) — translations for L1-commissioning-handover-management.yaml
+locale: it
+source: L1-commissioning-handover-management.yaml
+entries:
+  BC-1160:
+    name: Gestione del commissioning e della consegna
+    description: |
+      Pre-commissioning, commissioning, collaudo funzionale e consegna.
+  BC-1160.10:
+    name: Gestione del pre-commissioning
+    description: |
+      Completamento meccanico, lavaggio, prove di tenuta e messa sotto tensione.
+  BC-1160.10.10:
+    name: Verifica del completamento meccanico
+    description: |
+      Verifica del completamento meccanico rispetto alle punch list.
+  BC-1160.10.20:
+    name: Operazioni di lavaggio e pulizia
+    description: |
+      Lavaggio delle tubazioni, pulizia e condizionamento chimico.
+  BC-1160.10.30:
+    name: Prove di pressione e tenuta
+    description: |
+      Idrotest, prove pneumatiche e verifica della tenuta.
+  BC-1160.10.40:
+    name: Messa sotto tensione delle apparecchiature
+    description: |
+      Prima messa sotto tensione e verifiche funzionali delle apparecchiature.
+  BC-1160.20:
+    name: Gestione dell'esecuzione del commissioning
+    description: |
+      Commissioning di sistema, prove funzionali e prove integrate.
+  BC-1160.20.10:
+    name: Pianificazione del commissioning di sistema
+    description: |
+      Piani di commissioning per sistema e sotto-sistema.
+  BC-1160.20.20:
+    name: Prove funzionali di sistema
+    description: |
+      Prove funzionali dei singoli sistemi.
+  BC-1160.20.30:
+    name: Prove di sistema integrate
+    description: |
+      Prove integrate su più sistemi.
+  BC-1160.20.40:
+    name: Documentazione del commissioning
+    description: |
+      Registri, dossier e certificati di commissioning.
+  BC-1160.30:
+    name: Gestione del collaudo funzionale
+    description: |
+      Esecuzione delle prove di prestazione e validazione dei criteri di accettazione.
+  BC-1160.30.10:
+    name: Pianificazione del collaudo funzionale
+    description: |
+      Protocolli di collaudo funzionale e criteri di accettazione.
+  BC-1160.30.20:
+    name: Esecuzione del collaudo funzionale
+    description: |
+      Esecuzione delle prove di prestazione e raccolta dei dati.
+  BC-1160.30.30:
+    name: Valutazione del collaudo funzionale
+    description: |
+      Valutazione dei risultati delle prove e validazione rispetto alle garanzie contrattuali.
+  BC-1160.40:
+    name: Gestione della consegna e dell'accettazione
+    description: |
+      Accettazione finale, certificati, chiusura della punch list e trasferimento all'operatore.
+  BC-1160.40.10:
+    name: Chiusura della punch list
+    description: |
+      Monitoraggio e chiusura delle voci della punch list prima dell'accettazione.
+  BC-1160.40.20:
+    name: Certificazione di accettazione
+    description: |
+      Emissione dei certificati di accettazione provvisoria e definitiva.
+  BC-1160.40.30:
+    name: Formazione degli operatori e consegna
+    description: |
+      Formazione del team operativo e consegna dell'impianto.
+  BC-1160.40.40:
+    name: Trasferimento della custodia
+    description: |
+      Trasferimento formale della custodia dell'impianto e degli asset al cliente.
+  BC-1160.50:
+    name: Gestione del supporto post-consegna
+    description: |
+      Periodo di responsabilità per difetti, periodo di garanzia e supporto tecnico residuo.
+  BC-1160.50.10:
+    name: Gestione della responsabilità per difetti
+    description: |
+      Gestione del periodo di responsabilità per difetti e rettifica dei vizi.
+  BC-1160.50.20:
+    name: Supporto in garanzia
+    description: |
+      Coordinamento del supporto in garanzia e dei reclami in garanzia ai fornitori.
+  BC-1160.50.30:
+    name: Supporto tecnico residuo
+    description: |
+      Supporto tecnico alle operazioni durante il periodo di avviamento iniziale.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-commodity-origination-merchandising-management.yaml
+++ b/catalogue/i18n/it/L1-commodity-origination-merchandising-management.yaml
@@ -1,0 +1,133 @@
+# Gestione dell'origination e della commercializzazione delle materie prime agricole (it) — translations for L1-commodity-origination-merchandising-management.yaml
+locale: it
+source: L1-commodity-origination-merchandising-management.yaml
+entries:
+  BC-3570:
+    name: Gestione dell'origination e della commercializzazione delle materie prime agricole
+    description: |
+      Programmi di origination con i produttori, contrattualizzazione delle materie prime, pesatura e campionamento,
+      posizioni fisiche d'inventario, trading di cash e basis,
+      hedging e regolamento per cereali, oleaginose, soft commodities, bestiame e materie prime lattiero-casearie.
+  BC-3570.10:
+    name: Gestione del programma di origination
+    description: |
+      Contrattualizzazione dei produttori, gestione delle relazioni con i produttori e previsione dell'origination
+      a supporto del libro approvvigionamenti.
+  BC-3570.10.10:
+    name: Programmi di contrattualizzazione dei produttori
+    description: |
+      Progettazione ed esecuzione dei programmi di contrattualizzazione dei produttori per regione.
+  BC-3570.10.20:
+    name: Gestione delle relazioni con i produttori
+    description: |
+      Gestione delle relazioni con i produttori, distinta dal CRM generico.
+  BC-3570.10.30:
+    name: Previsione dell'origination
+    description: |
+      Previsione dei volumi di origination attesi per regione e coltura.
+  BC-3570.20:
+    name: Gestione dei contratti sulle materie prime
+    description: |
+      Emissione e monitoraggio dell'esecuzione di contratti a termine, di produzione e con prezzo differito.
+    in_scope:
+      - Contratti a termine con produttori e controparti
+      - Contratti di produzione con specifiche qualitative
+      - Monitoraggio dell'esecuzione contrattuale
+    out_of_scope:
+      - Gestione generica dei contratti legali (BC-150)
+  BC-3570.20.10:
+    name: Emissione di contratti a termine
+    description: |
+      Emissione di contratti a termine a prezzo fisso e in basis.
+  BC-3570.20.20:
+    name: Gestione dei contratti di produzione
+    description: |
+      Gestione dei contratti di produzione con specifiche qualitative e di consegna.
+  BC-3570.20.30:
+    name: Monitoraggio dell'esecuzione contrattuale
+    description: |
+      Monitoraggio delle tonnellate consegnate rispetto alle performance contrattuali.
+  BC-3570.30:
+    name: Pesatura e campionamento in ingresso
+    description: |
+      Operazioni di pesa, campionamento e calibratura qualitativa e calcolo del regolamento al ricevimento.
+  BC-3570.30.10:
+    name: Operazioni di pesa
+    description: |
+      Operazioni di pesatura in ingresso e in uscita e relativa documentazione.
+  BC-3570.30.20:
+    name: Campionamento e calibratura qualitativa
+    description: |
+      Campionamento al ricevimento e calibratura rispetto alle specifiche commerciali.
+  BC-3570.30.30:
+    name: Calcolo del regolamento al ricevimento
+    description: |
+      Calcolo degli sconti e dei premi di qualità al ricevimento.
+  BC-3570.40:
+    name: Gestione della posizione d'inventario delle materie prime
+    description: |
+      Monitoraggio delle posizioni fisiche delle materie prime, decisioni di miscelazione
+      e posizioni in transito nella rete.
+  BC-3570.40.10:
+    name: Monitoraggio della posizione fisica
+    description: |
+      Monitoraggio delle posizioni lunghe e corte fisiche per sito e grado.
+  BC-3570.40.20:
+    name: Decisioni di miscelazione qualitativa
+    description: |
+      Decisioni di miscelazione per soddisfare le specifiche qualitative dei contratti.
+  BC-3570.40.30:
+    name: Monitoraggio delle posizioni in transito
+    description: |
+      Monitoraggio delle posizioni in transito via nave, ferrovia e autocarro.
+  BC-3570.50:
+    name: Operazioni di trading delle materie prime
+    description: |
+      Trading di cash e basis, esecuzione di vendite spot e gestione degli spread tra materie prime sui libri fisici.
+  BC-3570.50.10:
+    name: Trading di cash e basis
+    description: |
+      Trading di posizioni cash e basis nelle materie prime fisiche.
+  BC-3570.50.20:
+    name: Esecuzione di vendite spot
+    description: |
+      Esecuzione di vendite spot a trasformatori ed esportatori.
+  BC-3570.50.30:
+    name: Gestione degli spread tra materie prime
+    description: |
+      Gestione degli spread tra materie prime quali i margini di crushing e cracking.
+  BC-3570.60:
+    name: Gestione del hedging e della posizione di rischio
+    description: |
+      Esecuzione e riconciliazione di hedging tramite futures e opzioni rispetto alle posizioni fisiche in materie prime.
+  BC-3570.60.10:
+    name: Esecuzione del hedging tramite futures
+    description: |
+      Esecuzione di hedging tramite futures su mercati regolamentati.
+  BC-3570.60.20:
+    name: Esecuzione del hedging tramite opzioni
+    description: |
+      Esecuzione di hedging tramite opzioni per gestire il rischio di coda sul prezzo.
+  BC-3570.60.30:
+    name: Riconciliazione della posizione di hedging
+    description: |
+      Riconciliazione delle posizioni di hedging rispetto alle esposizioni fisiche sottostanti.
+  BC-3570.70:
+    name: Regolamento e determinazione del prezzo delle materie prime
+    description: |
+      Determinazione finale del prezzo, emissione degli estratti conto di regolamento e risoluzione dei reclami qualitativi con le controparti.
+  BC-3570.70.10:
+    name: Determinazione finale del prezzo e calcolo degli sconti
+    description: |
+      Determinazione finale del prezzo, inclusa l'applicazione di sconti e premi di qualità.
+  BC-3570.70.20:
+    name: Emissione degli estratti conto di regolamento
+    description: |
+      Emissione degli estratti conto di regolamento ai produttori e alle controparti.
+  BC-3570.70.30:
+    name: Risoluzione dei reclami qualitativi
+    description: |
+      Risoluzione dei reclami qualitativi con produttori, acquirenti e organismi arbitrali.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-communication-navigation-surveillance-operations-management.yaml
+++ b/catalogue/i18n/it/L1-communication-navigation-surveillance-operations-management.yaml
@@ -1,0 +1,123 @@
+# Gestione delle operazioni CNS (it) — translations for L1-communication-navigation-surveillance-operations-management.yaml
+locale: it
+source: L1-communication-navigation-surveillance-operations-management.yaml
+entries:
+  BC-1240:
+    name: "Gestione delle operazioni di comunicazione, navigazione e sorveglianza"
+    description: |
+      Infrastruttura CNS — comunicazioni vocali e dati, radionavigazione, radar/ADS-B/multilaterazione.
+  BC-1240.10:
+    name: Gestione dei sistemi di comunicazione vocale
+    description: |
+      Sistemi vocali aria-terra, controllore-pilota e terra-terra.
+  BC-1240.10.10:
+    name: Operazioni vocali aria-terra
+    description: |
+      Operazione delle comunicazioni radio vocali aria-terra.
+  BC-1240.10.20:
+    name: Operazioni vocali terra-terra
+    description: |
+      Operazione dei circuiti vocali inter-centro e inter-settore.
+  BC-1240.10.30:
+    name: Registrazione e riproduzione vocale
+    description: |
+      Registrazione e riproduzione della voce operativa per la sicurezza e l'audit.
+  BC-1240.20:
+    name: Gestione delle comunicazioni datalink
+    description: |
+      Datalink CPDLC, ADS-C, FANS e ATN.
+  BC-1240.20.10:
+    name: Operazioni CPDLC
+    description: |
+      Operazione delle comunicazioni datalink controllore-pilota (CPDLC).
+  BC-1240.20.20:
+    name: Operazioni ADS-C
+    description: |
+      Operazione della sorveglianza dipendente automatica per contratto (ADS-C).
+  BC-1240.20.30:
+    name: Operazioni di rete ATN e FANS
+    description: |
+      Operazioni di rete datalink ATN e FANS.
+  BC-1240.30:
+    name: Gestione dei radionavigatori
+    description: |
+      Servizi di navigazione basati su VOR, DME, ILS e GNSS.
+  BC-1240.30.10:
+    name: Operazioni VOR e DME
+    description: |
+      Operazione e manutenzione dei radiofari VOR e DME.
+  BC-1240.30.20:
+    name: Operazioni ILS
+    description: |
+      Operazione e manutenzione dei sistemi di avvicinamento ILS.
+  BC-1240.30.30:
+    name: Servizio di navigazione basato su GNSS
+    description: |
+      Fornitura del servizio di navigazione GNSS, SBAS e GBAS.
+  BC-1240.30.40:
+    name: Ispezione in volo
+    description: |
+      Ispezione periodica in volo dei radionavigatori.
+  BC-1240.40:
+    name: Gestione dei sistemi di sorveglianza
+    description: |
+      Radar primario, radar secondario, ADS-B, multilaterazione.
+  BC-1240.40.10:
+    name: Operazioni del radar di sorveglianza primario
+    description: |
+      Operazione dei sistemi di radar di sorveglianza primario.
+  BC-1240.40.20:
+    name: Operazioni del radar di sorveglianza secondario
+    description: |
+      Operazione dei sistemi SSR Mode S e convenzionali Mode A/C.
+  BC-1240.40.30:
+    name: Operazioni di sorveglianza ADS-B
+    description: |
+      Operazione delle stazioni a terra ADS-B e del relativo trattamento dati.
+  BC-1240.40.40:
+    name: Operazioni di multilaterazione
+    description: |
+      Operazione della sorveglianza WAM/MLAT.
+  BC-1240.40.50:
+    name: Fusione dei dati di sorveglianza
+    description: |
+      Fusione delle sorgenti di sorveglianza per la visualizzazione ATC.
+  BC-1240.50:
+    name: Gestione della manutenzione dell'infrastruttura CNS
+    description: |
+      Manutenzione sul campo delle apparecchiature CNS, calibrazione, ispezione in volo.
+  BC-1240.50.10:
+    name: Manutenzione preventiva CNS
+    description: |
+      Manutenzione preventiva programmata delle apparecchiature CNS.
+  BC-1240.50.20:
+    name: Manutenzione correttiva CNS
+    description: |
+      Manutenzione correttiva e risposta ai guasti delle apparecchiature CNS.
+  BC-1240.50.30:
+    name: Calibrazione delle apparecchiature CNS
+    description: |
+      Calibrazione e allineamento delle apparecchiature CNS.
+  BC-1240.50.40:
+    name: Gestione dei ricambi CNS
+    description: |
+      Approvvigionamento e scorte di parti di ricambio e materiali di consumo CNS.
+  BC-1240.60:
+    name: Gestione dello spettro e delle frequenze
+    description: |
+      Allocazione delle frequenze aeronautiche, coordinamento, gestione delle interferenze.
+  BC-1240.60.10:
+    name: Allocazione delle frequenze
+    description: |
+      Allocazione delle frequenze aeronautiche ai servizi.
+  BC-1240.60.20:
+    name: Coordinamento delle frequenze
+    description: |
+      Coordinamento transfrontaliero e inter-servizio delle frequenze.
+  BC-1240.60.30:
+    name: Rilevamento e risoluzione delle interferenze
+    description: |
+      Rilevamento e risoluzione degli incidenti di interferenza di frequenza.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-compliance-management.yaml
+++ b/catalogue/i18n/it/L1-compliance-management.yaml
@@ -1,0 +1,119 @@
+# Gestione della conformità (it) — translations for L1-compliance-management.yaml
+locale: it
+source: L1-compliance-management.yaml
+entries:
+  BC-130:
+    name: Gestione della conformità
+    description: |
+      Garanzia del rispetto di leggi, regolamenti e politiche interne.
+  BC-130.10:
+    name: Gestione della conformità normativa
+    description: |
+      Conformità ai regolamenti specifici del settore.
+  BC-130.10.10:
+    name: Gestione dell'inventario normativo
+    description: |
+      Inventario delle normative applicabili e degli obblighi nelle varie giurisdizioni.
+  BC-130.10.20:
+    name: Monitoraggio delle novità normative
+    description: |
+      Horizon scanning degli sviluppi normativi e valutazione dell'impatto.
+  BC-130.10.30:
+    name: Valutazione del rischio di conformità
+    description: |
+      Valutazione del rischio di conformità per linea di business, area geografica e prodotto.
+  BC-130.10.40:
+    name: Monitoraggio e verifica della conformità
+    description: |
+      Piano di monitoraggio della conformità, test dei controlli e reporting.
+  BC-130.10.50:
+    name: Gestione dei rapporti con le autorità di regolamentazione
+    description: |
+      Notifiche alle autorità, ispezioni e monitoraggio delle misure correttive.
+  BC-130.20:
+    name: Gestione delle politiche
+    description: |
+      Ciclo di vita delle politiche: redazione, approvazione, attestazione e archiviazione.
+  BC-130.20.10:
+    name: Redazione delle politiche
+    description: |
+      Stesura e revisione delle politiche e degli standard aziendali.
+  BC-130.20.20:
+    name: Approvazione e pubblicazione delle politiche
+    description: |
+      Approvazione di governance e pubblicazione controllata delle politiche.
+  BC-130.20.30:
+    name: Attestazione delle politiche
+    description: |
+      Presa d'atto e attestazione da parte di dipendenti e terze parti.
+  BC-130.20.40:
+    name: Gestione delle eccezioni alle politiche
+    description: |
+      Registrazione e approvazione di eccezioni e deroghe alle politiche.
+  BC-130.30:
+    name: Gestione dell'etica e della condotta
+    description: |
+      Codice di condotta, etica e programmi di segnalazione degli illeciti.
+  BC-130.30.10:
+    name: Amministrazione del codice di condotta
+    description: |
+      Manutenzione e diffusione del codice di condotta aziendale.
+  BC-130.30.20:
+    name: Gestione dei conflitti di interesse
+    description: |
+      Comunicazione e gestione dei conflitti di interesse personali e organizzativi.
+  BC-130.30.30:
+    name: Gestione delle segnalazioni di illeciti
+    description: |
+      Canali di segnalazione, ricezione, triage e protezione per i segnalanti.
+  BC-130.30.40:
+    name: Indagini disciplinari
+    description: |
+      Indagini su presunti illeciti e gestione dei procedimenti disciplinari.
+  BC-130.40:
+    name: Gestione dell'anti-corruzione
+    description: |
+      Programmi ABC, due diligence su terze parti, omaggi e ospitalità.
+  BC-130.40.10:
+    name: Governance del programma anti-corruzione
+    description: |
+      Progettazione del programma anti-corruzione allineato con FCPA e UKBA.
+  BC-130.40.20:
+    name: Due diligence di integrità su terze parti
+    description: |
+      Due diligence di integrità e monitoraggio continuativo degli intermediari.
+  BC-130.40.30:
+    name: Gestione di omaggi, ospitalità e sponsorizzazioni
+    description: |
+      Pre-autorizzazione e registri per omaggi, ospitalità e sponsorizzazioni.
+  BC-130.40.40:
+    name: Formazione e sensibilizzazione anti-corruzione
+    description: |
+      Formazione mirata e comunicazioni sui requisiti anti-corruzione.
+  BC-130.50:
+    name: Gestione della privacy e della protezione dei dati
+    description: |
+      Conformità al GDPR e normative equivalenti, diritti degli interessati e privacy by design.
+  BC-130.50.10:
+    name: Governance del programma privacy
+    description: |
+      Framework privacy, funzione DPO e meccanismi di responsabilità.
+  BC-130.50.20:
+    name: Gestione dei registri delle attività di trattamento
+    description: |
+      Tenuta dei registri delle attività di trattamento e dei flussi di dati.
+  BC-130.50.30:
+    name: Valutazione d'impatto sulla protezione dei dati
+    description: |
+      DPIA e revisioni privacy by design per le nuove attività di trattamento.
+  BC-130.50.40:
+    name: Gestione dei diritti degli interessati
+    description: |
+      Ricezione ed evasione delle richieste di accesso, rettifica e cancellazione.
+  BC-130.50.50:
+    name: Gestione delle violazioni di dati personali
+    description: |
+      Rilevamento, notifica e rimedio in caso di violazioni di dati personali.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-connected-product-firmware-management.yaml
+++ b/catalogue/i18n/it/L1-connected-product-firmware-management.yaml
@@ -1,0 +1,149 @@
+# Gestione del prodotto connesso e del firmware (it) — translations for L1-connected-product-firmware-management.yaml
+locale: it
+source: L1-connected-product-firmware-management.yaml
+entries:
+  BC-1950:
+    name: Gestione del prodotto connesso e del firmware
+    description: |
+      Ciclo di vita operativo dei prodotti elettrici connessi in campo — identità del dispositivo,
+      build e rilascio del firmware, aggiornamenti OTA, telemetria, sicurezza informatica del
+      prodotto e operazioni sulla piattaforma IIoT.
+  BC-1950.10:
+    name: Gestione dell'identità e del provisioning del dispositivo
+    description: |
+      Emissione e ciclo di vita delle identità dei dispositivi e delle credenziali crittografiche.
+  BC-1950.10.10:
+    name: Emissione dell'identità del dispositivo
+    description: |
+      Emissione di identità univoche del dispositivo in fase di produzione.
+  BC-1950.10.20:
+    name: Provisioning delle chiavi crittografiche
+    description: |
+      Provisioning di chiavi crittografiche sui dispositivi.
+  BC-1950.10.30:
+    name: Onboarding del dispositivo sulla piattaforma
+    description: |
+      Onboarding dei dispositivi sulla piattaforma del prodotto connesso.
+  BC-1950.10.40:
+    name: Dismissione del dispositivo
+    description: |
+      Dismissione e revoca delle credenziali per i dispositivi ritirati.
+  BC-1950.20:
+    name: Gestione della build e del rilascio del firmware
+    description: |
+      Pipeline di build, approvazione del rilascio, firma e inventario delle versioni per il firmware in produzione.
+  BC-1950.20.10:
+    name: Gestione della pipeline di build del firmware
+    description: |
+      Gestione delle pipeline di build del firmware e di integrazione continua.
+  BC-1950.20.20:
+    name: Approvazione del rilascio del firmware
+    description: |
+      Approvazione a stage-gate dei rilasci di firmware per il deployment.
+  BC-1950.20.30:
+    name: Firma e gestione dell'integrità del firmware
+    description: |
+      Firma del codice e protezione dell'integrità degli artefatti firmware.
+  BC-1950.20.40:
+    name: Inventario delle versioni del firmware
+    description: |
+      Inventario delle versioni firmware distribuite sulla base installata.
+  BC-1950.30:
+    name: Gestione degli aggiornamenti over-the-air
+    description: |
+      Pianificazione, esecuzione e rollback degli aggiornamenti firmware OTA.
+  BC-1950.30.10:
+    name: Pianificazione delle campagne OTA
+    description: |
+      Pianificazione delle campagne OTA e dei gruppi di distribuzione.
+  BC-1950.30.20:
+    name: Esecuzione del rollout OTA
+    description: |
+      Esecuzione dei rollout OTA e monitoraggio dell'avanzamento.
+  BC-1950.30.30:
+    name: Gestione del rollback OTA
+    description: |
+      Rollback degli aggiornamenti OTA non riusciti a versioni funzionanti note.
+  BC-1950.30.40:
+    name: Verifica della compatibilità OTA
+    description: |
+      Verifica della compatibilità del firmware prima del rilascio OTA.
+  BC-1950.40:
+    name: Gestione della telemetria e della connettività del dispositivo
+    description: |
+      Acquisizione della telemetria, stato di connettività, instradamento e gestione degli operatori o delle SIM.
+  BC-1950.40.10:
+    name: Operazioni di acquisizione della telemetria
+    description: |
+      Acquisizione della telemetria del dispositivo negli archivi della piattaforma.
+  BC-1950.40.20:
+    name: Monitoraggio dello stato di connettività
+    description: |
+      Monitoraggio dello stato di connettività e raggiungibilità del dispositivo.
+  BC-1950.40.30:
+    name: Instradamento dei dati di telemetria
+    description: |
+      Instradamento della telemetria verso utenti downstream e sistemi di analisi.
+  BC-1950.40.40:
+    name: Gestione degli operatori di rete e delle SIM
+    description: |
+      Gestione dei rapporti con gli operatori di rete cellulare e dell'inventario SIM.
+  BC-1950.50:
+    name: Gestione della sicurezza informatica del prodotto connesso
+    description: |
+      Sicurezza informatica lato prodotto che copre minacce, vulnerabilità, avvio sicuro e conformità.
+  BC-1950.50.10:
+    name: Modellazione delle minacce del prodotto
+    description: |
+      Modellazione delle minacce per i progetti di prodotto connesso.
+  BC-1950.50.20:
+    name: Divulgazione e risposta alle vulnerabilità
+    description: |
+      Divulgazione coordinata e risposta alle vulnerabilità del prodotto.
+  BC-1950.50.30:
+    name: Avvio sicuro e attestazione
+    description: |
+      Meccanismi di avvio sicuro e attestazione sui dispositivi.
+  BC-1950.50.40:
+    name: Conformità della sicurezza informatica del prodotto
+    description: |
+      Conformità dei prodotti connessi a IEC 62443 e regimi equivalenti.
+  BC-1950.60:
+    name: Operazioni sulla piattaforma del prodotto connesso
+    description: |
+      Gestione della piattaforma IIoT alla base dei prodotti connessi.
+  BC-1950.60.10:
+    name: Gestione dei tenant della piattaforma IIoT
+    description: |
+      Onboarding e isolamento dei tenant sulla piattaforma IIoT.
+  BC-1950.60.20:
+    name: Capacità e prestazioni della piattaforma
+    description: |
+      Pianificazione della capacità e gestione delle prestazioni della piattaforma.
+  BC-1950.60.30:
+    name: Servizi di integrazione della piattaforma
+    description: |
+      Integrazione della piattaforma con sistemi aziendali e dei clienti.
+  BC-1950.60.40:
+    name: Ciclo di vita delle API della piattaforma
+    description: |
+      Ciclo di vita delle API e degli SDK esposti dalla piattaforma.
+  BC-1950.70:
+    name: Gestione delle operazioni edge e gateway
+    description: |
+      Gestione delle applicazioni edge e dei dispositivi gateway in campo.
+  BC-1950.70.10:
+    name: Deployment delle applicazioni edge
+    description: |
+      Deployment delle applicazioni edge su gateway e controllori.
+  BC-1950.70.20:
+    name: Gestione della configurazione del gateway
+    description: |
+      Gestione della configurazione dei dispositivi gateway in campo.
+  BC-1950.70.30:
+    name: Monitoraggio dello stato dell'edge
+    description: |
+      Monitoraggio dello stato dei dispositivi edge e delle applicazioni.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-construction-management.yaml
+++ b/catalogue/i18n/it/L1-construction-management.yaml
@@ -1,0 +1,135 @@
+# Gestione della costruzione (it) — translations for L1-construction-management.yaml
+locale: it
+source: L1-construction-management.yaml
+entries:
+  BC-1150:
+    name: Gestione della costruzione
+    description: |
+      Supervisione ed esecuzione della costruzione (per le imprese EPC).
+  BC-1150.10:
+    name: Gestione della pianificazione della costruzione
+    description: |
+      Sequenza delle attività di costruzione, metodi e programma lavori generale.
+  BC-1150.10.10:
+    name: Documento dei metodi costruttivi
+    description: |
+      Definizione dei metodi costruttivi e delle sequenze di esecuzione.
+  BC-1150.10.20:
+    name: Programma lavori generale della costruzione
+    description: |
+      Programma lavori generale e piani di avanzamento a breve termine.
+  BC-1150.10.30:
+    name: Pianificazione delle risorse per la costruzione
+    description: |
+      Pianificazione della manodopera, delle attrezzature e dei materiali per la costruzione.
+  BC-1150.10.40:
+    name: Piano di esecuzione della costruzione
+    description: |
+      Piano di esecuzione del progetto relativo alla strategia costruttiva.
+  BC-1150.20:
+    name: Gestione della mobilitazione e dell'allestimento del cantiere
+    description: |
+      Allestimento del cantiere, strutture provvisorie e logistica di cantiere.
+  BC-1150.20.10:
+    name: Allestimento del cantiere
+    description: |
+      Installazione di strutture provvisorie, uffici e servizi.
+  BC-1150.20.20:
+    name: Pianificazione della logistica di cantiere
+    description: |
+      Pianificazione degli accessi al cantiere, delle aree di deposito e della movimentazione dei materiali.
+  BC-1150.20.30:
+    name: Mobilitazione delle attrezzature di costruzione
+    description: |
+      Mobilitazione di gru, impianti e attrezzature di costruzione.
+  BC-1150.30:
+    name: Gestione della direzione lavori
+    description: |
+      Direzione lavori, gestione dei fronti di lavoro e operazioni giornaliere di cantiere.
+  BC-1150.30.10:
+    name: Operazioni giornaliere di cantiere
+    description: |
+      Coordinamento giornaliero di cantiere, briefing ed esecuzione.
+  BC-1150.30.20:
+    name: Gestione dei fronti di lavoro
+    description: |
+      Definizione e avanzamento dei fronti di lavoro della costruzione.
+  BC-1150.30.30:
+    name: Conformità ai permessi e ai metodi
+    description: |
+      Conformità ai permessi e ai documenti dei metodi approvati.
+  BC-1150.40:
+    name: Gestione dei subappaltatori
+    description: |
+      Selezione, supervisione, prestazioni e certificazione dei pagamenti dei subappaltatori.
+  BC-1150.40.10:
+    name: Selezione dei subappaltatori
+    description: |
+      Prequalifica e selezione dei subappaltatori di costruzione.
+  BC-1150.40.20:
+    name: Supervisione dei subappaltatori
+    description: |
+      Supervisione in cantiere delle prestazioni e della conformità dei subappaltatori.
+  BC-1150.40.30:
+    name: Certificazione dei pagamenti
+    description: |
+      Misurazione e certificazione dei pagamenti ai subappaltatori.
+  BC-1150.40.40:
+    name: Gestione delle varianti dei subappaltatori
+    description: |
+      Gestione delle varianti e delle rivendicazioni dei subappaltatori.
+  BC-1150.50:
+    name: Gestione della qualità della costruzione
+    description: |
+      QA/QC in cantiere, ispezioni e punti di controllo e testimonianza.
+  BC-1150.50.10:
+    name: Piani di ispezione e collaudo in cantiere
+    description: |
+      Definizione dei piani ITP, punti di blocco e testimonianza e programmi di ispezione.
+  BC-1150.50.20:
+    name: Ispezione qualità in cantiere
+    description: |
+      Esecuzione di ispezioni e collaudi di qualità in cantiere.
+  BC-1150.50.30:
+    name: Gestione delle non conformità e della punch list
+    description: |
+      Rapporti di non conformità in cantiere e chiusura della punch list.
+  BC-1150.60:
+    name: Gestione dell'avanzamento lavori
+    description: |
+      Misurazione dell'avanzamento, valore guadagnato e analisi degli scostamenti.
+  BC-1150.60.10:
+    name: Misurazione dell'avanzamento lavori
+    description: |
+      Misurazione quantitativa dell'avanzamento lavori in cantiere.
+  BC-1150.60.20:
+    name: Reportistica del valore guadagnato
+    description: |
+      Analisi del valore guadagnato e reportistica sulle prestazioni di progetto.
+  BC-1150.60.30:
+    name: Analisi degli scostamenti di programma e costi
+    description: |
+      Analisi degli scostamenti e azioni correttive.
+  BC-1150.70:
+    name: Gestione della sicurezza, salute e ambiente di cantiere
+    description: |
+      Sicurezza del cantiere, permessi di lavoro, gestione dei pericoli e risposta alle emergenze.
+  BC-1150.70.10:
+    name: Pianificazione HSE di cantiere
+    description: |
+      Piani HSE di cantiere e valutazioni dei rischi.
+  BC-1150.70.20:
+    name: Permesso di lavoro in cantiere
+    description: |
+      Permesso di lavoro in cantiere e permessi per lavori a caldo.
+  BC-1150.70.30:
+    name: Ispezioni e audit di sicurezza in cantiere
+    description: |
+      Ispezioni di sicurezza, audit e osservazioni comportamentali.
+  BC-1150.70.40:
+    name: Risposta alle emergenze in cantiere
+    description: |
+      Piani di risposta alle emergenze, esercitazioni e gestione degli incidenti.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-content-compliance-standards-management.yaml
+++ b/catalogue/i18n/it/L1-content-compliance-standards-management.yaml
@@ -1,0 +1,133 @@
+# Conformità e standard dei contenuti (it) — translations for L1-content-compliance-standards-management.yaml
+locale: it
+source: L1-content-compliance-standards-management.yaml
+entries:
+  BC-3780:
+    name: Conformità e standard dei contenuti
+    description: |
+      Classificazione e rating dei contenuti, standard editoriali, conformità normativa
+      broadcast e per i contenuti online, moderazione dei contenuti generati dagli utenti,
+      conformità sull'accessibilità e gestione delle segnalazioni di rimozione
+      sull'intero portfolio dei contenuti.
+  BC-3780.10:
+    name: Gestione della classificazione e del rating dei contenuti
+    description: |
+      Presentazione, applicazione e autoclassificazione dei rating per età
+      e contenuto per territori e piattaforme.
+  BC-3780.10.10:
+    name: Presentazione della classificazione pre-rilascio
+    description: |
+      Presentazione dei titoli agli enti di classificazione per i rating
+      di età territoriali prima del rilascio.
+  BC-3780.10.20:
+    name: Conformità della visualizzazione del rating
+    description: |
+      Visualizzazione dei rating per età, descrittori di contenuto e
+      avvertenze sulle superfici rivolte ai consumatori.
+  BC-3780.10.30:
+    name: Gestione dell'autoclassificazione
+    description: |
+      Operazione dei regimi di autoclassificazione e adesione agli
+      strumenti di rating per età delle piattaforme.
+  BC-3780.20:
+    name: Gestione degli standard editoriali
+    description: |
+      Redazione della policy editoriale, revisione di conformità pre-trasmissione
+      e gestione dei reclami editoriali.
+  BC-3780.20.10:
+    name: Gestione della policy editoriale
+    description: |
+      Redazione e ciclo di vita delle policy editoriali e degli standard
+      di imparzialità e accuratezza.
+  BC-3780.20.20:
+    name: Revisione di conformità pre-trasmissione
+    description: |
+      Revisione pre-trasmissione di programmi e interruzioni rispetto
+      agli standard editoriali e normativi.
+  BC-3780.20.30:
+    name: Gestione dei reclami editoriali
+    description: |
+      Triage, istruttoria e risposta ai reclami editoriali da parte di
+      spettatori e autorità di regolamentazione.
+  BC-3780.30:
+    name: Conformità normativa broadcast
+    description: |
+      Conformità alla regolamentazione broadcast e audiovisiva, compresi
+      le norme di palinsesto, le quote di contenuto e i codici pubblicitari.
+  BC-3780.30.10:
+    name: Conformità della fascia protetta e del palinsesto
+    description: |
+      Conformità alle regole di fascia protetta e di fascia oraria per la
+      programmazione di contenuti per adulti.
+  BC-3780.30.20:
+    name: Conformità delle quote e del contenuto locale
+    description: |
+      Conformità alle quote di contenuto, compresi opere europee,
+      produzione indipendente e obblighi in lingua locale.
+  BC-3780.30.30:
+    name: Conformità dei codici pubblicitari
+    description: |
+      Conformità della pubblicità e delle sponsorizzazioni ai codici
+      applicabili e alle restrizioni di categoria.
+  BC-3780.40:
+    name: Moderazione dei contenuti generati dagli utenti
+    description: |
+      Moderazione dei contenuti generati dagli utenti tramite triage
+      automatizzato, revisione umana e workflow di trusted flagger.
+  BC-3780.40.10:
+    name: Triage automatizzato dei contenuti
+    description: |
+      Triage e classificazione automatizzata dei contenuti generati dagli
+      utenti per problemi di sicurezza e policy.
+  BC-3780.40.20:
+    name: Gestione delle code di revisione umana
+    description: |
+      Operazione delle code di revisione umana, compresa la garanzia di
+      qualità e i controlli per il benessere dei revisori.
+  BC-3780.40.30:
+    name: Gestione dei trusted flagger
+    description: |
+      Gestione delle relazioni con i trusted flagger e dei canali di
+      revisione prioritizzata ai sensi della normativa sui contenuti online.
+  BC-3780.50:
+    name: Gestione della conformità sull'accessibilità
+    description: |
+      Conformità agli obblighi di accessibilità in materia di sottotitolazione,
+      audiodescrizione e servizi per persone con disabilità uditive.
+  BC-3780.50.10:
+    name: Conformità della sottotitolazione per non udenti
+    description: |
+      Conformità agli obblighi di closed captioning, compresi copertura,
+      qualità e standard di presentazione.
+  BC-3780.50.20:
+    name: Conformità dell'audiodescrizione
+    description: |
+      Conformità agli obblighi di copertura e qualità dell'audiodescrizione.
+  BC-3780.50.30:
+    name: Conformità del servizio in lingua dei segni
+    description: |
+      Conformità agli obblighi di interpretazione in lingua dei segni
+      e di traduzione in video.
+  BC-3780.60:
+    name: Gestione delle segnalazioni di rimozione e dei notice
+    description: |
+      Gestione dei notice per diritto d'autore e contenuti online, compresi
+      i processi di counter-notice e di appello.
+  BC-3780.60.10:
+    name: Gestione dei notice sul diritto d'autore
+    description: |
+      Gestione dei notice di rimozione per violazione del diritto d'autore
+      e applicazione della policy sui recidivi.
+  BC-3780.60.20:
+    name: Gestione dei notice sui contenuti online
+    description: |
+      Gestione dei notice e degli ordini per contenuti illegali ai sensi
+      della normativa sui contenuti online.
+  BC-3780.60.30:
+    name: Gestione dei counter-notice e dei ricorsi
+    description: |
+      Gestione dei counter-notice e dei meccanismi di ricorso stragiudiziale
+      per le decisioni di rimozione dei contenuti.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-content-distribution-delivery-management.yaml
+++ b/catalogue/i18n/it/L1-content-distribution-delivery-management.yaml
@@ -1,0 +1,133 @@
+# Distribuzione e consegna dei contenuti (it) — translations for L1-content-distribution-delivery-management.yaml
+locale: it
+source: L1-content-distribution-delivery-management.yaml
+entries:
+  BC-3740:
+    name: Distribuzione e consegna dei contenuti
+    description: |
+      Broadcast lineare, distribuzione OTT e streaming, operazioni CDN,
+      IPTV e multicast, protezione dei contenuti, e distribuzione
+      in syndication e a affiliati verso superfici consumer e partner.
+  BC-3740.10:
+    name: Distribuzione broadcast lineare
+    description: |
+      Operazione della distribuzione broadcast lineare attraverso percorsi
+      di trasmissione digitale terrestre, satellite e cavo.
+  BC-3740.10.10:
+    name: Operazioni di broadcast terrestre
+    description: |
+      Operazione delle catene di trasmissione digitale terrestre
+      e del trasporto multiplex.
+  BC-3740.10.20:
+    name: Operazioni di uplink satellitare
+    description: |
+      Operazione delle catene di uplink satellitare per la distribuzione
+      diretta a casa e di contribuzione.
+  BC-3740.10.30:
+    name: Operazioni di headend via cavo
+    description: |
+      Operazione del trasporto via cavo e integrazione dell'headend
+      con le piattaforme degli operatori.
+  BC-3740.20:
+    name: Distribuzione OTT e streaming
+    description: |
+      Operazione di origin streaming, packaging e streaming in diretta per
+      servizi OTT direct-to-consumer e partner.
+  BC-3740.20.10:
+    name: Operazioni del servizio di origin
+    description: |
+      Operazione dei servizi di origin streaming per la consegna di contenuti
+      on-demand e live alle superfici di distribuzione.
+  BC-3740.20.20:
+    name: Packaging per streaming adattivo
+    description: |
+      Packaging adattivo just-in-time e pre-impacchettato per HLS,
+      MPEG-DASH e CMAF.
+  BC-3740.20.30:
+    name: Operazioni di streaming in diretta
+    description: |
+      Operazione delle pipeline di streaming in diretta per eventi, canali
+      e servizi FAST.
+  BC-3740.30:
+    name: Operazioni della CDN
+    description: |
+      Gestione di capacità, caching e rapporto costo-prestazioni delle
+      CDN per la distribuzione dei contenuti.
+  BC-3740.30.10:
+    name: Pianificazione della capacità CDN
+    description: |
+      Previsione e provisioning della capacità CDN per regioni, peering
+      e picchi di eventi.
+  BC-3740.30.20:
+    name: Gestione della cache edge
+    description: |
+      Gestione del footprint della cache edge, del comportamento di riempimento
+      e dell'offload verso cache partner.
+  BC-3740.30.30:
+    name: Ottimizzazione del costo e delle prestazioni CDN
+    description: |
+      Steering multi-CDN e ottimizzazione del rapporto costo-prestazioni
+      tra i partner di distribuzione.
+  BC-3740.40:
+    name: Gestione della distribuzione IPTV e multicast
+    description: |
+      Operazione di headend IPTV di livello telco, stream multicast e
+      attivazione del servizio su set-top box.
+  BC-3740.40.10:
+    name: Operazioni dell'headend IPTV
+    description: |
+      Operazione degli headend IPTV, compresa l'acquisizione del segnale,
+      la codifica e l'integrazione del conditional access.
+  BC-3740.40.20:
+    name: Gestione degli stream multicast
+    description: |
+      Gestione del provisioning degli stream multicast su portanti
+      IP e broadcast 3GPP.
+  BC-3740.40.30:
+    name: Attivazione del servizio set-top box
+    description: |
+      Attivazione di set-top box e dispositivi gestiti sul servizio IPTV,
+      compreso il provisioning del lineup dei canali.
+  BC-3740.50:
+    name: Protezione dei contenuti e gestione del DRM
+    description: |
+      Operazione dei sistemi di protezione dei contenuti, compresa la gestione
+      di chiavi e licenze, il watermarking e il controllo degli stream concorrenti.
+  BC-3740.50.10:
+    name: Gestione di licenze e chiavi
+    description: |
+      Emissione e gestione di licenze DRM e chiavi di contenuto
+      su dispositivi e piattaforme.
+  BC-3740.50.20:
+    name: Watermarking e tracciamento forense
+    description: |
+      Applicazione di watermark di sessione e forensi per il rilevamento
+      della pirateria e la tracciabilità della sorgente.
+  BC-3740.50.30:
+    name: Controllo degli stream concorrenti
+    description: |
+      Applicazione dei limiti di stream concorrenti e della policy di
+      account sharing per spettatori e dispositivi.
+  BC-3740.60:
+    name: Distribuzione in syndication e agli affiliati
+    description: |
+      Distribuzione di programmi e feed agli affiliati in syndication e
+      alle piattaforme di terze parti con rendicontazione delle consegne.
+  BC-3740.60.10:
+    name: Gestione degli ordini di syndication
+    description: |
+      Acquisizione ed evasione degli ordini di syndication rispetto ai
+      diritti detenuti e agli slot di distribuzione.
+  BC-3740.60.20:
+    name: Distribuzione dei feed agli affiliati
+    description: |
+      Distribuzione di feed di rete e canale agli affiliati broadcast
+      con hand-off per la localizzazione.
+  BC-3740.60.30:
+    name: Tracciamento delle consegne dei programmi
+    description: |
+      Tracciamento delle consegne di programmi a piattaforme e partner,
+      comprese la prova di consegna e la gestione delle eccezioni.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-content-origination-production-management.yaml
+++ b/catalogue/i18n/it/L1-content-origination-production-management.yaml
@@ -1,0 +1,153 @@
+# Produzione e sviluppo dei contenuti (it) — translations for L1-content-origination-production-management.yaml
+locale: it
+source: L1-content-origination-production-management.yaml
+entries:
+  BC-3700:
+    name: Produzione e sviluppo dei contenuti
+    description: |
+      Greenlight, pre-produzione, riprese in studio o in location, produzione live e notizie,
+      post-produzione e localizzazione di contenuti audiovisivi, audio ed editoriali,
+      dal concept al master pronto per la distribuzione.
+  BC-3700.10:
+    name: Commissioning e greenlight dei contenuti
+    description: |
+      Valutazione di concept e pitch, composizione dello slate e autorità per
+      il commissioning di nuove produzioni o acquisizioni.
+  BC-3700.10.10:
+    name: Valutazione di concept e pitch
+    description: |
+      Valutazione strutturata di pitch, treatment e bible in arrivo
+      secondo criteri editoriali e commerciali.
+  BC-3700.10.20:
+    name: Pianificazione dello slate e del portfolio
+    description: |
+      Composizione dello slate di produzione per genere, budget,
+      audience e finestre di distribuzione.
+  BC-3700.10.30:
+    name: Decisione di greenlight
+    description: |
+      Autorità e registrazione della decisione di greenlight, comprensivi
+      di budget, pianificazione e impostazione creativa.
+  BC-3700.10.40:
+    name: Gestione del brief di commissioning
+    description: |
+      Redazione e ciclo di vita dei brief di commissioning emessi verso
+      unità produttive interne e produttori esterni.
+  BC-3700.20:
+    name: Gestione della pre-produzione
+    description: |
+      Sviluppo della sceneggiatura, budget di produzione, pianificazione
+      e progettazione di location e set per portare un progetto con greenlight
+      alla fase di ripresa.
+  BC-3700.20.10:
+    name: Sviluppo di sceneggiatura e storyboard
+    description: |
+      Sviluppo iterativo di sceneggiature, storyboard e shot list
+      per produzioni fiction e non-fiction.
+  BC-3700.20.20:
+    name: Pianificazione del budget di produzione
+    description: |
+      Budget di produzione dettagliato per reparto e fase, con considerazioni
+      su contingency e completion bond.
+  BC-3700.20.30:
+    name: Pianificazione della produzione
+    description: |
+      Costruzione del piano di ripresa e dello stripboard, disponibilità
+      di talento e cast tecnico e suddivisione delle unità.
+  BC-3700.20.40:
+    name: Pianificazione di location e set
+    description: |
+      Sopralluogo location, permessi e progettazione e costruzione del set
+      in studio e nelle location esterne.
+  BC-3700.30:
+    name: Gestione delle operazioni di produzione
+    description: |
+      Esecuzione delle riprese principali o della produzione in studio, compresa
+      la logistica di cast tecnico, attrezzatura e workflow sul set.
+  BC-3700.30.10:
+    name: Operazioni di produzione in studio
+    description: |
+      Produzione su studio per format di intrattenimento, fiction e non-fiction,
+      incluse configurazioni multi-camera.
+  BC-3700.30.20:
+    name: Operazioni di produzione in location
+    description: |
+      Esecuzione della produzione in location esterne e remote, compresa
+      la gestione delle unità e la sicurezza sul set.
+  BC-3700.30.30:
+    name: Logistica di produzione e gestione del cast tecnico
+    description: |
+      Logistica di call sheet, trasporti, catering e spostamento delle
+      attrezzature nel corso della produzione.
+  BC-3700.40:
+    name: Gestione della produzione live e delle notizie
+    description: |
+      Produzione in tempo reale di eventi live, sport e notiziari, compresa
+      la regia multi-camera e la grafica in diretta.
+  BC-3700.40.10:
+    name: Produzione di eventi live
+    description: |
+      Produzione di intrattenimento live ed eventi speciali con missaggio
+      video e audio in tempo reale.
+  BC-3700.40.20:
+    name: Produzione di notiziari
+    description: |
+      Produzione in newsroom di notiziari e informazione in continuo, compresa
+      la gestione del scaletta e il coordinamento degli inserti live.
+  BC-3700.40.30:
+    name: Produzione della copertura sportiva
+    description: |
+      Produzione multi-camera di sport live, comprese le operazioni
+      di outside broadcast e host broadcast.
+  BC-3700.40.40:
+    name: Grafica in tempo reale e replay
+    description: |
+      Grafica on-air, tabelloni segnapunti e operazioni di instant replay
+      per produzioni live e near-live.
+  BC-3700.50:
+    name: Gestione della post-produzione
+    description: |
+      Workflow di immagine, audio, color grading e finishing che portano
+      il materiale girato a un master di qualità per la distribuzione.
+  BC-3700.50.10:
+    name: Montaggio e visual effects
+    description: |
+      Montaggio offline e online, integrazione dei visual effects e
+      conform delle decisioni di montaggio.
+  BC-3700.50.20:
+    name: Post-produzione audio
+    description: |
+      Editing del dialogo, ADR, foley, sound design e mix finale
+      alle specifiche di loudness per la distribuzione.
+  BC-3700.50.30:
+    name: Color grading e finishing
+    description: |
+      Color grading creativo e tecnico e finishing per i deliverable
+      HDR e SDR.
+  BC-3700.50.40:
+    name: Mastering e conform
+    description: |
+      Produzione dei master di distribuzione, pacchetti IMF e mezzanino
+      broadcast, e conform alle specifiche di distribuzione.
+  BC-3700.60:
+    name: Gestione della localizzazione e del versioning
+    description: |
+      Sottotitolazione, captioning, doppiaggio e tagli regionali o
+      specifici per piattaforma e master di versione per la distribuzione.
+  BC-3700.60.10:
+    name: Produzione di sottotitoli e captioning
+    description: |
+      Redazione di sottotitoli e closed caption in più lingue e formati.
+  BC-3700.60.20:
+    name: Produzione del doppiaggio
+    description: |
+      Traduzione, casting e registrazione delle tracce audio doppiate
+      per la distribuzione territoriale.
+  BC-3700.60.30:
+    name: Gestione delle versioni linguistiche e dei tagli regionali
+    description: |
+      Produzione di master in versioni linguistiche e regionali, compresi
+      i tagli specifici per territorio.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-content-rights-licensing-management.yaml
+++ b/catalogue/i18n/it/L1-content-rights-licensing-management.yaml
@@ -1,0 +1,153 @@
+# Diritti e licenze sui contenuti (it) — translations for L1-content-rights-licensing-management.yaml
+locale: it
+source: L1-content-rights-licensing-management.yaml
+entries:
+  BC-3720:
+    name: Diritti e licenze sui contenuti
+    description: |
+      Acquisizione, inventario, licenze in uscita, diritti sportivi e musicali,
+      royalty in entrata, sgravamento e chain-of-title per contenuti audiovisivi,
+      audio ed editoriali.
+  BC-3720.10:
+    name: Gestione dell'acquisizione dei diritti
+    description: |
+      Negoziazione e contrattualizzazione dei diritti in entrata per i contenuti
+      acquisiti dall'azienda da detentori di diritti o produttori.
+  BC-3720.10.10:
+    name: Supporto alla negoziazione dei diritti
+    description: |
+      Preparazione di term sheet, analisi di deal comparabili e supporto alla
+      negoziazione per accordi di contenuto in entrata.
+  BC-3720.10.20:
+    name: Gestione dei contratti di acquisizione
+    description: |
+      Redazione, esecuzione e gestione del ciclo di vita dei contratti di
+      diritti in entrata e dei loro emendamenti.
+  BC-3720.10.30:
+    name: Tracciamento delle finestre di acquisizione dei diritti
+    description: |
+      Tracciamento delle finestre di distribuzione acquisite, territori,
+      piattaforme e condizioni di esclusiva rispetto al contratto.
+  BC-3720.20:
+    name: Gestione dell'inventario dei diritti
+    description: |
+      Gestione dell'inventario consolidato dei diritti detenuti e
+      interrogazione della disponibilità per la programmazione e le licenze.
+  BC-3720.20.10:
+    name: Tracciamento delle finestre e dei territori dei diritti
+    description: |
+      Tracciamento delle finestre di diritti disponibili per titolo,
+      territorio, piattaforma e lingua.
+  BC-3720.20.20:
+    name: Tracciamento dei holdback e delle esclusività
+    description: |
+      Tracciamento dei periodi di holdback e delle restrizioni di esclusiva
+      che condizionano l'uso downstream.
+  BC-3720.20.30:
+    name: Richiesta di disponibilità dei diritti
+    description: |
+      Servizi di interrogazione per verificare se un titolo è licenziabile
+      per un dato utilizzo, finestra e territorio.
+  BC-3720.30:
+    name: Gestione delle licenze in uscita
+    description: |
+      Vendita e gestione del ciclo di vita dei diritti ceduti in licenza
+      a broadcaster, piattaforme e terze parti.
+  BC-3720.30.10:
+    name: Gestione delle vendite di licenze
+    description: |
+      Pipeline, strutturazione e chiusura di accordi di licenza in uscita
+      per territori e piattaforme.
+  BC-3720.30.20:
+    name: Gestione degli output deal
+    description: |
+      Gestione di output deal e accordi a volume multi-titolo con
+      licenziatari downstream.
+  BC-3720.30.30:
+    name: Gestione delle licenze di format
+    description: |
+      Licenza di format non-fiction e fiction e relativi bible a produttori
+      locali e broadcaster.
+  BC-3720.40:
+    name: Gestione dei diritti sportivi e degli eventi live
+    description: |
+      Offerta, tracciamento e sfruttamento dei diritti sportivi e degli
+      eventi live, compresi i highlight derivati.
+  BC-3720.40.10:
+    name: Offerta per i diritti sportivi
+    description: |
+      Preparazione delle offerte, valutazione e risposta alle gare per
+      i diritti sportivi e degli eventi live.
+  BC-3720.40.20:
+    name: Tracciamento dei diritti sui programmi degli eventi
+    description: |
+      Tracciamento dei diritti a livello di singola partita rispetto ai
+      diritti di competizione e torneo detenuti.
+  BC-3720.40.30:
+    name: Gestione dei diritti su highlight e clip
+    description: |
+      Gestione dei diritti derivati per highlight, clip e sfruttamento
+      short-form su social e digitale.
+  BC-3720.50:
+    name: Gestione dei diritti musicali e di esecuzione
+    description: |
+      Licenza e rendicontazione dei diritti musicali e di esecuzione,
+      compresi sincronizzazione, diritti meccanici e comunicazione al pubblico.
+  BC-3720.50.10:
+    name: Licenza meccanica e di sincronizzazione
+    description: |
+      Sgravamento e licenza dei diritti meccanici e di sincronizzazione
+      per la musica usata nelle produzioni e sulle piattaforme.
+  BC-3720.50.20:
+    name: Rendicontazione dei diritti di esecuzione
+    description: |
+      Rendicontazione dell'esecuzione pubblica e dell'uso broadcast
+      alle società di gestione collettiva.
+  BC-3720.50.30:
+    name: Gestione dei cue sheet musicali
+    description: |
+      Produzione e distribuzione dei cue sheet musicali alle società
+      di gestione e ai detentori dei diritti.
+  BC-3720.60:
+    name: Gestione delle royalty in entrata
+    description: |
+      Ricezione, riconciliazione e distribuzione dei proventi da royalty
+      dovuti all'azienda in qualità di detentore dei diritti.
+  BC-3720.60.10:
+    name: Riconciliazione dei rendiconti di royalty
+    description: |
+      Riconciliazione dei rendiconti di royalty in entrata da licenziatari
+      e società di gestione rispetto ai diritti detenuti.
+  BC-3720.60.20:
+    name: Registrazione delle royalty ricevute
+    description: |
+      Registrazione delle royalty ricevute nel libro contabile dei diritti
+      e relativa contabilizzazione.
+  BC-3720.60.30:
+    name: Distribuzione ai detentori dei diritti sottostanti
+    description: |
+      Distribuzione delle royalty ricevute ai detentori dei diritti sottostanti
+      secondo i termini di partecipazione e sub-publishing.
+  BC-3720.70:
+    name: Gestione dello sgravamento dei diritti e della chain-of-title
+    description: |
+      Verifica e documentazione dei diritti sottostanti e della chain-of-title
+      per supportare lo sfruttamento e la copertura E&O.
+  BC-3720.70.10:
+    name: Verifica dei diritti sottostanti
+    description: |
+      Verifica dei diritti letterari, musicali e di immagine sgravati
+      nell'opera.
+  BC-3720.70.20:
+    name: Tracciamento dello stato di sgravamento
+    description: |
+      Tracciamento dello stato di sgravamento per elemento con gestione
+      delle azioni in sospeso.
+  BC-3720.70.30:
+    name: Documentazione della chain-of-title
+    description: |
+      Mantenimento dei record di chain-of-title sufficienti per la copertura
+      E&O e la due diligence dei licenziatari downstream.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-corporate-communications-management.yaml
+++ b/catalogue/i18n/it/L1-corporate-communications-management.yaml
@@ -1,0 +1,119 @@
+# Gestione delle comunicazioni aziendali (it) — translations for L1-corporate-communications-management.yaml
+locale: it
+source: L1-corporate-communications-management.yaml
+entries:
+  BC-850:
+    name: Gestione delle comunicazioni aziendali
+    description: |
+      Comunicazioni aziendali interne ed esterne.
+  BC-850.10:
+    name: Gestione delle comunicazioni interne
+    description: |
+      Comunicazioni ai dipendenti e comunicazioni della leadership.
+  BC-850.10.10:
+    name: Comunicazioni ai dipendenti
+    description: |
+      Newsletter, intranet e town hall per i dipendenti.
+  BC-850.10.20:
+    name: Comunicazioni della leadership
+    description: |
+      Comunicazioni e messaggi del CEO e del management.
+  BC-850.10.30:
+    name: Comunicazioni di cambiamento e trasformazione
+    description: |
+      Comunicazioni interne a supporto del cambiamento e della trasformazione.
+  BC-850.10.40:
+    name: Gestione dei canali interni
+    description: |
+      Gestione dei canali interni (intranet, Slack, Teams).
+  BC-850.20:
+    name: Gestione delle comunicazioni esterne
+    description: |
+      Messaggistica aziendale esterna e dichiarazioni ufficiali.
+  BC-850.20.10:
+    name: Architettura dei messaggi esterni
+    description: |
+      Architettura dei messaggi e narrativa per i pubblici esterni.
+  BC-850.20.20:
+    name: Dichiarazioni aziendali e position paper
+    description: |
+      Redazione di dichiarazioni aziendali e position paper.
+  BC-850.20.30:
+    name: Sito web aziendale e canali propri
+    description: |
+      Contenuti del sito web aziendale e dei canali esterni di proprietà.
+  BC-850.30:
+    name: Gestione delle relazioni pubbliche
+    description: |
+      Gestione della reputazione e PR verso gli stakeholder.
+  BC-850.30.10:
+    name: Gestione della reputazione
+    description: |
+      Monitoraggio della reputazione, analisi del sentiment e strategia reputazionale.
+  BC-850.30.20:
+    name: Gestione del thought leadership
+    description: |
+      Contenuti di thought leadership e posizionamento dei dirigenti.
+  BC-850.30.30:
+    name: Relazioni istituzionali e con il governo
+    description: |
+      Relazioni con le istituzioni governative e engagement con i decision maker.
+  BC-850.40:
+    name: Gestione delle relazioni con i media
+    description: |
+      Engagement con i media, comunicati stampa e briefing.
+  BC-850.40.10:
+    name: Gestione dei comunicati stampa
+    description: |
+      Redazione, approvazione e distribuzione dei comunicati stampa.
+  BC-850.40.20:
+    name: Engagement con i giornalisti
+    description: |
+      Relazioni con i giornalisti, interviste e briefing.
+  BC-850.40.30:
+    name: Monitoraggio dei media
+    description: |
+      Monitoraggio della copertura mediatica e della share of voice.
+  BC-850.40.40:
+    name: Preparazione dei portavoce dei media
+    description: |
+      Identificazione, formazione e preparazione dei messaggi per i portavoce.
+  BC-850.50:
+    name: Gestione delle comunicazioni di crisi
+    description: |
+      Comunicazioni durante crisi e incidenti.
+  BC-850.50.10:
+    name: Pianificazione delle comunicazioni di crisi
+    description: |
+      Piani di comunicazione di crisi predisposti per scenario.
+  BC-850.50.20:
+    name: Predisposizione dei comunicati di crisi
+    description: |
+      Predisposizione rapida di comunicati e Q&A durante gli incidenti.
+  BC-850.50.30:
+    name: Gestione dei portavoce di crisi
+    description: |
+      Gestione dei portavoce e media handling durante le crisi.
+  BC-850.50.40:
+    name: Recupero della reputazione post-crisi
+    description: |
+      Comunicazioni post-crisi e attività di recupero della reputazione.
+  BC-850.60:
+    name: Gestione delle comunicazioni agli stakeholder
+    description: |
+      Comunicazioni mirate a specifici gruppi di stakeholder.
+  BC-850.60.10:
+    name: Mappatura degli stakeholder
+    description: |
+      Mappatura e segmentazione degli stakeholder esterni.
+  BC-850.60.20:
+    name: Pianificazione del coinvolgimento degli stakeholder
+    description: |
+      Piani di engagement personalizzati per i gruppi di stakeholder.
+  BC-850.60.30:
+    name: Coinvolgimento della comunità e degli stakeholder locali
+    description: |
+      Engagement con le comunità locali e gli stakeholder del territorio.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-corporate-governance.yaml
+++ b/catalogue/i18n/it/L1-corporate-governance.yaml
@@ -1,0 +1,103 @@
+# Corporate governance (it) — translations for L1-corporate-governance.yaml
+locale: it
+source: L1-corporate-governance.yaml
+entries:
+  BC-110:
+    name: Corporate governance
+    description: |
+      Processi di governance del consiglio di amministrazione, dei comitati e degli azionisti.
+  BC-110.10:
+    name: Gestione del consiglio e dei comitati
+    description: |
+      Composizione del consiglio, riunioni, comitati e documentazione.
+  BC-110.10.10:
+    name: Gestione della composizione del consiglio
+    description: |
+      Nomina degli amministratori, successione, indipendenza e matrice delle competenze.
+  BC-110.10.20:
+    name: Amministrazione delle riunioni del consiglio
+    description: |
+      Ordini del giorno, documenti preparatori, verbali e delibere per le riunioni del consiglio.
+  BC-110.10.30:
+    name: Operatività dei comitati
+    description: |
+      Operatività dei comitati audit, rischi, remunerazione e nomine.
+  BC-110.10.40:
+    name: Inserimento e formazione degli amministratori
+    description: |
+      Induzione, formazione continua e revisioni dell'efficacia del consiglio.
+  BC-110.20:
+    name: Gestione degli azionisti e del patrimonio netto
+    description: |
+      Struttura del capitale, registro azionisti e diritti degli azionisti.
+  BC-110.20.10:
+    name: Tenuta del registro azionisti
+    description: |
+      Tenuta del registro dei soci e dei registri di proprietà effettiva.
+  BC-110.20.20:
+    name: Gestione delle assemblee degli azionisti
+    description: |
+      Convocazione di AGM/EGM, avvisi, votazioni e delibere.
+  BC-110.20.30:
+    name: Amministrazione dei dividendi e delle distribuzioni
+    description: |
+      Delibere sui dividendi, pagamenti e distribuzioni di capitale.
+  BC-110.20.40:
+    name: Gestione della struttura del capitale azionario
+    description: |
+      Classi di azioni, aumenti di capitale, riacquisti e frazionamenti azionari.
+  BC-110.30:
+    name: Gestione della segreteria societaria
+    description: |
+      Adempimenti statutari, libri sociali e formalità societarie.
+  BC-110.30.10:
+    name: Amministrazione degli adempimenti statutari
+    description: |
+      Depositi presso i registri delle imprese e le autorità societarie.
+  BC-110.30.20:
+    name: Gestione dei libri e dei registri societari
+    description: |
+      Tenuta dei libri sociali, dei registri statutari e degli archivi aziendali.
+  BC-110.30.30:
+    name: Amministrazione delle delibere societarie
+    description: |
+      Redazione, sottoscrizione e registrazione delle delibere del consiglio e degli azionisti.
+  BC-110.40:
+    name: Gestione delle controllate e delle entità del gruppo
+    description: |
+      Struttura delle entità legali e governance del gruppo.
+  BC-110.40.10:
+    name: Gestione del ciclo di vita delle entità legali
+    description: |
+      Costituzione, ristrutturazione, quiescenza e liquidazione delle entità.
+  BC-110.40.20:
+    name: Governance della struttura di gruppo
+    description: |
+      Tenuta e supervisione dell'organigramma delle entità legali e delle catene di controllo.
+  BC-110.40.30:
+    name: Standard di governance delle controllate
+    description: |
+      Standard di governance di gruppo applicati alle controllate.
+  BC-110.40.40:
+    name: Conformità delle entità estere
+    description: |
+      Conformità agli obblighi statutari e di corporate governance per le controllate estere.
+  BC-110.50:
+    name: Gestione delle deleghe e dei poteri
+    description: |
+      Matrici dei poteri, deleghe e diritti di firma.
+  BC-110.50.10:
+    name: Framework di delega dei poteri
+    description: |
+      Livelli di autorità, soglie di approvazione e gerarchie di delega.
+  BC-110.50.20:
+    name: Amministrazione dei poteri di firma
+    description: |
+      Elenchi dei firmatari autorizzati, procure e mandati bancari.
+  BC-110.50.30:
+    name: Monitoraggio della conformità delle deleghe
+    description: |
+      Monitoraggio delle decisioni adottate nel rispetto dei limiti di delega.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-corporate-real-estate-management.yaml
+++ b/catalogue/i18n/it/L1-corporate-real-estate-management.yaml
@@ -1,0 +1,87 @@
+# Gestione del patrimonio immobiliare aziendale (it) — translations for L1-corporate-real-estate-management.yaml
+locale: it
+source: L1-corporate-real-estate-management.yaml
+entries:
+  BC-710:
+    name: Gestione del patrimonio immobiliare aziendale
+    description: |
+      Portafoglio immobiliare, contratti di locazione, transazioni, pianificazione degli spazi.
+  BC-710.10:
+    name: Gestione della strategia e del portafoglio immobiliare
+    description: |
+      Strategia immobiliare, composizione del portafoglio, pianificazione del patrimonio.
+  BC-710.10.10:
+    name: Sviluppo della strategia immobiliare
+    description: |
+      Strategia immobiliare pluriennale allineata alle esigenze aziendali.
+  BC-710.10.20:
+    name: Pianificazione del patrimonio immobiliare
+    description: |
+      Pianificazione del patrimonio, strategia di localizzazione e analisi di consolidamento.
+  BC-710.10.30:
+    name: Gestione della performance degli immobili
+    description: |
+      Monitoraggio dei costi, dell'utilizzo e della performance per immobile.
+  BC-710.10.40:
+    name: Gestione del rischio immobiliare
+    description: |
+      Rischio di mercato immobiliare, paese e controparte.
+  BC-710.20:
+    name: Gestione dell'acquisizione e dismissione di immobili
+    description: |
+      Acquisizioni, dismissioni, uscite.
+  BC-710.20.10:
+    name: Acquisizione di immobili
+    description: |
+      Acquisizione di immobili di proprietà e in locazione, inclusa la due diligence.
+  BC-710.20.20:
+    name: Dismissione e uscita da immobili
+    description: |
+      Vendita, sublocazione e uscita da asset e contratti di locazione.
+  BC-710.20.30:
+    name: Selezione del sito e negoziazione
+    description: |
+      Analisi della localizzazione, selezione del sito e negoziazione del contratto di locazione.
+  BC-710.30:
+    name: Gestione dell'amministrazione dei contratti di locazione
+    description: |
+      Ciclo di vita dei contratti di locazione, contabilizzazione, opzioni.
+  BC-710.30.10:
+    name: Gestione della documentazione dei contratti di locazione
+    description: |
+      Manutenzione dei documenti, dei riepiloghi e dei termini chiave dei contratti di locazione.
+  BC-710.30.20:
+    name: Contabilizzazione dei contratti di locazione
+    description: |
+      Contabilizzazione dei contratti di locazione ai sensi di IFRS 16 / ASC 842.
+  BC-710.30.30:
+    name: Pagamenti e riconciliazione dei contratti di locazione
+    description: |
+      Pagamenti di canoni, oneri di servizio e CAM e riconciliazione.
+  BC-710.30.40:
+    name: Gestione delle opzioni e dei rinnovi dei contratti di locazione
+    description: |
+      Monitoraggio ed esercizio delle opzioni, dei recessi e dei rinnovi dei contratti di locazione.
+  BC-710.40:
+    name: Gestione della strategia del luogo di lavoro
+    description: |
+      Concept di luogo di lavoro, lavoro ibrido, standard progettuali.
+  BC-710.40.10:
+    name: Progettazione del concept del luogo di lavoro
+    description: |
+      Definizione dei concept del luogo di lavoro, incluso il lavoro per attività.
+  BC-710.40.20:
+    name: Standard di progettazione del luogo di lavoro
+    description: |
+      Guide progettuali, standard di allestimento e standard di brand per i luoghi di lavoro.
+  BC-710.40.30:
+    name: Implementazione della politica di lavoro ibrido
+    description: |
+      Implementazione dei modelli di lavoro ibrido e degli spazi di supporto.
+  BC-710.40.40:
+    name: Misurazione dell'esperienza del luogo di lavoro
+    description: |
+      Misurazione dell'esperienza e della soddisfazione del luogo di lavoro.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-credit-lending-management.yaml
+++ b/catalogue/i18n/it/L1-credit-lending-management.yaml
@@ -1,0 +1,139 @@
+# Gestione del credito e della concessione del credito (it) — translations for L1-credit-lending-management.yaml
+locale: it
+source: L1-credit-lending-management.yaml
+entries:
+  BC-1320:
+    name: Gestione del credito e della concessione del credito
+    description: |
+      Origination del credito, sottoscrizione, servicing del prestito, recupero crediti e gestione del portafoglio.
+  BC-1320.10:
+    name: Gestione dell'origination del credito
+    description: |
+      Acquisizione delle domande di credito, pre-screening e flussi di origination.
+  BC-1320.10.10:
+    name: Acquisizione delle domande di credito
+    description: |
+      Acquisizione delle domande di credito su tutti i canali.
+  BC-1320.10.20:
+    name: Pre-screening e verifica della sostenibilità del debito
+    description: |
+      Pre-screening, verifica della sostenibilità del debito e della capacità di rimborso.
+  BC-1320.10.30:
+    name: Orchestrazione del flusso di origination
+    description: |
+      Orchestrazione dei flussi di origination del credito e relativi SLA.
+  BC-1320.10.40:
+    name: Raccolta della documentazione di origination
+    description: |
+      Raccolta e verifica dei documenti a supporto dell'origination.
+  BC-1320.20:
+    name: Gestione della sottoscrizione e del processo decisionale del credito
+    description: |
+      Sottoscrizione del credito, analisi finanziaria, processo decisionale e autorità delegate.
+  BC-1320.20.10:
+    name: Valutazione del rischio di credito
+    description: |
+      Valutazione del rischio di credito dei richiedenti e delle esposizioni.
+  BC-1320.20.20:
+    name: Analisi e rielaborazione dei bilanci
+    description: |
+      Rielaborazione dei bilanci e analisi degli indici finanziari.
+  BC-1320.20.30:
+    name: Processo decisionale del credito
+    description: |
+      Motori decisionali e valutazione discrezionale delle pratiche di credito.
+  BC-1320.20.40:
+    name: Approvazione del credito e autorità delegate
+    description: |
+      Governance dell'approvazione del credito e applicazione delle autorità delegate.
+  BC-1320.20.50:
+    name: Valutazione e gestione delle garanzie
+    description: |
+      Identificazione, valutazione e perfezionamento del vincolo sulle garanzie.
+  BC-1320.30:
+    name: Gestione del servicing del prestito
+    description: |
+      Servicing del prestito, rimborsi, variazioni del piano di ammortamento e modifiche.
+  BC-1320.30.10:
+    name: Erogazione del prestito
+    description: |
+      Gestione dell'erogazione e del tiraggio del prestito.
+  BC-1320.30.20:
+    name: Elaborazione dei rimborsi
+    description: |
+      Pianificazione, elaborazione e riconciliazione dei rimborsi.
+  BC-1320.30.30:
+    name: Modifica del prestito
+    description: |
+      Modifiche dei termini del prestito, ristrutturazioni e rifinanziamenti.
+  BC-1320.30.40:
+    name: Estinzione e chiusura del prestito
+    description: |
+      Estinzione del prestito, emissione del conteggio estintivo e operazioni di chiusura.
+  BC-1320.40:
+    name: Gestione degli incassi e del recupero crediti
+    description: |
+      Gestione degli incassi, ristrutturazione, operazioni di recupero e workout degli NPL (crediti deteriorati).
+  BC-1320.40.10:
+    name: Gestione delle prime fasi di morosità
+    description: |
+      Gestione degli arretrati iniziali e solleciti di pagamento.
+  BC-1320.40.20:
+    name: Gestione delle fasi tardive di morosità
+    description: |
+      Gestione avanzata degli incassi e rinvio al contenzioso.
+  BC-1320.40.30:
+    name: Ristrutturazione del credito e misure di tolleranza
+    description: |
+      Proposte di ristrutturazione del credito, misure di tolleranza e supporto ai clienti in difficoltà.
+  BC-1320.40.40:
+    name: Recupero crediti e cancellazione dal bilancio
+    description: |
+      Operazioni di recupero crediti, cancellazione dal bilancio e attività post-stralcio.
+  BC-1320.40.50:
+    name: Workout degli NPL (crediti deteriorati)
+    description: |
+      Workout, vendita e cartolarizzazione degli NPL (crediti deteriorati).
+  BC-1320.50:
+    name: Gestione del portafoglio crediti
+    description: |
+      Analisi del portafoglio, ottimizzazione e gestione del capitale.
+  BC-1320.50.10:
+    name: Analisi del rischio del portafoglio
+    description: |
+      Analisi del portafoglio per vintage, concentrazione e stress test.
+  BC-1320.50.20:
+    name: Ottimizzazione del portafoglio
+    description: |
+      Ottimizzazione del mix di portafoglio, tariffazione e rapporto rischio-rendimento.
+  BC-1320.50.30:
+    name: Gestione del capitale del portafoglio
+    description: |
+      Gestione del capitale per i portafogli creditizi nel rispetto delle norme di Basilea III.
+  BC-1320.50.40:
+    name: Reportistica del portafoglio
+    description: |
+      Reportistica del portafoglio destinata ai comitati rischi e alle autorità di vigilanza.
+  BC-1320.60:
+    name: Gestione della modellistica del rischio di credito
+    description: |
+      Modelli PD/LGD/EAD, approccio IRB, ECL (perdite attese su crediti) secondo IFRS 9.
+  BC-1320.60.10:
+    name: Sviluppo dei modelli PD/LGD/EAD
+    description: |
+      Sviluppo dei modelli PD, LGD e EAD.
+  BC-1320.60.20:
+    name: Modellistica ECL secondo IFRS 9
+    description: |
+      Sviluppo e gestione del modello di ECL (perdite attese su crediti) secondo IFRS 9.
+  BC-1320.60.30:
+    name: Validazione dei modelli
+    description: |
+      Validazione indipendente dei modelli di rischio di credito.
+  BC-1320.60.40:
+    name: Monitoraggio dei modelli
+    description: |
+      Monitoraggio continuativo delle performance e ricalibrazione dei modelli.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-crop-production-management.yaml
+++ b/catalogue/i18n/it/L1-crop-production-management.yaml
@@ -1,0 +1,168 @@
+# Gestione della produzione delle colture (it) — translations for L1-crop-production-management.yaml
+locale: it
+source: L1-crop-production-management.yaml
+entries:
+  BC-3500:
+    name: Gestione della produzione delle colture
+    description: |
+      Operazioni colturali in azienda agricola — pianificazione del sistema colturale, preparazione del suolo,
+      semina, nutrizione, difesa delle colture, irrigazione, monitoraggio e previsione della resa
+      per colture di campo, ortofrutticole e specializzate.
+  BC-3500.10:
+    name: Pianificazione del sistema colturale
+    description: |
+      Pianificazione pluristagionale della rotazione delle colture, assegnazione dei campi, finestre di semina
+      e selezione delle varietà nell'insieme del portafoglio aziendale.
+    in_scope:
+      - Progettazione della rotazione delle colture
+      - Assegnazione delle colture per singolo campo
+      - Pianificazione delle finestre di semina
+      - Selezione di varietà e ibridi
+    out_of_scope:
+      - Esecuzione delle sperimentazioni varietali (BC-3530.60)
+      - Prescrizioni agronomiche (BC-3530.20)
+  BC-3500.10.10:
+    name: Pianificazione della rotazione delle colture
+    description: |
+      Progettazione pluriennale della rotazione delle colture, bilanciando la salute del suolo, la domanda di mercato e i cicli dei parassiti.
+  BC-3500.10.20:
+    name: Pianificazione dell'assegnazione dei campi
+    description: |
+      Assegnazione delle colture a campi e appezzamenti specifici per la stagione di semina.
+  BC-3500.10.30:
+    name: Pianificazione delle finestre di semina
+    description: |
+      Pianificazione delle finestre di semina ottimali per coltura, varietà e zona agro-climatica.
+  BC-3500.10.40:
+    name: Decisioni di selezione varietale
+    description: |
+      Selezione di varietà e ibridi per la stagione di semina in base a criteri agronomici e di mercato.
+  BC-3500.20:
+    name: Operazioni di preparazione del suolo
+    description: |
+      Lavorazioni, preparazione del letto di semina e interventi di ammendamento pre-semina
+      per creare un letto di semina idoneo.
+  BC-3500.20.10:
+    name: Operazioni di lavorazione del suolo
+    description: |
+      Operazioni di preparazione del campo con lavorazione convenzionale, ridotta e a semina diretta.
+  BC-3500.20.20:
+    name: Operazioni di preparazione del letto di semina
+    description: |
+      Formazione di aiole, rincalzatura e pacciamatura per la produzione orticola e in filari.
+  BC-3500.20.30:
+    name: Applicazione di ammendanti pre-semina
+    description: |
+      Applicazione di ammendanti pre-semina quali calce, gesso agricolo e sostanza organica.
+  BC-3500.30:
+    name: Operazioni di semina e trapianto
+    description: |
+      Posizionamento di seme e trapianti, comprese le decisioni di risemina e l'impianto della coltura.
+  BC-3500.30.10:
+    name: Finalizzazione del letto di semina
+    description: |
+      Preparazione finale del letto di semina immediatamente prima della semina.
+  BC-3500.30.20:
+    name: Posizionamento di seme e trapianti
+    description: |
+      Posizionamento meccanico e manuale di seme e trapianti in campo.
+  BC-3500.30.30:
+    name: Operazioni di risemina e colmatura delle lacune
+    description: |
+      Risemina e colmatura delle lacune nei casi in cui il primo impianto della coltura non abbia avuto successo.
+  BC-3500.40:
+    name: Operazioni di nutrizione delle colture
+    description: |
+      Somministrazione di nutrienti in stagione tramite metodi di applicazione solida, liquida, fogliare e fertirrigazione.
+  BC-3500.40.10:
+    name: Applicazione di fertilizzanti solidi
+    description: |
+      Applicazione a spaglio, a banda e a rateo variabile di fertilizzanti solidi.
+  BC-3500.40.20:
+    name: Applicazione fogliare di nutrienti
+    description: |
+      Applicazione fogliare di macro e micronutrienti durante la stagione di crescita.
+  BC-3500.40.30:
+    name: Operazioni di fertirrigazione
+    description: |
+      Somministrazione di nutrienti tramite impianti di irrigazione, inclusi iniezione e controllo della dosatura.
+  BC-3500.50:
+    name: Operazioni di difesa delle colture
+    description: |
+      Applicazione di interventi chimici, biologici e meccanici di difesa delle colture e relative registrazioni.
+    in_scope:
+      - Applicazione di pesticidi ed erbicidi
+      - Applicazione di prodotti per il controllo biologico
+      - Controllo meccanico e termico delle erbe infestanti
+      - Registrazioni dei trattamenti
+    out_of_scope:
+      - Pianificazione IPM (BC-3530.30)
+      - Monitoraggio della conformità agli LMR (BC-3590.50)
+  BC-3500.50.10:
+    name: Operazioni di applicazione dei pesticidi
+    description: |
+      Applicazione di pesticidi da terra e via aerea, inclusa la gestione della deriva dello spray.
+  BC-3500.50.20:
+    name: Applicazione del controllo biologico
+    description: |
+      Rilascio di agenti di controllo biologico e prodotti biopesticidi.
+  BC-3500.50.30:
+    name: Controllo meccanico e termico delle erbe infestanti
+    description: |
+      Controllo meccanico e termico delle erbe infestanti, incluse la lavorazione del suolo e la sarchiatura a fiamma.
+  BC-3500.50.40:
+    name: Registrazione dei trattamenti
+    description: |
+      Registrazioni dei trattamenti a livello di campo, con prodotto, dose, condizioni meteorologiche e operatore.
+  BC-3500.60:
+    name: Operazioni di irrigazione
+    description: |
+      Programmazione giornaliera dell'irrigazione, applicazione e decisioni di drenaggio che governano lo stato idrico della coltura.
+  BC-3500.60.10:
+    name: Programmazione dell'irrigazione
+    description: |
+      Programmazione dell'irrigazione basata sull'umidità del suolo e sulla domanda idrica della coltura.
+  BC-3500.60.20:
+    name: Operazioni di applicazione dell'irrigazione
+    description: |
+      Applicazione dell'acqua di irrigazione tramite sistemi a pioggia, a goccia e per scorrimento superficiale.
+  BC-3500.60.30:
+    name: Operazioni di drenaggio del campo
+    description: |
+      Operazioni di drenaggio superficiale e sotterraneo e controllo della falda freatica.
+  BC-3500.70:
+    name: Monitoraggio e scouting delle colture
+    description: |
+      Monitoraggio a livello di campo della salute delle colture, della pressione dei parassiti e della fenologia,
+      tramite sopralluogo, sensori e telerilevamento.
+  BC-3500.70.10:
+    name: Operazioni di scouting in campo
+    description: |
+      Sopralluoghi manuali per la valutazione di parassiti, malattie e condizioni della coltura.
+  BC-3500.70.20:
+    name: Sorveglianza di parassiti e malattie
+    description: |
+      Sorveglianza della pressione di parassiti e malattie tramite trappole e sensori.
+  BC-3500.70.30:
+    name: Monitoraggio della fenologia della coltura
+    description: |
+      Monitoraggio degli stadi di crescita, delle unità termiche e delle tappe fenologiche.
+  BC-3500.70.40:
+    name: Monitoraggio delle colture tramite telerilevamento
+    description: |
+      Monitoraggio dello stato della coltura tramite satellite, drone e sensori prossimali.
+  BC-3500.80:
+    name: Previsione della resa delle colture
+    description: |
+      Stima della resa in stagione e pre-raccolta a supporto dell'origination, della logistica e della pianificazione commerciale.
+  BC-3500.80.10:
+    name: Stima della resa in stagione
+    description: |
+      Stime di resa a metà stagione basate su indici colturali e misurazioni in campo.
+  BC-3500.80.20:
+    name: Previsione della resa pre-raccolta
+    description: |
+      Previsioni di resa pre-raccolta a supporto dei piani di raccolta, stoccaggio e origination.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-cruise-voyage-operations-management.yaml
+++ b/catalogue/i18n/it/L1-cruise-voyage-operations-management.yaml
@@ -1,0 +1,198 @@
+# Gestione delle operazioni di crociera (it) — translations for L1-cruise-voyage-operations-management.yaml
+locale: it
+source: L1-cruise-voyage-operations-management.yaml
+entries:
+  BC-4090:
+    name: Gestione delle operazioni di crociera
+    description: |
+      Operazione dei viaggi in crociera — pianificazione dell'itinerario, operazioni
+      portuali e di escursioni a terra, programmi di cabina e di intrattenimento a bordo,
+      operazioni marine e di plancia, imbarco e sanità a bordo — in conformità
+      alla normativa internazionale sulla sicurezza marittima.
+    in_scope:
+      - Progettazione e distribuzione dell'itinerario di viaggio
+      - Operazioni di scalo, tender ed escursioni a terra
+      - Operazioni di cabina, programmi e servizi agli ospiti a bordo
+      - Operazioni marine, di plancia e sala macchine
+      - Operazioni di imbarco e sbarco
+      - Operazioni sanitarie a bordo
+    out_of_scope:
+      - Vendite e distribuzione delle crociere (BC-4010, BC-4020)
+      - Operazioni alberghiere di strutture a terra (BC-4060)
+  BC-4090.10:
+    name: Pianificazione dell'itinerario di viaggio
+    description: |
+      Pianificazione degli itinerari di viaggio, distribuzione, riposizionamento
+      e decisioni di sostituzione dell'itinerario.
+  BC-4090.10.10:
+    name: Progettazione e distribuzione dell'itinerario
+    description: |
+      Progettazione degli itinerari di crociera e assegnazione delle navi
+      alle stagioni di distribuzione.
+  BC-4090.10.20:
+    name: Pianificazione di viaggi di riposizionamento e charter
+    description: |
+      Pianificazione dei viaggi di riposizionamento e delle distribuzioni
+      charter tra una stagione e l'altra.
+  BC-4090.10.30:
+    name: Sequenziamento delle soste nei porti
+    description: |
+      Sequenziamento delle soste nei porti all'interno di un itinerario,
+      rispetto a maree, tempi di turnaround e accordi con i partner.
+  BC-4090.10.40:
+    name: Modifica e sostituzione dell'itinerario
+    description: |
+      Modifica e sostituzione in tempo reale degli itinerari
+      per eventi meteorologici, medici o geopolitici.
+  BC-4090.20:
+    name: Operazioni portuali e di escursioni a terra
+    description: |
+      Operazioni negli scali portuali, inclusi turnaround, operazioni tender
+      e catalogo, vendita e consegna delle escursioni a terra.
+  BC-4090.20.10:
+    name: Operazioni di turnaround portuale
+    description: |
+      Coordinamento delle operazioni di turnaround portuale,
+      inclusi approvvigionamento, smaltimento rifiuti e cambio equipaggio.
+  BC-4090.20.20:
+    name: Operazioni di tender
+    description: |
+      Operazione dei servizi tender da e verso i porti in rada.
+  BC-4090.20.30:
+    name: Catalogo e vendita delle escursioni a terra
+    description: |
+      Catalogo e vendita delle escursioni a terra agli ospiti
+      tramite canali pre-crociera e a bordo.
+  BC-4090.20.40:
+    name: Coordinamento della consegna delle escursioni a terra
+    description: |
+      Coordinamento della consegna delle escursioni a terra, incluso
+      il passaggio agli operatori locali e la riconciliazione degli ospiti.
+  BC-4090.30:
+    name: Operazioni di cabina e suite a bordo
+    description: |
+      Operazioni di cabina e suite a bordo, inclusi cambio biancheria,
+      assegnazione, upsell a crociera in corso e servizio delle suite speciali.
+  BC-4090.30.10:
+    name: Operazioni di cambio biancheria nella cabina
+    description: |
+      Operazione del cambio biancheria nelle cabine durante l'imbarco
+      e i giorni di cambio ospite.
+  BC-4090.30.20:
+    name: Assegnazione della cabina e upsell
+    description: |
+      Assegnazione delle cabine ed esecuzione delle decisioni di upsell
+      prima e durante il viaggio.
+  BC-4090.30.30:
+    name: Operazioni di manutenzione della cabina
+    description: |
+      Manutenzione dei sistemi e degli arredi della cabina
+      durante il viaggio.
+  BC-4090.30.40:
+    name: Operazioni di servizio delle suite speciali
+    description: |
+      Operazioni di servizio per le suite speciali e le cabine
+      con servizio maggiordomo.
+  BC-4090.40:
+    name: Operazioni del programma per gli ospiti a bordo
+    description: |
+      Intrattenimento, attività, club per bambini e operazioni
+      delle venue speciali a bordo durante il viaggio.
+  BC-4090.40.10:
+    name: Operazioni del programma di intrattenimento
+    description: |
+      Operazione dei programmi di intrattenimento in teatro,
+      lounge e con artisti di richiamo a bordo.
+  BC-4090.40.20:
+    name: Operazioni di attività e arricchimento culturale
+    description: |
+      Operazione dei programmi di attività e arricchimento culturale,
+      incluse conferenze, corsi e sport.
+  BC-4090.40.30:
+    name: Operazioni del programma per bambini e giovani
+    description: |
+      Operazione dei programmi per bambini e giovani,
+      incluse attività adeguate all'età e supervisione.
+  BC-4090.40.40:
+    name: Prenotazioni nelle venue speciali
+    description: |
+      Prenotazioni a bordo per ristoranti speciali, spa
+      ed eventi a pagamento.
+  BC-4090.50:
+    name: Operazioni marine e di plancia
+    description: |
+      Operazioni marine e di plancia, inclusi navigazione, propulsione,
+      documentazione portuale e coordinamento dell'approvvigionamento.
+  BC-4090.50.10:
+    name: Operazioni di plancia e navigazione
+    description: |
+      Guardia di plancia e operazioni di navigazione
+      durante il viaggio.
+  BC-4090.50.20:
+    name: Operazioni di sala macchine e propulsione
+    description: |
+      Guardia di sala macchine e operazioni di propulsione.
+  BC-4090.50.30:
+    name: Documentazione portuale e sdoganamento
+    description: |
+      Predisposizione della documentazione portuale e gestione
+      del porto di scalo e delle pratiche doganali.
+  BC-4090.50.40:
+    name: Coordinamento del bunkering e dell'approvvigionamento
+    description: |
+      Coordinamento del bunkering e dell'approvvigionamento
+      durante gli scali nei porti.
+  BC-4090.60:
+    name: Operazioni di imbarco e sbarco a bordo
+    description: |
+      Operazioni di imbarco e sbarco, incluse la verifica
+      pre-imbarco, lo sdoganamento e il flusso bagagli a bordo.
+  BC-4090.60.10:
+    name: Verifica dei documenti pre-imbarco
+    description: |
+      Verifica dei documenti di viaggio degli ospiti e delle attestazioni
+      sanitarie prima dell'imbarco.
+  BC-4090.60.20:
+    name: Operazioni del flusso di imbarco
+    description: |
+      Operazione dei flussi di imbarco dal terminal alla nave
+      per finestre di arrivo scaglionate.
+  BC-4090.60.30:
+    name: Operazioni di sbarco e sdoganamento
+    description: |
+      Operazione dei flussi di sbarco, incluse le pratiche doganali
+      e di immigrazione nel porto.
+  BC-4090.60.40:
+    name: Operazioni bagagli a bordo
+    description: |
+      Operazione del flusso bagagli all'imbarco, nella consegna
+      in cabina e allo sbarco.
+  BC-4090.70:
+    name: Operazioni di sanità e igiene a bordo della nave da crociera
+    description: |
+      Operazioni di sanità e igiene a bordo, incluse la prontezza
+      alle ispezioni, il rilevamento e la risposta alle epidemie
+      e la sanificazione dell'acqua potabile e delle piscine.
+  BC-4090.70.10:
+    name: Prontezza alle ispezioni sanitarie
+    description: |
+      Manutenzione della prontezza alle ispezioni rispetto ai regimi
+      VSP, USPH ed equivalenti.
+  BC-4090.70.20:
+    name: Rilevamento delle epidemie a bordo
+    description: |
+      Rilevamento di epidemie gastrointestinali e respiratorie
+      tramite sorveglianza a bordo.
+  BC-4090.70.30:
+    name: Operazioni di risposta alle epidemie
+    description: |
+      Operazioni di risposta alle epidemie, inclusi contenimento
+      e notifica.
+  BC-4090.70.40:
+    name: Sanificazione dell'acqua potabile e delle piscine
+    description: |
+      Operazioni di sanificazione per i sistemi di acqua potabile
+      e di balneazione a bordo.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-curriculum-programme-management.yaml
+++ b/catalogue/i18n/it/L1-curriculum-programme-management.yaml
@@ -1,0 +1,151 @@
+# Gestione del curriculo e dei programmi didattici (it) — translations for L1-curriculum-programme-management.yaml
+locale: it
+source: L1-curriculum-programme-management.yaml
+entries:
+  BC-4700:
+    name: Gestione del curriculo e dei programmi didattici
+    description: |
+      Definizione, strutturazione, governance e miglioramento continuo dei programmi accademici,
+      dei corsi, dei moduli, delle qualifiche e dei risultati di apprendimento su cui si fondano.
+  BC-4700.10:
+    name: Architettura del programma
+    description: |
+      Definizione della struttura del programma, del livello di qualifica, del peso dei crediti
+      e dei risultati di apprendimento previsti per i titoli accademici.
+    in_scope:
+      - Struttura del programma e definizione dei percorsi
+      - Struttura di credenziali e qualifiche
+      - Risultati di apprendimento previsti a livello di programma
+    out_of_scope:
+      - Redazione del programma del corso a livello di insegnamento (trattato in Progettazione di corsi e moduli)
+      - Esiti dell'accreditamento esterno (trattati in Gestione della qualità accademica e dell'accreditamento)
+  BC-4700.10.10:
+    name: Definizione del programma
+    description: |
+      Definizione dello scopo del programma, del gruppo target, dei requisiti di accesso e della struttura complessiva.
+  BC-4700.10.20:
+    name: Strutturazione delle qualifiche e delle credenziali
+    description: |
+      Strutturazione dei titoli, dei valori in crediti e dei percorsi di credenziali componibili.
+  BC-4700.10.30:
+    name: Definizione dei risultati di apprendimento
+    description: |
+      Articolazione dei risultati di apprendimento previsti a livello di programma e di corso.
+  BC-4700.20:
+    name: Progettazione di corsi e moduli
+    description: |
+      Specifica e redazione dei singoli corsi, moduli e unità didattiche che compongono i programmi accademici.
+    in_scope:
+      - Specifiche del corso e descrittori del modulo
+      - Redazione e approvazione del programma del corso
+      - Obiettivi didattici a livello di unità e piani di valutazione
+    out_of_scope:
+      - Produzione di materiali didattici (trattata in Gestione dei contenuti educativi e delle risorse didattiche)
+  BC-4700.20.10:
+    name: Specifica del corso
+    description: |
+      Redazione e approvazione delle specifiche formali del corso e dei relativi descrittori.
+  BC-4700.20.20:
+    name: Progettazione di moduli e unità
+    description: |
+      Progettazione di moduli e unità didattiche all'interno dei corsi.
+  BC-4700.20.30:
+    name: Redazione del programma del corso
+    description: |
+      Redazione dei programmi dei corsi che descrivono contenuti, metodi e valutazioni per ciascuna edizione.
+  BC-4700.30:
+    name: Mappatura e allineamento del curriculo
+    description: |
+      Mappatura dei contenuti del curriculo ai framework di competenze, ai quadri di qualifica
+      e ai percorsi professionali e di carriera.
+    in_scope:
+      - Mappatura competenze-curriculo
+      - Allineamento a ISCED, EQF, NQF e framework equivalenti
+      - Mappatura dei percorsi professionali e di carriera
+    out_of_scope:
+      - Conseguimento individuale delle competenze da parte degli studenti (trattato in Gestione della valutazione e degli esami)
+  BC-4700.30.10:
+    name: Allineamento ai framework di competenze
+    description: |
+      Allineamento del curriculo a framework di competenze definiti (es. CASE).
+  BC-4700.30.20:
+    name: Mappatura ai framework di qualifica
+    description: |
+      Mappatura delle qualifiche a ISCED, EQF, NQF e framework di riferimento analoghi.
+  BC-4700.30.30:
+    name: Mappatura dei percorsi professionali e di carriera
+    description: |
+      Mappatura del curriculo a percorsi occupazionali, professionali e di carriera.
+  BC-4700.40:
+    name: Gestione del catalogo dei programmi
+    description: |
+      Redazione, versionamento e pubblicazione del catalogo istituzionale dei programmi
+      e dei corsi disponibili per i candidati e gli studenti iscritti.
+    in_scope:
+      - Redazione del catalogo e workflow editoriale
+      - Versionamento del catalogo e datazione di validità
+      - Pubblicazione interna e pubblica del catalogo
+    out_of_scope:
+      - Materiali di marketing per il reclutamento (trattati in Gestione del reclutamento e dell'ammissione degli studenti)
+  BC-4700.40.10:
+    name: Redazione del catalogo
+    description: |
+      Redazione delle voci del catalogo per programmi, corsi e moduli.
+  BC-4700.40.20:
+    name: Versionamento e datazione di validità del catalogo
+    description: |
+      Controllo delle versioni e gestione delle date di validità delle voci del catalogo.
+  BC-4700.40.30:
+    name: Pubblicazione del catalogo
+    description: |
+      Pubblicazione interna e pubblica del catalogo dei programmi e dei corsi.
+  BC-4700.50:
+    name: Approvazione e governance del programma
+    description: |
+      Percorsi di approvazione interni ed esterni per programmi nuovi, modificati e ritirati,
+      incluse le decisioni di sospensione e chiusura.
+    in_scope:
+      - Approvazione accademica interna e governance
+      - Approvazione da parte di enti regolatori e ordini professionali esterni
+      - Sospensione del programma e chiusura ordinata
+    out_of_scope:
+      - Revisione corrente del curriculo (trattata in Revisione del curriculo e miglioramento continuo)
+      - Accreditamento ciclico (trattato in Gestione della qualità accademica e dell'accreditamento)
+  BC-4700.50.10:
+    name: Approvazione interna del programma
+    description: |
+      Approvazione accademica interna di programmi nuovi e modificati.
+  BC-4700.50.20:
+    name: Approvazione esterna del programma
+    description: |
+      Approvazione del programma da parte di enti regolatori, ministeri o ordini professionali esterni.
+  BC-4700.50.30:
+    name: Sospensione e chiusura del programma
+    description: |
+      Sospensione ordinata, didattica di completamento e chiusura dei programmi.
+  BC-4700.60:
+    name: Revisione del curriculo e miglioramento continuo
+    description: |
+      Revisione periodica e miglioramento dei contenuti del curriculo sulla base degli esiti,
+      del contributo degli stakeholder e dei requisiti esterni.
+    in_scope:
+      - Cicli periodici di revisione del curriculo
+      - Contributo di stakeholder, datori di lavoro e studenti
+      - Monitoraggio dell'implementazione delle modifiche al curriculo
+    out_of_scope:
+      - Revisioni di assicurazione della qualità dei programmi (trattate in Gestione della qualità accademica e dell'accreditamento)
+  BC-4700.60.10:
+    name: Revisione periodica del curriculo
+    description: |
+      Revisione ciclica dell'efficacia e della rilevanza del curriculo.
+  BC-4700.60.20:
+    name: Contributo degli stakeholder al curriculo
+    description: |
+      Raccolta del contributo di studenti, datori di lavoro e comitati consultivi alla progettazione del curriculo.
+  BC-4700.60.30:
+    name: Implementazione delle modifiche al curriculo
+    description: |
+      Monitoraggio e implementazione delle modifiche approvate al curriculo.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-customer-relationship-management.yaml
+++ b/catalogue/i18n/it/L1-customer-relationship-management.yaml
@@ -1,0 +1,91 @@
+# Gestione delle relazioni con i clienti (it) — translations for L1-customer-relationship-management.yaml
+locale: it
+source: L1-customer-relationship-management.yaml
+entries:
+  BC-420:
+    name: Gestione delle relazioni con i clienti
+    description: |
+      Dati dei clienti, segmentazione, ciclo di vita, fidelizzazione.
+  BC-420.10:
+    name: Gestione dei dati dei clienti
+    description: |
+      Master data dei clienti, risoluzione delle identità, golden record.
+  BC-420.10.10:
+    name: Gestione del master data dei clienti
+    description: |
+      Creazione, manutenzione e governance dei record master dei clienti.
+  BC-420.10.20:
+    name: Risoluzione dell'identità del cliente
+    description: |
+      Corrispondenza, unione e deduplicazione dei record dei clienti.
+  BC-420.10.30:
+    name: Gestione del consenso e delle preferenze
+    description: |
+      Raccolta e applicazione dei consensi e delle preferenze di marketing.
+  BC-420.10.40:
+    name: Vista a 360° del cliente
+    description: |
+      Vista aggregata del cliente su prodotti, canali e interazioni.
+  BC-420.20:
+    name: Gestione della segmentazione dei clienti
+    description: |
+      Segmenti, personas, strategie di trattamento.
+  BC-420.20.10:
+    name: Segmentazione comportamentale
+    description: |
+      Segmentazione basata su comportamento, RFM e segnali di coinvolgimento.
+  BC-420.20.20:
+    name: Segmentazione basata sul valore
+    description: |
+      Segmentazione per valore del ciclo di vita del cliente e redditività.
+  BC-420.20.30:
+    name: Sviluppo delle personas dei clienti
+    description: |
+      Definizione di personas e archetipi di clienti target.
+  BC-420.20.40:
+    name: Definizione della strategia di trattamento
+    description: |
+      Strategie di trattamento differenziate per segmento.
+  BC-420.30:
+    name: Gestione del ciclo di vita del cliente
+    description: |
+      Acquisizione, crescita, fidelizzazione, recupero.
+  BC-420.30.10:
+    name: Gestione dell'acquisizione dei clienti
+    description: |
+      Campagne di acquisizione, conversione e orchestrazione dell'onboarding.
+  BC-420.30.20:
+    name: Crescita e cross-sell dei clienti
+    description: |
+      Programmi di cross-sell, up-sell e espansione della base clienti.
+  BC-420.30.30:
+    name: Gestione della fidelizzazione dei clienti
+    description: |
+      Previsione del churn, offerte di fidelizzazione e desk di salvataggio.
+  BC-420.30.40:
+    name: Gestione del recupero dei clienti persi
+    description: |
+      Campagne di win-back e riattivazione dei clienti inattivi.
+  BC-420.40:
+    name: Gestione della fedeltà e della fidelizzazione
+    description: |
+      Programmi fedeltà, iniziative di fidelizzazione.
+  BC-420.40.10:
+    name: Progettazione del programma fedeltà
+    description: |
+      Progettazione della struttura, dei livelli e dei benefici del programma fedeltà.
+  BC-420.40.20:
+    name: Operazioni del programma fedeltà
+    description: |
+      Accumulo punti, utilizzo e assistenza ai soci del programma fedeltà.
+  BC-420.40.30:
+    name: Gestione della passività del programma fedeltà
+    description: |
+      Contabilizzazione e gestione della passività e del breakage del programma fedeltà.
+  BC-420.40.40:
+    name: Gestione dell'ecosistema di partner del programma fedeltà
+    description: |
+      Integrazione dei partner, riscatto e accordi di coalizione.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-customer-service-management.yaml
+++ b/catalogue/i18n/it/L1-customer-service-management.yaml
@@ -1,0 +1,111 @@
+# Gestione dell'assistenza clienti (it) — translations for L1-customer-service-management.yaml
+locale: it
+source: L1-customer-service-management.yaml
+entries:
+  BC-430:
+    name: Gestione dell'assistenza clienti
+    description: |
+      Richieste, reclami, supporto, operazioni del contact centre.
+  BC-430.10:
+    name: Gestione delle richieste dei clienti
+    description: |
+      Contatti in entrata, instradamento, risoluzione.
+  BC-430.10.10:
+    name: Ricezione e instradamento delle richieste
+    description: |
+      Ricezione multicanale, classificazione e instradamento delle richieste.
+  BC-430.10.20:
+    name: Gestione dei casi
+    description: |
+      Creazione, assegnazione e monitoraggio della risoluzione dei casi.
+  BC-430.10.30:
+    name: Evasione delle richieste di servizio
+    description: |
+      Evasione di richieste di servizio standard e modifiche agli account.
+  BC-430.10.40:
+    name: Gestione delle escalation
+    description: |
+      Percorsi di escalation, regole di gravità e gestione dei casi escalati.
+  BC-430.20:
+    name: Gestione dei reclami e dei problemi
+    description: |
+      Raccolta dei reclami, analisi delle cause, risoluzione.
+  BC-430.20.10:
+    name: Raccolta e conferma dei reclami
+    description: |
+      Raccolta, conferma e triage dei reclami dei clienti.
+  BC-430.20.20:
+    name: Indagine e risoluzione dei reclami
+    description: |
+      Indagine, risarcimento e risoluzione dei reclami.
+  BC-430.20.30:
+    name: Analisi delle cause radice
+    description: |
+      Analisi delle cause radice e identificazione dei trend nei reclami.
+  BC-430.20.40:
+    name: Reporting normativo dei reclami
+    description: |
+      Reporting normativo dei reclami e gestione dei casi presso l'ombudsman.
+  BC-430.30:
+    name: Gestione delle operazioni del contact centre
+    description: |
+      Funzionamento del contact centre, gestione del personale, telefonia.
+  BC-430.30.10:
+    name: Gestione del personale del contact centre
+    description: |
+      Previsione, pianificazione e monitoraggio dell'aderenza nelle operazioni del contact centre.
+  BC-430.30.20:
+    name: Instradamento dei contatti e IVR
+    description: |
+      Progettazione dell'IVR, instradamento basato sulle competenze e orchestrazione dei canali.
+  BC-430.30.30:
+    name: Monitoraggio della qualità e coaching
+    description: |
+      Monitoraggio della qualità delle chiamate, scoring e coaching degli agenti.
+  BC-430.30.40:
+    name: Reporting della performance del contact centre
+    description: |
+      Reporting della performance operativa su livello di servizio, AHT e FCR.
+  BC-430.40:
+    name: Gestione del self-service
+    description: |
+      FAQ, knowledge base, chatbot, portali self-service.
+  BC-430.40.10:
+    name: Gestione della knowledge base
+    description: |
+      Redazione e manutenzione dei contenuti della knowledge base per i clienti.
+  BC-430.40.20:
+    name: Gestione del portale self-service
+    description: |
+      Portali self-service per i clienti e funzionalità di gestione degli account.
+  BC-430.40.30:
+    name: Gestione dell'intelligenza artificiale conversazionale
+    description: |
+      Progettazione, addestramento e operatività di chatbot e voicebot.
+  BC-430.40.40:
+    name: Gestione del supporto della community
+    description: |
+      Moderazione della community di utenti e supporto tra pari.
+  BC-430.50:
+    name: Gestione del feedback dei clienti
+    description: |
+      Sondaggi, Net Promoter Score, programmi di voice-of-customer.
+  BC-430.50.10:
+    name: Programma voice-of-customer
+    description: |
+      Programma strutturato di voice-of-customer attraverso i punti di contatto.
+  BC-430.50.20:
+    name: Gestione dei sondaggi ai clienti
+    description: |
+      Progettazione, distribuzione e analisi dei sondaggi Net Promoter Score, CSAT e CES.
+  BC-430.50.30:
+    name: Feedback a ciclo chiuso
+    description: |
+      Follow-up a ciclo chiuso sui feedback dei detrattori e azioni correttive.
+  BC-430.50.40:
+    name: Reporting degli insight sui clienti
+    description: |
+      Reporting degli insight sui clienti a prodotto, operazioni e leadership.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-customer-success-management.yaml
+++ b/catalogue/i18n/it/L1-customer-success-management.yaml
@@ -1,0 +1,157 @@
+# Gestione del customer success (it) — translations for L1-customer-success-management.yaml
+locale: it
+source: L1-customer-success-management.yaml
+entries:
+  BC-4260:
+    name: Gestione del customer success
+    description: |
+      Onboarding del cliente, adozione, monitoraggio della salute, retention, espansione,
+      advocacy e coltivazione di clienti di riferimento, distinte dal customer service reattivo.
+  BC-4260.10:
+    name: Onboarding e attivazione del cliente
+    description: |
+      Onboarding strutturato dei nuovi clienti verso il primo valore
+      e le milestone di attivazione.
+    in_scope:
+      - Piani di onboarding, kickoff e monitoraggio del time-to-value
+    out_of_scope:
+      - Provisioning tecnico del tenant (coperto da Gestione dei tenant SaaS)
+      - Provisioning degli abbonamenti (coperto da Gestione del ciclo di vita degli abbonamenti)
+  BC-4260.10.10:
+    name: Definizione del piano di onboarding
+    description: |
+      Definizione di piani di onboarding personalizzati
+      per segmento e caso d'uso.
+  BC-4260.10.20:
+    name: Monitoraggio delle milestone di attivazione
+    description: |
+      Monitoraggio delle milestone di attivazione rispetto
+      agli obiettivi di time-to-value.
+  BC-4260.10.30:
+    name: Coordinamento dell'implementazione
+    description: |
+      Coordinamento delle attività di implementazione lato cliente
+      e del coinvolgimento dei partner.
+  BC-4260.20:
+    name: Gestione dell'adozione
+    description: |
+      Programmi che aumentano l'adozione delle funzionalità
+      e l'ampiezza d'uso nella base clienti.
+  BC-4260.20.10:
+    name: Progettazione dei programmi di adozione
+    description: |
+      Progettazione di programmi di adozione strutturati
+      per segmenti, prodotti e personas.
+  BC-4260.20.20:
+    name: Esecuzione delle campagne di adozione
+    description: |
+      Esecuzione di campagne di adozione con touchpoint
+      in-product e outbound.
+  BC-4260.20.30:
+    name: Abilitazione dei power user
+    description: |
+      Abilitazione dei power user del cliente
+      e dei champion interni.
+  BC-4260.30:
+    name: Gestione della salute del cliente
+    description: |
+      Modellazione e monitoraggio della salute del cliente
+      per anticipare i rischi e guidare gli interventi.
+  BC-4260.30.10:
+    name: Modellazione dell'health score del cliente
+    description: |
+      Modellazione degli health score dei clienti da segnali
+      di prodotto, supporto e commerciali.
+  BC-4260.30.20:
+    name: Monitoraggio dei segnali di rischio
+    description: |
+      Monitoraggio dei segnali di rischio
+      nell'intera base clienti.
+  BC-4260.30.30:
+    name: Intervento sugli account a rischio
+    description: |
+      Intervento coordinato sugli account
+      identificati come a rischio.
+  BC-4260.40:
+    name: Gestione del ciclo di vita del cliente
+    description: |
+      Touchpoint ricorrenti nel ciclo di vita, inclusi business review,
+      sponsor esecutivi e pianificazione congiunta del successo.
+  BC-4260.40.10:
+    name: Gestione delle QBR
+    description: |
+      Pianificazione ed erogazione di business review ricorrenti
+      con i clienti.
+  BC-4260.40.20:
+    name: Programma di sponsor esecutivi
+    description: |
+      Gestione degli abbinamenti tra sponsor esecutivi
+      del fornitore e del cliente.
+  BC-4260.40.30:
+    name: Manutenzione del piano di successo
+    description: |
+      Manutenzione dei piani di successo condivisi che documentano
+      gli outcome e le milestone del cliente.
+  BC-4260.50:
+    name: Advocacy per la retention e il rinnovo
+    description: |
+      Advocacy e interventi focalizzati sul processo di rinnovo,
+      incluse le azioni di recupero e le previsioni di rinnovo.
+  BC-4260.50.10:
+    name: Mitigazione del rischio di rinnovo
+    description: |
+      Mitigazione dei rischi di rinnovo identificati
+      prima della data di rinnovo.
+  BC-4260.50.20:
+    name: Esecuzione delle azioni di recupero
+    description: |
+      Esecuzione di azioni di recupero sugli account
+      intenzionati a cancellare.
+  BC-4260.50.30:
+    name: Invio delle previsioni di rinnovo
+    description: |
+      Invio delle previsioni di rinnovo sulla base
+      dei segnali di salute e di engagement.
+  BC-4260.60:
+    name: Advocacy per l'espansione e il cross-selling
+    description: |
+      Identificazione e qualifica delle opportunità di espansione
+      e coordinamento con le vendite per il cross-selling.
+  BC-4260.60.10:
+    name: Identificazione delle opportunità di espansione
+    description: |
+      Identificazione delle opportunità di espansione dai segnali
+      di utilizzo e di engagement.
+  BC-4260.60.20:
+    name: Qualifica dell'upselling
+    description: |
+      Qualifica delle opportunità di upselling
+      prima del coinvolgimento del team di vendita.
+  BC-4260.60.30:
+    name: Coordinamento del cross-selling
+    description: |
+      Coordinamento con il team di vendita sui processi di cross-selling
+      nell'intera base clienti.
+  BC-4260.70:
+    name: Advocacy e clienti di riferimento
+    description: |
+      Coltivazione di clienti di riferimento, case study e misurazione strutturata
+      del sentiment dei clienti.
+  BC-4260.70.10:
+    name: Gestione del programma di riferimento
+    description: |
+      Gestione del programma di clienti di riferimento, inclusi
+      opt-in, governance e utilizzo.
+  BC-4260.70.20:
+    name: Sviluppo dei case study
+    description: |
+      Sviluppo di case study dei clienti
+      in collaborazione con il marketing.
+  BC-4260.70.30:
+    name: Programma di survey NPS
+    description: |
+      Gestione dei programmi di survey NPS e equivalenti
+      per la misurazione del sentiment dei clienti.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-customs-trade-compliance-management.yaml
+++ b/catalogue/i18n/it/L1-customs-trade-compliance-management.yaml
@@ -1,0 +1,120 @@
+# Gestione della conformità doganale e commerciale (it) — translations for L1-customs-trade-compliance-management.yaml
+locale: it
+source: L1-customs-trade-compliance-management.yaml
+entries:
+  BC-2480:
+    name: Gestione della conformità doganale e commerciale
+    description: |
+      Conformità ai regimi doganali, sanzionatori, di origine e di operatore affidabile
+      per i movimenti transfrontalieri, inclusa la determinazione dei dazi e delle imposte
+      indirette.
+  BC-2480.10:
+    name: Gestione della classificazione tariffaria
+    description: |
+      Determinazione e manutenzione delle classificazioni del codice SA (nomenclatura
+      doganale) per le merci commercializzate.
+    in_scope:
+      - Determinazione del codice SA per articolo e spedizione
+      - Informazioni tariffarie vincolanti (BTI)
+    out_of_scope:
+      - Screening delle sanzioni e delle parti (BC-2480.40)
+  BC-2480.10.10:
+    name: Determinazione del codice SA
+    description: |
+      Determinazione dei codici SA per articolo e spedizione.
+  BC-2480.10.20:
+    name: Gestione delle decisioni di classificazione
+    description: |
+      Richiesta e gestione delle decisioni tariffarie vincolanti.
+  BC-2480.10.30:
+    name: Manutenzione del database di classificazione
+    description: |
+      Manutenzione dei database di classificazione master per gli articoli commercializzati.
+  BC-2480.20:
+    name: Gestione delle dichiarazioni doganali
+    description: |
+      Presentazione di dichiarazioni di importazione, esportazione e transito alle
+      autorità doganali.
+  BC-2480.20.10:
+    name: Presentazione della dichiarazione di importazione
+    description: |
+      Predisposizione e presentazione delle dichiarazioni di importazione.
+  BC-2480.20.20:
+    name: Presentazione della dichiarazione di esportazione
+    description: |
+      Predisposizione e presentazione delle dichiarazioni di esportazione.
+  BC-2480.20.30:
+    name: Gestione delle dichiarazioni di transito
+    description: |
+      Presentazione e chiusura delle dichiarazioni di transito, inclusi TIR e NCTS.
+  BC-2480.30:
+    name: Gestione dell'origine e degli accordi di libero scambio
+    description: |
+      Determinazione e certificazione dell'origine preferenziale nell'ambito degli accordi
+      di libero scambio.
+  BC-2480.30.10:
+    name: Determinazione dell'origine
+    description: |
+      Determinazione dell'origine preferenziale e non preferenziale.
+  BC-2480.30.20:
+    name: Documentazione di qualificazione per accordi di libero scambio
+    description: |
+      Emissione e gestione dei certificati di origine per gli accordi di libero scambio.
+  BC-2480.30.30:
+    name: Audit trail dell'origine
+    description: |
+      Manutenzione delle prove documentali a supporto degli audit di origine.
+  BC-2480.40:
+    name: Gestione dello screening delle sanzioni e delle parti negate
+    description: |
+      Screening di parti, navi e merci rispetto alle liste di sanzioni e di parti negate.
+  BC-2480.40.10:
+    name: Screening di parti e navi
+    description: |
+      Screening di clienti, destinatari e mezzi di trasporto rispetto alle liste di
+      sanzioni.
+  BC-2480.40.20:
+    name: Gestione delle liste di sanzioni
+    description: |
+      Manutenzione delle liste consolidate di sanzioni e parti negate.
+  BC-2480.40.30:
+    name: Trattamento dei blocchi e dei rilasci
+    description: |
+      Trattamento dei riscontri dallo screening, dei blocchi e dei rilasci autorizzati.
+  BC-2480.50:
+    name: Gestione dei programmi di operatore affidabile
+    description: |
+      Richiesta, manutenzione e audit dei programmi di operatore affidabile quali AEO
+      e C-TPAT.
+  BC-2480.50.10:
+    name: Richiesta e manutenzione AEO
+    description: |
+      Richiesta AEO e manutenzione continuativa del programma.
+  BC-2480.50.20:
+    name: Gestione del programma C-TPAT
+    description: |
+      Adesione al C-TPAT e conformità ai criteri minimi di sicurezza.
+  BC-2480.50.30:
+    name: Coordinamento degli audit doganali
+    description: |
+      Coordinamento degli audit doganali e dei programmi di operatore affidabile.
+  BC-2480.60:
+    name: Gestione dei dazi e delle imposte indirette
+    description: |
+      Determinazione, pagamento e recupero di dazi, imposte indirette e drawback sui
+      movimenti transfrontalieri.
+  BC-2480.60.10:
+    name: Calcolo dei dazi
+    description: |
+      Calcolo dei dazi dovuti sulle importazioni ed esportazioni.
+  BC-2480.60.20:
+    name: Determinazione delle imposte indirette
+    description: |
+      Determinazione di IVA, GST e accise sui flussi transfrontalieri.
+  BC-2480.60.30:
+    name: Drawback e rimborso dei dazi
+    description: |
+      Recupero dei dazi tramite regimi di drawback, sospensione e rimborso.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-cyber-operations-management.yaml
+++ b/catalogue/i18n/it/L1-cyber-operations-management.yaml
@@ -1,0 +1,95 @@
+# Gestione delle operazioni cyber (it) — translations for L1-cyber-operations-management.yaml
+locale: it
+source: L1-cyber-operations-management.yaml
+entries:
+  BC-1740:
+    name: Gestione delle operazioni cyber
+    description: |
+      Operazioni cyber difensive e offensive e cyber intelligence.
+  BC-1740.10:
+    name: Gestione delle operazioni cyber difensive
+    description: |
+      Difesa delle reti, threat hunting e risposta agli incidenti.
+  BC-1740.10.10:
+    name: Operazioni di difesa delle reti
+    description: |
+      Operazione di sensori e strumenti cyber difensivi.
+  BC-1740.10.20:
+    name: Ricerca delle minacce cyber
+    description: |
+      Attività di threat hunting sulle reti militari.
+  BC-1740.10.30:
+    name: Risposta agli incidenti cyber
+    description: |
+      Rilevamento, risposta e ripristino da incidenti sulle reti di missione.
+  BC-1740.10.40:
+    name: Manovra difensiva nel cyberspazio
+    description: |
+      Manovra cyber difensiva e difesa attiva nel cyberspazio.
+  BC-1740.20:
+    name: Gestione delle operazioni cyber offensive
+    description: |
+      Capacità cyber offensive e rilascio di effetti cyber.
+  BC-1740.20.10:
+    name: Sviluppo di capacità cyber offensive
+    description: |
+      Sviluppo autorizzato di capacità cyber offensive.
+  BC-1740.20.20:
+    name: Rilascio di effetti cyber
+    description: |
+      Rilascio autorizzato di effetti cyber contro gli avversari.
+  BC-1740.20.30:
+    name: Autorizzazione delle operazioni cyber offensive
+    description: |
+      Framework di autorizzazione per le operazioni cyber offensive.
+  BC-1740.30:
+    name: Gestione della cyber intelligence
+    description: |
+      Cyber threat intelligence e monitoraggio degli avversari.
+  BC-1740.30.10:
+    name: Produzione di cyber threat intelligence
+    description: |
+      Produzione di valutazioni di cyber threat intelligence.
+  BC-1740.30.20:
+    name: Monitoraggio degli avversari cyber
+    description: |
+      Monitoraggio del tradecraft e delle infrastrutture degli avversari.
+  BC-1740.30.30:
+    name: Gestione degli indicatori cyber
+    description: |
+      Gestione degli indicatori di compromissione (IoC) nel dominio cyber.
+  BC-1740.40:
+    name: Gestione degli effetti cyber
+    description: |
+      Acquisizione degli obiettivi cyber, coordinamento degli effetti e deconflizione.
+  BC-1740.40.10:
+    name: Acquisizione degli obiettivi cyber
+    description: |
+      Acquisizione degli obiettivi specifici del dominio cyber e sviluppo dei target.
+  BC-1740.40.20:
+    name: Coordinamento degli effetti cyber
+    description: |
+      Coordinamento degli effetti cyber con le operazioni cinetiche.
+  BC-1740.40.30:
+    name: Deconflizione delle operazioni cyber
+    description: |
+      Deconflizione delle operazioni cyber tra le diverse formazioni.
+  BC-1740.50:
+    name: Gestione della sicurezza della missione cyber
+    description: |
+      Resilienza cyber e garanzia dei sistemi di missione.
+  BC-1740.50.10:
+    name: Valutazione del rischio cyber dei sistemi di missione
+    description: |
+      Valutazione del rischio cyber dei sistemi di missione.
+  BC-1740.50.20:
+    name: Ingegneria della resilienza della missione
+    description: |
+      Ingegneria della resilienza cyber per i sistemi di missione.
+  BC-1740.50.30:
+    name: Reportistica sulla garanzia cyber della missione
+    description: |
+      Reportistica sulla postura di garanzia cyber della missione.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-cybersecurity-management.yaml
+++ b/catalogue/i18n/it/L1-cybersecurity-management.yaml
@@ -1,0 +1,147 @@
+# Gestione della sicurezza informatica (it) — translations for L1-cybersecurity-management.yaml
+locale: it
+source: L1-cybersecurity-management.yaml
+entries:
+  BC-620:
+    name: Gestione della sicurezza informatica
+    description: |
+      Strategia di sicurezza, controlli, identità e risposta alle minacce.
+  BC-620.10:
+    name: Gestione della strategia e della governance della sicurezza
+    description: |
+      Strategia di sicurezza, politiche, framework, GRC.
+  BC-620.10.10:
+    name: Sviluppo della strategia di sicurezza
+    description: |
+      Strategia pluriennale di sicurezza informatica allineata al rischio aziendale.
+  BC-620.10.20:
+    name: Politiche e standard di sicurezza
+    description: |
+      Politiche e standard di sicurezza allineati a NIST CSF e ISO 27001.
+  BC-620.10.30:
+    name: Gestione del rischio informatico
+    description: |
+      Identificazione, valutazione e trattamento del rischio informatico.
+  BC-620.10.40:
+    name: Gestione della conformità della sicurezza
+    description: |
+      Conformità alle normative informatiche (DORA, NIS2, normative di settore).
+  BC-620.10.50:
+    name: Metriche e reporting della sicurezza
+    description: |
+      KPI di sicurezza, dashboard e reporting al consiglio di amministrazione.
+  BC-620.20:
+    name: Gestione delle identità e degli accessi
+    description: |
+      IAM, PAM, federazione, processi di ingresso-trasferimento-uscita.
+  BC-620.20.10:
+    name: Gestione del ciclo di vita delle identità
+    description: |
+      Processi di ingresso, trasferimento, uscita e provisioning delle identità.
+  BC-620.20.20:
+    name: Gestione degli accessi e autenticazione
+    description: |
+      Autenticazione, MFA, single sign-on e federazione.
+  BC-620.20.30:
+    name: Gestione degli accessi privilegiati
+    description: |
+      PAM, accesso just-in-time e monitoraggio delle sessioni privilegiate.
+  BC-620.20.40:
+    name: Governance degli accessi e ricertificazione
+    description: |
+      Revisioni degli accessi, segregazione dei compiti e ricertificazione.
+  BC-620.20.50:
+    name: Gestione delle identità dei clienti
+    description: |
+      CIAM per clienti esterni, partner e consumatori.
+  BC-620.30:
+    name: Gestione del rilevamento e della risposta alle minacce
+    description: |
+      SOC, SIEM, risposta agli incidenti.
+  BC-620.30.10:
+    name: Monitoraggio della sicurezza e operazioni SIEM
+    description: |
+      SIEM, SOAR e monitoraggio della telemetria di sicurezza.
+  BC-620.30.20:
+    name: Threat hunting
+    description: |
+      Threat hunting proattivo basato su ipotesi.
+  BC-620.30.30:
+    name: Cyber threat intelligence
+    description: |
+      Raccolta, analisi e diffusione della cyber threat intelligence.
+  BC-620.30.40:
+    name: Risposta agli incidenti informatici
+    description: |
+      Rilevamento, contenimento, eradicazione e ripristino da incidenti informatici.
+  BC-620.30.50:
+    name: Informatica forense
+    description: |
+      Acquisizione e analisi forense a supporto di incidenti e contenziosi.
+  BC-620.40:
+    name: Gestione delle vulnerabilità
+    description: |
+      Scansione delle vulnerabilità, patching, remediation.
+  BC-620.40.10:
+    name: Scansione delle vulnerabilità
+    description: |
+      Scansione autenticata e non autenticata del patrimonio IT.
+  BC-620.40.20:
+    name: Triage e definizione delle priorità delle vulnerabilità
+    description: |
+      Prioritizzazione basata sul rischio delle vulnerabilità per la remediation.
+  BC-620.40.30:
+    name: Gestione del patching e della remediation
+    description: |
+      Coordinamento del patching e della remediation tra i responsabili.
+  BC-620.40.40:
+    name: Penetration testing e red teaming
+    description: |
+      Penetration test, esercitazioni di red team e simulazione di avversari.
+  BC-620.50:
+    name: Gestione dell'architettura della sicurezza
+    description: |
+      Progettazione sicura, pattern di sicurezza, zero trust.
+  BC-620.50.10:
+    name: Pattern di architettura della sicurezza
+    description: |
+      Pattern di sicurezza di riferimento e controlli riutilizzabili.
+  BC-620.50.20:
+    name: Architettura zero trust
+    description: |
+      Principi zero trust, micro-segmentazione e applicazione delle policy.
+  BC-620.50.30:
+    name: Ingegneria della sicurezza delle applicazioni
+    description: |
+      Pratiche secure-by-design, SAST, DAST e threat modelling.
+  BC-620.50.40:
+    name: Architettura della sicurezza cloud
+    description: |
+      Baseline di sicurezza cloud, CSPM e progettazione dei controlli cloud-native.
+  BC-620.50.50:
+    name: Crittografia e gestione delle chiavi
+    description: |
+      Standard crittografici, gestione delle chiavi e operazioni PKI.
+  BC-620.60:
+    name: Gestione della sensibilizzazione alla sicurezza
+    description: |
+      Formazione sulla consapevolezza, simulazioni di phishing, cultura della sicurezza.
+  BC-620.60.10:
+    name: Formazione sulla consapevolezza della sicurezza
+    description: |
+      Formazione annuale e basata sui ruoli sulla consapevolezza della sicurezza.
+  BC-620.60.20:
+    name: Simulazione di phishing
+    description: |
+      Simulazioni di phishing e coaching di follow-up.
+  BC-620.60.30:
+    name: Programma di cultura della sicurezza
+    description: |
+      Programmi di cambiamento culturale e reti di security champion.
+  BC-620.60.40:
+    name: Comunicazioni sulla sicurezza
+    description: |
+      Avvisi di sicurezza, advisory e comunicazioni agli stakeholder.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-dangerous-goods-management.yaml
+++ b/catalogue/i18n/it/L1-dangerous-goods-management.yaml
@@ -1,0 +1,112 @@
+# Gestione delle merci pericolose (it) — translations for L1-dangerous-goods-management.yaml
+locale: it
+source: L1-dangerous-goods-management.yaml
+entries:
+  BC-2490:
+    name: Gestione delle merci pericolose
+    description: |
+      Accettazione, documentazione, movimentazione, formazione e risposta agli incidenti
+      per i movimenti di merci pericolose su strada, ferrovia, mare e aria nell'ambito
+      dei regimi IMDG, IATA DGR, ADR e RID.
+  BC-2490.10:
+    name: Gestione dell'accettazione delle merci pericolose
+    description: |
+      Esame pre-accettazione delle spedizioni di merci pericolose rispetto alle norme
+      modali e decisione di accettazione.
+    in_scope:
+      - Verifica della dichiarazione del mittente
+      - Controlli di compatibilità, segregazione e quantità
+    out_of_scope:
+      - Restrizioni doganali sulle sostanze pericolose (BC-2480)
+      - Richieste di risarcimento per danni a merci pericolose (BC-2530.40)
+  BC-2490.10.10:
+    name: Verifica della dichiarazione del mittente
+    description: |
+      Verifica delle dichiarazioni per merci pericolose del mittente e della relativa
+      documentazione di supporto.
+  BC-2490.10.20:
+    name: Controllo di compatibilità e segregazione
+    description: |
+      Controlli di compatibilità, segregazione e quantità secondo le normative modali.
+  BC-2490.10.30:
+    name: Decisione di accettazione e validazione
+    description: |
+      Decisione di accettazione, validazione o rifiuto delle spedizioni di merci pericolose.
+  BC-2490.20:
+    name: Gestione della documentazione delle merci pericolose
+    description: |
+      Emissione e manutenzione delle dichiarazioni per merci pericolose, NOTOC e
+      documentazione multimodale per merci pericolose.
+  BC-2490.20.10:
+    name: Emissione della dichiarazione per merci pericolose
+    description: |
+      Emissione delle dichiarazioni per merci pericolose conformemente a IMDG, IATA DGR,
+      ADR e RID.
+  BC-2490.20.20:
+    name: Predisposizione di NOTOC e manifesto
+    description: |
+      Predisposizione della notifica al comandante (NOTOC) e del manifesto delle merci
+      pericolose.
+  BC-2490.20.30:
+    name: Riconciliazione della documentazione multimodale
+    description: |
+      Riconciliazione dei documenti per merci pericolose tra i passaggi modali.
+  BC-2490.30:
+    name: Gestione della movimentazione e dello stivaggio delle merci pericolose
+    description: |
+      Conformità della movimentazione fisica e dello stivaggio ai requisiti per le merci
+      pericolose.
+  BC-2490.30.10:
+    name: Conformità alla segregazione e allo stivaggio
+    description: |
+      Conformità alla segregazione e allo stivaggio a bordo, in coperta e in magazzino.
+  BC-2490.30.20:
+    name: Stoccaggio in aree riservate
+    description: |
+      Stoccaggio delle merci pericolose in aree riservate, ventilate e con bacini di
+      contenimento.
+  BC-2490.30.30:
+    name: Utilizzo di attrezzature specializzate per la movimentazione
+    description: |
+      Utilizzo di attrezzature specializzate per la movimentazione di merci pericolose
+      e dispositivi di protezione individuale.
+  BC-2490.40:
+    name: Gestione della formazione e delle competenze per le merci pericolose
+    description: |
+      Formazione iniziale e ricorrente, valutazione delle competenze e registri per il
+      personale addetto alla movimentazione di merci pericolose.
+  BC-2490.40.10:
+    name: Formazione iniziale sulle merci pericolose
+    description: |
+      Formazione iniziale sulle merci pericolose secondo le autorità modali competenti.
+  BC-2490.40.20:
+    name: Formazione ricorrente sulle merci pericolose
+    description: |
+      Formazione ricorrente e di aggiornamento sulle merci pericolose.
+  BC-2490.40.30:
+    name: Gestione dei registri di competenza
+    description: |
+      Manutenzione dei registri di competenza sulle merci pericolose e delle prove per
+      gli audit.
+  BC-2490.50:
+    name: Gestione degli incidenti relativi alle merci pericolose
+    description: |
+      Rilevamento, risposta, notifica e reportistica per incidenti e sversamenti di merci
+      pericolose.
+  BC-2490.50.10:
+    name: Rilevamento degli incidenti relativi a merci pericolose
+    description: |
+      Rilevamento di incidenti con merci pericolose durante la movimentazione e il
+      trasporto.
+  BC-2490.50.20:
+    name: Risposta a sversamenti e rilasci di merci pericolose
+    description: |
+      Contenimento degli sversamenti, risposta ai rilasci e decontaminazione.
+  BC-2490.50.30:
+    name: Notifica e reportistica alle autorità
+    description: |
+      Notifica e reportistica degli incidenti con merci pericolose alle autorità
+      competenti.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-dealer-network-management.yaml
+++ b/catalogue/i18n/it/L1-dealer-network-management.yaml
@@ -1,0 +1,166 @@
+# Gestione della rete di concessionari (it) — translations for L1-dealer-network-management.yaml
+locale: it
+source: L1-dealer-network-management.yaml
+entries:
+  BC-3430:
+    name: Gestione della rete di concessionari
+    description: |
+      Governance della rete di concessionari franchisee o autorizzati — nomine,
+      accordi, standard di marca e delle strutture, performance, formazione e
+      sviluppo della rete nel rispetto del Regolamento UE di esenzione per categoria
+      e delle norme retail equivalenti.
+  BC-3430.10:
+    name: Strategia e pianificazione della rete di concessionari
+    description: |
+      Pianificazione strategica del footprint, del formato, della copertura e degli
+      standard di marca dei concessionari nei mercati.
+  BC-3430.10.10:
+    name: Pianificazione della copertura del mercato e della rete
+    description: |
+      Analisi delle lacune di copertura del mercato e definizione del footprint target
+      dei concessionari per area.
+  BC-3430.10.20:
+    name: Ottimizzazione del footprint della rete
+    description: |
+      Ottimizzazione del footprint esistente della rete di concessionari, incluse
+      consolidamento, rilocalizzazione ed espansione della capacità.
+  BC-3430.10.30:
+    name: Definizione del formato della rete e degli standard di marca
+    description: |
+      Definizione dei formati dei concessionari, dei concept di vendita al dettaglio e
+      degli standard di esperienza di marca.
+  BC-3430.20:
+    name: Gestione delle nomine e degli accordi con i concessionari
+    description: |
+      Inserimento, accordo e cessazione dei concessionari, inclusa la gestione
+      dei territori e dei diritti di marca.
+  BC-3430.20.10:
+    name: Candidatura e valutazione del concessionario
+    description: |
+      Ricezione e valutazione delle candidature dei concessionari, inclusa la due
+      diligence finanziaria, legale e operativa.
+  BC-3430.20.20:
+    name: Redazione ed esecuzione dell'accordo con il concessionario
+    description: |
+      Redazione, negoziazione ed esecuzione degli accordi con i concessionari in
+      linea con la normativa sulla concorrenza applicabile.
+  BC-3430.20.30:
+    name: Gestione del territorio e dei diritti di marca
+    description: |
+      Allocazione e gestione del territorio e dei diritti di marca, incluse le
+      definizioni delle aree di responsabilità.
+  BC-3430.20.40:
+    name: Gestione della cessazione del rapporto con il concessionario
+    description: |
+      Gestione della cessazione del rapporto con il concessionario, della fase di
+      esaurimento e della riassegnazione del territorio.
+  BC-3430.30:
+    name: Standard e conformità della rete di concessionari
+    description: |
+      Mantenimento e verifica degli standard di marca, delle strutture e operativi
+      nella rete di concessionari.
+  BC-3430.30.10:
+    name: Gestione degli standard di marca e delle strutture
+    description: |
+      Mantenimento degli standard di marca, delle strutture e di esperienza del cliente
+      per la conformità dei concessionari.
+  BC-3430.30.20:
+    name: Audit di conformità dei concessionari
+    description: |
+      Audit periodici dei concessionari rispetto agli standard di marca, vendita e
+      post-vendita.
+  BC-3430.30.30:
+    name: Gestione delle azioni correttive
+    description: |
+      Gestione dei piani di azione correttiva per i concessionari non conformi
+      fino alla chiusura.
+  BC-3430.40:
+    name: Gestione delle performance dei concessionari
+    description: |
+      Misurazione e miglioramento delle performance commerciali e operative dei
+      concessionari attraverso scorecard e programmi di incentivazione.
+  BC-3430.40.10:
+    name: Gestione della scorecard del concessionario
+    description: |
+      Definizione e operatività delle scorecard dei concessionari su metriche di
+      vendita, post-vendita ed esperienza del cliente.
+  BC-3430.40.20:
+    name: Revisioni delle performance di vendita e post-vendita
+    description: |
+      Revisioni periodiche delle performance dei concessionari e pianificazione
+      congiunta del business con i responsabili di area.
+  BC-3430.40.30:
+    name: Gestione del programma di incentivi per i concessionari
+    description: |
+      Progettazione e operatività dei programmi di bonus, margini e incentivi
+      per i concessionari.
+  BC-3430.50:
+    name: Gestione del finanziamento e del floorplan per i concessionari
+    description: |
+      Finanziamento delle scorte di veicoli all'ingrosso dei concessionari e gestione
+      dei crediti e dei programmi di supporto al capitale circolante.
+    in_scope:
+      - Amministrazione del floorplan all'ingrosso
+      - Monitoraggio dei limiti di credito e dell'esposizione dei concessionari
+      - Supporto al capitale circolante dei concessionari garantito dall'OEM
+    out_of_scope:
+      - Credito al dettaglio auto captive (coperto da credito e prestiti aziendali)
+  BC-3430.50.10:
+    name: Amministrazione del floorplan all'ingrosso
+    description: |
+      Amministrazione del finanziamento floorplan all'ingrosso per le scorte di
+      veicoli dei concessionari.
+  BC-3430.50.20:
+    name: Gestione del credito e dei crediti dei concessionari
+    description: |
+      Gestione dei limiti di credito, dell'anzianità dei crediti e degli incassi
+      dei concessionari.
+  BC-3430.50.30:
+    name: Supporto al capitale circolante dei concessionari
+    description: |
+      Supporto al capitale circolante garantito dall'OEM, finanziamento delle parti
+      e programmi di assistenza stagionale.
+  BC-3430.60:
+    name: Formazione e certificazione della rete di concessionari
+    description: |
+      Formazione e certificazione del personale di vendita, post-vendita e direttivo
+      dei concessionari.
+  BC-3430.60.10:
+    name: Certificazione delle vendite del concessionario
+    description: |
+      Certificazione dei consulenti di vendita del concessionario su prodotto, marca e
+      standard di esperienza del cliente.
+  BC-3430.60.20:
+    name: Certificazione dei tecnici di assistenza del concessionario
+    description: |
+      Certificazione dei tecnici di assistenza del concessionario su procedure
+      diagnostiche, di riparazione e sulle procedure EV/HV.
+  BC-3430.60.30:
+    name: Sviluppo manageriale della rete di concessionari
+    description: |
+      Programmi di sviluppo della leadership e del management per titolari di
+      concessionaria e responsabili di reparto.
+  BC-3430.70:
+    name: Operazioni sui sistemi e i dati della rete di concessionari
+    description: |
+      Operatività dei sistemi rivolti ai concessionari e dei flussi di dati che
+      collegano i concessionari alle piattaforme commerciali, tecniche e di
+      reportistica dell'OEM.
+  BC-3430.70.10:
+    name: Integrazione del sistema di gestione del concessionario
+    description: |
+      Integrazione dei sistemi di gestione del concessionario con i backbone
+      OEM di ordini, parti, garanzia e reportistica.
+  BC-3430.70.20:
+    name: Gestione dei dati master del concessionario
+    description: |
+      Manutenzione dei dati master del concessionario, inclusi punti vendita,
+      contatti e autorizzazioni.
+  BC-3430.70.30:
+    name: Reportistica e analytics della rete di concessionari
+    description: |
+      Reportistica, benchmarking e analytics a livello di concessionario su
+      dimensioni commerciali e operative.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-decommissioning-abandonment-management.yaml
+++ b/catalogue/i18n/it/L1-decommissioning-abandonment-management.yaml
@@ -1,0 +1,114 @@
+# Gestione del decommissioning e dell'abbandono (it) — translations for L1-decommissioning-abandonment-management.yaml
+locale: it
+source: L1-decommissioning-abandonment-management.yaml
+entries:
+  BC-3120:
+    name: Gestione del decommissioning e dell'abbandono
+    description: |
+      Gestione del tardo ciclo di vita degli asset petroliferi: P&A dei pozzi,
+      decommissioning degli impianti di superficie, decommissioning del pipeline,
+      ripristino del sito, accantonamento delle passività di decommissioning e
+      monitoraggio post-chiusura.
+  BC-3120.10:
+    name: Operazioni di P&A dei pozzi
+    description: |
+      Progettazione ed esecuzione di campagne permanenti di P&A dei pozzi.
+    in_scope:
+      - Progettazione P&A e verifica delle barriere
+      - Operazioni di esecuzione del plugging and abandonment
+      - Recisione e recupero della testa pozzo e del conduttore
+    out_of_scope:
+      - Sorveglianza dell'integrità dei pozzi in produzione (BC-3020.50)
+  BC-3120.10.10:
+    name: Progettazione del plugging and abandonment
+    description: |
+      Progettazione delle configurazioni di barriere permanenti per l'abbandono del pozzo.
+  BC-3120.10.20:
+    name: Esecuzione del plugging and abandonment
+    description: |
+      Esecuzione delle operazioni di cementazione, posizionamento dei tappi e verifica delle barriere.
+  BC-3120.10.30:
+    name: Recisione e recupero della testa pozzo
+    description: |
+      Recisione e recupero delle teste pozzo, conduttori e colonne di rivestimento.
+  BC-3120.20:
+    name: Decommissioning degli impianti di superficie
+    description: |
+      Decommissioning, rimozione e recupero degli impianti di superficie e subacquei
+      a monte e midstream.
+  BC-3120.20.10:
+    name: Pianificazione della rimozione delle strutture di testa
+    description: |
+      Ingegneria della rimozione delle strutture di testa e della metodologia di installazione inversa.
+  BC-3120.20.20:
+    name: Esecuzione della rimozione delle strutture di testa
+    description: |
+      Esecuzione della rimozione delle strutture di testa con sollevamento singolo, modulare o pezzi minuti.
+  BC-3120.20.30:
+    name: Recupero delle apparecchiature subacquee
+    description: |
+      Recupero di alberi subacquei, manifold, jumper e ombelicali.
+  BC-3120.30:
+    name: Decommissioning del pipeline
+    description: |
+      Decommissioning, rimozione o decisioni di abbandono in situ per pipeline fuori servizio.
+  BC-3120.30.10:
+    name: Lavaggio e pulizia del pipeline
+    description: |
+      Lavaggio, pulizia e inertizzazione dei pipeline prima del decommissioning.
+  BC-3120.30.20:
+    name: Decisione sul decommissioning del pipeline
+    description: |
+      Valutazione comparativa della rimozione del pipeline rispetto al decommissioning in situ.
+  BC-3120.30.30:
+    name: Esecuzione del decommissioning del pipeline
+    description: |
+      Esecuzione delle operazioni di rimozione, taglio e sollevamento, o abbandono in situ del pipeline.
+  BC-3120.40:
+    name: Ripristino e bonifica del sito
+    description: |
+      Ripristino del sito a terra e subacqueo, bonifica di suolo e sedimenti
+      e verifica della pulizia del fondale marino.
+  BC-3120.40.10:
+    name: Bonifica del suolo e dei sedimenti
+    description: |
+      Bonifica di suoli e sedimenti contaminati nei siti dismessi.
+  BC-3120.40.20:
+    name: Ripristino della vegetazione
+    description: |
+      Rivegetazione e profilatura dei siti dismessi a terra.
+  BC-3120.40.30:
+    name: Pulizia del sito subacqueo
+    description: |
+      Verifica della pulizia del fondale marino subacqueo e recupero degli oggetti caduti.
+  BC-3120.50:
+    name: Gestione delle passività di decommissioning
+    description: |
+      Stima dei costi, accantonamento e deposito di garanzie per gli obblighi di decommissioning.
+  BC-3120.50.10:
+    name: Stima dei costi di abbandono
+    description: |
+      Stima probabilistica dei costi di decommissioning e abbandono.
+  BC-3120.50.20:
+    name: Accantonamento per il decommissioning
+    description: |
+      Mantenimento degli accantonamenti per il decommissioning in linea con i principi contabili.
+  BC-3120.50.30:
+    name: Deposito di garanzia per il decommissioning
+    description: |
+      Deposito e rinnovo della garanzia di decommissioning ai governi ospitanti.
+  BC-3120.60:
+    name: Monitoraggio post-chiusura
+    description: |
+      Monitoraggio ambientale a lungo termine e monitoraggio delle passività residue dopo la chiusura.
+  BC-3120.60.10:
+    name: Monitoraggio ambientale a lungo termine
+    description: |
+      Monitoraggio a lungo termine delle acque sotterranee, del suolo e dell'ambiente marino.
+  BC-3120.60.20:
+    name: Monitoraggio delle passività residue
+    description: |
+      Monitoraggio delle passività e degli indennizzi residui post-chiusura.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-defense-capture-bid-management.yaml
+++ b/catalogue/i18n/it/L1-defense-capture-bid-management.yaml
@@ -1,0 +1,99 @@
+# Gestione dell'acquisizione e offerta difesa (it) — translations for L1-defense-capture-bid-management.yaml
+locale: it
+source: L1-defense-capture-bid-management.yaml
+entries:
+  BC-1750:
+    name: Gestione dell'acquisizione e offerta difesa
+    description: |
+      Gestione del capture plan, intelligence sul cliente e sviluppo delle offerte per i contratti della difesa.
+  BC-1750.10:
+    name: Gestione del capture plan
+    description: |
+      Attività di capture pre-RFP, orientamento del cliente e strategia di aggiudicazione.
+  BC-1750.10.10:
+    name: Identificazione delle opportunità
+    description: |
+      Identificazione delle opportunità e delle iniziative nel settore della difesa.
+  BC-1750.10.20:
+    name: Attività di orientamento del cliente
+    description: |
+      Orientamento del cliente pre-RFP e influenza sui requisiti.
+  BC-1750.10.30:
+    name: Sviluppo della strategia di aggiudicazione
+    description: |
+      Sviluppo della strategia di aggiudicazione, dei temi e dei fattori differenziatori.
+  BC-1750.10.40:
+    name: Analisi competitiva e black hat
+    description: |
+      Revisioni black hat e analisi competitiva dei concorrenti.
+  BC-1750.20:
+    name: Gestione dell'intelligence sul cliente della difesa
+    description: |
+      Relazioni con il cliente e intelligence su requisiti e budget.
+  BC-1750.20.10:
+    name: Mappatura delle relazioni con il cliente
+    description: |
+      Mappatura delle organizzazioni del cliente e degli stakeholder chiave.
+  BC-1750.20.20:
+    name: Intelligence su budget e acquisizione
+    description: |
+      Intelligence su budget, cicli di acquisizione e priorità del cliente.
+  BC-1750.20.30:
+    name: Raccolta dell'intelligence sui requisiti
+    description: |
+      Raccolta dei requisiti emergenti del cliente.
+  BC-1750.30:
+    name: Gestione delle offerte della difesa
+    description: |
+      Decisioni analisi bid/no-bid, governance e risorse per l'offerta.
+  BC-1750.30.10:
+    name: Decisione di analisi bid/no-bid
+    description: |
+      Governance e approvazioni per le decisioni di analisi bid/no-bid.
+  BC-1750.30.20:
+    name: Risorse e finanziamento dell'offerta
+    description: |
+      Allocazione delle risorse e dei fondi per la preparazione delle offerte.
+  BC-1750.30.30:
+    name: Gestione del rischio dell'offerta
+    description: |
+      Identificazione e gestione dei rischi associati all'offerta.
+  BC-1750.40:
+    name: Gestione delle proposte della difesa
+    description: |
+      Redazione della proposta, colour review e produzione dell'offerta.
+  BC-1750.40.10:
+    name: Redazione della proposta
+    description: |
+      Redazione dei volumi della proposta per contratti della difesa.
+  BC-1750.40.20:
+    name: Esecuzione delle colour review
+    description: |
+      Revisioni pink, red e gold e revisione finale della proposta.
+  BC-1750.40.30:
+    name: Produzione e presentazione della proposta
+    description: |
+      Produzione e presentazione nei tempi previsti delle proposte.
+  BC-1750.40.40:
+    name: Verifica della conformità della proposta
+    description: |
+      Verifica della conformità ai requisiti della RFP e alle istruzioni L/M.
+  BC-1750.50:
+    name: Gestione della strategia di teaming e dei subappaltatori
+    description: |
+      Accordi di teaming e selezione dei subappaltatori per le offerte.
+  BC-1750.50.10:
+    name: Definizione della strategia di teaming
+    description: |
+      Definizione della strategia di teaming e prime/sub per le offerte.
+  BC-1750.50.20:
+    name: Negoziazione degli accordi di teaming
+    description: |
+      Negoziazione ed esecuzione degli accordi di teaming e NDA.
+  BC-1750.50.30:
+    name: Selezione dei subappaltatori per l'offerta
+    description: |
+      Selezione dei subappaltatori e dei partner di piccole imprese per le offerte.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-defense-logistics-management.yaml
+++ b/catalogue/i18n/it/L1-defense-logistics-management.yaml
@@ -1,0 +1,107 @@
+# Gestione della logistica della difesa (it) — translations for L1-defense-logistics-management.yaml
+locale: it
+source: L1-defense-logistics-management.yaml
+entries:
+  BC-1720:
+    name: Gestione della logistica della difesa
+    description: |
+      Prontezza del materiale, sostentamento, logistica di dispiegamento e logistica in teatro operativo.
+  BC-1720.10:
+    name: Gestione della prontezza del materiale
+    description: |
+      Reportistica sulla prontezza operativa e disponibilità di flotta e equipaggiamenti.
+  BC-1720.10.10:
+    name: Monitoraggio della disponibilità degli equipaggiamenti
+    description: |
+      Monitoraggio della disponibilità e dell'efficienza operativa degli equipaggiamenti.
+  BC-1720.10.20:
+    name: Reportistica sulla prontezza operativa
+    description: |
+      Reportistica periodica sulla prontezza operativa al comando.
+  BC-1720.10.30:
+    name: Miglioramento del tasso di capacità operativa
+    description: |
+      Iniziative per migliorare i tassi di capacità operativa della missione.
+  BC-1720.20:
+    name: Gestione delle scorte militari della difesa
+    description: |
+      Classi di rifornimento militare I-IX, riserve di guerra.
+  BC-1720.20.10:
+    name: Gestione delle scorte classe I-V
+    description: |
+      Gestione delle scorte di vettovaglie, carburante, munizioni e materiali di consumo.
+  BC-1720.20.20:
+    name: Gestione delle scorte classe VII-IX
+    description: |
+      Gestione delle scorte di grandi sistemi completi e parti di ricambio.
+  BC-1720.20.30:
+    name: Gestione del materiale di riserva di guerra
+    description: |
+      Gestione delle riserve di guerra e delle scorte pre-posizionate.
+  BC-1720.20.40:
+    name: Gestione delle scorte di munizioni
+    description: |
+      Gestione delle scorte di munizioni ed esplosivi.
+  BC-1720.30:
+    name: Gestione del dispiegamento e della distribuzione logistica
+    description: |
+      Logistica di dispiegamento strategico e tattico.
+  BC-1720.30.10:
+    name: Pianificazione del dispiegamento strategico
+    description: |
+      Pianificazione del dispiegamento strategico e del TPFDD.
+  BC-1720.30.20:
+    name: Operazioni di proiezione strategica
+    description: |
+      Operazioni di proiezione strategica aerea, marittima e terrestre.
+  BC-1720.30.30:
+    name: Distribuzione logistica in teatro
+    description: |
+      Distribuzione e logistica di sostentamento in teatro operativo.
+  BC-1720.30.40:
+    name: Ricezione congiunta e movimento in avanti
+    description: |
+      Ricezione congiunta, allestimento e movimento in avanti delle forze.
+  BC-1720.40:
+    name: Gestione della manutenzione militare della difesa
+    description: |
+      Manutenzione organica e appaltata a livello organizzativo, intermedio e di deposito.
+  BC-1720.40.10:
+    name: Manutenzione a livello organizzativo
+    description: |
+      Manutenzione a livello di unità (O-level).
+  BC-1720.40.20:
+    name: Manutenzione a livello intermedio
+    description: |
+      Manutenzione e riparazione a livello intermedio (I-level).
+  BC-1720.40.30:
+    name: Manutenzione a livello di deposito
+    description: |
+      Manutenzione e revisione a livello di deposito (D-level).
+  BC-1720.40.40:
+    name: Supporto logistico appaltato
+    description: |
+      Accordi di supporto logistico appaltato a contraenti esterni.
+  BC-1720.50:
+    name: Gestione dei pezzi di ricambio e dell'approvvigionamento
+    description: |
+      Approvvigionamento iniziale, rifornimento e soddisfacimento della domanda.
+  BC-1720.50.10:
+    name: Approvvigionamento iniziale
+    description: |
+      Approvvigionamento iniziale dei pezzi di ricambio per le nuove piattaforme.
+  BC-1720.50.20:
+    name: Rifornimento dei pezzi di ricambio
+    description: |
+      Rifornimento dei pezzi di ricambio in base alla domanda e alle previsioni.
+  BC-1720.50.30:
+    name: Monitoraggio del soddisfacimento della domanda
+    description: |
+      Monitoraggio del soddisfacimento della domanda e del tasso di evasione degli ordini.
+  BC-1720.50.40:
+    name: Catalogazione e gestione NSN
+    description: |
+      Catalogazione con il NATO Stock Number (NSN) e identificazione degli articoli.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-defense-programme-management.yaml
+++ b/catalogue/i18n/it/L1-defense-programme-management.yaml
@@ -1,0 +1,119 @@
+# Gestione del programma della difesa (it) — translations for L1-defense-programme-management.yaml
+locale: it
+source: L1-defense-programme-management.yaml
+entries:
+  BC-1760:
+    name: Gestione del programma della difesa
+    description: |
+      Consegna di programmi su larga scala, earned value, governance del programma e gestione dei subappalti.
+  BC-1760.10:
+    name: Gestione dell'acquisizione del programma
+    description: |
+      Strategia di acquisizione, pianificazione del programma e milestone review.
+  BC-1760.10.10:
+    name: Definizione della strategia di acquisizione
+    description: |
+      Definizione della strategia di acquisizione allineata con DoD 5000 o equivalente.
+  BC-1760.10.20:
+    name: Pianificazione e baseline del programma
+    description: |
+      Pianificazione del programma e definizione della baseline dell'integrated master schedule.
+  BC-1760.10.30:
+    name: Revisioni delle milestone decisionali
+    description: |
+      Preparazione e conduzione delle revisioni delle milestone decisionali.
+  BC-1760.20:
+    name: Gestione dell'earned value del programma
+    description: |
+      Earned value, prestazioni di costo, prestazioni di schedule e IBR.
+  BC-1760.20.10:
+    name: Operatività del sistema EVM
+    description: |
+      Gestione di un sistema EVM conforme allo standard EIA-748.
+  BC-1760.20.20:
+    name: Revisione integrata della baseline
+    description: |
+      Conduzione delle revisioni integrate della baseline con il cliente.
+  BC-1760.20.30:
+    name: Analisi delle prestazioni di costo e schedule
+    description: |
+      Analisi delle metriche e dei trend CV, SV, CPI e SPI.
+  BC-1760.20.40:
+    name: Previsione della stima a completamento
+    description: |
+      Previsione dell'EAC e analisi dell'indice di prestazione a completamento.
+  BC-1760.30:
+    name: Gestione dei costi e della determinazione dei prezzi del programma
+    description: |
+      Standard di contabilità dei costi e determinazione dei prezzi per i contratti governativi.
+  BC-1760.30.10:
+    name: Conformità agli standard di contabilità dei costi
+    description: |
+      Conformità agli standard di contabilità dei costi (CAS).
+  BC-1760.30.20:
+    name: Determinazione dei prezzi per contratti governativi
+    description: |
+      Determinazione dei prezzi per contratti governativi, inclusi FAR/DFARS.
+  BC-1760.30.30:
+    name: Stima dei costi del programma
+    description: |
+      Stima dei costi del programma e documentazione della base di stima.
+  BC-1760.30.40:
+    name: Gestione delle aliquote indirette
+    description: |
+      Calcolo delle aliquote di costo indiretto e negoziazione con il governo.
+  BC-1760.40:
+    name: Gestione del cliente governativo
+    description: |
+      Relazione con il cliente governativo e interfaccia con il responsabile dei contratti.
+  BC-1760.40.10:
+    name: Interfaccia con il responsabile dei contratti
+    description: |
+      Interfaccia con i responsabili dei contratti e i loro rappresentanti.
+  BC-1760.40.20:
+    name: Gestione delle relazioni con l'ufficio programma
+    description: |
+      Gestione delle relazioni con gli uffici programma governativi e i PMO.
+  BC-1760.40.30:
+    name: Reportistica e revisioni con il cliente
+    description: |
+      Reportistica periodica al cliente e revisioni di gestione del programma.
+  BC-1760.50:
+    name: Gestione dei subappaltatori della difesa
+    description: |
+      Supply chain della difesa, clausole di flusso verso il basso e piani per le piccole imprese.
+  BC-1760.50.10:
+    name: Selezione e aggiudicazione dei subappalti
+    description: |
+      Selezione e aggiudicazione dei subappaltatori nel settore della difesa.
+  BC-1760.50.20:
+    name: Amministrazione delle clausole di flusso verso il basso
+    description: |
+      Amministrazione delle clausole FAR/DFARS a cascata verso i subappaltatori.
+  BC-1760.50.30:
+    name: Gestione delle prestazioni dei subappaltatori
+    description: |
+      Monitoraggio e sorveglianza delle prestazioni dei subappaltatori della difesa.
+  BC-1760.50.40:
+    name: Gestione del piano per le piccole imprese
+    description: |
+      Esecuzione e reportistica del piano di subappalto per le piccole imprese.
+  BC-1760.60:
+    name: Gestione del ciclo di vita del programma
+    description: |
+      Gestione del ciclo di vita secondo DoD 5000 o equivalente, con milestone definite.
+  BC-1760.60.10:
+    name: Gestione delle fasi del ciclo di vita
+    description: |
+      Gestione delle fasi del ciclo di vita del programma secondo DoD 5000 o equivalente.
+  BC-1760.60.20:
+    name: Gestione del rischio di programma
+    description: |
+      Gestione del rischio e delle opportunità a livello di programma.
+  BC-1760.60.30:
+    name: Chiusura e transizione del programma
+    description: |
+      Chiusura del programma, transizione e chiusura del contratto.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-defense-sustainment-support-management.yaml
+++ b/catalogue/i18n/it/L1-defense-sustainment-support-management.yaml
@@ -1,0 +1,115 @@
+# Gestione del sostentamento e supporto della difesa (it) — translations for L1-defense-sustainment-support-management.yaml
+locale: it
+source: L1-defense-sustainment-support-management.yaml
+entries:
+  BC-1780:
+    name: Gestione del sostentamento e supporto della difesa
+    description: |
+      Supporto in servizio, manutenzione di deposito, ingegneria RAM, ricambi e riparazioni e gestione dell'obsolescenza.
+  BC-1780.10:
+    name: Gestione del supporto in servizio
+    description: |
+      Contratti di supporto nel ciclo di vita (through-life support) e ingegneria del supporto.
+  BC-1780.10.10:
+    name: Operatività dei contratti di supporto nel ciclo di vita
+    description: |
+      Gestione dei contratti di supporto nel ciclo di vita (through-life support).
+  BC-1780.10.20:
+    name: Ingegneria del supporto
+    description: |
+      Supporto tecnico ai sistemi d'arma dispiegati.
+  BC-1780.10.30:
+    name: Supporto alla gestione della flotta militare
+    description: |
+      Supporto alla gestione della flotta militare incluso il monitoraggio della configurazione.
+  BC-1780.20:
+    name: Gestione della manutenzione di deposito
+    description: |
+      Riparazione, revisione e rimessa a nuovo a livello di deposito.
+  BC-1780.20.10:
+    name: Operazioni di riparazione a livello di deposito
+    description: |
+      Gestione delle officine di riparazione a livello di deposito.
+  BC-1780.20.20:
+    name: Programmi di revisione periodica di deposito
+    description: |
+      Programmi di revisione periodica e ripristino a livello di deposito.
+  BC-1780.20.30:
+    name: Gestione della capacità del deposito
+    description: |
+      Gestione della capacità del deposito e dei tempi di ripristino.
+  BC-1780.30:
+    name: Gestione dell'ingegneria RAM
+    description: |
+      Ingegneria di affidabilità, disponibilità e manutenibilità (RAM).
+  BC-1780.30.10:
+    name: Ingegneria dell'affidabilità
+    description: |
+      Previsione, allocazione e crescita dell'affidabilità.
+  BC-1780.30.20:
+    name: Modellazione della disponibilità
+    description: |
+      Modellazione e analisi della disponibilità operativa.
+  BC-1780.30.30:
+    name: Ingegneria della manutenibilità
+    description: |
+      Analisi di manutenibilità e influenza sulla progettazione.
+  BC-1780.30.40:
+    name: Analisi del supporto logistico
+    description: |
+      Analisi del supporto logistico secondo MIL-HDBK-502.
+  BC-1780.40:
+    name: Gestione dei ricambi e riparazioni della difesa
+    description: |
+      Pezzi di ricambio, pipeline di riparazione e unità di scambio.
+  BC-1780.40.10:
+    name: Approvvigionamento dei ricambi della difesa
+    description: |
+      Approvvigionamento dei ricambi per i sistemi della difesa.
+  BC-1780.40.20:
+    name: Gestione della pipeline di riparazione
+    description: |
+      Gestione delle pipeline di riparazione e restituzione dei componenti.
+  BC-1780.40.30:
+    name: Operazioni del pool di unità di scambio
+    description: |
+      Gestione del pool di componenti rotabili e unità di scambio.
+  BC-1780.50:
+    name: Gestione delle pubblicazioni tecniche
+    description: |
+      Ordini tecnici, IETM, manuali e documentazione S1000D.
+  BC-1780.50.10:
+    name: Documentazione tecnica S1000D
+    description: |
+      Redazione e aggiornamento delle pubblicazioni tecniche S1000D.
+  BC-1780.50.20:
+    name: Operatività dei manuali tecnici elettronici interattivi
+    description: |
+      Gestione e aggiornamento degli IETM sul campo.
+  BC-1780.50.30:
+    name: Gestione delle modifiche agli ordini tecnici
+    description: |
+      Gestione delle modifiche agli ordini tecnici (TO) e degli aggiornamenti sul campo.
+  BC-1780.60:
+    name: Gestione dell'obsolescenza della difesa
+    description: |
+      DMSMS, previsione dell'obsolescenza e mitigazione.
+  BC-1780.60.10:
+    name: Monitoraggio DMSMS
+    description: |
+      Monitoraggio DMSMS di componenti e fornitori.
+  BC-1780.60.20:
+    name: Previsione dell'obsolescenza
+    description: |
+      Previsione dell'obsolescenza di parti e materiali.
+  BC-1780.60.30:
+    name: Mitigazione dell'obsolescenza
+    description: |
+      Strategie di mitigazione dell'obsolescenza tramite LTB, riprogettazione e sostituzione.
+  BC-1780.60.40:
+    name: Mantenimento del piano di gestione dell'obsolescenza
+    description: |
+      Mantenimento dei piani di gestione dell'obsolescenza a livello di programma.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-defense-systems-engineering-management.yaml
+++ b/catalogue/i18n/it/L1-defense-systems-engineering-management.yaml
@@ -1,0 +1,115 @@
+# Gestione dell'ingegneria dei sistemi della difesa (it) — translations for L1-defense-systems-engineering-management.yaml
+locale: it
+source: L1-defense-systems-engineering-management.yaml
+entries:
+  BC-1770:
+    name: Gestione dell'ingegneria dei sistemi della difesa
+    description: |
+      Ingegneria dei sistemi secondo MIL-STD: requisiti, architettura del sistema, V&V, gestione della configurazione e integrazione.
+  BC-1770.10:
+    name: Gestione dell'ingegneria dei requisiti della difesa
+    description: |
+      Elicitazione, scomposizione e tracciabilità dei requisiti.
+  BC-1770.10.10:
+    name: Elicitazione dei requisiti degli stakeholder
+    description: |
+      Elicitazione dei bisogni degli stakeholder e dei requisiti operativi.
+  BC-1770.10.20:
+    name: Scomposizione dei requisiti di sistema
+    description: |
+      Scomposizione dei requisiti di sistema nei sottosistemi.
+  BC-1770.10.30:
+    name: Tracciabilità dei requisiti
+    description: |
+      Tracciabilità bidirezionale dei requisiti verso il progetto e i collaudi.
+  BC-1770.10.40:
+    name: Pianificazione della verifica dei requisiti
+    description: |
+      Definizione dei metodi di verifica e dei criteri di accettazione.
+  BC-1770.20:
+    name: Gestione dell'architettura del sistema della difesa
+    description: |
+      Architettura del sistema, modelli e baseline architetturali.
+  BC-1770.20.10:
+    name: Modellazione dell'architettura operativa e di sistema
+    description: |
+      Modellazione delle architetture operative e di sistema (DoDAF/MoDAF).
+  BC-1770.20.20:
+    name: Analisi dei trade-off architetturali
+    description: |
+      Analisi dei trade-off tra le opzioni architetturali.
+  BC-1770.20.30:
+    name: Gestione della baseline architetturale
+    description: |
+      Definizione e controllo delle baseline architetturali.
+  BC-1770.30:
+    name: Gestione della definizione delle interfacce della difesa
+    description: |
+      Controllo delle interfacce, ICD e piani di gestione delle interfacce.
+  BC-1770.30.10:
+    name: Identificazione delle interfacce
+    description: |
+      Identificazione delle interfacce interne ed esterne del sistema.
+  BC-1770.30.20:
+    name: Gestione dei documenti di controllo delle interfacce
+    description: |
+      Redazione e controllo di ICD e IRS (Interface Requirements Specification).
+  BC-1770.30.30:
+    name: Verifica delle interfacce
+    description: |
+      Verifica della conformità delle interfacce durante l'integrazione.
+  BC-1770.40:
+    name: Gestione della verifica e validazione della difesa
+    description: |
+      Pianificazione, esecuzione e certificazione della V&V.
+  BC-1770.40.10:
+    name: Pianificazione della V&V
+    description: |
+      Strategia e pianificazione della verifica e validazione.
+  BC-1770.40.20:
+    name: Esecuzione della V&V
+    description: |
+      Esecuzione della V&V tramite analisi, dimostrazioni, ispezioni e collaudi.
+  BC-1770.40.30:
+    name: Reportistica dei risultati della V&V
+    description: |
+      Reportistica dei risultati e delle discrepanze della V&V.
+  BC-1770.50:
+    name: Gestione della configurazione della difesa
+    description: |
+      Identificazione, controllo, contabilità dello stato della configurazione e audit.
+  BC-1770.50.10:
+    name: Identificazione della configurazione della difesa
+    description: |
+      Identificazione della configurazione secondo MIL-HDBK-61.
+  BC-1770.50.20:
+    name: Controllo delle modifiche alla configurazione della difesa
+    description: |
+      Controllo delle modifiche tramite ECP, RFD e DD-1694.
+  BC-1770.50.30:
+    name: Contabilità dello stato della configurazione della difesa
+    description: |
+      Contabilità e reportistica dello stato della configurazione.
+  BC-1770.50.40:
+    name: Audit della configurazione
+    description: |
+      Audit funzionale e fisico della configurazione.
+  BC-1770.60:
+    name: Gestione dell'integrazione del sistema della difesa
+    description: |
+      Integrazione dei sottosistemi, collaudi integrati e integrazione del sistema di sistemi.
+  BC-1770.60.10:
+    name: Esecuzione dell'integrazione dei sottosistemi
+    description: |
+      Esecuzione delle sequenze di integrazione dei sottosistemi.
+  BC-1770.60.20:
+    name: Esecuzione dei collaudi integrati
+    description: |
+      Esecuzione dei collaudi integrati in ambienti di laboratorio e sul campo.
+  BC-1770.60.30:
+    name: Integrazione del sistema di sistemi della difesa
+    description: |
+      Integrazione con il più ampio sistema di sistemi e le architetture interforze.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-defense-test-evaluation-management.yaml
+++ b/catalogue/i18n/it/L1-defense-test-evaluation-management.yaml
@@ -1,0 +1,99 @@
+# Gestione del collaudo e della valutazione della difesa (it) — translations for L1-defense-test-evaluation-management.yaml
+locale: it
+source: L1-defense-test-evaluation-management.yaml
+entries:
+  BC-1800:
+    name: Gestione del collaudo e della valutazione della difesa
+    description: |
+      DT&E, OT&E, operazioni al poligono di collaudo, piani di collaudo e dati di prova.
+  BC-1800.10:
+    name: Gestione del collaudo e valutazione di sviluppo
+    description: |
+      DT&E, collaudo da parte del contraente e collaudo di qualificazione.
+  BC-1800.10.10:
+    name: Programma di collaudo del contraente
+    description: |
+      Gestione del programma di collaudo di sviluppo condotto dal contraente.
+  BC-1800.10.20:
+    name: Coordinamento del DT&E governativo
+    description: |
+      Coordinamento delle attività di DT&E con il cliente governativo.
+  BC-1800.10.30:
+    name: Esecuzione del collaudo di qualificazione
+    description: |
+      Esecuzione dei collaudi di qualificazione rispetto alle specifiche.
+  BC-1800.20:
+    name: Gestione del collaudo e valutazione operativa
+    description: |
+      OT&E, collaudo da parte degli utenti e idoneità operativa.
+  BC-1800.20.10:
+    name: Collaudo e valutazione operativa iniziale
+    description: |
+      Esecuzione e reportistica dell'IOT&E (Initial Operational Test & Evaluation).
+  BC-1800.20.20:
+    name: Collaudo operativo di follow-on
+    description: |
+      Collaudo e valutazione operativa di follow-on (FOT&E).
+  BC-1800.20.30:
+    name: Valutazione dell'idoneità operativa
+    description: |
+      Valutazione dell'idoneità e dell'efficacia operativa del sistema.
+  BC-1800.30:
+    name: Gestione delle operazioni al poligono di collaudo
+    description: |
+      Pianificazione del poligono, sicurezza del poligono e dati del poligono.
+  BC-1800.30.10:
+    name: Pianificazione dell'utilizzo del poligono
+    description: |
+      Pianificazione dell'utilizzo del poligono di collaudo e delle relative risorse.
+  BC-1800.30.20:
+    name: Operazioni di sicurezza del poligono
+    description: |
+      Sicurezza del poligono e operazioni di autorizzazione al tiro.
+  BC-1800.30.30:
+    name: Acquisizione dei dati del poligono
+    description: |
+      Acquisizione dei dati di telemetria, ottici e di strumentazione del poligono.
+  BC-1800.30.40:
+    name: Manutenzione delle risorse del poligono
+    description: |
+      Manutenzione della strumentazione e delle infrastrutture del poligono.
+  BC-1800.40:
+    name: Gestione del piano e delle procedure di collaudo
+    description: |
+      Piani di collaudo, procedure e revisioni di preparazione al collaudo.
+  BC-1800.40.10:
+    name: Piano generale di collaudo e valutazione
+    description: |
+      Mantenimento del TEMP (Test and Evaluation Master Plan) secondo i requisiti del programma.
+  BC-1800.40.20:
+    name: Redazione delle procedure di collaudo dettagliate
+    description: |
+      Redazione delle procedure di collaudo dettagliate e delle schede pre-collaudo.
+  BC-1800.40.30:
+    name: Revisione di preparazione al collaudo
+    description: |
+      Revisioni di preparazione al collaudo prima dell'esecuzione delle prove.
+  BC-1800.50:
+    name: Gestione dei dati di collaudo
+    description: |
+      Acquisizione, analisi e archiviazione dei dati di collaudo.
+  BC-1800.50.10:
+    name: Acquisizione dei dati di collaudo
+    description: |
+      Acquisizione dei dati di telemetria e strumentazione durante i collaudi.
+  BC-1800.50.20:
+    name: Analisi dei dati di collaudo
+    description: |
+      Elaborazione e analisi dei dati acquisiti durante i collaudi.
+  BC-1800.50.30:
+    name: Archiviazione e riutilizzo dei dati di collaudo
+    description: |
+      Archiviazione e riutilizzo dei set di dati storici di collaudo.
+  BC-1800.50.40:
+    name: Reportistica delle anomalie di collaudo
+    description: |
+      Reportistica e monitoraggio delle anomalie e delle carenze rilevate nei collaudi.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-deposits-savings-management.yaml
+++ b/catalogue/i18n/it/L1-deposits-savings-management.yaml
@@ -1,0 +1,103 @@
+# Gestione dei depositi e del risparmio (it) — translations for L1-deposits-savings-management.yaml
+locale: it
+source: L1-deposits-savings-management.yaml
+entries:
+  BC-1330:
+    name: Gestione dei depositi e del risparmio
+    description: |
+      Ciclo di vita di conti correnti, risparmio e depositi vincolati.
+  BC-1330.10:
+    name: Gestione dei conti di deposito
+    description: |
+      Conti di deposito a vista e conti correnti.
+  BC-1330.10.10:
+    name: Operatività del conto corrente
+    description: |
+      Gestione dei conti correnti, inclusa la gestione dello scoperto.
+  BC-1330.10.20:
+    name: Gestione dei conti cointestati e con mandato
+    description: |
+      Amministrazione di conti cointestati, fiduciari e con mandato.
+  BC-1330.10.30:
+    name: Rendicontazione dei conti di deposito
+    description: |
+      Produzione e recapito degli estratti conto per i conti di deposito.
+  BC-1330.20:
+    name: Gestione dei prodotti di risparmio
+    description: |
+      Risparmio, piani di risparmio ricorrente, prodotti fiscalmente agevolati.
+  BC-1330.20.10:
+    name: Operatività dei conti di risparmio a libero accesso
+    description: |
+      Gestione dei conti di risparmio a libero accesso e con preavviso.
+  BC-1330.20.20:
+    name: Operatività dei piani di risparmio ricorrente
+    description: |
+      Gestione dei piani di risparmio ricorrente e degli ordini permanenti.
+  BC-1330.20.30:
+    name: Operatività del risparmio fiscalmente agevolato
+    description: |
+      Gestione di ISA, IRA e prodotti di risparmio fiscalmente agevolati equivalenti.
+  BC-1330.30:
+    name: Gestione dei depositi vincolati
+    description: |
+      Depositi vincolati, certificati di deposito e depositi strutturati.
+  BC-1330.30.10:
+    name: Prenotazione del deposito vincolato
+    description: |
+      Prenotazione e conferma dei depositi vincolati.
+  BC-1330.30.20:
+    name: Gestione della scadenza del deposito vincolato
+    description: |
+      Gestione della scadenza, rinnovo automatico e opzioni di rinnovo.
+  BC-1330.30.30:
+    name: Operatività dei depositi strutturati
+    description: |
+      Gestione di depositi strutturati e dual-currency.
+  BC-1330.30.40:
+    name: Calcolo del rimborso anticipato e del costo di svincolo
+    description: |
+      Gestione del rimborso anticipato e calcolo del costo di svincolo.
+  BC-1330.40:
+    name: Gestione del ciclo di vita operativo del conto
+    description: |
+      Operazioni di apertura del conto, gestione della dormienza e chiusura.
+  BC-1330.40.10:
+    name: Operazioni di apertura del conto
+    description: |
+      Apertura operativa di nuovi conti di deposito.
+  BC-1330.40.20:
+    name: Gestione dei conti dormienti
+    description: |
+      Identificazione e gestione dei conti dormienti.
+  BC-1330.40.30:
+    name: Operazioni di chiusura del conto
+    description: |
+      Operazioni di chiusura del conto e liquidazione finale.
+  BC-1330.40.40:
+    name: Segnalazione dei saldi non reclamati
+    description: |
+      Segnalazione e versamento dei saldi non reclamati.
+  BC-1330.50:
+    name: Gestione della tariffazione dei depositi e degli interessi
+    description: |
+      Tassi di interesse, rendiconto e maturazione degli interessi.
+  BC-1330.50.10:
+    name: Definizione del tasso di interesse sui depositi
+    description: |
+      Definizione dei tassi di interesse sui depositi e dei listini tassi.
+  BC-1330.50.20:
+    name: Maturazione e calcolo degli interessi
+    description: |
+      Maturazione giornaliera degli interessi e accredito periodico.
+  BC-1330.50.30:
+    name: Ritenuta fiscale sugli interessi
+    description: |
+      Ritenuta fiscale sugli interessi da deposito e relativa segnalazione.
+  BC-1330.50.40:
+    name: Segnalazione per la garanzia dei depositi
+    description: |
+      Segnalazione e contribuzione ai sistemi di garanzia dei depositi.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-design-management.yaml
+++ b/catalogue/i18n/it/L1-design-management.yaml
@@ -1,0 +1,119 @@
+# Gestione della progettazione (it) — translations for L1-design-management.yaml
+locale: it
+source: L1-design-management.yaml
+entries:
+  BC-1120:
+    name: Gestione della progettazione
+    description: |
+      Ciclo di vita della progettazione ingegneristica dalla progettazione concettuale alla progettazione di dettaglio e alla verifica.
+  BC-1120.10:
+    name: Gestione della progettazione concettuale
+    description: |
+      Studi di concetto, fattibilità, analisi delle opzioni e pre-FEED.
+  BC-1120.10.10:
+    name: Definizione dello studio di concetto
+    description: |
+      Ambito, base di progetto e assunti dello studio di concetto.
+  BC-1120.10.20:
+    name: Analisi di fattibilità
+    description: |
+      Analisi di fattibilità tecnica, temporale ed economica.
+  BC-1120.10.30:
+    name: Analisi e selezione delle opzioni
+    description: |
+      Analisi delle opzioni multicriteri e selezione del concetto.
+  BC-1120.20:
+    name: Gestione del FEED (Front-End Engineering Design)
+    description: |
+      FEED, engineering di base, definizione dell'ambito e dei costi.
+  BC-1120.20.10:
+    name: Progettazione engineering di base
+    description: |
+      Engineering di base delle discipline di processo, meccanica ed elettrica.
+  BC-1120.20.20:
+    name: Stima dei costi e dei tempi del FEED
+    description: |
+      Stime di costi e tempi di Classe 3/Classe 2 dal FEED.
+  BC-1120.20.30:
+    name: Produzione degli elaborati FEED
+    description: |
+      Produzione degli elaborati FEED e della base di progetto.
+  BC-1120.30:
+    name: Gestione della progettazione di dettaglio
+    description: |
+      Engineering di dettaglio, disegni esecutivi, specifiche e computo metrico estimativo.
+  BC-1120.30.10:
+    name: Calcoli di ingegneria di dettaglio
+    description: |
+      Calcoli e analisi di dettaglio per disciplina.
+  BC-1120.30.20:
+    name: Produzione dei disegni esecutivi
+    description: |
+      Produzione dei disegni emessi per la costruzione.
+  BC-1120.30.30:
+    name: Redazione delle specifiche di dettaglio
+    description: |
+      Redazione delle specifiche di dettaglio per apparecchiature e materiali.
+  BC-1120.30.40:
+    name: Produzione del computo metrico estimativo
+    description: |
+      Produzione e gestione del computo metrico estimativo per approvvigionamento e costruzione.
+  BC-1120.40:
+    name: Gestione della revisione e verifica della progettazione
+    description: |
+      HAZOP, revisioni di progettazione, verifica e validazione.
+  BC-1120.40.10:
+    name: Workshop HAZOP e HAZID
+    description: |
+      Identificazione dei pericoli e facilitazione dei workshop HAZOP.
+  BC-1120.40.20:
+    name: Gate di revisione della progettazione
+    description: |
+      Revisioni di progettazione a fasi (30%, 60%, 90%).
+  BC-1120.40.30:
+    name: Verifica della progettazione
+    description: |
+      Verifica della progettazione rispetto ai requisiti e alle norme.
+  BC-1120.40.40:
+    name: Validazione della progettazione
+    description: |
+      Validazione della progettazione rispetto all'uso previsto e alle esigenze del cliente.
+  BC-1120.50:
+    name: Gestione del software di progettazione e CAD
+    description: |
+      Strumenti CAD/CAE, modellazione 3D, BIM e ambiente digitale di progettazione.
+  BC-1120.50.10:
+    name: Gestione degli standard CAD
+    description: |
+      Standard CAD, schemi di livelli e librerie di template.
+  BC-1120.50.20:
+    name: Gestione del modello 3D
+    description: |
+      Gestione dei modelli 3D integrati tra le discipline.
+  BC-1120.50.30:
+    name: Gestione dell'ambiente BIM
+    description: |
+      Ambiente di dati comuni BIM e allineamento con ISO 19650.
+  BC-1120.50.40:
+    name: Amministrazione del software di ingegneria
+    description: |
+      Amministrazione e licenze degli strumenti software di ingegneria.
+  BC-1120.60:
+    name: Gestione del coordinamento multidisciplinare della progettazione
+    description: |
+      Coordinamento interdisciplinare, rilevamento delle interferenze e gestione del modello integrato.
+  BC-1120.60.10:
+    name: Rilevamento delle interferenze
+    description: |
+      Rilevamento delle interferenze tra i modelli 3D delle discipline.
+  BC-1120.60.20:
+    name: Coordinamento del modello integrato
+    description: |
+      Coordinamento dei modelli multidisciplinari integrati.
+  BC-1120.60.30:
+    name: Risoluzione delle problematiche di progettazione
+    description: |
+      Risoluzione delle problematiche di coordinamento della progettazione.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-developer-platform-api-ecosystem-management.yaml
+++ b/catalogue/i18n/it/L1-developer-platform-api-ecosystem-management.yaml
@@ -1,0 +1,173 @@
+# Gestione della piattaforma per sviluppatori ed ecosistema API (it) — translations for L1-developer-platform-api-ecosystem-management.yaml
+locale: it
+source: L1-developer-platform-api-ecosystem-management.yaml
+entries:
+  BC-4270:
+    name: Gestione della piattaforma per sviluppatori ed ecosistema API
+    description: |
+      API pubbliche, SDK, portale per sviluppatori, identità degli sviluppatori, governance
+      del consumo API, app partner, listing su software marketplace e sottoscrizioni webhook
+      in uscita per l'ecosistema SaaS.
+  BC-4270.10:
+    name: Gestione del ciclo di vita delle API pubbliche
+    description: |
+      Specifica, versioning e deprecazione delle API pubbliche
+      esposte agli sviluppatori esterni.
+  BC-4270.10.10:
+    name: Redazione delle specifiche API
+    description: |
+      Redazione e revisione delle specifiche delle API pubbliche
+      in formato leggibile dalla macchina.
+  BC-4270.10.20:
+    name: Versioning delle API
+    description: |
+      Versioning delle API pubbliche con garanzie
+      di compatibilità documentate.
+  BC-4270.10.30:
+    name: Gestione della deprecazione delle API
+    description: |
+      Comunicazione ed esecuzione delle deprecazioni delle API
+      con adeguato preavviso.
+  BC-4270.20:
+    name: Gestione degli SDK e delle librerie client
+    description: |
+      Generazione, copertura linguistica e manutenzione dei campioni di SDK
+      e delle librerie client che racchiudono le API pubbliche.
+  BC-4270.20.10:
+    name: Generazione e rilascio degli SDK
+    description: |
+      Generazione e rilascio degli SDK allineati
+      alle versioni delle API.
+  BC-4270.20.20:
+    name: Gestione della copertura linguistica degli SDK
+    description: |
+      Selezione e gestione dei linguaggi e dei runtime
+      supportati dagli SDK.
+  BC-4270.20.30:
+    name: Manutenzione dei campioni SDK
+    description: |
+      Manutenzione dei campioni di codice SDK
+      e dei progetti starter.
+  BC-4270.30:
+    name: Gestione del portale per sviluppatori
+    description: |
+      Documentazione, riferimenti interattivi e flussi di onboarding
+      che aiutano gli sviluppatori a integrarsi con la piattaforma.
+  BC-4270.30.10:
+    name: Redazione della documentazione per sviluppatori
+    description: |
+      Redazione di documentazione concettuale, operativa e di riferimento
+      per gli sviluppatori.
+  BC-4270.30.20:
+    name: Riferimento API interattivo
+    description: |
+      Gestione del riferimento API interattivo
+      e delle esperienze try-it-now.
+  BC-4270.30.30:
+    name: Onboarding degli sviluppatori
+    description: |
+      Flussi di onboarding che portano gli sviluppatori dalla registrazione
+      alla prima chiamata API riuscita.
+  BC-4270.40:
+    name: Gestione dell'identità e delle credenziali degli sviluppatori
+    description: |
+      Emissione e gestione delle credenziali degli sviluppatori,
+      dei client OAuth e dell'identità federata degli sviluppatori.
+  BC-4270.40.10:
+    name: Emissione delle API key
+    description: |
+      Emissione, rotazione e revoca
+      delle API key degli sviluppatori.
+  BC-4270.40.20:
+    name: Registrazione dei client OAuth
+    description: |
+      Registrazione e gestione
+      delle applicazioni client OAuth.
+  BC-4270.40.30:
+    name: Federazione dell'identità degli sviluppatori
+    description: |
+      Federazione dell'identità degli sviluppatori
+      da provider di identità esterni.
+  BC-4270.50:
+    name: Governance del consumo API
+    description: |
+      Quote, rate limiting, analytics d'utilizzo e mappatura del consumo API
+      ai livelli del piano commerciale.
+  BC-4270.50.10:
+    name: Gestione delle quote e del rate limiting API
+    description: |
+      Definizione e applicazione di quote e rate limit delle API
+      per consumer.
+  BC-4270.50.20:
+    name: Analytics d'utilizzo delle API
+    description: |
+      Analytics dei pattern di consumo API per endpoint,
+      consumer e piano.
+  BC-4270.50.30:
+    name: Mappatura dei livelli API ai piani
+    description: |
+      Mappatura dei livelli di accesso API
+      ai piani di abbonamento e ai diritti.
+  BC-4270.60:
+    name: Gestione del programma app partner
+    description: |
+      Gestione delle applicazioni partner di terze parti, inclusi listing,
+      certificazione e condivisione dei ricavi.
+  BC-4270.60.10:
+    name: Gestione del listing delle app partner
+    description: |
+      Listing delle applicazioni partner
+      nella directory app della piattaforma.
+  BC-4270.60.20:
+    name: Certificazione delle app partner
+    description: |
+      Certificazione delle applicazioni partner rispetto
+      agli standard di sicurezza e qualità.
+  BC-4270.60.30:
+    name: Condivisione dei ricavi con i partner
+    description: |
+      Accordi di condivisione dei ricavi
+      con gli sviluppatori di applicazioni partner.
+  BC-4270.70:
+    name: Gestione del listing su software marketplace
+    description: |
+      Listing e gestione dell'offerta SaaS su marketplace software
+      e marketplace cloud di terze parti.
+  BC-4270.70.10:
+    name: Redazione del listing su marketplace
+    description: |
+      Redazione dei listing su marketplace, inclusi metadati,
+      pricing e asset.
+  BC-4270.70.20:
+    name: Manutenzione del listing su marketplace
+    description: |
+      Manutenzione continuativa dei listing su marketplace
+      al variare dell'offerta.
+  BC-4270.70.30:
+    name: Coordinamento del co-sell su marketplace
+    description: |
+      Coordinamento dei processi di co-sell
+      con gli operatori dei marketplace.
+  BC-4270.80:
+    name: Gestione delle sottoscrizioni webhook e degli eventi
+    description: |
+      Ciclo di vita delle sottoscrizioni webhook in uscita, degli schemi degli eventi
+      e dell'affidabilità della consegna.
+  BC-4270.80.10:
+    name: Ciclo di vita delle sottoscrizioni webhook
+    description: |
+      Ciclo di vita delle sottoscrizioni webhook in uscita
+      dalla registrazione al ritiro.
+  BC-4270.80.20:
+    name: Catalogo degli schemi degli eventi
+    description: |
+      Catalogo degli schemi degli eventi in uscita
+      e delle relative garanzie di compatibilità.
+  BC-4270.80.30:
+    name: Gestione dell'affidabilità della consegna webhook
+    description: |
+      Gestione di retry, backoff e dead-letter
+      per la consegna webhook in uscita.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-diagnostic-services-management.yaml
+++ b/catalogue/i18n/it/L1-diagnostic-services-management.yaml
@@ -1,0 +1,138 @@
+# Gestione dei servizi diagnostici (it) — translations for L1-diagnostic-services-management.yaml
+locale: it
+source: L1-diagnostic-services-management.yaml
+entries:
+  BC-2860:
+    name: Gestione dei servizi diagnostici
+    description: |
+      Laboratorio, anatomia patologica, diagnostica per immagini, diagnostica cardio-polmonare,
+      test al letto del paziente e gestione end-to-end dei referti diagnostici.
+  BC-2860.10:
+    name: Gestione dei servizi di laboratorio
+    description: |
+      Raccolta dei campioni, chimica clinica, ematologia, microbiologia, diagnostica molecolare
+      e operazioni del LIS (Laboratory Information System).
+  BC-2860.10.10:
+    name: Raccolta e trasporto dei campioni
+    description: |
+      Flebotomia, raccolta dei campioni e logistica del trasporto.
+  BC-2860.10.20:
+    name: Chimica clinica ed ematologia
+    description: |
+      Operazioni di chimica clinica, ematologia e test della coagulazione.
+  BC-2860.10.30:
+    name: Microbiologia e diagnostica molecolare
+    description: |
+      Diagnostica microbiologica, virologica e molecolare.
+  BC-2860.10.40:
+    name: Operazioni del LIS
+    description: |
+      Gestione del LIS (Laboratory Information System) e delle interfacce con gli strumenti.
+  BC-2860.20:
+    name: Servizi di anatomia patologica
+    description: |
+      Operazioni di istopatologia, citologia, anatomia patologica chirurgica
+      e patologia digitale.
+  BC-2860.20.10:
+    name: Processazione istologica
+    description: |
+      Processazione, inclusione, sezionamento e colorazione dei tessuti per l'istopatologia.
+  BC-2860.20.20:
+    name: Servizi di citologia
+    description: |
+      Preparazione, screening e refertazione dei campioni citologici.
+  BC-2860.20.30:
+    name: Refertazione di anatomia patologica chirurgica
+    description: |
+      Interpretazione e refertazione da parte del patologo dei casi di anatomia patologica chirurgica.
+  BC-2860.20.40:
+    name: Operazioni di patologia digitale
+    description: |
+      Acquisizione di scansioni intere di vetrini, archiviazione e workflow di patologia digitale.
+  BC-2860.30:
+    name: Servizi di diagnostica per immagini
+    description: |
+      Acquisizione, lettura, archiviazione e gestione della dose per le modalità
+      di diagnostica per immagini.
+  BC-2860.30.10:
+    name: Acquisizione delle immagini
+    description: |
+      Acquisizione di esami di diagnostica per immagini con radiografia, TC, RMN, ecografia e medicina nucleare.
+  BC-2860.30.20:
+    name: Lettura e refertazione delle immagini
+    description: |
+      Lettura e refertazione strutturata degli esami di diagnostica per immagini da parte del radiologo.
+  BC-2860.30.30:
+    name: Operazioni di archiviazione delle immagini (PACS)
+    description: |
+      Gestione degli archivi di immagini e scambio di immagini tra strutture tramite PACS.
+  BC-2860.30.40:
+    name: Gestione della dose di radiazioni
+    description: |
+      Monitoraggio della dose di radiazioni, ottimizzazione e reportistica della dose al paziente.
+  BC-2860.40:
+    name: Diagnostica cardiologica e cardio-polmonare
+    description: |
+      Servizi di elettrocardiografia, ecocardiografia, cateterismo cardiaco
+      e test di funzionalità respiratoria.
+  BC-2860.40.10:
+    name: Elettrocardiografia e telemetria
+    description: |
+      Acquisizione dell'elettrocardiogramma, monitoraggio in telemetria e interpretazione delle aritmie.
+  BC-2860.40.20:
+    name: Ecocardiografia
+    description: |
+      Servizi di ecocardiografia transtoracica, transesofagea e da stress.
+  BC-2860.40.30:
+    name: Cateterismo cardiaco
+    description: |
+      Servizi di cateterismo cardiaco diagnostico e di studio elettrofisiologico.
+  BC-2860.40.40:
+    name: Test di funzionalità respiratoria
+    description: |
+      Spirometria, misurazione dei volumi polmonari, test di diffusione e test da sforzo per la funzionalità respiratoria.
+  BC-2860.50:
+    name: Test al letto del paziente
+    description: |
+      Governance, controllo di qualità, competenza degli operatori e integrazione dei risultati
+      per i test al letto del paziente nell'intera struttura.
+  BC-2860.50.10:
+    name: Gestione dei dispositivi per test al letto del paziente
+    description: |
+      Gestione dell'inventario e del ciclo di vita dei dispositivi per test al letto del paziente.
+  BC-2860.50.20:
+    name: Controllo di qualità dei test al letto del paziente
+    description: |
+      Controllo di qualità e test di idoneità per i dispositivi di test al letto del paziente.
+  BC-2860.50.30:
+    name: Gestione della competenza degli operatori
+    description: |
+      Certificazione e valutazione della competenza degli operatori per i test al letto del paziente.
+  BC-2860.50.40:
+    name: Integrazione dei risultati dei test al letto del paziente
+    description: |
+      Integrazione dei risultati dei test al letto del paziente nel registro di laboratorio e nella cartella clinica.
+  BC-2860.60:
+    name: Gestione dei referti diagnostici
+    description: |
+      Validazione, distribuzione e gestione delle regole di reflex testing per i referti
+      diagnostici di tutte le modalità.
+  BC-2860.60.10:
+    name: Validazione dei referti
+    description: |
+      Validazione tecnica e clinica dei referti diagnostici.
+  BC-2860.60.20:
+    name: Notifica dei valori critici
+    description: |
+      Notifica entro i tempi previsti dei valori critici ai professionisti ordinanti.
+  BC-2860.60.30:
+    name: Distribuzione dei referti
+    description: |
+      Distribuzione dei referti ai professionisti ordinanti, ai pazienti e ai sistemi esterni.
+  BC-2860.60.40:
+    name: Regole di reflex testing
+    description: |
+      Redazione e gestione delle regole di reflex testing e della logica degli esami aggiuntivi.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-distributed-energy-resource-management.yaml
+++ b/catalogue/i18n/it/L1-distributed-energy-resource-management.yaml
@@ -1,0 +1,133 @@
+# Gestione delle risorse energetiche distribuite (it) — translations for L1-distributed-energy-resource-management.yaml
+locale: it
+source: L1-distributed-energy-resource-management.yaml
+entries:
+  BC-3840:
+    name: Gestione delle risorse energetiche distribuite
+    description: |
+      Onboarding, aggregazione e coordinamento operativo delle risorse energetiche distribuite
+      connesse alla rete di distribuzione — fotovoltaico residenziale, accumulo behind-the-meter,
+      demand response, ricarica EV e microreti — e loro partecipazione ai mercati all'ingrosso
+      e della flessibilità.
+  BC-3840.10:
+    name: Registrazione e onboarding delle DER
+    description: |
+      Registrazione delle risorse energetiche distribuite, qualifica tecnica e
+      accettazione della connessione secondo IEEE 1547 / regole UE per i generatori.
+  BC-3840.10.10:
+    name: Valutazione delle domande di connessione DER
+    description: |
+      Valutazione delle domande di connessione DER rispetto alla capacità di hosting.
+  BC-3840.10.20:
+    name: Qualifica tecnica delle DER
+    description: |
+      Prove di tipo e verifica in loco della capacità e delle protezioni delle DER.
+  BC-3840.10.30:
+    name: Manutenzione del registro DER
+    description: |
+      Manutenzione del registro degli asset DER connessi e delle relative capacità.
+  BC-3840.20:
+    name: Operazioni della centrale virtuale (VPP)
+    description: |
+      Aggregazione e dispacciamento delle risorse distribuite come unica entità operativa
+      nei mercati all'ingrosso e del bilanciamento.
+  BC-3840.20.10:
+    name: Gestione del portafoglio VPP
+    description: |
+      Composizione e ribilanciamento del portafoglio VPP tra le classi di asset.
+  BC-3840.20.20:
+    name: Operazioni di dispacciamento VPP
+    description: |
+      Istruzioni di dispacciamento in tempo reale agli asset DER aggregati.
+  BC-3840.20.30:
+    name: Liquidazione delle prestazioni VPP
+    description: |
+      Liquidazione delle prestazioni VPP rispetto agli impegni di mercato e bilaterali.
+  BC-3840.30:
+    name: Operazioni di demand response
+    description: |
+      Reclutamento, dispacciamento e liquidazione dei programmi di demand response
+      per clienti residenziali, commerciali e industriali.
+  BC-3840.30.10:
+    name: Iscrizione ai programmi DR
+    description: |
+      Iscrizione dei clienti e gestione del consenso per i programmi di demand response.
+  BC-3840.30.20:
+    name: Dispacciamento degli eventi DR
+    description: |
+      Dispacciamento degli eventi DR e delle istruzioni di curtailment ai clienti partecipanti.
+  BC-3840.30.30:
+    name: Verifica delle prestazioni DR
+    description: |
+      Verifica della consegna del demand response rispetto ai baseline dei clienti.
+  BC-3840.40:
+    name: Gestione dell'integrazione EV nella rete
+    description: |
+      Gestione dell'interazione della ricarica dei veicoli elettrici con la rete,
+      inclusi la ricarica gestita, il V2G e le tariffe specifiche per EV.
+  BC-3840.40.10:
+    name: Operazioni di ricarica gestita
+    description: |
+      Operazione di schemi di ricarica gestita e smart per flotte EV e abitazioni.
+  BC-3840.40.20:
+    name: Coordinamento vehicle-to-grid
+    description: |
+      Coordinamento della scarica bidirezionale V2G verso la rete o behind-the-meter.
+  BC-3840.40.30:
+    name: Analisi della capacità di hosting EV
+    description: |
+      Analisi della capacità di hosting a livello di alimentatore per la penetrazione della ricarica EV.
+  BC-3840.50:
+    name: Coordinamento dello stoccaggio behind-the-meter
+    description: |
+      Coordinamento della partecipazione degli accumuli a batteria behind-the-meter
+      ai programmi delle utility e ai servizi di rete.
+  BC-3840.50.10:
+    name: Iscrizione delle batterie BTM
+    description: |
+      Iscrizione e consenso per la partecipazione delle batterie behind-the-meter.
+  BC-3840.50.20:
+    name: Dispacciamento dello stoccaggio BTM
+    description: |
+      Istruzioni di dispacciamento agli asset di stoccaggio behind-the-meter.
+  BC-3840.50.30:
+    name: Monitoraggio delle prestazioni dello stoccaggio BTM
+    description: |
+      Monitoraggio della consegna delle batterie BTM rispetto agli impegni con la utility.
+  BC-3840.60:
+    name: Previsione delle DER
+    description: |
+      Previsione a breve termine della generazione distribuita e dei carichi flessibili
+      che contribuiscono ai programmi del gestore del sistema e del mercato.
+  BC-3840.60.10:
+    name: Previsione del fotovoltaico behind-the-meter
+    description: |
+      Previsione della generazione fotovoltaica behind-the-meter a livello di alimentatore e zonale.
+  BC-3840.60.20:
+    name: Previsione del carico flessibile
+    description: |
+      Previsione dei profili di ricarica EV e dei carichi flessibili.
+  BC-3840.60.30:
+    name: Monitoraggio delle prestazioni delle previsioni DER
+    description: |
+      Monitoraggio del bias delle previsioni e della loro accuratezza rispetto ai dati consuntivi.
+  BC-3840.70:
+    name: Operazioni delle microreti
+    description: |
+      Operazione di microreti di utility e del cliente, incluse le modalità
+      connessa alla rete e isola, e il controllo delle transizioni senza interruzione.
+  BC-3840.70.10:
+    name: Operazioni del controllore della microrete
+    description: |
+      Operazione dei controllori di microrete e dispacciamento delle risorse interne.
+  BC-3840.70.20:
+    name: Operazioni di transizione in modalità isola
+    description: |
+      Transizioni programmate ed emergenziali tra operazione connessa alla rete e in isola.
+  BC-3840.70.30:
+    name: Esercitazioni di resilienza delle microreti
+    description: |
+      Esercitazioni di resilienza e prove di transizione senza interruzione per microreti a carico critico.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-drilling-wells-management.yaml
+++ b/catalogue/i18n/it/L1-drilling-wells-management.yaml
@@ -1,0 +1,163 @@
+# Gestione della perforazione e dei pozzi (it) — translations for L1-drilling-wells-management.yaml
+locale: it
+source: L1-drilling-wells-management.yaml
+entries:
+  BC-3020:
+    name: Gestione della perforazione e dei pozzi
+    description: |
+      Ingegneria, esecuzione e integrità nel ciclo di vita dei pozzi: dalla progettazione
+      e dalle operazioni di perforazione al completamento, all'intervento, al workover
+      e al controllo del pozzo.
+  BC-3020.10:
+    name: Ingegneria e progettazione del pozzo
+    description: |
+      Progettazione dell'architettura del pozzo, delle colonne di rivestimento, del tubing,
+      dei fluidi di perforazione e delle stime di costo per i programmi di perforazione.
+  BC-3020.10.10:
+    name: Progettazione dell'architettura del pozzo
+    description: |
+      Progettazione della traiettoria, delle sezioni e dell'architettura complessiva del pozzo.
+  BC-3020.10.20:
+    name: Progettazione delle colonne di rivestimento e del tubing
+    description: |
+      Progettazione delle colonne di rivestimento, liner e tubing incluse le verifiche di sforzo e collasso.
+  BC-3020.10.30:
+    name: Progettazione del fluido di perforazione
+    description: |
+      Selezione del sistema di fanghi e progettazione reologica per le sezioni di perforazione.
+  BC-3020.10.40:
+    name: Stima dei costi del pozzo
+    description: |
+      Stima dei costi per autorizzazione alle spese (AFE) per programmi di perforazione e completamento.
+  BC-3020.20:
+    name: Gestione delle operazioni di perforazione
+    description: |
+      Esecuzione delle operazioni di perforazione inclusi coordinamento dell'impianto,
+      monitoraggio in tempo reale, perforazione direzionale e cementazione.
+    in_scope:
+      - Supervisione delle operazioni di perforazione sull'impianto
+      - Monitoraggio in tempo reale dei dati di perforazione
+      - Perforazione direzionale e a pressione gestita
+      - Operazioni di cementazione e discesa colonne
+    out_of_scope:
+      - Installazione del completamento del pozzo (BC-3020.30)
+      - Sicurezza di processo sugli impianti di perforazione (BC-3050)
+  BC-3020.20.10:
+    name: Coordinamento delle operazioni dell'impianto
+    description: |
+      Coordinamento quotidiano delle operazioni dell'impianto e delle attività dei contractors.
+  BC-3020.20.20:
+    name: Monitoraggio in tempo reale della perforazione
+    description: |
+      Monitoraggio in tempo reale dei dati di perforazione dai centri di supporto operativo.
+  BC-3020.20.30:
+    name: Esecuzione della perforazione direzionale
+    description: |
+      Esecuzione di perforazioni direzionali, orizzontali e a raggiungimento esteso.
+  BC-3020.20.40:
+    name: Operazioni dei fluidi di perforazione
+    description: |
+      Ingegneria del fango, trattamento e controllo dei solidi durante la perforazione.
+  BC-3020.20.50:
+    name: Operazioni di cementazione
+    description: |
+      Operazioni di cementazione primaria e riparativa.
+  BC-3020.30:
+    name: Gestione dei completamenti dei pozzi
+    description: |
+      Progettazione e installazione dei completamenti incluse operazioni di perforazione
+      e stimolazione.
+  BC-3020.30.10:
+    name: Progettazione del completamento
+    description: |
+      Progettazione del completamento superiore e inferiore incluso il sand control ove applicabile.
+  BC-3020.30.20:
+    name: Installazione del completamento
+    description: |
+      Discesa e installazione delle colonne di completamento e degli accessori.
+  BC-3020.30.30:
+    name: Operazioni di perforazione dei tubolari
+    description: |
+      Selezione del perforatore e esecuzione per la creazione dei percorsi di flusso.
+  BC-3020.30.40:
+    name: Operazioni di stimolazione
+    description: |
+      Trattamenti di fratturazione idraulica, acidizzazione e altre stimolazioni.
+  BC-3020.40:
+    name: Gestione degli interventi e dei workover sui pozzi
+    description: |
+      Interventi sul pozzo nel ciclo di vita: dalle operazioni wireline ai workover completi.
+  BC-3020.40.10:
+    name: Operazioni di coiled tubing
+    description: |
+      Operazioni di intervento con coiled tubing.
+  BC-3020.40.20:
+    name: Operazioni wireline e slickline
+    description: |
+      Operazioni di acquisizione dati e intervento wireline e slickline.
+  BC-3020.40.30:
+    name: Operazioni di workover
+    description: |
+      Operazioni di workover su pozzi produttori e iniettori.
+  BC-3020.40.40:
+    name: Intervento through-tubing
+    description: |
+      Interventi riparativi e di stimolazione through-tubing.
+  BC-3020.50:
+    name: Gestione dell'integrità del pozzo
+    description: |
+      Verifica e sorveglianza delle barriere del pozzo lungo il suo ciclo di vita,
+      inclusa la gestione della pressione anulare e della pressione sostenuta della colonna.
+  BC-3020.50.10:
+    name: Verifica delle barriere del pozzo
+    description: |
+      Verifica delle barriere primarie e secondarie del pozzo secondo gli standard di integrità.
+  BC-3020.50.20:
+    name: Monitoraggio della pressione anulare
+    description: |
+      Monitoraggio continuo e periodico delle pressioni anulari del pozzo.
+  BC-3020.50.30:
+    name: Valutazione del rischio di integrità del pozzo
+    description: |
+      Valutazione del rischio dello stato di integrità del pozzo sul portafoglio pozzi.
+  BC-3020.50.40:
+    name: Gestione della pressione sostenuta della colonna
+    description: |
+      Diagnosi e gestione degli eventi di pressione sostenuta della colonna di rivestimento.
+  BC-3020.60:
+    name: Gestione del controllo del pozzo
+    description: |
+      Prevenzione e risposta agli eventi di controllo del pozzo inclusi rilevamento
+      del kick, operazioni del BOP e competenza nel controllo del pozzo.
+  BC-3020.60.10:
+    name: Rilevamento e risposta al kick
+    description: |
+      Metodologie di rilevamento del kick e procedure di risposta al controllo del pozzo.
+  BC-3020.60.20:
+    name: Operazioni del blow-out preventer
+    description: |
+      Operazione, test funzionale e manutenzione degli stack BOP.
+  BC-3020.60.30:
+    name: Assicurazione della competenza nel controllo del pozzo
+    description: |
+      Coordinamento dei programmi di competenza IWCF e IADC WellCAP.
+  BC-3020.70:
+    name: Gestione dei contractors di perforazione
+    description: |
+      Assurance, gestione delle performance e supervisione contrattuale degli impianti
+      di perforazione e dei contractors di servizio.
+  BC-3020.70.10:
+    name: Assurance e audit degli impianti
+    description: |
+      Audit pre-accettazione e in servizio degli impianti di perforazione e dei contractors.
+  BC-3020.70.20:
+    name: Gestione delle performance dei contractors di perforazione
+    description: |
+      Gestione delle performance rispetto ai contratti di impianto e ai KPI di servizio.
+  BC-3020.70.30:
+    name: Gestione dei contratti di servizi di perforazione
+    description: |
+      Gestione dei contratti delle linee di servizio di perforazione (fanghi, cementazione, direzionale, ecc.).
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-driver-crew-operations-management.yaml
+++ b/catalogue/i18n/it/L1-driver-crew-operations-management.yaml
@@ -1,0 +1,107 @@
+# Gestione delle operazioni degli autisti e del personale di bordo (it) — translations for L1-driver-crew-operations-management.yaml
+locale: it
+source: L1-driver-crew-operations-management.yaml
+entries:
+  BC-2440:
+    name: Gestione delle operazioni degli autisti e del personale di bordo
+    description: |
+      Qualificazione, pianificazione turni, conformità alle ore di servizio (HOS),
+      gestione della fatica e performance di autisti ed equipaggi operativi su strada,
+      ferrovia, mare e aria.
+  BC-2440.10:
+    name: Gestione della qualificazione degli autisti e del personale di bordo
+    description: |
+      Manutenzione delle licenze, abilitazioni, rating e documenti di idoneità medica
+      per autisti ed equipaggi.
+    in_scope:
+      - Qualifiche professionali CDL, STCW, ATPL ed equivalenti
+      - Documenti di idoneità medica e psicologica
+    out_of_scope:
+      - Archivi HR generici e gestione paghe (BC-300)
+      - Competenza dei controllori del traffico aereo (BC-1290)
+  BC-2440.10.10:
+    name: Monitoraggio di licenze e abilitazioni
+    description: |
+      Monitoraggio delle licenze professionali, abilitazioni e date di scadenza.
+  BC-2440.10.20:
+    name: Gestione dei rating specifici per modo di trasporto
+    description: |
+      Gestione dei rating specifici per modo di trasporto quali abilitazioni STCW e
+      qualifiche per tipo di aeromobile.
+  BC-2440.10.30:
+    name: Certificazione medica e di idoneità fisica
+    description: |
+      Certificazioni mediche e di idoneità fisica periodiche per il personale operativo.
+  BC-2440.20:
+    name: Gestione della pianificazione turni e degli orari
+    description: |
+      Costruzione dei turni di servizio, sistemi di guardia e accoppiamenti degli equipaggi
+      nel rispetto dei vincoli di servizio e normativi.
+  BC-2440.20.10:
+    name: Pianificazione dei turni di servizio
+    description: |
+      Pianificazione dei turni di servizio per base, deposito e servizio.
+  BC-2440.20.20:
+    name: Accoppiamento e rotazione degli equipaggi
+    description: |
+      Accoppiamento e rotazione degli equipaggi su viaggi multi-giorno o multi-tratta.
+  BC-2440.20.30:
+    name: Gestione delle riserve e dei reperibili
+    description: |
+      Disposizioni di standby, riserva e reperibilità.
+  BC-2440.30:
+    name: Gestione delle ore di servizio e della fatica
+    description: |
+      Conformità alle norme sulle ore di servizio (HOS) e gestione dei sistemi di
+      gestione del rischio di fatica.
+  BC-2440.30.10:
+    name: Conformità alle ore di servizio (HOS)
+    description: |
+      Registrazione e applicazione dei limiti HOS tramite tachigrafo, ELD ed equivalenti.
+  BC-2440.30.20:
+    name: Gestione del rischio di fatica
+    description: |
+      Gestione dei sistemi di gestione del rischio di fatica e modellizzazione
+      bio-matematica.
+  BC-2440.30.30:
+    name: Applicazione dei periodi di riposo
+    description: |
+      Applicazione dei periodi di riposo obbligatori, sosta e limiti settimanali.
+  BC-2440.40:
+    name: Gestione della performance degli autisti e del personale di bordo
+    description: |
+      Valutazione della performance, coaching e gestione delle infrazioni per autisti
+      ed equipaggi.
+  BC-2440.40.10:
+    name: Valutazione della performance degli autisti e del personale di bordo
+    description: |
+      Valutazione del personale operativo rispetto ai KPI di sicurezza, consumo di
+      carburante e servizio.
+  BC-2440.40.20:
+    name: Coaching e formazione ricorrente
+    description: |
+      Coaching, corsi di aggiornamento e formazione correttiva.
+  BC-2440.40.30:
+    name: Gestione degli incidenti e delle infrazioni
+    description: |
+      Tracciamento e risoluzione degli incidenti operativi e delle infrazioni alle regole.
+  BC-2440.50:
+    name: Gestione del viaggio e dell'alloggio dell'equipaggio
+    description: |
+      Viaggio, alloggio e logistica del cambio equipaggio per rotazioni su mare, aria
+      e ferrovia.
+  BC-2440.50.10:
+    name: Prenotazione del viaggio dell'equipaggio
+    description: |
+      Prenotazione del viaggio di posizionamento per le rotazioni degli equipaggi.
+  BC-2440.50.20:
+    name: Gestione dell'alloggio dell'equipaggio
+    description: |
+      Gestione di hotel e alloggi per la sosta e la rotazione.
+  BC-2440.50.30:
+    name: Coordinamento del cambio equipaggio
+    description: |
+      Coordinamento dei cambi equipaggio in porti, aeroporti e depositi.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-drug-development-management.yaml
+++ b/catalogue/i18n/it/L1-drug-development-management.yaml
@@ -1,0 +1,119 @@
+# Gestione dello sviluppo di farmaci (it) — translations for L1-drug-development-management.yaml
+locale: it
+source: L1-drug-development-management.yaml
+entries:
+  BC-1510:
+    name: Gestione dello sviluppo di farmaci
+    description: |
+      Sviluppo preclinico e clinico nelle diverse fasi.
+  BC-1510.10:
+    name: Gestione dello sviluppo preclinico
+    description: |
+      Farmacologia preclinica, tossicologia, ADME.
+  BC-1510.10.10:
+    name: Farmacologia preclinica
+    description: |
+      Studi di farmacologia preclinica e modellizzazione.
+  BC-1510.10.20:
+    name: Tossicologia preclinica
+    description: |
+      Studi di tossicologia GLP per la valutazione della sicurezza.
+  BC-1510.10.30:
+    name: Studi ADME e PK
+    description: |
+      Studi ADME e farmacocinetici.
+  BC-1510.10.40:
+    name: Bioanalisi preclinica
+    description: |
+      Sviluppo di metodi bioanalitici e analisi.
+  BC-1510.20:
+    name: Gestione dello sviluppo clinico di Fase I
+    description: |
+      First-in-human, sicurezza, PK/PD.
+  BC-1510.20.10:
+    name: Conduzione dello studio first-in-human
+    description: |
+      Pianificazione e conduzione dello studio first-in-human.
+  BC-1510.20.20:
+    name: Monitoraggio della sicurezza in Fase I
+    description: |
+      Monitoraggio della sicurezza ed escalation della dose in Fase I.
+  BC-1510.20.30:
+    name: Modellizzazione clinica PK/PD
+    description: |
+      Modellizzazione clinica PK/PD e selezione della dose.
+  BC-1510.30:
+    name: Gestione dello sviluppo clinico di Fase II
+    description: |
+      Proof of concept, ricerca della dose.
+  BC-1510.30.10:
+    name: Studi di proof of concept di Fase II
+    description: |
+      Conduzione degli studi di proof of concept.
+  BC-1510.30.20:
+    name: Studi di ricerca della dose di Fase II
+    description: |
+      Studi di ricerca della dose e di relazione dose-risposta.
+  BC-1510.30.30:
+    name: Operatività degli studi adattativi di Fase II
+    description: |
+      Gestione operativa dei disegni adattativi di Fase II.
+  BC-1510.40:
+    name: Gestione dello sviluppo clinico di Fase III
+    description: |
+      Studi pivotali, studi registrativi.
+  BC-1510.40.10:
+    name: Conduzione dello studio pivotale di Fase III
+    description: |
+      Conduzione degli studi pivotali di Fase III.
+  BC-1510.40.20:
+    name: Analisi statistica dello studio pivotale
+    description: |
+      Analisi statistica degli studi pivotali secondo ICH E9.
+  BC-1510.40.30:
+    name: Reportistica dello studio pivotale
+    description: |
+      Reportistica e divulgazione dei risultati degli studi pivotali.
+  BC-1510.50:
+    name: Gestione dello sviluppo di Fase IV e post-marketing
+    description: |
+      Studi post-marketing, RWE (real-world evidence).
+  BC-1510.50.10:
+    name: Studi a impegno post-marketing
+    description: |
+      Conduzione degli studi a impegno e a obbligo post-marketing.
+  BC-1510.50.20:
+    name: Generazione delle evidenze real-world
+    description: |
+      Generazione di RWE (real-world evidence) e studi osservazionali.
+  BC-1510.50.30:
+    name: Espansione delle indicazioni nel ciclo di vita
+    description: |
+      Sviluppo del ciclo di vita ed espansione delle indicazioni terapeutiche.
+  BC-1510.60:
+    name: Gestione dello sviluppo CMC
+    description: |
+      Sviluppo CMC (Chemistry, Manufacturing and Controls).
+  BC-1510.60.10:
+    name: Sviluppo della sostanza attiva
+    description: |
+      Sviluppo della sintesi e del processo della sostanza attiva.
+  BC-1510.60.20:
+    name: Sviluppo del prodotto medicinale
+    description: |
+      Sviluppo della forma farmaceutica e della formulazione del prodotto medicinale.
+  BC-1510.60.30:
+    name: Sviluppo del metodo analitico
+    description: |
+      Sviluppo e validazione dei metodi analitici.
+  BC-1510.60.40:
+    name: Gestione del programma di stabilità
+    description: |
+      Programma di stabilità allineato all'ICH Q1.
+  BC-1510.60.50:
+    name: Validazione del processo
+    description: |
+      Validazione del processo allineata agli ICH Q7-Q12.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-drug-discovery-management.yaml
+++ b/catalogue/i18n/it/L1-drug-discovery-management.yaml
@@ -1,0 +1,119 @@
+# Gestione della scoperta di farmaci (it) — translations for L1-drug-discovery-management.yaml
+locale: it
+source: L1-drug-discovery-management.yaml
+entries:
+  BC-1500:
+    name: Gestione della scoperta di farmaci
+    description: |
+      Identificazione del bersaglio, da hit a lead, ottimizzazione dei lead.
+  BC-1500.10:
+    name: Gestione dell'identificazione e validazione del bersaglio
+    description: |
+      Biologia della malattia, identificazione del bersaglio, validazione del bersaglio.
+  BC-1500.10.10:
+    name: Ricerca sulla biologia della malattia
+    description: |
+      Ricerca sui meccanismi e le vie patologiche delle malattie.
+  BC-1500.10.20:
+    name: Identificazione del bersaglio
+    description: |
+      Identificazione di bersagli biologici attraverso approcci omici e genetici.
+  BC-1500.10.30:
+    name: Validazione del bersaglio
+    description: |
+      Validazione dei bersagli mediante modelli in vitro e in vivo.
+  BC-1500.10.40:
+    name: Valutazione della druggability del bersaglio
+    description: |
+      Valutazione della druggability e della trattabilità del bersaglio.
+  BC-1500.20:
+    name: Gestione della scoperta degli hit
+    description: |
+      HTS (high-throughput screening), screening virtuale, identificazione degli hit.
+  BC-1500.20.10:
+    name: Sviluppo del saggio
+    description: |
+      Sviluppo di saggi biochimici e cellulari.
+  BC-1500.20.20:
+    name: HTS (high-throughput screening)
+    description: |
+      Esecuzione di campagne di HTS (high-throughput screening).
+  BC-1500.20.30:
+    name: Screening virtuale e basato su intelligenza artificiale
+    description: |
+      Screening virtuale e identificazione degli hit mediante intelligenza artificiale.
+  BC-1500.20.40:
+    name: Triage e conferma degli hit
+    description: |
+      Triage, conferma e prioritizzazione degli hit di screening.
+  BC-1500.30:
+    name: Gestione dell'ottimizzazione dei lead
+    description: |
+      Chimica medicinale, relazione struttura-attività, ottimizzazione dei lead.
+  BC-1500.30.10:
+    name: Sintesi di chimica medicinale
+    description: |
+      Sintesi e progettazione di chimica medicinale.
+  BC-1500.30.20:
+    name: Analisi della relazione struttura-attività
+    description: |
+      Analisi della relazione struttura-attività per guidare l'ottimizzazione strutturale.
+  BC-1500.30.30:
+    name: Profilazione ADMET
+    description: |
+      Profilazione ADMET in vitro delle serie in ottimizzazione.
+  BC-1500.30.40:
+    name: Selezione delle serie lead
+    description: |
+      Selezione delle serie lead dalle campagne di ottimizzazione.
+  BC-1500.40:
+    name: Gestione della selezione del candidato preclinico
+    description: |
+      Selezione del candidato farmaco, studi propedeutici all'IND.
+  BC-1500.40.10:
+    name: Profilazione del candidato preclinico
+    description: |
+      Profilazione dei candidati preclinici rispetto al profilo del prodotto target.
+  BC-1500.40.20:
+    name: Governance della nomina del candidato
+    description: |
+      Governance e nomina dei candidati preclinici.
+  BC-1500.40.30:
+    name: Coordinamento degli studi propedeutici all'IND
+    description: |
+      Coordinamento degli studi di tossicologia e sicurezza propedeutici all'IND.
+  BC-1500.50:
+    name: Gestione della ricerca traslazionale
+    description: |
+      Scienza traslazionale, sviluppo di biomarcatori.
+  BC-1500.50.10:
+    name: Scienza traslazionale
+    description: |
+      Scienza traslazionale a ponte tra la scoperta e lo sviluppo clinico.
+  BC-1500.50.20:
+    name: Scoperta e sviluppo di biomarcatori
+    description: |
+      Scoperta e sviluppo di biomarcatori.
+  BC-1500.50.30:
+    name: Strategia di stratificazione dei pazienti
+    description: |
+      Strategie di stratificazione dei pazienti per la progettazione degli studi clinici.
+  BC-1500.60:
+    name: Gestione dei composti e delle librerie
+    description: |
+      Librerie di composti, campioni, gestione del repository.
+  BC-1500.60.10:
+    name: Curazione della libreria di composti
+    description: |
+      Curazione e registrazione delle librerie di composti.
+  BC-1500.60.20:
+    name: Gestione dei campioni e del repository
+    description: |
+      Conservazione, recupero e catena di custodia dei campioni.
+  BC-1500.60.30:
+    name: Gestione di reagenti e materiali biologici
+    description: |
+      Gestione di reagenti e materiali biologici.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-education-compliance-regulatory-reporting-management.yaml
+++ b/catalogue/i18n/it/L1-education-compliance-regulatory-reporting-management.yaml
@@ -1,0 +1,153 @@
+# Conformità normativa e rendicontazione nel settore dell'istruzione (it) — translations for L1-education-compliance-regulatory-reporting-management.yaml
+locale: it
+source: L1-education-compliance-regulatory-reporting-management.yaml
+entries:
+  BC-4810:
+    name: Conformità normativa e rendicontazione nel settore dell'istruzione
+    description: |
+      Conformità normativa specifica del settore educativo e rendicontazione legale,
+      incluse la privacy dei dati degli studenti, i regimi sui diritti civili, gli obblighi
+      legali di istruzione speciale, la conformità al visto degli studenti internazionali
+      e la conformità al finanziamento pubblico. Affianca la Gestione della conformità per
+      gli obblighi normativi generali.
+  BC-4810.10:
+    name: Conformità alla privacy dei dati degli studenti
+    description: |
+      Conformità ai regimi specifici del settore per la privacy dei dati degli studenti,
+      inclusi FERPA, COPPA e regimi equivalenti.
+    in_scope:
+      - Operazioni di conformità FERPA
+      - Operazioni di conformità COPPA
+      - Gestione degli accordi di condivisione dei dati degli studenti
+    out_of_scope:
+      - Protezione dei dati generale (trattata in Gestione delle informazioni e dei dati)
+  BC-4810.10.10:
+    name: Operazioni di conformità FERPA
+    description: |
+      Conformità FERPA quotidiana, consensi e comunicazioni.
+  BC-4810.10.20:
+    name: Operazioni di conformità COPPA
+    description: |
+      Conformità COPPA per i servizi rivolti a bambini al di sotto dei 13 anni.
+  BC-4810.10.30:
+    name: Gestione degli accordi di condivisione dei dati degli studenti
+    description: |
+      Negoziazione e gestione degli accordi di condivisione dei dati degli studenti con i fornitori.
+  BC-4810.20:
+    name: Rendicontazione legale nel settore dell'istruzione
+    description: |
+      Presentazione di statistiche educative legali e comunicazioni sulle prestazioni
+      alle autorità nazionali, statali e locali.
+    in_scope:
+      - Presentazione di statistiche nazionali (es. IPEDS, HESA)
+      - Comunicazioni alle autorità educative statali e locali
+      - Comunicazione pubblica di finanziamenti e prestazioni
+    out_of_scope:
+      - Rendicontazione interna delle prestazioni (trattata in Gestione della qualità accademica e dell'accreditamento)
+  BC-4810.20.10:
+    name: Presentazione delle statistiche nazionali
+    description: |
+      Presentazione delle comunicazioni alle agenzie nazionali di statistica dell'istruzione.
+  BC-4810.20.20:
+    name: Comunicazioni alle autorità educative statali e locali
+    description: |
+      Comunicazioni alle autorità educative statali, provinciali e locali.
+  BC-4810.20.30:
+    name: Comunicazione pubblica di finanziamenti e prestazioni
+    description: |
+      Comunicazione pubblica dell'utilizzo dei finanziamenti e delle metriche di performance educativa.
+  BC-4810.30:
+    name: Conformità ai diritti civili
+    description: |
+      Conformità ai regimi specifici dei diritti civili nel settore educativo,
+      inclusi il Titolo IX, la Sezione 504 e l'ADA nel contesto accademico.
+    in_scope:
+      - Indagine e rendicontazione Titolo IX
+      - Conformità alla Sezione 504 e all'ADA
+      - Applicazione delle politiche di non discriminazione
+    out_of_scope:
+      - Accomodamenti quotidiani (trattati in Gestione del supporto e del benessere degli studenti)
+  BC-4810.30.10:
+    name: Indagine e rendicontazione Titolo IX
+    description: |
+      Ricezione, indagine, udienza e rendicontazione legale del Titolo IX.
+  BC-4810.30.20:
+    name: Conformità alla Sezione 504 e all'ADA
+    description: |
+      Conformità alla Sezione 504 e all'ADA nel contesto accademico e ammissivo.
+  BC-4810.30.30:
+    name: Applicazione delle politiche di non discriminazione
+    description: |
+      Applicazione delle politiche di non discriminazione nell'istruzione e gestione dei reclami.
+  BC-4810.40:
+    name: Conformità all'istruzione speciale
+    description: |
+      Conformità ai regimi legali di istruzione speciale per le popolazioni in età scolare
+      e di intervento precoce.
+    in_scope:
+      - Conformità all'IDEA Parte B
+      - Conformità all'IDEA Parte C e all'intervento precoce
+      - Conformità legale equivalente SEN/ALN
+    out_of_scope:
+      - Erogazione dei servizi di istruzione speciale (trattata in Gestione del supporto e del benessere degli studenti)
+  BC-4810.40.10:
+    name: Conformità all'IDEA Parte B
+    description: |
+      Conformità legale all'IDEA Parte B per l'istruzione speciale in età scolare.
+  BC-4810.40.20:
+    name: Conformità all'IDEA Parte C e all'intervento precoce
+    description: |
+      Conformità all'IDEA Parte C per i servizi di intervento precoce.
+  BC-4810.40.30:
+    name: Conformità legale equivalente SEN ALN
+    description: |
+      Conformità legale equivalente SEN, ALN e istruzione inclusiva al di fuori degli Stati Uniti.
+  BC-4810.50:
+    name: Conformità degli studenti internazionali
+    description: |
+      Conformità alla sponsorizzazione del visto e monitoraggio legale degli studenti internazionali
+      nell'ambito di regimi come SEVIS e il percorso per studenti nel Regno Unito.
+    in_scope:
+      - Operazioni di conformità SEVIS / I-20
+      - Rendicontazione sul visto studentesco (percorso studenti UK, equivalenti)
+      - Monitoraggio e rendicontazione degli studenti internazionali
+    out_of_scope:
+      - Emissione iniziale della documentazione per la sponsorizzazione del visto (trattata in Gestione del reclutamento e dell'ammissione degli studenti)
+  BC-4810.50.10:
+    name: Operazioni di conformità SEVIS / I-20
+    description: |
+      Conformità quotidiana a SEVIS e I-20 per gli studenti sponsorizzati negli Stati Uniti.
+  BC-4810.50.20:
+    name: Rendicontazione sul visto studentesco
+    description: |
+      Rendicontazione legale sugli studenti sponsorizzati nell'ambito di regimi di visto non statunitensi.
+  BC-4810.50.30:
+    name: Monitoraggio degli studenti internazionali
+    description: |
+      Monitoraggio dello status, della frequenza e dell'indirizzo degli studenti internazionali come richiesto dagli obblighi di sponsorizzazione.
+  BC-4810.60:
+    name: Conformità al Titolo IV e al finanziamento pubblico
+    description: |
+      Conformità ai regimi di finanziamento pubblico degli aiuti agli studenti e dell'istruzione,
+      incluso il Titolo IV negli Stati Uniti e regimi equivalenti altrove.
+    in_scope:
+      - Conformità all'idoneità e all'erogazione del Titolo IV
+      - Restituzione dei fondi e riconciliazione degli aiuti
+      - Risposta agli audit sul finanziamento pubblico
+    out_of_scope:
+      - Assegnazione delle offerte di aiuto finanziario (trattata in Gestione del reclutamento e dell'ammissione degli studenti)
+  BC-4810.60.10:
+    name: Conformità all'idoneità e all'erogazione del Titolo IV
+    description: |
+      Conformità istituzionale al Titolo IV e all'erogazione degli aiuti agli studenti.
+  BC-4810.60.20:
+    name: Restituzione dei fondi e riconciliazione degli aiuti
+    description: |
+      Riconciliazione e restituzione degli aiuti non guadagnati come richiesto dai regimi di finanziamento.
+  BC-4810.60.30:
+    name: Risposta agli audit sul finanziamento pubblico
+    description: |
+      Risposta agli audit e alle revisioni del finanziamento pubblico degli aiuti agli studenti e dell'istruzione.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-educational-content-learning-resource-management.yaml
+++ b/catalogue/i18n/it/L1-educational-content-learning-resource-management.yaml
@@ -1,0 +1,152 @@
+# Gestione dei contenuti educativi e delle risorse didattiche (it) — translations for L1-educational-content-learning-resource-management.yaml
+locale: it
+source: L1-educational-content-learning-resource-management.yaml
+entries:
+  BC-4790:
+    name: Gestione dei contenuti educativi e delle risorse didattiche
+    description: |
+      Creazione, catalogazione, concessione in licenza ed erogazione di contenuti educativi
+      e risorse didattiche utilizzati nell'insegnamento, inclusi i materiali dei corsi,
+      gli oggetti di apprendimento digitali, le OER (risorse educative aperte), le collezioni
+      bibliotecarie e i libri di testo.
+  BC-4790.10:
+    name: Creazione e produzione di contenuti dei corsi
+    description: |
+      Progettazione istruzionale e produzione dei contenuti dei corsi, inclusi
+      i contenuti multimediali e la compilazione dei materiali dei corsi.
+    in_scope:
+      - Progettazione istruzionale
+      - Produzione di contenuti multimediali
+      - Compilazione dei materiali dei corsi
+    out_of_scope:
+      - Erogazione della didattica (trattata in Gestione delle operazioni didattiche e di apprendimento)
+  BC-4790.10.10:
+    name: Progettazione istruzionale
+    description: |
+      Progettazione istruzionale di corsi, moduli ed esperienze di apprendimento.
+  BC-4790.10.20:
+    name: Produzione di contenuti multimediali
+    description: |
+      Produzione di contenuti di apprendimento video, audio e multimediali interattivi.
+  BC-4790.10.30:
+    name: Compilazione dei materiali dei corsi
+    description: |
+      Compilazione dei materiali dei corsi e dei pacchetti didattici per l'erogazione.
+  BC-4790.20:
+    name: Catalogo degli oggetti di apprendimento digitali
+    description: |
+      Catalogazione, versionamento e riutilizzo degli oggetti di apprendimento digitali
+      tra programmi e modalità.
+    in_scope:
+      - Catalogazione e metadatazione degli oggetti di apprendimento
+      - Versionamento degli oggetti di apprendimento
+      - Scoperta e riutilizzo degli oggetti riutilizzabili
+    out_of_scope:
+      - Erogazione operativa tramite LMS (trattata in Gestione delle operazioni didattiche e di apprendimento)
+  BC-4790.20.10:
+    name: Catalogazione e metadatazione degli oggetti di apprendimento
+    description: |
+      Catalogazione degli oggetti di apprendimento e metadatazione rispetto agli standard di interoperabilità.
+  BC-4790.20.20:
+    name: Versionamento degli oggetti di apprendimento
+    description: |
+      Versionamento e gestione del ciclo di vita degli oggetti di apprendimento.
+  BC-4790.20.30:
+    name: Scoperta e riutilizzo degli oggetti riutilizzabili
+    description: |
+      Scoperta e riutilizzo degli oggetti di apprendimento tra corsi e discipline.
+  BC-4790.30:
+    name: Gestione delle OER (risorse educative aperte)
+    description: |
+      Reperimento, concessione in licenza e contribuzione delle OER (risorse educative aperte)
+      utilizzate nell'insegnamento.
+    in_scope:
+      - Reperimento e curazione delle OER
+      - Conformità alle licenze delle OER
+      - Contribuzione e condivisione delle OER
+    out_of_scope:
+      - Approvvigionamento di libri di testo commerciali (trattato in Approvvigionamento di libri di testo e materiali didattici)
+  BC-4790.30.10:
+    name: Reperimento e curazione delle OER
+    description: |
+      Reperimento e curazione di OER (risorse educative aperte) per uso istituzionale.
+  BC-4790.30.20:
+    name: Conformità alle licenze delle OER
+    description: |
+      Conformità alle licenze delle OER (es. Creative Commons) nell'utilizzo e nel riutilizzo.
+  BC-4790.30.30:
+    name: Contribuzione e condivisione delle OER
+    description: |
+      Contribuzione di contenuti di autoria istituzionale all'ecosistema delle OER.
+  BC-4790.40:
+    name: Operazioni bibliotecarie e delle risorse informative
+    description: |
+      Sviluppo delle collezioni bibliotecarie, gestione delle liste di lettura e
+      supporto all'information literacy per la didattica e la ricerca.
+    in_scope:
+      - Sviluppo delle collezioni
+      - Gestione delle liste di lettura e delle riserve
+      - Supporto all'information literacy
+    out_of_scope:
+      - Operazioni delle biblioteche pubbliche non facenti parte dell'erogazione educativa
+  BC-4790.40.10:
+    name: Sviluppo delle collezioni
+    description: |
+      Sviluppo delle collezioni bibliotecarie cartacee ed elettroniche.
+  BC-4790.40.20:
+    name: Gestione delle liste di lettura e delle riserve
+    description: |
+      Gestione delle liste di lettura dei corsi e delle collezioni di riserva.
+  BC-4790.40.30:
+    name: Supporto all'information literacy
+    description: |
+      Supporto e istruzione in materia di information literacy e abilità di ricerca.
+  BC-4790.50:
+    name: Concessione in licenza dei contenuti e gestione dei diritti
+    description: |
+      Concessione in licenza, autorizzazione al diritto d'autore e gestione delle eccezioni
+      educative per l'utilizzo di contenuti di terze parti nell'insegnamento.
+    in_scope:
+      - Concessione in licenza di contenuti educativi
+      - Autorizzazione al diritto d'autore
+      - Gestione del fair use e delle eccezioni educative
+    out_of_scope:
+      - Proprietà intellettuale istituzionale (trattata in Gestione della proprietà intellettuale)
+  BC-4790.50.10:
+    name: Concessione in licenza di contenuti educativi
+    description: |
+      Concessione in licenza di contenuti di terze parti per uso educativo.
+  BC-4790.50.20:
+    name: Autorizzazione al diritto d'autore
+    description: |
+      Autorizzazione del diritto d'autore per i contenuti utilizzati nell'insegnamento e nella valutazione.
+  BC-4790.50.30:
+    name: Gestione del fair use e delle eccezioni educative
+    description: |
+      Gestione del fair use, del fair dealing e delle eccezioni al diritto d'autore in ambito educativo.
+  BC-4790.60:
+    name: Approvvigionamento di libri di testo e materiali didattici
+    description: |
+      Specifica e approvvigionamento di libri di testo e materiali didattici,
+      inclusi i programmi per materiali a prezzi accessibili.
+    in_scope:
+      - Specifica delle letture obbligatorie
+      - Approvvigionamento di libri di testo
+      - Programmi per materiali a prezzi accessibili (es. accesso inclusivo)
+    out_of_scope:
+      - Approvvigionamento generico (trattato in Gestione degli acquisti)
+  BC-4790.60.10:
+    name: Specifica delle letture obbligatorie
+    description: |
+      Specifica delle letture obbligatorie e consigliate per i corsi.
+  BC-4790.60.20:
+    name: Approvvigionamento di libri di testo
+    description: |
+      Approvvigionamento di libri di testo e materiali didattici.
+  BC-4790.60.30:
+    name: Programma per materiali a prezzi accessibili
+    description: |
+      Gestione dei programmi per materiali a prezzi accessibili e di accesso inclusivo.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-educator-workforce-management.yaml
+++ b/catalogue/i18n/it/L1-educator-workforce-management.yaml
@@ -1,0 +1,175 @@
+# Gestione del personale docente e accademico (it) — translations for L1-educator-workforce-management.yaml
+locale: it
+source: L1-educator-workforce-management.yaml
+entries:
+  BC-4760:
+    name: Gestione del personale docente e accademico
+    description: |
+      Gestione del ciclo di vita del personale accademico e docente specifica del settore educativo,
+      che comprende reclutamento, accreditamento, ruolo di ruolo e avanzamento di carriera,
+      assegnazione del carico didattico, sviluppo professionale e gestione dei docenti a contratto.
+      Affianca la Gestione del capitale umano per le questioni HR generali.
+  BC-4760.10:
+    name: Reclutamento e nomina del personale accademico
+    description: |
+      Definizione, ricerca, selezione e nomina del personale accademico,
+      incluse le pratiche specializzate di selezione accademica.
+    in_scope:
+      - Definizione delle posizioni accademiche
+      - Ricerca e selezione del personale accademico
+      - Nomina e onboarding del personale accademico
+    out_of_scope:
+      - Reclutamento del personale generale (trattato in Gestione del capitale umano)
+  BC-4760.10.10:
+    name: Definizione delle posizioni accademiche
+    description: |
+      Definizione delle posizioni accademiche, dei gradi e della specializzazione disciplinare.
+  BC-4760.10.20:
+    name: Ricerca e selezione del personale accademico
+    description: |
+      Operazioni del comitato di selezione accademica e scelta dei candidati.
+  BC-4760.10.30:
+    name: Nomina e onboarding del personale accademico
+    description: |
+      Nomina, contrattualizzazione e onboarding accademico dei nuovi docenti.
+  BC-4760.20:
+    name: Accreditamento accademico e verifica delle qualifiche dei docenti
+    description: |
+      Verifica e manutenzione continua delle credenziali accademiche e professionali
+      dei docenti e delle loro competenze disciplinari.
+    in_scope:
+      - Verifica delle qualifiche dei docenti
+      - Accreditamento nelle materie di insegnamento
+      - Manutenzione continua delle credenziali
+    out_of_scope:
+      - Certificazioni del personale non accademico (trattate in Gestione del capitale umano)
+  BC-4760.20.10:
+    name: Verifica delle qualifiche dei docenti
+    description: |
+      Verifica delle lauree, delle certificazioni e delle abilitazioni possedute dai docenti.
+  BC-4760.20.20:
+    name: Accreditamento nelle materie di insegnamento
+    description: |
+      Accreditamento dei docenti rispetto alle competenze disciplinari e pedagogiche.
+  BC-4760.20.30:
+    name: Manutenzione continua delle credenziali
+    description: |
+      Monitoraggio delle credenziali professionali continue e dei rinnovi.
+  BC-4760.30:
+    name: Gestione del ruolo di ruolo e dell'avanzamento di carriera
+    description: |
+      Amministrazione della progressione nel ruolo di ruolo, delle decisioni sul ruolo
+      e dei processi di avanzamento di carriera accademica.
+    in_scope:
+      - Gestione del percorso verso il ruolo di ruolo e del periodo di prova
+      - Revisione e decisione sul ruolo di ruolo
+      - Revisione e decisione sull'avanzamento di carriera
+    out_of_scope:
+      - Gestione generale delle prestazioni (trattata in Gestione del capitale umano)
+  BC-4760.30.10:
+    name: Gestione del percorso verso il ruolo di ruolo e del periodo di prova
+    description: |
+      Gestione del percorso verso il ruolo di ruolo e dei periodi di prova.
+  BC-4760.30.20:
+    name: Revisione e decisione sul ruolo di ruolo
+    description: |
+      Processi del comitato di revisione e decisioni finali sul ruolo di ruolo.
+  BC-4760.30.30:
+    name: Revisione e decisione sull'avanzamento di carriera
+    description: |
+      Revisione dell'avanzamento di carriera accademica e processo decisionale tra i gradi.
+  BC-4760.40:
+    name: Gestione del carico didattico e del carico di lavoro
+    description: |
+      Allocazione e bilanciamento dei carichi di lavoro didattici, di ricerca e di servizio,
+      e pianificazione dei congedi accademici inclusi gli anni sabbatico.
+    in_scope:
+      - Assegnazione degli incarichi didattici
+      - Bilanciamento del carico di lavoro tra didattica, ricerca e servizio
+      - Pianificazione degli anni sabbatico e dei congedi accademici
+    out_of_scope:
+      - Amministrazione generale dei congedi HR (trattata in Gestione del capitale umano)
+  BC-4760.40.10:
+    name: Assegnazione degli incarichi didattici
+    description: |
+      Assegnazione degli incarichi didattici ai docenti e agli istruttori.
+  BC-4760.40.20:
+    name: Bilanciamento del carico di lavoro
+    description: |
+      Bilanciamento degli obblighi di didattica, ricerca e servizio tra i docenti.
+  BC-4760.40.30:
+    name: Pianificazione degli anni sabbatico e dei congedi
+    description: |
+      Pianificazione degli anni sabbatico e della copertura dei congedi accademici.
+  BC-4760.50:
+    name: Sviluppo professionale continuo del personale accademico
+    description: |
+      Sviluppo professionale continuo incentrato sulla pedagogia, sulla disciplina e sull'induzione
+      per il personale accademico e docente.
+    in_scope:
+      - Sviluppo della pedagogia e delle pratiche didattiche
+      - Sviluppo disciplinare
+      - Mentoring e induzione dei docenti
+    out_of_scope:
+      - Formazione e sviluppo generali (trattati in Gestione del capitale umano)
+  BC-4760.50.10:
+    name: Sviluppo della pedagogia e delle pratiche didattiche
+    description: |
+      Sviluppo delle capacità pedagogiche e delle pratiche didattiche dei docenti.
+  BC-4760.50.20:
+    name: Sviluppo disciplinare
+    description: |
+      Sviluppo delle competenze disciplinari e di materia.
+  BC-4760.50.30:
+    name: Mentoring e induzione dei docenti
+    description: |
+      Programmi di mentoring e induzione per i nuovi docenti.
+  BC-4760.60:
+    name: Valutazione delle prestazioni e revisione tra pari dei docenti
+    description: |
+      Valutazione delle prestazioni specifica dei docenti, inclusa l'osservazione didattica,
+      la revisione tra pari e il riconoscimento accademico.
+    in_scope:
+      - Osservazione didattica e revisione tra pari
+      - Valutazione annuale delle prestazioni dei docenti
+      - Riconoscimento e premi per i docenti
+    out_of_scope:
+      - Gestione generale delle prestazioni del personale (trattata in Gestione del capitale umano)
+  BC-4760.60.10:
+    name: Osservazione didattica e revisione tra pari
+    description: |
+      Osservazione didattica e revisione tra pari della pratica dei docenti.
+  BC-4760.60.20:
+    name: Valutazione annuale delle prestazioni
+    description: |
+      Valutazione annuale delle prestazioni del personale accademico e docente.
+  BC-4760.60.30:
+    name: Riconoscimento e premi per i docenti
+    description: |
+      Schemi di riconoscimento e premi per i docenti.
+  BC-4760.70:
+    name: Gestione dei docenti a contratto e sessional
+    description: |
+      Gestione del personale docente part-time, sessional e a contratto, inclusi
+      sourcing, contrattualizzazione e assicurazione della qualità.
+    in_scope:
+      - Sourcing del pool di docenti a contratto
+      - Amministrazione dei contratti sessional
+      - Integrazione dei docenti a contratto e assicurazione della qualità
+    out_of_scope:
+      - Gestione generale dei fornitori (trattata in Gestione dei fornitori)
+  BC-4760.70.10:
+    name: Sourcing del pool di docenti a contratto
+    description: |
+      Sourcing e manutenzione di un pool attivo di docenti a contratto.
+  BC-4760.70.20:
+    name: Amministrazione dei contratti sessional
+    description: |
+      Amministrazione dei contratti di docenza sessional e a contratto.
+  BC-4760.70.30:
+    name: Integrazione dei docenti a contratto e assicurazione della qualità
+    description: |
+      Integrazione dei docenti a contratto con le norme accademiche e assicurazione della qualità continua.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-electoral-administration-management.yaml
+++ b/catalogue/i18n/it/L1-electoral-administration-management.yaml
@@ -1,0 +1,141 @@
+# Gestione dell'amministrazione elettorale (it) — translations for L1-electoral-administration-management.yaml
+locale: it
+source: L1-electoral-administration-management.yaml
+entries:
+  BC-3330:
+    name: Gestione dell'amministrazione elettorale
+    description: |
+      Gestione delle elezioni, incluse la tenuta delle liste elettorali, la gestione dei collegi, la registrazione dei candidati e dei partiti, la progettazione e la produzione delle schede elettorali, le operazioni di seggio, lo scrutinio e la tabulazione dei risultati, e la trasparenza nel finanziamento della campagna.
+  BC-3330.10:
+    name: Gestione della lista elettorale
+    description: |
+      Manutenzione del registro degli elettori, incluse l'iscrizione, il cambio di indirizzo e le attività di aggiornamento.
+    in_scope:
+      - Iscrizione e re-iscrizione degli elettori
+      - Manutenzione della lista elettorale
+      - Verifica dell'eleggibilità
+    out_of_scope:
+      - Registrazione dell'identità civile (coperta dalla Gestione dell'anagrafe e della registrazione dell'identità)
+  BC-3330.10.10:
+    name: Iscrizione degli elettori
+    description: |
+      Iscrizione degli aventi diritto al voto nelle liste elettorali su tutti i canali.
+  BC-3330.10.20:
+    name: Manutenzione della lista elettorale
+    description: |
+      Aggiornamento delle liste, inclusi variazioni di indirizzo, cancellazione dei deceduti e gestione dei duplicati.
+  BC-3330.10.30:
+    name: Verifica dell'eleggibilità degli elettori
+    description: |
+      Verifica dell'eleggibilità degli elettori rispetto ai criteri di cittadinanza, età e residenza.
+  BC-3330.10.40:
+    name: Informazione agli elettori
+    description: |
+      Fornitura di tessere elettorali, ricerca del seggio di votazione e informazioni sull'educazione civica.
+  BC-3330.20:
+    name: Gestione dei collegi e dei circoscrizioni elettorali
+    description: |
+      Manutenzione dei collegi elettorali, delle aree geografiche dei seggi e dei cicli di ridefinizione dei collegi.
+  BC-3330.20.10:
+    name: Manutenzione dei collegi elettorali
+    description: |
+      Manutenzione dei confini dei collegi e delle circoscrizioni elettorali.
+  BC-3330.20.20:
+    name: Designazione dei seggi elettorali
+    description: |
+      Designazione, valutazione dell'accessibilità e pubblicazione dei seggi elettorali.
+  BC-3330.20.30:
+    name: Coordinamento della ridefinizione dei collegi
+    description: |
+      Coordinamento dei cicli di ridefinizione dei collegi previsti dalla legge e delle commissioni per i confini.
+  BC-3330.30:
+    name: Registrazione dei candidati e dei partiti
+    description: |
+      Registrazione dei partiti politici, dei candidati, delle presentazioni delle candidature e dell'accesso alla scheda elettorale.
+  BC-3330.30.10:
+    name: Registrazione dei partiti politici
+    description: |
+      Registrazione e riconoscimento dei partiti politici e dei loro simboli.
+  BC-3330.30.20:
+    name: Presentazione delle candidature
+    description: |
+      Ricezione e verifica delle candidature e delle dichiarazioni di legge.
+  BC-3330.30.30:
+    name: Determinazione dell'accesso alla scheda elettorale
+    description: |
+      Determinazione dell'accesso alla scheda elettorale, inclusi i requisiti di firme e le soglie minime.
+  BC-3330.40:
+    name: Progettazione e produzione delle schede elettorali
+    description: |
+      Progettazione, impaginazione, accessibilità, traduzione e produzione delle schede elettorali in formato cartaceo ed elettronico.
+  BC-3330.40.10:
+    name: Progettazione del layout della scheda elettorale
+    description: |
+      Progettazione e impaginazione delle schede elettorali per chiarezza, accessibilità e copertura linguistica.
+  BC-3330.40.20:
+    name: Traduzione e accessibilità della scheda elettorale
+    description: |
+      Fornitura di schede elettorali tradotte e in formati accessibili per gli elettori con disabilità.
+  BC-3330.40.30:
+    name: Produzione e distribuzione delle schede elettorali
+    description: |
+      Stampa, programmazione e distribuzione sicura di schede elettorali cartacee ed elettroniche.
+  BC-3330.50:
+    name: Operazioni di seggio
+    description: |
+      Gestione dei seggi nel giorno delle elezioni, incluse la gestione degli scrutatori, la verifica degli elettori e il voto, nel rispetto dei controlli VVSG.
+  BC-3330.50.10:
+    name: Gestione degli scrutatori
+    description: |
+      Reclutamento, formazione e dispiegamento degli scrutatori e dei funzionari elettorali.
+  BC-3330.50.20:
+    name: Verifica degli elettori al seggio
+    description: |
+      Verifica degli elettori, controllo dell'identità e consegna della scheda elettorale al seggio.
+  BC-3330.50.30:
+    name: Voto di persona
+    description: |
+      Voto di persona su carta o con apparecchiature di voto certificate VVSG.
+  BC-3330.50.40:
+    name: Operazioni di voto per corrispondenza e per posta
+    description: |
+      Operazioni a supporto del voto per corrispondenza, postale e degli elettori residenti all'estero.
+  BC-3330.60:
+    name: Scrutinio e tabulazione dei risultati
+    description: |
+      Scrutinio delle schede, tabulazione dei risultati, audit e certificazione degli esiti elettorali.
+  BC-3330.60.10:
+    name: Scrutinio delle schede
+    description: |
+      Scrutinio delle schede cartacee ed elettroniche in conformità alla procedura di legge.
+  BC-3330.60.20:
+    name: Tabulazione e comunicazione dei risultati
+    description: |
+      Aggregazione dei risultati di sezione e comunicazione al pubblico.
+  BC-3330.60.30:
+    name: Audit post-elettorale
+    description: |
+      Audit a limitazione del rischio e audit post-elettorali dei conteggi e delle apparecchiature di voto.
+  BC-3330.60.40:
+    name: Certificazione dei risultati elettorali
+    description: |
+      Certificazione di legge dei risultati elettorali e proclamazione degli eletti.
+  BC-3330.70:
+    name: Trasparenza nel finanziamento della campagna
+    description: |
+      Registrazione dei comitati elettorali, trasparenza nelle donazioni e nelle spese ed esecuzione dei limiti al finanziamento della campagna.
+  BC-3330.70.10:
+    name: Registrazione dei comitati elettorali
+    description: |
+      Registrazione di comitati elettorali, partiti ed entità equivalenti ai PAC.
+  BC-3330.70.20:
+    name: Rendicontazione delle donazioni e delle spese
+    description: |
+      Ricezione, validazione e pubblicazione delle dichiarazioni sulle donazioni e le spese.
+  BC-3330.70.30:
+    name: Applicazione della normativa sul finanziamento della campagna
+    description: |
+      Indagine e applicazione delle violazioni dei limiti e degli obblighi di trasparenza nel finanziamento della campagna.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-electrical-equipment-service-operations-management.yaml
+++ b/catalogue/i18n/it/L1-electrical-equipment-service-operations-management.yaml
@@ -1,0 +1,145 @@
+# Gestione delle operazioni di assistenza per apparecchiature elettriche (it) — translations for L1-electrical-equipment-service-operations-management.yaml
+locale: it
+source: L1-electrical-equipment-service-operations-management.yaml
+entries:
+  BC-1960:
+    name: Gestione delle operazioni di assistenza per apparecchiature elettriche
+    description: |
+      Servizi dell'OEM sulle apparecchiature fornite — sopralluogo, FAT e SAT, messa in tensione,
+      impostazioni di protezione, configurazione della base installata, retrofit, contratti di
+      prestazione e monitoraggio delle condizioni.
+  BC-1960.10:
+    name: Sopralluogo e ingegneria di pre-commissioning
+    description: |
+      Valutazione del sito e preparazione tecnica prima della messa in servizio delle apparecchiature.
+  BC-1960.10.10:
+    name: Esecuzione del sopralluogo
+    description: |
+      Esecuzione di sopralluoghi per rilevare le condizioni esistenti del sito.
+  BC-1960.10.20:
+    name: Valutazione della prontezza del sito
+    description: |
+      Valutazione della prontezza del sito per la consegna e la messa in tensione delle apparecchiature.
+  BC-1960.10.30:
+    name: Studi tecnici di pre-commissioning
+    description: |
+      Studi tecnici preliminari alla messa in servizio, comprendenti coordinamento e messa a terra.
+  BC-1960.20:
+    name: Coordinamento della prova di accettazione in fabbrica
+    description: |
+      Pianificazione ed esecuzione delle prove di accettazione in fabbrica con la presenza del cliente.
+  BC-1960.20.10:
+    name: Redazione del piano FAT
+    description: |
+      Redazione dei piani FAT in linea con i requisiti contrattuali.
+  BC-1960.20.20:
+    name: Coordinamento dei testimoni al FAT
+    description: |
+      Coordinamento dei testimoni del cliente e degli enti certificatori al FAT.
+  BC-1960.20.30:
+    name: Gestione della punchlist del FAT
+    description: |
+      Monitoraggio e chiusura degli elementi della punchlist del FAT.
+  BC-1960.30:
+    name: Gestione della prova di accettazione in sito e della messa in tensione
+    description: |
+      Prove di accettazione in sito, messa in tensione e supervisione dell'avvio iniziale.
+  BC-1960.30.10:
+    name: Esecuzione della prova di accettazione in sito
+    description: |
+      Esecuzione delle prove di accettazione in sito sulle apparecchiature installate.
+  BC-1960.30.20:
+    name: Esecuzione della procedura di messa in tensione
+    description: |
+      Messa in tensione controllata delle apparecchiature secondo le procedure di manovra.
+  BC-1960.30.30:
+    name: Supervisione dell'avvio iniziale
+    description: |
+      Supervisione dell'avvio iniziale e del collaudo in esercizio.
+  BC-1960.30.40:
+    name: Documentazione di consegna
+    description: |
+      Compilazione dei dossier di consegna e dei record as-commissioned.
+  BC-1960.40:
+    name: Gestione delle impostazioni di protezione e controllo
+    description: |
+      Elaborazione e applicazione delle impostazioni di protezione e controllo sulle apparecchiature installate.
+  BC-1960.40.10:
+    name: Studio di coordinamento della protezione
+    description: |
+      Studi di coordinamento per i dispositivi di protezione sulla rete installata.
+  BC-1960.40.20:
+    name: Calcolo delle impostazioni dei relè
+    description: |
+      Calcolo delle impostazioni dei relè di protezione.
+  BC-1960.40.30:
+    name: Deployment e verifica dei file di impostazione
+    description: |
+      Deployment dei file di impostazione sui relè e verifica in sito.
+  BC-1960.50:
+    name: Gestione della configurazione della base installata
+    description: |
+      Manutenzione dei dati di configurazione as-installed sulla base installata globale.
+  BC-1960.50.10:
+    name: Registro della base installata
+    description: |
+      Registro delle apparecchiature installate per numero di serie, sito e cliente.
+  BC-1960.50.20:
+    name: Rilevamento della configurazione as-built
+    description: |
+      Rilevamento della configurazione as-built al momento della messa in servizio.
+  BC-1960.50.30:
+    name: Registro delle modifiche alla base installata
+    description: |
+      Registro delle modifiche post-commissioning alle apparecchiature installate.
+  BC-1960.60:
+    name: Servizi di retrofit e aggiornamento delle apparecchiature
+    description: |
+      Progettazione ed esecuzione di retrofit e aggiornamenti funzionali sulle apparecchiature installate.
+  BC-1960.60.10:
+    name: Ingegneria del retrofit
+    description: |
+      Progettazione tecnica di pacchetti di retrofit e aggiornamento.
+  BC-1960.60.20:
+    name: Esecuzione del retrofit
+    description: |
+      Esecuzione in sito di retrofit e installazione di aggiornamenti.
+  BC-1960.60.30:
+    name: Validazione dell'aggiornamento
+    description: |
+      Prove di validazione successive al retrofit o all'aggiornamento.
+  BC-1960.70:
+    name: Operazioni di contratti di assistenza a prestazione
+    description: |
+      Gestione di contratti di assistenza basati sulle prestazioni e sui risultati.
+  BC-1960.70.10:
+    name: Esecuzione del contratto di prestazione
+    description: |
+      Esecuzione delle obbligazioni di assistenza basate sulle prestazioni.
+  BC-1960.70.20:
+    name: Rendicontazione dei risultati del livello di servizio
+    description: |
+      Rendicontazione dei risultati contrattuali e delle metriche di livello di servizio.
+  BC-1960.70.30:
+    name: Operazioni sui meccanismi di condivisione del rischio
+    description: |
+      Gestione dei meccanismi di bonus e penale per la condivisione del rischio.
+  BC-1960.80:
+    name: Erogazione del servizio di monitoraggio delle condizioni
+    description: |
+      Erogazione di servizi di monitoraggio remoto delle condizioni e di analisi predittiva.
+  BC-1960.80.10:
+    name: Operazioni di monitoraggio remoto delle condizioni
+    description: |
+      Centro operativo per il monitoraggio remoto delle condizioni dei beni installati.
+  BC-1960.80.20:
+    name: Erogazione di analisi diagnostiche
+    description: |
+      Erogazione di analisi diagnostiche ai clienti.
+  BC-1960.80.30:
+    name: Raccomandazioni di manutenzione predittiva
+    description: |
+      Raccomandazioni di manutenzione predittiva sulle apparecchiature installate.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-electrical-product-catalogue-management.yaml
+++ b/catalogue/i18n/it/L1-electrical-product-catalogue-management.yaml
@@ -1,0 +1,116 @@
+# Gestione del catalogo prodotti elettrici (it) — translations for L1-electrical-product-catalogue-management.yaml
+locale: it
+source: L1-electrical-product-catalogue-management.yaml
+entries:
+  BC-1940:
+    name: Gestione del catalogo prodotti elettrici
+    description: |
+      Struttura dei prodotti commercializzabili per prodotti elettrici — varianti, regole del
+      configuratore, SKU per giurisdizione, introduzione e ritiro, schede tecniche e materiale promozionale.
+  BC-1940.10:
+    name: Gestione dell'anagrafica del prodotto commercializzabile
+    description: |
+      Manutenzione delle anagrafiche dei prodotti commercializzabili e delle gerarchie di famiglia.
+  BC-1940.10.10:
+    name: Gestione dei record del prodotto commercializzabile
+    description: |
+      Creazione e manutenzione delle anagrafiche dei prodotti commercializzabili.
+  BC-1940.10.20:
+    name: Gestione della gerarchia e della famiglia di prodotto
+    description: |
+      Definizione delle strutture di famiglia e gerarchia di prodotto.
+  BC-1940.10.30:
+    name: Standardizzazione degli attributi di prodotto
+    description: |
+      Standardizzazione degli attributi nelle famiglie di prodotto.
+  BC-1940.20:
+    name: Gestione delle varianti e delle opzioni di prodotto
+    description: |
+      Gestione delle varianti di tensione, frequenza, protezione, protocollo e accessori.
+  BC-1940.20.10:
+    name: Gestione delle varianti di tensione e frequenza
+    description: |
+      Gestione delle varianti di tensione nominale e frequenza.
+  BC-1940.20.20:
+    name: Gestione delle varianti di protezione e involucro
+    description: |
+      Gestione delle varianti di grado di protezione IP e involucro.
+  BC-1940.20.30:
+    name: Gestione delle varianti di protocollo di comunicazione
+    description: |
+      Gestione delle opzioni di protocollo di comunicazione sui prodotti connessi.
+  BC-1940.20.40:
+    name: Gestione di accessori e opzioni
+    description: |
+      Gestione delle definizioni di accessori e funzionalità opzionali.
+  BC-1940.30:
+    name: Gestione delle regole del configuratore di prodotto
+    description: |
+      Redazione e validazione delle regole di configurazione su ordine.
+  BC-1940.30.10:
+    name: Redazione delle regole di configurazione
+    description: |
+      Redazione delle regole di combinazione valida per prodotti configurabili.
+  BC-1940.30.20:
+    name: Gestione dei vincoli di compatibilità
+    description: |
+      Gestione dei vincoli di compatibilità tra le opzioni.
+  BC-1940.30.30:
+    name: Test di validazione del configuratore
+    description: |
+      Test di validazione dei set di regole del configuratore.
+  BC-1940.40:
+    name: Gestione degli SKU giurisdizionali
+    description: |
+      Gestione degli SKU specifici per giurisdizione, degli standard di presa e delle varianti linguistiche.
+  BC-1940.40.10:
+    name: Definizione delle varianti giurisdizionali
+    description: |
+      Definizione delle varianti commercializzabili richieste dalla giurisdizione di destinazione.
+  BC-1940.40.20:
+    name: Gestione degli standard di prese e connettori
+    description: |
+      Gestione delle varianti di standard di prese e connettori per regione.
+  BC-1940.40.30:
+    name: Varianti della documentazione in lingua locale
+    description: |
+      Manuali e varianti di etichettatura in lingua locale per giurisdizione.
+  BC-1940.50:
+    name: Gestione dell'introduzione e del ritiro del prodotto
+    description: |
+      Attivazione nel catalogo, mappatura delle sostituzioni, fine vendita e finestre di ultimo acquisto.
+  BC-1940.50.10:
+    name: Attivazione nel catalogo al lancio del prodotto
+    description: |
+      Attivazione dei nuovi prodotti nel catalogo commerciale al momento del lancio.
+  BC-1940.50.20:
+    name: Mappatura del prodotto sostitutivo
+    description: |
+      Mappatura dei prodotti sostituiti agli SKU di sostituzione.
+  BC-1940.50.30:
+    name: Notifica di fine vendita
+    description: |
+      Notifica delle date di fine vendita ai canali e ai clienti.
+  BC-1940.50.40:
+    name: Gestione dell'ultimo acquisto e della finestra di assistenza
+    description: |
+      Gestione delle finestre di ultimo acquisto e della disponibilità solo per l'assistenza.
+  BC-1940.60:
+    name: Gestione della documentazione e delle schede tecniche di prodotto
+    description: |
+      Redazione e manutenzione di schede tecniche, manuali e materiale promozionale collegati agli SKU.
+  BC-1940.60.10:
+    name: Redazione delle schede tecniche
+    description: |
+      Redazione di schede tecniche di prodotto e specifiche tecniche.
+  BC-1940.60.20:
+    name: Redazione dei manuali tecnici
+    description: |
+      Redazione di manuali di installazione e di utilizzo.
+  BC-1940.60.30:
+    name: Materiale promozionale del catalogo
+    description: |
+      Materiale promozionale collegato agli SKU del catalogo.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-electrical-product-certification-management.yaml
+++ b/catalogue/i18n/it/L1-electrical-product-certification-management.yaml
@@ -1,0 +1,121 @@
+# Gestione della certificazione del prodotto elettrico (it) — translations for L1-electrical-product-certification-management.yaml
+locale: it
+source: L1-electrical-product-certification-management.yaml
+entries:
+  BC-1910:
+    name: Gestione della certificazione del prodotto elettrico
+    description: |
+      Certificazione multi-giurisdizione di sicurezza, EMC ed efficienza energetica del prodotto —
+      strategia, fascicoli tecnici, gestione degli organismi di certificazione, licenze di marchio,
+      sorveglianza e gestione della non conformità in campo.
+  BC-1910.10:
+    name: Strategia e piano di certificazione
+    description: |
+      Definizione dei marchi e delle approvazioni richiesti e della relativa sequenza di ottenimento.
+  BC-1910.10.10:
+    name: Analisi dei requisiti di accesso al mercato
+    description: |
+      Identificazione dei requisiti di certificazione per ciascun mercato di destinazione.
+  BC-1910.10.20:
+    name: Selezione dello schema di certificazione
+    description: |
+      Selezione degli schemi di certificazione e dei percorsi di riconoscimento.
+  BC-1910.10.30:
+    name: Pianificazione della roadmap di certificazione
+    description: |
+      Sequenziamento delle approvazioni in funzione delle milestone di lancio del prodotto.
+  BC-1910.20:
+    name: Gestione del fascicolo tecnico e delle evidenze
+    description: |
+      Redazione e custodia dei fascicoli tecnici di costruzione e delle evidenze a supporto.
+  BC-1910.20.10:
+    name: Redazione del fascicolo tecnico di costruzione
+    description: |
+      Redazione dei fascicoli tecnici di costruzione a supporto dell'approvazione di tipo.
+  BC-1910.20.20:
+    name: Aggregazione dei rapporti di prova
+    description: |
+      Aggregazione e indicizzazione dei rapporti di prova accreditati.
+  BC-1910.20.30:
+    name: Redazione della dichiarazione di conformità
+    description: |
+      Redazione e firma delle dichiarazioni di conformità.
+  BC-1910.20.40:
+    name: Archivio delle evidenze di conformità
+    description: |
+      Archiviazione a lungo termine delle evidenze di conformità secondo i requisiti normativi di conservazione.
+  BC-1910.30:
+    name: Gestione degli organismi di certificazione e delle approvazioni
+    description: |
+      Rapporto con organismi notificati e organismi nazionali di certificazione fino al rilascio dell'approvazione di tipo.
+  BC-1910.30.10:
+    name: Selezione dell'organismo notificato
+    description: |
+      Selezione degli organismi notificati e degli organismi nazionali di certificazione.
+  BC-1910.30.20:
+    name: Gestione della presentazione della domanda di certificazione
+    description: |
+      Invio dei dossier di certificazione e coordinamento del follow-up.
+  BC-1910.30.30:
+    name: Coordinamento delle prove in presenza di testimoni
+    description: |
+      Coordinamento delle prove effettuate alla presenza di ispettori presso laboratori di fornitori o interni.
+  BC-1910.30.40:
+    name: Monitoraggio del rilascio delle approvazioni di tipo
+    description: |
+      Monitoraggio delle approvazioni di tipo rilasciate e della validità dei certificati.
+  BC-1910.40:
+    name: Licenza del marchio e conformità delle etichette
+    description: |
+      Concessione in licenza dei marchi di certificazione e controllo della grafica delle etichette di prodotto.
+  BC-1910.40.10:
+    name: Autorizzazione all'uso del marchio
+    description: |
+      Autorizzazione all'uso del marchio sui prodotti certificati.
+  BC-1910.40.20:
+    name: Controllo della grafica delle etichette di prodotto
+    description: |
+      Controllo del contenuto delle etichette, della marcatura e della grafica della targa dati.
+  BC-1910.40.30:
+    name: Rendicontazione dei diritti d'uso del marchio
+    description: |
+      Rendicontazione dei volumi unitari ai fini degli obblighi di royalty per il marchio.
+  BC-1910.50:
+    name: Sorveglianza e rinnovo delle approvazioni
+    description: |
+      Mantenimento delle approvazioni tramite audit di sorveglianza, variazioni e rinnovi.
+  BC-1910.50.10:
+    name: Coordinamento delle ispezioni in stabilimento
+    description: |
+      Coordinamento delle ispezioni in stabilimento da parte dell'ente certificatore e delle azioni conseguenti.
+  BC-1910.50.20:
+    name: Prove di sorveglianza periodica
+    description: |
+      Prove di sorveglianza periodica dei prodotti certificati rispetto alla baseline originale.
+  BC-1910.50.30:
+    name: Deposito di variazioni all'approvazione
+    description: |
+      Deposito di variazioni e modifiche tecniche rispetto alle approvazioni rilasciate.
+  BC-1910.50.40:
+    name: Gestione del rinnovo delle approvazioni
+    description: |
+      Rinnovo di approvazioni e certificati prossimi alla scadenza.
+  BC-1910.60:
+    name: Gestione degli incidenti di conformità in campo
+    description: |
+      Gestione delle non conformità di prodotto rilevate dopo l'immissione sul mercato.
+  BC-1910.60.10:
+    name: Triage degli incidenti di non conformità
+    description: |
+      Triage delle sospette non conformità di prodotto segnalate dal campo.
+  BC-1910.60.20:
+    name: Notifica alle autorità di regolamentazione
+    description: |
+      Notifica obbligatoria ad autorità ed enti certificatori in caso di non conformità accertate.
+  BC-1910.60.30:
+    name: Coordinamento del richiamo e del blocco delle spedizioni
+    description: |
+      Coordinamento di richiami, ordini di blocco delle spedizioni e campagne di azione correttiva.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-electrical-product-engineering-management.yaml
+++ b/catalogue/i18n/it/L1-electrical-product-engineering-management.yaml
@@ -1,0 +1,172 @@
+# Gestione dell'ingegneria del prodotto elettrico (it) — translations for L1-electrical-product-engineering-management.yaml
+locale: it
+source: L1-electrical-product-engineering-management.yaml
+entries:
+  BC-1900:
+    name: Gestione dell'ingegneria del prodotto elettrico
+    description: |
+      Progettazione multidisciplinare di prodotti elettrici ed elettronici: circuiti, elettronica
+      di potenza, embedded, EMC, termica e meccanica fino alla verifica del progetto.
+  BC-1900.10:
+    name: Progettazione del circuito elettrico
+    description: |
+      Progettazione schematica di circuiti analogici, digitali, a segnale misto e RF.
+  BC-1900.10.10:
+    name: Progettazione di circuiti analogici
+    description: |
+      Progettazione di circuiti di condizionamento del segnale analogico e dell'alimentazione.
+  BC-1900.10.20:
+    name: Progettazione di circuiti digitali
+    description: |
+      Progettazione di circuiti logici digitali e di clock.
+  BC-1900.10.30:
+    name: Progettazione di circuiti a segnale misto
+    description: |
+      Progettazione di interfacce a segnale misto, sottosistemi ADC/DAC e stadi di conversione.
+  BC-1900.10.40:
+    name: Progettazione di circuiti RF
+    description: |
+      Progettazione di front-end a radiofrequenza, reti di adattamento e antenne.
+  BC-1900.20:
+    name: Progettazione dell'elettronica di potenza
+    description: |
+      Progettazione di conversione dell'energia, azionamenti motore e topologie di commutazione.
+  BC-1900.20.10:
+    name: Progettazione di convertitori di potenza
+    description: |
+      Progettazione di convertitori di potenza AC/DC, DC/DC e DC/AC.
+  BC-1900.20.20:
+    name: Progettazione della topologia dell'azionamento motore
+    description: |
+      Selezione e progettazione della topologia di azionamenti motore a velocità variabile.
+  BC-1900.20.30:
+    name: Progettazione di componenti magnetici e filtri
+    description: |
+      Progettazione di induttori, trasformatori e filtri EMI.
+  BC-1900.20.40:
+    name: Progettazione dell'anello di controllo di commutazione
+    description: |
+      Progettazione del controllo in anello chiuso per gli stadi di commutazione di potenza.
+  BC-1900.30:
+    name: Progettazione PCB e packaging elettronico
+    description: |
+      Layout PCB, packaging elettronico e ingegneria delle interconnessioni.
+  BC-1900.30.10:
+    name: Layout PCB
+    description: |
+      Stack-up multistrato e layout fisico del PCB.
+  BC-1900.30.20:
+    name: Progettazione del packaging elettronico
+    description: |
+      Progettazione di moduli, alloggiamenti e packaging a ball-grid-array.
+  BC-1900.30.30:
+    name: Progettazione di interconnessioni e cablaggio
+    description: |
+      Progettazione di cablaggio, barre omnibus e interconnessioni tra schede.
+  BC-1900.30.40:
+    name: Gestione della libreria di footprint dei componenti
+    description: |
+      Manutenzione delle librerie di footprint e simboli CAD.
+  BC-1900.40:
+    name: Progettazione hardware embedded
+    description: |
+      Progettazione di hardware per microcontrollori, FPGA, interfacce sensori e gestione dell'alimentazione.
+  BC-1900.40.10:
+    name: Progettazione della piattaforma microcontrollore
+    description: |
+      Selezione e integrazione di piattaforme a microcontrollore.
+  BC-1900.40.20:
+    name: Integrazione FPGA e SoC
+    description: |
+      Integrazione di dispositivi FPGA e SoC nell'hardware del prodotto.
+  BC-1900.40.30:
+    name: Progettazione dell'interfaccia sensori e attuatori
+    description: |
+      Interfacce analogiche e digitali verso sensori e attuatori.
+  BC-1900.40.40:
+    name: Progettazione del circuito di gestione dell'alimentazione
+    description: |
+      Circuiti di gestione e regolazione dell'alimentazione a bordo scheda.
+  BC-1900.50:
+    name: Ingegneria del firmware embedded
+    description: |
+      Disciplina di sviluppo firmware che comprende RTOS, driver, logica applicativa e verifica.
+  BC-1900.50.10:
+    name: Architettura software real-time
+    description: |
+      Architettura del sistema operativo real-time e dei task.
+  BC-1900.50.20:
+    name: Sviluppo di device driver
+    description: |
+      Sviluppo di driver di basso livello e board support package.
+  BC-1900.50.30:
+    name: Sviluppo di applicazioni embedded
+    description: |
+      Logica applicativa e sviluppo di funzionalità per sistemi embedded.
+  BC-1900.50.40:
+    name: Verifica e test del firmware
+    description: |
+      Verifica del firmware tramite test unitari, di integrazione e hardware-in-the-loop.
+  BC-1900.60:
+    name: Ingegneria EMC e integrità del segnale
+    description: |
+      Gestione in fase di progettazione della compatibilità elettromagnetica e dell'integrità del segnale.
+  BC-1900.60.10:
+    name: Analisi del progetto EMC
+    description: |
+      Analisi di emissioni e immunità in fase di progettazione.
+  BC-1900.60.20:
+    name: Analisi dell'integrità del segnale
+    description: |
+      Analisi dell'integrità dei segnali ad alta velocità e della diafonia.
+  BC-1900.60.30:
+    name: Progettazione di schermatura e messa a terra
+    description: |
+      Strategie di schermatura, bonding e messa a terra.
+  BC-1900.60.40:
+    name: Valutazione pre-conformità EMC
+    description: |
+      Scansioni di pre-conformità e valutazione EMC in fase di progettazione.
+  BC-1900.70:
+    name: Ingegneria termica e meccanica
+    description: |
+      Ingegneria termica, degli involucri e meccanica di prodotti elettrici.
+  BC-1900.70.10:
+    name: Analisi termica e progettazione del raffreddamento
+    description: |
+      Modellazione termica e progettazione della strategia di raffreddamento.
+  BC-1900.70.20:
+    name: Progettazione dell'involucro e del grado di protezione IP
+    description: |
+      Progettazione meccanica dell'involucro e conformità al grado di protezione IP.
+  BC-1900.70.30:
+    name: Ingegneria di vibrazione e shock
+    description: |
+      Robustezza meccanica in presenza di vibrazioni e carichi di shock.
+  BC-1900.70.40:
+    name: Progettazione di connettori e interfacce meccaniche
+    description: |
+      Selezione dei connettori e progettazione delle interfacce meccaniche.
+  BC-1900.80:
+    name: Verifica del progetto elettrico
+    description: |
+      Verifica del progetto tramite simulazione, realizzazione di prototipi e test.
+  BC-1900.80.10:
+    name: Simulazione del progetto
+    description: |
+      Studi di simulazione circuitale, elettromagnetica e termica.
+  BC-1900.80.20:
+    name: Realizzazione e bring-up del prototipo
+    description: |
+      Assemblaggio del prototipo e avvio funzionale iniziale.
+  BC-1900.80.30:
+    name: Test di verifica del progetto
+    description: |
+      Test di verifica rispetto alle specifiche di progetto.
+  BC-1900.80.40:
+    name: Governance delle revisioni di progettazione
+    description: |
+      Revisioni di progettazione a stage-gate e assicurazione della qualità del progetto.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-electrical-product-qualification-management.yaml
+++ b/catalogue/i18n/it/L1-electrical-product-qualification-management.yaml
@@ -1,0 +1,172 @@
+# Gestione della qualificazione del prodotto elettrico (it) — translations for L1-electrical-product-qualification-management.yaml
+locale: it
+source: L1-electrical-product-qualification-management.yaml
+entries:
+  BC-1920:
+    name: Gestione della qualificazione del prodotto elettrico
+    description: |
+      Orchestrazione delle prove di tipo su campioni rappresentativi — dielettrica, cortocircuito,
+      EMC, climatica, meccanica e di vita — inclusa la gestione dei laboratori accreditati.
+  BC-1920.10:
+    name: Gestione del piano e delle specifiche di prova
+    description: |
+      Redazione e approvazione di piani e specifiche di prova derivati dalle norme di prodotto.
+  BC-1920.10.10:
+    name: Redazione delle specifiche di prova
+    description: |
+      Redazione di specifiche di prova dettagliate.
+  BC-1920.10.20:
+    name: Approvazione del piano di prova
+    description: |
+      Approvazione dei piani di prova da parte delle funzioni ingegneria, qualità e certificazione.
+  BC-1920.10.30:
+    name: Allocazione dei campioni di prova
+    description: |
+      Allocazione e gestione dei campioni di prova rappresentativi.
+  BC-1920.10.40:
+    name: Manutenzione delle procedure di prova
+    description: |
+      Manutenzione e revisione delle procedure di prova standard.
+  BC-1920.20:
+    name: Prove dielettriche e ad alta tensione
+    description: |
+      Prove di isolamento, tenuta dielettrica, scarica parziale e impulso.
+  BC-1920.20.10:
+    name: Prove di resistenza di isolamento
+    description: |
+      Misurazione della resistenza di isolamento nelle condizioni specificate.
+  BC-1920.20.20:
+    name: Prove di tenuta dielettrica
+    description: |
+      Prove di tenuta dielettrica in AC e DC ai livelli di tensione nominale.
+  BC-1920.20.30:
+    name: Misura delle scariche parziali
+    description: |
+      Misurazione delle scariche parziali nei sistemi di isolamento.
+  BC-1920.20.40:
+    name: Prove a impulso di tensione
+    description: |
+      Prove di tenuta a impulso di fulmine e di manovra.
+  BC-1920.30:
+    name: Prove di cortocircuito e commutazione
+    description: |
+      Verifica delle prestazioni in cortocircuito e commutazione nelle condizioni di guasto nominali.
+  BC-1920.30.10:
+    name: Prove di capacità di chiusura in cortocircuito
+    description: |
+      Verifica della capacità di chiusura su cortocircuiti nominali.
+  BC-1920.30.20:
+    name: Prove di capacità di interruzione in cortocircuito
+    description: |
+      Verifica della capacità di interruzione ai livelli di guasto nominali.
+  BC-1920.30.30:
+    name: Prove di resistenza alla commutazione
+    description: |
+      Resistenza meccanica ed elettrica alla commutazione ripetuta.
+  BC-1920.30.40:
+    name: Prove di guasto ad arco
+    description: |
+      Prove di contenimento del guasto ad arco e di prestazione dell'arco elettrico.
+  BC-1920.40:
+    name: Prove EMC ed EMI
+    description: |
+      Prove di emissioni e immunità condotte e irradiate.
+  BC-1920.40.10:
+    name: Prove di emissioni condotte
+    description: |
+      Misurazione delle emissioni condotte su linee di potenza e segnale.
+  BC-1920.40.20:
+    name: Prove di emissioni irradiate
+    description: |
+      Misurazione delle emissioni elettromagnetiche irradiate.
+  BC-1920.40.30:
+    name: Prove di immunità EMC
+    description: |
+      Verifica dell'immunità a disturbi condotti e irradiati.
+  BC-1920.40.40:
+    name: Prove di immunità ESD e sovratensione
+    description: |
+      Prove di immunità alle scariche elettrostatiche ESD e alle sovratensioni.
+  BC-1920.50:
+    name: Prove ambientali e climatiche
+    description: |
+      Prove climatiche, di corrosione, di protezione dall'ingresso e di esposizione dei prodotti.
+  BC-1920.50.10:
+    name: Ciclaggio di temperatura e umidità
+    description: |
+      Ciclaggio di temperatura e umidità e prove in condizioni stazionarie.
+  BC-1920.50.20:
+    name: Prove a nebbia salina e di corrosione
+    description: |
+      Prove di esposizione a nebbia salina e atmosfera corrosiva.
+  BC-1920.50.30:
+    name: Prove di protezione dall'ingresso
+    description: |
+      Verifica del grado di protezione IP contro polvere e acqua.
+  BC-1920.50.40:
+    name: Prove di esposizione solare e UV
+    description: |
+      Prove di esposizione a radiazione solare e ultravioletta.
+  BC-1920.60:
+    name: Prove meccaniche e di vibrazione
+    description: |
+      Prove di vibrazione, shock, resistenza meccanica e qualificazione sismica.
+  BC-1920.60.10:
+    name: Prove di vibrazione e shock
+    description: |
+      Prove di vibrazione sinusoidale, casuale e di shock.
+  BC-1920.60.20:
+    name: Prove di resistenza meccanica
+    description: |
+      Resistenza meccanica sotto cicli operativi.
+  BC-1920.60.30:
+    name: Prove di caduta e impatto
+    description: |
+      Prove di caduta, caduta libera e impatto su prodotti e imballaggi.
+  BC-1920.60.40:
+    name: Prove di qualificazione sismica
+    description: |
+      Qualificazione sismica per apparecchiature di potenza e di stazione.
+  BC-1920.70:
+    name: Prove di vita accelerata e di affidabilità
+    description: |
+      Prove di vita accelerata, screening da stress e dimostrazione di affidabilità.
+  BC-1920.70.10:
+    name: Prove di vita altamente accelerata
+    description: |
+      HALT per evidenziare i margini di progetto tramite stress incrementali.
+  BC-1920.70.20:
+    name: Screening da stress altamente accelerato
+    description: |
+      Screening di produzione HASS per rilevare difetti latenti.
+  BC-1920.70.30:
+    name: Prove di dimostrazione dell'affidabilità
+    description: |
+      Prove di dimostrazione rispetto agli obiettivi di affidabilità.
+  BC-1920.70.40:
+    name: Prove di burn-in
+    description: |
+      Burn-in sotto tensione per indurre guasti in mortalità infantile.
+  BC-1920.80:
+    name: Gestione delle operazioni del laboratorio di prova
+    description: |
+      Gestione dei laboratori di prova interni accreditati.
+  BC-1920.80.10:
+    name: Accreditamento del laboratorio di prova
+    description: |
+      Mantenimento dell'ambito di accreditamento ISO/IEC 17025.
+  BC-1920.80.20:
+    name: Taratura delle apparecchiature di prova
+    description: |
+      Taratura e tracciabilità delle apparecchiature di prova.
+  BC-1920.80.30:
+    name: Gestione dei record dei dati di prova
+    description: |
+      Gestione a lungo termine dei record di dati e rapporti di prova.
+  BC-1920.80.40:
+    name: Confronto interlaboratorio
+    description: |
+      Prove di proficiency in round-robin tra laboratori.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-electricity-distribution-operations-management.yaml
+++ b/catalogue/i18n/it/L1-electricity-distribution-operations-management.yaml
@@ -1,0 +1,160 @@
+# Gestione delle operazioni di distribuzione dell'energia elettrica (it) — translations for L1-electricity-distribution-operations-management.yaml
+locale: it
+source: L1-electricity-distribution-operations-management.yaml
+entries:
+  BC-3820:
+    name: Gestione delle operazioni di distribuzione dell'energia elettrica
+    description: |
+      Operazione delle reti di distribuzione MT/BT — dispacciamento dalla sala controllo,
+      risposta ai guasti e ripristino, manovre, operazioni nelle cabine primarie e secondarie
+      e coordinamento delle squadre di campo per la fornitura di energia ai clienti finali.
+  BC-3820.10:
+    name: Operazioni di controllo della distribuzione
+    description: |
+      Operazione 24/7 del centro di controllo della rete di distribuzione tramite
+      DMS / OMS / ADMS, consapevolezza situazionale e analisi del flusso di carico.
+  BC-3820.10.10:
+    name: Operazioni ADMS
+    description: |
+      Operazione dei sistemi avanzati di gestione della distribuzione per il monitoraggio e il controllo.
+  BC-3820.10.20:
+    name: Operazioni SCADA di distribuzione
+    description: |
+      Acquisizione in tempo reale tramite SCADA e controllo degli alimentatori e degli interruttori di distribuzione.
+  BC-3820.10.30:
+    name: Gestione della topologia di rete
+    description: |
+      Manutenzione della topologia di rete as-operated nel sistema di controllo.
+  BC-3820.20:
+    name: Operazioni di manovra e ripristino
+    description: |
+      Riconfigurazione della rete e ripristino dell'alimentazione dopo fermate programmate
+      e non programmate, incluso il self-healing basato su FLISR.
+  BC-3820.20.10:
+    name: Esecuzione dei programmi di manovra
+    description: |
+      Esecuzione autorizzata dei programmi di manovra della distribuzione.
+  BC-3820.20.20:
+    name: Localizzazione dei guasti, isolamento e ripristino del servizio
+    description: |
+      Rilevamento, isolamento e ripristino dell'alimentazione su alimentatori guasti tramite FLISR.
+  BC-3820.20.30:
+    name: Coordinamento del backfeed e dell'isola intenzionale
+    description: |
+      Coordinamento del backfeed degli alimentatori e dell'isola intenzionale per il ripristino.
+  BC-3820.30:
+    name: Operazioni di risposta ai guasti
+    description: |
+      Risposta end-to-end ai guasti sulla rete di distribuzione, dal rilevamento
+      alla riparazione sul campo e alla comunicazione con i clienti.
+    in_scope:
+      - Rilevamento e pattugliamento dei guasti
+      - Assegnazione delle squadre ai lavori di guasto
+      - Notifica delle interruzioni ai clienti
+    out_of_scope:
+      - Gestione delle interruzioni legate alle DER (BC-3840)
+      - Interruzioni della generazione all'ingrosso (BC-3800.10)
+  BC-3820.30.10:
+    name: Triage dei guasti
+    description: |
+      Triage delle segnalazioni di guasto provenienti dal campo, dai clienti e dalla telemetria.
+  BC-3820.30.20:
+    name: Pattugliamento sul campo
+    description: |
+      Pattugliamenti sul campo per localizzare e confermare i guasti su asset aerei e sotterranei.
+  BC-3820.30.30:
+    name: Monitoraggio del ripristino delle interruzioni
+    description: |
+      Monitoraggio dell'avanzamento del ripristino delle interruzioni e delle statistiche sui minuti cliente persi.
+  BC-3820.30.40:
+    name: Risposta agli eventi maggiori
+    description: |
+      Risposta alle tempeste e agli eventi maggiori nella distribuzione, incluse le squadre di mutuo soccorso.
+  BC-3820.40:
+    name: Operazioni di dispacciamento delle squadre di campo
+    description: |
+      Dispacciamento, instradamento e supporto operativo sul campo per le squadre di distribuzione
+      impegnate in guasti, lavori programmati e interventi sui clienti.
+  BC-3820.40.10:
+    name: Pianificazione delle squadre
+    description: |
+      Pianificazione giornaliera dei turni delle squadre e delle rotazioni di reperibilità.
+  BC-3820.40.20:
+    name: Dispacciamento e instradamento dei lavori
+    description: |
+      Dispacciamento e instradamento dei lavori alle squadre di campo dai sistemi di gestione lavori.
+  BC-3820.40.30:
+    name: Chiusura dei lavori sul campo
+    description: |
+      Acquisizione delle modifiche as-built, dei materiali utilizzati e del tempo impiegato alla chiusura del lavoro.
+  BC-3820.50:
+    name: Operazioni di ispezione degli asset di distribuzione
+    description: |
+      Ispezioni periodiche e basate sulle condizioni di linee aeree, pali,
+      cavi sotterranei e cabine di distribuzione.
+  BC-3820.50.10:
+    name: Ispezione di pali e linee aeree
+    description: |
+      Ispezione ciclica di pali e linee aeree, incluse le termografie.
+  BC-3820.50.20:
+    name: Ispezione della rete sotterranea
+    description: |
+      Ispezione e valutazione delle condizioni degli alimentatori sotterranei, dei link-box e delle giunzioni.
+  BC-3820.50.30:
+    name: Ispezione delle cabine di distribuzione
+    description: |
+      Ispezione periodica delle cabine primarie, secondarie e del cliente.
+  BC-3820.60:
+    name: Gestione della vegetazione e della fascia di rispetto
+    description: |
+      Taglio della vegetazione e manutenzione della fascia di rispetto sui circuiti
+      di distribuzione per gestire il rischio di interruzione e i corridoi normativi.
+  BC-3820.60.10:
+    name: Pianificazione dei cicli di vegetazione
+    description: |
+      Programmazione ciclica e basata sul rischio degli interventi di vegetazione sui circuiti di distribuzione.
+  BC-3820.60.20:
+    name: Operazioni di vegetazione sul campo
+    description: |
+      Esecuzione sul campo di potatura, abbattimento e applicazione di diserbanti.
+  BC-3820.60.30:
+    name: Operazioni di mitigazione del rischio incendio boschivo
+    description: |
+      Operazioni di PSPS, fast-trip e hardening dei circuiti nelle aree a rischio incendio boschivo.
+  BC-3820.70:
+    name: Operazioni per le nuove connessioni
+    description: |
+      Realizzazione di connessioni elettriche nuove e modificate per clienti
+      domestici, commerciali, industriali e sviluppatori.
+  BC-3820.70.10:
+    name: Valutazione delle domande di connessione
+    description: |
+      Valutazione tecnica delle domande di nuova connessione e disponibilità di capacità.
+  BC-3820.70.20:
+    name: Progettazione delle connessioni
+    description: |
+      Progettazione dettagliata della connessione, punto di connessione e requisiti di rinforzo.
+  BC-3820.70.30:
+    name: Collaudo delle connessioni
+    description: |
+      Collaudo delle nuove connessioni e accettazione dell'energizzazione.
+  BC-3820.80:
+    name: Gestione della qualità della fornitura
+    description: |
+      Sorveglianza e rimedio dei livelli di tensione di distribuzione,
+      flicker, armoniche e reclami sulla qualità della fornitura dei clienti.
+  BC-3820.80.10:
+    name: Sorveglianza della tensione
+    description: |
+      Sorveglianza dei profili di tensione degli alimentatori rispetto ai limiti normativi.
+  BC-3820.80.20:
+    name: Monitoraggio delle armoniche e del flicker
+    description: |
+      Monitoraggio della rete per la distorsione armonica e il flicker di tensione.
+  BC-3820.80.30:
+    name: Indagine sulla qualità della fornitura del cliente
+    description: |
+      Indagine e rimedio dei problemi di qualità della fornitura segnalati dai clienti.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-electricity-transmission-operations-management.yaml
+++ b/catalogue/i18n/it/L1-electricity-transmission-operations-management.yaml
@@ -1,0 +1,145 @@
+# Gestione delle operazioni di trasmissione dell'energia elettrica (it) — translations for L1-electricity-transmission-operations-management.yaml
+locale: it
+source: L1-electricity-transmission-operations-management.yaml
+entries:
+  BC-3810:
+    name: Gestione delle operazioni di trasmissione dell'energia elettrica
+    description: |
+      Operazione della rete di trasmissione ad alta tensione — dispacciamento dalla sala
+      controllo, manovre, operazioni su linee e stazioni elettriche, coordinamento delle fermate,
+      protezione e sicurezza fisica e cibernetica del sistema elettrico di trasmissione.
+  BC-3810.10:
+    name: Operazioni di controllo della trasmissione
+    description: |
+      Operazione 24/7 della sala controllo della rete di trasmissione tramite
+      EMS / SCADA, consapevolezza situazionale e analisi delle contingenze.
+  BC-3810.10.10:
+    name: Operazioni EMS
+    description: |
+      Operazione del sistema EMS, dello stimatore di stato e degli strumenti di analisi delle contingenze.
+  BC-3810.10.20:
+    name: Operazioni SCADA di trasmissione
+    description: |
+      Acquisizione in tempo reale tramite SCADA e controllo supervisivo degli asset di trasmissione.
+  BC-3810.10.30:
+    name: Gestione del registro operatori della trasmissione
+    description: |
+      Tenuta dei registri degli operatori, passaggi di consegna dei turni e registrazione degli eventi operativi.
+  BC-3810.20:
+    name: Manovre e isolamento della trasmissione
+    description: |
+      Pianificazione ed esecuzione di manovre, isolamenti e operazioni
+      sotto tensione sul sistema di trasmissione.
+  BC-3810.20.10:
+    name: Preparazione dei programmi di manovra
+    description: |
+      Preparazione e verifica dei programmi di manovra per i lavori programmati.
+  BC-3810.20.20:
+    name: Emissione dei permessi di lavoro
+    description: |
+      Emissione e controllo dei permessi di lavoro e delle autorizzazioni alle prove sugli impianti di trasmissione.
+  BC-3810.20.30:
+    name: Operazioni sotto tensione
+    description: |
+      Coordinamento degli accessi sotto tensione e delle attività in prossimità su circuiti in tensione.
+  BC-3810.30:
+    name: Operazioni sulle linee di trasmissione
+    description: |
+      Operazione, ispezione e lavori sotto tensione su linee aeree, sostegni
+      e cavi sotterranei di trasmissione.
+  BC-3810.30.10:
+    name: Ispezione delle linee aeree
+    description: |
+      Ispezioni periodiche, arrampicata e aeree delle linee aeree di trasmissione.
+  BC-3810.30.20:
+    name: Operazioni sui cavi sotterranei
+    description: |
+      Operazione, sorveglianza delle scariche parziali e gestione delle giunzioni dei cavi HV.
+  BC-3810.30.30:
+    name: Gestione della fascia di rispetto e della vegetazione
+    description: |
+      Taglio della vegetazione e manutenzione della fascia di rispetto secondo gli standard NERC FAC-003 o equivalenti.
+  BC-3810.30.40:
+    name: Manutenzione dei sostegni di trasmissione
+    description: |
+      Verniciatura, fondazioni e interventi sull'integrità strutturale dei sostegni di trasmissione.
+  BC-3810.40:
+    name: Operazioni delle stazioni elettriche
+    description: |
+      Operazione e sorveglianza delle stazioni elettriche HV, trasformatori,
+      interruttori e impianti di compensazione reattiva.
+  BC-3810.40.10:
+    name: Operazioni dei trasformatori di potenza
+    description: |
+      Sorveglianza, analisi dei gas disciolti e operazione dei variatori dei trasformatori HV.
+  BC-3810.40.20:
+    name: Operazioni dei sezionatori e interruttori
+    description: |
+      Operazione e sorveglianza dello stato degli interruttori e dei sezionatori HV.
+  BC-3810.40.30:
+    name: Operazioni di compensazione reattiva
+    description: |
+      Operazione di banchi di condensatori, reattori, SVC e STATCOM per il supporto reattivo.
+  BC-3810.40.40:
+    name: Operazioni delle stazioni di conversione HVDC
+    description: |
+      Operazione delle stazioni di conversione HVDC e controllo degli interconnettori in corrente continua.
+  BC-3810.50:
+    name: Coordinamento delle fermate di trasmissione
+    description: |
+      Pianificazione, programmazione e approvazione delle fermate programmate e impreviste
+      degli elementi di trasmissione con valutazione dell'impatto sul sistema e sul mercato.
+  BC-3810.50.10:
+    name: Presentazione dei piani di fermata
+    description: |
+      Presentazione e revisione dei piani di fermata della trasmissione al gestore del sistema.
+  BC-3810.50.20:
+    name: Valutazione del rischio di fermata
+    description: |
+      Valutazione dell'impatto sulla sicurezza del sistema e sul mercato delle fermate proposte.
+  BC-3810.50.30:
+    name: Rendicontazione delle fermate forzate
+    description: |
+      Rendicontazione delle fermate forzate e delle indisponibilità al gestore del sistema e al regolatore.
+  BC-3810.60:
+    name: Protezione e controllo della trasmissione
+    description: |
+      Taratura, sorveglianza e analisi post-evento dei sistemi di protezione
+      della trasmissione e degli schemi speciali di protezione.
+  BC-3810.60.10:
+    name: Gestione delle tarature delle protezioni
+    description: |
+      Calcolo, approvazione e distribuzione delle tarature dei relè di protezione.
+  BC-3810.60.20:
+    name: Operazioni degli schemi speciali di protezione
+    description: |
+      Operazione e sorveglianza degli schemi di azione correttiva e degli schemi speciali di protezione.
+  BC-3810.60.30:
+    name: Analisi degli eventi di perturbazione
+    description: |
+      Analisi delle registrazioni delle perturbazioni e delle prestazioni della protezione dopo eventi sulla rete.
+  BC-3810.70:
+    name: Gestione della sicurezza del sistema di trasmissione
+    description: |
+      Sicurezza cibernetica e fisica del sistema elettrico di trasmissione,
+      inclusa l'implementazione dei controlli NERC CIP, la sicurezza perimetrale
+      e la registrazione degli asset con impatto sul sistema elettrico.
+  BC-3810.70.10:
+    name: Identificazione degli asset cibernetici del sistema elettrico
+    description: |
+      Identificazione e classificazione dei sistemi cibernetici del sistema elettrico secondo NERC CIP-002.
+  BC-3810.70.20:
+    name: Operazioni del perimetro di sicurezza elettronica
+    description: |
+      Operazione dei perimetri di sicurezza elettronica e dei controlli di accesso remoto interattivo.
+  BC-3810.70.30:
+    name: Operazioni del perimetro di sicurezza fisica
+    description: |
+      Controlli di sicurezza fisica per i centri di controllo e le stazioni elettriche critiche (NERC CIP-014).
+  BC-3810.70.40:
+    name: Gestione delle evidenze di conformità NERC CIP
+    description: |
+      Raccolta di evidenze, attestazioni e risposta agli audit per gli standard NERC CIP.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-electronic-component-sourcing-management.yaml
+++ b/catalogue/i18n/it/L1-electronic-component-sourcing-management.yaml
@@ -1,0 +1,133 @@
+# Gestione dell'approvvigionamento di componenti elettronici (it) — translations for L1-electronic-component-sourcing-management.yaml
+locale: it
+source: L1-electronic-component-sourcing-management.yaml
+entries:
+  BC-1930:
+    name: Gestione dell'approvvigionamento di componenti elettronici
+    description: |
+      Approvvigionamento e gestione del ciclo di vita dei componenti elettronici — liste fornitori
+      approvati, gestione dell'obsolescenza, allocazione, prevenzione dei componenti contraffatti,
+      qualifica e dati sulle sostanze.
+  BC-1930.10:
+    name: Gestione della lista fornitori approvati
+    description: |
+      Manutenzione delle fonti approvate di componenti, delle alternative e dei riferimenti incrociati.
+  BC-1930.10.10:
+    name: Gestione della lista dei componenti preferenziali
+    description: |
+      Manutenzione delle liste di componenti preferenziali con approvazione tecnica.
+  BC-1930.10.20:
+    name: Qualifica di fonti alternative
+    description: |
+      Qualifica di fonti alternative di approvvigionamento dei componenti.
+  BC-1930.10.30:
+    name: Gestione dei riferimenti incrociati
+    description: |
+      Mappatura dei componenti equivalenti tra diversi produttori.
+  BC-1930.20:
+    name: Gestione del ciclo di vita e dell'obsolescenza dei componenti
+    description: |
+      Monitoraggio dello stato del ciclo di vita dei componenti e gestione degli eventi di obsolescenza.
+  BC-1930.20.10:
+    name: Triage delle notifiche di modifica del prodotto
+    description: |
+      Triage e valutazione dell'impatto delle notifiche di modifica del prodotto da parte dei fornitori.
+  BC-1930.20.20:
+    name: Triage degli avvisi di fine vita
+    description: |
+      Triage degli avvisi di fine vita e impatto sulle distinte base.
+  BC-1930.20.30:
+    name: Decisione sull'ultimo acquisto disponibile
+    description: |
+      Decisioni sulle quantità di last-time-buy e sulle scorte di transizione.
+  BC-1930.20.40:
+    name: Previsione del ciclo di vita dei componenti
+    description: |
+      Previsione delle fasi del ciclo di vita dei componenti nell'intera distinta base.
+  BC-1930.30:
+    name: Gestione dell'allocazione di semiconduttori
+    description: |
+      Gestione dell'allocazione di semiconduttori in condizioni di carenza.
+  BC-1930.30.10:
+    name: Gestione delle previsioni di allocazione
+    description: |
+      Previsione della domanda a supporto del posizionamento nell'allocazione dei fornitori.
+  BC-1930.30.20:
+    name: Negoziazione dell'allocazione con i fornitori
+    description: |
+      Negoziazione della quota di allocazione con i fornitori di semiconduttori.
+  BC-1930.30.30:
+    name: Prioritizzazione interna della domanda di allocazione
+    description: |
+      Prioritizzazione interna delle forniture allocate tra le linee di prodotto.
+  BC-1930.40:
+    name: Prevenzione dei componenti contraffatti
+    description: |
+      Rilevamento e prevenzione di componenti elettronici contraffatti nella catena di fornitura.
+  BC-1930.40.10:
+    name: Valutazione del rischio di contraffazione
+    description: |
+      Valutazione del rischio di esposizione alla contraffazione nei canali di approvvigionamento.
+  BC-1930.40.20:
+    name: Autenticazione dei componenti in ingresso
+    description: |
+      Autenticazione e ispezione dei componenti in ingresso.
+  BC-1930.40.30:
+    name: Tracciabilità della catena di fornitura
+    description: |
+      Tracciabilità dei componenti fino ai produttori autorizzati.
+  BC-1930.50:
+    name: Qualifica dei componenti elettronici
+    description: |
+      Qualifica dei componenti elettronici per l'utilizzo in produzione.
+  BC-1930.50.10:
+    name: Ispezione del primo articolo
+    description: |
+      Ispezione del primo articolo dei componenti rispetto alle specifiche.
+  BC-1930.50.20:
+    name: Qualifica di affidabilità dei componenti
+    description: |
+      Qualifica di affidabilità dei componenti rispetto ai profili operativi.
+  BC-1930.50.30:
+    name: Qualifica automotive AEC-Q
+    description: |
+      Qualifica dei componenti secondo i profili di stress AEC-Q100 / AEC-Q200.
+  BC-1930.50.40:
+    name: Qualifica JEDEC per semiconduttori
+    description: |
+      Qualifica dei semiconduttori secondo le norme JEDEC.
+  BC-1930.60:
+    name: Gestione di distributori e broker
+    description: |
+      Gestione dei canali di distributori autorizzati e broker.
+  BC-1930.60.10:
+    name: Onboarding di distributori autorizzati
+    description: |
+      Inserimento nella rete di distributori autorizzati di componenti elettronici.
+  BC-1930.60.20:
+    name: Valutazione del rischio delle fonti broker
+    description: |
+      Valutazione del rischio dell'approvvigionamento da broker indipendenti.
+  BC-1930.60.30:
+    name: Revisione periodica delle prestazioni dei distributori
+    description: |
+      Revisione periodica delle prestazioni e della conformità dei distributori.
+  BC-1930.70:
+    name: Gestione dei dati di conformità dei componenti
+    description: |
+      Raccolta e gestione dei dati sulle sostanze e sulla conformità dei componenti.
+  BC-1930.70.10:
+    name: Raccolta dei dati sulle sostanze
+    description: |
+      Raccolta dei dati sulla composizione delle sostanze dai fornitori di componenti.
+  BC-1930.70.20:
+    name: Dati sulle fonderie per minerali provenienti da zone di conflitto
+    description: |
+      Raccolta di dati a livello di fonderia per la due diligence sui minerali provenienti da zone di conflitto.
+  BC-1930.70.30:
+    name: Monitoraggio delle sostanze REACH SVHC
+    description: |
+      Monitoraggio delle sostanze estremamente preoccupanti REACH a livello di componente.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-energy-trading-settlement-management.yaml
+++ b/catalogue/i18n/it/L1-energy-trading-settlement-management.yaml
@@ -1,0 +1,144 @@
+# Gestione del trading e della liquidazione dell'energia (it) — translations for L1-energy-trading-settlement-management.yaml
+locale: it
+source: L1-energy-trading-settlement-management.yaml
+entries:
+  BC-3850:
+    name: Gestione del trading e della liquidazione dell'energia
+    description: |
+      Trading all'ingrosso di energia elettrica, gas e commodity ambientali —
+      partecipazione al mercato nei timeframe day-ahead, infragiornaliero e del bilanciamento,
+      gestione del rischio energetico, programmazione e nomine, partecipazione al mercato della capacità,
+      e liquidazione back-office e rendicontazione normativa nei regimi REMIT / EMIR / Dodd-Frank.
+  BC-3850.10:
+    name: Trading all'ingrosso di energia elettrica
+    description: |
+      Trading front-office di energia elettrica fisica e finanziaria nei mercati
+      del giorno prima, infragiornaliero e forward.
+  BC-3850.10.10:
+    name: Trading nel mercato del giorno prima
+    description: |
+      Presentazione e gestione di offerte di acquisto e vendita nel mercato del giorno prima.
+  BC-3850.10.20:
+    name: Trading nel mercato infragiornaliero
+    description: |
+      Trading continuo e in asta nel mercato infra-giornaliero in funzione delle variazioni di posizione.
+  BC-3850.10.30:
+    name: Trading forward e bilaterale
+    description: |
+      Trading fisico forward e bilaterale OTC per la copertura e l'origination.
+  BC-3850.10.40:
+    name: Trading di capacità transfrontaliera
+    description: |
+      Trading di prodotti di capacità sugli interconnettori transfrontalieri.
+  BC-3850.20:
+    name: Gestione del rischio energetico
+    description: |
+      Sorveglianza del rischio di mercato, di credito e operativo del portafoglio
+      di trading con amministrazione dei limiti e stress testing.
+    in_scope:
+      - Calcolo del VaR e dell'earnings-at-risk
+      - Gestione dei limiti di credito per le controparti
+      - Test di efficacia delle coperture
+    out_of_scope:
+      - Gestione del rischio aziendale (BC-120)
+      - Rischio di credito sui clienti retail (BC-3910)
+  BC-3850.20.10:
+    name: Sorveglianza del rischio di mercato
+    description: |
+      Sorveglianza del VaR, dell'earnings-at-risk e dell'esposizione del portafoglio di trading.
+  BC-3850.20.20:
+    name: Gestione del rischio di credito delle controparti
+    description: |
+      Limiti di credito delle controparti, garanzie collaterali e monitoraggio dell'esposizione.
+  BC-3850.20.30:
+    name: Gestione del programma di copertura
+    description: |
+      Progettazione ed esecuzione di programmi di copertura rispetto all'esposizione sul combustibile e sull'energia.
+  BC-3850.30:
+    name: Gestione delle posizioni e programmazione
+    description: |
+      Aggregazione delle posizioni di trading e fisiche e presentazione di programmi
+      e nomine ai gestori del sistema elettrico e dei gasdotti.
+  BC-3850.30.10:
+    name: Aggregazione delle posizioni di trading
+    description: |
+      Aggregazione delle posizioni tra prodotti, libri e controparti.
+  BC-3850.30.20:
+    name: Presentazione dei programmi elettrici
+    description: |
+      Presentazione dei programmi elettrici fisici ai TSO e ai responsabili del bilanciamento.
+  BC-3850.30.30:
+    name: Presentazione delle nomine del gas
+    description: |
+      Presentazione delle nomine del gas e ribilanciamento sui gasdotti di trasmissione.
+  BC-3850.40:
+    name: Partecipazione al mercato della capacità
+    description: |
+      Partecipazione ai meccanismi di mercato della capacità e di sicurezza degli approvvigionamenti,
+      inclusi strategia d'asta, qualifica e monitoraggio della consegna.
+  BC-3850.40.10:
+    name: Strategia d'asta della capacità
+    description: |
+      Strategia e preparazione delle offerte per le aste del mercato della capacità.
+  BC-3850.40.20:
+    name: Qualifica del fornitore di capacità
+    description: |
+      Qualifica degli asset e gestione del fattore di de-rating per i prodotti di capacità.
+  BC-3850.40.30:
+    name: Monitoraggio della consegna della capacità
+    description: |
+      Monitoraggio della consegna della capacità durante gli eventi di stress e dell'esposizione a penali.
+  BC-3850.50:
+    name: Trading di commodity ambientali
+    description: |
+      Trading e restituzione di quote di carbonio, certificati di energia rinnovabile,
+      garanzie di origine e certificati bianchi.
+  BC-3850.50.10:
+    name: Trading di quote di emissione di carbonio
+    description: |
+      Trading di EUA, CCA e altre quote di conformità al carbonio.
+  BC-3850.50.20:
+    name: Trading di certificati di energia rinnovabile
+    description: |
+      Trading di REC, ROC e GO (garanzie di origine).
+  BC-3850.50.30:
+    name: Operazioni sui certificati bianchi
+    description: |
+      Trading e restituzione di certificati bianchi per l'efficienza energetica.
+  BC-3850.60:
+    name: Operazioni di liquidazione dei contratti
+    description: |
+      Conferma back-office, calcolo della liquidazione, fatturazione e gestione
+      della liquidità dei contratti di energia all'ingrosso.
+  BC-3850.60.10:
+    name: Conferma dei contratti
+    description: |
+      Conferme in uscita e in entrata dei contratti e risoluzione delle discrepanze.
+  BC-3850.60.20:
+    name: Calcolo della liquidazione
+    description: |
+      Calcolo degli importi di liquidazione fisica e finanziaria per contratto.
+  BC-3850.60.30:
+    name: Fatturazione e gestione della liquidità dei contratti
+    description: |
+      Fatturazione, pagamento e riconciliazione dei flussi di cassa dei contratti all'ingrosso.
+  BC-3850.70:
+    name: Rendicontazione normativa del trading
+    description: |
+      Rendicontazione normativa delle transazioni di energia all'ingrosso ai sensi
+      dei regimi REMIT, EMIR, MiFID II e Dodd-Frank.
+  BC-3850.70.10:
+    name: Rendicontazione REMIT delle transazioni
+    description: |
+      Rendicontazione delle transazioni di energia all'ingrosso (Tabelle 1 e 2) ad ACER.
+  BC-3850.70.20:
+    name: Rendicontazione EMIR e Dodd-Frank
+    description: |
+      Rendicontazione dei contratti derivati ai trade repository ai sensi di EMIR e Dodd-Frank.
+  BC-3850.70.30:
+    name: Divulgazione di informazioni privilegiate
+    description: |
+      Divulgazione delle informazioni privilegiate ai sensi dell'Articolo 4 di REMIT.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-engagement-quality-management.yaml
+++ b/catalogue/i18n/it/L1-engagement-quality-management.yaml
@@ -1,0 +1,140 @@
+# Gestione della qualità dell'incarico (it) — translations for L1-engagement-quality-management.yaml
+locale: it
+source: L1-engagement-quality-management.yaml
+entries:
+  BC-4340:
+    name: Gestione della qualità dell'incarico
+    description: |
+      Sistema di gestione della qualità a livello di studio, revisioni della qualità dell'incarico,
+      revisioni dei fascicoli, consulenza tecnica, monitoraggio e risposta alle ispezioni esterne
+      sugli incarichi di servizi professionali.
+  BC-4340.10:
+    name: Sistema di gestione della qualità dello studio
+    description: |
+      Progettazione, implementazione e gestione del sistema di gestione della qualità
+      a livello di studio in linea con ISQM 1 e regimi equivalenti.
+  BC-4340.10.10:
+    name: Valutazione del rischio di qualità
+    description: |
+      Identificazione e valutazione dei rischi di qualità
+      negli incarichi e nelle operazioni dello studio.
+  BC-4340.10.20:
+    name: Progettazione delle risposte ai rischi di qualità
+    description: |
+      Progettazione di politiche e procedure in risposta
+      ai rischi di qualità identificati.
+  BC-4340.10.30:
+    name: Governance e responsabilità per la qualità
+    description: |
+      Attribuzione della responsabilità per il sistema di gestione della qualità
+      al managing partner, alla leadership della qualità e ai partner d'incarico.
+  BC-4340.10.40:
+    name: Valutazione annuale del sistema di gestione della qualità
+    description: |
+      Valutazione annuale dell'efficacia operativa del sistema
+      di gestione della qualità dello studio.
+  BC-4340.20:
+    name: Revisione della qualità dell'incarico
+    description: |
+      Revisione della qualità dell'incarico (EQR) indipendente da parte di un revisore
+      non altrimenti coinvolto nell'incarico, eseguita prima del rilascio del report
+      sugli incarichi che soddisfano i trigger di rischio o normativi.
+  BC-4340.20.10:
+    name: Valutazione dell'idoneità e dei trigger per l'EQR
+    description: |
+      Identificazione degli incarichi che richiedono l'EQR sulla base di trigger
+      normativi, di rischio o di policy dello studio.
+  BC-4340.20.20:
+    name: Assegnazione del revisore della qualità dell'incarico
+    description: |
+      Assegnazione di revisori della qualità dell'incarico qualificati e indipendenti
+      agli incarichi che soddisfano i trigger.
+  BC-4340.20.30:
+    name: Esecuzione e firma dell'EQR
+    description: |
+      Esecuzione delle procedure di EQR e firma come precondizione
+      per il rilascio del deliverable.
+  BC-4340.30:
+    name: Revisione del fascicolo dell'incarico
+    description: |
+      Revisioni hot e cold post-emissione su un campione di fascicoli di incarichi completati
+      per valutare la conformità alla metodologia dello studio e agli standard professionali.
+  BC-4340.30.10:
+    name: Revisione preventiva del fascicolo
+    description: |
+      Revisione del fascicolo pre-emissione su incarichi selezionati
+      dove è richiesta un'ulteriore assurance sulla conformità.
+  BC-4340.30.20:
+    name: Revisione a posteriori del fascicolo
+    description: |
+      Revisione retrospettiva post-emissione su base campionaria
+      per valutare la conformità metodologica e la qualità.
+  BC-4340.30.30:
+    name: Definizione degli esiti della revisione del fascicolo
+    description: |
+      Definizione degli esiti della revisione del fascicolo, incluse rimediazione,
+      implicazioni formative e feedback al partner d'incarico.
+  BC-4340.40:
+    name: Gestione della consulenza tecnica
+    description: |
+      Consulenza tecnica obbligatoria e facoltativa su questioni complesse degli incarichi
+      con funzioni di ufficio nazionale, tecnico o specialistico.
+  BC-4340.40.10:
+    name: Consulenza tecnica obbligatoria
+    description: |
+      Consulenza richiesta dalla policy dello studio in situazioni complesse definite,
+      quali continuità aziendale, rischio di frode o questioni nuove.
+  BC-4340.40.20:
+    name: Consulenza tecnica facoltativa
+    description: |
+      Consulenza discrezionale richiesta dal team dell'incarico
+      su questioni tecniche complesse.
+  BC-4340.40.30:
+    name: Documentazione della consulenza tecnica
+    description: |
+      Documentazione delle richieste di consulenza, dei pareri forniti e delle conclusioni
+      raggiunte nel fascicolo dell'incarico.
+  BC-4340.50:
+    name: Monitoraggio della qualità e rimediazione
+    description: |
+      Attività di monitoraggio continuativo, analisi delle cause radice delle carenze
+      di qualità e programmi di rimediazione.
+  BC-4340.50.10:
+    name: Monitoraggio degli indicatori di qualità
+    description: |
+      Monitoraggio degli indicatori leading e lagging di qualità
+      nel portafoglio di incarichi.
+  BC-4340.50.20:
+    name: Analisi delle cause radice delle carenze
+    description: |
+      Analisi delle cause radice delle carenze di qualità identificate
+      e dei risultati sistemici.
+  BC-4340.50.30:
+    name: Gestione delle azioni di rimediazione
+    description: |
+      Definizione, esecuzione e verifica delle azioni di rimediazione
+      derivanti da monitoraggio e ispezioni.
+  BC-4340.60:
+    name: Gestione della risposta alle ispezioni della pratica
+    description: |
+      Coordinamento delle risposte alle ispezioni esterne della pratica da parte di regolatori
+      e organismi di supervisione quali PCAOB, FRC, IAASA, ICAEW
+      e regimi equivalenti.
+  BC-4340.60.10:
+    name: Coordinamento della selezione dei fascicoli per ispezione
+    description: |
+      Coordinamento delle selezioni dei fascicoli e delle richieste di informazioni
+      da parte degli organismi ispettivi.
+  BC-4340.60.20:
+    name: Risposta ai rilievi dell'ispezione
+    description: |
+      Bozza e invio di risposte formali ai rilievi dell'ispezione
+      e ai piani di azione correttiva richiesti.
+  BC-4340.60.30:
+    name: Comunicazione degli esiti dell'ispezione
+    description: |
+      Comunicazione interna e, ove richiesta, esterna
+      degli esiti dell'ispezione.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-engineering-discipline-management.yaml
+++ b/catalogue/i18n/it/L1-engineering-discipline-management.yaml
@@ -1,0 +1,151 @@
+# Gestione delle discipline ingegneristiche (it) — translations for L1-engineering-discipline-management.yaml
+locale: it
+source: L1-engineering-discipline-management.yaml
+entries:
+  BC-1100:
+    name: Gestione delle discipline ingegneristiche
+    description: |
+      Pool di competenze multidisciplinari di ingegneria — meccanica, elettrica, civile, di processo, strumentazione e piping.
+  BC-1100.10:
+    name: Gestione dell'ingegneria meccanica
+    description: |
+      Competenze della disciplina meccanica — apparecchiature, macchinari rotanti e sistemi meccanici.
+  BC-1100.10.10:
+    name: Ingegneria delle apparecchiature statiche
+    description: |
+      Progettazione di recipienti in pressione, scambiatori di calore e altre apparecchiature statiche.
+  BC-1100.10.20:
+    name: Ingegneria delle apparecchiature rotanti
+    description: |
+      Ingegneria di pompe, compressori, turbine e macchinari rotanti.
+  BC-1100.10.30:
+    name: Ingegneria HVAC
+    description: |
+      Progettazione e analisi dei sistemi HVAC.
+  BC-1100.10.40:
+    name: Ingegneria dei materiali meccanici e della saldatura
+    description: |
+      Selezione dei materiali, specifiche di saldatura e progettazione anticorrosione.
+  BC-1100.20:
+    name: Gestione dell'ingegneria elettrica
+    description: |
+      Ingegneria elettrica di potenza, distribuzione e controllo.
+  BC-1100.20.10:
+    name: Ingegneria dei sistemi di potenza
+    description: |
+      Ingegneria dei sistemi di potenza ad alta e media tensione.
+  BC-1100.20.20:
+    name: Progettazione della distribuzione elettrica
+    description: |
+      Distribuzione a bassa tensione, quadri elettrici e piani di carico.
+  BC-1100.20.30:
+    name: Specifica delle apparecchiature elettriche
+    description: |
+      Specifica di motori, trasformatori e apparecchiature elettriche.
+  BC-1100.20.40:
+    name: Progettazione della messa a terra e protezione dai fulmini
+    description: |
+      Progettazione della messa a terra, dei collegamenti equipotenziali e della protezione dai fulmini.
+  BC-1100.30:
+    name: Gestione dell'ingegneria civile e strutturale
+    description: |
+      Opere civili, acciaio strutturale, calcestruzzo, fondazioni e geotecnica.
+  BC-1100.30.10:
+    name: Progettazione delle strutture in acciaio
+    description: |
+      Progettazione di strutture in acciaio e connessioni.
+  BC-1100.30.20:
+    name: Progettazione in calcestruzzo e fondazioni
+    description: |
+      Progettazione di strutture in calcestruzzo, fondazioni e armature.
+  BC-1100.30.30:
+    name: Ingegneria geotecnica
+    description: |
+      Indagine geotecnica e ingegneria del terreno.
+  BC-1100.30.40:
+    name: Ingegneria delle opere civili di cantiere
+    description: |
+      Progettazione di livellamento del sito, drenaggio e infrastrutture civili.
+  BC-1100.40:
+    name: Gestione dell'ingegneria di processo
+    description: |
+      Progettazione di processo, simulazione, P&ID, bilanci di massa ed energia, idraulica.
+  BC-1100.40.10:
+    name: Simulazione e modellazione di processo
+    description: |
+      Simulazione di processo in regime stazionario e dinamico.
+  BC-1100.40.20:
+    name: Sviluppo di P&ID e PFD
+    description: |
+      Diagrammi di flusso di processo e P&ID.
+  BC-1100.40.30:
+    name: Ingegneria dei bilanci di massa ed energia
+    description: |
+      Bilanci di calore e materiali e dimensionamento delle apparecchiature di processo.
+  BC-1100.40.40:
+    name: Ingegneria della sicurezza di processo
+    description: |
+      Sistemi di sfiato e torcia, classificazione SIL e sicurezza di processo.
+  BC-1100.50:
+    name: Gestione dell'ingegneria della strumentazione e del controllo
+    description: |
+      Strumentazione sul campo, automazione e ingegneria dei sistemi di controllo.
+  BC-1100.50.10:
+    name: Ingegneria della strumentazione sul campo
+    description: |
+      Specifica di trasmettitori, sensori e elementi finali di controllo.
+  BC-1100.50.20:
+    name: Progettazione del sistema di controllo
+    description: |
+      Architettura DCS e PLC e progettazione degli anelli di controllo.
+  BC-1100.50.30:
+    name: Progettazione del sistema strumentato di sicurezza
+    description: |
+      Progettazione SIS secondo IEC 61511 e verifica SIL.
+  BC-1100.50.40:
+    name: Ingegneria del software di automazione e controllo
+    description: |
+      Configurazione della logica di controllo e ingegneria del software di automazione.
+  BC-1100.60:
+    name: Gestione dell'ingegneria del piping
+    description: |
+      Progettazione del piping, layout, isometrici, analisi delle sollecitazioni e selezione dei materiali.
+  BC-1100.60.10:
+    name: Progettazione del layout del piping
+    description: |
+      Schemi generali di piping e layout 3D del piping.
+  BC-1100.60.20:
+    name: Analisi delle sollecitazioni del piping
+    description: |
+      Analisi delle sollecitazioni sulle tubazioni e progettazione dei supporti.
+  BC-1100.60.30:
+    name: Selezione dei materiali per il piping
+    description: |
+      Classi di materiali per piping, guarnizioni, valvole e selezione dell'isolamento.
+  BC-1100.60.40:
+    name: Produzione dei disegni isometrici
+    description: |
+      Produzione degli isometrici di piping e delle distinte materiali.
+  BC-1100.70:
+    name: Gestione delle risorse e delle competenze disciplinari
+    description: |
+      Pool di disciplina, framework di competenze e percorsi di carriera tecnica.
+  BC-1100.70.10:
+    name: Gestione del pool di risorse ingegneristiche
+    description: |
+      Allocazione delle risorse disciplinari tra i progetti.
+  BC-1100.70.20:
+    name: Framework delle competenze ingegneristiche
+    description: |
+      Framework delle competenze disciplinari e matrici delle competenze.
+  BC-1100.70.30:
+    name: Gestione del percorso di carriera tecnica
+    description: |
+      Percorsi di carriera tecnica e sviluppo del professionista iscritto all'albo.
+  BC-1100.70.40:
+    name: Gestione della conoscenza ingegneristica
+    description: |
+      Condivisione della conoscenza ingegneristica, comunità di pratica e lezioni apprese.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-engineering-document-management.yaml
+++ b/catalogue/i18n/it/L1-engineering-document-management.yaml
@@ -1,0 +1,107 @@
+# Gestione della documentazione di ingegneria (it) — translations for L1-engineering-document-management.yaml
+locale: it
+source: L1-engineering-document-management.yaml
+entries:
+  BC-1130:
+    name: Gestione della documentazione di ingegneria
+    description: |
+      Documenti di ingegneria controllati, disegni, specifiche e dati fornitore.
+  BC-1130.10:
+    name: Gestione del controllo documentale
+    description: |
+      Numerazione dei documenti, controllo delle revisioni e registro principale dei documenti.
+  BC-1130.10.10:
+    name: Numerazione e codifica dei documenti
+    description: |
+      Schemi di numerazione, tassonomia e codifica dei documenti.
+  BC-1130.10.20:
+    name: Controllo delle revisioni
+    description: |
+      Tracciabilità delle revisioni, stato e storico delle versioni.
+  BC-1130.10.30:
+    name: Registro principale dei documenti
+    description: |
+      Manutenzione del registro principale dei documenti e degli stati.
+  BC-1130.20:
+    name: Gestione dei disegni
+    description: |
+      Ciclo di vita, distribuzione e approvazione dei disegni.
+  BC-1130.20.10:
+    name: Flusso di produzione dei disegni
+    description: |
+      Flusso di produzione dei disegni con verifica, revisione ed emissione.
+  BC-1130.20.20:
+    name: Approvazione ed emissione dei disegni
+    description: |
+      Approvazione ed emissione dei disegni alla costruzione e agli stakeholder.
+  BC-1130.20.30:
+    name: Monitoraggio del ciclo di vita dei disegni
+    description: |
+      Monitoraggio del ciclo di vita dal preliminare all'as-built.
+  BC-1130.30:
+    name: Gestione delle specifiche
+    description: |
+      Specifiche tecniche, schede tecniche e conformità alle norme.
+  BC-1130.30.10:
+    name: Redazione delle specifiche tecniche
+    description: |
+      Redazione di specifiche tecniche e schede tecniche.
+  BC-1130.30.20:
+    name: Biblioteca delle norme di ingegneria
+    description: |
+      Manutenzione della biblioteca delle norme di ingegneria e dei riferimenti.
+  BC-1130.30.30:
+    name: Approvazione ed emissione delle specifiche
+    description: |
+      Approvazione ed emissione delle specifiche all'approvvigionamento.
+  BC-1130.40:
+    name: Gestione dei documenti fornitore
+    description: |
+      Requisiti dei dati fornitore, consegne, revisioni e disposizioni.
+  BC-1130.40.10:
+    name: Definizione dei requisiti dei dati fornitore
+    description: |
+      Definizione delle liste dei requisiti dei dati fornitore per gli ordini di acquisto.
+  BC-1130.40.20:
+    name: Monitoraggio delle consegne dei documenti fornitore
+    description: |
+      Monitoraggio delle consegne dei documenti fornitore e degli stati.
+  BC-1130.40.30:
+    name: Revisione e disposizione dei documenti fornitore
+    description: |
+      Revisione e disposizione dei documenti fornitore (Codice 1/2/3).
+  BC-1130.50:
+    name: Gestione della distribuzione e della trasmissione dei documenti
+    description: |
+      Trasmissioni documentali, corrispondenza formale e monitoraggio dei destinatari.
+  BC-1130.50.10:
+    name: Emissione delle trasmissioni documentali
+    description: |
+      Emissione formale delle trasmissioni documentali.
+  BC-1130.50.20:
+    name: Gestione della matrice di distribuzione
+    description: |
+      Matrici di distribuzione e definizioni dei destinatari.
+  BC-1130.50.30:
+    name: Monitoraggio degli accusati di ricevimento
+    description: |
+      Accusato di ricevimento e audit trail delle ricezioni.
+  BC-1130.60:
+    name: Gestione della documentazione as-built
+    description: |
+      Annotazioni redline, consolidamento as-built e pacchetti di documentazione per la consegna.
+  BC-1130.60.10:
+    name: Acquisizione delle annotazioni redline
+    description: |
+      Acquisizione delle annotazioni redline di cantiere durante la costruzione.
+  BC-1130.60.20:
+    name: Consolidamento as-built
+    description: |
+      Consolidamento delle annotazioni redline negli elaborati as-built.
+  BC-1130.60.30:
+    name: Compilazione del pacchetto documentale di consegna
+    description: |
+      Compilazione dei pacchetti di documentazione operativa e di manutenzione per la consegna.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-engineering-tendering-estimation-management.yaml
+++ b/catalogue/i18n/it/L1-engineering-tendering-estimation-management.yaml
@@ -1,0 +1,115 @@
+# Gestione delle offerte tecniche e della preventivazione ingegneristica (it) — translations for L1-engineering-tendering-estimation-management.yaml
+locale: it
+source: L1-engineering-tendering-estimation-management.yaml
+entries:
+  BC-1140:
+    name: Gestione delle offerte tecniche e della preventivazione ingegneristica
+    description: |
+      Preparazione delle offerte, sviluppo di proposte tecniche e commerciali.
+  BC-1140.10:
+    name: Gestione della decisione di partecipare all'offerta
+    description: |
+      Qualificazione delle opportunità, decisioni strategiche sulle offerte e pianificazione dell'acquisizione.
+  BC-1140.10.10:
+    name: Qualificazione delle opportunità
+    description: |
+      Qualificazione delle opportunità rispetto ai criteri di offerta.
+  BC-1140.10.20:
+    name: Governance della decisione di partecipare all'offerta
+    description: |
+      Governance delle decisioni di partecipare all'offerta e approvazioni ai gate.
+  BC-1140.10.30:
+    name: Pianificazione dell'acquisizione
+    description: |
+      Piani di acquisizione, temi di successo e posizionamento competitivo.
+  BC-1140.20:
+    name: Gestione della preventivazione ingegneristica
+    description: |
+      Ore di ingegneria, fattori di complessità e preventivazione basata sugli elaborati.
+  BC-1140.20.10:
+    name: Preventivazione delle ore di ingegneria
+    description: |
+      Preventivazione delle ore di ingegneria bottom-up per disciplina.
+  BC-1140.20.20:
+    name: Norme e benchmark di preventivazione
+    description: |
+      Manutenzione di norme, fattori e benchmark di preventivazione.
+  BC-1140.20.30:
+    name: Preventivazione basata sugli elaborati
+    description: |
+      Preventivazione basata sugli elaborati con fattori di complessità.
+  BC-1140.30:
+    name: Gestione della stima dei costi e dei tempi
+    description: |
+      Stima dei costi di costruzione, dei costi delle apparecchiature e dei tempi di progetto.
+  BC-1140.30.10:
+    name: Stima dei costi delle apparecchiature
+    description: |
+      Stima dei costi delle apparecchiature tramite preventivi e metodi parametrici.
+  BC-1140.30.20:
+    name: Stima dei costi di costruzione
+    description: |
+      Stima dei costi di costruzione secondo la classificazione AACE.
+  BC-1140.30.30:
+    name: Stima del programma di progetto
+    description: |
+      Stima del programma di progetto top-down e bottom-up.
+  BC-1140.30.40:
+    name: Assurance della qualità delle stime
+    description: |
+      QA indipendente delle stime e benchmarking.
+  BC-1140.40:
+    name: Gestione dello sviluppo delle proposte
+    description: |
+      Redazione di proposte tecniche e commerciali e gestione delle proposte.
+  BC-1140.40.10:
+    name: Redazione della proposta tecnica
+    description: |
+      Redazione delle sezioni tecniche della proposta.
+  BC-1140.40.20:
+    name: Redazione della proposta commerciale
+    description: |
+      Redazione delle sezioni commerciali della proposta e dei prospetti dei prezzi.
+  BC-1140.40.30:
+    name: Produzione e revisione della proposta
+    description: |
+      Produzione della proposta, revisioni a colori e verifica finale della conformità.
+  BC-1140.50:
+    name: Gestione della presentazione dell'offerta
+    description: |
+      Processo di presentazione, chiarimenti, trattative e assegnazione del contratto.
+  BC-1140.50.10:
+    name: Logistica di presentazione dell'offerta
+    description: |
+      Logistica di presentazione e conformità alla piattaforma.
+  BC-1140.50.20:
+    name: Gestione dei chiarimenti dell'offerta
+    description: |
+      Gestione dei chiarimenti pre-offerta e post-offerta.
+  BC-1140.50.30:
+    name: Trattativa e assegnazione
+    description: |
+      Supporto alla trattativa e trasferimento all'esecuzione al momento dell'assegnazione del contratto.
+  BC-1140.60:
+    name: Gestione dei prezzi e dei margini d'offerta
+    description: |
+      Strategia di tariffazione, analisi dei margini, contingenze e tariffazione del rischio.
+  BC-1140.60.10:
+    name: Strategia di tariffazione dell'offerta
+    description: |
+      Strategia di tariffazione dell'offerta e posizionamento competitivo.
+  BC-1140.60.20:
+    name: Definizione del margine e della contingenza
+    description: |
+      Decisioni su margine, contingenza e tariffazione del rischio.
+  BC-1140.60.30:
+    name: Accantonamento per il rischio d'offerta
+    description: |
+      Accantonamenti per il rischio inclusi nelle offerte in base al registro dei rischi.
+  BC-1140.60.40:
+    name: Governance di approvazione dell'offerta
+    description: |
+      Gate di approvazione dei prezzi dell'offerta e governance del top management.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-enterprise-risk-management.yaml
+++ b/catalogue/i18n/it/L1-enterprise-risk-management.yaml
@@ -1,0 +1,111 @@
+# Gestione del rischio d'impresa (it) — translations for L1-enterprise-risk-management.yaml
+locale: it
+source: L1-enterprise-risk-management.yaml
+entries:
+  BC-120:
+    name: Gestione del rischio d'impresa
+    description: |
+      Identificazione, valutazione, mitigazione e monitoraggio dei rischi a livello d'impresa.
+  BC-120.10:
+    name: Gestione del framework e dell'appetito al rischio
+    description: |
+      Tassonomia del rischio, framework, appetito e tolleranza al rischio.
+  BC-120.10.10:
+    name: Gestione della tassonomia del rischio
+    description: |
+      Definizione e manutenzione della tassonomia e delle categorie di rischio d'impresa.
+  BC-120.10.20:
+    name: Definizione dell'appetito al rischio
+    description: |
+      Dichiarazioni di appetito al rischio e soglie di tolleranza approvate dal consiglio.
+  BC-120.10.30:
+    name: Gestione delle politiche e degli standard di rischio
+    description: |
+      Politiche, standard e metodologie di rischio a livello di gruppo.
+  BC-120.10.40:
+    name: Gestione della cultura del rischio
+    description: |
+      Valutazione della cultura del rischio, programmi di sensibilizzazione e responsabilità.
+  BC-120.20:
+    name: Identificazione e valutazione del rischio
+    description: |
+      Rilevamento, valutazione, scoring e prioritizzazione dei rischi.
+  BC-120.20.10:
+    name: Identificazione del rischio
+    description: |
+      Workshop, scansioni e input per portare alla luce rischi nuovi ed emergenti.
+  BC-120.20.20:
+    name: Analisi e scoring del rischio
+    description: |
+      Analisi di probabilità, impatto, velocità e rischio inerente rispetto al rischio residuo.
+  BC-120.20.30:
+    name: Analisi per scenario e stress test
+    description: |
+      Analisi prospettica per scenario, stress test e reverse stress test.
+  BC-120.20.40:
+    name: Sorveglianza dei rischi emergenti
+    description: |
+      Horizon scanning per rischi emergenti e segnali deboli.
+  BC-120.30:
+    name: Gestione del trattamento del rischio
+    description: |
+      Decisioni di mitigazione, trasferimento, evitamento e accettazione del rischio.
+  BC-120.30.10:
+    name: Pianificazione della mitigazione del rischio
+    description: |
+      Definizione delle azioni di mitigazione, dei responsabili e delle scadenze target.
+  BC-120.30.20:
+    name: Gestione del trasferimento del rischio
+    description: |
+      Trasferimento del rischio tramite assicurazioni, contratti e hedging.
+  BC-120.30.30:
+    name: Governance dell'accettazione del rischio
+    description: |
+      Accettazione formale dei rischi residui superiori all'appetito con relative approvazioni.
+  BC-120.30.40:
+    name: Progettazione e valutazione dei controlli
+    description: |
+      Definizione e valutazione dell'efficacia dei controlli di rischio.
+  BC-120.40:
+    name: Monitoraggio e reporting del rischio
+    description: |
+      Indicatori di rischio, dashboard e reporting agli organi di governance.
+  BC-120.40.10:
+    name: Gestione degli indicatori chiave di rischio
+    description: |
+      Definizione, impostazione delle soglie e monitoraggio degli indicatori chiave di rischio.
+  BC-120.40.20:
+    name: Rilevazione degli eventi di rischio e delle perdite
+    description: |
+      Registrazione di eventi di rischio operativo, quasi-incidenti e perdite.
+  BC-120.40.30:
+    name: Reporting e dashboard del rischio
+    description: |
+      Reporting periodico al comitato esecutivo, al consiglio e al comitato rischi.
+  BC-120.40.40:
+    name: Analisi di aggregazione e concentrazione del rischio
+    description: |
+      Aggregazione dei rischi a livello d'impresa e analisi delle concentrazioni.
+  BC-120.50:
+    name: Gestione delle assicurazioni aziendali
+    description: |
+      Acquisto e gestione dei programmi assicurativi aziendali.
+  BC-120.50.10:
+    name: Progettazione del programma assicurativo
+    description: |
+      Strategia di copertura, franchigia e massimali per linea assicurativa.
+  BC-120.50.20:
+    name: Collocamento e rinnovo delle polizze assicurative
+    description: |
+      Gestione del broker, collocamento sul mercato e rinnovo delle polizze.
+  BC-120.50.30:
+    name: Gestione dei sinistri assicurativi
+    description: |
+      Notifica, gestione e recupero dei sinistri assicurativi aziendali.
+  BC-120.50.40:
+    name: Gestione della captive assicurativa
+    description: |
+      Operatività e governance dei veicoli di captive assicurativa.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-ev-charging-network-operations-management.yaml
+++ b/catalogue/i18n/it/L1-ev-charging-network-operations-management.yaml
@@ -1,0 +1,178 @@
+# Gestione delle operazioni della rete di ricarica EV (it) — translations for L1-ev-charging-network-operations-management.yaml
+locale: it
+source: L1-ev-charging-network-operations-management.yaml
+entries:
+  BC-3480:
+    name: Gestione delle operazioni della rete di ricarica EV
+    description: |
+      Operazioni delle reti di ricarica EV per CPO ed EMSP — pianificazione dei siti,
+      operazioni dei punti di ricarica, gestione dell'energia e delle tariffe, operazioni
+      clienti e di roaming, fatturazione e regolamento, manutenzione dei caricatori e
+      partecipazione ai servizi di rete.
+  BC-3480.10:
+    name: Pianificazione e deployment dei siti di ricarica
+    description: |
+      Selezione del sito, permessi, connessione alla rete e deployment fisico
+      dell'infrastruttura di ricarica.
+  BC-3480.10.10:
+    name: Selezione dei siti di ricarica
+    description: |
+      Identificazione e qualificazione dei siti di ricarica rispetto ai criteri
+      di domanda, terreno e rete elettrica.
+  BC-3480.10.20:
+    name: Permessi e connessione alla rete del sito
+    description: |
+      Autorizzazioni, approvazione urbanistica e coordinamento della connessione
+      alla rete elettrica per i siti di ricarica.
+  BC-3480.10.30:
+    name: Coordinamento dell'installazione dei caricatori
+    description: |
+      Coordinamento dell'installazione dei caricatori, delle opere civili, del
+      collaudo e del passaggio in esercizio.
+  BC-3480.20:
+    name: Operazioni dei punti di ricarica
+    description: |
+      Operatività quotidiana dei punti di ricarica, inclusi monitoraggio, ciclo di vita
+      della sessione e controllo del firmware tramite OCPP.
+  BC-3480.20.10:
+    name: Monitoraggio dei punti di ricarica
+    description: |
+      Monitoraggio in tempo reale della salute, della disponibilità e degli stati
+      di allarme dei punti di ricarica.
+  BC-3480.20.20:
+    name: Gestione del ciclo di vita della sessione di ricarica
+    description: |
+      Gestione del ciclo di vita della sessione di ricarica dall'autorizzazione
+      attraverso l'erogazione di energia fino alla conclusione.
+  BC-3480.20.30:
+    name: Gestione del firmware e della configurazione dei caricatori
+    description: |
+      Gestione delle versioni del firmware dei caricatori, dei profili di
+      configurazione e degli aggiornamenti remoti.
+  BC-3480.30:
+    name: Gestione dell'energia e delle tariffe di ricarica
+    description: |
+      Gestione del coordinamento dell'approvvigionamento energetico, delle tariffe
+      di ricarica e dell'ottimizzazione time-of-use nella rete di ricarica.
+  BC-3480.30.10:
+    name: Coordinamento dell'approvvigionamento energetico all'ingrosso
+    description: |
+      Coordinamento con l'approvvigionamento energetico su volumi, hedging e PPA
+      a supporto delle operazioni di ricarica.
+  BC-3480.30.20:
+    name: Definizione delle tariffe di ricarica
+    description: |
+      Definizione delle tariffe di ricarica pubblica, per i soci e di roaming
+      nei vari mercati.
+  BC-3480.30.30:
+    name: Ottimizzazione delle fasce di picco e time-of-use
+    description: |
+      Ottimizzazione delle operazioni di ricarica rispetto alle strutture di costo
+      per picchi di domanda e time-of-use dell'energia.
+  BC-3480.40:
+    name: Gestione dei clienti e degli abbonamenti di ricarica
+    description: |
+      Onboarding dei clienti, piani di abbonamento e autenticazione per i servizi
+      di ricarica.
+  BC-3480.40.10:
+    name: Onboarding dell'account di ricarica
+    description: |
+      Onboarding dei clienti di ricarica, inclusi identità, pagamento e selezione
+      del piano.
+  BC-3480.40.20:
+    name: Gestione dei piani di abbonamento di ricarica
+    description: |
+      Gestione dei piani di abbonamento, membership e prepagati per i clienti
+      di ricarica.
+  BC-3480.40.30:
+    name: Autenticazione e autorizzazione alla ricarica
+    description: |
+      Autenticazione e autorizzazione delle sessioni di ricarica tramite RFID,
+      app o Plug-and-Charge.
+  BC-3480.50:
+    name: Fatturazione e regolamento della ricarica
+    description: |
+      Fatturazione delle sessioni di ricarica, regolamento con i partner di roaming
+      e gestione delle ricevute per i clienti di ricarica.
+  BC-3480.50.10:
+    name: Fatturazione delle sessioni di ricarica
+    description: |
+      Tariffazione e fatturazione delle sessioni di ricarica per clienti diretti
+      e in roaming.
+  BC-3480.50.20:
+    name: Regolamento del roaming
+    description: |
+      Regolamento delle sessioni di roaming con CPO ed EMSP partner tramite
+      OCPI e protocolli equivalenti.
+  BC-3480.50.30:
+    name: Gestione dei rimborsi e delle ricevute
+    description: |
+      Emissione di ricevute, supporto al rimborso spese e documentazione fiscale
+      per i clienti di ricarica.
+  BC-3480.60:
+    name: Interoperabilità della rete di ricarica
+    description: |
+      Interoperabilità con i partner di roaming e conformità agli standard di ricarica
+      per connettori e protocolli.
+  BC-3480.60.10:
+    name: Gestione dei partner di roaming
+    description: |
+      Onboarding e gestione dei partner di roaming e degli hub.
+  BC-3480.60.20:
+    name: Operazioni Plug-and-Charge
+    description: |
+      Operatività dei certificati di contratto Plug-and-Charge ISO 15118 e dei
+      flussi di autenticazione.
+  BC-3480.60.30:
+    name: Gestione della compatibilità dei connettori dei caricatori
+    description: |
+      Gestione della compatibilità dei connettori CCS, NACS, CHAdeMO e GB/T
+      e delle strategie di adattatori.
+  BC-3480.70:
+    name: Assistenza tecnica in campo e manutenzione dei caricatori
+    description: |
+      Assistenza tecnica in campo e manutenzione degli asset di ricarica, inclusi
+      dispatch, manutenzione preventiva e ricambi.
+  BC-3480.70.10:
+    name: Dispatch per guasti dei caricatori
+    description: |
+      Dispatch dei tecnici di campo in risposta a guasti dei caricatori e
+      segnalazioni dei clienti.
+  BC-3480.70.20:
+    name: Manutenzione preventiva dei caricatori
+    description: |
+      Manutenzione preventiva pianificata e ispezione degli asset di ricarica.
+  BC-3480.70.30:
+    name: Gestione dei ricambi dei caricatori
+    description: |
+      Gestione delle scorte di ricambi dei caricatori, dei pool di riparazione e
+      dell'obsolescenza.
+  BC-3480.80:
+    name: Partecipazione a servizi di rete e di energia
+    description: |
+      Partecipazione degli asset di ricarica ai mercati di rete e dell'energia,
+      inclusi demand response, V2G e ricarica intelligente.
+    in_scope:
+      - Servizi di esportazione di energia V2G e di capacità
+      - Partecipazione a programmi di demand-response
+      - Ottimizzazione della schedulazione della ricarica intelligente
+    out_of_scope:
+      - Operazioni di asset di generazione e trading di energia all'ingrosso
+  BC-3480.80.10:
+    name: Operazioni del servizio V2G
+    description: |
+      Operatività dei servizi V2G che erogano prodotti di energia e capacità
+      ai mercati di bilanciamento della rete.
+  BC-3480.80.20:
+    name: Partecipazione a programmi di demand-response
+    description: |
+      Partecipazione a programmi di demand-response, incluse risposta al dispatch
+      e regolamento.
+  BC-3480.80.30:
+    name: Gestione della schedulazione della ricarica intelligente
+    description: |
+      Ricarica intelligente basata su schedulazione attraverso siti e veicoli per
+      ottimizzare costo e impatto sulla rete.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-events-group-operations-management.yaml
+++ b/catalogue/i18n/it/L1-events-group-operations-management.yaml
@@ -1,0 +1,206 @@
+# Gestione di eventi e gruppi (it) — translations for L1-events-group-operations-management.yaml
+locale: it
+source: L1-events-group-operations-management.yaml
+entries:
+  BC-4110:
+    name: Gestione di eventi e gruppi
+    description: |
+      Operazione di meeting, incentive, conferenze, esposizioni e eventi di banchettistica
+      presso venue di ospitalità — inclusa la vendita ai gruppi, l'allocazione degli spazi,
+      l'esecuzione del banquet event order, la gestione del blocco camere di gruppo,
+      produzione A/V, fatturazione e reporting post-evento.
+    in_scope:
+      - Lead di gruppo, contrattazione e definizione dei prezzi
+      - Allocazione degli spazi funzionali e risoluzione dei conflitti
+      - Redazione ed esecuzione del banquet event order
+      - Contratto, lista camere e pickup del blocco camere di gruppo
+      - Produzione A/V, allestimento scenografico ed eventi ibridi
+      - Fatturazione del conto principale e regolamento finale
+      - Reporting su blocco/pickup e performance post-evento
+    out_of_scope:
+      - Marketing degli eventi aziendali generico (BC-410)
+      - Produzione in cucina e sicurezza alimentare in banchettistica (BC-4070)
+      - Check-in al front office per gli arrivi di gruppo (BC-4060.10)
+  BC-4110.10:
+    name: Gestione delle vendite di gruppo ed eventi
+    description: |
+      Qualificazione dei lead di gruppo, operazioni di proposta e contratto,
+      concessioni di prezzo e reporting della pipeline per il business di gruppo.
+  BC-4110.10.10:
+    name: Qualificazione del lead di gruppo
+    description: |
+      Qualificazione dei lead di gruppo in entrata rispetto alla destinazione,
+      agli spazi e all'adeguatezza tariffaria.
+  BC-4110.10.20:
+    name: Operazioni di proposta e contratto di gruppo
+    description: |
+      Redazione delle proposte ed esecuzione dei contratti
+      di vendita ai gruppi.
+  BC-4110.10.30:
+    name: Gestione dei prezzi e delle concessioni di gruppo
+    description: |
+      Gestione dei prezzi di gruppo e della negoziazione delle concessioni
+      rispetto alle indicazioni sui ricavi.
+  BC-4110.10.40:
+    name: Reporting sulla pipeline di gruppo
+    description: |
+      Reporting sulla pipeline di vendita ai gruppi
+      e sulla conversione per fase.
+  BC-4110.20:
+    name: Gestione degli spazi per eventi e del function diary
+    description: |
+      Definizione e allocazione dell'inventario degli spazi funzionali,
+      risoluzione dei conflitti e pianificazione degli allestimenti e delle capacità.
+  BC-4110.20.10:
+    name: Definizione dell'inventario degli spazi funzionali
+    description: |
+      Definizione dell'inventario degli spazi funzionali, inclusi
+      capacità, allestimenti e sale combinabili.
+  BC-4110.20.20:
+    name: Prenotazione e allocazione degli spazi
+    description: |
+      Prenotazione e allocazione degli spazi funzionali
+      per eventi confermati e provvisori.
+  BC-4110.20.30:
+    name: Risoluzione dei conflitti sugli spazi
+    description: |
+      Risoluzione dei conflitti sugli spazi tra richieste sovrapposte
+      e dipendenze tra spazi adiacenti.
+  BC-4110.20.40:
+    name: Pianificazione degli allestimenti e delle capacità
+    description: |
+      Pianificazione degli allestimenti e della capacità per evento,
+      nel rispetto dei vincoli antincendio e di accessibilità.
+  BC-4110.30:
+    name: Esecuzione del banquet event order
+    description: |
+      Redazione dei banquet event order, distribuzione ai team operativi,
+      esecuzione delle fasi di allestimento-servizio-smontaggio
+      e gestione delle modifiche al BEO.
+  BC-4110.30.10:
+    name: Redazione del banquet event order
+    description: |
+      Redazione dei banquet event order con dettaglio di F&B,
+      A/V, allestimento e timing.
+  BC-4110.30.20:
+    name: Distribuzione del BEO e briefing
+    description: |
+      Distribuzione dei BEO ai team operativi e briefing
+      del personale di esecuzione.
+  BC-4110.30.30:
+    name: Operazioni di allestimento, servizio e smontaggio
+    description: |
+      Operazioni di allestimento, servizio e smontaggio rispetto
+      al BEO e ai tempi dell'evento.
+  BC-4110.30.40:
+    name: Operazioni di modifica del BEO
+    description: |
+      Operazioni di gestione delle modifiche al BEO,
+      inclusi gli aggiornamenti dell'ultimo momento.
+  BC-4110.40:
+    name: Gestione del blocco camere di gruppo e della lista camere
+    description: |
+      Configurazione dei contratti del blocco camere di gruppo, operazioni
+      sulla lista camere, cut-off, wash e reporting del pickup
+      a livello di erogazione dell'evento.
+  BC-4110.40.10:
+    name: Configurazione del contratto del blocco
+    description: |
+      Configurazione dei termini del contratto del blocco
+      nei sistemi operativi per l'evento.
+  BC-4110.40.20:
+    name: Operazioni sulla lista camere
+    description: |
+      Operazioni sulla lista camere, inclusi aggiornamenti, richieste
+      speciali e sequenziamento degli arrivi.
+  BC-4110.40.30:
+    name: Operazioni di cut-off e wash del blocco
+    description: |
+      Operazioni di cut-off e wash che rilasciano l'inventario del blocco
+      non utilizzato in vendita libera.
+  BC-4110.40.40:
+    name: Reporting sul pickup del blocco
+    description: |
+      Reporting sul pickup del blocco rispetto al contratto
+      per la rendicontazione dei ricavi e delle performance.
+  BC-4110.50:
+    name: Operazioni A/V e di produzione dell'evento
+    description: |
+      Operazioni audio-visive e di produzione, inclusi A/V interno,
+      allestimento scenografico, streaming ibrido e coordinamento
+      dei fornitori esterni.
+  BC-4110.50.10:
+    name: Operazioni A/V interne
+    description: |
+      Operazione delle attrezzature e degli equipaggi A/V interni
+      per gli eventi.
+  BC-4110.50.20:
+    name: Allestimento scenografico e produzione del set
+    description: |
+      Allestimento scenografico e produzione del set per gli eventi,
+      inclusi elementi scenici e di attrezzatura.
+  BC-4110.50.30:
+    name: Operazioni di live streaming ed eventi ibridi
+    description: |
+      Operazione del live streaming e dell'erogazione di eventi ibridi
+      per pubblici remoti e in sala.
+  BC-4110.50.40:
+    name: Coordinamento dei fornitori A/V esterni
+    description: |
+      Coordinamento dei fornitori A/V esterni rispetto ai requisiti
+      della venue e assicurativi.
+  BC-4110.60:
+    name: Fatturazione dell'evento e gestione del conto principale
+    description: |
+      Configurazione dei conti principali, fatturazione individuale
+      e per spese accessorie, depositi e regolamento e riconciliazione
+      finale dell'evento.
+  BC-4110.60.10:
+    name: Configurazione del conto principale
+    description: |
+      Configurazione dei conti principali dell'evento e delle regole
+      di addebito per le voci imputabili.
+  BC-4110.60.20:
+    name: Operazioni di fatturazione individuale e per spese accessorie
+    description: |
+      Operazione della fatturazione individuale e per spese accessorie
+      dei partecipanti al di là del conto principale.
+  BC-4110.60.30:
+    name: Gestione di depositi e pagamenti anticipati
+    description: |
+      Gestione di depositi e pagamenti anticipati rispetto alle
+      scadenze dell'evento.
+  BC-4110.60.40:
+    name: Regolamento e riconciliazione finale dell'evento
+    description: |
+      Regolamento e riconciliazione finale del conto principale
+      dell'evento rispetto al contratto e ai consumi.
+  BC-4110.70:
+    name: Reporting sulle performance e post-evento
+    description: |
+      Reporting sulle performance degli eventi di gruppo, inclusi
+      blocco/pickup, risultati finanziari, feedback dei partecipanti
+      e tracciamento dei rinnovi.
+  BC-4110.70.10:
+    name: Reporting su blocco e pickup
+    description: |
+      Reporting sulle performance di blocco e pickup
+      per gli eventi completati.
+  BC-4110.70.20:
+    name: Reporting sulle performance finanziarie dell'evento
+    description: |
+      Reporting sulle performance finanziarie dell'evento
+      rispetto a budget e previsioni.
+  BC-4110.70.30:
+    name: Raccolta del feedback dei partecipanti
+    description: |
+      Raccolta del feedback dei partecipanti tramite sondaggi
+      post-evento e canali di segnale in tempo reale.
+  BC-4110.70.40:
+    name: Tracciamento delle prenotazioni ripetute e dei rinnovi
+    description: |
+      Tracciamento delle pipeline di prenotazioni ripetute
+      e delle opportunità di rinnovo derivanti dagli eventi completati.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-export-control-defense-trade-management.yaml
+++ b/catalogue/i18n/it/L1-export-control-defense-trade-management.yaml
@@ -1,0 +1,95 @@
+# Gestione del controllo delle esportazioni e del commercio della difesa (it) — translations for L1-export-control-defense-trade-management.yaml
+locale: it
+source: L1-export-control-defense-trade-management.yaml
+entries:
+  BC-1790:
+    name: Gestione del controllo delle esportazioni e del commercio della difesa
+    description: |
+      Licenze di esportazione, conformità ITAR/EAR, controllo del trasferimento di tecnologia e divulgazione a stranieri.
+  BC-1790.10:
+    name: Gestione delle licenze di esportazione
+    description: |
+      Licenze ITAR ed EAR, domande e condizioni associate.
+  BC-1790.10.10:
+    name: Classificazione e giurisdizione delle esportazioni
+    description: |
+      Classificazione della giurisdizione ITAR/EAR e della classificazione ECCN degli articoli.
+  BC-1790.10.20:
+    name: Domanda di licenza di esportazione
+    description: |
+      Presentazione delle domande di licenza DSP (ITAR) e BIS (EAR).
+  BC-1790.10.30:
+    name: Conformità alle condizioni della licenza
+    description: |
+      Monitoraggio e conformità alle condizioni e ai proviso della licenza di esportazione.
+  BC-1790.10.40:
+    name: Reportistica sull'utilizzo della licenza
+    description: |
+      Reportistica periodica sull'utilizzo delle licenze concesse.
+  BC-1790.20:
+    name: Gestione dello screening di conformità al commercio
+    description: |
+      Screening di sanzioni, soggetti negati ed embarghi.
+  BC-1790.20.10:
+    name: Screening dei soggetti negati
+    description: |
+      Screening rispetto agli elenchi di soggetti negati e a restrizione.
+  BC-1790.20.20:
+    name: Screening dei paesi soggetti a sanzioni
+    description: |
+      Screening per sanzioni e paesi sotto embargo.
+  BC-1790.20.30:
+    name: Screening dell'uso finale limitato
+    description: |
+      Screening di diligenza sull'uso finale e sull'utente finale.
+  BC-1790.30:
+    name: Gestione del controllo del trasferimento di tecnologia
+    description: |
+      Rilascio controllato della tecnologia e accordi di assistenza tecnica.
+  BC-1790.30.10:
+    name: Controllo del rilascio di dati tecnici
+    description: |
+      Controllo del rilascio di dati tecnici soggetti a restrizioni.
+  BC-1790.30.20:
+    name: Gestione degli accordi di assistenza tecnica
+    description: |
+      Gestione di TAA, MLA e accordi di magazzino.
+  BC-1790.30.30:
+    name: Gestione delle esportazioni ritenute
+    description: |
+      Gestione delle esportazioni ritenute a cittadini stranieri sul territorio nazionale.
+  BC-1790.40:
+    name: Gestione della conformità doganale e tariffaria
+    description: |
+      Dogana della difesa, carnet ATA e documentazione di importazione/esportazione.
+  BC-1790.40.10:
+    name: Operazioni doganali della difesa
+    description: |
+      Operazioni doganali specifiche per gli articoli della difesa.
+  BC-1790.40.20:
+    name: Gestione del carnet ATA
+    description: |
+      Gestione del carnet ATA per le esportazioni temporanee di materiale della difesa.
+  BC-1790.40.30:
+    name: Classificazione tariffaria e valutazione doganale
+    description: |
+      Classificazione tariffaria HS e valutazione doganale degli articoli.
+  BC-1790.50:
+    name: Gestione della divulgazione a stranieri
+    description: |
+      Decisioni di divulgazione a stranieri, rilasciabilità e rilasci controllati.
+  BC-1790.50.10:
+    name: Decisioni di divulgazione a stranieri
+    description: |
+      Processo decisionale per la divulgazione di informazioni controllate a soggetti stranieri.
+  BC-1790.50.20:
+    name: Marcatura della rilasciabilità
+    description: |
+      Marcatura della rilasciabilità e controllo della diffusione delle informazioni.
+  BC-1790.50.30:
+    name: Controllo delle visite di stranieri
+    description: |
+      Controllo dei visitatori stranieri e approvazione delle relative richieste.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-facilities-management.yaml
+++ b/catalogue/i18n/it/L1-facilities-management.yaml
@@ -1,0 +1,119 @@
+# Gestione delle strutture e servizi generali (it) — translations for L1-facilities-management.yaml
+locale: it
+source: L1-facilities-management.yaml
+entries:
+  BC-700:
+    name: Gestione delle strutture e servizi generali
+    description: |
+      Servizi agli edifici, luogo di lavoro, FM tecnico e soft.
+  BC-700.10:
+    name: Gestione dei servizi al luogo di lavoro
+    description: |
+      Reception, posta, servizi di workplace experience.
+  BC-700.10.10:
+    name: Gestione della reception e dei visitatori
+    description: |
+      Pre-registrazione, accoglienza e accesso dei visitatori.
+  BC-700.10.20:
+    name: Servizi di posta e distribuzione
+    description: |
+      Posta in entrata e in uscita, pacchi e distribuzione interna.
+  BC-700.10.30:
+    name: Concierge e helpdesk del luogo di lavoro
+    description: |
+      Concierge del luogo di lavoro, helpdesk e gestione delle richieste di servizio.
+  BC-700.10.40:
+    name: Servizi di sale riunioni ed eventi
+    description: |
+      Prenotazione delle sale riunioni, allestimento AV e supporto agli eventi.
+  BC-700.20:
+    name: Gestione del FM tecnico
+    description: |
+      Impianti dell'edificio — HVAC, elettrico, idraulico, struttura.
+  BC-700.20.10:
+    name: Operazioni degli impianti HVAC
+    description: |
+      Esercizio e manutenzione degli impianti di riscaldamento, ventilazione e climatizzazione.
+  BC-700.20.20:
+    name: Operazioni degli impianti elettrici
+    description: |
+      Esercizio e manutenzione degli impianti elettrici dell'edificio.
+  BC-700.20.30:
+    name: Operazioni meccaniche e idrauliche
+    description: |
+      Operazioni degli impianti meccanici, idraulici e idrici.
+  BC-700.20.40:
+    name: Manutenzione delle strutture dell'edificio
+    description: |
+      Manutenzione della struttura, degli involucri e delle finiture dell'edificio.
+  BC-700.20.50:
+    name: Gestione dell'energia dell'edificio
+    description: |
+      Monitoraggio e ottimizzazione dei consumi energetici dell'edificio.
+  BC-700.30:
+    name: Gestione del FM soft
+    description: |
+      Pulizie, ristorazione, sicurezza fisica, aree esterne.
+  BC-700.30.10:
+    name: Servizi di pulizia
+    description: |
+      Pulizie quotidiane, pulizie profonde e servizi di igiene.
+  BC-700.30.20:
+    name: Ristorazione e servizi di catering
+    description: |
+      Ristorazione aziendale, distributori automatici e servizi di ospitalità.
+  BC-700.30.30:
+    name: Operazioni di sicurezza fisica
+    description: |
+      Guardiani, pattugliamenti, TVCC e operazioni di controllo degli accessi.
+  BC-700.30.40:
+    name: Aree esterne e landscaping
+    description: |
+      Manutenzione delle aree esterne, landscaping e spazi aperti.
+  BC-700.30.50:
+    name: Servizi di gestione dei rifiuti
+    description: |
+      Raccolta, separazione e riciclaggio dei rifiuti nei siti.
+  BC-700.40:
+    name: Gestione degli spazi
+    description: |
+      Pianificazione degli spazi, gestione dell'occupazione, traslochi.
+  BC-700.40.10:
+    name: Pianificazione degli spazi
+    description: |
+      Pianificazione, allocazione e stack planning degli spazi.
+  BC-700.40.20:
+    name: Monitoraggio dell'occupazione
+    description: |
+      Rilevamento dell'occupazione, analytics dell'utilizzo e previsioni.
+  BC-700.40.30:
+    name: Gestione dei traslochi
+    description: |
+      Pianificazione ed esecuzione di traslochi, aggiunte e modifiche.
+  BC-700.40.40:
+    name: Prenotazione delle postazioni e hot-desking
+    description: |
+      Piattaforme di prenotazione delle postazioni e operazioni del luogo di lavoro ibrido.
+  BC-700.50:
+    name: Gestione della salute e sicurezza delle strutture
+    description: |
+      Sicurezza degli edifici, antincendio, sistemi di emergenza.
+  BC-700.50.10:
+    name: Gestione della sicurezza antincendio
+    description: |
+      Rilevamento incendi, sistemi di soppressione e prove di evacuazione.
+  BC-700.50.20:
+    name: Coordinamento della risposta alle emergenze
+    description: |
+      Risposta alle emergenze in sede e coordinamento del primo soccorso.
+  BC-700.50.30:
+    name: Gestione dei permessi di lavoro
+    description: |
+      Governance dei permessi di lavoro per attività pericolose nelle strutture.
+  BC-700.50.40:
+    name: Conformità normativa dell'edificio
+    description: |
+      Ispezioni e certificazioni obbligatorie per la sicurezza degli edifici.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-farm-land-asset-management.yaml
+++ b/catalogue/i18n/it/L1-farm-land-asset-management.yaml
@@ -1,0 +1,120 @@
+# Gestione del patrimonio fondiario agricolo e degli asset aziendali (it) — translations for L1-farm-land-asset-management.yaml
+locale: it
+source: L1-farm-land-asset-management.yaml
+entries:
+  BC-3540:
+    name: Gestione del patrimonio fondiario agricolo e degli asset aziendali
+    description: |
+      Registrazioni di titolarità fondiaria e contratti di affitto, gestione di campi e appezzamenti,
+      telemetria delle macchine e attrezzature aziendali, infrastruttura irrigua,
+      fabbricati rurali e impianti energetici aziendali.
+  BC-3540.10:
+    name: Gestione della titolarità fondiaria e dei contratti di affitto
+    description: |
+      Registrazioni di titoli fondiari, diritti di possesso, contratti di affitto e servitù
+      a supporto dei diritti operativi sul portafoglio fondiario.
+    in_scope:
+      - Registrazioni di titoli e diritti di possesso
+      - Amministrazione dei contratti di affitto
+      - Registrazioni di servitù e diritti di accesso
+    out_of_scope:
+      - Immobili aziendali non agricoli (BC-1410)
+  BC-3540.10.10:
+    name: Registrazioni di titolarità e diritti fondiari
+    description: |
+      Registrazioni di proprietà, affitto e possesso consuetudinario nel portafoglio fondiario.
+  BC-3540.10.20:
+    name: Amministrazione dei contratti di affitto
+    description: |
+      Amministrazione dei contratti di affitto agricolo e dei relativi rinnovi.
+  BC-3540.10.30:
+    name: Gestione delle servitù fondiarie
+    description: |
+      Gestione delle servitù di accesso, dei diritti di passaggio e delle servitù di conservazione.
+  BC-3540.20:
+    name: Gestione dei campi e degli appezzamenti
+    description: |
+      Registrazioni dei confini dei campi, storia del campo e zonazione della produttività a livello di campo e appezzamento.
+  BC-3540.20.10:
+    name: Registrazione dei confini dei campi
+    description: |
+      Acquisizione e aggiornamento dei confini dei campi nei sistemi GIS aziendali.
+  BC-3540.20.20:
+    name: Registrazioni storiche del campo
+    description: |
+      Registrazioni pluriennali della storia del campo con colture, input e rese.
+  BC-3540.20.30:
+    name: Zonazione della produttività del campo
+    description: |
+      Zonazione della produttività e delimitazione delle zone di gestione all'interno dei campi.
+  BC-3540.30:
+    name: Gestione delle macchine agricole
+    description: |
+      Inventario delle macchine aziendali, operazioni di campo, telemetria ISOBUS e accordi di condivisione delle attrezzature.
+  BC-3540.30.10:
+    name: Inventario delle macchine agricole
+    description: |
+      Inventario di trattori, attrezzature portate e macchine semoventi.
+  BC-3540.30.20:
+    name: Operazioni di campo con le macchine
+    description: |
+      Impiego giornaliero delle macchine in campo e assegnazione degli operatori.
+  BC-3540.30.30:
+    name: Integrazione della telemetria ISOBUS
+    description: |
+      Integrazione della telemetria delle macchine conformi ISOBUS con i sistemi di gestione aziendale.
+  BC-3540.30.40:
+    name: Condivisione e contoterzismo delle macchine
+    description: |
+      Accordi di condivisione delle macchine, contoterzismo e operatori in appalto.
+  BC-3540.40:
+    name: Gestione dell'infrastruttura irrigua
+    description: |
+      Gestione del ciclo di vita degli impianti di irrigazione, delle concessioni idriche e della manutenzione dell'infrastruttura irrigua.
+  BC-3540.40.10:
+    name: Progettazione dell'impianto di irrigazione
+    description: |
+      Progettazione e dimensionamento degli impianti di irrigazione aziendali.
+  BC-3540.40.20:
+    name: Conformità alle concessioni idriche
+    description: |
+      Conformità alle concessioni di acque superficiali e sotterranee e alla misurazione dei prelievi.
+  BC-3540.40.30:
+    name: Manutenzione dell'infrastruttura irrigua
+    description: |
+      Manutenzione di pompe, condotte principali, ali laterali ed erogatori.
+  BC-3540.50:
+    name: Gestione dei fabbricati e dei cortili aziendali
+    description: |
+      Gestione e manutenzione di magazzini, ricoveri per animali, cortili e viabilità aziendale.
+  BC-3540.50.10:
+    name: Operazioni nei fabbricati di stoccaggio
+    description: |
+      Gestione dei fabbricati di stoccaggio per cereali, fieno e prodotti chimici.
+  BC-3540.50.20:
+    name: Operazioni nei ricoveri per animali
+    description: |
+      Gestione e lettiera nei ricoveri per animali.
+  BC-3540.50.30:
+    name: Manutenzione di cortili e viabilità aziendale
+    description: |
+      Manutenzione dei cortili, della viabilità aziendale e delle strutture di movimentazione degli animali.
+  BC-3540.60:
+    name: Gestione dell'energia aziendale
+    description: |
+      Produzione di energia in azienda, coordinamento degli approvvigionamenti di carburante ed energia e registrazione dei consumi energetici.
+  BC-3540.60.10:
+    name: Produzione di energia in azienda
+    description: |
+      Produzione di energia solare, eolica e da biogas in azienda.
+  BC-3540.60.20:
+    name: Coordinamento degli approvvigionamenti di carburante ed energia
+    description: |
+      Coordinamento degli approvvigionamenti aziendali di carburante, energia elettrica e gas.
+  BC-3540.60.30:
+    name: Registrazione dei consumi energetici
+    description: |
+      Registrazione dei consumi energetici aziendali per attività e asset.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-field-service-management.yaml
+++ b/catalogue/i18n/it/L1-field-service-management.yaml
@@ -1,0 +1,115 @@
+# Gestione dell'assistenza sul campo (it) — translations for L1-field-service-management.yaml
+locale: it
+source: L1-field-service-management.yaml
+entries:
+  BC-1050:
+    name: Gestione dell'assistenza sul campo
+    description: |
+      Assistenza sulla base installata, tecnici sul campo, riparazione in loco e commissioning.
+  BC-1050.10:
+    name: Gestione delle richieste di assistenza
+    description: |
+      Acquisizione, triage e qualificazione delle richieste di assistenza.
+  BC-1050.10.10:
+    name: Ricezione delle richieste di assistenza
+    description: |
+      Acquisizione multicanale delle richieste di assistenza dei clienti.
+  BC-1050.10.20:
+    name: Triage delle richieste di assistenza
+    description: |
+      Triage, classificazione e instradamento delle richieste di assistenza.
+  BC-1050.10.30:
+    name: Diagnostica remota e risoluzione
+    description: |
+      Diagnostica remota e risoluzione al primo intervento da remoto.
+  BC-1050.20:
+    name: Gestione del dispacciamento sul campo
+    description: |
+      Pianificazione, instradamento e dispacciamento dei tecnici.
+  BC-1050.20.10:
+    name: Pianificazione dei tecnici
+    description: |
+      Pianificazione dei tecnici sul campo in base alle competenze e alla disponibilità.
+  BC-1050.20.20:
+    name: Ottimizzazione dei percorsi
+    description: |
+      Ottimizzazione dei percorsi e degli spostamenti per gli interventi di assistenza.
+  BC-1050.20.30:
+    name: Esecuzione del dispacciamento
+    description: |
+      Dispacciamento in tempo reale e riassegnazione degli ordini di assistenza.
+  BC-1050.30:
+    name: Gestione dell'esecuzione dell'assistenza
+    description: |
+      Esecuzione dell'assistenza in loco e reportistica.
+  BC-1050.30.10:
+    name: Erogazione dell'assistenza in loco
+    description: |
+      Esecuzione in loco delle attività di assistenza in base all'ordine di lavoro.
+  BC-1050.30.20:
+    name: Acquisizione della documentazione di assistenza
+    description: |
+      Acquisizione di note di assistenza, foto e firme.
+  BC-1050.30.30:
+    name: Gestione dell'accettazione da parte del cliente
+    description: |
+      Firma e accettazione da parte del cliente al termine dell'assistenza.
+  BC-1050.40:
+    name: Gestione dei ricambi sul campo
+    description: |
+      Ricambi dispiegati sul campo, scorte a bordo veicolo e reintegro.
+  BC-1050.40.10:
+    name: Gestione delle scorte a bordo veicolo
+    description: |
+      Definizione e gestione delle scorte a bordo veicolo e dei magazzini avanzati.
+  BC-1050.40.20:
+    name: Reintegro dei ricambi sul campo
+    description: |
+      Reintegro dei magazzini avanzati e delle dotazioni dei tecnici.
+  BC-1050.40.30:
+    name: Resi dei ricambi sul campo
+    description: |
+      Resa di ricambi non utilizzati, difettosi o riparabili dal campo.
+  BC-1050.50:
+    name: Gestione dei contratti di assistenza
+    description: |
+      Accordi di assistenza, SLA e diritti contrattuali.
+  BC-1050.50.10:
+    name: Redazione degli accordi di assistenza
+    description: |
+      Redazione di contratti di assistenza, livelli di servizio e condizioni.
+  BC-1050.50.20:
+    name: Gestione dei diritti di assistenza
+    description: |
+      Verifica dei diritti contrattuali al momento della richiesta e del dispacciamento.
+  BC-1050.50.30:
+    name: Rinnovo dei contratti di assistenza
+    description: |
+      Rinnovo e adeguamento dei contratti di assistenza.
+  BC-1050.50.40:
+    name: Fatturazione dell'assistenza
+    description: |
+      Fatturazione di contratti di assistenza e lavori a tempo e materiale.
+  BC-1050.60:
+    name: Gestione delle prestazioni dell'assistenza sul campo
+    description: |
+      Tasso di risoluzione al primo intervento, tempo di risposta, NPS e produttività dei tecnici.
+  BC-1050.60.10:
+    name: Monitoraggio della risoluzione al primo intervento
+    description: |
+      Misurazione e miglioramento del tasso di risoluzione al primo intervento.
+  BC-1050.60.20:
+    name: Monitoraggio dei tempi di risposta e risoluzione
+    description: |
+      Monitoraggio dei tempi di risposta e risoluzione basato sugli SLA.
+  BC-1050.60.30:
+    name: Reportistica sulla produttività dei tecnici
+    description: |
+      Rendicontazione del tasso di utilizzo, del tempo operativo e della produttività dei tecnici.
+  BC-1050.60.40:
+    name: NPS e soddisfazione del cliente (assistenza)
+    description: |
+      Misurazione del NPS e della soddisfazione del cliente relativa all'assistenza.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-financial-crime-management.yaml
+++ b/catalogue/i18n/it/L1-financial-crime-management.yaml
@@ -1,0 +1,107 @@
+# Gestione della criminalità finanziaria (it) — translations for L1-financial-crime-management.yaml
+locale: it
+source: L1-financial-crime-management.yaml
+entries:
+  BC-1400:
+    name: Gestione della criminalità finanziaria
+    description: |
+      Monitoraggio delle transazioni antiriciclaggio, screening delle sanzioni, rilevamento delle frodi e segnalazione di operazioni sospette.
+  BC-1400.10:
+    name: Gestione del monitoraggio delle transazioni antiriciclaggio
+    description: |
+      Regole, alert e scenari di monitoraggio delle transazioni per l'antiriciclaggio.
+  BC-1400.10.10:
+    name: Progettazione di scenari e regole antiriciclaggio
+    description: |
+      Progettazione di scenari, regole e soglie di antiriciclaggio.
+  BC-1400.10.20:
+    name: Generazione degli alert antiriciclaggio
+    description: |
+      Generazione degli alert antiriciclaggio dal monitoraggio delle transazioni.
+  BC-1400.10.30:
+    name: Triage degli alert antiriciclaggio
+    description: |
+      Triage e prioritizzazione basata sul rischio degli alert antiriciclaggio.
+  BC-1400.10.40:
+    name: Calibrazione e validazione dei modelli antiriciclaggio
+    description: |
+      Calibrazione, validazione e verifica dell'efficacia dei modelli antiriciclaggio.
+  BC-1400.20:
+    name: Gestione dello screening delle sanzioni
+    description: |
+      Liste delle sanzioni, screening nominativo e delle transazioni, gestione degli hit.
+  BC-1400.20.10:
+    name: Gestione delle liste delle sanzioni
+    description: |
+      Aggregazione e manutenzione delle watchlist delle sanzioni.
+  BC-1400.20.20:
+    name: Screening nominativo della clientela
+    description: |
+      Screening di clienti e controparti rispetto alle liste delle sanzioni.
+  BC-1400.20.30:
+    name: Screening delle sanzioni sulle transazioni
+    description: |
+      Screening in tempo reale delle transazioni rispetto alle liste delle sanzioni.
+  BC-1400.20.40:
+    name: Gestione degli hit delle sanzioni
+    description: |
+      Indagine e gestione degli hit delle sanzioni.
+  BC-1400.30:
+    name: Gestione del rilevamento e delle indagini sulle frodi
+    description: |
+      Rilevamento delle frodi su prodotti e canali e gestione delle relative indagini.
+  BC-1400.30.10:
+    name: Rilevamento delle frodi in fase di richiesta
+    description: |
+      Rilevamento delle frodi nella fase di richiesta di prodotti o di apertura del rapporto con il cliente.
+  BC-1400.30.20:
+    name: Rilevamento delle frodi sulle transazioni
+    description: |
+      Rilevamento in tempo reale delle transazioni fraudolente.
+  BC-1400.30.30:
+    name: Indagini sulle frodi
+    description: |
+      Indagine e risoluzione dei casi di frode.
+  BC-1400.30.40:
+    name: Gestione delle perdite da frode e del recupero
+    description: |
+      Monitoraggio delle perdite da frode e delle attività di recupero.
+  BC-1400.30.50:
+    name: Gestione delle frodi da bonifico autorizzato (APP)
+    description: |
+      Gestione dei casi di frode da bonifico autorizzato (APP) e rimborso alla clientela.
+  BC-1400.40:
+    name: Gestione della segnalazione di operazioni sospette
+    description: |
+      Presentazione di SAR/STR (segnalazione di operazione sospetta) e segnalazione alle autorità.
+  BC-1400.40.10:
+    name: Redazione e invio delle SAR
+    description: |
+      Redazione e invio di SAR/STR alle unità di informazione finanziaria (FIU).
+  BC-1400.40.20:
+    name: Segnalazione regolatoria sulla criminalità finanziaria
+    description: |
+      Segnalazione periodica alle autorità di vigilanza in materia di criminalità finanziaria.
+  BC-1400.40.30:
+    name: Raccordo con le autorità di contrasto
+    description: |
+      Raccordo con le autorità di contrasto e gestione delle richieste di informazioni.
+  BC-1400.50:
+    name: Gestione delle indagini sulla criminalità finanziaria
+    description: |
+      Gestione dei casi, indagini ed escalation.
+  BC-1400.50.10:
+    name: Gestione dei casi
+    description: |
+      Gestione dei casi per le indagini sulla criminalità finanziaria.
+  BC-1400.50.20:
+    name: Conduzione delle indagini
+    description: |
+      Conduzione delle indagini e raccolta delle prove.
+  BC-1400.50.30:
+    name: Escalation e chiusura
+    description: |
+      Escalation, processo decisionale e chiusura delle indagini.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-financial-management.yaml
+++ b/catalogue/i18n/it/L1-financial-management.yaml
@@ -1,0 +1,163 @@
+# Gestione finanziaria (it) — translations for L1-financial-management.yaml
+locale: it
+source: L1-financial-management.yaml
+entries:
+  BC-200:
+    name: Gestione finanziaria
+    description: |
+      Contabilità, controllo, reporting statutario e direzionale, budgeting.
+  BC-200.10:
+    name: Gestione del libro mastro generale
+    description: |
+      Piano dei conti, scritture contabili e chiusura del periodo.
+  BC-200.10.10:
+    name: Gestione del piano dei conti
+    description: |
+      Definizione e governance del piano dei conti e delle gerarchie contabili.
+  BC-200.10.20:
+    name: Elaborazione delle scritture contabili
+    description: |
+      Scritture contabili manuali e automatizzate con flusso di approvazione.
+  BC-200.10.30:
+    name: Contabilità intercompany
+    description: |
+      Transazioni intercompany, eliminazioni e riconciliazioni.
+  BC-200.10.40:
+    name: Chiusura del periodo contabile
+    description: |
+      Calendario di chiusura del periodo, ratei e certificazioni di chiusura.
+  BC-200.10.50:
+    name: Riconciliazione dei conti
+    description: |
+      Riconciliazioni e substantiation dei conti patrimoniali.
+  BC-200.20:
+    name: Gestione della contabilità fornitori
+    description: |
+      Elaborazione fatture, pagamenti e contabilità fornitori.
+  BC-200.20.10:
+    name: Ricezione e validazione delle fatture fornitori
+    description: |
+      Ricezione, acquisizione e abbinamento a tre vie delle fatture fornitori.
+  BC-200.20.20:
+    name: Esecuzione dei pagamenti
+    description: |
+      Pianificazione ed esecuzione dei pagamenti ai fornitori.
+  BC-200.20.30:
+    name: Gestione dei dati anagrafici contabili dei fornitori
+    description: |
+      Dati finanziari anagrafici dei fornitori, coordinate bancarie e attributi fiscali.
+  BC-200.20.40:
+    name: Elaborazione delle note spese
+    description: |
+      Acquisizione, approvazione e rimborso delle note spese dei dipendenti.
+  BC-200.20.50:
+    name: Riconciliazione del partitario fornitori
+    description: |
+      Riconciliazione degli estratti conto fornitori e del partitario contabilità fornitori.
+  BC-200.30:
+    name: Gestione della contabilità clienti
+    description: |
+      Fatturazione ai clienti, incassi e applicazione dei pagamenti.
+  BC-200.30.10:
+    name: Fatturazione ai clienti
+    description: |
+      Generazione e emissione di fatture e note di credito ai clienti.
+  BC-200.30.20:
+    name: Applicazione dei pagamenti
+    description: |
+      Abbinamento dei pagamenti ricevuti dai clienti alle partite aperte.
+  BC-200.30.30:
+    name: Gestione degli incassi
+    description: |
+      Solleciti, strategia di recupero crediti e follow-up dei pagamenti clienti.
+  BC-200.30.40:
+    name: Rischio di credito e limiti dei clienti
+    description: |
+      Valutazione del merito creditizio dei clienti, definizione dei limiti e blocchi.
+  BC-200.30.50:
+    name: Gestione delle contestazioni e delle deduzioni
+    description: |
+      Indagine e risoluzione di contestazioni su fatture e deduzioni.
+  BC-200.40:
+    name: Contabilità delle immobilizzazioni
+    description: |
+      Registro delle immobilizzazioni, ammortamento e svalutazione.
+  BC-200.40.10:
+    name: Tenuta del registro delle immobilizzazioni
+    description: |
+      Capitalizzazione, classificazione e monitoraggio delle immobilizzazioni.
+  BC-200.40.20:
+    name: Ammortamento e svalutazione periodica
+    description: |
+      Metodi, piani e registrazione degli ammortamenti.
+  BC-200.40.30:
+    name: Svalutazione e rivalutazione delle immobilizzazioni
+    description: |
+      Test di impairment e rivalutazione delle immobilizzazioni secondo IFRS o GAAP locale.
+  BC-200.40.40:
+    name: Contabilità delle dismissioni di immobilizzazioni
+    description: |
+      Contabilizzazione di ritiri, cessioni e write-off di immobilizzazioni.
+  BC-200.50:
+    name: Gestione della contabilità analitica
+    description: |
+      Oggetti di costo, allocazioni di costo e costificazione standard.
+  BC-200.50.10:
+    name: Gestione degli oggetti di costo e dei centri di costo
+    description: |
+      Definizione di centri di costo, ordini interni e oggetti di costo di progetto.
+  BC-200.50.20:
+    name: Costificazione standard
+    description: |
+      Definizione dei costi standard, analisi degli scostamenti e rivalutazione.
+  BC-200.50.30:
+    name: Allocazione e assorbimento dei costi
+    description: |
+      Cicli di allocazione, driver e assorbimento dei costi generali.
+  BC-200.50.40:
+    name: Calcolo del costo di prodotti e servizi
+    description: |
+      Calcolo del costo di prodotti, servizi e commesse clienti.
+  BC-200.60:
+    name: Gestione del reporting finanziario
+    description: |
+      Reporting finanziario interno e consolidamento.
+  BC-200.60.10:
+    name: Consolidamento finanziario
+    description: |
+      Consolidamento delle entità legali con eliminazioni e conversione valutaria.
+  BC-200.60.20:
+    name: Reporting finanziario interno
+    description: |
+      Produzione di report interni di conto economico, stato patrimoniale e flusso di cassa.
+  BC-200.60.30:
+    name: Reporting per segmento e direzionale
+    description: |
+      Reporting per segmento e per visione di management.
+  BC-200.60.40:
+    name: Redazione delle informative finanziarie
+    description: |
+      Redazione di note e informativa a supporto dei report finanziari.
+  BC-200.70:
+    name: Reporting statutario e regolamentare
+    description: |
+      Bilanci d'esercizio e adempimenti normativi finanziari.
+  BC-200.70.10:
+    name: Predisposizione del bilancio d'esercizio
+    description: |
+      Predisposizione del bilancio d'esercizio delle singole entità legali.
+  BC-200.70.20:
+    name: Adempimenti normativi finanziari
+    description: |
+      Segnalazioni finanziarie regolamentari di settore e adempimenti prudenziali.
+  BC-200.70.30:
+    name: Coordinamento della revisione esterna
+    description: |
+      Raccordo con i revisori esterni e gestione dei deliverable di audit.
+  BC-200.70.40:
+    name: Rendicontazione di sostenibilità e non finanziaria
+    description: |
+      Informativa non finanziaria e di sostenibilità (es. CSRD, IFRS S1/S2).
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-financial-planning-analysis.yaml
+++ b/catalogue/i18n/it/L1-financial-planning-analysis.yaml
@@ -1,0 +1,111 @@
+# Pianificazione e analisi finanziaria (it) — translations for L1-financial-planning-analysis.yaml
+locale: it
+source: L1-financial-planning-analysis.yaml
+entries:
+  BC-230:
+    name: Pianificazione e analisi finanziaria
+    description: |
+      Previsione, pianificazione, analisi della performance e reporting direzionale.
+  BC-230.10:
+    name: Gestione del budget
+    description: |
+      Processo di budget annuale e consolidamento.
+  BC-230.10.10:
+    name: Calendario e governance del processo di budget
+    description: |
+      Calendario del budget, template e governance del processo.
+  BC-230.10.20:
+    name: Definizione degli obiettivi top-down
+    description: |
+      Definizione degli obiettivi finanziari top-down allineati alla strategia.
+  BC-230.10.30:
+    name: Costruzione del budget bottom-up
+    description: |
+      Budgeting bottom-up per centro di costo, progetto e prodotto.
+  BC-230.10.40:
+    name: Consolidamento e approvazione del budget
+    description: |
+      Consolidamento di gruppo, iterazioni e approvazione definitiva del budget.
+  BC-230.20:
+    name: Gestione delle previsioni
+    description: |
+      Previsioni rolling e pianificazione per scenario.
+  BC-230.20.10:
+    name: Produzione delle previsioni rolling
+    description: |
+      Previsioni rolling di ricavi, costi e flusso di cassa con cadenza mensile o trimestrale.
+  BC-230.20.20:
+    name: Previsione basata sui driver
+    description: |
+      Utilizzo dei driver operativi per prevedere i risultati finanziari.
+  BC-230.20.30:
+    name: Modellazione per scenario e analisi di sensitività
+    description: |
+      Previsioni multi-scenario e analisi di sensitività.
+  BC-230.20.40:
+    name: Monitoraggio dell'accuratezza delle previsioni
+    description: |
+      Monitoraggio e miglioramento dell'accuratezza delle previsioni per voce.
+  BC-230.30:
+    name: Reporting direzionale
+    description: |
+      Reporting direzionale periodico, KPI e dashboard.
+  BC-230.30.10:
+    name: Reporting per il top management e il consiglio
+    description: |
+      Dashboard executive e report di performance per il consiglio di amministrazione.
+  BC-230.30.20:
+    name: Reporting della performance delle business unit
+    description: |
+      Reporting per business unit, segmento e linea di prodotto.
+  BC-230.30.30:
+    name: Definizione e governance dei KPI
+    description: |
+      Tassonomia dei KPI, definizioni e governance sulle metriche.
+  BC-230.30.40:
+    name: Analitiche self-service per il management
+    description: |
+      Abilitazione dell'analisi self-service per i business partner finanziari.
+  BC-230.40:
+    name: Gestione dell'analisi della performance
+    description: |
+      Analisi degli scostamenti, redditività e analisi approfondite.
+  BC-230.40.10:
+    name: Analisi degli scostamenti e consuntivo vs piano
+    description: |
+      Analisi degli scostamenti tra consuntivo, budget e previsione.
+  BC-230.40.20:
+    name: Analisi della redditività
+    description: |
+      Analisi della redditività per cliente, prodotto e canale.
+  BC-230.40.30:
+    name: Analisi dei costi e dell'efficienza
+    description: |
+      Analisi dei driver di costo, indici di efficienza e benchmarking.
+  BC-230.40.40:
+    name: Analisi del capitale circolante
+    description: |
+      Analisi dei cicli di crediti, debiti e magazzino.
+  BC-230.50:
+    name: Gestione dei business case
+    description: |
+      Sviluppo dei business case, valutazione e revisione post-implementazione.
+  BC-230.50.10:
+    name: Sviluppo dei business case
+    description: |
+      Template e metodologie standardizzate per i business case.
+  BC-230.50.20:
+    name: Valutazione degli investimenti
+    description: |
+      Valutazione degli investimenti tramite VAN, TIR, payback e criteri qualitativi.
+  BC-230.50.30:
+    name: Governance dell'allocazione del capitale
+    description: |
+      Comitati di approvazione degli investimenti, soglie e prioritizzazione.
+  BC-230.50.40:
+    name: Monitoraggio della realizzazione dei benefici
+    description: |
+      Revisioni post-implementazione e monitoraggio della realizzazione dei benefici.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-fleet-mobile-asset-management.yaml
+++ b/catalogue/i18n/it/L1-fleet-mobile-asset-management.yaml
@@ -1,0 +1,137 @@
+# Gestione della flotta e degli asset mobili (it) — translations for L1-fleet-mobile-asset-management.yaml
+locale: it
+source: L1-fleet-mobile-asset-management.yaml
+entries:
+  BC-2430:
+    name: Gestione della flotta e degli asset mobili
+    description: |
+      Approvvigionamento, manutenzione, utilizzo e dismissione di veicoli, navi, aeromobili,
+      materiale rotabile e attrezzature in pool quali container, semirimorchi e ULD.
+  BC-2430.10:
+    name: Gestione dell'acquisizione e della dismissione della flotta
+    description: |
+      Specifica, acquisizione, leasing, noleggio e dismissione a fine vita degli asset
+      mobili.
+    in_scope:
+      - Approvvigionamento di veicoli, navi, aeromobili e materiale rotabile
+      - Contratti di noleggio wet, dry e bareboat
+      - Decisioni di fine vita e rivendita
+    out_of_scope:
+      - Approvvigionamento generico di beni indiretti (BC-500)
+      - Contabilità delle immobilizzazioni (BC-200)
+  BC-2430.10.10:
+    name: Specifica e approvvigionamento della flotta
+    description: |
+      Specifica e approvvigionamento di nuovi asset della flotta.
+  BC-2430.10.20:
+    name: Gestione di leasing e noleggio
+    description: |
+      Contratti di leasing operativo, leasing finanziario e noleggio per gli asset della
+      flotta.
+  BC-2430.10.30:
+    name: Dismissione a fine vita
+    description: |
+      Rivendita, demolizione e riciclo degli asset della flotta ritirati.
+  BC-2430.20:
+    name: Gestione della manutenzione della flotta
+    description: |
+      Manutenzione preventiva, correttiva e pesante di veicoli, navi, aeromobili e
+      materiale rotabile.
+  BC-2430.20.10:
+    name: Pianificazione della manutenzione preventiva
+    description: |
+      Pianificazione della manutenzione preventiva basata su tempo e condizione.
+  BC-2430.20.20:
+    name: Esecuzione della manutenzione correttiva
+    description: |
+      Riparazione di guasti e interventi correttivi sugli asset mobili.
+  BC-2430.20.30:
+    name: Conformità alle ispezioni obbligatorie
+    description: |
+      Conformità alle ispezioni obbligatorie per legge e alle direttive di navigabilità
+      aerea o marittima.
+  BC-2430.20.40:
+    name: Revisione e manutenzione pesante
+    description: |
+      Revisione generale, lavori in bacino di carenaggio e interventi di manutenzione
+      pesante.
+  BC-2430.30:
+    name: Gestione del pool di attrezzature
+    description: |
+      Gestione del pool di container, semirimorchi, chassis e ULD tra depositi, clienti
+      e partner.
+  BC-2430.30.10:
+    name: Gestione del pool container
+    description: |
+      Tracciamento e bilanciamento delle flotte di container tra depositi.
+  BC-2430.30.20:
+    name: Gestione del pool di semirimorchi e chassis
+    description: |
+      Gestione del pool di semirimorchi e chassis, inclusa la condivisione grey-pool.
+  BC-2430.30.30:
+    name: Gestione del pool ULD
+    description: |
+      Tracciamento, riparazione e bilanciamento degli ULD tra le stazioni.
+  BC-2430.30.40:
+    name: Operazioni di riposizionamento delle attrezzature vuote
+    description: |
+      Esecuzione dei movimenti di riposizionamento a vuoto tra depositi in surplus e
+      in deficit.
+  BC-2430.40:
+    name: Telematica e monitoraggio della flotta
+    description: |
+      Monitoraggio continuo della posizione, delle condizioni e del comportamento
+      dell'operatore degli asset per supportare manutenzione e operazioni.
+  BC-2430.40.10:
+    name: Operazioni di telematica della flotta
+    description: |
+      Gestione delle piattaforme di telematica che acquisiscono dati di posizione e
+      motore.
+  BC-2430.40.20:
+    name: Monitoraggio delle condizioni degli asset
+    description: |
+      Monitoraggio delle condizioni degli asset mobili, incluso lo stato reefer e delle
+      merci.
+  BC-2430.40.30:
+    name: Monitoraggio del comportamento dell'autista
+    description: |
+      Monitoraggio dei segnali di comportamento dell'autista quali frenate brusche e
+      velocità eccessiva.
+  BC-2430.50:
+    name: Gestione della conformità e delle certificazioni della flotta
+    description: |
+      Immatricolazione, certificazione e conformità alle emissioni degli asset della flotta
+      con autorità di regolamentazione e società di classificazione.
+  BC-2430.50.10:
+    name: Immatricolazione di veicoli, navi e aeromobili
+    description: |
+      Immatricolazione iniziale e continuativa presso le autorità nazionali e internazionali.
+  BC-2430.50.20:
+    name: Ispezione e certificazione obbligatoria
+    description: |
+      Certificati e audit di classificazione, navigabilità aerea e idoneità alla
+      circolazione.
+  BC-2430.50.30:
+    name: Conformità alle emissioni e all'ambiente
+    description: |
+      Conformità ai regimi di emissioni di veicoli, navi e aeromobili.
+  BC-2430.60:
+    name: Gestione dell'utilizzo e della performance della flotta
+    description: |
+      Misurazione dell'utilizzo degli asset, dei tempi di rotazione e del costo totale di
+      proprietà per orientare le decisioni sulla flotta.
+  BC-2430.60.10:
+    name: Reportistica sull'utilizzo degli asset
+    description: |
+      Reportistica sull'utilizzo per tipo di asset, tratta e deposito.
+  BC-2430.60.20:
+    name: Analisi dei tempi di rotazione delle attrezzature
+    description: |
+      Analisi dei tempi di rotazione di container, semirimorchi e ULD.
+  BC-2430.60.30:
+    name: Analisi del costo totale di proprietà
+    description: |
+      Analisi del costo totale di proprietà per tipo di flotta e fornitore.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-food-beverage-operations-management.yaml
+++ b/catalogue/i18n/it/L1-food-beverage-operations-management.yaml
@@ -1,0 +1,194 @@
+# Gestione delle operazioni di ristorazione (it) — translations for L1-food-beverage-operations-management.yaml
+locale: it
+source: L1-food-beverage-operations-management.yaml
+entries:
+  BC-4070:
+    name: Gestione delle operazioni di ristorazione
+    description: |
+      Operazione dei servizi F&B in ristorante, bar, room service, banchettistica
+      e cucina — incluse ingegneria del menù, approvvigionamento, produzione
+      in cucina, servizio, igiene e conformità alla sicurezza alimentare.
+    in_scope:
+      - Gestione di menù e ricette con dati su allergeni e valori nutrizionali
+      - Approvvigionamento F&B, gestione della cantina e operazioni di inventario
+      - Pianificazione della produzione in cucina ed esecuzione in linea
+      - Operazioni di servizio in ristorante, room service e banchettistica
+      - Operazioni HACCP e di sicurezza alimentare
+    out_of_scope:
+      - Ingegneria della struttura (BC-4060.30)
+      - Origine del banquet event order e vendite di gruppo (BC-4110)
+      - Operazioni di cucina a bordo nave nell'ambito di framework specifici per le crociere (BC-4090)
+  BC-4070.10:
+    name: Ingegneria del menù e gestione delle ricette
+    description: |
+      Progettazione di menù e ricette, incluse specifiche, dichiarazioni
+      di allergeni e valori nutrizionali, calcolo del costo e versionamento.
+  BC-4070.10.10:
+    name: Gestione delle ricette e delle specifiche
+    description: |
+      Gestione di ricette, sotto-ricette e specifiche di prodotto
+      per tutti gli outlet.
+  BC-4070.10.20:
+    name: Dichiarazione degli allergeni e dei valori nutrizionali
+    description: |
+      Dichiarazione degli allergeni e dei dati nutrizionali per le voci
+      del menù in conformità alla normativa.
+  BC-4070.10.30:
+    name: Calcolo del costo delle ricette e ingegneria del margine
+    description: |
+      Calcolo del costo delle ricette e progettazione del margine
+      del menù rispetto al food cost target.
+  BC-4070.10.40:
+    name: Versionamento e rollout del menù
+    description: |
+      Versionamento e rollout dei menù per stagioni, outlet e mercati.
+  BC-4070.20:
+    name: Approvvigionamento F&B e gestione dell'inventario
+    description: |
+      Approvvigionamento delle forniture F&B, inventario di cantina,
+      rifornimento ai livelli di par e analisi degli scostamenti teorico/reale.
+  BC-4070.20.10:
+    name: Selezione dei fornitori F&B
+    description: |
+      Selezione dei fornitori F&B, inclusi approvazione
+      e condizioni contrattuali.
+  BC-4070.20.20:
+    name: Gestione dell'inventario di bevande e cantina
+    description: |
+      Gestione dell'inventario di bevande e delle giacenze di cantina,
+      incluso il tracciamento per annata e rotazione.
+  BC-4070.20.30:
+    name: Gestione dei livelli di par e del rifornimento
+    description: |
+      Gestione dei livelli di par e dei cicli di rifornimento
+      tra gli outlet.
+  BC-4070.20.40:
+    name: Analisi degli scostamenti teorico/reale
+    description: |
+      Analisi degli scostamenti del costo effettivo rispetto al teorico
+      per food e beverage, con attribuzione delle cause principali.
+  BC-4070.30:
+    name: Operazioni di produzione in cucina
+    description: |
+      Operazione della produzione in cucina, incluse pianificazione,
+      esecuzione in linea, impiattamento e controllo del food cost.
+  BC-4070.30.10:
+    name: Pianificazione della produzione e mise-en-place
+    description: |
+      Pianificazione dei cicli di produzione in cucina e della
+      mise-en-place prima del servizio.
+  BC-4070.30.20:
+    name: Operazioni di produzione in linea durante il servizio
+    description: |
+      Produzione in linea e coordinamento alla pass durante i periodi di servizio.
+  BC-4070.30.30:
+    name: Impiattamento e controllo qualità
+    description: |
+      Impiattamento e controllo qualità alla pass prima del servizio agli ospiti.
+  BC-4070.30.40:
+    name: Operazioni di controllo del food cost in cucina
+    description: |
+      Operazioni di gestione del food cost, inclusi controlli di resa
+      e rilevazione degli sprechi.
+  BC-4070.40:
+    name: Operazioni di servizio in ristorante e outlet
+    description: |
+      Operazioni di servizio in ristoranti e outlet, incluse prenotazione,
+      disposizione dei tavoli, gestione dei coperti e reset dell'outlet.
+  BC-4070.40.10:
+    name: Gestione delle prenotazioni e della disposizione dei tavoli
+    description: |
+      Gestione delle prenotazioni, dell'allocazione dei tavoli e della
+      lista d'attesa negli outlet.
+  BC-4070.40.20:
+    name: Gestione dei coperti e del ritmo del servizio
+    description: |
+      Gestione del numero di coperti e del ritmo del servizio
+      durante i periodi di servizio.
+  BC-4070.40.30:
+    name: Operazioni di servizio al tavolo
+    description: |
+      Operazioni di servizio al tavolo, inclusi la presa degli ordini,
+      gli standard di servizio e la presentazione del conto.
+  BC-4070.40.40:
+    name: Operazioni di chiusura e reset dell'outlet
+    description: |
+      Chiusura, cassa e reset dell'outlet per il servizio successivo.
+  BC-4070.50:
+    name: Operazioni di room service e mini-bar
+    description: |
+      Acquisizione e consegna degli ordini di room service, rifornimento
+      del mini-bar e operazioni di omaggi in camera.
+  BC-4070.50.10:
+    name: Acquisizione degli ordini di room service
+    description: |
+      Acquisizione degli ordini di room service tramite telefono,
+      app e door-hanger.
+  BC-4070.50.20:
+    name: Operazioni di consegna del room service
+    description: |
+      Consegna degli ordini di room service entro i tempi
+      standard del servizio.
+  BC-4070.50.30:
+    name: Operazioni di rifornimento del mini-bar
+    description: |
+      Rifornimento e rilevazione dei consumi dell'inventario del mini-bar.
+  BC-4070.50.40:
+    name: Operazioni di dotazioni e regalo di benvenuto
+    description: |
+      Operazione delle dotazioni in camera e dell'allestimento del regalo
+      di benvenuto per ospiti VIP e di riconoscimento.
+  BC-4070.60:
+    name: Operazioni di banchettistica e catering
+    description: |
+      Operazioni di banchettistica e catering, inclusi allestimento, servizio,
+      catering off-site e servizio bevande per gli eventi.
+  BC-4070.60.10:
+    name: Operazioni di allestimento e reset della sala banchetti
+    description: |
+      Allestimento, cambio e reset delle sale banchetti
+      tra eventi consecutivi.
+  BC-4070.60.20:
+    name: Operazioni di servizio con piatto unico e buffet
+    description: |
+      Operazioni di servizio per eventi banchetto con piatto unico,
+      buffet e servizio alla famiglia.
+  BC-4070.60.30:
+    name: Operazioni di catering off-site
+    description: |
+      Operazione dei servizi di catering erogati fuori
+      dalla struttura ospitante.
+  BC-4070.60.40:
+    name: Operazioni di servizio bevande in banchettistica
+    description: |
+      Operazioni di servizio bevande negli eventi banchetto,
+      inclusi allestimento del bar e tracciamento dei consumi.
+  BC-4070.70:
+    name: Operazioni di igiene e sicurezza alimentare F&B
+    description: |
+      Operazioni di igiene e sicurezza alimentare, incluse l'esecuzione
+      del piano HACCP, il monitoraggio delle temperature, i controlli
+      sugli allergeni e la gestione degli incidenti.
+  BC-4070.70.10:
+    name: Esecuzione del piano HACCP
+    description: |
+      Esecuzione dei piani HACCP nelle fasi di ricevimento, stoccaggio,
+      preparazione, cottura e mantenimento.
+  BC-4070.70.20:
+    name: Monitoraggio delle temperature e della catena del freddo
+    description: |
+      Monitoraggio della temperatura e dell'integrità della catena del freddo
+      nello stoccaggio e nel servizio F&B.
+  BC-4070.70.30:
+    name: Controlli sulla contaminazione crociata da allergeni
+    description: |
+      Operazione dei controlli sulla contaminazione crociata da allergeni
+      nelle fasi di ricevimento, preparazione e servizio.
+  BC-4070.70.40:
+    name: Gestione degli incidenti di sicurezza alimentare
+    description: |
+      Gestione degli incidenti di sicurezza alimentare, incluse
+      le segnalazioni di sospetta malattia da alimenti.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-food-beverage-processing-operations-management.yaml
+++ b/catalogue/i18n/it/L1-food-beverage-processing-operations-management.yaml
@@ -1,0 +1,161 @@
+# Gestione delle operazioni di trasformazione alimentare e delle bevande (it) — translations for L1-food-beverage-processing-operations-management.yaml
+locale: it
+source: L1-food-beverage-processing-operations-management.yaml
+entries:
+  BC-3580:
+    name: Gestione delle operazioni di trasformazione alimentare e delle bevande
+    description: |
+      Operazioni di produzione industriale di alimenti e bevande — ricevimento delle materie prime,
+      lavorazione primaria e secondaria, confezionamento, produzione in catena del freddo,
+      sanificazione, produzione di mangimi e recupero dei sottoprodotti
+      nei settori della carne, del lattiero-caseario, della molitura, della birra, della panificazione e dei prodotti freschi a taglio.
+  BC-3580.10:
+    name: Ricevimento e ispezione delle materie prime
+    description: |
+      Ricevimento, test sensoriali e di laboratorio e accettazione dei lotti di input agricoli grezzi presso gli stabilimenti di trasformazione.
+  BC-3580.10.10:
+    name: Ricevimento delle materie prime
+    description: |
+      Ricevimento di bestiame, latte, cereali, frutta e verdura come input.
+  BC-3580.10.20:
+    name: Test sensoriali e qualitativi delle materie prime
+    description: |
+      Test sensoriali e di laboratorio sulle materie prime in ingresso.
+  BC-3580.10.30:
+    name: Accettazione dei lotti di materie prime
+    description: |
+      Decisioni di accettazione, rifiuto e riclassificazione dei lotti.
+  BC-3580.20:
+    name: Operazioni di lavorazione primaria
+    description: |
+      Prima trasformazione degli input agricoli grezzi — macellazione e sezionamento,
+      separazione del latte, molitura e preparazione dei prodotti ortofrutticoli.
+    in_scope:
+      - Macellazione e sezionamento delle carcasse
+      - Ricevimento e separazione del latte
+      - Molitura dei cereali e spremitura delle oleaginose
+      - Preparazione di frutta e verdura
+    out_of_scope:
+      - Operazioni manifatturiere generiche (BC-1010)
+  BC-3580.20.10:
+    name: Macellazione e sezionamento delle carcasse
+    description: |
+      Macellazione, sezionamento e refrigerazione delle carcasse di bestiame e avicoli.
+  BC-3580.20.20:
+    name: Ricevimento e separazione del latte
+    description: |
+      Ricevimento del latte, standardizzazione e operazioni di separazione della panna.
+  BC-3580.20.30:
+    name: Molitura dei cereali e spremitura delle oleaginose
+    description: |
+      Molitura dei cereali e spremitura delle oleaginose, inclusa l'estrazione meccanica e con solventi.
+  BC-3580.20.40:
+    name: Preparazione di frutta e verdura
+    description: |
+      Lavaggio, sbucciatura, taglio e blanching di frutta e verdura.
+  BC-3580.30:
+    name: Operazioni di lavorazione secondaria
+    description: |
+      Operazioni di miscelazione, cottura, fermentazione e concentrazione per la produzione di alimenti e bevande finiti.
+  BC-3580.30.10:
+    name: Operazioni di miscelazione e blending
+    description: |
+      Miscelazione e blending di ricette formulate per alimenti e bevande.
+  BC-3580.30.20:
+    name: Cottura e trattamento termico
+    description: |
+      Operazioni di cottura, pastorizzazione e sterilizzazione.
+  BC-3580.30.30:
+    name: Operazioni di fermentazione e produzione birra
+    description: |
+      Fermentazione, produzione di birra e maturazione di bevande e prodotti a cultura microbica.
+  BC-3580.30.40:
+    name: Operazioni di essiccazione e concentrazione
+    description: |
+      Essiccazione spray, evaporazione e concentrazione di prodotti liquidi.
+  BC-3580.40:
+    name: Operazioni di confezionamento e riempimento
+    description: |
+      Riempimento, sigillatura, etichettatura e pallettizzazione dei prodotti alimentari e delle bevande finiti.
+  BC-3580.40.10:
+    name: Operazioni di riempimento e sigillatura
+    description: |
+      Riempimento e sigillatura di bottiglie, lattine, buste e contenitori rigidi.
+  BC-3580.40.20:
+    name: Operazioni di etichettatura
+    description: |
+      Etichettatura, datazione e applicazione di dispositivi antimanomissione.
+  BC-3580.40.30:
+    name: Inscatolamento e pallettizzazione
+    description: |
+      Inscatolamento, fascettatura termoretraibile e pallettizzazione dei prodotti finiti.
+  BC-3580.50:
+    name: Operazioni di produzione in catena del freddo
+    description: |
+      Refrigerazione, congelamento e monitoraggio della catena del freddo negli stabilimenti nelle linee di lavorazione e confezionamento.
+  BC-3580.50.10:
+    name: Operazioni di refrigerazione e congelamento
+    description: |
+      Gestione dei refrigeratori, dei tunnel di surgelazione e dei congelatori rapidi negli stabilimenti.
+  BC-3580.50.20:
+    name: Monitoraggio della catena del freddo negli stabilimenti
+    description: |
+      Monitoraggio della catena del freddo nelle zone degli stabilimenti e nei magazzini.
+  BC-3580.60:
+    name: Operazioni di sanificazione e controllo degli allergeni
+    description: |
+      CIP, controllo del cambio produzione per allergeni e programmi di monitoraggio ambientale a salvaguardia della sicurezza del prodotto.
+    in_scope:
+      - Programmi di CIP (Clean-in-Place)
+      - Validazione del cambio produzione per allergeni
+      - Monitoraggio ambientale degli agenti patogeni
+    out_of_scope:
+      - Programmi di sicurezza alimentare lato distribuzione al dettaglio (BC-2380.10)
+  BC-3580.60.10:
+    name: Operazioni CIP
+    description: |
+      Esecuzione e validazione del CIP nei cambi produzione.
+  BC-3580.60.20:
+    name: Controllo del cambio produzione per allergeni
+    description: |
+      Controlli e campionamenti di verifica per il cambio produzione in presenza di allergeni.
+  BC-3580.60.30:
+    name: Programmi di monitoraggio ambientale
+    description: |
+      Monitoraggio ambientale degli agenti patogeni nelle zone degli stabilimenti.
+  BC-3580.70:
+    name: Operazioni di produzione di mangimi composti
+    description: |
+      Produzione di mangimi composti, inclusi ricevimento degli ingredienti, miscelazione,
+      pellettizzazione e produzione di mangimi medicati per l'uso zootecnico a valle.
+  BC-3580.70.10:
+    name: Ricevimento degli ingredienti per mangimi
+    description: |
+      Ricevimento di cereali, farine proteiche e additivi presso i mangimifici.
+  BC-3580.70.20:
+    name: Miscelazione e pellettizzazione dei mangimi
+    description: |
+      Miscelazione e pellettizzazione di mangimi composti secondo le formulazioni delle razioni.
+  BC-3580.70.30:
+    name: Produzione di mangimi medicati
+    description: |
+      Produzione di mangimi medicati su prescrizione con controlli del riporto.
+  BC-3580.80:
+    name: Gestione dei sottoprodotti e co-prodotti
+    description: |
+      Recupero e destinazione dei sottoprodotti e co-prodotti di processo, quali prodotti della fusione, siero di latte e trebbie, verso usi a valle.
+  BC-3580.80.10:
+    name: Operazioni di fusione
+    description: |
+      Fusione dei sottoprodotti della lavorazione delle carni in sego e farina.
+  BC-3580.80.20:
+    name: Recupero di siero di latte e permeato
+    description: |
+      Recupero dei flussi di siero di latte e permeato dalla trasformazione lattiero-casearia.
+  BC-3580.80.30:
+    name: Recupero delle trebbie esaurite
+    description: |
+      Recupero e destinazione delle trebbie di birrificio e distilleria.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-food-safety-traceability-management.yaml
+++ b/catalogue/i18n/it/L1-food-safety-traceability-management.yaml
@@ -1,0 +1,143 @@
+# Gestione della sicurezza alimentare e della tracciabilità (it) — translations for L1-food-safety-traceability-management.yaml
+locale: it
+source: L1-food-safety-traceability-management.yaml
+entries:
+  BC-2380:
+    name: Gestione della sicurezza alimentare e della tracciabilità
+    description: |
+      Programmi di sicurezza alimentare, tracciabilità di lotti e partite, coordinamento
+      dei richiami, gestione della shelf life dei prodotti deperibili e conformità della
+      catena del freddo per le operazioni di vendita al dettaglio alimentare e di
+      produzione.
+  BC-2380.10:
+    name: Gestione del programma di sicurezza alimentare
+    description: |
+      Policy di sicurezza alimentare, HACCP e programmi di certificazione (BRCGS, SQF,
+      FSSC 22000, IFS Food, ISO 22000) che regolano la gestione e la fornitura degli
+      alimenti.
+    in_scope:
+      - HACCP e policy di sicurezza alimentare
+      - Certificazioni di terze parti (BRCGS, SQF, FSSC 22000, IFS Food)
+      - Gestione degli incidenti di sicurezza alimentare
+    out_of_scope:
+      - Gestione generica della qualità (BC-720)
+  BC-2380.10.10:
+    name: Gestione della policy di sicurezza alimentare
+    description: |
+      Redazione e tutela della policy di sicurezza alimentare in tutta la rete.
+  BC-2380.10.20:
+    name: Gestione del piano HACCP
+    description: |
+      Sviluppo del piano HACCP, analisi dei rischi e monitoraggio dei punti critici di
+      controllo.
+  BC-2380.10.30:
+    name: Gestione della certificazione di sicurezza alimentare
+    description: |
+      Certificazione rispetto agli standard BRCGS, SQF, FSSC 22000, IFS Food e
+      ISO 22000.
+  BC-2380.10.40:
+    name: Gestione degli incidenti di sicurezza alimentare
+    description: |
+      Gestione degli incidenti di sicurezza alimentare, incluso il rilevamento di
+      agenti patogeni.
+  BC-2380.20:
+    name: Gestione della tracciabilità di lotti e partite
+    description: |
+      Tracciabilità di lotti e partite di tipo one-up/one-down lungo la filiera tramite
+      acquisizione di eventi GS1 EPCIS e scambio di dati con i partner commerciali.
+  BC-2380.20.10:
+    name: Codifica di lotti e partite
+    description: |
+      Generazione e stampa dei codici di lotto e partita secondo gli standard GS1.
+  BC-2380.20.20:
+    name: Acquisizione degli eventi EPCIS
+    description: |
+      Acquisizione degli eventi EPCIS (commission, ship, receive) lungo la filiera.
+  BC-2380.20.30:
+    name: Traccia one-up one-down
+    description: |
+      Tracciabilità one-up/one-down degli input e degli output in ciascun nodo di
+      movimentazione.
+  BC-2380.20.40:
+    name: Scambio di dati di tracciabilità con i partner commerciali
+    description: |
+      Scambio di dati di tracciabilità con fornitori e partner commerciali a valle.
+  BC-2380.30:
+    name: Gestione del coordinamento di richiami e ritiri
+    description: |
+      Coordinamento dei richiami e dei ritiri di prodotti alimentari e di largo consumo,
+      incluse la notifica alle autorità di controllo e la comunicazione ai consumatori.
+    in_scope:
+      - Classificazione del richiamo e processo decisionale
+      - Notifica alle autorità di controllo e reporting
+      - Comunicazione ai consumatori e ai partner commerciali
+  BC-2380.30.10:
+    name: Decisione e classificazione del richiamo
+    description: |
+      Decisione e classificazione del perimetro e della gravità del richiamo del
+      prodotto.
+  BC-2380.30.20:
+    name: Notifica alle autorità di controllo
+    description: |
+      Notifica alle autorità di sicurezza alimentare secondo le normative
+      giurisdizionali.
+  BC-2380.30.30:
+    name: Comunicazione ai consumatori e ai partner commerciali
+    description: |
+      Comunicazione ai consumatori e ai partner commerciali riguardo alle azioni di
+      richiamo.
+  BC-2380.30.40:
+    name: Verifica dell'efficacia del richiamo
+    description: |
+      Verifica dell'efficacia del richiamo e dei tassi di recupero.
+  BC-2380.40:
+    name: Gestione dei prodotti deperibili e della shelf life
+    description: |
+      Monitoraggio della shelf life, rotazione FEFO, disciplina delle date di scadenza
+      e riduzione degli sprechi nelle categorie di prodotti deperibili.
+  BC-2380.40.10:
+    name: Shelf life e codifica delle date
+    description: |
+      Definizione e stampa della shelf life e dei codici di data secondo le normative
+      di mercato.
+  BC-2380.40.20:
+    name: Rotazione FEFO (First-Expire-First-Out)
+    description: |
+      Rotazione FEFO nei punti vendita e nei centri di distribuzione.
+  BC-2380.40.30:
+    name: Coordinamento dei markdown sui prodotti deperibili
+    description: |
+      Coordinamento dei markdown sui prodotti deperibili prima della scadenza per la
+      riduzione degli sprechi.
+  BC-2380.40.40:
+    name: Programmi di riduzione degli sprechi alimentari
+    description: |
+      Programmi per la riduzione degli sprechi alimentari, la donazione e il
+      reindirizzamento circolare.
+  BC-2380.50:
+    name: Gestione della conformità della catena del freddo
+    description: |
+      Integrità della catena del freddo per alimenti refrigerati e congelati, inclusi
+      monitoraggio della temperatura, gestione delle deviazioni e decisioni di
+      disposizione.
+    in_scope:
+      - Monitoraggio della temperatura della catena del freddo su tutti i nodi
+      - Indagine sulle deviazioni e disposizione
+      - Procedure operative standard e audit della catena del freddo
+    out_of_scope:
+      - Catena del freddo farmaceutica (BC-1570.10)
+  BC-2380.50.10:
+    name: Monitoraggio della temperatura della catena del freddo
+    description: |
+      Monitoraggio end-to-end della temperatura lungo la catena del freddo alimentare.
+  BC-2380.50.20:
+    name: Gestione delle deviazioni della catena del freddo
+    description: |
+      Indagine e disposizione delle deviazioni di temperatura nella catena del freddo.
+  BC-2380.50.30:
+    name: Audit e verifica della catena del freddo
+    description: |
+      Audit e verifica delle pratiche della catena del freddo in tutta la rete.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-freight-billing-settlement-management.yaml
+++ b/catalogue/i18n/it/L1-freight-billing-settlement-management.yaml
@@ -1,0 +1,112 @@
+# Gestione della fatturazione e del regolamento del trasporto (it) — translations for L1-freight-billing-settlement-management.yaml
+locale: it
+source: L1-freight-billing-settlement-management.yaml
+entries:
+  BC-2530:
+    name: Gestione della fatturazione e del regolamento del trasporto merci
+    description: |
+      Emissione di fatture di trasporto, audit e pagamento delle fatture dei vettori,
+      regolamento interline e pooling, richieste di risarcimento per merci e contabilità
+      dei ricavi da trasporto.
+  BC-2530.10:
+    name: Gestione della fatturazione del trasporto
+    description: |
+      Generazione e distribuzione di fatture di trasporto, addebiti accessori e
+      fatture self-billing ai clienti.
+    in_scope:
+      - Generazione delle fatture di trasporto
+      - Riconciliazione del self-billing dei clienti
+    out_of_scope:
+      - Processi generici di contabilità clienti (BC-200)
+      - Strategia di pricing dei clienti (BC-440)
+  BC-2530.10.10:
+    name: Generazione delle fatture di trasporto
+    description: |
+      Generazione delle fatture di trasporto dai movimenti completati.
+  BC-2530.10.20:
+    name: Generazione delle fatture per addebiti accessori
+    description: |
+      Generazione delle fatture per addebiti accessori e supplementi.
+  BC-2530.10.30:
+    name: Coordinamento del self-billing dei clienti
+    description: |
+      Riconciliazione degli estratti conto di self-billing dei clienti rispetto alle
+      spedizioni.
+  BC-2530.20:
+    name: Gestione dell'audit e del pagamento del trasporto
+    description: |
+      Audit delle fatture dei vettori ed esecuzione dei pagamenti ai vettori da parte
+      di mittenti e spedizionieri.
+  BC-2530.20.10:
+    name: Audit delle fatture dei vettori
+    description: |
+      Audit delle fatture dei vettori rispetto a contratti, tariffari e spedizioni.
+  BC-2530.20.20:
+    name: Riconciliazione pre-audit e post-audit
+    description: |
+      Riconciliazione pre-audit e post-audit delle fatture dei vettori.
+  BC-2530.20.30:
+    name: Esecuzione del pagamento ai vettori
+    description: |
+      Esecuzione dei pagamenti ai vettori e reportistica della rimessa.
+  BC-2530.30:
+    name: Gestione del regolamento interline e multi-vettore
+    description: |
+      Regolamento di ricavi e costi tra partner interline, alleanze e uffici degli
+      spedizionieri.
+  BC-2530.30.10:
+    name: Calcolo del pro-rata interline
+    description: |
+      Calcolo del pro-rata dei ricavi interline tra partner.
+  BC-2530.30.20:
+    name: Operazioni di liquidazione IATA CASS
+    description: |
+      Gestione della liquidazione IATA CASS per il cargo aereo.
+  BC-2530.30.30:
+    name: Regolamento inter-ufficio
+    description: |
+      Regolamento inter-ufficio dei ricavi e dei costi degli spedizionieri.
+  BC-2530.40:
+    name: Gestione delle richieste di risarcimento per merci
+    description: |
+      Ricezione, valutazione e liquidazione delle richieste di risarcimento per merci
+      nell'ambito delle convenzioni sulla responsabilità del trasporto.
+  BC-2530.40.10:
+    name: Ricezione e conferma delle richieste
+    description: |
+      Ricezione e conferma di ricezione delle richieste di risarcimento per perdita e
+      danni alle merci.
+  BC-2530.40.20:
+    name: Valutazione della responsabilità
+    description: |
+      Valutazione della responsabilità del vettore ai sensi delle convenzioni
+      Hague-Visby, Montreal, CMR e COTIF.
+  BC-2530.40.30:
+    name: Liquidazione e recupero delle richieste
+    description: |
+      Liquidazione delle richieste accettate e pagamento al cliente.
+  BC-2530.40.40:
+    name: Rivalsa e surrogazione
+    description: |
+      Rivalsa verso i vettori sottostanti e surrogazione verso le compagnie di
+      assicurazione.
+  BC-2530.50:
+    name: Gestione della contabilità dei ricavi da trasporto
+    description: |
+      Rilevazione, monitoraggio e reportistica dei ricavi da trasporto, incluse le
+      posizioni non fatturate e differite.
+  BC-2530.50.10:
+    name: Rilevazione dei ricavi da trasporto
+    description: |
+      Rilevazione dei ricavi da trasporto secondo i principi contabili applicabili.
+  BC-2530.50.20:
+    name: Monitoraggio dei ricavi non fatturati
+    description: |
+      Monitoraggio dei ricavi da trasporto non fatturati e maturati.
+  BC-2530.50.30:
+    name: Reportistica dei ricavi da trasporto
+    description: |
+      Reportistica dei ricavi da trasporto alle funzioni finanziarie e commerciali.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-freight-capacity-management.yaml
+++ b/catalogue/i18n/it/L1-freight-capacity-management.yaml
@@ -1,0 +1,118 @@
+# Gestione della capacità di trasporto merci (it) — translations for L1-freight-capacity-management.yaml
+locale: it
+source: L1-freight-capacity-management.yaml
+entries:
+  BC-2400:
+    name: Gestione della capacità di trasporto merci
+    description: |
+      Vendita, allocazione e yield management della capacità di trasporto per navigazioni,
+      voli, tratte stradali e ferroviarie e pool di attrezzature.
+  BC-2400.10:
+    name: Gestione dell'inventario di capacità
+    description: |
+      Manutenzione della capacità di trasporto disponibile per modo, tratta, orario e tipo
+      di attrezzatura, come fonte per allocazione e prenotazione.
+    in_scope:
+      - Registri di capacità per navi, voli, veicoli e materiale rotabile
+      - Capacità del pool di attrezzature (container, semirimorchi, ULD)
+      - Capacità della tratta collegata agli orari
+    out_of_scope:
+      - Progettazione a lungo termine della rete e degli orari (BC-2410)
+      - Accettazione di prenotazioni e riserve (BC-2400.40)
+  BC-2400.10.10:
+    name: Inventario di capacità di navi e mezzi di trasporto
+    description: |
+      Registrazione della capacità in termini di carico utile, spazio coperta e spazio
+      cabina per nave, aeromobile, treno o veicolo.
+  BC-2400.10.20:
+    name: Inventario di capacità delle attrezzature
+    description: |
+      Inventario dei container, semirimorchi, chassis e ULD disponibili per ubicazione
+      e condizione.
+  BC-2400.10.30:
+    name: Capacità della tratta e degli orari
+    description: |
+      Capacità per servizio programmato su una tratta, compresi i tratti di collegamento.
+  BC-2400.10.40:
+    name: Pooling della capacità e scambio di slot
+    description: |
+      Capacità condivisa nelle alleanze e accordi di scambio slot con vettori partner.
+  BC-2400.20:
+    name: Gestione dell'allocazione della capacità
+    description: |
+      Allocazione della capacità disponibile tra contratti clienti, segmenti di mercato
+      e domanda spot.
+  BC-2400.20.10:
+    name: Allocazione della capacità contrattuale
+    description: |
+      Allocazione di capacità ai clienti coperti da impegni di quantità minima e accordi
+      nominativi.
+  BC-2400.20.20:
+    name: Allocazione della capacità sul mercato spot
+    description: |
+      Allocazione di capacità rilasciata sui canali di prenotazione del mercato spot.
+  BC-2400.20.30:
+    name: Riallocazione e recupero della capacità
+    description: |
+      Riallocazione della capacità inutilizzata o recuperata prima del cut-off.
+  BC-2400.30:
+    name: Yield e revenue management
+    description: |
+      Ottimizzazione del ricavo per unità di capacità attraverso decisioni di pricing,
+      mix e overbooking.
+  BC-2400.30.10:
+    name: Previsione della domanda di capacità
+    description: |
+      Previsione delle prenotazioni, no-show e rischio di offload per servizio.
+  BC-2400.30.20:
+    name: Ottimizzazione dello yield
+    description: |
+      Ottimizzazione del mix di classi tariffarie per massimizzare lo yield per tonnellata,
+      slot o TEU.
+  BC-2400.30.30:
+    name: Gestione dell'overbooking
+    description: |
+      Definizione e monitoraggio dei limiti di overbooking e dell'esposizione agli offload.
+  BC-2400.30.40:
+    name: Gestione del mix di ricavi
+    description: |
+      Gestione del mix di ricavi tra linee contrattuali, spot e accessorie.
+  BC-2400.40:
+    name: Gestione delle prenotazioni e delle riserve
+    description: |
+      Accettazione, modifica e cancellazione delle prenotazioni di capacità rispetto agli
+      orari e alle quotazioni pubblicate.
+  BC-2400.40.10:
+    name: Prenotazione della capacità
+    description: |
+      Accettazione delle prenotazioni rispetto alla capacità disponibile e alla validità
+      delle tariffe.
+  BC-2400.40.20:
+    name: Modifica e cancellazione delle prenotazioni
+    description: |
+      Variazioni, rollover e cancellazioni delle prenotazioni, incluse le penali per
+      no-show.
+  BC-2400.40.30:
+    name: Gestione delle liste d'attesa e stand-by
+    description: |
+      Gestione del carico in stand-by e in lista d'attesa per la capacità confermata.
+  BC-2400.50:
+    name: Gestione della performance della capacità
+    description: |
+      Monitoraggio del fattore di carico, del riempimento e dell'utilizzo per orientare
+      le decisioni sul mix di capacità e le modifiche alla rete.
+  BC-2400.50.10:
+    name: Analisi del fattore di carico
+    description: |
+      Analisi del fattore di carico per servizio, tratta e segmento.
+  BC-2400.50.20:
+    name: Reportistica sull'utilizzo della capacità
+    description: |
+      Reportistica sull'utilizzo della capacità destinata ai team commerciali e operativi.
+  BC-2400.50.30:
+    name: Miglioramento della performance della capacità
+    description: |
+      Iniziative per migliorare il ricavo per slot e ridurre il riposizionamento a vuoto.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-freight-forwarding-brokerage-management.yaml
+++ b/catalogue/i18n/it/L1-freight-forwarding-brokerage-management.yaml
@@ -1,0 +1,102 @@
+# Gestione delle spedizioni e del brokeraggio logistico (it) — translations for L1-freight-forwarding-brokerage-management.yaml
+locale: it
+source: L1-freight-forwarding-brokerage-management.yaml
+entries:
+  BC-2450:
+    name: Gestione delle spedizioni e del brokeraggio logistico
+    description: |
+      Organizzazione del trasporto per conto dei mittenti nelle vesti di spedizioniere,
+      NVOCC, broker di trasporto o spedizioniere doganale, incluso il coordinamento
+      multimodale e le operazioni della rete partner.
+  BC-2450.10:
+    name: Gestione delle quotazioni ai mittenti
+    description: |
+      Ricezione delle richieste di offerta (RFQ) dai mittenti ed emissione di tariffe
+      dello spedizioniere su più modi e vettori.
+    in_scope:
+      - Ricerca tariffaria multi-vettore per le richieste dei mittenti
+      - Monitoraggio della validità e della conferma delle offerte
+    out_of_scope:
+      - Gestione dei listini tariffe e dei tariffari lato vettore (BC-2520)
+  BC-2450.10.10:
+    name: Acquisizione delle richieste di offerta
+    description: |
+      Acquisizione delle richieste di offerta dei mittenti attraverso i vari canali.
+  BC-2450.10.20:
+    name: Ricerca tariffaria multi-vettore
+    description: |
+      Ricerca e comparazione delle tariffe tra i vettori sottostanti.
+  BC-2450.10.30:
+    name: Emissione e validità dell'offerta
+    description: |
+      Emissione di offerte vincolanti e indicative e monitoraggio della loro validità.
+  BC-2450.20:
+    name: Gestione dell'approvvigionamento e dell'allocazione dei vettori
+    description: |
+      Prenotazione di capacità presso i vettori sottostanti e gestione delle allocazioni
+      e della spesa verso i vettori.
+  BC-2450.20.10:
+    name: Selezione del vettore
+    description: |
+      Selezione dei vettori sottostanti per spedizione.
+  BC-2450.20.20:
+    name: Esecuzione della prenotazione presso il vettore
+    description: |
+      Prenotazione della capacità presso i vettori selezionati.
+  BC-2450.20.30:
+    name: Ottimizzazione della spesa sulle allocazioni
+    description: |
+      Ottimizzazione della spesa dello spedizioniere sulle allocazioni dei vettori.
+  BC-2450.30:
+    name: Coordinamento del trasporto multimodale
+    description: |
+      Coordinamento di movimenti multi-tratta e multimodali, inclusi consolidamento,
+      deconsolidamento e polizze house.
+  BC-2450.30.10:
+    name: Emissione della polizza di carico house
+    description: |
+      Emissione delle polizze di carico house dello spedizioniere per i mittenti.
+  BC-2450.30.20:
+    name: Coordinamento dei movimenti multi-tratta
+    description: |
+      Coordinamento di movimenti multi-tratta tra vettori e modi di trasporto.
+  BC-2450.30.30:
+    name: Consolidamento e deconsolidamento
+    description: |
+      Consolidamento delle merci all'origine e deconsolidamento a destinazione.
+  BC-2450.40:
+    name: Gestione del brokeraggio doganale
+    description: |
+      Erogazione di servizi di brokeraggio doganale per conto di importatori ed esportatori.
+  BC-2450.40.10:
+    name: Predisposizione della dichiarazione doganale
+    description: |
+      Predisposizione delle dichiarazioni doganali per conto dei clienti.
+  BC-2450.40.20:
+    name: Calcolo di dazi e imposte
+    description: |
+      Calcolo e pagamento di dazi e imposte indirette per conto dei clienti.
+  BC-2450.40.30:
+    name: Monitoraggio dello stato del brokeraggio
+    description: |
+      Monitoraggio dell'avanzamento del brokeraggio e risoluzione delle eccezioni.
+  BC-2450.50:
+    name: Coordinamento della rete degli spedizionieri
+    description: |
+      Coordinamento con gli agenti di origine, destinazione e partner nella rete degli
+      spedizionieri, incluso il regolamento inter-ufficio.
+  BC-2450.50.10:
+    name: Coordinamento con gli agenti di origine e destinazione
+    description: |
+      Coordinamento delle attività con gli agenti di origine e destinazione.
+  BC-2450.50.20:
+    name: Regolamento inter-ufficio
+    description: |
+      Regolamento inter-ufficio e inter-agente dei ricavi e dei costi di spedizione.
+  BC-2450.50.30:
+    name: Gestione della performance degli agenti partner
+    description: |
+      Gestione della qualità del servizio e della conformità degli agenti partner.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-freight-rating-tariff-management.yaml
+++ b/catalogue/i18n/it/L1-freight-rating-tariff-management.yaml
@@ -1,0 +1,109 @@
+# Gestione della tariffazione e dei tariffari del trasporto (it) — translations for L1-freight-rating-tariff-management.yaml
+locale: it
+source: L1-freight-rating-tariff-management.yaml
+entries:
+  BC-2520:
+    name: Gestione della tariffazione e dei tariffari del trasporto merci
+    description: |
+      Definizione e gestione delle tariffe di trasporto, dei tariffari, dei prezzi
+      contrattuali, dei prezzi spot, degli addebiti accessori e del motore di tariffazione
+      che calcola i costi dei movimenti merci.
+  BC-2520.10:
+    name: Gestione dei tariffari e dei listini tariffe
+    description: |
+      Definizione, pubblicazione e versionamento dei tariffari pubblici e dei listini
+      tariffe base.
+    in_scope:
+      - Definizione del listino tariffe base per tratta e unità
+      - Pubblicazione del tariffario pubblico ove richiesto
+    out_of_scope:
+      - Quotazione rivolta al cliente nel contesto della spedizione (BC-2450.10)
+      - Metodi di pricing aziendale generico (BC-440)
+  BC-2520.10.10:
+    name: Definizione della tariffa base
+    description: |
+      Definizione delle tariffe di trasporto base per tratta, unità e livello di servizio.
+  BC-2520.10.20:
+    name: Pubblicazione del tariffario pubblico
+    description: |
+      Deposito dei tariffari pubblici presso le autorità di regolamentazione e le
+      conferenze ove richiesto.
+  BC-2520.10.30:
+    name: Versionamento del listino tariffe
+    description: |
+      Controllo delle versioni e gestione delle date di entrata in vigore dei listini
+      tariffe.
+  BC-2520.20:
+    name: Gestione delle tariffe contrattuali
+    description: |
+      Configurazione e manutenzione delle tariffe negoziate con clienti nominativi e
+      impegni di volume.
+  BC-2520.20.10:
+    name: Configurazione delle tariffe contrattuali
+    description: |
+      Configurazione delle tariffe negoziate rispetto ai contratti clienti nominativi.
+  BC-2520.20.20:
+    name: Monitoraggio degli impegni di volume
+    description: |
+      Monitoraggio degli impegni di volume dei clienti e degli obiettivi di quantità
+      minima.
+  BC-2520.20.30:
+    name: Rinnovo delle tariffe contrattuali
+    description: |
+      Rinnovo e rinegoziazione delle tariffe contrattuali in scadenza.
+  BC-2520.30:
+    name: Gestione delle tariffe spot
+    description: |
+      Pricing, accettazione e benchmarking delle tariffe di trasporto sul mercato spot.
+  BC-2520.30.10:
+    name: Quotazione della tariffa spot
+    description: |
+      Quotazione delle tariffe spot per spedizione.
+  BC-2520.30.20:
+    name: Accettazione della tariffa spot
+    description: |
+      Accettazione e conferma delle prenotazioni a tariffa spot.
+  BC-2520.30.30:
+    name: Benchmarking degli indici delle tariffe spot
+    description: |
+      Benchmarking delle tariffe spot rispetto agli indici di mercato.
+  BC-2520.40:
+    name: Gestione degli addebiti accessori e dei supplementi
+    description: |
+      Definizione e applicazione di addebiti accessori, supplementi, demurrage e tariffe
+      di detention.
+  BC-2520.40.10:
+    name: Gestione del supplemento carburante
+    description: |
+      Definizione e applicazione di supplementi carburante e bunker.
+  BC-2520.40.20:
+    name: Definizione degli addebiti accessori
+    description: |
+      Definizione degli addebiti accessori per attesa, movimentazione speciale e
+      attrezzature.
+  BC-2520.40.30:
+    name: Tariffe di demurrage e detention
+    description: |
+      Definizione delle tariffe di demurrage e detention per attrezzature e utilizzo
+      del terminal.
+  BC-2520.50:
+    name: Gestione del motore di tariffazione
+    description: |
+      Gestione del motore di tariffazione che calcola e valida i costi di trasporto
+      su ordini e spedizioni.
+  BC-2520.50.10:
+    name: Esecuzione del calcolo tariffario
+    description: |
+      Esecuzione dei calcoli tariffari su ordini e spedizioni.
+  BC-2520.50.20:
+    name: Distribuzione dei listini tariffe
+    description: |
+      Distribuzione dei listini tariffe a clienti, partner e canali.
+  BC-2520.50.30:
+    name: Audit e validazione delle tariffe
+    description: |
+      Validazione delle tariffe applicate rispetto ai contratti e ai tariffari di
+      riferimento.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-functional-safety-reliability-management.yaml
+++ b/catalogue/i18n/it/L1-functional-safety-reliability-management.yaml
@@ -1,0 +1,133 @@
+# Gestione della sicurezza funzionale e dell'affidabilità (it) — translations for L1-functional-safety-reliability-management.yaml
+locale: it
+source: L1-functional-safety-reliability-management.yaml
+entries:
+  BC-1970:
+    name: Gestione della sicurezza funzionale e dell'affidabilità
+    description: |
+      Analisi della sicurezza funzionale a livello di prodotto (IEC 61508/61511/13849, ISO 26262)
+      e ingegneria dell'affidabilità — distinta dalla qualità generica e dall'esecuzione delle
+      prove di produzione.
+  BC-1970.10:
+    name: Gestione dell'analisi della sicurezza funzionale
+    description: |
+      Analisi dei pericoli, del rischio e del concetto di sicurezza per prodotti elettrici safety-related.
+  BC-1970.10.10:
+    name: Analisi dei pericoli e del rischio
+    description: |
+      Identificazione dei pericoli e analisi del rischio per prodotti safety-related.
+  BC-1970.10.20:
+    name: Definizione del concetto di sicurezza
+    description: |
+      Definizione dei concetti di sicurezza funzionale e tecnica.
+  BC-1970.10.30:
+    name: Allocazione dei requisiti di sicurezza
+    description: |
+      Allocazione dei requisiti di sicurezza a sottosistemi e componenti.
+  BC-1970.10.40:
+    name: Redazione del caso di sicurezza
+    description: |
+      Redazione dei casi di sicurezza a supporto del rilascio del prodotto.
+  BC-1970.20:
+    name: Determinazione del livello di integrità della sicurezza
+    description: |
+      Definizione degli obiettivi di integrità secondo IEC 61508, ISO 26262 e ISO 13849.
+  BC-1970.20.10:
+    name: Definizione dell'obiettivo SIL
+    description: |
+      Determinazione dei livelli di integrità della sicurezza SIL secondo IEC 61508.
+  BC-1970.20.20:
+    name: Scomposizione ASIL
+    description: |
+      Scomposizione ASIL per l'elettronica automotive safety-related.
+  BC-1970.20.30:
+    name: Determinazione del livello di prestazione
+    description: |
+      Determinazione del livello di prestazione secondo ISO 13849.
+  BC-1970.30:
+    name: Gestione dell'ingegneria dell'affidabilità
+    description: |
+      Definizione dei requisiti di affidabilità, previsione, allocazione e pianificazione della crescita.
+  BC-1970.30.10:
+    name: Definizione dei requisiti di affidabilità
+    description: |
+      Definizione dei requisiti di affidabilità in linea con i profili missione.
+  BC-1970.30.20:
+    name: Modellazione della previsione di affidabilità
+    description: |
+      Modellazione previsionale tramite metodi di conteggio dei componenti e di stress.
+  BC-1970.30.30:
+    name: Allocazione dell'affidabilità
+    description: |
+      Allocazione top-down dei budget di affidabilità ai sottosistemi.
+  BC-1970.30.40:
+    name: Pianificazione della crescita dell'affidabilità
+    description: |
+      Pianificazione della crescita dell'affidabilità e delle azioni correttive.
+  BC-1970.40:
+    name: Declassamento e analisi dello stress dei componenti
+    description: |
+      Analisi dello stress elettrico, termico e meccanico e del declassamento dei componenti.
+  BC-1970.40.10:
+    name: Declassamento elettrico
+    description: |
+      Applicazione delle regole di declassamento elettrico ai componenti.
+  BC-1970.40.20:
+    name: Declassamento termico
+    description: |
+      Analisi del declassamento termico per i componenti nel loro ambiente operativo.
+  BC-1970.40.30:
+    name: Analisi dello stress meccanico
+    description: |
+      Analisi dello stress meccanico e della fatica sui componenti.
+  BC-1970.50:
+    name: Analisi dei modi di guasto
+    description: |
+      FMEA di progetto e di processo, e analisi della criticità FMECA.
+  BC-1970.50.10:
+    name: FMEA di progetto
+    description: |
+      Analisi dei modi di guasto e degli effetti di progetto sui prodotti.
+  BC-1970.50.20:
+    name: FMEA di processo
+    description: |
+      Analisi dei modi di guasto e degli effetti di processo sulla produzione.
+  BC-1970.50.30:
+    name: Analisi della criticità FMECA
+    description: |
+      Analisi della criticità sovrapposta agli output della FMEA.
+  BC-1970.60:
+    name: Gestione dei guasti in campo e della crescita dell'affidabilità
+    description: |
+      Raccolta e analisi dei dati sui guasti in campo per la crescita dell'affidabilità.
+  BC-1970.60.10:
+    name: Raccolta dei dati sui guasti in campo
+    description: |
+      Raccolta dei dati sui guasti dalla base installata.
+  BC-1970.60.20:
+    name: Analisi delle tendenze dei modi di guasto
+    description: |
+      Analisi delle tendenze sui modi di guasto osservati.
+  BC-1970.60.30:
+    name: Monitoraggio della crescita dell'affidabilità
+    description: |
+      Monitoraggio della crescita dell'affidabilità nelle successive generazioni di prodotto.
+  BC-1970.70:
+    name: Coordinamento della certificazione di sicurezza funzionale
+    description: |
+      Rapporto con i valutatori di sicurezza funzionale e gli organismi di certificazione.
+  BC-1970.70.10:
+    name: Coinvolgimento del valutatore di sicurezza funzionale
+    description: |
+      Coinvolgimento di valutatori indipendenti di sicurezza funzionale.
+  BC-1970.70.20:
+    name: Presentazione della domanda di certificazione della sicurezza
+    description: |
+      Invio dei dossier di sicurezza funzionale per la certificazione.
+  BC-1970.70.30:
+    name: Sorveglianza della sicurezza funzionale
+    description: |
+      Audit di sorveglianza periodica sui processi di sicurezza funzionale.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-gas-processing-lng-operations-management.yaml
+++ b/catalogue/i18n/it/L1-gas-processing-lng-operations-management.yaml
@@ -1,0 +1,118 @@
+# Gestione del trattamento del gas e delle operazioni GNL (it) — translations for L1-gas-processing-lng-operations-management.yaml
+locale: it
+source: L1-gas-processing-lng-operations-management.yaml
+entries:
+  BC-3070:
+    name: Gestione del trattamento del gas e delle operazioni GNL
+    description: |
+      Operazione del trattamento del gas, frazionamento degli NGL, liquefazione del GNL,
+      carico e send-out, rigassificazione e garanzia della qualità del gas nelle catene
+      del valore del gas midstream.
+  BC-3070.10:
+    name: Operazioni dell'impianto di trattamento del gas
+    description: |
+      Operazione degli impianti di ricezione in ingresso, trattamento, disidratazione
+      e recupero dello zolfo presso gli impianti di trattamento del gas.
+  BC-3070.10.10:
+    name: Ricezione del gas e gestione dell'ingresso
+    description: |
+      Ricezione, separazione dei slug e condizionamento del gas di alimentazione in ingresso.
+  BC-3070.10.20:
+    name: Operazioni di trattamento dell'acido gassoso
+    description: |
+      Operazioni di trattamento dell'acido gassoso con ammina e solvente fisico.
+  BC-3070.10.30:
+    name: Operazioni di disidratazione del gas
+    description: |
+      Disidratazione del gas naturale con glicole e setacci molecolari.
+  BC-3070.10.40:
+    name: Operazioni di recupero dello zolfo
+    description: |
+      Operazioni Claus e di trattamento del tail gas per il recupero dello zolfo.
+  BC-3070.20:
+    name: Operazioni di frazionamento degli NGL
+    description: |
+      Operazione di demetanizzatori, deetanizzatori e torri di frazionamento a valle
+      che producono etano, propano, butano e benzina naturale.
+  BC-3070.20.10:
+    name: Operazioni del demetanizzatore
+    description: |
+      Operazione delle colonne criogeniche del demetanizzatore per il recupero dell'etano.
+  BC-3070.20.20:
+    name: Operazioni del deetanizzatore e del depropanizzatore
+    description: |
+      Operazione delle colonne di deetanizzazione, depropanizzazione e debutanizzazione.
+  BC-3070.20.30:
+    name: Operazioni di stoccaggio degli NGL
+    description: |
+      Operazione dello stoccaggio degli NGL pressurizzato e refrigerato.
+  BC-3070.30:
+    name: Operazioni di liquefazione del GNL
+    description: |
+      Operazione dei treni di liquefazione, dei cicli di refrigerazione e dei serbatoi di stoccaggio del GNL.
+  BC-3070.30.10:
+    name: Operazioni del ciclo di refrigerazione
+    description: |
+      Operazione dei cicli di refrigerazione a refrigerante misto e a cascata.
+  BC-3070.30.20:
+    name: Operazioni del treno GNL
+    description: |
+      Operazione end-to-end dei treni di liquefazione del GNL.
+  BC-3070.30.30:
+    name: Operazioni del serbatoio di stoccaggio del GNL
+    description: |
+      Operazione dei serbatoi criogenici di stoccaggio del GNL inclusa la prevenzione del rollover.
+  BC-3070.40:
+    name: Operazioni di carico e send-out del GNL
+    description: |
+      Carico delle navi, raffreddamento del carico e vaporizzazione per il send-out via pipeline
+      presso i terminali di liquefazione.
+  BC-3070.40.10:
+    name: Carico navi GNL
+    description: |
+      Operazioni di carico delle navi ai pontili di export del GNL.
+  BC-3070.40.20:
+    name: Vaporizzazione per il send-out
+    description: |
+      Vaporizzazione per il send-out ed export via pipeline dagli impianti di liquefazione.
+  BC-3070.40.30:
+    name: Coordinamento del raffreddamento del carico
+    description: |
+      Coordinamento del raffreddamento delle navi da trasporto GNL prima del carico.
+  BC-3070.50:
+    name: Operazioni di rigassificazione del GNL
+    description: |
+      Operazione dei terminali GNL di importazione: vaporizzazione, controllo della
+      pressione di send-out e gestione del boil-off gas.
+  BC-3070.50.10:
+    name: Operazioni dei vaporizzatori
+    description: |
+      Operazione di vaporizzatori a griglia aperta, a combustione sommersa e a fascio tubiero.
+  BC-3070.50.20:
+    name: Controllo della pressione di send-out
+    description: |
+      Controllo della pressione di send-out e iniezione in rete dai terminali di importazione.
+  BC-3070.50.30:
+    name: Gestione del boil-off gas
+    description: |
+      Ri-liquefazione o send-out del boil-off gas dai serbatoi di stoccaggio.
+  BC-3070.60:
+    name: Gestione della qualità del gas
+    description: |
+      Conformità alle specifiche di qualità del gas per pipeline e GNL e gestione
+      dei flussi fuori specifica.
+  BC-3070.60.10:
+    name: Monitoraggio della conformità alle specifiche
+    description: |
+      Monitoraggio continuo delle specifiche di qualità del gas per pipeline e GNL.
+  BC-3070.60.20:
+    name: Campionamento e analisi del gas
+    description: |
+      Campionamento di routine del gas, cromatografia e generazione dei certificati.
+  BC-3070.60.30:
+    name: Gestione del gas fuori specifica
+    description: |
+      Instradamento, miscelazione e rilavorazione dei flussi di gas fuori specifica.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-government-grants-funding-management.yaml
+++ b/catalogue/i18n/it/L1-government-grants-funding-management.yaml
@@ -1,0 +1,115 @@
+# Gestione delle sovvenzioni e dei finanziamenti pubblici (it) — translations for L1-government-grants-funding-management.yaml
+locale: it
+source: L1-government-grants-funding-management.yaml
+entries:
+  BC-3260:
+    name: Gestione delle sovvenzioni e dei finanziamenti pubblici
+    description: |
+      Assegnazione e gestione di contributi competitivi e formulari e di finanziamenti pubblici a organizzazioni, comunità e individui, inclusi avviso, esame delle domande, concessione, monitoraggio e chiusura.
+  BC-3260.10:
+    name: Progettazione dei programmi di contributi
+    description: |
+      Progettazione dei programmi di contributi, inclusi obiettivi, eleggibilità, formule di finanziamento e criteri di valutazione.
+  BC-3260.10.10:
+    name: Definizione degli obiettivi del programma
+    description: |
+      Definizione degli obiettivi del programma di contributi, dei risultati attesi e della teoria del cambiamento.
+  BC-3260.10.20:
+    name: Modellazione dell'allocazione dei finanziamenti
+    description: |
+      Modellazione delle allocazioni di finanziamento, inclusi schemi formulari, competitivi e di cofinanziamento.
+  BC-3260.10.30:
+    name: Definizione dei criteri di valutazione
+    description: |
+      Definizione dei criteri di revisione del merito e di valutazione per la selezione dei contributi.
+  BC-3260.20:
+    name: Gestione degli avvisi di finanziamento
+    description: |
+      Pubblicazione delle opportunità di finanziamento, degli avvisi di disponibilità dei fondi e della documentazione dei bandi.
+  BC-3260.20.10:
+    name: Pubblicazione delle opportunità di finanziamento
+    description: |
+      Pubblicazione dei bandi, degli avvisi di disponibilità dei fondi e della documentazione correlata.
+  BC-3260.20.20:
+    name: Sensibilizzazione e supporto ai richiedenti
+    description: |
+      Attività di sensibilizzazione, sessioni informative e supporto ai richiedenti per i programmi di contributi.
+  BC-3260.20.30:
+    name: Gestione delle domande pre-concessione
+    description: |
+      Gestione delle domande e dei chiarimenti pre-concessione da parte dei potenziali richiedenti.
+  BC-3260.30:
+    name: Ricezione e revisione delle domande
+    description: |
+      Ricezione, screening e revisione del merito delle domande di contributo, inclusa la revisione in commissione e la valutazione.
+  BC-3260.30.10:
+    name: Presentazione della domanda
+    description: |
+      Presentazione e ricezione delle domande di contributo e della documentazione a supporto.
+  BC-3260.30.20:
+    name: Verifica dell'eleggibilità
+    description: |
+      Verifica delle domande rispetto ai criteri di eleggibilità e alle soglie minime.
+  BC-3260.30.30:
+    name: Revisione del merito e valutazione
+    description: |
+      Revisione in commissione, valutazione e classificazione delle domande rispetto ai criteri pubblicati.
+  BC-3260.30.40:
+    name: Gestione dei revisori e dei conflitti di interesse
+    description: |
+      Reclutamento dei revisori e gestione dei conflitti di interesse.
+  BC-3260.40:
+    name: Decisione di concessione e finanziamento
+    description: |
+      Decisioni di concessione, emissione dell'accordo di contributo e impegno dei fondi ai beneficiari.
+  BC-3260.40.10:
+    name: Selezione dei contributi
+    description: |
+      Selezione finale delle domande ammesse e degli importi concessi.
+  BC-3260.40.20:
+    name: Emissione dell'accordo di contributo
+    description: |
+      Redazione e sottoscrizione degli accordi di contributo e dei relativi termini e condizioni.
+  BC-3260.40.30:
+    name: Impegno e definizione delle erogazioni
+    description: |
+      Impegno dei fondi e definizione dei calendari di erogazione.
+  BC-3260.50:
+    name: Monitoraggio e rendicontazione dei beneficiari
+    description: |
+      Monitoraggio della performance dei beneficiari, rendicontazione finanziaria e conformità alle condizioni del contributo.
+  BC-3260.50.10:
+    name: Revisione dei rapporti di performance
+    description: |
+      Revisione dei rapporti di performance e di avanzamento dei beneficiari rispetto alle tappe fondamentali.
+  BC-3260.50.20:
+    name: Revisione dei rapporti finanziari
+    description: |
+      Revisione dei rapporti finanziari e delle richieste di prelievo dei beneficiari.
+  BC-3260.50.30:
+    name: Monitoraggio in loco e verifica
+    description: |
+      Visite in loco e verifica delle attività e dei prodotti dei beneficiari.
+  BC-3260.50.40:
+    name: Supervisione dei sub-beneficiari
+    description: |
+      Supervisione degli accordi di trasferimento e dei sub-beneficiari.
+  BC-3260.60:
+    name: Chiusura del contributo e risoluzione dell'audit
+    description: |
+      Rendicontazione finale, chiusura, risoluzione degli audit e recupero dei costi non ammissibili.
+  BC-3260.60.10:
+    name: Accettazione del rapporto finale e dei prodotti
+    description: |
+      Accettazione dei rapporti finali e dei prodotti alla conclusione del programma.
+  BC-3260.60.20:
+    name: Risoluzione degli audit di conformità
+    description: |
+      Risoluzione dei rilievi degli audit unici e di conformità nei confronti dei beneficiari.
+  BC-3260.60.30:
+    name: Recupero dei costi non ammissibili
+    description: |
+      Recupero dei costi non ammissibili e dei saldi non impegnati alla chiusura.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-grid-control-balancing-management.yaml
+++ b/catalogue/i18n/it/L1-grid-control-balancing-management.yaml
@@ -1,0 +1,133 @@
+# Gestione del controllo e bilanciamento della rete (it) — translations for L1-grid-control-balancing-management.yaml
+locale: it
+source: L1-grid-control-balancing-management.yaml
+entries:
+  BC-3830:
+    name: Gestione del controllo e bilanciamento della rete
+    description: |
+      Funzione di gestore del sistema per il sistema elettrico di trasmissione — bilanciamento
+      in tempo reale di generazione e domanda, controllo della frequenza e della tensione,
+      riserve e servizi ancillari, pianificazione operativa, coordinamento transfrontaliero
+      e preparazione al ripristino da black-start.
+  BC-3830.10:
+    name: Operazioni del sistema in tempo reale
+    description: |
+      Supervisione e controllo continui in tempo reale della generazione,
+      della domanda e degli scambi del sistema per mantenere un'operazione sicura.
+  BC-3830.10.10:
+    name: Consapevolezza situazionale del sistema
+    description: |
+      Consapevolezza continua della generazione, del carico e dei margini di contingenza dal centro di controllo.
+  BC-3830.10.20:
+    name: Analisi delle contingenze in tempo reale
+    description: |
+      Analisi N-1 e N-1-1 in tempo reale e attivazione delle azioni correttive.
+  BC-3830.10.30:
+    name: Emissione delle istruzioni operative
+    description: |
+      Emissione di istruzioni operative ai responsabili del bilanciamento e ai TSO.
+  BC-3830.20:
+    name: Controllo della frequenza e della tensione
+    description: |
+      Regolazione attiva della frequenza e della tensione tramite controllo
+      automatico della generazione e dispacciamento della potenza reattiva.
+  BC-3830.20.10:
+    name: Controllo automatico della generazione
+    description: |
+      Dispacciamento AGC e gestione dell'errore di controllo di area per la regolazione della frequenza.
+  BC-3830.20.20:
+    name: Dispacciamento della potenza reattiva
+    description: |
+      Dispacciamento delle risorse reattive per mantenere il profilo di tensione sulla rete.
+  BC-3830.20.30:
+    name: Gestione dell'inerzia e della risposta in frequenza
+    description: |
+      Gestione dell'inerzia, della risposta rapida in frequenza e dei servizi di droop.
+  BC-3830.30:
+    name: Pianificazione operativa
+    description: |
+      Analisi della sicurezza del sistema day-ahead e infragiornaliera, valutazione
+      delle fermate e pianificazione dei margini operativi.
+  BC-3830.30.10:
+    name: Analisi della sicurezza day-ahead
+    description: |
+      Impegno delle unità vincolato alla sicurezza e analisi delle contingenze per il giorno operativo.
+  BC-3830.30.20:
+    name: Re-dispacciamento infragiornaliero
+    description: |
+      Re-dispacciamento infragiornaliero di generazione e domanda in funzione degli aggiornamenti delle previsioni.
+  BC-3830.30.30:
+    name: Valutazione stagionale del margine operativo
+    description: |
+      Valutazione stagionale del margine di capacità e dell'adeguatezza del sistema.
+  BC-3830.40:
+    name: Riserve e servizi ancillari
+    description: |
+      Approvvigionamento e attivazione delle riserve operative e dei servizi ancillari,
+      inclusi i prodotti di frequenza, tensione e inerzia.
+  BC-3830.40.10:
+    name: Approvvigionamento delle riserve
+    description: |
+      Approvvigionamento di prodotti di riserva primaria, secondaria e terziaria.
+  BC-3830.40.20:
+    name: Attivazione dei servizi ancillari
+    description: |
+      Attivazione e dispacciamento dei fornitori di servizi ancillari contrattualizzati.
+  BC-3830.40.30:
+    name: Monitoraggio delle prestazioni delle riserve
+    description: |
+      Monitoraggio delle prestazioni e della disponibilità dei fornitori di riserva.
+  BC-3830.50:
+    name: Operazioni di liquidazione degli sbilanciamenti
+    description: |
+      Calcolo lato gestore del sistema e notifica dei volumi e dei prezzi di sbilanciamento
+      ai responsabili del bilanciamento.
+  BC-3830.50.10:
+    name: Aggregazione dei volumi misurati
+    description: |
+      Aggregazione dei volumi misurati per responsabile del bilanciamento.
+  BC-3830.50.20:
+    name: Calcolo del prezzo di sbilanciamento
+    description: |
+      Calcolo dei prezzi di sbilanciamento del sistema secondo le regole di mercato.
+  BC-3830.50.30:
+    name: Notifica di liquidazione ai responsabili del bilanciamento
+    description: |
+      Notifica dei volumi di sbilanciamento e degli addebiti ai responsabili del bilanciamento.
+  BC-3830.60:
+    name: Coordinamento transfrontaliero
+    description: |
+      Coordinamento dei flussi sugli interconnettori, del re-dispacciamento e della sicurezza
+      con i TSO vicini e i coordinatori regionali della sicurezza.
+  BC-3830.60.10:
+    name: Programmazione degli interconnettori
+    description: |
+      Programmazione dei flussi fisici e commerciali sugli interconnettori.
+  BC-3830.60.20:
+    name: Calcolo coordinato della capacità
+    description: |
+      Calcolo coordinato della capacità tra zone di offerta con i paesi vicini.
+  BC-3830.60.30:
+    name: Re-dispacciamento transfrontaliero e countertrading
+    description: |
+      Re-dispacciamento transfrontaliero e countertrading per alleviare la congestione.
+  BC-3830.70:
+    name: Pianificazione del black-start e del ripristino
+    description: |
+      Manutenzione dei contratti di black-start, dei piani di ripristino
+      e delle esercitazioni per scenari di collasso totale o parziale del sistema.
+  BC-3830.70.10:
+    name: Gestione dei contratti di black-start
+    description: |
+      Approvvigionamento e sorveglianza dei contratti di servizio di black-start.
+  BC-3830.70.20:
+    name: Manutenzione del piano di ripristino del sistema
+    description: |
+      Manutenzione delle sequenze di ripristino e dei piani di isola intenzionale.
+  BC-3830.70.30:
+    name: Esercitazioni di ripristino
+    description: |
+      Esercitazioni di ripristino tra operatori e tra utility e revisioni post-evento.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-guest-traveller-management.yaml
+++ b/catalogue/i18n/it/L1-guest-traveller-management.yaml
@@ -1,0 +1,183 @@
+# Gestione degli ospiti e dei viaggiatori (it) — translations for L1-guest-traveller-management.yaml
+locale: it
+source: L1-guest-traveller-management.yaml
+entries:
+  BC-4040:
+    name: Gestione degli ospiti e dei viaggiatori
+    description: |
+      Amministrazione del record unico dell'ospite e del viaggiatore in tutta l'impresa —
+      identità, preferenze, consenso, riconoscimento, segmentazione e dati di documenti
+      di viaggio e conformità — indipendentemente da qualsiasi canale o struttura.
+    in_scope:
+      - Profilo e identità unici dell'ospite e del viaggiatore
+      - Preferenze, requisiti dietetici e di accessibilità
+      - Consenso, autorizzazione marketing e diritti dell'interessato
+      - Segnali di riconoscimento e comunicazione dello stato di livello
+      - Segmentazione degli ospiti e analisi del valore nel tempo
+      - Documenti di viaggio, dati APIS e screening delle liste di controllo
+    out_of_scope:
+      - Motori di accumulo e utilizzo punti del programma fedeltà (BC-4050)
+      - Esecuzione del check-in al front office (BC-4060.10)
+      - Operazioni CRM generiche cross-settoriali (BC-400)
+  BC-4040.10:
+    name: Gestione del profilo e dell'identità dell'ospite
+    description: |
+      Creazione, deduplicazione e verifica dell'identità del profilo unico
+      dell'ospite nei sistemi di prenotazione e operativi.
+  BC-4040.10.10:
+    name: Creazione del profilo dell'ospite
+    description: |
+      Creazione dei profili degli ospiti da qualsiasi canale
+      o punto di contatto di origine.
+  BC-4040.10.20:
+    name: Deduplicazione del profilo dell'ospite
+    description: |
+      Deduplicazione dei profili degli ospiti tramite corrispondenza
+      deterministica e probabilistica.
+  BC-4040.10.30:
+    name: Verifica dell'identità dell'ospite
+    description: |
+      Verifica dell'identità dell'ospite per interazioni ad alto valore
+      o regolamentate.
+  BC-4040.10.40:
+    name: Fusione del profilo e gestione della sopravvivenza degli attributi
+    description: |
+      Fusione dei profili duplicati e risoluzione della sopravvivenza
+      degli attributi.
+  BC-4040.20:
+    name: Gestione delle preferenze e della personalizzazione dell'ospite
+    description: |
+      Acquisizione e amministrazione delle preferenze dell'ospite relative
+      al soggiorno, all'alimentazione e ai requisiti di accessibilità, oltre
+      alle regole di personalizzazione.
+  BC-4040.20.10:
+    name: Acquisizione delle preferenze di soggiorno
+    description: |
+      Acquisizione delle preferenze di soggiorno, come il tipo di letto,
+      il piano e le preferenze sull'orario di arrivo.
+  BC-4040.20.20:
+    name: Gestione delle preferenze dietetiche e degli allergeni
+    description: |
+      Gestione delle preferenze dietetiche, religiose e relative agli allergeni
+      per il servizio F&B e il servizio a bordo.
+  BC-4040.20.30:
+    name: Gestione dei requisiti di accessibilità
+    description: |
+      Gestione dei requisiti di accessibilità e delle esigenze di assistenza
+      speciale nei punti di contatto del viaggio.
+  BC-4040.20.40:
+    name: Definizione delle regole di personalizzazione
+    description: |
+      Definizione delle regole di personalizzazione che applicano le preferenze
+      alle interazioni di servizio e di merchandising.
+  BC-4040.30:
+    name: Gestione del consenso e della privacy dell'ospite
+    description: |
+      Gestione del consenso dell'ospite, delle autorizzazioni marketing,
+      dei diritti dell'interessato e della conformità ai trasferimenti transfrontalieri
+      dei dati di viaggio.
+  BC-4040.30.10:
+    name: Acquisizione e gestione del consenso
+    description: |
+      Acquisizione e gestione continuativa dei record di consenso
+      per finalità e canali.
+  BC-4040.30.20:
+    name: Gestione delle autorizzazioni marketing
+    description: |
+      Gestione delle autorizzazioni marketing, inclusi gli stati di opt-in
+      e opt-out per canale.
+  BC-4040.30.30:
+    name: Gestione delle richieste degli interessati
+    description: |
+      Gestione delle richieste di accesso, portabilità, rettifica
+      e cancellazione degli interessati.
+  BC-4040.30.40:
+    name: Conformità ai trasferimenti transfrontalieri di dati
+    description: |
+      Conformità ai requisiti di trasferimento transfrontaliero applicabili
+      ai dati dei viaggiatori e degli ospiti.
+  BC-4040.40:
+    name: Riconoscimento dell'ospite e comunicazione dello stato di livello
+    description: |
+      Comunicazione dei segnali di riconoscimento e dello stato di livello ai team
+      operativi, affinché gli ospiti vengano riconosciuti in modo coerente
+      in tutti i punti di contatto.
+    in_scope:
+      - Segnali di riconoscimento pre-arrivo e in struttura
+      - Registrazione e chiusura del riconoscimento erogato
+    out_of_scope:
+      - Progettazione del programma fedeltà e accumulo/utilizzo (BC-4050)
+  BC-4040.40.10:
+    name: Segnali di riconoscimento pre-arrivo
+    description: |
+      Comunicazione delle aspettative di riconoscimento ai team operativi
+      prima dell'arrivo dell'ospite.
+  BC-4040.40.20:
+    name: Erogazione del riconoscimento in struttura
+    description: |
+      Erogazione del riconoscimento da parte dei team di front office, F&B
+      e concierge durante il soggiorno dell'ospite.
+  BC-4040.40.30:
+    name: Registrazione del servizio di riconoscimento
+    description: |
+      Registrazione degli eventi di erogazione del riconoscimento per l'audit
+      del servizio e i cicli di feedback.
+  BC-4040.40.40:
+    name: Reporting sulla chiusura del riconoscimento
+    description: |
+      Reporting sui tassi di chiusura del riconoscimento rispetto
+      ai segnali di riconoscimento pre-arrivo.
+  BC-4040.50:
+    name: Gestione della segmentazione e degli insight sull'ospite
+    description: |
+      Definizione dei segmenti di ospiti, modellazione del valore nel tempo
+      e del tasso di abbandono, e generazione di insight coortali e comportamentali.
+  BC-4040.50.10:
+    name: Definizione della segmentazione degli ospiti
+    description: |
+      Definizione e manutenzione dei segmenti di ospiti utilizzati
+      nel marketing e nel merchandising.
+  BC-4040.50.20:
+    name: Modellazione del valore nel tempo
+    description: |
+      Modellazione del valore nel tempo dell'ospite come input per le decisioni
+      di investimento e di riconoscimento.
+  BC-4040.50.30:
+    name: Analisi dell'abbandono e della fidelizzazione degli ospiti
+    description: |
+      Analisi dei fattori di abbandono degli ospiti e delle opportunità
+      di fidelizzazione per segmento.
+  BC-4040.50.40:
+    name: Insight coortali e comportamentali
+    description: |
+      Generazione di insight coortali e comportamentali dagli eventi
+      di prenotazione, soggiorno e coinvolgimento.
+  BC-4040.60:
+    name: Gestione dei documenti di viaggio e dei dati di conformità del viaggiatore
+    description: |
+      Gestione dei documenti di viaggio, dei dati APIS, dei visti e delle liste
+      di controllo necessari per soddisfare gli obblighi di trasporto e di controllo
+      alle frontiere.
+  BC-4040.60.10:
+    name: Acquisizione dei documenti di viaggio
+    description: |
+      Acquisizione di dati di passaporto, documento di identità e visto
+      per i controlli di idoneità al viaggio e documentali.
+  BC-4040.60.20:
+    name: Invio APIS e informazioni anticipate sui passeggeri
+    description: |
+      Invio dei dati APIS e delle informazioni anticipate sui passeggeri
+      alle autorità di controllo delle frontiere.
+  BC-4040.60.30:
+    name: Riferimento per l'idoneità a visto ed ESTA
+    description: |
+      Controlli di riferimento rispetto ai regimi di idoneità
+      a visto, ESTA ed equivalenti.
+  BC-4040.60.40:
+    name: Screening Secure Flight e liste di controllo no-fly
+    description: |
+      Screening dei viaggiatori rispetto ai programmi Secure Flight
+      ed equivalenti di no-fly e liste di controllo.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-harvest-post-harvest-operations-management.yaml
+++ b/catalogue/i18n/it/L1-harvest-post-harvest-operations-management.yaml
@@ -1,0 +1,125 @@
+# Gestione delle operazioni di raccolta e post-raccolta (it) — translations for L1-harvest-post-harvest-operations-management.yaml
+locale: it
+source: L1-harvest-post-harvest-operations-management.yaml
+entries:
+  BC-3560:
+    name: Gestione delle operazioni di raccolta e post-raccolta
+    description: |
+      Programmazione ed esecuzione della raccolta, condizionamento in campo e post-raccolta,
+      stoccaggio aziendale, calibratura e confezionamento e ricevimento in ingresso
+      al punto successivo della filiera agroalimentare.
+  BC-3560.10:
+    name: Pianificazione e programmazione della raccolta
+    description: |
+      Pianificazione delle finestre di raccolta, programmazione di manodopera e macchine
+      e coordinamento logistico della raccolta su campi e colture.
+  BC-3560.10.10:
+    name: Pianificazione delle finestre di raccolta
+    description: |
+      Pianificazione della finestra di raccolta campo per campo in funzione della maturazione e delle condizioni meteorologiche.
+  BC-3560.10.20:
+    name: Programmazione di manodopera e macchine per la raccolta
+    description: |
+      Programmazione delle squadre di raccolta, dei terzisti e delle macchine.
+  BC-3560.10.30:
+    name: Coordinamento della logistica di raccolta
+    description: |
+      Coordinamento di autocarri, cassoni e rimorchi sui fronti di raccolta attivi.
+  BC-3560.20:
+    name: Operazioni di raccolta in campo
+    description: |
+      Operazioni di raccolta meccanica e manuale, inclusa la selezione in campo e il trasferimento sul bordo del campo.
+  BC-3560.20.10:
+    name: Raccolta meccanica
+    description: |
+      Raccolta meccanica con mietitrebbiatrici, falciacondizionatrici e macchine specializzate.
+  BC-3560.20.20:
+    name: Raccolta manuale
+    description: |
+      Raccolta manuale e selettiva a mano per le colture orticole.
+  BC-3560.20.30:
+    name: Selezione in campo
+    description: |
+      Selezione e rifinitura in campo del prodotto raccolto.
+  BC-3560.30:
+    name: Condizionamento post-raccolta
+    description: |
+      Essiccazione, raffreddamento, stagionatura e decontaminazione del prodotto raccolto
+      per stabilizzarlo in vista dello stoccaggio o dell'impiego a valle.
+    in_scope:
+      - Essiccazione di cereali e sementi
+      - Pre-raffreddamento dei prodotti orticoli
+      - Stagionatura di radici e bulbi
+      - Pulizia e decontaminazione in campo
+  BC-3560.30.10:
+    name: Operazioni di essiccazione
+    description: |
+      Essiccazione di cereali, sementi e foraggio fino ai livelli di umidità sicuri.
+  BC-3560.30.20:
+    name: Operazioni di raffreddamento e pre-raffreddamento
+    description: |
+      Pre-raffreddamento idrico, a vuoto e ad aria forzata dei prodotti orticoli.
+  BC-3560.30.30:
+    name: Operazioni di stagionatura
+    description: |
+      Stagionatura di patate, cipolle, patate dolci e colture analoghe.
+  BC-3560.30.40:
+    name: Pulizia e decontaminazione
+    description: |
+      Pulizia e decontaminazione del prodotto raccolto prima dello stoccaggio.
+  BC-3560.40:
+    name: Operazioni di stoccaggio aziendale
+    description: |
+      Gestione dei sili, dei cassoni e delle celle aziendali, incluse aerazione e controllo degli infestanti dello stoccaggio.
+  BC-3560.40.10:
+    name: Gestione dei cassoni e dei sili
+    description: |
+      Carico, monitoraggio e scarico di cassoni e sili per cereali.
+  BC-3560.40.20:
+    name: Operazioni di stoccaggio a freddo
+    description: |
+      Gestione di celle frigorifere e in atmosfera controllata aziendali.
+  BC-3560.40.30:
+    name: Aerazione del cereale stoccato
+    description: |
+      Gestione dell'aerazione del cereale stoccato per mantenere temperatura e umidità.
+  BC-3560.40.40:
+    name: Gestione degli infestanti dello stoccaggio
+    description: |
+      Monitoraggio e trattamento della pressione di insetti e roditori nei magazzini.
+  BC-3560.50:
+    name: Calibratura e confezionamento del prodotto
+    description: |
+      Operazioni di calibratura, centrale di confezionamento e etichettatura dei lotti per predisporre il prodotto al trasporto.
+  BC-3560.50.10:
+    name: Operazioni di calibratura qualitativa
+    description: |
+      Calibratura del prodotto in base a dimensione, colore e specifiche difettologiche.
+  BC-3560.50.20:
+    name: Operazioni della centrale di confezionamento
+    description: |
+      Operazioni della linea di confezionamento, inclusi lavaggio, ceratura e imballaggio.
+  BC-3560.50.30:
+    name: Identificazione e etichettatura dei lotti
+    description: |
+      Assegnazione di identificativi di lotto e GS1 e stampa delle etichette.
+  BC-3560.60:
+    name: Ricevimento in ingresso presso il trasformatore
+    description: |
+      Coordinamento del ricevimento in ingresso dall'azienda agricola o dall'aggregatore
+      presso gli stabilimenti del trasformatore o dell'acquirente.
+  BC-3560.60.10:
+    name: Programmazione e ricevimento degli autocarri
+    description: |
+      Programmazione e ricevimento degli autocarri in ingresso alle porte degli stabilimenti di trasformazione.
+  BC-3560.60.20:
+    name: Campionamento al ricevimento
+    description: |
+      Campionamento in ingresso di carichi di cereali, bestiame, latte e prodotti.
+  BC-3560.60.30:
+    name: Test qualitativi al ricevimento
+    description: |
+      Test qualitativi sui carichi in ingresso a supporto dell'accettazione e della determinazione del prezzo.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-health-information-management.yaml
+++ b/catalogue/i18n/it/L1-health-information-management.yaml
@@ -1,0 +1,137 @@
+# Gestione delle informazioni sanitarie (it) — translations for L1-health-information-management.yaml
+locale: it
+source: L1-health-information-management.yaml
+entries:
+  BC-2900:
+    name: Gestione delle informazioni sanitarie
+    description: |
+      Indice maestro dei pazienti, operazioni di codifica clinica, rilascio delle informazioni,
+      ciclo di vita della cartella clinica, sottomissioni ai registri clinici e operazioni di
+      interoperabilità sanitaria per l'organizzazione erogatrice.
+  BC-2900.10:
+    name: Gestione dell'indice maestro dei pazienti
+    description: |
+      Gestione dell'indice maestro dei pazienti e risoluzione di duplicati
+      e record sovrapposti.
+  BC-2900.10.10:
+    name: Gestione dell'indice maestro dei pazienti
+    description: |
+      Gestione quotidiana dell'indice maestro dei pazienti dell'azienda.
+  BC-2900.10.20:
+    name: Risoluzione dei duplicati
+    description: |
+      Identificazione e risoluzione dei record paziente duplicati e sovrapposti.
+  BC-2900.10.30:
+    name: Algoritmi di corrispondenza dei pazienti
+    description: |
+      Configurazione e ottimizzazione degli algoritmi di corrispondenza dei pazienti.
+  BC-2900.10.40:
+    name: Cross-reference delle identità
+    description: |
+      Cross-reference delle identità dei pazienti tra organizzazioni affiliate e sistemi di scambio.
+  BC-2900.20:
+    name: Operazioni di codifica clinica
+    description: |
+      Operazioni di codifica clinica per gli episodi di ricovero e ambulatoriali,
+      inclusi audit e gestione degli arretrati.
+  BC-2900.20.10:
+    name: Produzione della codifica per il ricovero
+    description: |
+      Workflow di codifica e assegnazione lato produzione per gli episodi di ricovero.
+  BC-2900.20.20:
+    name: Produzione della codifica ambulatoriale
+    description: |
+      Workflow di codifica e assegnazione lato produzione per gli episodi ambulatoriali.
+  BC-2900.20.30:
+    name: Gestione degli arretrati di codifica
+    description: |
+      Gestione degli episodi dimessi e non ancora codificati e degli arretrati di codifica.
+  BC-2900.20.40:
+    name: Audit dei codificatori
+    description: |
+      Audit interno dell'accuratezza dei codificatori e feedback agli stessi.
+  BC-2900.30:
+    name: Rilascio delle informazioni sanitarie
+    description: |
+      Ricezione, validazione e gestione delle richieste di informazioni sanitarie protette.
+  BC-2900.30.10:
+    name: Ricezione delle richieste di informazioni
+    description: |
+      Ricezione delle richieste di informazioni sanitarie da parte di pazienti, pagatori, legali e professionisti.
+  BC-2900.30.20:
+    name: Validazione delle autorizzazioni
+    description: |
+      Validazione delle autorizzazioni e delle comunicazioni consentite ai sensi della normativa sulla privacy.
+  BC-2900.30.30:
+    name: Monitoraggio delle comunicazioni
+    description: |
+      Monitoraggio delle comunicazioni di informazioni sanitarie protette ai fini della rendicontazione.
+  BC-2900.30.40:
+    name: Gestione di citazioni in giudizio e richieste legali
+    description: |
+      Gestione di citazioni in giudizio, ordinanze del tribunale e richieste legali di cartelle cliniche.
+  BC-2900.40:
+    name: Ciclo di vita della cartella clinica
+    description: |
+      Gestione del ciclo di vita delle cartelle cliniche dalla creazione alla conservazione
+      e alla distruzione.
+  BC-2900.40.10:
+    name: Chiusura dell'episodio
+    description: |
+      Verifica e monitoraggio dei prerequisiti per la chiusura dell'episodio.
+  BC-2900.40.20:
+    name: Monitoraggio del completamento della cartella clinica
+    description: |
+      Monitoraggio del completamento in arretrato della cartella clinica e follow-up con i professionisti.
+  BC-2900.40.30:
+    name: Pianificazione della conservazione dei documenti
+    description: |
+      Pianificazione della conservazione delle cartelle cliniche secondo i requisiti normativi.
+  BC-2900.40.40:
+    name: Distruzione dei documenti
+    description: |
+      Distruzione autorizzata delle cartelle cliniche al termine del periodo di conservazione.
+  BC-2900.50:
+    name: Registri clinici e sottomissioni
+    description: |
+      Sottomissione ai registri delle malattie, del cancro, dei traumi e della qualità.
+  BC-2900.50.10:
+    name: Sottomissione ai registri delle malattie
+    description: |
+      Sottomissione ai registri di sanità pubblica e delle malattie.
+  BC-2900.50.20:
+    name: Operazioni del registro tumori
+    description: |
+      Operazioni di astrazione e sottomissione del registro tumori.
+  BC-2900.50.30:
+    name: Operazioni del registro traumi
+    description: |
+      Operazioni di astrazione e sottomissione del registro traumi.
+  BC-2900.50.40:
+    name: Sottomissione ai registri di qualità
+    description: |
+      Sottomissione ai registri di qualità specialistici a supporto della ricerca clinica e del benchmarking.
+  BC-2900.60:
+    name: Operazioni di interoperabilità sanitaria
+    description: |
+      Gestione delle connessioni per lo scambio di informazioni sanitarie, degli endpoint FHIR,
+      della condivisione dei dati su iniziativa del paziente e della directory dei professionisti.
+  BC-2900.60.10:
+    name: Operazioni di scambio di informazioni sanitarie
+    description: |
+      Gestione delle connessioni in entrata e in uscita per lo scambio di informazioni sanitarie.
+  BC-2900.60.20:
+    name: Gestione degli endpoint FHIR
+    description: |
+      Gestione degli endpoint FHIR per l'integrazione con applicazioni e partner.
+  BC-2900.60.30:
+    name: Condivisione dei dati su iniziativa del paziente
+    description: |
+      Condivisione delle informazioni sanitarie diretta dal paziente con applicazioni di terze parti.
+  BC-2900.60.40:
+    name: Manutenzione della directory dei professionisti
+    description: |
+      Manutenzione dei dati della directory dei professionisti per i fruitori interni ed esterni.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-health-safety-environment-management.yaml
+++ b/catalogue/i18n/it/L1-health-safety-environment-management.yaml
@@ -1,0 +1,119 @@
+# Gestione HSE (it) — translations for L1-health-safety-environment-management.yaml
+locale: it
+source: L1-health-safety-environment-management.yaml
+entries:
+  BC-730:
+    name: Gestione della salute, sicurezza e ambiente
+    description: |
+      Politica HSE, gestione degli incidenti, sicurezza del sito e salute occupazionale.
+  BC-730.10:
+    name: Gestione della salute occupazionale
+    description: |
+      Salute occupazionale, ergonomia e benessere dei lavoratori.
+  BC-730.10.10:
+    name: Sorveglianza sanitaria
+    description: |
+      Sorveglianza sanitaria periodica per i gruppi di lavoratori esposti a rischi specifici.
+  BC-730.10.20:
+    name: Ergonomia e salute sul luogo di lavoro
+    description: |
+      Valutazioni ergonomiche e programmi di salute sul luogo di lavoro.
+  BC-730.10.30:
+    name: Monitoraggio dell'igiene occupazionale
+    description: |
+      Monitoraggio dell'esposizione a rumore, polveri, agenti chimici e biologici.
+  BC-730.10.40:
+    name: Programmi di benessere dei dipendenti
+    description: |
+      Programmi di benessere mentale, fisico e sociale per i dipendenti.
+  BC-730.20:
+    name: Gestione della sicurezza
+    description: |
+      Sicurezza sul lavoro, sicurezza comportamentale e DPI.
+  BC-730.20.10:
+    name: Identificazione dei pericoli e valutazione del rischio
+    description: |
+      Identificazione dei pericoli e valutazione del rischio per attività e siti.
+  BC-730.20.20:
+    name: Permessi di lavoro e sistemi di lavoro in sicurezza
+    description: |
+      Permessi di lavoro, isolamento e sistemi di lavoro in sicurezza.
+  BC-730.20.30:
+    name: Gestione dei dispositivi di protezione individuale
+    description: |
+      Selezione, distribuzione, formazione e ispezione dei DPI.
+  BC-730.20.40:
+    name: Programma di sicurezza comportamentale
+    description: |
+      Osservazioni sulla sicurezza comportamentale, leadership walk e coaching.
+  BC-730.20.50:
+    name: Gestione della sicurezza degli appaltatori
+    description: |
+      Pre-qualifica, induzione e supervisione della sicurezza in loco degli appaltatori.
+  BC-730.30:
+    name: Gestione ambientale
+    description: |
+      Emissioni, acqua, rifiuti e conformità ambientale.
+  BC-730.30.10:
+    name: Valutazione degli aspetti e degli impatti ambientali
+    description: |
+      Identificazione degli aspetti ambientali e valutazione dell'impatto ambientale.
+  BC-730.30.20:
+    name: Gestione delle emissioni
+    description: |
+      Gestione delle emissioni atmosferiche, dei gas a effetto serra e degli inquinanti nei siti.
+  BC-730.30.30:
+    name: Gestione dell'acqua e degli effluenti
+    description: |
+      Consumo idrico, trattamento degli effluenti e gestione degli scarichi.
+  BC-730.30.40:
+    name: Gestione dei rifiuti
+    description: |
+      Gestione e smaltimento dei rifiuti pericolosi e non pericolosi.
+  BC-730.30.50:
+    name: Biodiversità e tutela del territorio
+    description: |
+      Attività di tutela della biodiversità, uso del suolo e bonifica.
+  BC-730.40:
+    name: Gestione degli incidenti e delle indagini
+    description: |
+      Incidenti HSE, quasi-incidenti e indagini.
+  BC-730.40.10:
+    name: Segnalazione di incidenti e quasi-incidenti
+    description: |
+      Raccolta e classificazione degli incidenti HSE e dei quasi-incidenti.
+  BC-730.40.20:
+    name: Indagine sugli incidenti HSE
+    description: |
+      Metodologia di indagine, analisi delle cause radice e lezioni apprese.
+  BC-730.40.30:
+    name: Preparazione e risposta alle emergenze
+    description: |
+      Piani di emergenza del sito, esercitazioni e coordinamento della risposta.
+  BC-730.40.40:
+    name: Gestione della sicurezza di processo
+    description: |
+      Pericoli di sicurezza di processo, gestione delle modifiche e controlli sui rischi di incidente rilevante.
+  BC-730.50:
+    name: Conformità e reporting HSE
+    description: |
+      Reporting normativo HSE e audit.
+  BC-730.50.10:
+    name: Conformità normativa HSE
+    description: |
+      Identificazione e monitoraggio degli obblighi normativi in ambito HSE.
+  BC-730.50.20:
+    name: Audit e ispezione HSE
+    description: |
+      Audit e ispezioni HSE interni ed esterni.
+  BC-730.50.30:
+    name: Reporting delle performance HSE
+    description: |
+      Monitoraggio dei KPI HSE e reporting alla direzione (TRIR, LTIFR).
+  BC-730.50.40:
+    name: Certificazione del sistema di gestione HSE
+    description: |
+      Certificazione del sistema di gestione ISO 45001 / ISO 14001.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-healthcare-revenue-cycle-management.yaml
+++ b/catalogue/i18n/it/L1-healthcare-revenue-cycle-management.yaml
@@ -1,0 +1,159 @@
+# Gestione del ciclo delle entrate sanitarie (it) — translations for L1-healthcare-revenue-cycle-management.yaml
+locale: it
+source: L1-healthcare-revenue-cycle-management.yaml
+entries:
+  BC-2870:
+    name: Gestione del ciclo delle entrate sanitarie
+    description: |
+      Acquisizione delle prestazioni e gestione del tariffario, codifica medica, produzione e
+      presentazione delle richieste di rimborso, gestione dei rifiuti e dei ricorsi, registrazione
+      dei pagamenti, servizi finanziari ai pazienti e gestione dei contratti con i pagatori per le
+      organizzazioni erogatrici.
+  BC-2870.10:
+    name: Acquisizione delle prestazioni e gestione del tariffario
+    description: |
+      Acquisizione delle prestazioni cliniche e gestione del tariffario nei diversi
+      servizi erogati.
+  BC-2870.10.10:
+    name: Acquisizione delle prestazioni
+    description: |
+      Acquisizione delle prestazioni dalla documentazione clinica e dai sistemi ancillari.
+  BC-2870.10.20:
+    name: Manutenzione del tariffario
+    description: |
+      Manutenzione delle voci, dei codici e dei prezzi del tariffario.
+  BC-2870.10.30:
+    name: Riconciliazione delle prestazioni
+    description: |
+      Riconciliazione tra le prestazioni attese e quelle acquisite per area di servizio.
+  BC-2870.10.40:
+    name: Audit delle prestazioni
+    description: |
+      Audit interno ed esterno dell'accuratezza e della completezza delle prestazioni.
+  BC-2870.20:
+    name: Gestione della codifica medica
+    description: |
+      Produzione della codifica per le prestazioni di ricovero, ambulatoriali e professionali
+      e audit di conformità.
+  BC-2870.20.10:
+    name: Codifica delle prestazioni di ricovero
+    description: |
+      Codifica degli episodi di ricovero con metodologia DRG.
+  BC-2870.20.20:
+    name: Codifica delle prestazioni ambulatoriali
+    description: |
+      Codifica degli episodi ambulatoriali con metodologia di classificazione dei pagamenti ambulatoriali.
+  BC-2870.20.30:
+    name: Codifica delle prestazioni professionali
+    description: |
+      Codifica delle prestazioni professionali con codici procedurali e di valutazione e gestione.
+  BC-2870.20.40:
+    name: Audit e conformità della codifica
+    description: |
+      Audit della codifica, programmi di conformità ed educazione.
+  BC-2870.30:
+    name: Produzione e presentazione delle richieste di rimborso
+    description: |
+      Produzione, controllo, presentazione e monitoraggio dello stato delle richieste di rimborso
+      ai pagatori.
+  BC-2870.30.10:
+    name: Controllo e verifica delle richieste di rimborso
+    description: |
+      Applicazione di controlli pre-presentazione e regole di verifica delle richieste.
+  BC-2870.30.20:
+    name: Presentazione delle richieste di rimborso
+    description: |
+      Presentazione elettronica delle richieste di rimborso ai pagatori e alle stanze di compensazione.
+  BC-2870.30.30:
+    name: Verifica dello stato delle richieste di rimborso
+    description: |
+      Verifica elettronica e manuale dello stato delle richieste e follow-up.
+  BC-2870.30.40:
+    name: Sequenziamento del coordinamento dei benefici
+    description: |
+      Sequenziamento delle richieste primarie, secondarie e terziarie tra i pagatori.
+  BC-2870.40:
+    name: Gestione dei rifiuti e dei ricorsi
+    description: |
+      Triage, ricorso e prevenzione dei rifiuti dei pagatori e dei sottopagamenti.
+  BC-2870.40.10:
+    name: Triage dei rifiuti
+    description: |
+      Triage e instradamento delle richieste rifiutate per motivazione e probabilità di recupero.
+  BC-2870.40.20:
+    name: Redazione e presentazione dei ricorsi
+    description: |
+      Redazione e presentazione di ricorsi clinici e tecnici.
+  BC-2870.40.30:
+    name: Analisi dei sottopagamenti
+    description: |
+      Identificazione e recupero dei sottopagamenti dei pagatori rispetto alle tariffe contrattuali.
+  BC-2870.40.40:
+    name: Analisi per la prevenzione dei rifiuti
+    description: |
+      Analytics sulle cause radice per prevenire i rifiuti ricorrenti.
+  BC-2870.50:
+    name: Registrazione dei pagamenti e riconciliazione con i pagatori
+    description: |
+      Registrazione delle rimesse dei pagatori e dei pagamenti dei pazienti e riconciliazione
+      rispetto al rimborso atteso.
+  BC-2870.50.10:
+    name: Registrazione delle rimesse
+    description: |
+      Registrazione della rimessa elettronica e riconciliazione.
+  BC-2870.50.20:
+    name: Registrazione dei pagamenti dei pazienti
+    description: |
+      Registrazione dei pagamenti dei pazienti attraverso i diversi canali.
+  BC-2870.50.30:
+    name: Applicazione degli adeguamenti contrattuali
+    description: |
+      Applicazione degli adeguamenti contrattuali in base agli accordi con i pagatori.
+  BC-2870.50.40:
+    name: Risoluzione dei pagamenti non applicati
+    description: |
+      Risoluzione e applicazione dei pagamenti non identificati e non applicati.
+  BC-2870.60:
+    name: Servizi finanziari ai pazienti
+    description: |
+      Fatturazione ai pazienti, riscossione, piani di pagamento e cessione dei crediti inesigibili.
+  BC-2870.60.10:
+    name: Generazione degli estratti conto dei pazienti
+    description: |
+      Generazione degli estratti conto dei pazienti su canali cartacei e digitali.
+  BC-2870.60.20:
+    name: Riscossione dai pazienti
+    description: |
+      Operazioni di riscossione e outreach per i pazienti in regime di pagamento diretto.
+  BC-2870.60.30:
+    name: Gestione dei piani di pagamento
+    description: |
+      Configurazione e gestione dei piani di pagamento rateale dei pazienti.
+  BC-2870.60.40:
+    name: Cessione dei crediti inesigibili
+    description: |
+      Cessione e gestione dei crediti a agenzie di riscossione esterne.
+  BC-2870.70:
+    name: Gestione dei contratti con i pagatori
+    description: |
+      Modellizzazione, supporto alla negoziazione, analisi degli scostamenti e monitoraggio
+      delle performance dei contratti con i pagatori.
+  BC-2870.70.10:
+    name: Modellizzazione dei contratti
+    description: |
+      Modellizzazione delle clausole contrattuali dei pagatori e delle metodologie di rimborso.
+  BC-2870.70.20:
+    name: Analisi degli scostamenti di rimborso
+    description: |
+      Analisi degli scostamenti tra il rimborso contrattuale e quello effettivo.
+  BC-2870.70.30:
+    name: Supporto alla negoziazione dei contratti
+    description: |
+      Supporto analitico e operativo alle trattative contrattuali con i pagatori.
+  BC-2870.70.40:
+    name: Monitoraggio delle performance dei pagatori
+    description: |
+      Monitoraggio continuo delle performance dei pagatori rispetto agli SLA contrattuali.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-human-capital-management.yaml
+++ b/catalogue/i18n/it/L1-human-capital-management.yaml
@@ -1,0 +1,211 @@
+# Gestione del capitale umano (it) — translations for L1-human-capital-management.yaml
+locale: it
+source: L1-human-capital-management.yaml
+entries:
+  BC-300:
+    name: Gestione del capitale umano
+    description: |
+      Ciclo di vita end-to-end dei dipendenti, comunemente noto anche come gestione delle risorse umane.
+  BC-300.10:
+    name: Gestione dell'acquisizione del talento
+    description: |
+      Sourcing, selezione del personale, assunzione e onboarding.
+  BC-300.10.10:
+    name: Sourcing della forza lavoro
+    description: |
+      Ricerca di candidati tramite canali, referral e pipeline di talento.
+  BC-300.10.20:
+    name: Screening e selezione dei candidati
+    description: |
+      Screening dei candidati, valutazioni e gestione dei colloqui.
+  BC-300.10.30:
+    name: Gestione delle offerte e delle assunzioni
+    description: |
+      Preparazione delle offerte, negoziazione, background check e contrattualizzazione.
+  BC-300.10.40:
+    name: Onboarding dei dipendenti
+    description: |
+      Pre-boarding, esperienza del primo giorno e percorsi di onboarding.
+  BC-300.10.50:
+    name: Gestione del brand del datore di lavoro
+    description: |
+      Proposta di valore per il datore di lavoro, campagne di employer brand e reputazione.
+  BC-300.20:
+    name: Gestione del talento
+    description: |
+      Performance, successione e sviluppo professionale.
+  BC-300.20.10:
+    name: Gestione della performance
+    description: |
+      Definizione degli obiettivi, valutazioni della performance e cicli di feedback.
+  BC-300.20.20:
+    name: Pianificazione della successione
+    description: |
+      Identificazione e sviluppo dei candidati alla successione per i ruoli chiave.
+  BC-300.20.30:
+    name: Sviluppo professionale e mobilità interna
+    description: |
+      Percorsi di carriera, mobilità interna e pianificazione dello sviluppo.
+  BC-300.20.40:
+    name: Talent review e calibrazione
+    description: |
+      Sessioni di talent review, calibrazione e valutazioni con la matrice 9-box.
+  BC-300.20.50:
+    name: Sviluppo della leadership
+    description: |
+      Pipeline di leadership, sviluppo executive e coaching.
+  BC-300.30:
+    name: Gestione della remunerazione e dei benefit
+    description: |
+      Strutture retributive, bonus, equity e amministrazione dei benefit.
+  BC-300.30.10:
+    name: Architettura dei ruoli e grading
+    description: |
+      Catalogo dei ruoli, livellamento e strutture di grading.
+  BC-300.30.20:
+    name: Gestione della retribuzione base
+    description: |
+      Range salariali, benchmarking di mercato e cicli di revisione retributiva.
+  BC-300.30.30:
+    name: Gestione della retribuzione variabile e degli incentivi
+    description: |
+      Amministrazione di bonus, piani di incentivazione alla vendita e incentivi a breve termine.
+  BC-300.30.40:
+    name: Amministrazione di equity e incentivi a lungo termine
+    description: |
+      Piani azionari, RSU, opzioni e piani di incentivazione a lungo termine.
+  BC-300.30.50:
+    name: Amministrazione dei benefit
+    description: |
+      Amministrazione dei benefit sanitari, pensionistici e degli altri benefit per i dipendenti.
+  BC-300.40:
+    name: Gestione della formazione e dello sviluppo
+    description: |
+      Formazione, sviluppo delle competenze e certificazioni.
+  BC-300.40.10:
+    name: Analisi dei fabbisogni formativi
+    description: |
+      Identificazione dei gap di competenze e dei fabbisogni formativi per funzione.
+  BC-300.40.20:
+    name: Curation dei contenuti formativi
+    description: |
+      Curation e creazione di contenuti formativi interni e di terze parti.
+  BC-300.40.30:
+    name: Erogazione e amministrazione della formazione
+    description: |
+      Erogazione e monitoraggio della formazione in aula e digitale.
+  BC-300.40.40:
+    name: Gestione delle competenze e delle certificazioni
+    description: |
+      Inventario delle competenze, skill framework e monitoraggio delle certificazioni.
+  BC-300.40.50:
+    name: Valutazione dell'efficacia della formazione
+    description: |
+      Valutazione dell'impatto della formazione e del ROI sull'investimento formativo.
+  BC-300.50:
+    name: Gestione della pianificazione della forza lavoro
+    description: |
+      Pianificazione strategica della domanda e dell'offerta di forza lavoro.
+  BC-300.50.10:
+    name: Previsione della domanda di forza lavoro
+    description: |
+      Previsione del fabbisogno di forza lavoro per competenza, ruolo e sede.
+  BC-300.50.20:
+    name: Analisi dell'offerta di forza lavoro
+    description: |
+      Analisi dell'offerta interna, del turnover e del mercato del lavoro.
+  BC-300.50.30:
+    name: Sviluppo del piano strategico della forza lavoro
+    description: |
+      Piani strategici pluriennali della forza lavoro e scenari.
+  BC-300.50.40:
+    name: Pianificazione e controllo dell'organico
+    description: |
+      Budget operativo dell'organico e flussi di approvazione.
+  BC-300.60:
+    name: Gestione dell'esperienza dei dipendenti
+    description: |
+      Engagement, comunicazione interna ed esperienza sul posto di lavoro.
+  BC-300.60.10:
+    name: Misurazione dell'engagement dei dipendenti
+    description: |
+      Survey sull'engagement, pulse check e programmi di ascolto.
+  BC-300.60.20:
+    name: Progettazione del percorso del dipendente
+    description: |
+      Progettazione dei momenti chiave e delle journey map dei dipendenti.
+  BC-300.60.30:
+    name: Benessere sul posto di lavoro
+    description: |
+      Programmi di benessere mentale, fisico e finanziario.
+  BC-300.60.40:
+    name: Riconoscimento e premi
+    description: |
+      Programmi di riconoscimento e schemi di reward non monetario.
+  BC-300.70:
+    name: Gestione delle operazioni HR
+    description: |
+      Dati anagrafici dei dipendenti, elaborazione delle paghe e erogazione dei servizi HR.
+  BC-300.70.10:
+    name: Gestione dei dati anagrafici dei dipendenti
+    description: |
+      Dati anagrafici dei dipendenti, eventi del ciclo di vita e integrità dei dati master.
+  BC-300.70.20:
+    name: Elaborazione delle paghe
+    description: |
+      Elaborazione del cedolino, trattenute di legge e distribuzione dei prospetti paga.
+  BC-300.70.30:
+    name: Gestione del tempo e delle assenze
+    description: |
+      Rilevazione delle presenze, gestione dei congedi e delle assenze.
+  BC-300.70.40:
+    name: Help desk e gestione dei casi HR
+    description: |
+      Help desk HR, gestione dei casi e assistenza di primo livello.
+  BC-300.70.50:
+    name: HR analytics e reporting
+    description: |
+      Analisi della forza lavoro, dashboard e reporting HR obbligatorio.
+  BC-300.80:
+    name: Relazioni con i dipendenti e relazioni sindacali
+    description: |
+      Comitati aziendali, sindacati, reclami e diritto del lavoro.
+  BC-300.80.10:
+    name: Contrattazione collettiva e rapporti con i sindacati
+    description: |
+      Contrattazione collettiva, accordi e relazioni sindacali.
+  BC-300.80.20:
+    name: Comitato aziendale e rappresentanze dei dipendenti
+    description: |
+      Consultazione del comitato aziendale e degli organismi di rappresentanza dei dipendenti.
+  BC-300.80.30:
+    name: Gestione dei reclami e dei provvedimenti disciplinari
+    description: |
+      Gestione di reclami, provvedimenti disciplinari e indagini.
+  BC-300.80.40:
+    name: Conformità al diritto del lavoro
+    description: |
+      Conformità al diritto del lavoro, all'orario di lavoro e agli standard occupazionali.
+  BC-300.90:
+    name: Gestione di diversità, equità e inclusione
+    description: |
+      Strategia DEI, programmi e reporting.
+  BC-300.90.10:
+    name: Strategia e governance DEI
+    description: |
+      Strategia DEI, sponsorship e strutture di governance.
+  BC-300.90.20:
+    name: Pratiche di talento inclusive
+    description: |
+      Pratiche inclusive di sourcing, assunzione e sviluppo professionale.
+  BC-300.90.30:
+    name: Erogazione dei programmi DEI
+    description: |
+      Employee resource group, sensibilizzazione e programmi DEI.
+  BC-300.90.40:
+    name: Equità retributiva e reporting DEI
+    description: |
+      Analisi dell'equità retributiva e metriche e informativa DEI.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-hvac-bas-service-operations-management.yaml
+++ b/catalogue/i18n/it/L1-hvac-bas-service-operations-management.yaml
@@ -1,0 +1,202 @@
+# Gestione delle operazioni di assistenza HVAC e BAS (it) — translations for L1-hvac-bas-service-operations-management.yaml
+locale: it
+source: L1-hvac-bas-service-operations-management.yaml
+entries:
+  BC-2060:
+    name: Gestione delle operazioni di assistenza HVAC e BAS
+    description: |
+      Assistenza guidata da OEM e da appaltatore sulle apparecchiature HVAC e BAS installate —
+      gestione della configurazione della base installata, manutenzione preventiva e reattiva,
+      riprogrammazione BAS e assistenza software, retrofit e modernizzazione delle apparecchiature,
+      contratti di assistenza basati sulle prestazioni e assistenza remota connessa.
+    in_scope:
+      - Registro della configurazione delle apparecchiature installate e del BAS
+      - Erogazione del contratto di manutenzione preventiva e assistenza reattiva/d'emergenza
+      - Riprogrammazione BAS, aggiornamenti del firmware e operazioni di backup/ripristino
+      - Esecuzione di retrofit e modernizzazione sulle apparecchiature HVAC installate
+      - Contratti di assistenza basati sulle prestazioni e sui risultati
+      - Assistenza remota connessa e operazioni del centro di diagnostica
+      - Gestione dei contratti di servizio e della soddisfazione del cliente
+    out_of_scope:
+      - Assistenza sul campo generica trasversale (BC-1050) e ricambi (BC-1060)
+      - Commissioning e erogazione Cx di progetto (BC-2050)
+      - Approvvigionamento e reporting del refrigerante (BC-2040)
+      - Ingegneria del prodotto delle apparecchiature HVAC (BC-2000)
+
+  BC-2060.10:
+    name: Gestione della configurazione della base installata
+    description: |
+      Manutenzione dei dati di configurazione as-installed e as-maintained per la base
+      installata globale.
+
+  BC-2060.10.10:
+    name: Registro delle risorse apparecchiature
+    description: Registro delle apparecchiature HVAC installate per numero seriale, sito e cliente.
+
+  BC-2060.10.20:
+    name: Registro delle configurazioni BAS
+    description: Registro delle configurazioni BAS, controllori, punti e sequenze in servizio.
+
+  BC-2060.10.30:
+    name: Registrazioni as-maintained
+    description: Registrazioni della configurazione as-maintained a seguito di ogni evento di assistenza.
+
+  BC-2060.10.40:
+    name: Registrazioni delle modifiche alla base installata
+    description: Registrazioni delle modifiche post-collaudo alle apparecchiature installate e al BAS.
+
+  BC-2060.20:
+    name: Operazioni di assistenza per la manutenzione preventiva
+    description: |
+      Erogazione della manutenzione preventiva programmata a contratto.
+
+  BC-2060.20.10:
+    name: Esecuzione del contratto di manutenzione
+    description: Esecuzione della manutenzione preventiva rispetto allo scope contrattuale.
+
+  BC-2060.20.20:
+    name: Pianificazione degli interventi programmati
+    description: Pianificazione e dispatch degli interventi di assistenza programmati.
+
+  BC-2060.20.30:
+    name: Assistenza filtri e cinghie
+    description: Sostituzione di routine di filtri, cinghie e materiali di consumo.
+
+  BC-2060.20.40:
+    name: Assistenza refrigerante e serpentine
+    description: Reintegro di routine del refrigerante e pulizia delle serpentine.
+
+  BC-2060.20.50:
+    name: Reporting della conformità alla manutenzione
+    description: Reporting della conformità alla manutenzione preventiva ai clienti.
+
+  BC-2060.30:
+    name: Operazioni di assistenza reattiva e d'emergenza
+    description: |
+      Assistenza reattiva e fuori orario d'emergenza sulle apparecchiature installate.
+
+  BC-2060.30.10:
+    name: Triage delle richieste di assistenza
+    description: Triage delle richieste di assistenza in entrata per urgenza e competenza.
+
+  BC-2060.30.20:
+    name: Dispatch dell'intervento d'emergenza
+    description: Dispatch degli interventi d'emergenza per guasti critici delle apparecchiature.
+
+  BC-2060.30.30:
+    name: Esecuzione della riparazione in situ
+    description: Esecuzione della riparazione in situ da parte dei tecnici di assistenza.
+
+  BC-2060.30.40:
+    name: Risposta d'emergenza alle perdite di refrigerante
+    description: Risposta d'emergenza alle emissioni di refrigerante e alle perdite importanti.
+
+  BC-2060.40:
+    name: Riprogrammazione BAS e assistenza software
+    description: |
+      Assistenza lato software sul BAS installato — aggiornamenti delle sequenze, aggiornamenti
+      del firmware e modifiche alla configurazione.
+
+  BC-2060.40.10:
+    name: Distribuzione degli aggiornamenti delle sequenze
+    description: Distribuzione delle sequenze operative aggiornate ai controllori installati.
+
+  BC-2060.40.20:
+    name: Aggiornamento del firmware del controllore
+    description: Aggiornamento del firmware dei controllori BAS installati.
+
+  BC-2060.40.30:
+    name: Modifica di punti e calendari
+    description: Modifica sul campo dei punti BAS, dei calendari e dei trend.
+
+  BC-2060.40.40:
+    name: Operazioni di backup e ripristino BAS
+    description: Backup della configurazione BAS e ripristino in caso di eventi di guasto.
+
+  BC-2060.50:
+    name: Servizio di retrofit e modernizzazione delle apparecchiature HVAC
+    description: |
+      Servizi di retrofit, sostituzione e modernizzazione erogati sulla base installata HVAC.
+
+  BC-2060.50.10:
+    name: Ingegneria del retrofit in situ
+    description: Ingegneria in situ dei pacchetti di retrofit adattati all'installazione.
+
+  BC-2060.50.20:
+    name: Esecuzione della sostituzione delle apparecchiature
+    description: Esecuzione in situ dello scope di sostituzione delle apparecchiature.
+
+  BC-2060.50.30:
+    name: Servizio di conversione del refrigerante
+    description: Conversione delle apparecchiature installate a refrigeranti alternativi.
+
+  BC-2060.50.40:
+    name: Test di validazione del retrofit
+    description: Test di validazione a seguito di lavori di retrofit o modernizzazione.
+
+  BC-2060.60:
+    name: Operazioni del contratto di assistenza basato sulle prestazioni
+    description: |
+      Gestione dei contratti di assistenza basati sulle prestazioni e sui risultati.
+
+  BC-2060.60.10:
+    name: Esecuzione del contratto di prestazione
+    description: Esecuzione degli obblighi di assistenza basata sulle prestazioni.
+
+  BC-2060.60.20:
+    name: Tracciamento dei risparmi garantiti
+    description: Tracciamento dei risultati dei risparmi garantiti rispetto alla baseline.
+
+  BC-2060.60.30:
+    name: Operazioni dei meccanismi di condivisione del rischio
+    description: Gestione dei meccanismi di bonus e penale per la condivisione del rischio.
+
+  BC-2060.60.40:
+    name: Reporting dei risultati
+    description: Reporting dei risultati contrattuali e delle metriche del livello di servizio.
+
+  BC-2060.70:
+    name: Operazioni del servizio remoto connesso
+    description: |
+      Operazioni del centro di assistenza remota che utilizza i dati HVAC e BAS connessi.
+
+  BC-2060.70.10:
+    name: Operazioni del centro di diagnostica remota
+    description: Operazioni del centro di diagnostica remota per le apparecchiature connesse.
+
+  BC-2060.70.20:
+    name: Triage remoto delle problematiche
+    description: Triage delle problematiche identificate tramite telemetria remota.
+
+  BC-2060.70.30:
+    name: Esecuzione della risoluzione remota
+    description: Esecuzione delle risoluzioni solo da remoto quando il problema non richiede una visita in sito.
+
+  BC-2060.70.40:
+    name: Onboarding del cliente per il servizio connesso
+    description: Onboarding dei clienti sulle offerte di servizio connesso.
+
+  BC-2060.80:
+    name: Gestione della qualità del servizio e dei contratti di servizio
+    description: |
+      Gestione della qualità del servizio, dei contratti di servizio e della soddisfazione del cliente.
+
+  BC-2060.80.10:
+    name: Tracciamento del contratto di servizio
+    description: Tracciamento delle prestazioni del contratto di servizio.
+
+  BC-2060.80.20:
+    name: Raccolta della soddisfazione del cliente
+    description: Raccolta della soddisfazione del cliente nelle interazioni di assistenza.
+
+  BC-2060.80.30:
+    name: Gestione delle escalation del servizio
+    description: Gestione delle escalation del servizio e delle azioni di recupero.
+
+  BC-2060.80.40:
+    name: Reporting delle prestazioni del servizio
+    description: Reporting periodico delle prestazioni del servizio a clienti e management.
+
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-hvac-equipment-certification-management.yaml
+++ b/catalogue/i18n/it/L1-hvac-equipment-certification-management.yaml
@@ -1,0 +1,174 @@
+# Gestione della certificazione delle apparecchiature HVAC (it) — translations for L1-hvac-equipment-certification-management.yaml
+locale: it
+source: L1-hvac-equipment-certification-management.yaml
+entries:
+  BC-2030:
+    name: Gestione della certificazione delle apparecchiature HVAC
+    description: |
+      Certificazione dei prodotti HVAC per più giurisdizioni — certificazione delle prestazioni
+      (AHRI, Eurovent), certificazione di sicurezza (UL, CSA, IEC 60335-2-40, marcatura CE),
+      approvazioni dei refrigeranti (F-gas, EPA SNAP) ed etichettatura di efficienza energetica
+      (ENERGY STAR, Ecodesign UE/ErP, MEPS) — fino alla licenza del marchio, alla conformità
+      dell'etichetta e alla sorveglianza delle norme.
+    in_scope:
+      - Strategia di certificazione e roadmap per i mercati
+      - Sottomissioni per la certificazione delle prestazioni e pubblicazione delle omologazioni
+      - Certificazione di sicurezza delle apparecchiature e valutazione di conformità CE
+      - Approvazione normativa del refrigerante a livello di prodotto
+      - Registrazione e conformità dell'etichetta di efficienza energetica
+      - Licenza del marchio, conformità dell'artwork dell'etichetta e sorveglianza delle norme
+    out_of_scope:
+      - Contabilità operativa del refrigerante sulle apparecchiature installate (BC-2040)
+      - Certificazione generica di prodotti elettrici/elettronici (BC-1910)
+      - Indagine su non conformità sul campo derivante dall'assistenza (BC-2060)
+
+  BC-2030.10:
+    name: Strategia di certificazione e roadmap
+    description: |
+      Definizione dello scope di certificazione, degli schemi e della sequenza nei mercati target.
+
+  BC-2030.10.10:
+    name: Analisi dei requisiti di accesso al mercato
+    description: Identificazione degli obblighi di certificazione ed etichettatura per mercato target.
+
+  BC-2030.10.20:
+    name: Selezione degli schemi di certificazione
+    description: Selezione degli schemi di certificazione e delle vie di riconoscimento per le apparecchiature HVAC.
+
+  BC-2030.10.30:
+    name: Pianificazione della roadmap di certificazione
+    description: Sequenziamento delle certificazioni rispetto alle milestone di lancio delle apparecchiature.
+
+  BC-2030.20:
+    name: Gestione della certificazione delle prestazioni
+    description: |
+      Rapporti con i programmi di certificazione delle prestazioni HVAC e pubblicazione delle
+      prestazioni omologate.
+
+  BC-2030.20.10:
+    name: Coordinamento del programma di test di prestazione
+    description: Coordinamento dei test di omologazione delle apparecchiature con laboratori accreditati.
+
+  BC-2030.20.20:
+    name: Sottomissione delle omologazioni delle prestazioni
+    description: Sottomissione delle omologazioni certificate ai programmi di certificazione delle prestazioni.
+
+  BC-2030.20.30:
+    name: Tracciamento dell'emissione del marchio di prestazione
+    description: Tracciamento dei certificati di prestazione emessi e delle finestre di validità.
+
+  BC-2030.20.40:
+    name: Partecipazione a programmi volontari
+    description: Partecipazione a programmi volontari di prestazione e qualità.
+
+  BC-2030.30:
+    name: Gestione della certificazione di sicurezza delle apparecchiature
+    description: |
+      Rapporti con gli schemi di certificazione di sicurezza per le apparecchiature HVAC nelle diverse giurisdizioni.
+
+  BC-2030.30.10:
+    name: Sottomissione della certificazione di sicurezza
+    description: Sottomissione delle certificazioni di sicurezza rispetto alla norma IEC 60335-2-40 e standard equivalenti.
+
+  BC-2030.30.20:
+    name: Verifica della conformità agli standard di sicurezza
+    description: Verifica della conformità agli standard di sicurezza tramite audit interno.
+
+  BC-2030.30.30:
+    name: Coordinamento dei marchi di sicurezza internazionali
+    description: Coordinamento tra più marchi di sicurezza nazionali e accordi di riconoscimento.
+
+  BC-2030.30.40:
+    name: Gestione delle modifiche di sicurezza sul campo
+    description: Gestione delle modifiche di sicurezza sul campo e delle azioni correttive che interessano le certificazioni.
+
+  BC-2030.40:
+    name: Gestione della conformità del refrigerante
+    description: |
+      Approvazioni del refrigerante a livello di prodotto, conformità alla riduzione graduale
+      e divulgazione delle sostanze per la certificazione.
+
+  BC-2030.40.10:
+    name: Tracciamento delle approvazioni del refrigerante
+    description: Tracciamento dei refrigeranti approvati per ciascuna famiglia di prodotti per giurisdizione.
+
+  BC-2030.40.20:
+    name: Conformità alla riduzione graduale degli HFC
+    description: Conformità ai calendari di riduzione graduale degli HFC e agli impegni di Kigali a livello di prodotto.
+
+  BC-2030.40.30:
+    name: Registrazioni di conformità GWP e ODP
+    description: Registrazioni del GWP e dell'ODP rispetto alle soglie regolamentari.
+
+  BC-2030.40.40:
+    name: Comunicazione delle sostanze del refrigerante
+    description: Comunicazione delle sostanze richiesta come parte dei dossier di certificazione del prodotto.
+
+  BC-2030.50:
+    name: Gestione dell'etichetta di energia ed efficienza
+    description: |
+      Registrazione e conformità continuativa con i programmi di etichettatura di efficienza
+      energetica e di efficienza minima.
+
+  BC-2030.50.10:
+    name: Registrazione dell'etichetta energetica
+    description: Registrazione delle etichette energetiche delle apparecchiature presso i programmi nazionali.
+
+  BC-2030.50.20:
+    name: Conformità Ecodesign
+    description: Conformità al regolamento Ecodesign UE e ai regimi equivalenti.
+
+  BC-2030.50.30:
+    name: Conformità agli standard minimi di efficienza
+    description: Conformità agli standard minimi di efficienza nei diversi mercati.
+
+  BC-2030.50.40:
+    name: Partecipazione a eco-etichette volontarie
+    description: Partecipazione a programmi di eco-etichette volontarie per apparecchiature sostenibili.
+
+  BC-2030.60:
+    name: Gestione della conformità del marchio di certificazione e dell'etichetta
+    description: |
+      Gestione del ciclo di vita dei marchi di certificazione e dell'artwork dell'etichetta sul prodotto.
+
+  BC-2030.60.10:
+    name: Emissione del marchio
+    description: Emissione e applicazione sul prodotto dei marchi di certificazione.
+
+  BC-2030.60.20:
+    name: Rinnovo del marchio
+    description: Rinnovo dei marchi di certificazione prima della scadenza.
+
+  BC-2030.60.30:
+    name: Ritiro del marchio
+    description: Ritiro dei marchi di certificazione per apparecchiature ritirate o non conformi.
+
+  BC-2030.60.40:
+    name: Conformità dell'etichetta sul prodotto
+    description: Controllo dell'artwork dell'etichetta sul prodotto rispetto al contenuto di certificazione approvato.
+
+  BC-2030.70:
+    name: Gestione della sorveglianza delle norme
+    description: |
+      Sorveglianza delle norme e dei regolamenti HVAC, con valutazione dell'impatto e comunicazione
+      della roadmap.
+
+  BC-2030.70.10:
+    name: Intelligence sulle norme HVAC
+    description: Intelligence sulle norme HVAC emergenti e riviste.
+
+  BC-2030.70.20:
+    name: Valutazione dell'impatto dei cambiamenti normativi
+    description: Valutazione dell'impatto dei cambiamenti normativi sulle certificazioni esistenti.
+
+  BC-2030.70.30:
+    name: Partecipazione agli organismi di settore
+    description: Partecipazione agli organismi di normazione del settore e ai comitati tecnici.
+
+  BC-2030.70.40:
+    name: Comunicazione della roadmap normativa
+    description: Comunicazione delle roadmap normative ai team di ingegneria e di prodotto.
+
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-hvac-equipment-engineering-management.yaml
+++ b/catalogue/i18n/it/L1-hvac-equipment-engineering-management.yaml
@@ -1,0 +1,219 @@
+# Gestione dell'ingegneria delle apparecchiature HVAC (it) — translations for L1-hvac-equipment-engineering-management.yaml
+locale: it
+source: L1-hvac-equipment-engineering-management.yaml
+entries:
+  BC-2000:
+    name: Gestione dell'ingegneria delle apparecchiature HVAC
+    description: |
+      Ingegneria di prodotto meccanica, frigorifera e termo-fluidica delle apparecchiature HVAC —
+      chiller, pompe di calore, UTA, RTU, VRF, fan coil e unità terminali — fino alla verifica
+      delle prestazioni e alla preparazione per i test di omologazione AHRI/Eurovent.
+    in_scope:
+      - Progettazione del ciclo frigorifero e del ciclo della pompa di calore
+      - Ingegneria degli scambiatori di calore e delle serpentine
+      - Ingegneria delle apparecchiature di movimentazione aria e idroniche
+      - Ingegneria di compressori, azionamenti e controlli di bordo
+      - Verifica delle prestazioni acustiche, vibrazionali e a livello di apparecchiatura
+    out_of_scope:
+      - Selezione e integrazione del sistema a livello di progetto (BC-2020)
+      - Ingegneria del prodotto controllore BAS (BC-2010)
+      - Sottomissioni per la certificazione di tipo e licenza del marchio (BC-2030)
+      - Contabilità operativa del refrigerante (BC-2040)
+
+  BC-2000.10:
+    name: Ingegneria del ciclo frigorifero
+    description: |
+      Ingegneria dei cicli a compressione di vapore, ad assorbimento e della pompa di calore
+      per apparecchiature HVAC.
+
+  BC-2000.10.10:
+    name: Progettazione del ciclo a compressione di vapore
+    description: Progettazione dei cicli frigoriferi a compressione di vapore per apparecchiature di raffreddamento e riscaldamento.
+
+  BC-2000.10.20:
+    name: Progettazione del ciclo ad assorbimento
+    description: Progettazione di chiller e pompe di calore a ciclo ad assorbimento.
+
+  BC-2000.10.30:
+    name: Progettazione del ciclo della pompa di calore
+    description: Progettazione di cicli reversibili per pompe di calore nelle varianti aria-aria, acqua-acqua e geotermiche.
+
+  BC-2000.10.40:
+    name: Ingegneria della selezione del refrigerante
+    description: Selezione dei refrigeranti in funzione di obiettivi termodinamici, normativi, di GWP e di infiammabilità.
+
+  BC-2000.10.50:
+    name: Ottimizzazione delle prestazioni del ciclo
+    description: Ottimizzazione delle prestazioni del ciclo ai punti di omologazione e in condizioni di carico parziale.
+
+  BC-2000.20:
+    name: Ingegneria degli scambiatori di calore e delle serpentine
+    description: |
+      Ingegneria di evaporatori, condensatori, ruote di recupero e scambiatori brasati
+      e a fascio tubiero per apparecchiature HVAC.
+
+  BC-2000.20.10:
+    name: Progettazione della serpentina evaporante
+    description: Progettazione di serpentine evaporanti a tubi alettati e a microcanali.
+
+  BC-2000.20.20:
+    name: Progettazione della serpentina condensante
+    description: Progettazione di serpentine condensanti a raffreddamento aria e a raffreddamento acqua.
+
+  BC-2000.20.30:
+    name: Progettazione del recupero di calore aria-aria
+    description: Progettazione di ruote di recupero energetico, scambiatori a piastre e circuiti run-around.
+
+  BC-2000.20.40:
+    name: Progettazione a piastre brasate e a fascio tubiero
+    description: Progettazione di scambiatori a piastre brasate e a fascio tubiero per servizio idronico e frigorifero.
+
+  BC-2000.20.50:
+    name: Ingegneria dei materiali e dei rivestimenti della serpentina
+    description: Selezione della metallurgia e dei rivestimenti protettivi delle serpentine per la durabilità ambientale.
+
+  BC-2000.30:
+    name: Ingegneria delle apparecchiature di movimentazione aria
+    description: |
+      Ingegneria di ventilatori, soffiatori, unità di trattamento aria (UTA), serrande e
+      assemblaggi di filtrazione.
+
+  BC-2000.30.10:
+    name: Progettazione del ventilatore centrifugo
+    description: Progettazione aerodinamica e meccanica dei ventilatori centrifughi.
+
+  BC-2000.30.20:
+    name: Progettazione del ventilatore assiale e a tappo
+    description: Progettazione aerodinamica e meccanica dei ventilatori assiali e a tappo.
+
+  BC-2000.30.30:
+    name: Ingegneria dell'unità di trattamento aria
+    description: Ingegneria delle sezioni modulari, dell'involucro e del flusso d'aria dell'UTA.
+
+  BC-2000.30.40:
+    name: Ingegneria delle serrande e delle griglie
+    description: Ingegneria delle serrande di regolazione, antifumo/antincendio e delle griglie di ventilazione.
+
+  BC-2000.30.50:
+    name: Ingegneria del sistema di filtrazione
+    description: Ingegneria delle sezioni di filtrazione per particolato, fase gassosa e HEPA.
+
+  BC-2000.40:
+    name: Ingegneria dei sistemi idronici e fluidici
+    description: |
+      Ingegneria di pompe, tubazioni, circuiti idronici e accessori ausiliari
+      all'interno delle apparecchiature HVAC.
+
+  BC-2000.40.10:
+    name: Ingegneria delle pompe
+    description: Selezione e integrazione di pompe circolatrici e a fine aspirazione in skid di apparecchiature.
+
+  BC-2000.40.20:
+    name: Progettazione di tubazioni e collettori
+    description: Progettazione delle tubazioni interne, collettori e distributrici all'interno delle apparecchiature preassemblate.
+
+  BC-2000.40.30:
+    name: Ingegneria del circuito acqua refrigerata e calda
+    description: Ingegneria dei circuiti integrati di acqua refrigerata e calda a livello di apparecchiatura.
+
+  BC-2000.40.40:
+    name: Ingegneria degli accessori idronici
+    description: Ingegneria di vasi di espansione, separatori d'aria e filtri come accessori preassemblati.
+
+  BC-2000.50:
+    name: Ingegneria dei compressori e degli azionamenti
+    description: |
+      Ingegneria delle famiglie di compressori e degli azionamenti che li alimentano.
+
+  BC-2000.50.10:
+    name: Ingegneria del compressore scroll
+    description: Ingegneria dei compressori scroll utilizzati nelle apparecchiature per uso commerciale leggero.
+
+  BC-2000.50.20:
+    name: Ingegneria del compressore a vite
+    description: Ingegneria dei compressori a vite utilizzati in chiller commerciali e industriali.
+
+  BC-2000.50.30:
+    name: Ingegneria del compressore centrifugo
+    description: Ingegneria dei compressori centrifughi utilizzati in chiller di grande potenza.
+
+  BC-2000.50.40:
+    name: Ingegneria del compressore alternativo
+    description: Ingegneria dei compressori alternativi utilizzati nelle pompe di calore e nella refrigerazione.
+
+  BC-2000.50.50:
+    name: Integrazione degli azionamenti a velocità variabile
+    description: Integrazione degli azionamenti a velocità variabile con compressori e ventilatori HVAC.
+
+  BC-2000.60:
+    name: Ingegneria acustica e vibrazionale delle apparecchiature HVAC
+    description: |
+      Ingegneria acustica, vibrazionale e della rumorosità a livello di apparecchiatura.
+
+  BC-2000.60.10:
+    name: Modellazione della potenza sonora
+    description: Modellazione della potenza sonora e della pressione sonora delle apparecchiature HVAC.
+
+  BC-2000.60.20:
+    name: Progettazione dell'isolamento dalle vibrazioni
+    description: Progettazione dell'isolamento dalle vibrazioni per compressori, ventilatori e pompe.
+
+  BC-2000.60.30:
+    name: Ingegneria dell'involucro acustico
+    description: Ingegneria di involucri acustici e attenuatori integrati con le apparecchiature.
+
+  BC-2000.60.40:
+    name: Ottimizzazione delle prestazioni psicoacustiche
+    description: Ottimizzazione della qualità sonora percepita al di là delle metriche aggregate di potenza sonora.
+
+  BC-2000.70:
+    name: Ingegneria del controllo e dell'elettronica integrata delle apparecchiature
+    description: |
+      Ingegneria dei controllori di bordo, del firmware e degli stack di connettività
+      residenti nelle apparecchiature HVAC.
+
+  BC-2000.70.10:
+    name: Ingegneria del controllore di bordo
+    description: Ingegneria dei controllori residenti nelle apparecchiature e dei controllori di unità.
+
+  BC-2000.70.20:
+    name: Ingegneria del firmware delle apparecchiature
+    description: Sviluppo del firmware per le apparecchiature HVAC, inclusi controllori di unità e azionamenti.
+
+  BC-2000.70.30:
+    name: Ingegneria della comunicazione delle apparecchiature intelligenti
+    description: Ingegneria della comunicazione BAS lato apparecchiatura, inclusi BACnet e Modbus.
+
+  BC-2000.70.40:
+    name: Ingegneria della logica diagnostica delle apparecchiature
+    description: Ingegneria della logica di diagnostica, allarme e codici guasto delle apparecchiature.
+
+  BC-2000.80:
+    name: Verifica e test delle apparecchiature HVAC
+    description: |
+      Verifica delle prestazioni a livello di apparecchiatura, esecuzione dei test di omologazione
+      AHRI/Eurovent e test di durabilità.
+
+  BC-2000.80.10:
+    name: Test in camera psicrometrica
+    description: Test delle apparecchiature HVAC in camere psicrometriche in condizioni controllate.
+
+  BC-2000.80.20:
+    name: Esecuzione dei test di omologazione delle prestazioni
+    description: Esecuzione di test standardizzati di omologazione delle prestazioni sulle apparecchiature HVAC.
+
+  BC-2000.80.30:
+    name: Verifica delle prestazioni termiche
+    description: Verifica della capacità, COP, IPLV e altre metriche di prestazione termica.
+
+  BC-2000.80.40:
+    name: Test di resistenza e affidabilità
+    description: Test di resistenza, vita accelerata e affidabilità delle apparecchiature HVAC.
+
+  BC-2000.80.50:
+    name: Redazione del piano di test delle apparecchiature
+    description: Redazione dei piani di verifica e qualificazione a livello di apparecchiatura.
+
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-hvac-system-integration-management.yaml
+++ b/catalogue/i18n/it/L1-hvac-system-integration-management.yaml
@@ -1,0 +1,196 @@
+# Gestione dell'integrazione del sistema HVAC (it) — translations for L1-hvac-system-integration-management.yaml
+locale: it
+source: L1-hvac-system-integration-management.yaml
+entries:
+  BC-2020:
+    name: Gestione dell'integrazione del sistema HVAC
+    description: |
+      Ingegneria a livello di progetto delle soluzioni HVAC e BAS integrate per un edificio specifico —
+      calcolo del carico termico, selezione delle apparecchiature, progettazione schematica, lista punti
+      BAS e architettura, redazione delle sequenze operative, coordinamento BIM/MEP, specifiche di
+      progetto, gestione delle approvazioni e supporto ingegneristico sul campo.
+    in_scope:
+      - Calcoli del carico termico specifici per l'edificio e selezione delle apparecchiature
+      - Progettazione schematica meccanica, idronicca e frigorifera a scala di progetto
+      - Liste punti BAS, topologia di rete e disposizione dei quadri per i progetti
+      - Redazione delle sequenze operative specifiche per il progetto
+      - Coordinamento BIM, specifiche di progetto e gestione delle approvazioni
+    out_of_scope:
+      - Ingegneria del prodotto apparecchiatura (BC-2000) e ingegneria del prodotto BAS (BC-2010)
+      - Disciplina di progettazione MEP trasversale (BC-1100)
+      - Erogazione del servizio di messa in servizio (BC-2050)
+      - Gestione generica dei progetti di ingegneria (BC-1110)
+
+  BC-2020.10:
+    name: Dimensionamento e selezione HVAC dell'edificio
+    description: |
+      Dimensionamento specifico per progetto dei carichi e selezione delle apparecchiature HVAC
+      per soddisfare l'intento progettuale.
+
+  BC-2020.10.10:
+    name: Calcolo del carico di raffreddamento e riscaldamento
+    description: Calcolo dei carichi di raffreddamento e riscaldamento dell'edificio.
+
+  BC-2020.10.20:
+    name: Selezione delle apparecchiature e distinta
+    description: Selezione dei modelli di apparecchiature rispetto ai carichi calcolati e alle distinte.
+
+  BC-2020.10.30:
+    name: Dimensionamento del circuito idronico
+    description: Dimensionamento dei circuiti idronici, delle pompe e dei diametri delle tubazioni.
+
+  BC-2020.10.40:
+    name: Dimensionamento delle canalizzazioni e analisi della perdita di carico
+    description: Dimensionamento delle canalizzazioni e analisi della perdita di carico del sistema.
+
+  BC-2020.10.50:
+    name: Modellazione energetica per la selezione
+    description: Simulazione energetica a supporto dei compromessi nella selezione delle apparecchiature.
+
+  BC-2020.20:
+    name: Progettazione schematica del sistema HVAC
+    description: |
+      Progettazione schematica dei sistemi meccanici, idronici e frigoriferi integrati.
+
+  BC-2020.20.10:
+    name: Progettazione schematica meccanica
+    description: Progettazione a livello schematico dei sistemi meccanici lato aria.
+
+  BC-2020.20.20:
+    name: Progettazione schematica idronicca
+    description: Progettazione a livello schematico dei circuiti di acqua refrigerata, calda e del condensatore.
+
+  BC-2020.20.30:
+    name: Progettazione schematica della tubazione frigorifera
+    description: Progettazione a livello schematico delle tubazioni frigorifere per sistemi VRF e split.
+
+  BC-2020.20.40:
+    name: Progettazione dello schema di controllo monofilo
+    description: Schemi monofilo che rappresentano la sovrapposizione del controllo BAS sui sistemi meccanici.
+
+  BC-2020.30:
+    name: Progettazione della lista punti BAS e dell'architettura
+    description: |
+      Liste punti specifiche per progetto, topologia della rete BAS e allocazione dei quadri.
+
+  BC-2020.30.10:
+    name: Redazione della lista punti
+    description: Redazione delle liste punti BAS specifiche per il progetto.
+
+  BC-2020.30.20:
+    name: Progettazione della topologia di rete BAS
+    description: Progettazione della topologia di rete BAS e della segmentazione per il progetto.
+
+  BC-2020.30.30:
+    name: Allocazione dei controllori e disposizione dei quadri
+    description: Allocazione dei controllori e progettazione dei quadri di controllo per il progetto.
+
+  BC-2020.30.40:
+    name: Applicazione delle convenzioni di tag e denominazione
+    description: Applicazione delle convenzioni di tag e denominazione ai punti e alle risorse del progetto.
+
+  BC-2020.40:
+    name: Redazione delle sequenze operative
+    description: |
+      Redazione specifica per progetto delle sequenze operative per i sistemi HVAC.
+
+  BC-2020.40.10:
+    name: Redazione delle sequenze di zona
+    description: Redazione delle sequenze di controllo di zona a livello di progetto.
+
+  BC-2020.40.20:
+    name: Redazione delle sequenze dell'impianto centrale
+    description: Redazione delle sequenze di controllo dell'impianto centrale a livello di progetto.
+
+  BC-2020.40.30:
+    name: Redazione della strategia di risparmio energetico
+    description: Redazione delle strategie di controllo per il risparmio energetico a livello di progetto.
+
+  BC-2020.40.40:
+    name: Redazione delle sequenze di allarme e override
+    description: Redazione della logica degli allarmi e delle sequenze di override dell'operatore a livello di progetto.
+
+  BC-2020.50:
+    name: Coordinamento BIM e MEP
+    description: |
+      Modellazione BIM e coordinamento multi-disciplina dello scope HVAC all'interno del progetto.
+
+  BC-2020.50.10:
+    name: Modellazione BIM HVAC
+    description: Modellazione BIM dello scope HVAC per il progetto.
+
+  BC-2020.50.20:
+    name: Rilevamento delle interferenze MEP
+    description: Rilevamento delle interferenze di coordinamento tra le discipline MEP.
+
+  BC-2020.50.30:
+    name: Coordinamento dello scambio di modelli
+    description: Coordinamento dei formati di scambio dei modelli BIM e dei deliverable.
+
+  BC-2020.50.40:
+    name: Emissione del modello di coordinamento
+    description: Emissione dei modelli BIM coordinati agli stakeholder del progetto.
+
+  BC-2020.60:
+    name: Redazione delle specifiche di progetto HVAC
+    description: |
+      Redazione delle specifiche di progetto per lo scope HVAC e dei controlli.
+
+  BC-2020.60.10:
+    name: Redazione delle specifiche meccaniche
+    description: Redazione delle specifiche meccaniche per il progetto.
+
+  BC-2020.60.20:
+    name: Redazione delle specifiche dei controlli
+    description: Redazione delle specifiche BAS e dei controlli per il progetto.
+
+  BC-2020.60.30:
+    name: Redazione dei criteri di prestazione e accettazione
+    description: Redazione dei criteri di prestazione e dei test di accettazione per il progetto.
+
+  BC-2020.70:
+    name: Gestione delle approvazioni dell'integrazione di sistema
+    description: |
+      Gestione delle approvazioni, dei disegni costruttivi e delle RFI durante la fase di esecuzione del progetto.
+
+  BC-2020.70.10:
+    name: Preparazione del pacchetto di approvazione
+    description: Preparazione dei pacchetti di approvazione per la revisione da parte del committente e del progettista.
+
+  BC-2020.70.20:
+    name: Coordinamento dei disegni costruttivi
+    description: Coordinamento dei disegni costruttivi con l'intento progettuale.
+
+  BC-2020.70.30:
+    name: Gestione delle risposte alle RFI
+    description: Gestione delle RFI progettuali da parte dell'appaltatore e dell'integratore.
+
+  BC-2020.70.40:
+    name: Revisione delle sostituzioni
+    description: Revisione delle richieste di sostituzione di apparecchiature e materiali.
+
+  BC-2020.80:
+    name: Supporto ingegneristico sul sito
+    description: |
+      Supporto ingegneristico durante la costruzione e l'installazione, incluse le risoluzioni sul campo
+      e i documenti as-installed.
+
+  BC-2020.80.10:
+    name: Risoluzione di problemi ingegneristici sul campo
+    description: Risoluzione di problemi ingegneristici sul campo durante l'installazione.
+
+  BC-2020.80.20:
+    name: Ingegneria delle varianti
+    description: Attività ingegneristica a supporto delle varianti durante la costruzione.
+
+  BC-2020.80.30:
+    name: Aggiornamento dei disegni as-installed
+    description: Aggiornamento dei disegni per rispecchiare le condizioni as-installed.
+
+  BC-2020.80.40:
+    name: Ispezione di testimonianza dell'installazione
+    description: Testimonianza delle fasi di installazione per l'accettazione ingegneristica.
+
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-hydrocarbon-exploration-management.yaml
+++ b/catalogue/i18n/it/L1-hydrocarbon-exploration-management.yaml
@@ -1,0 +1,151 @@
+# Gestione dell'esplorazione di idrocarburi (it) — translations for L1-hydrocarbon-exploration-management.yaml
+locale: it
+source: L1-hydrocarbon-exploration-management.yaml
+entries:
+  BC-3000:
+    name: Gestione dell'esplorazione di idrocarburi
+    description: |
+      Identificazione e acquisizione di nuove risorse di idrocarburi attraverso
+      rilevamenti geofisici, valutazione di bacini e prospetti geologici, acquisizione
+      di licenze e concessioni, e decisioni di perforazione esplorativa.
+  BC-3000.10:
+    name: Gestione dei rilevamenti geofisici
+    description: |
+      Acquisizione, elaborazione e interpretazione di dati geofisici sismici e
+      non sismici per l'imaging del sottosuolo.
+    in_scope:
+      - Campagne di acquisizione sismica 2D e 3D
+      - Elaborazione e rielaborazione sismica
+      - Interpretazione sismica per la generazione di prospetti geologici
+    out_of_scope:
+      - Geomodellazione a scala di giacimento per asset in sviluppo (BC-3010)
+  BC-3000.10.10:
+    name: Acquisizione sismica 3D
+    description: |
+      Operazioni di acquisizione sismica 3D marino, a terra e su fondale oceanico.
+  BC-3000.10.20:
+    name: Acquisizione sismica 2D
+    description: |
+      Operazioni di acquisizione sismica 2D su scala di ricognizione.
+  BC-3000.10.30:
+    name: Acquisizione geofisica non sismica
+    description: |
+      Rilevamenti gravimetrici, magnetici, elettromagnetici e altri rilevamenti non sismici.
+  BC-3000.10.40:
+    name: Elaborazione dei dati sismici
+    description: |
+      Elaborazione pre-stack e post-stack, migrazione in profondità e rielaborazione dei dati sismici.
+  BC-3000.10.50:
+    name: Interpretazione dei dati sismici
+    description: |
+      Interpretazione strutturale e stratigrafica di volumi sismici per la generazione di prospetti geologici.
+  BC-3000.20:
+    name: Valutazione di bacini e prospetti geologici
+    description: |
+      Analisi dei sistemi petroliferi, mappatura delle fairway di play e valutazione
+      del rischio e dei volumi dei prospetti esplorativi.
+    in_scope:
+      - Modellazione dei sistemi petroliferi
+      - Inventario e classificazione dei prospetti geologici
+      - Stima volumetrica rischiata
+    out_of_scope:
+      - Classificazione delle riserve di volumi scoperti (BC-3010.30)
+  BC-3000.20.10:
+    name: Analisi dei sistemi petroliferi
+    description: |
+      Analisi di sorgente, giacimento, cappellaccio, trappola e tempistica per la qualifica dei sistemi petroliferi.
+  BC-3000.20.20:
+    name: Mappatura delle fairway di play
+    description: |
+      Mappatura dei play regionali e dei segmenti a rischio comune sull'acreage.
+  BC-3000.20.30:
+    name: Gestione dell'inventario dei prospetti geologici
+    description: |
+      Mantenimento dell'inventario classificato di prospetti e lead e della loro maturazione.
+  BC-3000.20.40:
+    name: Valutazione del rischio dei prospetti geologici
+    description: |
+      Valutazione probabilistica della probabilità geologica di successo dei prospetti.
+  BC-3000.20.50:
+    name: Stima volumetrica
+    description: |
+      Stima probabilistica pre-perforazione dei volumi in posto e recuperabili.
+  BC-3000.30:
+    name: Acquisizione di licenze e concessioni
+    description: |
+      Acquisizione di acreage esplorativo attraverso tornate di licenze, negoziazione
+      diretta e transazioni di farm-in.
+    in_scope:
+      - Selezione e partecipazione alle tornate di licenze
+      - Offerte per concessioni e PSA
+      - Negoziazione di farm-in e farm-out
+    out_of_scope:
+      - Monitoraggio continuativo degli obblighi di licenza (BC-3110.40)
+  BC-3000.30.10:
+    name: Selezione delle tornate di licenze
+    description: |
+      Selezione delle tornate di licenze dei governi ospitanti per le decisioni di partecipazione.
+  BC-3000.30.20:
+    name: Offerta per concessioni
+    description: |
+      Preparazione e presentazione di offerte competitive per concessioni e contratti di production sharing.
+  BC-3000.30.30:
+    name: Negoziazione di farm-in e farm-out
+    description: |
+      Negoziazione di transazioni di farm-in, farm-out e scambio di acreage.
+  BC-3000.30.40:
+    name: Gestione del portafoglio acreage
+    description: |
+      Mantenimento del portafoglio di acreage esplorativo e decisioni di razionalizzazione.
+  BC-3000.40:
+    name: Gestione del programma di perforazione esplorativa
+    description: |
+      Definizione, approvazione e valutazione post-pozzo dei programmi di perforazione wildcat e di valutazione.
+  BC-3000.40.10:
+    name: Definizione del programma pozzi esplorativi
+    description: |
+      Definizione degli obiettivi e della sequenza dei pozzi wildcat e di valutazione.
+  BC-3000.40.20:
+    name: Approvazione dei pozzi wildcat
+    description: |
+      Governance di approvazione interna e con i partner per i pozzi esplorativi wildcat.
+  BC-3000.40.30:
+    name: Gestione del programma pozzi di valutazione
+    description: |
+      Gestione dei programmi di pozzi di valutazione in seguito a scoperte.
+  BC-3000.40.40:
+    name: Valutazione post-pozzo
+    description: |
+      Valutazione del sottosuolo post-pozzo e acquisizione di insegnamenti per l'inventario dei prospetti.
+  BC-3000.50:
+    name: Orientamento del portafoglio esplorativo
+    description: |
+      Orientamento strategico del portafoglio esplorativo attraverso aree geografiche, play e classi di rischio.
+  BC-3000.50.10:
+    name: Definizione della strategia esplorativa
+    description: |
+      Definizione della strategia esplorativa attraverso bacini, play e classi di rischio.
+  BC-3000.50.20:
+    name: Allocazione degli investimenti esplorativi
+    description: |
+      Allocazione del capitale esplorativo tra aree geografiche e tipi di play.
+  BC-3000.50.30:
+    name: Monitoraggio delle performance esplorative
+    description: |
+      Monitoraggio del costo di scoperta esplorativa, dei tassi di successo e delle aggiunte di risorse.
+  BC-3000.60:
+    name: Rendicontazione delle scoperte del sottosuolo
+    description: |
+      Notifica delle scoperte ai governi ospitanti, ai partner e ai mercati dei capitali,
+      e monitoraggio della maturazione delle risorse fino alla sanzione allo sviluppo.
+  BC-3000.60.10:
+    name: Notifica delle scoperte
+    description: |
+      Notifica delle scoperte ai governi ospitanti, ai partner e comunicazioni ai mercati dei capitali.
+  BC-3000.60.20:
+    name: Monitoraggio della maturazione delle risorse
+    description: |
+      Monitoraggio delle risorse contingenti dalla scoperta alla sanzione allo sviluppo.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-hydrocarbon-logistics-management.yaml
+++ b/catalogue/i18n/it/L1-hydrocarbon-logistics-management.yaml
@@ -1,0 +1,108 @@
+# Gestione della logistica degli idrocarburi (it) — translations for L1-hydrocarbon-logistics-management.yaml
+locale: it
+source: L1-hydrocarbon-logistics-management.yaml
+entries:
+  BC-3100:
+    name: Gestione della logistica degli idrocarburi
+    description: |
+      Operazioni di cargo marino, terminal e stoccaggio sfuso per greggio,
+      prodotti raffinati e GNL, oltre al coordinamento del lifting e alla gestione
+      del bunker fuel. Distinto dal trasporto cross-industry (serie BC-2400), che
+      comprende le reti di trasporto merci, la gestione della flotta e il trasporto intermodale.
+  BC-3100.10:
+    name: Operazioni di cargo marino
+    description: |
+      Operazione di petroliere per greggio, petroliere per prodotti, gasiere GNL e
+      trasferimenti nave-nave nel servizio petrolifero.
+    in_scope:
+      - Coordinamento operativo di petroliere e gasiere
+      - Alleggerimento e alleggerimento inverso nave-nave
+    out_of_scope:
+      - Gestione generica della flotta di navi (BC-2430)
+      - Prenotazioni di cargo per la navigazione di linea (BC-2400)
+  BC-3100.10.10:
+    name: Operazioni delle petroliere per greggio
+    description: |
+      Coordinamento operativo delle petroliere per greggio in noleggio a viaggio e a tempo.
+  BC-3100.10.20:
+    name: Operazioni delle petroliere per prodotti
+    description: |
+      Coordinamento operativo delle petroliere per prodotti raffinati inclusi i carichi parcel.
+  BC-3100.10.30:
+    name: Operazioni delle gasiere GNL
+    description: |
+      Coordinamento operativo delle gasiere GNL inclusa la gestione del raffreddamento e della pressione dei serbatoi.
+  BC-3100.10.40:
+    name: Coordinamento dei trasferimenti nave-nave
+    description: |
+      Coordinamento dei trasferimenti STS per greggio, prodotti e GNL.
+  BC-3100.20:
+    name: Operazioni terminali
+    description: |
+      Operazione di terminal petroliferi di importazione, esportazione e intermedi:
+      pontili, bracci di carico e ricezione in serbatoio.
+  BC-3100.20.10:
+    name: Operazioni dei bracci di carico e del pontile
+    description: |
+      Operazione delle apparecchiature del pontile e dei bracci di carico marini.
+  BC-3100.20.20:
+    name: Operazioni di ricezione in serbatoio
+    description: |
+      Ricezione e misurazione dei carichi nello stoccaggio del terminal.
+  BC-3100.20.30:
+    name: Operazioni di carico dai serbatoi
+    description: |
+      Carico dallo stoccaggio del terminal sulle navi e nei pipeline.
+  BC-3100.20.40:
+    name: Programmazione delle banchine
+    description: |
+      Allocazione e programmazione delle banchine per gli arrivi delle navi.
+  BC-3100.30:
+    name: Gestione dello stoccaggio sfuso
+    description: |
+      Allocazione dei serbatoi, monitoraggio dei movimenti e taratura dei serbatoi
+      per greggio, prodotti e NGL.
+  BC-3100.30.10:
+    name: Allocazione dei serbatoi
+    description: |
+      Allocazione della capacità dei serbatoi a qualità, proprietari e pool.
+  BC-3100.30.20:
+    name: Monitoraggio dei movimenti serbatoio-serbatoio
+    description: |
+      Monitoraggio dei movimenti interni del terminal e delle posizioni di inventario.
+  BC-3100.30.30:
+    name: Strappatura e taratura dei serbatoi
+    description: |
+      Strappatura dei serbatoi e mantenimento delle tabelle di calibrazione per l'accuratezza fiscale.
+  BC-3100.40:
+    name: Programmazione dei cargo e coordinamento del lifting
+    description: |
+      Nomine di lifting, conferma degli stem delle navi e monitoraggio delle controstallie
+      per i cargo petroliferi.
+  BC-3100.40.10:
+    name: Gestione delle nomine di lifting
+    description: |
+      Ricezione e conferma delle nomine di lifting dei clienti e dell'equity.
+  BC-3100.40.20:
+    name: Conferma degli stem delle navi
+    description: |
+      Conferma degli stem e dei parcel rispetto agli obblighi contrattuali.
+  BC-3100.40.30:
+    name: Monitoraggio operativo delle controstallie
+    description: |
+      Monitoraggio operativo degli eventi di controstallie nei porti di carico e scarico.
+  BC-3100.50:
+    name: Gestione del bunker e del carburante marino
+    description: |
+      Approvvigionamento e garanzia della qualità del bunker per la flotta operata e noleggiata.
+  BC-3100.50.10:
+    name: Approvvigionamento del bunker
+    description: |
+      Approvvigionamento spot e a termine di carburanti marini per la flotta.
+  BC-3100.50.20:
+    name: Garanzia della qualità del bunker
+    description: |
+      Campionamento, analisi e gestione delle controversie sui bunker forniti.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-hydrocarbon-measurement-allocation-management.yaml
+++ b/catalogue/i18n/it/L1-hydrocarbon-measurement-allocation-management.yaml
@@ -1,0 +1,106 @@
+# Gestione della misurazione e allocazione degli idrocarburi (it) — translations for L1-hydrocarbon-measurement-allocation-management.yaml
+locale: it
+source: L1-hydrocarbon-measurement-allocation-management.yaml
+entries:
+  BC-3040:
+    name: Gestione della misurazione e allocazione degli idrocarburi
+    description: |
+      Misurazione fiscale e allocazione degli idrocarburi prodotti: misura fiscale
+      per il trasferimento fiscale, allocazione tra giacimenti e comproprietari,
+      contabilità della produzione, rendiconto delle spese operative e analisi
+      delle perdite e degli scarti.
+  BC-3040.10:
+    name: Misura fiscale e trasferimento fiscale
+    description: |
+      Operazione, taratura e assurance dei misuratori di qualità fiscale nei punti
+      di trasferimento fiscale.
+  BC-3040.10.10:
+    name: Operazione del misuratore fiscale
+    description: |
+      Operazione quotidiana dei misuratori fiscali di liquidi e gas.
+  BC-3040.10.20:
+    name: Verifica e taratura del misuratore
+    description: |
+      Verifica e taratura periodica degli impianti di misura fiscale.
+  BC-3040.10.30:
+    name: Documentazione del trasferimento fiscale
+    description: |
+      Emissione e scambio di ticket e certificati di trasferimento fiscale.
+  BC-3040.10.40:
+    name: Indagine sulle misurazioni errate
+    description: |
+      Indagine e bonifica degli eventi di misurazione errata sospetti.
+  BC-3040.20:
+    name: Allocazione della produzione
+    description: |
+      Allocazione dei volumi misurati ai pozzi, ai giacimenti e ai comproprietari.
+  BC-3040.20.10:
+    name: Allocazione per pozzo
+    description: |
+      Allocazione della produzione dell'impianto ai pozzi contribuenti.
+  BC-3040.20.20:
+    name: Allocazione per giacimento
+    description: |
+      Allocazione tra giacimenti e pool commingled.
+  BC-3040.20.30:
+    name: Allocazione per comproprietario
+    description: |
+      Allocazione dei volumi di produzione tra i titolari di quota di partecipazione.
+  BC-3040.20.40:
+    name: Riconciliazione dell'allocazione
+    description: |
+      Riconciliazione dei risultati dell'allocazione tra dati di misura, test di pozzo e contabilità.
+  BC-3040.30:
+    name: Contabilità della produzione
+    description: |
+      Rendicontazione giornaliera della produzione, bilancio di massa e chiusura mensile
+      della contabilità della produzione.
+  BC-3040.30.10:
+    name: Rendicontazione giornaliera della produzione
+    description: |
+      Rendicontazione giornaliera dei volumi di produzione agli stakeholder interni ed esterni.
+  BC-3040.30.20:
+    name: Bilancio di massa degli idrocarburi
+    description: |
+      Bilancio di massa degli idrocarburi end-to-end attraverso i sistemi produttivi.
+  BC-3040.30.30:
+    name: Chiusura della contabilità della produzione
+    description: |
+      Chiusura mensile dei libri contabili della produzione e interfaccia con i sistemi finanziari.
+  BC-3040.40:
+    name: Gestione del rendiconto delle spese operative del lease
+    description: |
+      Preparazione dei rendiconti delle spese operative del lease, calcolo dei volumi
+      di royalty e rendicontazione delle imposte di produzione e severance.
+  BC-3040.40.10:
+    name: Preparazione del rendiconto delle spese operative del lease
+    description: |
+      Preparazione dei rapporti LOS per i titolari di quota di partecipazione.
+  BC-3040.40.20:
+    name: Calcolo dei volumi di royalty
+    description: |
+      Calcolo dei volumi e del valore dei titolari di royalty a livello di lease.
+  BC-3040.40.30:
+    name: Rendicontazione delle imposte di produzione e severance
+    description: |
+      Rendicontazione delle imposte di produzione e severance alle autorità fiscali.
+  BC-3040.50:
+    name: Analisi delle perdite e degli scarti
+    description: |
+      Indagine sugli scarti di misurazione, eventi di perdita e squilibri dell'inventario
+      di idrocarburi.
+  BC-3040.50.10:
+    name: Analisi degli scarti di misurazione
+    description: |
+      Analisi degli scarti di misurazione rispetto alle bande di tolleranza.
+  BC-3040.50.20:
+    name: Indagine sulle perdite
+    description: |
+      Indagine sulle perdite non contabilizzate tra i punti di misurazione.
+  BC-3040.50.30:
+    name: Riconciliazione dell'inventario di idrocarburi
+    description: |
+      Riconciliazione dell'inventario fisico di idrocarburi con le registrazioni contabili.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-hydrocarbon-production-operations-management.yaml
+++ b/catalogue/i18n/it/L1-hydrocarbon-production-operations-management.yaml
@@ -1,0 +1,145 @@
+# Gestione delle operazioni di produzione di idrocarburi (it) — translations for L1-hydrocarbon-production-operations-management.yaml
+locale: it
+source: L1-hydrocarbon-production-operations-management.yaml
+entries:
+  BC-3030:
+    name: Gestione delle operazioni di produzione di idrocarburi
+    description: |
+      Operazione degli impianti di superficie a monte dalla testa pozzo all'export:
+      separazione, trattamento, sollevamento artificiale, flow assurance, sorveglianza
+      della produzione e mantenimento della pressione di giacimento.
+  BC-3030.10:
+    name: Gestione delle operazioni alla testa pozzo
+    description: |
+      Operazione quotidiana delle apparecchiature della testa pozzo, gestione della
+      strozzatura e test di pozzi.
+  BC-3030.10.10:
+    name: Sorveglianza della testa pozzo
+    description: |
+      Sorveglianza continua dei parametri di pressione, temperatura e portata alla testa pozzo.
+  BC-3030.10.20:
+    name: Gestione della strozzatura della testa pozzo
+    description: |
+      Regolazione delle strozzature di superficie per la gestione della portata del pozzo e del drawdown.
+  BC-3030.10.30:
+    name: Operazioni di test del pozzo
+    description: |
+      Test di pozzi di routine e di sorveglianza per l'allocazione e i dati del giacimento.
+  BC-3030.20:
+    name: Operazioni di separazione e trattamento in superficie
+    description: |
+      Operazione degli impianti di superficie per la separazione olio-acqua-gas,
+      stabilizzazione del greggio, trattamento dell'acqua prodotta e condizionamento del gas.
+  BC-3030.20.10:
+    name: Separazione olio, acqua e gas
+    description: |
+      Separazione trifasica dei fluidi prodotti negli impianti a monte.
+  BC-3030.20.20:
+    name: Stabilizzazione del greggio
+    description: |
+      Stabilizzazione del greggio prodotto alle specifiche di export.
+  BC-3030.20.30:
+    name: Trattamento dell'acqua prodotta
+    description: |
+      Trattamento dell'acqua prodotta per la re-iniezione o lo scarico.
+  BC-3030.20.40:
+    name: Disidratazione e desolforazione del gas
+    description: |
+      Disidratazione e sweetening in campo dei flussi di gas associato.
+  BC-3030.30:
+    name: Gestione del sollevamento artificiale
+    description: |
+      Selezione, operazione e ottimizzazione dei sistemi di sollevamento artificiale.
+  BC-3030.30.10:
+    name: Operazioni di gas lift
+    description: |
+      Operazioni di gas lift continuo e intermittente e sorveglianza.
+  BC-3030.30.20:
+    name: Operazioni della pompa elettrocentrifuga sommersa
+    description: |
+      Operazione, sorveglianza e gestione della durata di vita degli impianti ESP.
+  BC-3030.30.30:
+    name: Operazioni della pompa a stantuffo
+    description: |
+      Operazione e sorveglianza dinamometrica delle pompe a stantuffo.
+  BC-3030.30.40:
+    name: Ottimizzazione del sollevamento artificiale
+    description: |
+      Ottimizzazione trasversale della selezione e dei parametri del sollevamento artificiale.
+  BC-3030.40:
+    name: Ottimizzazione e sorveglianza della produzione
+    description: |
+      Sorveglianza in tempo reale e ottimizzazione delle portate di produzione,
+      dei colli di bottiglia e delle performance dei pozzi rispetto alle previsioni.
+  BC-3030.40.10:
+    name: Sorveglianza della produzione in tempo reale
+    description: |
+      Sorveglianza in tempo reale della produzione di pozzo e di campo dai centri operativi.
+  BC-3030.40.20:
+    name: Diagnostica delle performance dei pozzi
+    description: |
+      Analisi diagnostica dei pozzi sottoperformanti e raccomandazioni di intervento.
+  BC-3030.40.30:
+    name: Contabilità delle perdite di produzione
+    description: |
+      Categorizzazione e rendicontazione delle perdite di produzione rispetto al potenziale.
+  BC-3030.40.40:
+    name: Identificazione dei colli di bottiglia
+    description: |
+      Identificazione dei colli di bottiglia di sistema tra giacimento, pozzo e impianto.
+  BC-3030.50:
+    name: Gestione della flow assurance
+    description: |
+      Prevenzione e gestione dei problemi di flow assurance come idrati, cere,
+      asfalteni ed erosione-corrosione nei sistemi produttivi.
+  BC-3030.50.10:
+    name: Gestione degli idrati
+    description: |
+      Prevenzione e bonifica degli idrati nelle flowline e nei riser.
+  BC-3030.50.20:
+    name: Gestione delle cere e degli asfalteni
+    description: |
+      Prevenzione e bonifica del deposito di cere e asfalteni.
+  BC-3030.50.30:
+    name: Monitoraggio dell'erosione e della corrosione
+    description: |
+      Monitoraggio dell'erosione e della corrosione nelle flowline e nelle apparecchiature produttive.
+  BC-3030.50.40:
+    name: Operazioni di pigging
+    description: |
+      Pigging operativo delle flowline per la pulizia e l'ispezione.
+  BC-3030.60:
+    name: Gestione dei prodotti chimici di produzione
+    description: |
+      Selezione, dosaggio e monitoraggio dell'efficacia dei prodotti chimici di produzione.
+  BC-3030.60.10:
+    name: Selezione e dosaggio dei prodotti chimici
+    description: |
+      Strategia di selezione e dosaggio dei prodotti chimici di produzione a livello di pozzo e impianto.
+  BC-3030.60.20:
+    name: Gestione dell'inibitore di corrosione
+    description: |
+      Applicazione e monitoraggio dei programmi di inibizione della corrosione.
+  BC-3030.60.30:
+    name: Gestione dell'inibitore di scale
+    description: |
+      Gestione dello squeeze dell'inibitore di scale e del trattamento continuo.
+  BC-3030.70:
+    name: Operazioni di mantenimento della pressione di giacimento
+    description: |
+      Operazione dei sistemi di iniezione d'acqua e gas e monitoraggio del voidage replacement.
+  BC-3030.70.10:
+    name: Operazioni di iniezione d'acqua
+    description: |
+      Operazione del trattamento dell'acqua di iniezione e dei pozzi iniettori.
+  BC-3030.70.20:
+    name: Operazioni di iniezione del gas
+    description: |
+      Operazione della compressione per l'iniezione di gas e dei pozzi iniettori di gas.
+  BC-3030.70.30:
+    name: Monitoraggio del voidage replacement
+    description: |
+      Monitoraggio dei rapporti di voidage replacement sugli asset produttivi.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-hydrocarbon-trading-marketing-management.yaml
+++ b/catalogue/i18n/it/L1-hydrocarbon-trading-marketing-management.yaml
@@ -1,0 +1,139 @@
+# Gestione del trading e della commercializzazione di idrocarburi (it) — translations for L1-hydrocarbon-trading-marketing-management.yaml
+locale: it
+source: L1-hydrocarbon-trading-marketing-management.yaml
+entries:
+  BC-3090:
+    name: Gestione del trading e della commercializzazione di idrocarburi
+    description: |
+      Trading fisico e cartaceo di greggio, prodotti raffinati, gas naturale e GNL;
+      gestione del rischio delle materie prime; regolamento e conformità degli scambi;
+      commercializzazione a lungo termine; e noleggio delle navi per il trading.
+  BC-3090.10:
+    name: Operazioni di trading fisico
+    description: |
+      Desk di trading fisico per greggio, prodotti raffinati, gas naturale e GNL.
+  BC-3090.10.10:
+    name: Trading del petrolio greggio
+    description: |
+      Trading fisico di qualità di petrolio greggio nei mercati regionali.
+  BC-3090.10.20:
+    name: Trading dei prodotti raffinati
+    description: |
+      Trading fisico di benzina, distillati, jet, olio combustibile e NGL.
+  BC-3090.10.30:
+    name: Trading del gas naturale
+    description: |
+      Trading fisico di gas naturale via pipeline tra gli hub.
+  BC-3090.10.40:
+    name: Trading del GNL
+    description: |
+      Trading fisico di carichi GNL incluse operazioni di diversion e reload.
+  BC-3090.20:
+    name: Trading di derivati e cartaceo
+    description: |
+      Trading di derivati quotati in borsa e OTC per hedging e posizionamento proprietario.
+  BC-3090.20.10:
+    name: Trading di futures e opzioni
+    description: |
+      Trading di futures e opzioni quotati in borsa su materie prime energetiche.
+  BC-3090.20.20:
+    name: Scambi e operazioni di hedging
+    description: |
+      Trading di swap OTC per l'hedging del prezzo e della base.
+  BC-3090.20.30:
+    name: Gestione dell'esposizione agli indici di materie prime
+    description: |
+      Gestione dell'esposizione agli strumenti indicizzati sulle materie prime.
+  BC-3090.30:
+    name: Gestione del rischio di trading
+    description: |
+      Gestione del rischio di posizione, rischio di credito delle controparti e VaR
+      sulle materie prime per le attività di trading.
+  BC-3090.30.10:
+    name: Gestione del rischio di posizione
+    description: |
+      Monitoraggio delle posizioni rispetto ai mandati e ai limiti di trading approvati.
+  BC-3090.30.20:
+    name: Valutazione mark-to-market
+    description: |
+      Valutazione mark-to-market giornaliera delle posizioni di trading e delle curve.
+  BC-3090.30.30:
+    name: Gestione del rischio di credito delle controparti
+    description: |
+      Definizione dei limiti di credito e monitoraggio dell'esposizione delle controparti nel trading.
+  BC-3090.30.40:
+    name: Calcolo del VaR sulle materie prime
+    description: |
+      Calcolo del value-at-risk e degli scenari di stress per i portafogli di materie prime.
+  BC-3090.40:
+    name: Conferma e regolamento degli scambi
+    description: |
+      Acquisizione, conferma e regolamento post-trade e riconciliazione degli scambi.
+  BC-3090.40.10:
+    name: Acquisizione degli scambi
+    description: |
+      Acquisizione degli scambi eseguiti dal front office nei sistemi di trading.
+  BC-3090.40.20:
+    name: Conferma degli scambi
+    description: |
+      Emissione e riconciliazione delle conferme degli scambi con le controparti.
+  BC-3090.40.30:
+    name: Regolamento degli scambi
+    description: |
+      Regolamento in contanti e fisico degli scambi alla scadenza.
+  BC-3090.40.40:
+    name: Riconciliazione degli scambi
+    description: |
+      Riconciliazione degli scambi con i registri di broker, borsa e controparte.
+  BC-3090.50:
+    name: Gestione della conformità del trading
+    description: |
+      Screening delle sanzioni, sorveglianza della condotta di mercato e rendicontazione
+      normativa per le attività di trading energetico.
+  BC-3090.50.10:
+    name: Screening delle sanzioni
+    description: |
+      Screening pre-trade e post-trade delle controparti e dei carichi rispetto alle sanzioni.
+  BC-3090.50.20:
+    name: Sorveglianza della condotta di mercato
+    description: |
+      Sorveglianza della condotta di trading rispetto agli standard di abuso di mercato (REMIT, Dodd-Frank).
+  BC-3090.50.30:
+    name: Rendicontazione normativa degli scambi
+    description: |
+      Rendicontazione degli scambi alle autorità di regolamentazione secondo REMIT, EMIR e Dodd-Frank.
+  BC-3090.60:
+    name: Gestione della commercializzazione e dei contratti a lungo termine
+    description: |
+      Gestione dei contratti di vendita a lungo termine e dei programmi di lifting con i clienti.
+  BC-3090.60.10:
+    name: Negoziazione dei contratti a lungo termine
+    description: |
+      Negoziazione di contratti di vendita a lungo termine con raffinatori e utility.
+  BC-3090.60.20:
+    name: Gestione del programma di lifting
+    description: |
+      Gestione dei programmi mensili e trimestrali di lifting rispetto ai contratti a lungo termine.
+  BC-3090.60.30:
+    name: Gestione dell'allocazione ai clienti
+    description: |
+      Allocazione delle forniture limitate tra clienti a lungo termine e spot.
+  BC-3090.70:
+    name: Noleggio navi per il trading
+    description: |
+      Noleggio a viaggio e a tempo e gestione delle controstallie a supporto delle posizioni di trading.
+  BC-3090.70.10:
+    name: Noleggio a viaggio
+    description: |
+      Noleggio a viaggio di petroliere e gasiere per i carichi di trading.
+  BC-3090.70.20:
+    name: Noleggio a tempo
+    description: |
+      Noleggio a tempo e ottimizzazione della posizione delle navi.
+  BC-3090.70.30:
+    name: Gestione delle controstallie e del laytime
+    description: |
+      Calcolo e regolamento delle richieste di controstallie e laytime.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-independence-and-conflicts-management.yaml
+++ b/catalogue/i18n/it/L1-independence-and-conflicts-management.yaml
@@ -1,0 +1,140 @@
+# Gestione dell'indipendenza e dei conflitti di interesse (it) — translations for L1-independence-and-conflicts-management.yaml
+locale: it
+source: L1-independence-and-conflicts-management.yaml
+entries:
+  BC-4350:
+    name: Gestione dell'indipendenza e dei conflitti di interesse
+    description: |
+      Indipendenza del revisore, conflitti di interesse professionali, gestione delle barriere
+      informative, dichiarazioni di interessi personali e clearance per l'accettazione
+      e la continuazione degli incarichi tipiche degli studi di servizi professionali.
+  BC-4350.10:
+    name: Gestione dell'indipendenza del revisore
+    description: |
+      Applicazione delle regole di indipendenza degli studi di revisione, inclusi
+      servizi vietati, rotazione dei partner, limiti di dipendenza dagli onorari
+      e requisiti specifici per gli enti di interesse pubblico.
+  BC-4350.10.10:
+    name: Identificazione dei clienti di revisione
+    description: |
+      Identificazione e manutenzione della popolazione dei clienti di revisione limitati,
+      incluse le affiliate e le relazioni beneficiarie.
+  BC-4350.10.20:
+    name: Pre-clearance dei servizi vietati
+    description: |
+      Pre-clearance dei servizi non di revisione a clienti di revisione
+      rispetto alle liste dei servizi vietati.
+  BC-4350.10.30:
+    name: Gestione della rotazione dei partner di revisione
+    description: |
+      Monitoraggio e applicazione della rotazione per i partner d'incarico
+      e i partner EQR sui clienti di revisione.
+  BC-4350.10.40:
+    name: Monitoraggio della dipendenza dagli onorari
+    description: |
+      Monitoraggio degli onorari di revisione e totali rispetto al reddito dello studio
+      per identificare le minacce di dipendenza dagli onorari.
+  BC-4350.20:
+    name: Gestione dei conflitti di interesse
+    description: |
+      Identificazione, valutazione e risoluzione dei conflitti di interesse tra incarichi,
+      tra clienti e tra gli interessi del cliente e dello studio.
+  BC-4350.20.10:
+    name: Ricerca e identificazione dei conflitti
+    description: |
+      Ricerca nei registri dei clienti e delle pratiche per identificare
+      potenziali conflitti su incarichi potenziali.
+  BC-4350.20.20:
+    name: Valutazione e categorizzazione dei conflitti
+    description: |
+      Valutazione dei conflitti identificati rispetto alla policy dello studio
+      e alle norme professionali per determinare la categoria e il trattamento.
+  BC-4350.20.30:
+    name: Risoluzione dei conflitti e gestione delle rinunce
+    description: |
+      Risoluzione dei conflitti, incluse l'ottenimento del consenso informato,
+      le rinunce e il declino degli incarichi, ove appropriato.
+  BC-4350.30:
+    name: Gestione delle barriere informative
+    description: |
+      Progettazione, implementazione e gestione di barriere informative,
+      chinese wall e disposizioni di screening per incarichi sensibili.
+  BC-4350.30.10:
+    name: Progettazione della barriera informativa
+    description: |
+      Definizione dell'ambito della barriera, del personale soggetto a screening
+      e dei controlli fisici o di sistema per un incarico.
+  BC-4350.30.20:
+    name: Implementazione della barriera informativa
+    description: |
+      Implementazione operativa delle restrizioni di accesso
+      nei sistemi documentali, email e di pratica.
+  BC-4350.30.30:
+    name: Rilevamento e risposta alle violazioni della barriera
+    description: |
+      Rilevamento e risposta a potenziali o effettive violazioni della barriera,
+      incluse escalation e rimediazione.
+  BC-4350.40:
+    name: Gestione degli interessi e delle relazioni personali
+    description: |
+      Acquisizione, dichiarazione e monitoraggio degli interessi finanziari personali,
+      delle relazioni familiari e dei precedenti impieghi che possono minacciare
+      l'indipendenza o creare conflitti.
+  BC-4350.40.10:
+    name: Dichiarazione degli investimenti personali
+    description: |
+      Acquisizione e manutenzione delle dichiarazioni di investimento personale
+      di partner e staff rispetto alla lista delle entità soggette a restrizioni.
+  BC-4350.40.20:
+    name: Dichiarazione di familiari e strette associazioni
+    description: |
+      Raccolta delle dichiarazioni riguardanti i familiari stretti e altre
+      strette associazioni rilevanti per l'indipendenza.
+  BC-4350.40.30:
+    name: Monitoraggio del precedente impiego e del periodo di cooling-off
+    description: |
+      Monitoraggio dei precedenti impieghi con clienti di revisione
+      e dei periodi di cooling-off prima del coinvolgimento nell'incarico.
+  BC-4350.50:
+    name: Clearance per l'accettazione dell'incarico
+    description: |
+      Workflow che combina le clearance di indipendenza, conflitti e integrità
+      in un unico input decisionale che alimenta l'accettazione dell'incarico.
+  BC-4350.50.10:
+    name: Coordinamento del workflow di clearance
+    description: |
+      Orchestrazione delle clearance di indipendenza, conflitti e AML
+      necessarie prima dell'accettazione dell'incarico.
+  BC-4350.50.20:
+    name: Registrazione della decisione di clearance
+    description: |
+      Registrazione delle decisioni di clearance, delle condizioni
+      e delle motivazioni nel fascicolo dell'incarico.
+  BC-4350.50.30:
+    name: Gestione della ri-clearance per la continuazione
+    description: |
+      Ri-clearance periodica di indipendenza e conflitti sugli incarichi
+      in corso e sulle relazioni di revisione ricorrenti.
+  BC-4350.60:
+    name: Monitoraggio dell'indipendenza e dei conflitti
+    description: |
+      Monitoraggio continuativo della postura di indipendenza e conflitti
+      durante l'esecuzione degli incarichi e nel portafoglio.
+  BC-4350.60.10:
+    name: Sorveglianza dei nuovi servizi a clienti di revisione
+    description: |
+      Sorveglianza dei nuovi servizi proposti a clienti di revisione esistenti
+      per l'esposizione a servizi vietati.
+  BC-4350.60.20:
+    name: Manutenzione della lista delle entità soggette a restrizioni
+    description: |
+      Manutenzione e distribuzione della lista delle entità soggette a restrizioni
+      e delle relative avvertenze ai professionisti.
+  BC-4350.60.30:
+    name: Indagine sulle violazioni dell'indipendenza
+    description: |
+      Indagine e segnalazione di sospette o effettive violazioni dell'indipendenza
+      e azioni correttive.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-information-data-management.yaml
+++ b/catalogue/i18n/it/L1-information-data-management.yaml
@@ -1,0 +1,143 @@
+# Gestione delle informazioni e dei dati (it) — translations for L1-information-data-management.yaml
+locale: it
+source: L1-information-data-management.yaml
+entries:
+  BC-610:
+    name: Gestione delle informazioni e dei dati
+    description: |
+      Data governance, master data, qualità dei dati, analytics e intelligenza artificiale.
+  BC-610.10:
+    name: Gestione della data governance
+    description: |
+      Ownership dei dati, stewardship, politiche, standard.
+  BC-610.10.10:
+    name: Ownership e stewardship dei dati
+    description: |
+      Assegnazione e operatività dei ruoli di data owner e data steward.
+  BC-610.10.20:
+    name: Politiche e standard dei dati
+    description: |
+      Definizione di politiche, standard e framework di riferimento per i dati.
+  BC-610.10.30:
+    name: Catalogazione e lineage dei dati
+    description: |
+      Catalogo dei dati, glossario e lineage dei dati end-to-end.
+  BC-610.10.40:
+    name: Privacy e classificazione dei dati
+    description: |
+      Classificazione dei dati e applicazione dei controlli sulla privacy.
+  BC-610.10.50:
+    name: Monitoraggio del rischio e della conformità dei dati
+    description: |
+      Monitoraggio del rischio dei dati e della conformità normativa (es. BCBS 239, GDPR).
+  BC-610.20:
+    name: Gestione del master data
+    description: |
+      MDM per cliente, prodotto, fornitore, dipendente, ecc.
+  BC-610.20.10:
+    name: Master data dei clienti
+    description: |
+      Mastering e governance del master data dei clienti.
+  BC-610.20.20:
+    name: Master data dei prodotti
+    description: |
+      Mastering e governance del master data dei prodotti e dei materiali.
+  BC-610.20.30:
+    name: Master data dei fornitori
+    description: |
+      Mastering e governance del master data dei fornitori.
+  BC-610.20.40:
+    name: Master data dei dipendenti
+    description: |
+      Mastering e governance del master data dei dipendenti.
+  BC-610.20.50:
+    name: Gestione dei dati di riferimento
+    description: |
+      Set di dati di riferimento, elenchi di codici e gerarchie.
+  BC-610.30:
+    name: Gestione della qualità dei dati
+    description: |
+      Monitoraggio della qualità dei dati, profilazione, remediation.
+  BC-610.30.10:
+    name: Profilazione della qualità dei dati
+    description: |
+      Profilazione, baseline e valutazione della qualità dei dati.
+  BC-610.30.20:
+    name: Gestione delle regole di qualità dei dati
+    description: |
+      Definizione, deployment e monitoraggio delle regole di qualità dei dati.
+  BC-610.30.30:
+    name: Risoluzione dei problemi di qualità dei dati
+    description: |
+      Triage, remediation e analisi delle cause radice dei problemi di qualità dei dati.
+  BC-610.30.40:
+    name: Reporting della qualità dei dati
+    description: |
+      Scorecard di qualità dei dati e reporting ai data owner e ai dirigenti.
+  BC-610.40:
+    name: Gestione dell'architettura dei dati
+    description: |
+      Architettura dei dati logica e fisica.
+  BC-610.40.10:
+    name: Modellazione dei dati concettuale e logica
+    description: |
+      Modelli di dati concettuali e logici aziendali.
+  BC-610.40.20:
+    name: Architettura della piattaforma dati
+    description: |
+      Architettura di data lake, data warehouse, lakehouse e data mesh.
+  BC-610.40.30:
+    name: Architettura di integrazione dei dati
+    description: |
+      Pattern per l'integrazione dei dati in batch, streaming e CDC.
+  BC-610.40.40:
+    name: Progettazione dello storage e della conservazione dei dati
+    description: |
+      Progettazione dello storage incluse conservazione, archiviazione e tiering.
+  BC-610.50:
+    name: Gestione degli analytics e della BI
+    description: |
+      Reporting, analytics, erogazione della business intelligence.
+  BC-610.50.10:
+    name: Erogazione di report e dashboard
+    description: |
+      Erogazione di report operativi e direzionali e dashboard.
+  BC-610.50.20:
+    name: Analytics self-service
+    description: |
+      Abilitazione dell'analytics self-service e dei data product per il business.
+  BC-610.50.30:
+    name: Analytics avanzate e data science
+    description: |
+      Analytics avanzate, modelli di data science e sperimentazione.
+  BC-610.50.40:
+    name: Operazioni della piattaforma analytics
+    description: |
+      Gestione delle piattaforme BI e analytics e delle librerie di contenuti.
+  BC-610.60:
+    name: Gestione dell'intelligenza artificiale
+    description: |
+      Ciclo di vita dei modelli AI/ML, MLOps, intelligenza artificiale responsabile.
+  BC-610.60.10:
+    name: Identificazione dei casi d'uso AI
+    description: |
+      Identificazione e definizione delle priorità dei casi d'uso AI/ML.
+  BC-610.60.20:
+    name: Sviluppo di modelli ML
+    description: |
+      Feature engineering, addestramento e validazione dei modelli ML.
+  BC-610.60.30:
+    name: MLOps e deployment dei modelli
+    description: |
+      Deployment, monitoraggio e gestione del ciclo di vita dei modelli (MLOps).
+  BC-610.60.40:
+    name: Governance dell'intelligenza artificiale responsabile
+    description: |
+      Principi di intelligenza artificiale responsabile, valutazione del rischio e monitoraggio dei bias.
+  BC-610.60.50:
+    name: Gestione dell'intelligenza artificiale generativa
+    description: |
+      Casi d'uso dell'intelligenza artificiale generativa, selezione dei foundation model e guardrail.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-information-technology-management.yaml
+++ b/catalogue/i18n/it/L1-information-technology-management.yaml
@@ -1,0 +1,195 @@
+# Gestione della tecnologia informatica (it) — translations for L1-information-technology-management.yaml
+locale: it
+source: L1-information-technology-management.yaml
+entries:
+  BC-600:
+    name: Gestione della tecnologia informatica
+    description: |
+      Strategia IT, architettura, servizi e operazioni.
+  BC-600.10:
+    name: Gestione della strategia e dell'architettura IT
+    description: |
+      Strategia IT, architettura enterprise, standard tecnologici.
+  BC-600.10.10:
+    name: Sviluppo della strategia IT
+    description: |
+      Definizione della strategia IT allineata alla strategia aziendale.
+  BC-600.10.20:
+    name: Gestione dell'architettura enterprise
+    description: |
+      Architettura enterprise allineata a TOGAF su business, dati, applicazioni e tecnologia.
+  BC-600.10.30:
+    name: Gestione degli standard tecnologici
+    description: |
+      Definizione e governance degli standard e dei pattern tecnologici.
+  BC-600.10.40:
+    name: Gestione della roadmap tecnologica
+    description: |
+      Roadmap tecnologiche pluriennali ed evoluzione delle capacità.
+  BC-600.10.50:
+    name: Governance e revisione dell'architettura
+    description: |
+      Architecture review board, design authority e governance delle eccezioni.
+  BC-600.20:
+    name: Gestione del portafoglio e della domanda IT
+    description: |
+      Portafoglio IT, raccolta della domanda, definizione delle priorità.
+  BC-600.20.10:
+    name: Raccolta della domanda IT
+    description: |
+      Raccolta e triage delle nuove richieste IT dall'azienda.
+  BC-600.20.20:
+    name: Gestione del portafoglio degli investimenti IT
+    description: |
+      Vista del portafoglio degli investimenti IT, progetti e benefici.
+  BC-600.20.30:
+    name: Pianificazione della capacità e delle risorse IT
+    description: |
+      Pianificazione della capacità di erogazione IT tra team e competenze.
+  BC-600.20.40:
+    name: Gestione delle relazioni con il business
+    description: |
+      Partnership tra IT e funzioni aziendali.
+  BC-600.30:
+    name: Gestione dei servizi IT
+    description: |
+      Incidente, problema, cambiamento, catalogo dei servizi, ITSM.
+  BC-600.30.10:
+    name: Gestione del catalogo dei servizi
+    description: |
+      Definizione e manutenzione del catalogo dei servizi e degli SLA.
+  BC-600.30.20:
+    name: Gestione degli incidenti
+    description: |
+      Rilevamento, triage, risoluzione e comunicazione degli incidenti.
+  BC-600.30.30:
+    name: Gestione dei problemi
+    description: |
+      Analisi delle cause radice e prevenzione degli incidenti ricorrenti.
+  BC-600.30.40:
+    name: Gestione dei cambiamenti e dei rilasci
+    description: |
+      Approvazione dei cambiamenti IT e gestione dei rilasci.
+  BC-600.30.50:
+    name: Gestione dei livelli di servizio
+    description: |
+      Definizione, misurazione e reporting dei livelli di servizio.
+  BC-600.30.60:
+    name: Gestione della configurazione
+    description: |
+      Elementi di configurazione, CMDB e gestione delle dipendenze.
+  BC-600.40:
+    name: Gestione delle operazioni IT
+    description: |
+      Operazioni IT quotidiane, monitoraggio, automazione.
+  BC-600.40.10:
+    name: Gestione degli eventi e del monitoraggio
+    description: |
+      Telemetria, osservabilità, correlazione degli eventi e alerting.
+  BC-600.40.20:
+    name: Schedulazione dei job IT e operazioni batch
+    description: |
+      Schedulazione dei job, orchestrazione batch e automazione dei carichi di lavoro.
+  BC-600.40.30:
+    name: Gestione della capacità e della performance IT
+    description: |
+      Pianificazione della capacità e ottimizzazione della performance dei servizi.
+  BC-600.40.40:
+    name: Operazioni di continuità del servizio IT
+    description: |
+      Test di continuità del servizio IT e operazioni di ripristino.
+  BC-600.40.50:
+    name: Gestione dell'automazione IT
+    description: |
+      Automazione, runbook e orchestrazione per le operazioni IT.
+  BC-600.50:
+    name: Gestione dell'infrastruttura IT
+    description: |
+      Infrastruttura di calcolo, storage, rete e cloud.
+  BC-600.50.10:
+    name: Gestione dei server e del calcolo
+    description: |
+      Provisioning e gestione del calcolo fisico e virtuale.
+  BC-600.50.20:
+    name: Gestione dello storage
+    description: |
+      Provisioning, tiering e protezione dello storage.
+  BC-600.50.30:
+    name: Gestione della rete
+    description: |
+      Gestione dei servizi LAN, WAN, SD-WAN e di rete.
+  BC-600.50.40:
+    name: Gestione della piattaforma cloud
+    description: |
+      Operazioni della piattaforma cloud pubblica, privata e ibrida.
+  BC-600.50.50:
+    name: Gestione del computing per gli utenti finali
+    description: |
+      Dispositivi aziendali, gestione degli endpoint e strumenti di collaborazione.
+  BC-600.60:
+    name: Gestione delle applicazioni IT
+    description: |
+      Ciclo di vita delle applicazioni, razionalizzazione, AMS.
+  BC-600.60.10:
+    name: Gestione del portafoglio applicativo
+    description: |
+      Catalogo delle applicazioni, ownership e stato del ciclo di vita.
+  BC-600.60.20:
+    name: Sviluppo e ingegneria delle applicazioni
+    description: |
+      Sviluppo software, pratiche di ingegneria e DevOps.
+  BC-600.60.30:
+    name: Manutenzione e supporto delle applicazioni
+    description: |
+      AMS, risoluzione dei difetti e rilascio di miglioramenti minori.
+  BC-600.60.40:
+    name: Razionalizzazione delle applicazioni
+    description: |
+      Razionalizzazione, consolidamento e dismissione delle applicazioni.
+  BC-600.60.50:
+    name: Gestione delle integrazioni e delle API
+    description: |
+      Piattaforme di integrazione, API e streaming di eventi.
+  BC-600.70:
+    name: Gestione dei fornitori IT
+    description: |
+      Contratti con i fornitori IT, performance, ecosistema.
+  BC-600.70.10:
+    name: Qualifica dei fornitori IT
+    description: |
+      Onboarding e contrattualizzazione di fornitori e partner IT.
+  BC-600.70.20:
+    name: Gestione della performance dei fornitori IT
+    description: |
+      Scorecard di performance e gestione degli SLA per i fornitori IT.
+  BC-600.70.30:
+    name: Gestione delle licenze software
+    description: |
+      Licenze software, diritti e gestione degli audit.
+  BC-600.70.40:
+    name: Strategia di sourcing IT
+    description: |
+      Strategia di sourcing build vs buy e managed service per l'IT.
+  BC-600.80:
+    name: Gestione finanziaria dell'IT
+    description: |
+      Spesa IT, chargeback/showback, ottimizzazione dei costi IT.
+  BC-600.80.10:
+    name: Budget e previsione IT
+    description: |
+      Pianificazione del budget IT, previsione e analisi degli scostamenti.
+  BC-600.80.20:
+    name: Allocazione dei costi IT e chargeback
+    description: |
+      Showback, chargeback e allocazione dei costi basata su TBM.
+  BC-600.80.30:
+    name: Gestione del Cloud FinOps
+    description: |
+      Pratiche FinOps per la visibilità e l'ottimizzazione dei costi cloud.
+  BC-600.80.40:
+    name: Monitoraggio del valore e dei benefici IT
+    description: |
+      Monitoraggio del valore degli investimenti IT e della realizzazione dei benefici.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-innovation-management.yaml
+++ b/catalogue/i18n/it/L1-innovation-management.yaml
@@ -1,0 +1,107 @@
+# Gestione dell'innovazione (it) — translations for L1-innovation-management.yaml
+locale: it
+source: L1-innovation-management.yaml
+entries:
+  BC-800:
+    name: Gestione dell'innovazione
+    description: |
+      Generazione di idee, incubazione, portafoglio di innovazione e venture aziendali.
+  BC-800.10:
+    name: Gestione delle idee e delle opportunità
+    description: |
+      Raccolta di idee, screening e valutazione delle opportunità.
+  BC-800.10.10:
+    name: Raccolta e invio di idee
+    description: |
+      Canali di raccolta idee da crowd, dipendenti e partner.
+  BC-800.10.20:
+    name: Screening e valutazione delle idee
+    description: |
+      Screening, valutazione e selezione delle idee più promettenti.
+  BC-800.10.30:
+    name: Definizione delle opportunità
+    description: |
+      Inquadramento delle opportunità di business, degli enunciati del problema e dei casi di valore.
+  BC-800.20:
+    name: Gestione del portafoglio di innovazione
+    description: |
+      Portafoglio di innovazione sugli orizzonti temporali (H1/H2/H3).
+  BC-800.20.10:
+    name: Gestione della pipeline di innovazione
+    description: |
+      Pipeline delle iniziative di innovazione attraverso le diverse fasi di sviluppo.
+  BC-800.20.20:
+    name: Bilanciamento del portafoglio sui tre orizzonti
+    description: |
+      Bilanciamento del portafoglio sugli orizzonti H1, H2 e H3.
+  BC-800.20.30:
+    name: Governance stage gate
+    description: |
+      Revisione stage gate e governance delle decisioni per le innovazioni.
+  BC-800.20.40:
+    name: Gestione del finanziamento dell'innovazione
+    description: |
+      Allocazione dei fondi tra le iniziative di innovazione.
+  BC-800.30:
+    name: Incubazione e accelerazione dell'innovazione
+    description: |
+      Incubatori, acceleratori e corporate venturing interno.
+  BC-800.30.10:
+    name: Operatività degli incubatori di innovazione
+    description: |
+      Gestione di incubatori aziendali e laboratori di innovazione.
+  BC-800.30.20:
+    name: Venturing interno
+    description: |
+      Creazione di spin-out e venture aziendali interni.
+  BC-800.30.30:
+    name: Sviluppo del prodotto minimo valido
+    description: |
+      Sviluppo del MVP, validazione con i clienti e iterazione.
+  BC-800.30.40:
+    name: Scale-up dell'innovazione
+    description: |
+      Transizione delle innovazioni validate verso offerte scalate sul mercato.
+  BC-800.40:
+    name: Gestione del corporate venturing
+    description: |
+      Investimenti corporate VC e partnership con startup.
+  BC-800.40.10:
+    name: Ricerca e scouting di startup
+    description: |
+      Identificazione di startup allineate ai temi strategici.
+  BC-800.40.20:
+    name: Investimento corporate venture
+    description: |
+      Investimento diretto in equity e operatività del fondo CVC.
+  BC-800.40.30:
+    name: Gestione delle partnership con startup
+    description: |
+      Partnership commerciali e pilot con le startup.
+  BC-800.40.40:
+    name: Gestione del portafoglio venture
+    description: |
+      Monitoraggio delle performance degli investimenti del portafoglio venture.
+  BC-800.50:
+    name: Gestione dell'open innovation
+    description: |
+      Reti di innovazione esterna, crowdsourcing e partnership accademiche.
+  BC-800.50.10:
+    name: Partnership accademiche e di ricerca
+    description: |
+      Partnership con università e istituti di ricerca.
+  BC-800.50.20:
+    name: Sfide di innovazione e crowdsourcing
+    description: |
+      Sfide di innovazione esterna, hackathon e crowdsourcing.
+  BC-800.50.30:
+    name: Coinvolgimento nell'ecosistema dell'innovazione
+    description: |
+      Engagement con hub di innovazione, acceleratori ed ecosistemi.
+  BC-800.50.40:
+    name: Approvvigionamento esterno di tecnologie
+    description: |
+      Concessione di licenze in entrata e acquisizione di tecnologie esterne.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-institutional-advancement-alumni-management.yaml
+++ b/catalogue/i18n/it/L1-institutional-advancement-alumni-management.yaml
@@ -1,0 +1,152 @@
+# Gestione dello sviluppo istituzionale e degli alumni (it) — translations for L1-institutional-advancement-alumni-management.yaml
+locale: it
+source: L1-institutional-advancement-alumni-management.yaml
+entries:
+  BC-4800:
+    name: Gestione dello sviluppo istituzionale e degli alumni
+    description: |
+      Coinvolgimento delle comunità di alumni, coltivazione dei donatori e gestione
+      delle campagne di raccolta fondi, delle donazioni, della gestione dei donatori
+      e della rendicontazione ai donatori di fondi di dotazione.
+  BC-4800.10:
+    name: Coinvolgimento degli alumni
+    description: |
+      Coinvolgimento delle comunità di alumni attraverso programmi, eventi e
+      comunicazioni che mantengono relazioni durature con l'istituzione.
+    in_scope:
+      - Operazioni della comunità alumni
+      - Eventi e riunioni degli alumni
+      - Comunicazioni agli alumni
+    out_of_scope:
+      - Servizi carriere per gli studenti iscritti (trattati in Gestione del supporto e del benessere degli studenti)
+  BC-4800.10.10:
+    name: Operazioni della comunità alumni
+    description: |
+      Gestione delle associazioni alumni, dei capitoli e delle comunità online.
+  BC-4800.10.20:
+    name: Eventi e riunioni degli alumni
+    description: |
+      Pianificazione e realizzazione di eventi e riunioni degli alumni.
+  BC-4800.10.30:
+    name: Comunicazioni agli alumni
+    description: |
+      Canali editoriali e di comunicazione per il pubblico degli alumni.
+  BC-4800.20:
+    name: Gestione dei rapporti con i donatori
+    description: |
+      Identificazione, coltivazione e gestione dei rapporti con i potenziali
+      e gli attuali donatori.
+    in_scope:
+      - Ricerca dei potenziali donatori e identificazione
+      - Coltivazione e sollecitazione dei donatori
+      - Gestione delle relazioni per donazioni di rilievo
+    out_of_scope:
+      - Operazioni CRM generali (trattate in Gestione delle relazioni con i clienti)
+  BC-4800.20.10:
+    name: Ricerca dei potenziali donatori e identificazione
+    description: |
+      Ricerca dei potenziali donatori e identificazione delle prospettive di donazione.
+  BC-4800.20.20:
+    name: Coltivazione e sollecitazione dei donatori
+    description: |
+      Coltivazione e sollecitazione del supporto dei donatori.
+  BC-4800.20.30:
+    name: Gestione delle relazioni per donazioni di rilievo
+    description: |
+      Gestione personalizzata delle relazioni con i donatori di donazioni di rilievo.
+  BC-4800.30:
+    name: Gestione delle campagne di raccolta fondi
+    description: |
+      Pianificazione e gestione delle campagne di raccolta fondi nei canali
+      di donazione annuale, campagne di raccolta fondi e digitali.
+    in_scope:
+      - Campagne di donazione annuale
+      - Gestione della campagna di raccolta fondi
+      - Campagne di crowdfunding e peer-to-peer
+    out_of_scope:
+      - Campagne di marketing non legate alla raccolta fondi (trattate in Gestione del marketing)
+  BC-4800.30.10:
+    name: Campagne di donazione annuale
+    description: |
+      Gestione delle campagne di donazione annuale e di donazioni ricorrenti.
+  BC-4800.30.20:
+    name: Gestione della campagna di raccolta fondi
+    description: |
+      Gestione delle campagne di raccolta fondi pluriennali.
+  BC-4800.30.30:
+    name: Campagne di crowdfunding e peer-to-peer
+    description: |
+      Gestione delle campagne di crowdfunding e di raccolta fondi peer-to-peer.
+  BC-4800.40:
+    name: Amministrazione delle donazioni e delle promesse di donazione
+    description: |
+      Ricezione, registrazione e amministrazione delle donazioni e delle promesse di donazione,
+      inclusi gli strumenti di donazione pianificata.
+    in_scope:
+      - Ricezione ed elaborazione delle donazioni
+      - Monitoraggio delle promesse di donazione
+      - Amministrazione delle donazioni pianificate e differite
+    out_of_scope:
+      - Contabilità generale clienti (trattata in Gestione finanziaria)
+  BC-4800.40.10:
+    name: Ricezione ed elaborazione delle donazioni
+    description: |
+      Ricezione ed elaborazione di donazioni in contanti, assegni, online e in natura.
+  BC-4800.40.20:
+    name: Monitoraggio delle promesse di donazione
+    description: |
+      Monitoraggio delle promesse di donazione e dei piani di pagamento.
+  BC-4800.40.30:
+    name: Amministrazione delle donazioni pianificate e differite
+    description: |
+      Amministrazione di lasciti, trust caritatevoli e altri strumenti di donazione pianificata.
+  BC-4800.50:
+    name: Gestione dei donatori e riconoscimento
+    description: |
+      Gestione dei rapporti con i donatori attraverso il riconoscimento, i programmi
+      di apprezzamento e il coinvolgimento continuativo dei donatori di fondi nominati.
+    in_scope:
+      - Riconoscimento dei donatori
+      - Programmi di riconoscimento dei donatori
+      - Gestione dei fondi di dotazione
+    out_of_scope:
+      - Comunicazioni di pubbliche relazioni (trattate in Gestione delle comunicazioni aziendali)
+  BC-4800.50.10:
+    name: Riconoscimento dei donatori
+    description: |
+      Riconoscimento delle donazioni e delle promesse dei donatori.
+  BC-4800.50.20:
+    name: Programmi di riconoscimento dei donatori
+    description: |
+      Gestione dei programmi e delle società di riconoscimento dei donatori.
+  BC-4800.50.30:
+    name: Gestione dei fondi di dotazione nominati
+    description: |
+      Gestione dei donatori di fondi di dotazione e nominati.
+  BC-4800.60:
+    name: Rendicontazione ai donatori relativa al fondo di dotazione
+    description: |
+      Rendicontazione ai donatori sull'utilizzo, le prestazioni e l'impatto dei fondi
+      vincolati e di dotazione.
+    in_scope:
+      - Rendicontazione sull'utilizzo dei fondi vincolati
+      - Rendicontazione delle prestazioni dei fondi di dotazione nominati
+      - Rendicontazione dell'impatto ai donatori
+    out_of_scope:
+      - Rendicontazione finanziaria istituzionale (trattata in Gestione finanziaria)
+      - Gestione degli investimenti del fondo di dotazione (trattata in Gestione della tesoreria)
+  BC-4800.60.10:
+    name: Rendicontazione sull'utilizzo dei fondi vincolati
+    description: |
+      Rendicontazione sull'utilizzo dei fondi vincolati e designati dai donatori.
+  BC-4800.60.20:
+    name: Rendicontazione delle prestazioni dei fondi di dotazione nominati
+    description: |
+      Rendicontazione delle prestazioni dei fondi di dotazione nominati ai rispettivi donatori.
+  BC-4800.60.30:
+    name: Rendicontazione dell'impatto ai donatori
+    description: |
+      Rendicontazione delle narrative e degli esiti di impatto rivolte ai donatori.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-insurance-claims-management.yaml
+++ b/catalogue/i18n/it/L1-insurance-claims-management.yaml
@@ -1,0 +1,167 @@
+# Gestione dei sinistri assicurativi (it) — translations for L1-insurance-claims-management.yaml
+locale: it
+source: L1-insurance-claims-management.yaml
+entries:
+  BC-2160:
+    name: Gestione dei sinistri assicurativi
+    description: |
+      Prima denuncia del sinistro, triage, perizia, costituzione delle riserve, liquidazione del danno, regolamento, recuperi e surroga, contenzioso, frode/SIU e risposta alle catastrofi in tutti i rami assicurativi.
+  BC-2160.10:
+    name: Gestione della prima denuncia del sinistro
+    description: |
+      Apertura del sinistro multicanale, verifica della copertura, registrazione e conferma di ricezione.
+  BC-2160.10.10:
+    name: Apertura del sinistro multicanale
+    description: |
+      Apertura del sinistro tramite telefono, canale digitale, broker e canali IoT.
+  BC-2160.10.20:
+    name: Verifica iniziale della copertura
+    description: |
+      Verifica della ricomprensione del sinistro nell'ambito della copertura alla data del sinistro.
+  BC-2160.10.30:
+    name: Registrazione del sinistro
+    description: |
+      Registrazione dei nuovi sinistri e assegnazione degli identificativi del sinistro.
+  BC-2160.10.40:
+    name: Conferma di ricezione e comunicazione
+    description: |
+      Conferma di ricezione iniziale al danneggiato e comunicazione continuativa sullo stato del sinistro.
+  BC-2160.20:
+    name: Triage e segmentazione dei sinistri
+    description: |
+      Scoring della gravità, instradamento STP, assegnazione del liquidatore e instradamento verso specialisti.
+  BC-2160.20.10:
+    name: Scoring della gravità e della complessità
+    description: |
+      Scoring della gravità e della complessità del sinistro per le decisioni di instradamento.
+  BC-2160.20.20:
+    name: Instradamento tramite STP (straight-through processing)
+    description: |
+      Instradamento dei sinistri di bassa gravità attraverso l'elaborazione automatica STP.
+  BC-2160.20.30:
+    name: Assegnazione del liquidatore
+    description: |
+      Assegnazione dei sinistri ai liquidatori in base alle competenze, alla capacità e alla geografia.
+  BC-2160.20.40:
+    name: Instradamento verso specialisti e contenzioso
+    description: |
+      Instradamento dei sinistri complessi, specialistici e in contenzioso verso i team dedicati.
+  BC-2160.30:
+    name: Perizia e liquidazione del danno
+    description: |
+      Liquidazione in campo e da scrivania, valutazione del danno, determinazione della responsabilità e consulenza di esperti.
+  BC-2160.30.10:
+    name: Liquidazione in campo e da scrivania
+    description: |
+      Liquidazione dei sinistri in campo e da scrivania, inclusi i sopralluoghi.
+  BC-2160.30.20:
+    name: Valutazione del danno e della perdita
+    description: |
+      Valutazione del danno, del quantum della perdita e dell'entità della riparazione o sostituzione.
+  BC-2160.30.30:
+    name: Determinazione della responsabilità
+    description: |
+      Determinazione della responsabilità e della risposta della polizza sui sinistri da responsabilità civile verso terzi.
+  BC-2160.30.40:
+    name: Consulenza di esperti del settore
+    description: |
+      Consulenza con periti, ingegneri, esperti medici e contabili forensi.
+  BC-2160.40:
+    name: Gestione della riserva sinistri
+    description: |
+      Costituzione della riserva iniziale del singolo sinistro, rivalutazione e coordinamento IBNR.
+  BC-2160.40.10:
+    name: Costituzione della riserva iniziale del sinistro
+    description: |
+      Costituzione della riserva iniziale del singolo sinistro sui sinistri registrati.
+  BC-2160.40.20:
+    name: Rivalutazione della riserva
+    description: |
+      Rivalutazione periodica della riserva del singolo sinistro al sopraggiungere di nuove informazioni.
+  BC-2160.40.30:
+    name: Coordinamento IBNR con l'attuariato
+    description: |
+      Coordinamento con l'attuariato sulle riserve IBNR per la costituzione delle riserve a livello di portafoglio.
+  BC-2160.50:
+    name: Liquidazione e pagamento dei sinistri
+    description: |
+      Trattativa di liquidazione del sinistro, pagamenti di indennizzo e di spesa, realizzo del salvo e recuperi/surroga.
+  BC-2160.50.10:
+    name: Trattativa di liquidazione del sinistro
+    description: |
+      Trattativa degli importi di liquidazione con i danneggiati e le terze parti.
+  BC-2160.50.20:
+    name: Emissione dei pagamenti di indennizzo
+    description: |
+      Emissione dei pagamenti di indennizzo agli assicurati e alle terze parti.
+  BC-2160.50.30:
+    name: Emissione dei pagamenti di spesa
+    description: |
+      Emissione dei pagamenti per le spese di liquidazione del danno allocate e non allocate (ALAE e ULAE).
+  BC-2160.50.40:
+    name: Realizzo del salvo
+    description: |
+      Realizzo e recupero del salvo sui sinistri liquidati.
+  BC-2160.50.50:
+    name: Recupero sinistri e surroga
+    description: |
+      Recupero sinistri e surroga nei confronti di terze parti e di altre compagnie assicurative.
+  BC-2160.60:
+    name: Gestione del contenzioso assicurativo
+    description: |
+      Strategia del contenzioso, coordinamento del legale difensivo e monitoraggio dei costi del contenzioso.
+  BC-2160.60.10:
+    name: Strategia del contenzioso
+    description: |
+      Definizione della strategia sui sinistri in contenzioso e decisione tra liquidazione e dibattimento.
+  BC-2160.60.20:
+    name: Coordinamento del legale difensivo
+    description: |
+      Coordinamento degli studi legali di panel e dei legali difensivi incaricati.
+  BC-2160.60.30:
+    name: Monitoraggio dei costi del contenzioso
+    description: |
+      Monitoraggio dei costi del contenzioso rispetto alle tariffe di panel e ai budget.
+  BC-2160.70:
+    name: Gestione della frode sinistri e della SIU
+    description: |
+      Rilevamento dei sinistri sospetti, indagine della SIU, segnalazione delle frodi e analisi anti-frode.
+  BC-2160.70.10:
+    name: Rilevamento dei sinistri sospetti
+    description: |
+      Rilevamento dei sinistri sospetti tramite regole, modelli e indicatori di allerta.
+  BC-2160.70.20:
+    name: Indagine della SIU
+    description: |
+      Attività investigativa dell'unità speciale di indagine (SIU) sui sinistri presumibilmente fraudolenti.
+  BC-2160.70.30:
+    name: Segnalazione delle frodi e procedimento penale
+    description: |
+      Segnalazione dei casi di frode alle autorità giudiziarie e ai registri di settore.
+  BC-2160.70.40:
+    name: Analisi anti-frode
+    description: |
+      Analisi anti-frode sui portafogli sinistri e analisi delle reti.
+  BC-2160.80:
+    name: Gestione dei sinistri da catastrofe
+    description: |
+      Attivazione per eventi CAT, mobilitazione della capacità di surge, monitoraggio dei sinistri CAT e coordinamento dei recuperi CAT.
+  BC-2160.80.10:
+    name: Attivazione per eventi CAT
+    description: |
+      Attivazione delle procedure di risposta alle catastrofi in caso di eventi dichiarati.
+  BC-2160.80.20:
+    name: Mobilitazione della capacità di surge
+    description: |
+      Mobilitazione di liquidatori di surge, appaltatori e capacità del call center.
+  BC-2160.80.30:
+    name: Triage e monitoraggio dei sinistri CAT
+    description: |
+      Triage e monitoraggio dei sinistri codificati CAT fino alla liquidazione.
+  BC-2160.80.40:
+    name: Coordinamento dei recuperi CAT
+    description: |
+      Coordinamento dei recuperi di riassicurazione e di pool sugli eventi CAT.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-insurance-customer-management.yaml
+++ b/catalogue/i18n/it/L1-insurance-customer-management.yaml
@@ -1,0 +1,111 @@
+# Gestione della clientela assicurativa (it) — translations for L1-insurance-customer-management.yaml
+locale: it
+source: L1-insurance-customer-management.yaml
+entries:
+  BC-2120:
+    name: Gestione della clientela assicurativa
+    description: |
+      Identità del contraente, aggregazione per nucleo familiare e gruppo, KYC, consensi e servicing del ciclo di vita della clientela assicurativa su tutti i canali.
+  BC-2120.10:
+    name: Gestione dell'onboarding del contraente
+    description: |
+      Acquisizione della domanda, verifica dell'identità, attivazione e comunicazioni di onboarding.
+  BC-2120.10.10:
+    name: Acquisizione della domanda
+    description: |
+      Acquisizione delle domande di nuovi contraenti attraverso i canali.
+  BC-2120.10.20:
+    name: Verifica dell'identità e della titolarità effettiva
+    description: |
+      Verifica dell'identità e identificazione della titolarità effettiva per contraenti persone fisiche e giuridiche.
+  BC-2120.10.30:
+    name: Attivazione del contraente
+    description: |
+      Attivazione dei record, dei conti e dell'accesso ai canali del contraente.
+  BC-2120.10.40:
+    name: Comunicazione di onboarding
+    description: |
+      Comunicazione dello stato dell'onboarding, dei kit di benvenuto e dei passi successivi.
+  BC-2120.20:
+    name: Gestione KYC e sanzioni assicurative
+    description: |
+      Rating del rischio del cliente, documentazione KYC, screening di sanzioni e PEP, e aggiornamento periodico.
+  BC-2120.20.10:
+    name: Rating del rischio del cliente
+    description: |
+      Rating del rischio della clientela assicurativa basato su fattori AML e di rischio di condotta.
+  BC-2120.20.20:
+    name: Raccolta della documentazione KYC
+    description: |
+      Raccolta e validazione della documentazione KYC per la clientela assicurativa.
+  BC-2120.20.30:
+    name: Screening di sanzioni e PEP
+    description: |
+      Screening di sanzioni, PEP e media negative dei contraenti e dei beneficiari.
+  BC-2120.20.40:
+    name: Aggiornamento periodico del KYC
+    description: |
+      Aggiornamento periodico delle informazioni KYC e rivalutazione del rischio.
+  BC-2120.30:
+    name: Gestione del servicing del contraente
+    description: |
+      Manutenzione self-service, gestione delle richieste di servizio in entrata, fornitura di documenti e manutenzione dei beneficiari.
+  BC-2120.30.10:
+    name: Manutenzione self-service del conto
+    description: |
+      Aggiornamenti self-service di indirizzo, contatti e dati di preferenza.
+  BC-2120.30.20:
+    name: Gestione delle richieste di servizio in entrata
+    description: |
+      Gestione delle richieste di servizio in entrata dei contraenti attraverso i canali.
+  BC-2120.30.30:
+    name: Fornitura di documenti e estratti conto
+    description: |
+      Fornitura di documenti di polizza, estratti conto e attestati di assicurazione.
+  BC-2120.30.40:
+    name: Manutenzione dei beneficiari e dei designati
+    description: |
+      Acquisizione e manutenzione dei beneficiari e dei designati su contratti vita e previdenziali.
+  BC-2120.40:
+    name: Gestione delle informazioni e del consenso del cliente
+    description: |
+      Profilo, aggregazione per nucleo familiare e gruppo, gestione del consenso e record unico del cliente.
+  BC-2120.40.10:
+    name: Manutenzione del profilo del contraente
+    description: |
+      Manutenzione del profilo del contraente e dei dati anagrafici.
+  BC-2120.40.20:
+    name: Aggregazione per nucleo familiare e gruppo
+    description: |
+      Aggregazione dei contraenti in nuclei familiari, gruppi e società capogruppo.
+  BC-2120.40.30:
+    name: Consenso per marketing e condivisione dei dati
+    description: |
+      Acquisizione e applicazione dei consensi per marketing e condivisione dei dati.
+  BC-2120.40.40:
+    name: Gestione del record unico del cliente
+    description: |
+      Manutenzione del record unico del contraente attraverso i sistemi.
+  BC-2120.50:
+    name: Gestione dell'esperienza del cliente e della fidelizzazione
+    description: |
+      Raccolta dei feedback, programmi fedeltà, gestione dei reclami e previsione del churn.
+  BC-2120.50.10:
+    name: Raccolta del feedback del cliente
+    description: |
+      Raccolta del feedback del cliente, degli indici NPS e dei segnali CSAT.
+  BC-2120.50.20:
+    name: Operatività dei programmi di fedeltà e fidelizzazione
+    description: |
+      Operatività dei programmi di fedeltà, fidelizzazione e premi legati alla durata del contratto.
+  BC-2120.50.30:
+    name: Gestione dei reclami ed escalation
+    description: |
+      Gestione dei reclami dei contraenti, delle escalation e dei ricorsi all'arbitro.
+  BC-2120.50.40:
+    name: Previsione del churn e del tasso di abbandono
+    description: |
+      Analisi predittiva del churn e del tasso di abbandono per interventi di fidelizzazione.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-insurance-distribution-management.yaml
+++ b/catalogue/i18n/it/L1-insurance-distribution-management.yaml
@@ -1,0 +1,135 @@
+# Gestione della distribuzione assicurativa (it) — translations for L1-insurance-distribution-management.yaml
+locale: it
+source: L1-insurance-distribution-management.yaml
+entries:
+  BC-2110:
+    name: Gestione della distribuzione assicurativa
+    description: |
+      Relazioni con produttori, broker, agenti, MGA e canale diretto, incluse le nomine, le provvigioni, le licenze, le deleghe e il flusso di preventivi e proposte verso la sottoscrizione.
+  BC-2110.10:
+    name: Gestione dei produttori e degli intermediari
+    description: |
+      Onboarding, gerarchia, monitoraggio delle performance e offboarding di produttori e intermediari.
+  BC-2110.10.10:
+    name: Onboarding del produttore
+    description: |
+      Onboarding di produttori, intermediari, broker e MGA.
+  BC-2110.10.20:
+    name: Manutenzione della gerarchia e del conto del produttore
+    description: |
+      Manutenzione della gerarchia dei produttori, delle strutture di conto e dei dati di contatto.
+  BC-2110.10.30:
+    name: Monitoraggio delle performance del produttore
+    description: |
+      Monitoraggio della produzione, del loss ratio e della redditività del produttore.
+  BC-2110.10.40:
+    name: Offboarding del produttore
+    description: |
+      Offboarding dei produttori, gestione del run-off dei portafogli in vigore e regolamento finale.
+  BC-2110.20:
+    name: Gestione delle licenze e delle nomine dei produttori
+    description: |
+      Verifica delle licenze, nomine giurisdizionali, formazione continua e conformità del produttore.
+  BC-2110.20.10:
+    name: Verifica delle licenze
+    description: |
+      Verifica delle licenze dei produttori nei confronti dei registri statali e giurisdizionali.
+  BC-2110.20.20:
+    name: Gestione delle nomine giurisdizionali
+    description: |
+      Gestione delle nomine, delle revoche e dei rinnovi statali e giurisdizionali.
+  BC-2110.20.30:
+    name: Monitoraggio della formazione continua
+    description: |
+      Monitoraggio dei crediti di formazione continua dei produttori e dell'eleggibilità al rinnovo.
+  BC-2110.20.40:
+    name: Monitoraggio della conformità del produttore
+    description: |
+      Monitoraggio della condotta dei produttori, dei reclami e dei provvedimenti disciplinari.
+  BC-2110.30:
+    name: Gestione delle provvigioni e degli incentivi
+    description: |
+      Configurazione dei piani provvigionali, calcolo, override e bonus, e generazione degli estratti conto.
+  BC-2110.30.10:
+    name: Configurazione del piano provvigionale
+    description: |
+      Configurazione dei piani provvigionali e delle aliquote per prodotto e per produttore.
+  BC-2110.30.20:
+    name: Calcolo delle provvigioni
+    description: |
+      Calcolo delle provvigioni sugli eventi di premio, inclusi gli storni in caso di disdetta.
+  BC-2110.30.30:
+    name: Calcolo degli override e dei bonus
+    description: |
+      Calcolo delle provvigioni di override, della partecipazione agli utili e dei bonus incentivo.
+  BC-2110.30.40:
+    name: Generazione degli estratti conto provvigionali
+    description: |
+      Generazione e distribuzione degli estratti conto provvigionali ai produttori.
+  BC-2110.40:
+    name: Gestione dei canali di distribuzione
+    description: |
+      Operatività dei canali agente, broker, digitale diretto, bancassurance, affinità e aggregatori.
+  BC-2110.40.10:
+    name: Operatività del canale agente
+    description: |
+      Operatività dei canali agente monomandatario e plurimandatario.
+  BC-2110.40.20:
+    name: Operatività del canale broker
+    description: |
+      Operatività dei canali broker e broker all'ingrosso.
+  BC-2110.40.30:
+    name: Operatività del canale digitale diretto
+    description: |
+      Operatività del canale digitale assicurativo diretto al cliente.
+  BC-2110.40.40:
+    name: Operatività del canale bancassurance e affinità
+    description: |
+      Operatività delle partnership di bancassurance e dei canali per gruppi di affinità.
+  BC-2110.40.50:
+    name: Operatività del canale aggregatori e comparatori
+    description: |
+      Operatività dei canali aggregatori e dei comparatori di prezzo online.
+  BC-2110.50:
+    name: Gestione delle deleghe
+    description: |
+      Configurazione delle facoltà del coverholder, monitoraggio delle performance, ricezione del bordereau e audit delle facoltà.
+  BC-2110.50.10:
+    name: Configurazione delle deleghe
+    description: |
+      Configurazione delle binding authority e degli accordi di sottoscrizione delegata.
+  BC-2110.50.20:
+    name: Monitoraggio delle performance del coverholder
+    description: |
+      Monitoraggio delle performance di sottoscrizione del coverholder e del rispetto delle facoltà.
+  BC-2110.50.30:
+    name: Ricezione e riconciliazione del bordereau
+    description: |
+      Ricezione, acquisizione e riconciliazione dei bordereau di premio e sinistro.
+  BC-2110.50.40:
+    name: Audit e revoca delle facoltà
+    description: |
+      Audit delle operazioni del coverholder e revoca della binding authority ove necessario.
+  BC-2110.60:
+    name: Gestione dei preventivi e delle proposte
+    description: |
+      Acquisizione delle proposte, generazione dei preventivi, comparazione e monitoraggio del tasso di conversione preventivo-polizza.
+  BC-2110.60.10:
+    name: Acquisizione delle proposte
+    description: |
+      Acquisizione delle proposte assicurative attraverso i canali e i portali broker.
+  BC-2110.60.20:
+    name: Generazione dei preventivi
+    description: |
+      Generazione dei preventivi assicurativi dalla configurazione del prodotto e della tariffazione del rischio.
+  BC-2110.60.30:
+    name: Comparazione dei preventivi e contro-offerta
+    description: |
+      Comparazione multi-compagnia dei preventivi e gestione delle contro-offerte.
+  BC-2110.60.40:
+    name: Monitoraggio del tasso di conversione preventivo-polizza
+    description: |
+      Monitoraggio dei tassi di conversione preventivo-polizza e delle ragioni della mancata conversione.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-insurance-investment-management.yaml
+++ b/catalogue/i18n/it/L1-insurance-investment-management.yaml
@@ -1,0 +1,111 @@
+# Gestione degli investimenti assicurativi (it) — translations for L1-insurance-investment-management.yaml
+locale: it
+source: L1-insurance-investment-management.yaml
+entries:
+  BC-2200:
+    name: Gestione degli investimenti assicurativi
+    description: |
+      Gestione del lato attivo delle riserve assicurative da parte di un assicuratore-investitore istituzionale: politica degli investimenti, ALM, asset allocation strategica e tattica, supervisione dei gestori, rischio e compliance degli investimenti e reporting degli investimenti.
+  BC-2200.10:
+    name: Gestione della politica e della strategia degli investimenti
+    description: |
+      Dichiarazione di politica degli investimenti, definizione del mandato e integrazione della politica di investimento ESG.
+  BC-2200.10.10:
+    name: Manutenzione della dichiarazione di politica degli investimenti
+    description: |
+      Manutenzione della dichiarazione di politica degli investimenti e allineamento al principio della persona prudente.
+  BC-2200.10.20:
+    name: Definizione del mandato di investimento
+    description: |
+      Definizione dei mandati di investimento per portafoglio, ramo assicurativo e profilo di rischio.
+  BC-2200.10.30:
+    name: Integrazione della politica di investimento ESG
+    description: |
+      Integrazione delle politiche ESG e di stewardship nei mandati di investimento.
+  BC-2200.20:
+    name: Gestione dell'attivo-passivo (ALM)
+    description: |
+      Modellizzazione ALM e corrispondenza dei flussi di cassa, monitoraggio della duration e della convessità, e dimensionamento del buffer di liquidità.
+  BC-2200.20.10:
+    name: Modellizzazione ALM e corrispondenza dei flussi di cassa
+    description: |
+      Modellizzazione ALM e corrispondenza attivo-passivo dei flussi di cassa con le riserve assicurative.
+  BC-2200.20.20:
+    name: Monitoraggio della duration e della convessità
+    description: |
+      Monitoraggio dei gap di duration e convessità tra attivi e passivi.
+  BC-2200.20.30:
+    name: Dimensionamento del buffer di liquidità
+    description: |
+      Dimensionamento dei buffer di liquidità degli investimenti per far fronte ai deflussi attesi e stressati da sinistri.
+  BC-2200.30:
+    name: Asset allocation strategica e tattica
+    description: |
+      Decisioni di asset allocation strategica e tattica e ribilanciamento del portafoglio.
+  BC-2200.30.10:
+    name: Definizione dell'asset allocation strategica
+    description: |
+      Definizione delle asset allocation strategiche di lungo periodo nelle varie classi di attivo.
+  BC-2200.30.20:
+    name: Decisioni di asset allocation tattica
+    description: |
+      Decisioni di allocazione tattica all'interno degli intervalli strategici.
+  BC-2200.30.30:
+    name: Ribilanciamento dell'allocazione
+    description: |
+      Ribilanciamento periodico e event-driven verso le allocazioni target.
+  BC-2200.40:
+    name: Supervisione del mandato e dei gestori di investimento
+    description: |
+      Selezione dei gestori esterni, monitoraggio della conformità al mandato, revisione delle performance e supervisione delle commissioni di gestione.
+  BC-2200.40.10:
+    name: Selezione dei gestori esterni
+    description: |
+      Selezione e onboarding dei gestori di investimento esterni.
+  BC-2200.40.20:
+    name: Monitoraggio della conformità al mandato
+    description: |
+      Monitoraggio della conformità al mandato di investimento e gestione delle violazioni.
+  BC-2200.40.30:
+    name: Revisione delle performance dei gestori
+    description: |
+      Revisione periodica delle performance dei gestori di investimento esterni.
+  BC-2200.40.40:
+    name: Supervisione delle commissioni di gestione
+    description: |
+      Supervisione delle commissioni di gestione e delle valutazioni del rapporto qualità-prezzo.
+  BC-2200.50:
+    name: Monitoraggio del rischio e della compliance degli investimenti
+    description: |
+      Monitoraggio dei limiti di investimento, dei limiti di controparte ed emittente, e dell'eleggibilità degli attivi ai sensi di Solvency II.
+  BC-2200.50.10:
+    name: Monitoraggio dei limiti di investimento
+    description: |
+      Monitoraggio dei limiti di investimento nelle varie classi di attivo e fattori di rischio.
+  BC-2200.50.20:
+    name: Monitoraggio dei limiti di controparte ed emittente
+    description: |
+      Monitoraggio della concentrazione e dei limiti verso controparti ed emittenti.
+  BC-2200.50.30:
+    name: Monitoraggio dell'eleggibilità degli attivi ai sensi di Solvency II
+    description: |
+      Monitoraggio dell'eleggibilità degli attivi in conformità alle regole Solvency II e equivalenti.
+  BC-2200.60:
+    name: Performance e reporting degli investimenti
+    description: |
+      Misurazione delle performance, attribuzione e reporting degli investimenti al consiglio di amministrazione e all'autorità di vigilanza.
+  BC-2200.60.10:
+    name: Misurazione della performance del portafoglio
+    description: |
+      Misurazione della performance del portafoglio rispetto ai benchmark e alle riserve assicurative.
+  BC-2200.60.20:
+    name: Analisi di attribuzione
+    description: |
+      Attribuzione della performance per allocazione, selezione e valuta.
+  BC-2200.60.30:
+    name: Reporting degli investimenti al consiglio e all'autorità di vigilanza
+    description: |
+      Produzione del reporting degli investimenti per il consiglio di amministrazione, l'ALCO e l'autorità di vigilanza.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-insurance-product-management.yaml
+++ b/catalogue/i18n/it/L1-insurance-product-management.yaml
@@ -1,0 +1,123 @@
+# Gestione del prodotto assicurativo (it) — translations for L1-insurance-product-management.yaml
+locale: it
+source: L1-insurance-product-management.yaml
+entries:
+  BC-2100:
+    name: Gestione del prodotto assicurativo
+    description: |
+      Fabbrica del prodotto assicurativo: definizione delle coperture, condizioni, tabelle di tariffazione, bundle e ciclo di vita per vita, danni, salute e rami speciali, incluse le strutture di programma e coverholder utilizzate nei mercati a delega.
+  BC-2100.10:
+    name: Gestione del catalogo dei prodotti assicurativi
+    description: |
+      Catalogo dei prodotti assicurativi, master data, libreria delle coperture e dei moduli, documentazione informativa e pubblicazione del catalogo.
+  BC-2100.10.10:
+    name: Gestione dei master data di prodotto
+    description: |
+      Manutenzione dei master data dei prodotti assicurativi e delle gerarchie di prodotto.
+  BC-2100.10.20:
+    name: Libreria delle coperture e dei moduli
+    description: |
+      Manutenzione delle definizioni standardizzate di copertura, dei moduli di polizza e della libreria delle appendici.
+  BC-2100.10.30:
+    name: Documentazione informativa del prodotto
+    description: |
+      Produzione e manutenzione dei documenti informativi sul prodotto e delle schede informative precontrattuali.
+  BC-2100.10.40:
+    name: Pubblicazione del catalogo dei prodotti
+    description: |
+      Pubblicazione del catalogo dei prodotti assicurativi attraverso i canali e i partner.
+  BC-2100.20:
+    name: Configurazione della tariffazione e del pricing del prodotto
+    description: |
+      Configurazione degli algoritmi di tariffazione del rischio, fattori, tariffe depositate, sconti e soprapprezzi.
+  BC-2100.20.10:
+    name: Configurazione dell'algoritmo di tariffazione
+    description: |
+      Configurazione degli algoritmi di tariffazione del rischio e dei modelli di pricing per i prodotti assicurativi.
+  BC-2100.20.20:
+    name: Manutenzione dei fattori e delle variabili di tariffazione
+    description: |
+      Manutenzione dei fattori di tariffazione, delle tabelle e delle variabili di rating.
+  BC-2100.20.30:
+    name: Gestione delle tariffe depositate
+    description: |
+      Gestione delle tariffe depositate, delle deviazioni e delle approvazioni nelle varie giurisdizioni.
+  BC-2100.20.40:
+    name: Configurazione di sconti e soprapprezzi
+    description: |
+      Configurazione degli sconti sul premio, dei soprapprezzi e dei programmi di credito.
+  BC-2100.30:
+    name: Configurazione delle regole di eleggibilità e di sottoscrizione del prodotto
+    description: |
+      Configurazione dell'eleggibilità, delle linee guida di sottoscrizione e delle regole di escalation e rifiuto incorporate nel prodotto.
+  BC-2100.30.10:
+    name: Configurazione delle regole di eleggibilità
+    description: |
+      Configurazione delle regole di eleggibilità del cliente e del rischio per prodotto.
+  BC-2100.30.20:
+    name: Codifica delle linee guida di sottoscrizione
+    description: |
+      Codifica delle linee guida di sottoscrizione assicurativa nella configurazione del prodotto.
+  BC-2100.30.30:
+    name: Configurazione delle regole di escalation e rifiuto
+    description: |
+      Configurazione delle regole automatiche di escalation (sottoscrizione) e rifiuto per prodotto.
+  BC-2100.40:
+    name: Gestione del ciclo di vita del prodotto assicurativo
+    description: |
+      Introduzione di nuovi prodotti, deposito tariffario, predisposizione al lancio, revisione delle performance e ritiro.
+  BC-2100.40.10:
+    name: Concetto di nuovo prodotto
+    description: |
+      Definizione del concetto per nuovi prodotti assicurativi e governance del comitato prodotto.
+  BC-2100.40.20:
+    name: Deposito tariffario e approvazione del prodotto
+    description: |
+      Deposito tariffario dei prodotti assicurativi e monitoraggio dell'approvazione nelle varie giurisdizioni.
+  BC-2100.40.30:
+    name: Predisposizione al lancio del prodotto
+    description: |
+      Predisposizione operativa e dei canali per il lancio dei prodotti assicurativi.
+  BC-2100.40.40:
+    name: Revisione delle performance del prodotto
+    description: |
+      Revisioni periodiche delle performance e del rapporto qualità-prezzo dei prodotti assicurativi.
+  BC-2100.40.50:
+    name: Ritiro e sostituzione del prodotto
+    description: |
+      Ritiro, sostituzione e migrazione dei contraenti verso i prodotti successori.
+  BC-2100.50:
+    name: Gestione del bundle di prodotti assicurativi
+    description: |
+      Bundle multi-ramo, prodotti pacchetto e monitoraggio delle performance dei bundle.
+  BC-2100.50.10:
+    name: Definizione del bundle multi-ramo
+    description: |
+      Definizione dei bundle multi-ramo e delle regole di confezionamento del prodotto.
+  BC-2100.50.20:
+    name: Configurazione delle regole di eleggibilità del bundle
+    description: |
+      Regole di eleggibilità e di qualificazione per i bundle di prodotti assicurativi.
+  BC-2100.50.30:
+    name: Monitoraggio delle performance del bundle
+    description: |
+      Monitoraggio dell'uptake, della fidelizzazione e dell'economics del bundle.
+  BC-2100.60:
+    name: Gestione dei prodotti speciali e di programma
+    description: |
+      Definizione del programma di business, facoltà di prodotto del coverholder e libreria delle condizioni di polizza per rami speciali.
+  BC-2100.60.10:
+    name: Definizione del programma
+    description: |
+      Definizione del programma di business e delle strutture di prodotto in binding authority.
+  BC-2100.60.20:
+    name: Facoltà di prodotto del coverholder
+    description: |
+      Definizione dell'ambito di prodotto e delle facoltà concesse ai coverholder.
+  BC-2100.60.30:
+    name: Libreria delle condizioni di polizza speciali e delle appendici
+    description: |
+      Libreria delle condizioni di polizza speciali, delle appendici manoscritte e delle clausole di mercato.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-insurance-risk-management.yaml
+++ b/catalogue/i18n/it/L1-insurance-risk-management.yaml
@@ -1,0 +1,139 @@
+# Gestione del rischio assicurativo (it) — translations for L1-insurance-risk-management.yaml
+locale: it
+source: L1-insurance-risk-management.yaml
+entries:
+  BC-2190:
+    name: Gestione del rischio assicurativo
+    description: |
+      Tipologie di rischio specifiche del settore assicurativo: rischio di sottoscrizione, catastrofale e di accumulo, rischio di riserva, di solvibilità e di capitale, di controparte riassicurativa, vita e longevità, tasso di abbandono, rischio operativo assicurativo e di condotta — distinti dal rischio d'impresa generico.
+  BC-2190.10:
+    name: Gestione del rischio di sottoscrizione
+    description: |
+      Propensione al rischio di sottoscrizione, monitoraggio dei limiti e sorveglianza dell'antiselezione.
+  BC-2190.10.10:
+    name: Propensione al rischio di sottoscrizione
+    description: |
+      Definizione e articolazione della propensione al rischio di sottoscrizione.
+  BC-2190.10.20:
+    name: Monitoraggio dei limiti di sottoscrizione
+    description: |
+      Monitoraggio delle facoltà di sottoscrizione e dei limiti di aggregazione.
+  BC-2190.10.30:
+    name: Sorveglianza dell'antiselezione
+    description: |
+      Sorveglianza dell'antiselezione e dei fenomeni di selezione avversa.
+  BC-2190.20:
+    name: Gestione del rischio catastrofale e di accumulo
+    description: |
+      Monitoraggio dell'aggregazione delle esposizioni, gestione del PML e degli scenari di disastro realistici, e pianificazione della mitigazione del rischio catastrofale.
+  BC-2190.20.10:
+    name: Monitoraggio dell'aggregazione delle esposizioni
+    description: |
+      Monitoraggio dell'aggregazione delle esposizioni per rischio, area geografica e destinazione d'uso.
+  BC-2190.20.20:
+    name: Gestione del PML e degli scenari di disastro realistici
+    description: |
+      Gestione delle metriche PML e degli scenari di disastro realistici.
+  BC-2190.20.30:
+    name: Pianificazione della mitigazione del rischio catastrofale
+    description: |
+      Pianificazione delle azioni di mitigazione, inclusa la riassicurazione e il trasferimento del rischio.
+  BC-2190.30:
+    name: Gestione della riserva e del rischio di riserva assicurativa
+    description: |
+      Monitoraggio dell'adeguatezza della riserva, analisi della volatilità della riserva e stress testing del rischio di riserva.
+  BC-2190.30.10:
+    name: Monitoraggio dell'adeguatezza della riserva
+    description: |
+      Monitoraggio dell'adeguatezza della riserva rispetto alla best estimate e ai benchmark esterni.
+  BC-2190.30.20:
+    name: Analisi della volatilità della riserva
+    description: |
+      Analisi della volatilità della riserva e del rischio di riserva a un anno.
+  BC-2190.30.30:
+    name: Stress testing del rischio di riserva
+    description: |
+      Stress e scenario testing dell'adeguatezza della riserva.
+  BC-2190.40:
+    name: Gestione del rischio di solvibilità e di capitale
+    description: |
+      Monitoraggio dell'adeguatezza del capitale, operatività dell'ORSA, stress testing della solvibilità e pianificazione del risanamento e della risoluzione.
+  BC-2190.40.10:
+    name: Monitoraggio dell'adeguatezza del capitale
+    description: |
+      Monitoraggio dei ratio di capitale di solvibilità (SCR/MCR) e dei trigger di capitale.
+  BC-2190.40.20:
+    name: Operatività dell'ORSA
+    description: |
+      Conduzione del ciclo di valutazione del rischio proprio e della solvibilità (ORSA).
+  BC-2190.40.30:
+    name: Stress e scenario testing della solvibilità
+    description: |
+      Stress e reverse stress testing delle posizioni di solvibilità.
+  BC-2190.40.40:
+    name: Pianificazione del risanamento e della risoluzione
+    description: |
+      Pianificazione del risanamento e della risoluzione per gli scenari di wind-down dell'assicuratore.
+  BC-2190.50:
+    name: Gestione del rischio di credito della controparte riassicurativa
+    description: |
+      Monitoraggio della controparte riassicurativa, adeguatezza delle garanzie collaterali e stress testing del default della controparte.
+  BC-2190.50.10:
+    name: Monitoraggio della controparte riassicurativa
+    description: |
+      Monitoraggio della solidità finanziaria del riassicuratore e della concentrazione delle esposizioni.
+  BC-2190.50.20:
+    name: Monitoraggio dell'adeguatezza delle garanzie collaterali e delle lettere di credito
+    description: |
+      Monitoraggio dell'adeguatezza delle garanzie collaterali e delle lettere di credito dei riassicuratori.
+  BC-2190.50.30:
+    name: Stress testing del default della controparte
+    description: |
+      Stress testing degli impatti del default del riassicuratore sulla solvibilità.
+  BC-2190.60:
+    name: Gestione del rischio vita e longevità
+    description: |
+      Monitoraggio del rischio di mortalità, supervisione della copertura del rischio di longevità e gestione del rischio pandemico.
+  BC-2190.60.10:
+    name: Monitoraggio del rischio di mortalità
+    description: |
+      Monitoraggio del rischio di mortalità sui portafogli vita e protezione.
+  BC-2190.60.20:
+    name: Supervisione della copertura del rischio di longevità
+    description: |
+      Supervisione degli strumenti di copertura del rischio di longevità e dell'esposizione verso la controparte.
+  BC-2190.60.30:
+    name: Gestione del rischio pandemico
+    description: |
+      Gestione del rischio di mortalità e morbilità da pandemia ed epidemia.
+  BC-2190.70:
+    name: Gestione del rischio di tasso di abbandono e persistenza
+    description: |
+      Monitoraggio del rischio di tasso di abbandono e stress testing della persistenza.
+  BC-2190.70.10:
+    name: Monitoraggio del rischio di tasso di abbandono
+    description: |
+      Monitoraggio dei tassi di abbandono e delle perdite da tasso di abbandono sui prodotti vita e risparmio.
+  BC-2190.70.20:
+    name: Stress testing della persistenza
+    description: |
+      Stress testing delle ipotesi di persistenza e del comportamento dinamico del tasso di abbandono.
+  BC-2190.80:
+    name: Gestione del rischio operativo assicurativo e di condotta
+    description: |
+      Monitoraggio del rischio di condotta assicurativo, del rischio di gestione dei sinistri e del rischio di distribuzione.
+  BC-2190.80.10:
+    name: Monitoraggio del rischio di condotta assicurativo
+    description: |
+      Monitoraggio degli indicatori di rischio di condotta su prodotto, distribuzione e sinistri.
+  BC-2190.80.20:
+    name: Supervisione del rischio di gestione dei sinistri
+    description: |
+      Supervisione del rischio di gestione dei sinistri e degli esiti di equità per il contraente.
+  BC-2190.80.30:
+    name: Monitoraggio del rischio di distribuzione
+    description: |
+      Monitoraggio del rischio di distribuzione, inclusi la vendita non adeguata e la condotta degli intermediari.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-insurance-underwriting-management.yaml
+++ b/catalogue/i18n/it/L1-insurance-underwriting-management.yaml
@@ -1,0 +1,123 @@
+# Gestione della sottoscrizione assicurativa (it) — translations for L1-insurance-underwriting-management.yaml
+locale: it
+source: L1-insurance-underwriting-management.yaml
+entries:
+  BC-2130:
+    name: Gestione della sottoscrizione assicurativa
+    description: |
+      Valutazione del rischio, tariffazione del rischio, accettazione, rifiuto e conferma della copertura di proposte assicurative nei rami personali, commerciali e speciali, inclusa l'applicazione delle facoltà di sottoscrizione e la gestione del portafoglio.
+  BC-2130.10:
+    name: Acquisizione del rischio in sottoscrizione
+    description: |
+      Triage delle proposte, raccolta dei dati sul rischio, recupero della storia sinistri e arricchimento con dati di terze parti.
+  BC-2130.10.10:
+    name: Triage delle proposte
+    description: |
+      Triage delle proposte di sottoscrizione e instradamento verso i team di sottoscrizione.
+  BC-2130.10.20:
+    name: Raccolta dei dati sul rischio
+    description: |
+      Raccolta dei dati rilevanti sul rischio dal proponente, dal broker e da sopralluoghi.
+  BC-2130.10.30:
+    name: Recupero della storia sinistri
+    description: |
+      Recupero della storia sinistri da uffici statistici, compagnie precedenti e registri condivisi.
+  BC-2130.10.40:
+    name: Arricchimento con dati di terze parti
+    description: |
+      Arricchimento delle proposte con dati di terze parti, telematici e IoT.
+  BC-2130.20:
+    name: Valutazione e selezione del rischio
+    description: |
+      Scoring del rischio, valutazione dell'aggregazione delle esposizioni, sopralluoghi di loss control ed escalation di sottoscrizione.
+  BC-2130.20.10:
+    name: Scoring e modellizzazione del rischio
+    description: |
+      Applicazione di modelli di sottoscrizione, scorecard e punteggi di rischio tramite machine learning.
+  BC-2130.20.20:
+    name: Valutazione dell'aggregazione delle esposizioni
+    description: |
+      Valutazione dell'aggregazione delle esposizioni rispetto al portafoglio in vigore.
+  BC-2130.20.30:
+    name: Coordinamento dei sopralluoghi di loss control
+    description: |
+      Coordinamento dei sopralluoghi di loss control e delle perizie di risk engineering.
+  BC-2130.20.40:
+    name: Gestione delle escalation di sottoscrizione
+    description: |
+      Gestione delle escalation verso i sottoscrittori senior, le linee di autorità e i riassicuratori.
+  BC-2130.30:
+    name: Gestione della tariffazione in sottoscrizione
+    description: |
+      Tariffazione manuale, crediti di schedule rating, experience rating e pricing bespoke per rami speciali.
+  BC-2130.30.10:
+    name: Applicazione delle tariffe manuali
+    description: |
+      Applicazione delle tariffe manuali dalla configurazione del prodotto depositato.
+  BC-2130.30.20:
+    name: Applicazione dello schedule rating e dei crediti
+    description: |
+      Applicazione dei crediti e dei debiti di schedule rating.
+  BC-2130.30.30:
+    name: Experience rating
+    description: |
+      Tariffazione del rischio basata sulla storia sinistri del contraente.
+  BC-2130.30.40:
+    name: Pricing speciale e bespoke
+    description: |
+      Pricing bespoke per rami speciali, grandi clienti e rischi complessi.
+  BC-2130.40:
+    name: Gestione della decisione e delle facoltà di sottoscrizione
+    description: |
+      Decisione di accettazione o rifiuto, definizione dei termini e delle condizioni, applicazione delle facoltà e conferma della copertura.
+  BC-2130.40.10:
+    name: Decisione di accettazione e rifiuto
+    description: |
+      Decisione di accettazione, rifiuto o contro-offerta sulle proposte.
+  BC-2130.40.20:
+    name: Definizione dei termini e delle condizioni di copertura
+    description: |
+      Definizione dei termini, delle condizioni, delle esclusioni e delle garanzie di copertura.
+  BC-2130.40.30:
+    name: Applicazione delle facoltà di sottoscrizione
+    description: |
+      Applicazione dei limiti delle facoltà di sottoscrizione e delle soglie di escalation.
+  BC-2130.40.40:
+    name: Emissione del preventivo e conferma della copertura
+    description: |
+      Emissione dei preventivi vincolanti e conferma della copertura assicurativa.
+  BC-2130.50:
+    name: Gestione del portafoglio di sottoscrizione
+    description: |
+      Monitoraggio del mix e dei limiti del portafoglio, analisi della redditività e pianificazione delle azioni correttive.
+  BC-2130.50.10:
+    name: Monitoraggio del mix e dei limiti del portafoglio
+    description: |
+      Monitoraggio del mix del portafoglio rispetto alla propensione al rischio assicurativo e ai limiti di concentrazione.
+  BC-2130.50.20:
+    name: Analisi della redditività della sottoscrizione
+    description: |
+      Analisi della redditività della sottoscrizione assicurativa per segmento, prodotto e produttore.
+  BC-2130.50.30:
+    name: Pianificazione delle azioni correttive di sottoscrizione
+    description: |
+      Pianificazione delle azioni correttive di sottoscrizione, della remediation e delle uscite dai segmenti.
+  BC-2130.60:
+    name: Gestione della frode e della falsa dichiarazione in sottoscrizione
+    description: |
+      Screening per frode nelle proposte, indagine sulla falsa dichiarazione materiale e segnalazione delle frodi in sottoscrizione.
+  BC-2130.60.10:
+    name: Screening per frode nelle proposte
+    description: |
+      Screening delle proposte assicurative per indicatori di frode.
+  BC-2130.60.20:
+    name: Indagine sulla falsa dichiarazione materiale
+    description: |
+      Indagine su sospette false dichiarazioni materiali nelle proposte.
+  BC-2130.60.30:
+    name: Segnalazione delle frodi in sottoscrizione
+    description: |
+      Segnalazione delle frodi in sottoscrizione assicurativa confermate ai registri di settore e alle autorità di vigilanza.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-intellectual-property-management.yaml
+++ b/catalogue/i18n/it/L1-intellectual-property-management.yaml
@@ -1,0 +1,103 @@
+# Gestione della proprietà intellettuale (it) — translations for L1-intellectual-property-management.yaml
+locale: it
+source: L1-intellectual-property-management.yaml
+entries:
+  BC-840:
+    name: Gestione della proprietà intellettuale
+    description: |
+      Brevetti, marchi, diritti d'autore, segreti commerciali e licenze.
+  BC-840.10:
+    name: Gestione del portafoglio brevetti
+    description: |
+      Strategia brevettuale, deposito, mantenimento e revisione del portafoglio.
+  BC-840.10.10:
+    name: Gestione delle divulgazioni di invenzione
+    description: |
+      Raccolta, valutazione e decisione sulle divulgazioni di invenzione.
+  BC-840.10.20:
+    name: Deposito e prosecution dei brevetti
+    description: |
+      Redazione, deposito e prosecution delle domande di brevetto.
+  BC-840.10.30:
+    name: Mantenimento dei brevetti
+    description: |
+      Pagamento delle annualità e mantenimento dei brevetti concessi.
+  BC-840.10.40:
+    name: Revisione del portafoglio brevetti
+    description: |
+      Revisione periodica e razionalizzazione del portafoglio brevetti.
+  BC-840.20:
+    name: Gestione del marchio
+    description: |
+      Deposito, sorveglianza e difesa del marchio.
+  BC-840.20.10:
+    name: Clearance e deposito del marchio
+    description: |
+      Ricerche di disponibilità e deposito dei marchi.
+  BC-840.20.20:
+    name: Sorveglianza e vigilanza del marchio
+    description: |
+      Sorveglianza sui depositi e usi di marchi confliggenti.
+  BC-840.20.30:
+    name: Gestione del rinnovo del marchio
+    description: |
+      Rinnovo e mantenimento delle registrazioni di marchio.
+  BC-840.30:
+    name: Gestione del diritto d'autore e dei segreti commerciali
+    description: |
+      Asset protetti da diritto d'autore, segreti commerciali e riservatezza.
+  BC-840.30.10:
+    name: Registrazione degli asset tutelati dal diritto d'autore
+    description: |
+      Identificazione e registrazione degli asset soggetti a tutela del diritto d'autore.
+  BC-840.30.20:
+    name: Identificazione e protezione dei segreti commerciali
+    description: |
+      Identificazione e protezione dei segreti commerciali aziendali.
+  BC-840.30.30:
+    name: Gestione della riservatezza e degli NDA
+    description: |
+      NDA, accordi di riservatezza e controlli sugli accessi.
+  BC-840.40:
+    name: Gestione delle licenze di proprietà intellettuale
+    description: |
+      Licenze in entrata, licenze in uscita e royalty.
+  BC-840.40.10:
+    name: Negoziazione delle licenze in entrata
+    description: |
+      Negoziazione e stipula di licenze di proprietà intellettuale in entrata.
+  BC-840.40.20:
+    name: Licenze in uscita e commercializzazione
+    description: |
+      Concessione di licenze di proprietà intellettuale e commercializzazione dei brevetti.
+  BC-840.40.30:
+    name: Amministrazione delle royalty
+    description: |
+      Calcolo, riscossione e pagamento delle royalty sulla proprietà intellettuale.
+  BC-840.40.40:
+    name: Licenze incrociate e patent pool
+    description: |
+      Accordi di licenza incrociata e partecipazione a patent pool.
+  BC-840.50:
+    name: Difesa e tutela della proprietà intellettuale
+    description: |
+      Rilevamento delle violazioni e azioni di tutela.
+  BC-840.50.10:
+    name: Monitoraggio delle violazioni
+    description: |
+      Monitoraggio delle presunte violazioni della proprietà intellettuale.
+  BC-840.50.20:
+    name: Azioni di tutela della proprietà intellettuale
+    description: |
+      Diffide, opposizioni e contenzioso per la tutela della proprietà intellettuale.
+  BC-840.50.30:
+    name: Difesa e controrichieste sulla proprietà intellettuale
+    description: |
+      Difesa da richieste di proprietà intellettuale e contro-contenzioso.
+  BC-840.50.40:
+    name: Anticontraffazione e protezione del brand
+    description: |
+      Rilevamento e rimozione di prodotti contraffatti e abusi del brand.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-intelligence-operations-management.yaml
+++ b/catalogue/i18n/it/L1-intelligence-operations-management.yaml
@@ -1,0 +1,103 @@
+# Gestione delle operazioni di intelligence (it) — translations for L1-intelligence-operations-management.yaml
+locale: it
+source: L1-intelligence-operations-management.yaml
+entries:
+  BC-1730:
+    name: Gestione delle operazioni di intelligence
+    description: |
+      Raccolta, analisi, diffusione e fusione delle informazioni di intelligence.
+  BC-1730.10:
+    name: Gestione della raccolta di informazioni di intelligence
+    description: |
+      Raccolta di HUMINT, SIGINT, GEOINT, IMINT e OSINT.
+  BC-1730.10.10:
+    name: Gestione dei requisiti di raccolta
+    description: |
+      Definizione e gestione dei requisiti di raccolta di informazioni di intelligence.
+  BC-1730.10.20:
+    name: Raccolta HUMINT
+    description: |
+      Operazioni di raccolta di intelligence umana (HUMINT).
+  BC-1730.10.30:
+    name: Raccolta SIGINT
+    description: |
+      Operazioni di raccolta di intelligence sui segnali (SIGINT).
+  BC-1730.10.40:
+    name: Raccolta GEOINT e IMINT
+    description: |
+      Raccolta di intelligence geospaziale e di immagini (GEOINT e IMINT).
+  BC-1730.10.50:
+    name: Raccolta OSINT
+    description: |
+      Raccolta e cura dell'intelligence da fonti aperte (OSINT).
+  BC-1730.20:
+    name: Gestione dell'analisi dell'intelligence
+    description: |
+      Analisi da tutte le fonti, fusione delle informazioni e prodotti di intelligence.
+  BC-1730.20.10:
+    name: Analisi da tutte le fonti
+    description: |
+      Analisi e valutazione dell'intelligence da tutte le fonti.
+  BC-1730.20.20:
+    name: Fusione delle informazioni di intelligence
+    description: |
+      Fusione dei dati multi-INT in valutazioni integrate.
+  BC-1730.20.30:
+    name: Redazione dei prodotti di intelligence
+    description: |
+      Redazione dei prodotti e delle valutazioni di intelligence.
+  BC-1730.20.40:
+    name: Garanzia della qualità dell'intelligence
+    description: |
+      Garanzia della qualità dei prodotti di intelligence.
+  BC-1730.30:
+    name: Gestione della diffusione dell'intelligence
+    description: |
+      Reportistica, diffusione e supporto alle decisioni basato sull'intelligence.
+  BC-1730.30.10:
+    name: Reportistica di intelligence
+    description: |
+      Produzione di rapporti e briefing di intelligence.
+  BC-1730.30.20:
+    name: Controllo della diffusione dell'intelligence
+    description: |
+      Controllo della diffusione e applicazione del principio "need to know".
+  BC-1730.30.30:
+    name: Gestione delle relazioni con i clienti dell'intelligence
+    description: |
+      Gestione delle relazioni con gli utenti dell'intelligence e raccolta del feedback.
+  BC-1730.40:
+    name: Gestione del controspionaggio
+    description: |
+      Controspionaggio, minacce interne e rilevamento degli inganni.
+  BC-1730.40.10:
+    name: Operazioni di controspionaggio
+    description: |
+      Operazioni di controspionaggio contro i servizi stranieri.
+  BC-1730.40.20:
+    name: Programma per le minacce interne
+    description: |
+      Rilevamento e gestione delle minacce interne all'organizzazione.
+  BC-1730.40.30:
+    name: Rilevamento di inganni e negazioni
+    description: |
+      Rilevamento di attività di inganno e negazione da parte avversaria.
+  BC-1730.50:
+    name: Gestione delle fonti e dei metodi di intelligence
+    description: |
+      Gestione delle fonti, protezione dei metodi e standard di tradecraft.
+  BC-1730.50.10:
+    name: Gestione delle fonti
+    description: |
+      Gestione e protezione delle fonti di intelligence.
+  BC-1730.50.20:
+    name: Gestione degli standard di tradecraft analitico
+    description: |
+      Mantenimento degli standard di tradecraft analitico (ICD 203).
+  BC-1730.50.30:
+    name: Protezione dei metodi di raccolta
+    description: |
+      Protezione dei metodi di raccolta dell'intelligence.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-internal-audit-management.yaml
+++ b/catalogue/i18n/it/L1-internal-audit-management.yaml
@@ -1,0 +1,79 @@
+# Gestione dell'audit interno (it) — translations for L1-internal-audit-management.yaml
+locale: it
+source: L1-internal-audit-management.yaml
+entries:
+  BC-140:
+    name: Gestione dell'audit interno
+    description: |
+      Assurance indipendente sull'efficacia di governance, rischio e controllo.
+  BC-140.10:
+    name: Gestione della pianificazione dell'audit
+    description: |
+      Pianificazione dell'audit basata sul rischio e gestione dell'universo di audit.
+  BC-140.10.10:
+    name: Gestione dell'universo di audit
+    description: |
+      Definizione e manutenzione dell'universo auditabile e delle valutazioni del rischio.
+  BC-140.10.20:
+    name: Sviluppo del piano annuale basato sul rischio
+    description: |
+      Piano annuale di audit prioritizzato per rischio e allocazione delle risorse.
+  BC-140.10.30:
+    name: Definizione dell'ambito degli incarichi di audit
+    description: |
+      Obiettivi, ambito, criteri e progettazione del programma di audit per ciascun incarico.
+  BC-140.20:
+    name: Gestione dell'esecuzione dell'audit
+    description: |
+      Attività sul campo, raccolta delle prove e reporting dell'audit.
+  BC-140.20.10:
+    name: Attività sul campo dell'audit
+    description: |
+      Walkthrough, test dei controlli e raccolta delle evidenze.
+  BC-140.20.20:
+    name: Gestione della documentazione di audit
+    description: |
+      Documentazione delle evidenze, delle conclusioni e revisione supervisionale.
+  BC-140.20.30:
+    name: Reporting dell'audit
+    description: |
+      Redazione, clearance ed emissione dei rapporti e delle opinioni di audit.
+  BC-140.20.40:
+    name: Audit continuo e basato sui dati
+    description: |
+      Utilizzo di analisi e monitoraggio continuo nell'ambito degli audit.
+  BC-140.30:
+    name: Gestione dei rilievi e dei piani di rimedio
+    description: |
+      Monitoraggio dei rilievi, azioni di management e follow-up.
+  BC-140.30.10:
+    name: Rilevazione e rating dei rilievi
+    description: |
+      Rilevazione standardizzata e rating dei rilievi di audit.
+  BC-140.30.20:
+    name: Monitoraggio delle azioni del management
+    description: |
+      Monitoraggio delle azioni di management concordate fino alla chiusura.
+  BC-140.30.30:
+    name: Validazione delle misure correttive
+    description: |
+      Validazione indipendente dell'efficacia delle misure correttive.
+  BC-140.40:
+    name: Assurance della qualità dell'audit
+    description: |
+      Controllo della qualità sulla metodologia e sull'esecuzione dell'audit.
+  BC-140.40.10:
+    name: Gestione della metodologia di audit
+    description: |
+      Manutenzione della metodologia di audit allineata agli standard IIA.
+  BC-140.40.20:
+    name: Revisioni interne della qualità
+    description: |
+      Revisioni periodiche interne di QA sugli incarichi di audit.
+  BC-140.40.30:
+    name: Valutazione esterna della qualità
+    description: |
+      Valutazioni esterne della qualità e conformità agli standard professionali.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-inventory-management.yaml
+++ b/catalogue/i18n/it/L1-inventory-management.yaml
@@ -1,0 +1,95 @@
+# Gestione dell'inventario (it) — translations for L1-inventory-management.yaml
+locale: it
+source: L1-inventory-management.yaml
+entries:
+  BC-530:
+    name: Gestione dell'inventario
+    description: |
+      Livelli delle scorte, riordino e allocazione nella rete di fornitura.
+  BC-530.10:
+    name: Gestione dei livelli delle scorte
+    description: |
+      Livelli di scorte obiettivo, scorta di sicurezza, punti di riordino.
+  BC-530.10.10:
+    name: Definizione delle scorte obiettivo e di sicurezza
+    description: |
+      Definizione dei livelli di scorta obiettivo e della scorta di sicurezza per SKU e ubicazione.
+  BC-530.10.20:
+    name: Gestione del punto di riordino e del min/max
+    description: |
+      Punti di riordino, politiche di scorta minima e massima.
+  BC-530.10.30:
+    name: Ottimizzazione del livello di servizio
+    description: |
+      Ottimizzazione del compromesso tra livello di servizio e costo dell'inventario.
+  BC-530.10.40:
+    name: Segmentazione dell'inventario e analisi ABC
+    description: |
+      Segmentazione ABC/XYZ per differenziare le politiche di inventario.
+  BC-530.20:
+    name: Gestione del riordino
+    description: |
+      Politiche di riordino, riordino automatizzato.
+  BC-530.20.10:
+    name: Definizione della politica di riordino
+    description: |
+      Definizione delle politiche di riordino (push, pull, kanban).
+  BC-530.20.20:
+    name: Esecuzione del riordino automatizzato
+    description: |
+      Esecuzione di ordini di riordino automatizzati verso i nodi di fornitura.
+  BC-530.20.30:
+    name: Operazioni di inventario gestito dal fornitore
+    description: |
+      Accordi VMI e di scorte in conto deposito con i fornitori.
+  BC-530.30:
+    name: Gestione dell'allocazione dell'inventario
+    description: |
+      Allocazione nella rete, prenotazioni.
+  BC-530.30.10:
+    name: Allocazione cross-network
+    description: |
+      Allocazione delle scorte disponibili tra centri di distribuzione, punti vendita e canali.
+  BC-530.30.20:
+    name: Prenotazioni per clienti e ordini
+    description: |
+      Prenotazione dell'inventario a fronte di ordini o account dei clienti.
+  BC-530.30.30:
+    name: Ribilanciamento dell'inventario
+    description: |
+      Ribilanciamento delle scorte tra ubicazioni per soddisfare la domanda.
+  BC-530.40:
+    name: Gestione dell'accuratezza dell'inventario
+    description: |
+      Inventari ciclici, inventari fisici, risoluzione delle discrepanze.
+  BC-530.40.10:
+    name: Inventario ciclico
+    description: |
+      Programmi di inventario ciclico per frequenza e classificazione ABC.
+  BC-530.40.20:
+    name: Conteggio fisico dell'inventario
+    description: |
+      Programmi di conteggio fisico completo dell'inventario annuali o periodici.
+  BC-530.40.30:
+    name: Indagine e rettifica delle discrepanze
+    description: |
+      Indagine, analisi delle cause e rettifica delle discrepanze di inventario.
+  BC-530.50:
+    name: Gestione delle scorte a lenta movimentazione e obsolete
+    description: |
+      Identificazione degli SLOB, svalutazione, smaltimento.
+  BC-530.50.10:
+    name: Identificazione delle scorte a lenta movimentazione
+    description: |
+      Identificazione e invecchiamento delle scorte a lenta movimentazione e obsolete.
+  BC-530.50.20:
+    name: Accantonamento e svalutazione delle scorte
+    description: |
+      Accantonamento, svalutazione e stralcio delle scorte obsolete.
+  BC-530.50.30:
+    name: Smaltimento dell'inventario
+    description: |
+      Smaltimento delle scorte obsolete tramite liquidazione o rottamazione.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-investor-relations-management.yaml
+++ b/catalogue/i18n/it/L1-investor-relations-management.yaml
@@ -1,0 +1,83 @@
+# Gestione delle investor relations (it) — translations for L1-investor-relations-management.yaml
+locale: it
+source: L1-investor-relations-management.yaml
+entries:
+  BC-240:
+    name: Gestione delle investor relations
+    description: |
+      Comunicazione con gli azionisti, gli analisti e i mercati dei capitali.
+  BC-240.10:
+    name: Comunicazione con i mercati dei capitali
+    description: |
+      Strategia di investor relations, equity story e capital markets day.
+  BC-240.10.10:
+    name: Strategia di investor relations ed equity story
+    description: |
+      Definizione della strategia di investor relations e dell'equity story.
+  BC-240.10.20:
+    name: Gestione del capital markets day
+    description: |
+      Pianificazione ed esecuzione di capital markets day ed eventi per investitori.
+  BC-240.10.30:
+    name: Gestione dell'informativa di investor relations
+    description: |
+      Controlli sull'informativa, fair disclosure e comunicazione degli eventi rilevanti.
+  BC-240.10.40:
+    name: Comunicazione ESG e di sostenibilità
+    description: |
+      Narrativa ESG per i mercati dei capitali e raccordo con le agenzie di rating ESG.
+  BC-240.20:
+    name: Gestione del ciclo dei risultati
+    description: |
+      Comunicati sui risultati trimestrali, call con gli analisti e trascrizioni.
+  BC-240.20.10:
+    name: Predisposizione del comunicato sui risultati
+    description: |
+      Redazione e diffusione dei comunicati stampa sui risultati finanziari.
+  BC-240.20.20:
+    name: Gestione della call con gli analisti
+    description: |
+      Preparazione degli script, delle sessioni Q&A e gestione delle call con gli analisti.
+  BC-240.20.30:
+    name: Gestione del consenso e della guidance
+    description: |
+      Monitoraggio delle stime di consenso e comunicazione della guidance.
+  BC-240.30:
+    name: Gestione del dialogo con gli azionisti
+    description: |
+      AGM, assemblee degli azionisti e outreach verso gli azionisti retail.
+  BC-240.30.10:
+    name: Dialogo con gli investitori istituzionali
+    description: |
+      Roadshow, incontri individuali e dialogo continuativo con gli investitori istituzionali.
+  BC-240.30.20:
+    name: Dialogo con gli azionisti retail
+    description: |
+      Comunicazioni e programmi di outreach verso gli azionisti retail.
+  BC-240.30.30:
+    name: Coordinamento dell'assemblea degli azionisti
+    description: |
+      Contributo delle investor relations alla logistica, ai materiali e alle sessioni Q&A dell'AGM.
+  BC-240.30.40:
+    name: Dialogo su governance e assemblea degli azionisti
+    description: |
+      Raccordo con i proxy advisor e gli investitori focalizzati sulla governance.
+  BC-240.40:
+    name: Gestione delle relazioni con gli analisti
+    description: |
+      Raccordo con gli analisti sell-side e buy-side.
+  BC-240.40.10:
+    name: Gestione della copertura degli analisti sell-side
+    description: |
+      Sviluppo della copertura, revisione dei modelli e raccordo con il sell-side.
+  BC-240.40.20:
+    name: Targeting degli investitori buy-side
+    description: |
+      Identificazione e targeting degli investitori buy-side.
+  BC-240.40.30:
+    name: Studi sulla percezione degli investitori
+    description: |
+      Studi sulla percezione e survey di feedback con la base degli investitori.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-justice-court-administration-management.yaml
+++ b/catalogue/i18n/it/L1-justice-court-administration-management.yaml
@@ -1,0 +1,153 @@
+# Gestione della giustizia e dell'amministrazione dei tribunali (it) — translations for L1-justice-court-administration-management.yaml
+locale: it
+source: L1-justice-court-administration-management.yaml
+entries:
+  BC-3320:
+    name: Gestione della giustizia e dell'amministrazione dei tribunali
+    description: |
+      Gestione dei tribunali, incluse la presentazione degli atti, la gestione del ruolo e la calendarizzazione, le operazioni di udienza e dibattimento, la sentenza e l'esecuzione degli ordini, la gestione penitenziaria e custodiale, la libertà condizionale e il regime di sorveglianza, e l'accesso ai fascicoli giudiziari.
+  BC-3320.10:
+    name: Presentazione e iscrizione dei casi
+    description: |
+      Presentazione di casi civili, penali, di famiglia e amministrativi, inclusi deposito telematico, valutazione delle spese e classificazione iniziale dei casi.
+    in_scope:
+      - Deposito di atti civili e penali
+      - Deposito telematico e ricezione dei documenti
+      - Valutazione delle spese di deposito
+    out_of_scope:
+      - Esame dei ricorsi su gare per appalti pubblici (coperto dalla Gestione degli appalti pubblici e della contrattualistica)
+  BC-3320.10.10:
+    name: Iscrizione del caso
+    description: |
+      Ricezione di denunce, imputazioni e atti introduttivi per l'iscrizione dei casi.
+  BC-3320.10.20:
+    name: Deposito telematico presso il tribunale
+    description: |
+      Deposito telematico di atti giudiziari da parte delle parti e dei loro difensori.
+  BC-3320.10.30:
+    name: Classificazione e numerazione dei casi
+    description: |
+      Classificazione dei casi per tipo, sezione e assegnazione del numero di ruolo.
+  BC-3320.10.40:
+    name: Valutazione dei diritti di cancelleria
+    description: |
+      Valutazione, riscossione e rinuncia dei diritti di cancelleria e di deposito.
+  BC-3320.20:
+    name: Gestione del ruolo e della calendarizzazione
+    description: |
+      Manutenzione del ruolo del tribunale, calendarizzazione e assegnazione dei casi ai giudici, delle udienze e dei dibattimenti.
+  BC-3320.20.10:
+    name: Manutenzione del ruolo
+    description: |
+      Manutenzione del ruolo generale e delle sezioni e della cronologia degli eventi del fascicolo.
+  BC-3320.20.20:
+    name: Calendarizzazione delle udienze e dei dibattimenti
+    description: |
+      Fissazione delle udienze, dei dibattimenti e dei calendari delle istanze tra le aule e i giudici.
+  BC-3320.20.30:
+    name: Assegnazione del giudice
+    description: |
+      Assegnazione dei casi ai giudici e rotazione tra le sezioni.
+  BC-3320.20.40:
+    name: Gestione dei rinvii e dei differimenti
+    description: |
+      Gestione delle istanze di rinvio e differimento e ricalendarizzazione.
+  BC-3320.30:
+    name: Operazioni di udienza e dibattimento
+    description: |
+      Supporto operativo alle udienze e ai dibattimenti, incluse la gestione della giuria, la logistica dell'aula e l'interpretazione.
+  BC-3320.30.10:
+    name: Gestione della giuria
+    description: |
+      Convocazione, qualificazione, selezione e gestione del servizio in giuria.
+  BC-3320.30.20:
+    name: Operazioni dell'aula di udienza
+    description: |
+      Logistica dell'aula di udienza, coordinamento della sicurezza e registrazione audio-video.
+  BC-3320.30.30:
+    name: Servizi di interpretazione giudiziaria
+    description: |
+      Fornitura di servizi di interpretazione e traduzione giudiziaria.
+  BC-3320.30.40:
+    name: Supporto ai testimoni e alle vittime
+    description: |
+      Servizi di supporto ai testimoni e alle vittime e coordinamento delle misure speciali.
+  BC-3320.40:
+    name: Sentenza ed esecuzione degli ordini
+    description: |
+      Registrazione delle sentenze e delle condanne, gestione delle ammende e delle restituzioni ed esecuzione degli ordini del tribunale.
+  BC-3320.40.10:
+    name: Registrazione delle sentenze e delle condanne
+    description: |
+      Registrazione delle sentenze, delle condanne e degli ordini dispositivi.
+  BC-3320.40.20:
+    name: Gestione di ammende e restituzioni
+    description: |
+      Gestione di ammende, ordini di restituzione e risarcimento alle vittime.
+  BC-3320.40.30:
+    name: Esecuzione delle sentenze civili
+    description: |
+      Esecuzione delle sentenze civili tramite atti esecutivi, pignoramenti e sequestri.
+  BC-3320.40.40:
+    name: Emissione di mandati del tribunale
+    description: |
+      Emissione di mandati di arresto, accompagnamento e perquisizione su autorizzazione giudiziaria.
+  BC-3320.50:
+    name: Gestione penitenziaria e custodiale
+    description: |
+      Gestione custodiale dei detenuti in attesa di giudizio e dei condannati in carceri e istituti penitenziari.
+  BC-3320.50.10:
+    name: Ingresso e schedatura del detenuto
+    description: |
+      Ingresso, schedatura e classificazione del rischio dei detenuti all'ingresso in custodia.
+  BC-3320.50.20:
+    name: Operazioni di custodia
+    description: |
+      Operazioni quotidiane di custodia, incluse la gestione della popolazione carceraria e i trasferimenti.
+  BC-3320.50.30:
+    name: Coordinamento dell'assistenza sanitaria ai detenuti
+    description: |
+      Coordinamento dell'assistenza sanitaria, della salute mentale e dei servizi per le dipendenze per i detenuti.
+  BC-3320.50.40:
+    name: Programmi per detenuti e riabilitazione
+    description: |
+      Gestione dei programmi di istruzione, formazione professionale e riabilitazione in custodia.
+  BC-3320.60:
+    name: Gestione della libertà condizionale e della sorveglianza
+    description: |
+      Sorveglianza in comunità degli autori di reato in libertà vigilata, in libertà condizionale e in regime di rilascio condizionato.
+  BC-3320.60.10:
+    name: Indagine pre-sentenza
+    description: |
+      Relazioni di indagine pre-sentenza e valutazioni dei rischi e dei bisogni per il tribunale.
+  BC-3320.60.20:
+    name: Sorveglianza in comunità
+    description: |
+      Sorveglianza quotidiana degli autori di reato nella comunità.
+  BC-3320.60.30:
+    name: Gestione delle udienze di libertà condizionale
+    description: |
+      Gestione delle udienze della commissione per la libertà condizionale e delle decisioni di rilascio condizionato.
+  BC-3320.60.40:
+    name: Gestione delle violazioni e delle revoche
+    description: |
+      Gestione delle violazioni della sorveglianza e dei procedimenti di revoca.
+  BC-3320.70:
+    name: Fascicoli giudiziari e accesso pubblico
+    description: |
+      Manutenzione dei fascicoli giudiziari e accesso pubblico nel rispetto dei limiti di secretazione, oscuramento e restrizioni di legge.
+  BC-3320.70.10:
+    name: Manutenzione dei fascicoli giudiziari
+    description: |
+      Manutenzione dei fascicoli giudiziari e dei documenti di causa ufficiali.
+  BC-3320.70.20:
+    name: Accesso pubblico e servizi equivalenti a PACER
+    description: |
+      Fornitura dell'accesso pubblico ai fascicoli giudiziari tramite servizi equivalenti a PACER.
+  BC-3320.70.30:
+    name: Secretazione e cancellazione dal casellario
+    description: |
+      Elaborazione degli ordini di secretazione, cancellazione dal casellario e soppressione dei dati.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-knowledge-management.yaml
+++ b/catalogue/i18n/it/L1-knowledge-management.yaml
@@ -1,0 +1,75 @@
+# Gestione della conoscenza (it) — translations for L1-knowledge-management.yaml
+locale: it
+source: L1-knowledge-management.yaml
+entries:
+  BC-830:
+    name: Gestione della conoscenza
+    description: |
+      Cattura, cura e condivisione della conoscenza organizzativa.
+  BC-830.10:
+    name: Gestione della cattura della conoscenza
+    description: |
+      Cattura della conoscenza da esperti, progetti e lezioni apprese.
+  BC-830.10.10:
+    name: Elicitazione della conoscenza tacita
+    description: |
+      Elicitazione della conoscenza tacita degli esperti attraverso interviste e affiancamento.
+  BC-830.10.20:
+    name: Cattura delle lezioni apprese
+    description: |
+      Raccolta delle lezioni apprese da progetti e operazioni.
+  BC-830.10.30:
+    name: Redazione di asset di conoscenza
+    description: |
+      Redazione di articoli, playbook e asset procedurali.
+  BC-830.20:
+    name: Gestione della cura della conoscenza e della tassonomia
+    description: |
+      Tassonomie, ontologie e cura dei contenuti.
+  BC-830.20.10:
+    name: Gestione della tassonomia e dell'ontologia
+    description: |
+      Manutenzione di tassonomie, ontologie e schemi di metadati.
+  BC-830.20.20:
+    name: Cura e revisione dei contenuti
+    description: |
+      Cicli di cura e revisione dell'aggiornamento dei contenuti di conoscenza.
+  BC-830.20.30:
+    name: Gestione della ricerca e della scoperta
+    description: |
+      Ricerca enterprise e funzionalità di scoperta dei contenuti.
+  BC-830.30:
+    name: Gestione della condivisione della conoscenza e della collaborazione
+    description: |
+      Comunità di pratica e piattaforme di collaborazione.
+  BC-830.30.10:
+    name: Operatività delle comunità di pratica
+    description: |
+      Presidio e gestione operativa delle comunità di pratica.
+  BC-830.30.20:
+    name: Gestione delle piattaforme di collaborazione
+    description: |
+      Gestione delle piattaforme di collaborazione e intranet per la condivisione della conoscenza.
+  BC-830.30.30:
+    name: Eventi e forum sulla conoscenza
+    description: |
+      Eventi interni, brown bag e forum di apprendimento.
+  BC-830.40:
+    name: Gestione delle best practice
+    description: |
+      Identificazione, codifica e disseminazione delle best practice.
+  BC-830.40.10:
+    name: Identificazione delle best practice
+    description: |
+      Identificazione delle best practice interne ed esterne.
+  BC-830.40.20:
+    name: Codifica delle best practice
+    description: |
+      Codifica delle best practice in asset riutilizzabili e standard.
+  BC-830.40.30:
+    name: Disseminazione delle best practice
+    description: |
+      Disseminazione, formazione e supporto all'adozione delle best practice.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-legal-management.yaml
+++ b/catalogue/i18n/it/L1-legal-management.yaml
@@ -1,0 +1,111 @@
+# Gestione legale (it) — translations for L1-legal-management.yaml
+locale: it
+source: L1-legal-management.yaml
+entries:
+  BC-150:
+    name: Gestione legale
+    description: |
+      Consulenza legale, contratti, contenzioso e affari legali societari.
+  BC-150.10:
+    name: Gestione dei contratti
+    description: |
+      Ciclo di vita dei contratti dalla redazione alla chiusura.
+  BC-150.10.10:
+    name: Redazione dei contratti e gestione dei template
+    description: |
+      Manutenzione di librerie di clausole, template e playbook contrattuali.
+  BC-150.10.20:
+    name: Supporto alla negoziazione dei contratti
+    description: |
+      Supporto legale per la negoziazione, il redlining e la gestione del rischio contrattuale.
+  BC-150.10.30:
+    name: Gestione dell'esecuzione dei contratti
+    description: |
+      Flussi di approvazione, firma e controllo dell'esecuzione dei contratti.
+  BC-150.10.40:
+    name: Archivio contratti e monitoraggio degli obblighi
+    description: |
+      Archivio centralizzato, scadenze chiave e monitoraggio degli obblighi contrattuali.
+  BC-150.10.50:
+    name: Rinnovo e risoluzione dei contratti
+    description: |
+      Amministrazione di rinnovi, modifiche e risoluzioni contrattuali.
+  BC-150.20:
+    name: Gestione del contenzioso e delle controversie
+    description: |
+      Controversie, contenzioso e arbitrato.
+  BC-150.20.10:
+    name: Gestione precontenziosa delle controversie
+    description: |
+      Lettere di messa in mora, mediazione e negoziazione precontenziosa.
+  BC-150.20.20:
+    name: Gestione delle cause in giudizio
+    description: |
+      Gestione end-to-end dei procedimenti giudiziari.
+  BC-150.20.30:
+    name: Arbitrato e risoluzione alternativa delle controversie
+    description: |
+      Arbitrato, mediazione e altri meccanismi di ADR.
+  BC-150.20.40:
+    name: Blocco legale e eDiscovery
+    description: |
+      Avvisi di blocco legale, conservazione dei documenti e discovery elettronica.
+  BC-150.30:
+    name: Diritto societario e commerciale
+    description: |
+      Diritto societario, supporto legale a M&A e transazioni commerciali.
+  BC-150.30.10:
+    name: Consulenza di diritto societario
+    description: |
+      Consulenza su diritto societario, governance e strutturazione delle entità.
+  BC-150.30.20:
+    name: Supporto legale a operazioni di M&A
+    description: |
+      Due diligence legale, documentazione delle transazioni e closing.
+  BC-150.30.30:
+    name: Consulenza su transazioni commerciali
+    description: |
+      Supporto legale a operazioni commerciali, partnership e licensing.
+  BC-150.30.40:
+    name: Consulenza legale su valori mobiliari e mercati dei capitali
+    description: |
+      Diritto dei valori mobiliari, quotazione e operazioni sui mercati dei capitali.
+  BC-150.40:
+    name: Affari legali regolamentari
+    description: |
+      Interpretazione legale dei regolamenti e rapporti con le autorità.
+  BC-150.40.10:
+    name: Interpretazione legale delle normative
+    description: |
+      Pareri legali sull'applicabilità e l'interpretazione delle normative.
+  BC-150.40.20:
+    name: Raccordo con le autorità di regolamentazione e presentazione di istanze
+    description: |
+      Supporto legale nelle interazioni con le autorità e nelle presentazioni formali.
+  BC-150.40.30:
+    name: Supporto legale per gli affari pubblici e governativi
+    description: |
+      Supporto legale ad attività di lobbying, consultazioni pubbliche e advocacy.
+  BC-150.50:
+    name: Gestione delle operazioni legali
+    description: |
+      Operatività del dipartimento legale, fatturazione elettronica e gestione dei fascicoli.
+  BC-150.50.10:
+    name: Gestione dei fascicoli legali
+    description: |
+      Ricezione, assegnazione e monitoraggio del ciclo di vita dei fascicoli.
+  BC-150.50.20:
+    name: Gestione dei legali esterni
+    description: |
+      Gestione del panel, incarichi e performance dei consulenti esterni.
+  BC-150.50.30:
+    name: Spesa legale e fatturazione elettronica
+    description: |
+      Budget legale, fatturazione elettronica e analisi della spesa.
+  BC-150.50.40:
+    name: Gestione delle conoscenze legali
+    description: |
+      Precedenti, know-how e supporto tecnologico per la funzione legale.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-legislative-regulatory-drafting-management.yaml
+++ b/catalogue/i18n/it/L1-legislative-regulatory-drafting-management.yaml
@@ -1,0 +1,121 @@
+# Gestione della redazione legislativa e normativa (it) — translations for L1-legislative-regulatory-drafting-management.yaml
+locale: it
+source: L1-legislative-regulatory-drafting-management.yaml
+entries:
+  BC-3210:
+    name: Gestione della redazione legislativa e normativa
+    description: |
+      Redazione, revisione legale, analisi dell'impatto, coordinamento dell'iter parlamentare e codificazione di leggi primarie, regolamenti secondari, strumenti normativi e decreti esecutivi.
+  BC-3210.10:
+    name: Redazione legislativa
+    description: |
+      Redazione di leggi primarie, disegni di legge e emendamenti da parte di consulenti parlamentari o redattori legislativi.
+    in_scope:
+      - Redazione di disegni di legge e emendamenti
+      - Gestione delle istruzioni di redazione
+      - Redazione in linguaggio chiaro e bilingue
+    out_of_scope:
+      - Regolamenti e strumenti normativi (coperti dalla Redazione normativa)
+  BC-3210.10.10:
+    name: Acquisizione delle istruzioni di redazione
+    description: |
+      Ricezione e chiarimento delle istruzioni di redazione dai promotori politici e ministeriali.
+  BC-3210.10.20:
+    name: Redazione di disegni di legge e emendamenti
+    description: |
+      Redazione di disegni di legge, emendamenti e disposizioni consequenziali.
+  BC-3210.10.30:
+    name: Revisione della qualità della redazione
+    description: |
+      Revisione da parte di consulenti senior degli atti legislativi in bozza per chiarezza, coerenza ed efficacia.
+  BC-3210.20:
+    name: Redazione normativa
+    description: |
+      Redazione di regolamenti secondari, strumenti normativi, decreti esecutivi e norme amministrative.
+  BC-3210.20.10:
+    name: Redazione di regolamenti e strumenti normativi
+    description: |
+      Redazione di regolamenti e strumenti normativi ai sensi della legislazione abilitante.
+  BC-3210.20.20:
+    name: Redazione di decreti esecutivi
+    description: |
+      Redazione di decreti esecutivi, decreti e proclami.
+  BC-3210.20.30:
+    name: Redazione di norme amministrative
+    description: |
+      Redazione di norme e avvisi amministrativi delle agenzie.
+  BC-3210.30:
+    name: Revisione legale e conformità costituzionale
+    description: |
+      Esame legale degli strumenti in bozza per la conformità costituzionale, sui diritti umani e al diritto internazionale.
+  BC-3210.30.10:
+    name: Revisione della conformità costituzionale
+    description: |
+      Revisione delle bozze rispetto ai poteri, ai diritti e ai limiti costituzionali.
+  BC-3210.30.20:
+    name: Valutazione della compatibilità con i diritti umani
+    description: |
+      Valutazione della compatibilità con i trattati e le carte sui diritti umani.
+  BC-3210.30.30:
+    name: Revisione della conformità al diritto internazionale
+    description: |
+      Revisione delle bozze per la conformità agli obblighi derivanti da trattati e norme sovranazionali.
+  BC-3210.40:
+    name: Analisi dell'impatto regolatorio
+    description: |
+      Valutazione dei costi, dei benefici e degli effetti distributivi attesi degli strumenti proposti, in linea con i principi OCSE di better regulation.
+  BC-3210.40.10:
+    name: Definizione dell'ambito dell'impatto
+    description: |
+      Definizione dell'ambito delle analisi dell'impatto regolatorio e determinazione della proporzionalità.
+  BC-3210.40.20:
+    name: Analisi costi-benefici
+    description: |
+      Quantificazione dei costi e dei benefici normativi, incluso l'onere di conformità.
+  BC-3210.40.30:
+    name: Test sulle piccole imprese e PMI
+    description: |
+      Valutazione degli impatti sproporzionati sulle piccole imprese e sulle PMI.
+  BC-3210.40.40:
+    name: Pubblicazione dell'analisi dell'impatto
+    description: |
+      Pubblicazione delle analisi dell'impatto insieme allo strumento e alle prove a supporto.
+  BC-3210.50:
+    name: Coordinamento dell'iter legislativo
+    description: |
+      Coordinamento dell'iter parlamentare o legislativo dei disegni di legge, incluse le prove in commissione, gli emendamenti e la promulgazione o la sanzione.
+  BC-3210.50.10:
+    name: Raccordo parlamentare
+    description: |
+      Raccordo con gli organi parlamentari o legislativi sui disegni di legge governativi.
+  BC-3210.50.20:
+    name: Preparazione delle prove in commissione
+    description: |
+      Preparazione di prove, briefing e testimoni per le commissioni legislative.
+  BC-3210.50.30:
+    name: Monitoraggio degli emendamenti
+    description: |
+      Monitoraggio e valutazione degli emendamenti legislativi nelle diverse fasi.
+  BC-3210.50.40:
+    name: Coordinamento della promulgazione e della sanzione
+    description: |
+      Coordinamento della promulgazione finale, della sanzione reale o della firma esecutiva.
+  BC-3210.60:
+    name: Codificazione e pubblicazione legale
+    description: |
+      Compilazione, consolidamento, pubblicazione sulla Gazzetta Ufficiale e manutenzione dei testi normativi e regolamentari.
+  BC-3210.60.10:
+    name: Pubblicazione nella Gazzetta Ufficiale
+    description: |
+      Pubblicazione degli strumenti adottati nella Gazzetta Ufficiale o nel bollettino ufficiale.
+  BC-3210.60.20:
+    name: Consolidamento e codificazione
+    description: |
+      Consolidamento degli emendamenti e codificazione nei codici normativi.
+  BC-3210.60.30:
+    name: Manutenzione dei testi giuridici
+    description: |
+      Manutenzione continuativa e pubblicazione in formato leggibile da macchina dei testi normativi e regolamentari.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-livestock-production-management.yaml
+++ b/catalogue/i18n/it/L1-livestock-production-management.yaml
@@ -1,0 +1,174 @@
+# Gestione della produzione zootecnica (it) — translations for L1-livestock-production-management.yaml
+locale: it
+source: L1-livestock-production-management.yaml
+entries:
+  BC-3510:
+    name: Gestione della produzione zootecnica
+    description: |
+      Produzione in azienda di animali terrestri — pianificazione di mandria e gregge,
+      selezione genetica, nutrizione animale, salute e benessere animale, parto,
+      registrazione dell'accrescimento e preparazione alla macellazione per bovini, ovini, suini e avicoli.
+  BC-3510.10:
+    name: Pianificazione della mandria e del gregge
+    description: |
+      Pianificazione del carico animale, dei rimpiazzi e del ciclo produttivo nelle varie imprese zootecniche.
+  BC-3510.10.10:
+    name: Pianificazione del carico animale
+    description: |
+      Decisioni sul carico animale commisurate alla disponibilità foraggera e alla capacità portante del territorio.
+  BC-3510.10.20:
+    name: Pianificazione degli animali di rimpiazzo
+    description: |
+      Pianificazione del tasso di rimpiazzo per il bestiame da riproduzione e i gruppi di galline ovaiole.
+  BC-3510.10.30:
+    name: Pianificazione del ciclo produttivo
+    description: |
+      Pianificazione calendariale dei cicli produttivi, inclusi il parto a lotti dei suini e il parto stagionale dei bovini.
+  BC-3510.20:
+    name: Gestione della selezione genetica degli animali
+    description: |
+      Selezione genetica, accoppiamento, inseminazione, registrazione del pedigree e monitoraggio delle performance riproduttive.
+    in_scope:
+      - Decisioni di selezione genetica e per carattere
+      - Monta naturale e inseminazione artificiale
+      - Registrazione del pedigree e della parentela
+      - Valutazione dei valori genetici
+  BC-3510.20.10:
+    name: Decisioni di selezione genetica
+    description: |
+      Selezione degli animali riproduttori in base ai valori genetici stimati e agli obiettivi di carattere.
+  BC-3510.20.20:
+    name: Operazioni di monta e inseminazione
+    description: |
+      Operazioni di monta naturale, inseminazione artificiale e trasferimento embrionale.
+  BC-3510.20.30:
+    name: Registrazione del pedigree e della parentela
+    description: |
+      Registrazione del pedigree, della parentela e delle iscrizioni al libro genealogico.
+  BC-3510.20.40:
+    name: Valutazione delle performance riproduttive
+    description: |
+      Valutazione delle performance riproduttive e aggiornamento dei valori genetici.
+  BC-3510.30:
+    name: Gestione della nutrizione animale
+    description: |
+      Formulazione delle razioni, distribuzione del mangime, gestione del pascolo e monitoraggio dell'indice di conversione alimentare per categorie zootecniche.
+  BC-3510.30.10:
+    name: Formulazione delle razioni
+    description: |
+      Formulazione delle razioni a minimo costo in base alle esigenze della specie e dello stadio produttivo.
+  BC-3510.30.20:
+    name: Distribuzione e consegna del mangime
+    description: |
+      Distribuzione giornaliera, miscelazione e consegna del mangime in box, capannoni e paddock.
+  BC-3510.30.30:
+    name: Gestione del pascolamento
+    description: |
+      Gestione del pascolamento rotazionale e continuo e monitoraggio del residuo pascolativo.
+  BC-3510.30.40:
+    name: Monitoraggio dell'indice di conversione alimentare
+    description: |
+      Monitoraggio dell'indice di conversione alimentare e degli incrementi giornalieri medi.
+  BC-3510.40:
+    name: Gestione della salute animale
+    description: |
+      Trattamenti veterinari, vaccinazioni, controllo dei parassiti, sorveglianza delle malattie e gestione dei tempi di sospensione.
+    in_scope:
+      - Registrazioni dei trattamenti veterinari
+      - Programmi di vaccinazione e controllo dei parassiti
+      - Sorveglianza delle malattie soggette a denuncia obbligatoria
+      - Monitoraggio dei tempi di sospensione dei medicinali
+    out_of_scope:
+      - Audit sul benessere animale (BC-3510.50)
+      - Monitoraggio dei residui LMR (BC-3590.50)
+  BC-3510.40.10:
+    name: Registrazioni dei trattamenti veterinari
+    description: |
+      Registrazione dei trattamenti veterinari, delle prescrizioni e degli esiti.
+  BC-3510.40.20:
+    name: Esecuzione dei programmi vaccinali
+    description: |
+      Esecuzione dei programmi di vaccinazione della mandria e del gregge.
+  BC-3510.40.30:
+    name: Programmi di controllo dei parassiti
+    description: |
+      Programmi di controllo dei parassiti interni ed esterni e gestione della resistenza.
+  BC-3510.40.40:
+    name: Sorveglianza e notifica delle malattie
+    description: |
+      Sorveglianza e notifica obbligatoria delle malattie soggette a denuncia e delle zoonosi.
+  BC-3510.40.50:
+    name: Gestione dei tempi di sospensione
+    description: |
+      Monitoraggio dei tempi di sospensione dei medicinali veterinari e degli additivi per mangimi.
+  BC-3510.50:
+    name: Gestione del benessere animale
+    description: |
+      Pratiche quotidiane di benessere animale riguardanti ricovero, gestione e monitoraggio del benessere in conformità agli standard di certificazione.
+  BC-3510.50.10:
+    name: Condizioni di stabulazione e densità di allevamento
+    description: |
+      Gestione del ricovero, della ventilazione e della densità di stabulazione per categorie zootecniche.
+  BC-3510.50.20:
+    name: Standard di movimentazione degli animali
+    description: |
+      Standard di movimentazione a basso stress e pratiche di stockmanship.
+  BC-3510.50.30:
+    name: Monitoraggio degli esiti di benessere
+    description: |
+      Misurazione degli esiti di benessere e revisioni del benessere in azienda.
+  BC-3510.60:
+    name: Operazioni di riproduzione e parto
+    description: |
+      Rilevamento del calore, parto e cure neonatali per bovini, ovini, suini e avicoli.
+  BC-3510.60.10:
+    name: Operazioni di rilevamento del calore
+    description: |
+      Rilevamento del calore tramite osservazione, sensori e programmi di sincronizzazione.
+  BC-3510.60.20:
+    name: Operazioni di parto
+    description: |
+      Operazioni di vitellazione, agnellatura, figliatura e schiusa e relativa assistenza.
+  BC-3510.60.30:
+    name: Operazioni di cura neonatale
+    description: |
+      Nutrizione neonatale, gestione del colostro e cure nella prima fase di vita.
+  BC-3510.70:
+    name: Registrazione dell'accrescimento e delle performance produttive
+    description: |
+      Registrazione delle performance di accrescimento, latte, uova e carcassa per le decisioni produttive e riproduttive.
+  BC-3510.70.10:
+    name: Registrazione dell'accrescimento ponderale
+    description: |
+      Pesature periodiche e registrazione degli incrementi giornalieri medi.
+  BC-3510.70.20:
+    name: Registrazione della produzione di latte
+    description: |
+      Registrazione della produzione e della composizione del latte per singola bovina e per vasca di raccolta.
+  BC-3510.70.30:
+    name: Registrazione della produzione di uova
+    description: |
+      Registrazione giornaliera della produzione di uova per capannone e per gruppo.
+  BC-3510.70.40:
+    name: Monitoraggio delle performance della carcassa
+    description: |
+      Monitoraggio della resa della carcassa, della classificazione e delle performance dei tagli principali.
+  BC-3510.80:
+    name: Idoneità alla macellazione e spedizione
+    description: |
+      Selezione degli animali pronti alla vendita e coordinamento della spedizione ai macelli, inclusa la documentazione di movimentazione.
+  BC-3510.80.10:
+    name: Selezione pre-macellazione
+    description: |
+      Selezione degli animali finiti in base a peso, stato di ingrassamento e specifiche contrattuali.
+  BC-3510.80.20:
+    name: Documentazione di movimentazione degli animali
+    description: |
+      Documentazione di movimentazione e trasferimento delle informazioni sulla filiera alimentare.
+  BC-3510.80.30:
+    name: Coordinamento della spedizione al macello
+    description: |
+      Coordinamento della spedizione e del trasporto dall'azienda agricola al macello.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-manufacturing-engineering-management.yaml
+++ b/catalogue/i18n/it/L1-manufacturing-engineering-management.yaml
@@ -1,0 +1,119 @@
+# Gestione dell'ingegneria di produzione (it) — translations for L1-manufacturing-engineering-management.yaml
+locale: it
+source: L1-manufacturing-engineering-management.yaml
+entries:
+  BC-1020:
+    name: Gestione dell'ingegneria di produzione
+    description: |
+      Ingegneria di processo, attrezzatura, progettazione delle macchine e industrializzazione.
+  BC-1020.10:
+    name: Gestione dell'ingegneria dei processi produttivi
+    description: |
+      Progettazione dei processi produttivi, cicli di lavorazione e istruzioni di lavoro.
+  BC-1020.10.10:
+    name: Progettazione del processo e del ciclo di lavorazione
+    description: |
+      Definizione dei cicli di lavorazione manifatturieri e delle fasi di processo.
+  BC-1020.10.20:
+    name: Redazione delle istruzioni di lavoro
+    description: |
+      Redazione del lavoro standard e delle istruzioni di lavoro visive.
+  BC-1020.10.30:
+    name: Validazione del processo
+    description: |
+      Validazione dei processi produttivi e studi di capability.
+  BC-1020.10.40:
+    name: Controllo delle modifiche di processo
+    description: |
+      Controllo delle modifiche ai processi manifatturieri e ai cicli di lavorazione.
+  BC-1020.20:
+    name: Gestione delle attrezzature e delle dime
+    description: |
+      Ciclo di vita di utensili, attrezzature e dime.
+  BC-1020.20.10:
+    name: Progettazione delle attrezzature
+    description: |
+      Progettazione di utensili, attrezzature e dime per la produzione.
+  BC-1020.20.20:
+    name: Approvvigionamento e costruzione delle attrezzature
+    description: |
+      Approvvigionamento, costruzione e validazione delle attrezzature.
+  BC-1020.20.30:
+    name: Manutenzione e ispezione degli utensili
+    description: |
+      Manutenzione, ispezione e ripristino degli utensili di produzione.
+  BC-1020.20.40:
+    name: Gestione dell'inventario degli utensili
+    description: |
+      Gestione del tool crib e tracciabilità degli utensili.
+  BC-1020.30:
+    name: Gestione dell'ingegneria delle macchine
+    description: |
+      Specifiche, qualifica e modifica delle macchine.
+  BC-1020.30.10:
+    name: Specifica delle macchine
+    description: |
+      Specifica utente e funzionale delle macchine di produzione.
+  BC-1020.30.20:
+    name: Qualifica delle macchine
+    description: |
+      Qualifica IQ, OQ, PQ delle macchine di produzione.
+  BC-1020.30.30:
+    name: Gestione delle modifiche alle macchine
+    description: |
+      Modifiche tecniche e aggiornamenti alle macchine installate.
+  BC-1020.40:
+    name: Gestione dell'industrializzazione
+    description: |
+      Trasferimento dalla ricerca e sviluppo alla produzione e ramp-up.
+  BC-1020.40.10:
+    name: Gestione del trasferimento in produzione
+    description: |
+      Trasferimento dei prodotti dalla ricerca e sviluppo o dal pilot alla produzione.
+  BC-1020.40.20:
+    name: Pre-serie e produzione pilota
+    description: |
+      Produzione pre-serie e di lotti pilota con curva di apprendimento.
+  BC-1020.40.30:
+    name: Gestione del ramp-up produttivo
+    description: |
+      Ramp-up produttivo verso i volumi e le rese nominali.
+  BC-1020.50:
+    name: Gestione dei metodi produttivi
+    description: |
+      Metodi, studi dei tempi ed ergonomia.
+  BC-1020.50.10:
+    name: Studi di tempi e metodi
+    description: |
+      Studi dei tempi, MTM e definizione dei tempi standard.
+  BC-1020.50.20:
+    name: Ergonomia del posto di lavoro
+    description: |
+      Progettazione ergonomica delle postazioni di lavoro e delle attività.
+  BC-1020.50.30:
+    name: Definizione del lavoro standard
+    description: |
+      Definizione del lavoro standard e delle sequenze operative ottimali.
+  BC-1020.60:
+    name: Gestione del miglioramento continuo manifatturiero
+    description: |
+      Kaizen sui processi produttivi e trasformazioni lean.
+  BC-1020.60.10:
+    name: Realizzazione di eventi kaizen
+    description: |
+      Realizzazione di eventi kaizen sui processi produttivi.
+  BC-1020.60.20:
+    name: Gestione della trasformazione lean
+    description: |
+      Programmi di trasformazione lean end-to-end negli stabilimenti.
+  BC-1020.60.30:
+    name: Mappatura del flusso del valore
+    description: |
+      Mappatura del flusso del valore nello stato attuale e in quello futuro.
+  BC-1020.60.40:
+    name: Sviluppo delle competenze di miglioramento continuo
+    description: |
+      Sviluppo delle competenze e coaching nei metodi di miglioramento continuo.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-manufacturing-operations-management.yaml
+++ b/catalogue/i18n/it/L1-manufacturing-operations-management.yaml
@@ -1,0 +1,139 @@
+# Gestione delle operazioni manifatturiere (it) — translations for L1-manufacturing-operations-management.yaml
+locale: it
+source: L1-manufacturing-operations-management.yaml
+entries:
+  BC-1010:
+    name: Gestione delle operazioni manifatturiere
+    description: |
+      Esecuzione sul reparto produttivo, gestione degli ordini di lavoro e operazioni a livello MES.
+  BC-1010.10:
+    name: Gestione degli ordini di lavoro
+    description: |
+      Creazione, rilascio, monitoraggio e chiusura degli ordini di lavoro.
+  BC-1010.10.10:
+    name: Creazione degli ordini di lavoro
+    description: |
+      Creazione degli ordini di lavoro dagli ordini di produzione e dalla distinta base/ciclo.
+  BC-1010.10.20:
+    name: Rilascio degli ordini di lavoro
+    description: |
+      Rilascio degli ordini di lavoro al reparto produttivo con verifica della disponibilità dei materiali.
+  BC-1010.10.30:
+    name: Conferma degli ordini di lavoro
+    description: |
+      Conferma delle attività, delle quantità e dei tempi rispetto agli ordini di lavoro.
+  BC-1010.10.40:
+    name: Chiusura degli ordini di lavoro
+    description: |
+      Chiusura definitiva e liquidazione degli ordini di lavoro.
+  BC-1010.20:
+    name: Gestione dell'esecuzione sul reparto produttivo
+    description: |
+      Controllo del reparto produttivo ed esecuzione MES.
+  BC-1010.20.10:
+    name: Gestione della definizione di produzione
+    description: |
+      Definizione di produzione ISA-95 per prodotti e processi.
+  BC-1010.20.20:
+    name: Gestione delle risorse di produzione
+    description: |
+      Gestione della disponibilità e della capacità delle risorse di produzione.
+  BC-1010.20.30:
+    name: Coordinamento dell'esecuzione della produzione
+    description: |
+      Coordinamento in tempo reale dell'esecuzione tra i centri di lavoro.
+  BC-1010.20.40:
+    name: Tracciabilità e genealogia della produzione
+    description: |
+      Genealogia di lotto, batch e seriale e record as-built.
+  BC-1010.30:
+    name: Gestione delle operazioni macchina
+    description: |
+      Setup, avviamento, changeover e monitoraggio delle macchine.
+  BC-1010.30.10:
+    name: Setup e changeover delle macchine
+    description: |
+      Setup della macchina, changeover basato su SMED e qualifica.
+  BC-1010.30.20:
+    name: Conduzione delle macchine
+    description: |
+      Conduzione della macchina, controllo dei parametri e supervisione del processo.
+  BC-1010.30.30:
+    name: Monitoraggio delle macchine
+    description: |
+      Monitoraggio in tempo reale delle macchine e rilevamento dello stato.
+  BC-1010.40:
+    name: Gestione della guida all'operatore
+    description: |
+      Istruzioni di lavoro, andon digitale e supporto all'operatore.
+  BC-1010.40.10:
+    name: Erogazione delle istruzioni di lavoro digitali
+    description: |
+      Erogazione di istruzioni di lavoro digitali alla postazione di lavoro.
+  BC-1010.40.20:
+    name: Gestione dell'andon e delle escalation
+    description: |
+      Segnali andon, escalation e supporto all'operatore.
+  BC-1010.40.30:
+    name: Competenze e autorizzazione dell'operatore
+    description: |
+      Certificazione e autorizzazione dell'operatore per le attività.
+  BC-1010.50:
+    name: Gestione della movimentazione interna dei materiali
+    description: |
+      Movimentazione interna dei materiali, kitting e alimentazione delle linee.
+  BC-1010.50.10:
+    name: Rifornimento a bordo linea
+    description: |
+      Rifornimento just-in-time a bordo linea e milk run.
+  BC-1010.50.20:
+    name: Kitting dei materiali
+    description: |
+      Kitting e pre-assemblaggio dei componenti per le linee di produzione.
+  BC-1010.50.30:
+    name: Movimentazione interna dei materiali
+    description: |
+      Logistica interna e trasporto tra le operations.
+  BC-1010.60:
+    name: Gestione dell'acquisizione dei dati manifatturieri
+    description: |
+      Dati dei sensori, dati macchina e integrazione OT-IT.
+  BC-1010.60.10:
+    name: Raccolta dei dati macchina
+    description: |
+      Raccolta dei segnali macchina e dei dati di processo.
+  BC-1010.60.20:
+    name: Integrazione di sensori e IoT
+    description: |
+      Integrazione di sensori e dispositivi IIoT nel reparto produttivo.
+  BC-1010.60.30:
+    name: Integrazione dei dati OT-IT
+    description: |
+      Integrazione dei dati OT con i sistemi IT allineata a ISA-95.
+  BC-1010.60.40:
+    name: Operatività del data historian manifatturiero
+    description: |
+      Raccolta e accesso a dati time-series tramite historian.
+  BC-1010.70:
+    name: Gestione delle performance manifatturiere
+    description: |
+      Performance in tempo reale, fermi macchina e analisi delle micro-fermate.
+  BC-1010.70.10:
+    name: Monitoraggio delle performance in tempo reale
+    description: |
+      Monitoraggio in tempo reale di OEE e KPI del reparto produttivo.
+  BC-1010.70.20:
+    name: Analisi delle micro-fermate
+    description: |
+      Analisi delle micro-fermate e delle perdite ricorrenti.
+  BC-1010.70.30:
+    name: Reporting del cambio turno
+    description: |
+      Report strutturati di cambio turno e bacheche digitali.
+  BC-1010.70.40:
+    name: Rilevamento delle anomalie di produzione
+    description: |
+      Rilevamento delle anomalie e alerting sui dati di produzione.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-market-access-reimbursement-management.yaml
+++ b/catalogue/i18n/it/L1-market-access-reimbursement-management.yaml
@@ -1,0 +1,95 @@
+# Gestione dell'accesso al mercato e del rimborso (it) — translations for L1-market-access-reimbursement-management.yaml
+locale: it
+source: L1-market-access-reimbursement-management.yaml
+entries:
+  BC-1600:
+    name: Gestione dell'accesso al mercato e del rimborso
+    description: |
+      Strategia verso i payer, HEOR, presentazioni per il pricing/rimborso, gare e prezzi governativi.
+  BC-1600.10:
+    name: Gestione della strategia verso i payer
+    description: |
+      Engagement con i payer, panorama dei payer, proposta di valore.
+  BC-1600.10.10:
+    name: Analisi del panorama dei payer
+    description: |
+      Analisi del panorama dei payer e degli organismi decisionali.
+  BC-1600.10.20:
+    name: Sviluppo della proposta di valore verso i payer
+    description: |
+      Sviluppo di proposte di valore orientate ai payer.
+  BC-1600.10.30:
+    name: Operazioni di engagement con i payer
+    description: |
+      Engagement operativo con i payer e gli account manager.
+  BC-1600.20:
+    name: Gestione della ricerca sull'economia sanitaria e gli outcome
+    description: |
+      Studi HEOR, costo-efficacia, RWE per i payer.
+  BC-1600.20.10:
+    name: Modellizzazione costo-efficacia
+    description: |
+      Modellizzazione costo-efficacia e impatto sul budget.
+  BC-1600.20.20:
+    name: Conduzione degli studi HEOR
+    description: |
+      Conduzione di studi HEOR e analisi economiche.
+  BC-1600.20.30:
+    name: RWE per l'accesso al mercato
+    description: |
+      Generazione di RWE (real-world evidence) a supporto dei requisiti di evidenza dei payer.
+  BC-1600.20.40:
+    name: Confronto indiretto dei trattamenti
+    description: |
+      Confronto indiretto dei trattamenti e metanalisi a rete.
+  BC-1600.30:
+    name: Gestione delle presentazioni per il pricing e il rimborso
+    description: |
+      Dossier di pricing, presentazioni HTA, pratiche di rimborso.
+  BC-1600.30.10:
+    name: Redazione del dossier HTA
+    description: |
+      Redazione dei dossier HTA (NICE, IQWiG, HAS, CADTH).
+  BC-1600.30.20:
+    name: Pratiche di rimborso
+    description: |
+      Pratiche di rimborso e domande di pricing farmaceutico.
+  BC-1600.30.30:
+    name: Negoziazione e ricorso HTA
+    description: |
+      Negoziazione, risposta e ricorso in sede di HTA.
+  BC-1600.40:
+    name: Gestione delle gare e del pricing governativo
+    description: |
+      Gare governative, pricing di gara, appalti pubblici.
+  BC-1600.40.10:
+    name: Gestione delle offerte di gara
+    description: |
+      Preparazione e presentazione di offerte per gare pubbliche.
+  BC-1600.40.20:
+    name: Operazioni di pricing governativo
+    description: |
+      Operazioni di pricing governativo e presentazioni dei prezzi di legge.
+  BC-1600.40.30:
+    name: Amministrazione di rebate e sconti
+    description: |
+      Amministrazione di rebate e sconti di legge.
+  BC-1600.50:
+    name: Gestione dei programmi di accesso per i pazienti
+    description: |
+      Programmi di assistenza ai pazienti, supporto al co-pagamento.
+  BC-1600.50.10:
+    name: Operatività dei programmi di assistenza ai pazienti
+    description: |
+      Gestione dei programmi di assistenza e accesso per i pazienti.
+  BC-1600.50.20:
+    name: Gestione del co-pagamento e dei coupon
+    description: |
+      Gestione dei programmi di co-pagamento e coupon.
+  BC-1600.50.30:
+    name: Operatività dei programmi di accesso controllato
+    description: |
+      Operazioni di uso compassionevole e programmi di accesso controllato.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-marketing-management.yaml
+++ b/catalogue/i18n/it/L1-marketing-management.yaml
@@ -1,0 +1,155 @@
+# Gestione del marketing (it) — translations for L1-marketing-management.yaml
+locale: it
+source: L1-marketing-management.yaml
+entries:
+  BC-400:
+    name: Gestione del marketing
+    description: |
+      Brand, intelligence di mercato, generazione della domanda, operazioni di marketing.
+  BC-400.10:
+    name: Gestione della strategia di marketing
+    description: |
+      Strategia di marketing, posizionamento, pianificazione go-to-market.
+  BC-400.10.10:
+    name: Segmentazione e targeting di mercato
+    description: |
+      Definizione dei mercati target, dei segmenti e delle personas.
+  BC-400.10.20:
+    name: Posizionamento e proposta di valore
+    description: |
+      Articolazione del posizionamento, dei messaggi e delle proposte di valore.
+  BC-400.10.30:
+    name: Pianificazione go-to-market
+    description: |
+      Modelli go-to-market, piani di lancio e strategia di canale.
+  BC-400.10.40:
+    name: Pianificazione del marketing mix
+    description: |
+      Marketing mix, allocazione dei canali e piani di marketing integrati.
+  BC-400.20:
+    name: Gestione del brand
+    description: |
+      Strategia di brand, identità, brand equity, governance.
+  BC-400.20.10:
+    name: Strategia e architettura del brand
+    description: |
+      Portafoglio di brand, architettura e strategia del brand.
+  BC-400.20.20:
+    name: Identità e standard del brand
+    description: |
+      Identità visiva, tono della voce e standard del brand.
+  BC-400.20.30:
+    name: Misurazione della brand equity
+    description: |
+      Monitoraggio della notorietà del brand, della considerazione e della brand equity.
+  BC-400.20.40:
+    name: Conformità e tutela del brand
+    description: |
+      Tutela dell'utilizzo del brand attraverso canali e partner.
+  BC-400.30:
+    name: Gestione dell'intelligence di mercato
+    description: |
+      Ricerche di mercato, intelligence competitiva, insight dei clienti.
+  BC-400.30.10:
+    name: Ricerca di mercato
+    description: |
+      Ricerche di mercato primarie e secondarie e analisi dei trend.
+  BC-400.30.20:
+    name: Intelligence competitiva
+    description: |
+      Monitoraggio della concorrenza, schede di battaglia e analisi competitiva.
+  BC-400.30.30:
+    name: Generazione di insight sui clienti
+    description: |
+      Sintesi degli insight sui clienti dai dati e dalla ricerca qualitativa.
+  BC-400.30.40:
+    name: Dimensionamento e previsione del mercato
+    description: |
+      Dimensionamento del mercato, quota di mercato e previsione della domanda.
+  BC-400.40:
+    name: Gestione della generazione della domanda
+    description: |
+      Campagne di lead generation, marketing del ciclo di vita.
+  BC-400.40.10:
+    name: Pianificazione delle campagne
+    description: |
+      Pianificazione delle campagne, selezione del pubblico e sviluppo dell'offerta.
+  BC-400.40.20:
+    name: Generazione di lead
+    description: |
+      Lead generation inbound, outbound e guidata dagli eventi.
+  BC-400.40.30:
+    name: Nurturing e scoring dei lead
+    description: |
+      Scoring dei lead, percorsi di nurturing e passaggio degli MQL alle vendite.
+  BC-400.40.40:
+    name: Marketing del ciclo di vita e fidelizzazione
+    description: |
+      Marketing del ciclo di vita, cross-sell e campagne di fidelizzazione dei clienti.
+  BC-400.50:
+    name: Gestione delle operazioni di marketing
+    description: |
+      Budget di marketing, tecnologia, processi, misurazione.
+  BC-400.50.10:
+    name: Gestione del budget di marketing
+    description: |
+      Budgeting di marketing, allocazione e monitoraggio della spesa.
+  BC-400.50.20:
+    name: Gestione del technology stack di marketing
+    description: |
+      Selezione e integrazione di strumenti di marketing automation e analytics.
+  BC-400.50.30:
+    name: Misurazione della performance di marketing
+    description: |
+      Attribuzione del marketing, ROI e dashboard di performance.
+  BC-400.50.40:
+    name: Gestione della conformità di marketing
+    description: |
+      Conformità del marketing in materia di consenso, privacy e regole pubblicitarie.
+  BC-400.60:
+    name: Gestione del marketing digitale
+    description: |
+      Web, SEO, paid media, social, marketing automation.
+  BC-400.60.10:
+    name: Gestione dell'esperienza web
+    description: |
+      Proprietà web aziendali, gestione dei contenuti e personalizzazione.
+  BC-400.60.20:
+    name: Ottimizzazione per i motori di ricerca
+    description: |
+      Ottimizzazione della ricerca organica e reperibilità dei contenuti.
+  BC-400.60.30:
+    name: Gestione dei paid media
+    description: |
+      Acquisto di paid media su search, display, video e programmatic.
+  BC-400.60.40:
+    name: Gestione dei social media
+    description: |
+      Presenza social organica, community management e coinvolgimento degli influencer.
+  BC-400.60.50:
+    name: Operazioni di marketing automation
+    description: |
+      Email, orchestrazione dei percorsi e operazioni di marketing automation.
+  BC-400.70:
+    name: Gestione del content marketing
+    description: |
+      Pianificazione editoriale, produzione di contenuti, distribuzione dei contenuti.
+  BC-400.70.10:
+    name: Pianificazione editoriale
+    description: |
+      Calendario editoriale, temi e strategia dei contenuti.
+  BC-400.70.20:
+    name: Produzione di contenuti
+    description: |
+      Produzione di articoli, video, podcast e asset multimediali.
+  BC-400.70.30:
+    name: Gestione degli asset digitali
+    description: |
+      Archiviazione, tagging e riutilizzo degli asset di marketing digitale.
+  BC-400.70.40:
+    name: Distribuzione e sindacazione dei contenuti
+    description: |
+      Distribuzione dei contenuti attraverso canali di proprietà, guadagnati e a pagamento.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-materials-management.yaml
+++ b/catalogue/i18n/it/L1-materials-management.yaml
@@ -1,0 +1,95 @@
+# Gestione dei materiali (it) — translations for L1-materials-management.yaml
+locale: it
+source: L1-materials-management.yaml
+entries:
+  BC-1070:
+    name: Gestione dei materiali
+    description: |
+      Gestione delle materie prime, del work-in-process e delle distinte base a livello di stabilimento.
+  BC-1070.10:
+    name: Gestione della distinta base
+    description: |
+      Struttura della distinta base, distinte di ingegneria e di produzione.
+  BC-1070.10.10:
+    name: Gestione della distinta base di ingegneria
+    description: |
+      Distinte base di ingegneria allineate con la progettazione del prodotto e le revisioni.
+  BC-1070.10.20:
+    name: Gestione della distinta base di produzione
+    description: |
+      Distinte base di produzione che riflettono le sequenze di assemblaggio specifiche dello stabilimento.
+  BC-1070.10.30:
+    name: Gestione delle modifiche e dell'efficacia della distinta base
+    description: |
+      Controllo delle modifiche, revisioni e datazione dell'efficacia della distinta base.
+  BC-1070.10.40:
+    name: Gestione delle varianti della distinta base
+    description: |
+      Distinte base configurabili e varianti per le opzioni di prodotto.
+  BC-1070.20:
+    name: Gestione delle materie prime
+    description: |
+      Scorte, qualità e tracciabilità delle materie prime.
+  BC-1070.20.10:
+    name: Controllo delle scorte di materie prime
+    description: |
+      Monitoraggio delle scorte di materie prime nelle ubicazioni di stabilimento e magazzino.
+  BC-1070.20.20:
+    name: Ispezione qualità delle materie prime
+    description: |
+      Ispezione in ingresso, campionatura e rilascio delle materie prime.
+  BC-1070.20.30:
+    name: Tracciabilità delle materie prime
+    description: |
+      Tracciabilità per lotto, numero di serie e numero di serie delle materie prime.
+  BC-1070.30:
+    name: Gestione del work-in-process
+    description: |
+      Monitoraggio, valorizzazione e controllo del WIP.
+  BC-1070.30.10:
+    name: Monitoraggio del WIP
+    description: |
+      Monitoraggio del work-in-process attraverso le operazioni di produzione.
+  BC-1070.30.20:
+    name: Valorizzazione del WIP
+    description: |
+      Accumulo dei costi e valorizzazione delle posizioni WIP.
+  BC-1070.30.30:
+    name: Controllo e invecchiamento del WIP
+    description: |
+      Invecchiamento e controllo del WIP bloccato o in stallo.
+  BC-1070.40:
+    name: Gestione dei prodotti finiti
+    description: |
+      Scorte di prodotti finiti a livello di stabilimento.
+  BC-1070.40.10:
+    name: Ricevimento dei prodotti finiti
+    description: |
+      Ricevimento dei prodotti finiti dalla produzione all'inventario dello stabilimento.
+  BC-1070.40.20:
+    name: Stoccaggio dei prodotti finiti
+    description: |
+      Stoccaggio e movimentazione dei prodotti finiti nei magazzini dello stabilimento.
+  BC-1070.40.30:
+    name: Spedizione dei prodotti finiti
+    description: |
+      Spedizione e consegna dei prodotti finiti ai nodi a valle.
+  BC-1070.50:
+    name: Gestione della pianificazione dei materiali
+    description: |
+      MRP, fabbisogni di materiali e pianificazione degli approvvigionamenti a livello di stabilimento.
+  BC-1070.50.10:
+    name: Pianificazione dei fabbisogni di materiali
+    description: |
+      Elaborazioni MRP per derivare il fabbisogno netto di materiali dalla domanda e dalla distinta base.
+  BC-1070.50.20:
+    name: Analisi della copertura dei materiali
+    description: |
+      Analisi della copertura, messaggi di eccezione e proposte d'ordine.
+  BC-1070.50.30:
+    name: Esecuzione del piano di approvvigionamento a livello di stabilimento
+    description: |
+      Conversione dei piani di materiali in ordini di acquisto e ordini di produzione.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-media-asset-management.yaml
+++ b/catalogue/i18n/it/L1-media-asset-management.yaml
@@ -1,0 +1,138 @@
+# Gestione degli asset multimediali (it) — translations for L1-media-asset-management.yaml
+locale: it
+source: L1-media-asset-management.yaml
+entries:
+  BC-3710:
+    name: Gestione degli asset multimediali
+    description: |
+      Acquisizione, catalogazione, archiviazione, trasformazione, conservazione
+      e gestione degli identificatori degli asset multimediali lungo l'intero
+      ciclo di vita dei contenuti, dalla produzione alla distribuzione.
+  BC-3710.10:
+    name: Acquisizione degli asset e controllo qualità
+    description: |
+      Onboarding del materiale sorgente nella piattaforma di asset management
+      con controllo qualità tecnico ed editoriale prima di qualsiasi utilizzo.
+  BC-3710.10.10:
+    name: Acquisizione degli asset sorgente
+    description: |
+      Acquisizione di file sorgente e cattura da nastro o da feed
+      nella piattaforma di asset management.
+  BC-3710.10.20:
+    name: Ispezione di controllo qualità
+    description: |
+      Ispezione di controllo qualità automatizzata e operativa per
+      difetti di immagine, audio e metadati.
+  BC-3710.10.30:
+    name: Validazione della conformità tecnica
+    description: |
+      Validazione rispetto alle specifiche di distribuzione, comprensiva
+      di formato, frame rate, loudness e conformità del segnale.
+  BC-3710.20:
+    name: Catalogazione dei metadati
+    description: |
+      Redazione e cura dei metadati descrittivi, tecnici e di diritti
+      che rendono gli asset individuabili e utilizzabili.
+  BC-3710.20.10:
+    name: Redazione dei metadati descrittivi
+    description: |
+      Catalogazione di titoli, sinossi, contributor e attributi editoriali
+      secondo uno schema controllato.
+  BC-3710.20.20:
+    name: Acquisizione dei metadati tecnici
+    description: |
+      Estrazione e archiviazione dei metadati tecnici relativi a essence,
+      container e segnale.
+  BC-3710.20.30:
+    name: Collegamento dei metadati di diritti
+    description: |
+      Collegamento dei record degli asset ai record dei diritti per
+      territorio, finestra di distribuzione e restrizioni di piattaforma.
+  BC-3710.20.40:
+    name: Gestione della tassonomia e del vocabolario controllato
+    description: |
+      Gestione delle tassonomie, dei generi e dei vocabolari controllati
+      utilizzati nell'intero catalogo.
+  BC-3710.30:
+    name: Archiviazione e stratificazione degli asset
+    description: |
+      Archiviazione stratificata degli asset multimediali su tier online,
+      nearline e archivio per bilanciare latenza di accesso e costi.
+  BC-3710.30.10:
+    name: Archiviazione online degli asset
+    description: |
+      Archiviazione ad alte prestazioni per gli asset in uso attivo
+      nella produzione e distribuzione.
+  BC-3710.30.20:
+    name: Gestione del tier nearline e archivio
+    description: |
+      Spostamento degli asset verso i tier nearline e archivio
+      con livelli di servizio per il ripristino.
+  BC-3710.30.30:
+    name: Ottimizzazione dei costi di archiviazione
+    description: |
+      Ottimizzazione della policy di tiering, deduplicazione e riduzione
+      dell'impronta su tutti gli asset.
+  BC-3710.40:
+    name: Transcodifica e conversione di formato
+    description: |
+      Produzione di rendition intermedie e di distribuzione attraverso
+      pipeline di transcodifica e packaging.
+  BC-3710.40.10:
+    name: Generazione del mezzanino
+    description: |
+      Produzione di master mezzanino ad alta qualità come intermedi
+      per le codifiche di distribuzione downstream.
+  BC-3710.40.20:
+    name: Codifica del formato di distribuzione
+    description: |
+      Codifica delle rendition di distribuzione per le specifiche
+      di broadcast, OTT e partner di distribuzione.
+  BC-3710.40.30:
+    name: Packaging a bitrate adattivo
+    description: |
+      Packaging di ladder a bitrate adattivo per la distribuzione
+      in streaming HLS, MPEG-DASH e CMAF.
+  BC-3710.50:
+    name: Archivio a lungo termine e conservazione
+    description: |
+      Conservazione a lungo termine dei master e degli asset storici,
+      incluso il restauro del materiale di repertorio.
+  BC-3710.50.10:
+    name: Catalogazione dell'archivio
+    description: |
+      Catalogazione delle collezioni dell'archivio a lungo termine,
+      comprese le registrazioni su supporti fisici e storici.
+  BC-3710.50.20:
+    name: Migrazione per la conservazione
+    description: |
+      Migrazione periodica del materiale archiviato verso generazioni
+      di archiviazione successive per prevenire l'obsolescenza.
+  BC-3710.50.30:
+    name: Restauro e rimasterizzazione
+    description: |
+      Restauro e rimasterizzazione di immagine e audio del materiale
+      di repertorio agli standard moderni di distribuzione.
+  BC-3710.60:
+    name: Gestione degli identificatori e del versioning dei contenuti
+    description: |
+      Assegnazione e tracciamento degli identificatori di contenuto e
+      dei record di versione che descrivono univocamente ogni montaggio e rendition.
+  BC-3710.60.10:
+    name: Assegnazione degli identificatori di contenuto
+    description: |
+      Assegnazione di identificatori interni e di registro (EIDR, ISAN, ISRC,
+      ISWC) a opere e rendition.
+  BC-3710.60.20:
+    name: Gestione della lineage di versione e montaggio
+    description: |
+      Tracciamento della lineage di versione per montaggio, lingua, requisiti
+      normativi e piattaforma rispetto ai record del master padre.
+  BC-3710.60.30:
+    name: Mappatura cross-reference degli identificatori esterni
+    description: |
+      Mappatura cross-reference tra identificatori interni e identificatori
+      di partner, retailer e registro.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-medical-affairs-management.yaml
+++ b/catalogue/i18n/it/L1-medical-affairs-management.yaml
@@ -1,0 +1,123 @@
+# Gestione degli affari medici (it) — translations for L1-medical-affairs-management.yaml
+locale: it
+source: L1-medical-affairs-management.yaml
+entries:
+  BC-1580:
+    name: Gestione degli affari medici
+    description: |
+      Scambio scientifico con i professionisti sanitari, KOL (key opinion leader), MSL (medical science liaison), RWE (real-world evidence).
+  BC-1580.10:
+    name: Gestione della strategia medica
+    description: |
+      Strategia medica, piattaforma scientifica, piano di generazione delle evidenze.
+  BC-1580.10.10:
+    name: Definizione della piattaforma scientifica
+    description: |
+      Definizione della piattaforma scientifica e dei messaggi chiave.
+  BC-1580.10.20:
+    name: Pianificazione della generazione delle evidenze
+    description: |
+      Pianificazione della generazione delle evidenze, inclusi studi IIS e RWE.
+  BC-1580.10.30:
+    name: Pianificazione del ciclo di vita medico
+    description: |
+      Piano degli affari medici nel ciclo di vita per asset.
+  BC-1580.20:
+    name: Gestione dell'engagement con KOL e professionisti sanitari
+    description: |
+      Engagement con KOL (key opinion leader) e professionisti sanitari.
+  BC-1580.20.10:
+    name: Mappatura e profilazione dei KOL
+    description: |
+      Identificazione e profilazione dei KOL (key opinion leader).
+  BC-1580.20.20:
+    name: Gestione degli advisory board dei professionisti sanitari
+    description: |
+      Pianificazione e conduzione degli advisory board dei professionisti sanitari.
+  BC-1580.20.30:
+    name: Tracciamento degli engagement scientifici
+    description: |
+      Tracciamento degli engagement e delle interazioni scientifiche.
+  BC-1580.30:
+    name: Gestione dell'informazione medica
+    description: |
+      Richieste di informazione medica, generazione delle risposte.
+  BC-1580.30.10:
+    name: Ricezione delle richieste di informazione medica
+    description: |
+      Ricezione multicanale delle richieste di informazione medica.
+  BC-1580.30.20:
+    name: Libreria dei documenti di risposta standard
+    description: |
+      Manutenzione della libreria dei documenti di risposta standard.
+  BC-1580.30.30:
+    name: Generazione di risposte mediche personalizzate
+    description: |
+      Generazione di risposte personalizzate alle richieste mediche.
+  BC-1580.40:
+    name: Gestione delle comunicazioni mediche
+    description: |
+      Pubblicazioni scientifiche, strategia congressuale, comunicazioni scientifiche.
+  BC-1580.40.10:
+    name: Pianificazione delle pubblicazioni scientifiche
+    description: |
+      Pianificazione delle pubblicazioni scientifiche allineata a GPP3 e ICMJE.
+  BC-1580.40.20:
+    name: Produzione di manoscritti scientifici
+    description: |
+      Redazione e invio di manoscritti scientifici.
+  BC-1580.40.30:
+    name: Gestione di congressi e simposi
+    description: |
+      Strategia congressuale, abstract e gestione dei simposi.
+  BC-1580.50:
+    name: Gestione degli studi sponsorizzati dagli sperimentatori
+    description: |
+      Programmi IIS, ricerca sponsorizzata dagli sperimentatori.
+  BC-1580.50.10:
+    name: Governance del programma IIS
+    description: |
+      Governance dei programmi di studi sponsorizzati dagli sperimentatori (IIS).
+  BC-1580.50.20:
+    name: Revisione delle proposte IIS
+    description: |
+      Revisione e approvazione delle proposte IIS.
+  BC-1580.50.30:
+    name: Finanziamento e supporto IIS
+    description: |
+      Finanziamento e supporto agli sperimentatori IIS.
+  BC-1580.60:
+    name: Gestione della formazione medica
+    description: |
+      Formazione medica continua, grant, programmi.
+  BC-1580.60.10:
+    name: Grant per la formazione medica indipendente
+    description: |
+      Erogazione di grant per la formazione medica indipendente.
+  BC-1580.60.20:
+    name: Formazione medica a carattere promozionale
+    description: |
+      Programmi di formazione medica a carattere promozionale.
+  BC-1580.60.30:
+    name: Sviluppo di contenuti formativi
+    description: |
+      Sviluppo di contenuti formativi accreditati.
+  BC-1580.70:
+    name: Gestione operativa degli MSL
+    description: |
+      Operazioni del field force MSL (medical science liaison), pianificazione e performance.
+  BC-1580.70.10:
+    name: Territorio e targeting degli MSL
+    description: |
+      Progettazione del territorio e targeting dei KOL per gli MSL (medical science liaison).
+  BC-1580.70.20:
+    name: Pianificazione delle attività degli MSL
+    description: |
+      Pianificazione delle attività e delle chiamate degli MSL (medical science liaison).
+  BC-1580.70.30:
+    name: Tracciamento delle performance degli MSL
+    description: |
+      Performance, raccolta di insight e reportistica degli MSL (medical science liaison).
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-medical-staff-credentialing-management.yaml
+++ b/catalogue/i18n/it/L1-medical-staff-credentialing-management.yaml
@@ -1,0 +1,135 @@
+# Gestione del personale medico e dell'accreditamento professionale (it) — translations for L1-medical-staff-credentialing-management.yaml
+locale: it
+source: L1-medical-staff-credentialing-management.yaml
+entries:
+  BC-2890:
+    name: Gestione del personale medico e dell'accreditamento professionale
+    description: |
+      Accreditamento professionale e concessione dei privilegi clinici, valutazione della performance
+      e peer review, governance del personale medico, iscrizione ai programmi dei pagatori e
+      programmi di salute e benessere dei professionisti.
+  BC-2890.10:
+    name: Accreditamento professionale
+    description: |
+      Accreditamento iniziale e continuativo dei professionisti, inclusa la verifica primaria.
+  BC-2890.10.10:
+    name: Raccolta delle domande di accreditamento
+    description: |
+      Raccolta e verifica della completezza delle domande di accreditamento professionale.
+  BC-2890.10.20:
+    name: Verifica primaria
+    description: |
+      Verifica primaria di formazione, specializzazione, abilitazione professionale e referenze.
+  BC-2890.10.30:
+    name: Gestione del fascicolo professionale
+    description: |
+      Manutenzione e audit dei fascicoli di accreditamento e dei documenti di supporto.
+  BC-2890.10.40:
+    name: Re-accreditamento
+    description: |
+      Re-accreditamento periodico dei professionisti medici e sanitari attivi.
+  BC-2890.20:
+    name: Gestione della concessione dei privilegi clinici
+    description: |
+      Definizione, concessione e rinnovo dei privilegi clinici.
+  BC-2890.20.10:
+    name: Definizione dei privilegi clinici
+    description: |
+      Definizione e manutenzione dei privilegi clinici per reparto e specialità.
+  BC-2890.20.20:
+    name: Concessione iniziale dei privilegi
+    description: |
+      Concessione dei privilegi clinici iniziali ai nuovi professionisti.
+  BC-2890.20.30:
+    name: Rinnovo dei privilegi clinici
+    description: |
+      Rinnovo periodico dei privilegi clinici in base ai dati di performance e competenza.
+  BC-2890.20.40:
+    name: Gestione dei privilegi specialistici
+    description: |
+      Gestione delle richieste di privilegi specialistici, avanzati e procedurali.
+  BC-2890.30:
+    name: Valutazione della performance e peer review
+    description: |
+      Valutazione continuativa e focalizzata della performance dei professionisti e peer review.
+  BC-2890.30.10:
+    name: Valutazione continuativa della performance
+    description: |
+      Valutazione continuativa della pratica professionale rispetto agli indicatori specifici della specialità.
+  BC-2890.30.20:
+    name: Valutazione focalizzata della performance
+    description: |
+      Valutazione focalizzata della pratica professionale attivata da segnali di performance o nuovi privilegi.
+  BC-2890.30.30:
+    name: Revisione dei casi in peer review
+    description: |
+      Revisione strutturata in peer review dei casi clinici con implicazioni sulla performance.
+  BC-2890.30.40:
+    name: Reportistica della performance dei professionisti
+    description: |
+      Reportistica della performance dei professionisti ai comitati del personale medico e ai singoli.
+  BC-2890.40:
+    name: Governance del personale medico
+    description: |
+      Governance del personale medico, inclusi statuto, comitato esecutivo e
+      operazioni dei dipartimenti.
+  BC-2890.40.10:
+    name: Manutenzione dello statuto
+    description: |
+      Manutenzione e modifica dello statuto e dei regolamenti del personale medico.
+  BC-2890.40.20:
+    name: Supporto al comitato esecutivo medico
+    description: |
+      Supporto operativo e analitico al comitato esecutivo medico.
+  BC-2890.40.30:
+    name: Operazioni dei comitati di dipartimento
+    description: |
+      Operazioni dei comitati di dipartimento, sezione e commissioni permanenti.
+  BC-2890.40.40:
+    name: Supporto alle elezioni degli organi di governo
+    description: |
+      Supporto alle candidature e alle elezioni degli organi di governo del personale medico.
+  BC-2890.50:
+    name: Gestione dell'iscrizione ai programmi dei pagatori
+    description: |
+      Iscrizione dei professionisti ai programmi dei pagatori e a quelli governativi.
+  BC-2890.50.10:
+    name: Iscrizione ai programmi dei pagatori commerciali
+    description: |
+      Iscrizione dei professionisti alle reti dei pagatori commerciali.
+  BC-2890.50.20:
+    name: Manutenzione del repository centralizzato delle credenziali
+    description: |
+      Manutenzione dei dati centralizzati di accreditamento dei professionisti condivisi con i pagatori.
+  BC-2890.50.30:
+    name: Iscrizione ai programmi governativi
+    description: |
+      Iscrizione dei professionisti ai programmi assicurativi governativi.
+  BC-2890.50.40:
+    name: Monitoraggio del rinnovo dell'iscrizione
+    description: |
+      Monitoraggio e gestione tempestiva dei cicli di rinnovo dell'iscrizione dei professionisti.
+  BC-2890.60:
+    name: Salute e benessere dei professionisti
+    description: |
+      Programmi a supporto della salute dei professionisti, della prevenzione del burnout e
+      del supporto riservato.
+  BC-2890.60.10:
+    name: Gestione del professionista con compromissione della capacità
+    description: |
+      Identificazione, intervento e monitoraggio dei professionisti con compromissione della capacità lavorativa.
+  BC-2890.60.20:
+    name: Operazioni dei programmi di benessere
+    description: |
+      Gestione dei programmi di benessere e resilienza per i professionisti.
+  BC-2890.60.30:
+    name: Sorveglianza del burnout
+    description: |
+      Sorveglianza degli indicatori di burnout e benessere dei professionisti.
+  BC-2890.60.40:
+    name: Risorse di supporto riservato
+    description: |
+      Risorse riservate di salute mentale, supporto tra pari e counselling per i professionisti.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-merchandising-management.yaml
+++ b/catalogue/i18n/it/L1-merchandising-management.yaml
@@ -1,0 +1,182 @@
+# Gestione del merchandising (it) — translations for L1-merchandising-management.yaml
+locale: it
+source: L1-merchandising-management.yaml
+entries:
+  BC-2300:
+    name: Gestione del merchandising
+    description: |
+      Decisioni di assortimento, gestione delle categorie, pianificazione degli spazi,
+      acquisti, marca propria e markdown che determinano quali prodotti sono venduti ai
+      consumatori, dove e con quale ampiezza di scelta.
+  BC-2300.10:
+    name: Pianificazione dell'assortimento e del range
+    description: |
+      Architettura del range, conteggio delle scelte e piani di assortimento per cluster
+      di punti vendita che traducono la strategia nei SKU presenti in ogni location.
+    in_scope:
+      - Architettura del range e struttura good-better-best
+      - Piani di assortimento per cluster e canale
+      - Introduzione di nuovi articoli e slot di discontinuazione
+    out_of_scope:
+      - Gestione generica del ciclo di vita del prodotto (BC-820)
+      - Previsione della domanda (BC-520.10)
+  BC-2300.10.10:
+    name: Definizione dell'architettura del range
+    description: |
+      Definizione dell'architettura del range, della stratificazione e della struttura
+      good-better-best attraverso le categorie.
+  BC-2300.10.20:
+    name: Pianificazione dell'assortimento per cluster di punti vendita
+    description: |
+      Piani di assortimento personalizzati per cluster di punti vendita in base all'area
+      di influenza e alla missione d'acquisto.
+  BC-2300.10.30:
+    name: Ottimizzazione del numero di referenze
+    description: |
+      Ottimizzazione del numero di SKU per categoria per bilanciare varietà, complessità
+      e margine.
+  BC-2300.10.40:
+    name: Pianificazione dell'introduzione di nuovi articoli
+    description: |
+      Inserimento e posizionamento di nuovi articoli, inclusi la cadenza di introduzione
+      e le decisioni di sostituzione.
+  BC-2300.10.50:
+    name: Pianificazione della discontinuazione
+    description: |
+      Decisioni di uscita dal range, scelte di sostituzione e gestione degli articoli
+      discontinuati.
+  BC-2300.20:
+    name: Gestione delle categorie
+    description: |
+      Strategia di categoria, definizione del ruolo e gestione delle performance, trattando
+      ogni categoria come un'unità di business secondo le pratiche CGF/ECR.
+    in_scope:
+      - Strategia e definizione del ruolo di categoria
+      - Performance di categoria e scorecard
+      - Collaborazione con i category captain dei fornitori
+  BC-2300.20.10:
+    name: Definizione della strategia di categoria
+    description: |
+      Definizione della strategia di categoria, del target di shopper e del posizionamento
+      competitivo.
+  BC-2300.20.20:
+    name: Assegnazione del ruolo di categoria
+    description: |
+      Assegnazione dei ruoli di categoria quali destinazione, routine, convenienza o
+      stagionale.
+  BC-2300.20.30:
+    name: Analisi delle performance di categoria
+    description: |
+      Scorecard di categoria, quota di mercato, analisi della crescita e del margine.
+  BC-2300.20.40:
+    name: Coinvolgimento del category captain
+    description: |
+      Coinvolgimento dei category captain dei fornitori con controlli di separazione delle
+      informazioni.
+  BC-2300.30:
+    name: Gestione degli spazi e dei planogram
+    description: |
+      Allocazione degli spazi a pavimento e sugli scaffali, planogram e layout degli
+      arredi che traducono il piano di assortimento in uno scaffale fisico o digitale.
+  BC-2300.30.10:
+    name: Progettazione del planogram
+    description: |
+      Progettazione dei planogram per categoria, cluster di punti vendita e tipo di
+      arredo.
+  BC-2300.30.20:
+    name: Allocazione dello spazio sullo scaffale
+    description: |
+      Allocazione dello spazio sullo scaffale tra categorie e marchi in base alle
+      performance.
+  BC-2300.30.30:
+    name: Layout degli arredi e della planimetria
+    description: |
+      Pianimetria del punto vendita e posizionamento degli arredi per supportare le
+      adiacenze e il flusso dello shopper.
+  BC-2300.30.40:
+    name: Monitoraggio della conformità al planogram
+    description: |
+      Monitoraggio della conformità al planogram tramite audit in negozio e flussi di
+      image recognition.
+  BC-2300.40:
+    name: Gestione degli acquisti e dell'open-to-buy
+    description: |
+      Pianificazione dell'open-to-buy, esecuzione del piano acquisti e allocazione ai
+      punti vendita che convertono i piani di assortimento in impegni di acquisto con i
+      fornitori.
+    in_scope:
+      - Budget open-to-buy per reparto e stagione
+      - Esecuzione del piano acquisti con i fornitori
+      - Allocazione della merce ricevuta ai punti vendita
+    out_of_scope:
+      - Approvvigionamento generico (BC-500)
+  BC-2300.40.10:
+    name: Pianificazione open-to-buy
+    description: |
+      Definizione del budget open-to-buy per reparto, classe e stagione.
+  BC-2300.40.20:
+    name: Esecuzione del piano acquisti
+    description: |
+      Esecuzione dei piani di acquisto con i fornitori, inclusa la selezione di modelli
+      e SKU.
+  BC-2300.40.30:
+    name: Allocazione ai punti vendita e ai canali
+    description: |
+      Allocazione della merce ricevuta a punti vendita e canali per attributo e
+      performance.
+  BC-2300.40.40:
+    name: Gestione degli acquisti di rifornimento
+    description: |
+      Decisioni di acquisto per il rifornimento di articoli stabili e never-out-of-stock.
+  BC-2300.50:
+    name: Gestione dello sviluppo della marca propria
+    description: |
+      Strategia, specifica, sourcing e tutela del marchio delle linee di prodotto a
+      marca propria e private label.
+  BC-2300.50.10:
+    name: Strategia della marca propria
+    description: |
+      Strategia del portafoglio marca propria e stratificazione tra i marchi di proprietà.
+  BC-2300.50.20:
+    name: Specifiche della marca propria
+    description: |
+      Specifiche di prodotto, brief di packaging e standard qualitativi per i marchi di
+      proprietà.
+  BC-2300.50.30:
+    name: Sourcing della marca propria
+    description: |
+      Ricerca di produttori a contratto e co-packer per la produzione a marca propria.
+  BC-2300.50.40:
+    name: Tutela del marchio proprio
+    description: |
+      Tutela dell'identità del marchio di proprietà, governance del packaging e del
+      patrimonio di marca.
+  BC-2300.60:
+    name: Gestione dei markdown e della dismissione delle scorte
+    description: |
+      Cadenza dei markdown, liquidazione e decisioni di dismissione che retirano le
+      scorte retail in eccesso e a fine vita.
+    in_scope:
+      - Decisioni su cadenza e profondità dei markdown
+      - Piani di liquidazione di fine stagione
+      - Dismissione tramite liquidazione, outlet, donazione e distruzione
+    out_of_scope:
+      - Variazioni di prezzo ordinarie (BC-440.20.20)
+      - Sconti promozionali (BC-440.30)
+  BC-2300.60.10:
+    name: Strategia di markdown
+    description: |
+      Strategia per la profondità, la cadenza e la tempistica dei markdown attraverso le
+      categorie.
+  BC-2300.60.20:
+    name: Pianificazione della liquidazione di fine stagione
+    description: |
+      Piani di liquidazione di fine stagione e gestione del prezzo di uscita.
+  BC-2300.60.30:
+    name: Instradamento per la dismissione delle scorte
+    description: |
+      Instradamento delle scorte residue verso outlet, liquidazione, donazione o
+      distruzione.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-mine-closure-rehabilitation-management.yaml
+++ b/catalogue/i18n/it/L1-mine-closure-rehabilitation-management.yaml
@@ -1,0 +1,101 @@
+# Gestione della chiusura e bonifica delle miniere (it) — translations for L1-mine-closure-rehabilitation-management.yaml
+locale: it
+source: L1-mine-closure-rehabilitation-management.yaml
+entries:
+  BC-4470:
+    name: Gestione della chiusura e bonifica delle miniere
+    description: |
+      Pianificazione della chiusura, accantonamento finanziario, bonifica progressiva, decommissioning e gestione post-chiusura dei terreni e delle infrastrutture minerarie.
+  BC-4470.10:
+    name: Pianificazione della chiusura
+    description: |
+      Sviluppo del piano di chiusura dal livello concettuale al dettaglio, con coinvolgimento degli stakeholder e approvazione del regolatore.
+    in_scope:
+      - Piani di chiusura concettuali e dell'intera vita dell'asset
+      - Revisioni del piano di chiusura dettagliato prima della cessazione
+      - Consultazione sulla chiusura con regolatori e comunità
+    out_of_scope:
+      - Strumenti di accantonamento finanziario (BC-4470.20)
+  BC-4470.10.10:
+    name: Sviluppo del piano di chiusura concettuale
+    description: |
+      Sviluppo di piani di chiusura concettuali nelle fasi iniziali del progetto.
+  BC-4470.10.20:
+    name: Sviluppo del piano di chiusura dettagliato
+    description: |
+      Sviluppo di piani di chiusura dettagliati per l'approvazione del regolatore prima della cessazione.
+  BC-4470.10.30:
+    name: Coinvolgimento degli stakeholder sulla chiusura
+    description: |
+      Coinvolgimento di regolatori, comunità e proprietari tradizionali sugli esiti della chiusura.
+  BC-4470.20:
+    name: Accantonamento finanziario per la chiusura
+    description: |
+      Stima dei costi, gestione degli strumenti di garanzia finanziaria e contabilità degli accantonamenti per la chiusura.
+  BC-4470.20.10:
+    name: Stima dei costi di chiusura
+    description: |
+      Stima dei costi di chiusura per attività di bonifica, decommissioning e post-chiusura.
+  BC-4470.20.20:
+    name: Gestione degli strumenti di garanzia finanziaria
+    description: |
+      Gestione di cauzioni, garanzie e strumenti fideiussori depositati presso i regolatori.
+  BC-4470.20.30:
+    name: Contabilità degli accantonamenti per la chiusura
+    description: |
+      Rimisura e rilevazione periodica degli accantonamenti per la chiusura nel bilancio d'esercizio.
+  BC-4470.30:
+    name: Operazioni di bonifica progressiva
+    description: |
+      Bonifica contestuale dei terreni disturbati durante le operazioni, inclusi modellamento del rilievo, revegetazione e ripristino dei corsi d'acqua.
+  BC-4470.30.10:
+    name: Modellamento del rilievo
+    description: |
+      Modellamento delle discariche di sterili, delle pareti di cava e delle morfologie delle TSF in profili di chiusura stabili.
+  BC-4470.30.20:
+    name: Restituzione del suolo e revegetazione
+    description: |
+      Restituzione del suolo superficiale in deposito e ripristino della copertura vegetale autoctona.
+  BC-4470.30.30:
+    name: Ripristino dei corsi d'acqua
+    description: |
+      Ripristino di corsi d'acqua naturali e costruiti sui terreni bonificati.
+  BC-4470.30.40:
+    name: Decommissioning delle infrastrutture
+    description: |
+      Decommissioning progressivo delle infrastrutture operative ridondanti durante le operazioni.
+  BC-4470.40:
+    name: Decommissioning del sito minerario
+    description: |
+      Smantellamento a fine vita, dismissione degli asset e pulizia del sito alla cessazione delle operazioni.
+  BC-4470.40.10:
+    name: Smantellamento dell'impianto
+    description: |
+      Smantellamento dell'impianto di trattamento, delle infrastrutture minerarie e degli edifici in superficie.
+  BC-4470.40.20:
+    name: Dismissione e recupero degli asset
+    description: |
+      Dismissione, recupero o trasferimento degli asset minerari e di trattamento al decommissioning.
+  BC-4470.40.30:
+    name: Operazioni di pulizia del sito
+    description: |
+      Pulizia dei suoli contaminati, degli idrocarburi e dei materiali stoccati al decommissioning.
+  BC-4470.50:
+    name: Gestione post-chiusura
+    description: |
+      Monitoraggio a lungo termine, restituzione e gestione delle passività residue dopo la cessazione delle operazioni.
+  BC-4470.50.10:
+    name: Operazioni di monitoraggio a lungo termine
+    description: |
+      Operazione di programmi di monitoraggio a lungo termine dell'acqua, geotecnico e della revegetazione.
+  BC-4470.50.20:
+    name: Gestione della restituzione e della rinuncia
+    description: |
+      Gestione della restituzione dei terreni, della rinuncia alla concessione e dell'approvazione normativa.
+  BC-4470.50.30:
+    name: Monitoraggio delle passività residue
+    description: |
+      Monitoraggio e divulgazione delle passività ambientali residue mantenute.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-mine-planning-engineering-management.yaml
+++ b/catalogue/i18n/it/L1-mine-planning-engineering-management.yaml
@@ -1,0 +1,137 @@
+# Gestione della pianificazione e ingegneria mineraria (it) — translations for L1-mine-planning-engineering-management.yaml
+locale: it
+source: L1-mine-planning-engineering-management.yaml
+entries:
+  BC-4420:
+    name: Gestione della pianificazione e ingegneria mineraria
+    description: |
+      Pianificazione mineraria strategica, di lungo termine e di breve termine, unitamente alle discipline di ingegneria mineraria, geotecnica e idrogeologica che traducono la risorsa in piani di produzione eseguibili.
+  BC-4420.10:
+    name: Pianificazione mineraria strategica
+    description: |
+      Definizione della strategia di estrazione per l'intera vita della miniera, selezione del metodo di coltivazione, limiti di cava e sequenziamento dei progetti di capitale.
+    in_scope:
+      - Piano di vita della miniera e profili di cava
+      - Selezione del metodo di coltivazione in sotterraneo
+      - Sequenziamento e approvazioni dei progetti di capitale
+    out_of_scope:
+      - Schedulazione della produzione a budget annuale (BC-4420.20)
+  BC-4420.10.10:
+    name: Pianificazione della vita della miniera
+    description: |
+      Definizione della strategia di estrazione, del sequenziamento e dell'involucro di capitale per l'intera vita della miniera.
+  BC-4420.10.20:
+    name: Ottimizzazione della cava
+    description: |
+      Ottimizzazione del profilo di cava con metodo Lerchs-Grossmann ed equivalenti rispetto a input economici e geotecnici.
+  BC-4420.10.30:
+    name: Selezione del metodo di coltivazione in sotterraneo
+    description: |
+      Selezione dei metodi di coltivazione in sotterraneo quali block caving, sub-level caving o stoping in funzione della geometria del giacimento.
+  BC-4420.10.40:
+    name: Sequenziamento dei progetti di capitale
+    description: |
+      Sequenziamento dei principali progetti di capitale nell'orizzonte della vita della miniera.
+  BC-4420.20:
+    name: Pianificazione mineraria di lungo termine
+    description: |
+      Pianificazione della produzione annuale e pluriennale, strategia degli stockpile e pianificazione delle attrezzature di capitale.
+  BC-4420.20.10:
+    name: Definizione del piano di produzione annuale
+    description: |
+      Definizione del piano di produzione mineraria annuale e del relativo budget.
+  BC-4420.20.20:
+    name: Pianificazione della strategia degli stockpile
+    description: |
+      Pianificazione pluriennale della strategia di accumulo, prelievo e rielaborazione degli stockpile.
+  BC-4420.20.30:
+    name: Strategia del tenore di cut-off
+    description: |
+      Strategia del tenore di cut-off variabile nel tempo nell'arco della vita della miniera.
+  BC-4420.20.40:
+    name: Pianificazione delle attrezzature di capitale
+    description: |
+      Pianificazione a lungo termine del rinnovo della flotta mineraria e delle aggiunte di attrezzature di capitale.
+  BC-4420.30:
+    name: Pianificazione mineraria di breve termine
+    description: |
+      Schedulazione mineraria trimestrale, settimanale e giornaliera che guida l'esecuzione della produzione e il controllo del tenore.
+  BC-4420.30.10:
+    name: Schedulazione della produzione trimestrale
+    description: |
+      Preparazione del programma di produzione trimestrale allineato al piano annuale.
+  BC-4420.30.20:
+    name: Definizione del programma minerario settimanale
+    description: |
+      Definizione del programma minerario settimanale per banco, stope e attrezzatura.
+  BC-4420.30.30:
+    name: Pianificazione del dispacciamento giornaliero
+    description: |
+      Pianificazione del dispacciamento giornaliero e per turno dell'assegnazione della flotta mineraria.
+  BC-4420.30.40:
+    name: Pianificazione del controllo del tenore
+    description: |
+      Pianificazione del campionamento per il controllo del tenore e dell'instradamento dei blocchi di minerale per l'esecuzione a breve termine.
+  BC-4420.40:
+    name: Ingegneria di progettazione della miniera
+    description: |
+      Progettazione ingegneristica di cave, scavi sotterranei, schemi di perforazione e brillamento, strade di trasporto e infrastrutture di ventilazione.
+  BC-4420.40.10:
+    name: Progettazione di cava a cielo aperto
+    description: |
+      Progettazione ingegneristica di bancate, rampe e profilo di cava per operazioni a cielo aperto.
+  BC-4420.40.20:
+    name: Progettazione della miniera in sotterraneo
+    description: |
+      Progettazione ingegneristica di gallerie, decline, shaft e stope per operazioni in sotterraneo.
+  BC-4420.40.30:
+    name: Progettazione di perforazione e brillamento
+    description: |
+      Progettazione dello schema, della carica e della sequenza di innesco per il brillamento di produzione.
+  BC-4420.40.40:
+    name: Progettazione delle strade di trasporto
+    description: |
+      Progettazione geometrica e strutturale delle reti di strade di trasporto minerario.
+  BC-4420.40.50:
+    name: Progettazione della ventilazione e dei servizi
+    description: |
+      Progettazione ingegneristica di sistemi di ventilazione, drenaggio, alimentazione elettrica e aria compressa per miniere in sotterraneo.
+  BC-4420.50:
+    name: Ingegneria geotecnica
+    description: |
+      Ingegneria geotecnica per la stabilità dei pendii, il supporto del terreno e la gestione dei pericoli geologici nelle miniere a cielo aperto e in sotterraneo.
+  BC-4420.50.10:
+    name: Ingegneria della stabilità dei pendii
+    description: |
+      Analisi di stabilità dei pendii e progettazione delle pareti di cava per operazioni a cielo aperto.
+  BC-4420.50.20:
+    name: Progettazione del supporto del terreno in sotterraneo
+    description: |
+      Progettazione ingegneristica di bullonatura, rete metallica, calcestruzzo proiettato e tiranti per scavi in sotterraneo.
+  BC-4420.50.30:
+    name: Definizione del programma di monitoraggio geotecnico
+    description: |
+      Definizione dei programmi di monitoraggio geotecnico con densità strumentale, soglie e cicli di revisione.
+  BC-4420.50.40:
+    name: Valutazione del rischio di pericolo geologico
+    description: |
+      Valutazione dei pericoli di caduta massi, sismici e di subsidenza nelle operazioni minerarie.
+  BC-4420.60:
+    name: Ingegneria idrogeologica della miniera
+    description: |
+      Ingegneria idrogeologica comprendente la modellizzazione delle acque sotterranee, la progettazione del drenaggio e il bilancio idrico del sito.
+  BC-4420.60.10:
+    name: Modellizzazione delle acque sotterranee
+    description: |
+      Modellizzazione numerica del comportamento delle acque sotterranee attorno all'impronta della miniera.
+  BC-4420.60.20:
+    name: Progettazione del drenaggio della miniera
+    description: |
+      Progettazione ingegneristica dei sistemi di drenaggio di cava e di sotterraneo.
+  BC-4420.60.30:
+    name: Modellizzazione del bilancio idrico
+    description: |
+      Modellizzazione del bilancio idrico a livello di sito per la pianificazione operativa e di chiusura.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-mine-production-operations-management.yaml
+++ b/catalogue/i18n/it/L1-mine-production-operations-management.yaml
@@ -1,0 +1,154 @@
+# Gestione delle operazioni di produzione mineraria (it) — translations for L1-mine-production-operations-management.yaml
+locale: it
+source: L1-mine-production-operations-management.yaml
+entries:
+  BC-4430:
+    name: Gestione delle operazioni di produzione mineraria
+    description: |
+      Esecuzione della produzione mineraria attraverso cicli di perforazione-brillamento-caricamento-trasporto, coltivazione in sotterraneo, controllo del tenore, controllo del terreno, ventilazione e drenaggio nelle operazioni a cielo aperto e in sotterraneo.
+  BC-4430.10:
+    name: Operazioni di perforazione e brillamento
+    description: |
+      Perforazione di produzione, carica, innesco e analisi delle prestazioni post-brillamento per operazioni a cielo aperto e in sotterraneo.
+    in_scope:
+      - Perforazione di fori da mina di produzione
+      - Carica e innesco
+      - Analisi della frammentazione e del movimento post-brillamento
+    out_of_scope:
+      - Perforazione esplorativa (BC-4400.30)
+      - Progettazione dello schema di perforazione e brillamento (BC-4420.40.30)
+  BC-4430.10.10:
+    name: Perforazione di produzione
+    description: |
+      Perforazione di fori da mina di produzione secondo lo schema di brillamento progettato.
+  BC-4430.10.20:
+    name: Carica dei fori da mina
+    description: |
+      Caricamento di esplosivi e accessori nei fori da mina.
+  BC-4430.10.30:
+    name: Innesco e allontanamento dal brillamento
+    description: |
+      Collegamento, allontanamento del personale, innesco e allontanamento post-brillamento dai brillamenti di produzione.
+  BC-4430.10.40:
+    name: Analisi delle prestazioni del brillamento
+    description: |
+      Analisi della frammentazione, del movimento e delle vibrazioni dei brillamenti eseguiti.
+  BC-4430.20:
+    name: Operazioni di caricamento e trasporto
+    description: |
+      Caricamento, trasporto e dispacciamento della roccia frantumata dal fronte all'impianto di trattamento o al discarico degli sterili.
+  BC-4430.20.10:
+    name: Operazioni di pala e scavatore
+    description: |
+      Operazione di pale a cavo, escavatori idraulici e pale caricatrici frontali.
+  BC-4430.20.20:
+    name: Operazioni di trasporto con autocarri
+    description: |
+      Operazione di autocarri da miniera fuoristrada e trasporto con assistenza filoviaria.
+  BC-4430.20.30:
+    name: Dispacciamento della flotta e telematica
+    description: |
+      Dispacciamento in tempo reale della flotta, assegnazione e gestione della produttività basata sulla telematica.
+  BC-4430.20.40:
+    name: Riconciliazione del movimento dei materiali
+    description: |
+      Riconciliazione delle tonnate movimentate con i dati di rilievo, dispacciamento e saldo degli stockpile.
+  BC-4430.30:
+    name: Operazioni di produzione in sotterraneo
+    description: |
+      Sviluppo delle stope, produzione, riempimento e movimentazione dei materiali in sotterraneo specifici ai metodi di coltivazione sotterranea.
+  BC-4430.30.10:
+    name: Sviluppo delle stope
+    description: |
+      Sviluppo degli accessi in sotterraneo, gallerie e infrastrutture delle stope.
+  BC-4430.30.20:
+    name: Produzione nelle stope
+    description: |
+      Brillamento di produzione e sgombero del materiale dalle stope in sotterraneo.
+  BC-4430.30.30:
+    name: Posa del riempimento
+    description: |
+      Posa di riempimento cementato o in roccia nelle stope esaurite.
+  BC-4430.30.40:
+    name: Movimentazione dei materiali in sotterraneo
+    description: |
+      Operazione di nastri trasportatori, orepass e sistema di sollevamento dello shaft in sotterraneo.
+  BC-4430.40:
+    name: Operazioni di controllo del tenore
+    description: |
+      Discriminazione operativa minerale-sterile tramite campionamento, definizione dei blocchi di minerale e decisioni di instradamento al fronte di scavo.
+  BC-4430.40.10:
+    name: Campionamento per il controllo del tenore
+    description: |
+      Campionamento in fase di produzione della roccia frantumata e dei fronti per la determinazione del tenore.
+  BC-4430.40.20:
+    name: Definizione dei blocchi di minerale
+    description: |
+      Definizione dei blocchi di minerale coltivabili per l'esecuzione a breve termine.
+  BC-4430.40.30:
+    name: Marcatura del confine minerale-sterile
+    description: |
+      Marcatura sul campo dei confini minerale-sterile per gli operatori di pale e caricatrici.
+  BC-4430.40.40:
+    name: Allocazione allo stockpile ROM
+    description: |
+      Allocazione del materiale estratto agli stockpile run-of-mine e di tenore.
+  BC-4430.50:
+    name: Controllo del terreno e monitoraggio geotecnico
+    description: |
+      Controllo del terreno operativo tramite monitoraggio e piani di risposta ai trigger sui pendii di cava e negli scavi in sotterraneo.
+  BC-4430.50.10:
+    name: Monitoraggio dei pendii
+    description: |
+      Monitoraggio in tempo reale dei pendii di cava con radar, prismi e inclinometri.
+  BC-4430.50.20:
+    name: Installazione del supporto del terreno
+    description: |
+      Installazione di bullonatura, rete metallica, calcestruzzo proiettato e tiranti in sotterraneo.
+  BC-4430.50.30:
+    name: Monitoraggio sismico sotterraneo
+    description: |
+      Monitoraggio microsismico degli scavi in sotterraneo per la gestione dei rockburst e delle tensioni.
+  BC-4430.50.40:
+    name: Piano di risposta ai trigger geotecnici
+    description: |
+      Esecuzione dei piani di risposta ai trigger al superamento delle soglie di monitoraggio geotecnico.
+  BC-4430.60:
+    name: Gestione della ventilazione e dell'atmosfera della miniera
+    description: |
+      Operazione dei sistemi di ventilazione primaria e ausiliaria e monitoraggio della qualità dell'atmosfera della miniera.
+  BC-4430.60.10:
+    name: Operazioni di ventilazione primaria
+    description: |
+      Operazione dei ventilatori primari di superficie e sotterranei e delle vie d'aria.
+  BC-4430.60.20:
+    name: Operazioni di ventilazione ausiliaria
+    description: |
+      Operazione di ventilatori ausiliari e tubazioni al fronte di scavo.
+  BC-4430.60.30:
+    name: Monitoraggio dell'atmosfera della miniera
+    description: |
+      Monitoraggio in tempo reale e di routine di polveri, gas e livelli di ossigeno nell'atmosfera della miniera.
+  BC-4430.60.40:
+    name: Gestione del particolato diesel
+    description: |
+      Gestione dell'esposizione al particolato diesel negli ambienti di lavoro in sotterraneo.
+  BC-4430.70:
+    name: Operazioni di drenaggio della miniera
+    description: |
+      Operazione dei sistemi di drenaggio di cava e sotterranei e delle infrastrutture delle stazioni di pompaggio.
+  BC-4430.70.10:
+    name: Operazioni di drenaggio della cava a cielo aperto
+    description: |
+      Operazione di pompaggio in cava e sondaggi di drenaggio perimetrali.
+  BC-4430.70.20:
+    name: Operazioni di drenaggio in sotterraneo
+    description: |
+      Operazione di vasche di raccolta, pompe e reti di drenaggio in sotterraneo.
+  BC-4430.70.30:
+    name: Gestione delle stazioni di pompaggio
+    description: |
+      Operazione e manutenzione di stazioni di pompaggio fisse e colonne montanti.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-mineral-exploration-management.yaml
+++ b/catalogue/i18n/it/L1-mineral-exploration-management.yaml
@@ -1,0 +1,159 @@
+# Gestione dell'esplorazione mineraria (it) — translations for L1-mineral-exploration-management.yaml
+locale: it
+source: L1-mineral-exploration-management.yaml
+entries:
+  BC-4400:
+    name: Gestione dell'esplorazione mineraria
+    description: |
+      Scoperta di nuove mineralizzazioni e qualificazione di prospetti esplorativi tramite rilievi geologici, geochimica, geofisica, perforazione esplorativa e analisi del campione, fino alla comunicazione delle scoperte e alle decisioni di maturazione dei prospetti.
+  BC-4400.10:
+    name: Gestione dei rilievi geoscientifici
+    description: |
+      Acquisizione, elaborazione e interpretazione di dati di rilievi geofisici, geochimici e geologici aerei e terrestri sulle concessioni esplorative.
+    in_scope:
+      - Rilievi magnetici ed elettromagnetici aerei
+      - Rilievi gravimetrici terrestri, IP e sismici
+      - Geochimica di suolo, sedimenti fluviali e campioni di roccia
+      - Cartografia geologica in scala 1:50k e di dettaglio
+    out_of_scope:
+      - Carotaggio geologico di sondaggi di grado risorsa (BC-4400.30)
+      - Riconciliazione geologica in fase di produzione (BC-4410.60)
+  BC-4400.10.10:
+    name: Rilievo geofisico aereo
+    description: |
+      Acquisizione di rilievi geofisici aerei magnetici, elettromagnetici, radiometrici e gravimetrici sulle aree in esplorazione.
+  BC-4400.10.20:
+    name: Rilievo geofisico terrestre
+    description: |
+      Acquisizione di rilievi gravimetrici, di polarizzazione indotta, elettromagnetici e sismici su scala di prospetto.
+  BC-4400.10.30:
+    name: Campionamento geochimico
+    description: |
+      Programmi di campionamento di suolo, sedimenti fluviali, biogeochimici e di roccia per la delimitazione di anomalie geochimiche.
+  BC-4400.10.40:
+    name: Cartografia geologica
+    description: |
+      Cartografia geologica di affioramenti e a scala di prospetto per definire litologia, struttura e alterazione.
+  BC-4400.10.50:
+    name: Interpretazione dei dati di rilievo
+    description: |
+      Interpretazione integrata di dataset geofisici e geochimici per la generazione di target esplorativi.
+  BC-4400.20:
+    name: Generazione di target esplorativi
+    description: |
+      Conversione di dati regionali e di prospetto in target di perforazione classificati tramite analisi del sistema mineralizzato e modellizzazione della prospettività.
+    in_scope:
+      - Applicazione di modelli di sistema mineralizzato e di giacimento
+      - Modellizzazione della prospettività basata sui dati
+      - Classificazione di lead e target
+    out_of_scope:
+      - Stima delle risorse sulla mineralizzazione scoperta (BC-4410.20)
+  BC-4400.20.10:
+    name: Analisi del sistema mineralizzato
+    description: |
+      Applicazione di criteri di sorgente, trasporto, trappola e preservazione per definire i sistemi mineralizzati.
+  BC-4400.20.20:
+    name: Modellizzazione della prospettività
+    description: |
+      Mappatura della prospettività basata sulla conoscenza e sui dati per prevedere la posizione dei target esplorativi.
+  BC-4400.20.30:
+    name: Classificazione dei target
+    description: |
+      Classificazione probabilistica dei target generati in base alla probabilità di scoperta e al tonnellaggio potenziale.
+  BC-4400.20.40:
+    name: Gestione dell'inventario dei lead esplorativi
+    description: |
+      Manutenzione dell'inventario classificato di lead e target esplorativi e del relativo percorso di maturazione.
+  BC-4400.30:
+    name: Operazioni di perforazione esplorativa
+    description: |
+      Esecuzione di programmi di perforazione esplorativa a circolazione inversa, a carotaggio e di altro tipo, inclusi rilievo del foro, registrazione del campione e supervisione dei contrattisti.
+    in_scope:
+      - Perforazione a circolazione inversa e aircore
+      - Perforazione a carotaggio diamantato
+      - Rilievo della deviazione del sondaggio
+    out_of_scope:
+      - Perforazione di produzione per la carica dei fori da mina (BC-4430.10)
+      - Perforazione geotecnica per la progettazione dei pendii (BC-4420.50)
+  BC-4400.30.10:
+    name: Perforazione a circolazione inversa
+    description: |
+      Perforazione a circolazione inversa e aircore per il recupero di campioni esplorativi.
+  BC-4400.30.20:
+    name: Perforazione a carotaggio diamantato
+    description: |
+      Perforazione a carotaggio diamantato per il recupero di campioni litologici orientati e continui.
+  BC-4400.30.30:
+    name: Registrazione del campione di perforazione
+    description: |
+      Registrazione geologica, geotecnica e strutturale di cuttings e carote di perforazione.
+  BC-4400.30.40:
+    name: Gestione del rilievo del sondaggio
+    description: |
+      Rilievo della deviazione in profondità e controllo del posizionamento del collare.
+  BC-4400.30.50:
+    name: Gestione dei contrattisti di perforazione
+    description: |
+      Coinvolgimento, mobilitazione e gestione delle prestazioni dei contrattisti di perforazione.
+  BC-4400.40:
+    name: Gestione dei campioni e delle analisi
+    description: |
+      Custodia, preparazione e coordinamento delle analisi dei campioni esplorativi nell'ambito di regimi di garanzia della qualità documentati conformi agli standard di reporting pubblico.
+    in_scope:
+      - Catena di custodia dei campioni
+      - Selezione del laboratorio e gestione dei tempi di risposta
+      - Inserimento e monitoraggio dei controlli di qualità
+    out_of_scope:
+      - Analisi dell'impianto di trattamento (BC-4440.60)
+      - Analisi di liquidazione della fonderia (BC-4450.70)
+  BC-4400.40.10:
+    name: Preparazione del campione
+    description: |
+      Frantumazione, divisione e polverizzazione dei campioni esplorativi per l'analisi del campione.
+  BC-4400.40.20:
+    name: Coordinamento dell'analisi di laboratorio
+    description: |
+      Selezione, invio e gestione dei tempi di risposta del lavoro analitico di laboratorio.
+  BC-4400.40.30:
+    name: Gestione del programma di garanzia della qualità
+    description: |
+      Inserimento e monitoraggio di standard, bianchi e duplicati a supporto della qualità delle analisi per il reporting pubblico.
+  BC-4400.40.40:
+    name: Gestione dei materiali di riferimento
+    description: |
+      Approvvigionamento, caratterizzazione e distribuzione di materiali di riferimento certificati.
+  BC-4400.50:
+    name: Indirizzo del programma esplorativo
+    description: |
+      Direzione strategica del portafoglio esplorativo per commodity, giurisdizioni e classi di rischio, inclusa l'allocazione degli investimenti e il monitoraggio delle performance di scoperta.
+  BC-4400.50.10:
+    name: Definizione della strategia esplorativa
+    description: |
+      Definizione della strategia esplorativa per commodity, giurisdizione e classe di giacimento.
+  BC-4400.50.20:
+    name: Allocazione degli investimenti esplorativi
+    description: |
+      Allocazione del capitale esplorativo tra programmi regionali e di prospetto.
+  BC-4400.50.30:
+    name: Monitoraggio delle performance di scoperta
+    description: |
+      Monitoraggio del costo di scoperta, delle aggiunte di risorse e della conversione in riserve.
+  BC-4400.60:
+    name: Comunicazione delle scoperte
+    description: |
+      Comunicazione interna ed esterna dei risultati esplorativi, incluse le divulgazioni ai partner e ai mercati dei capitali conformi ai codici di reporting pubblico.
+  BC-4400.60.10:
+    name: Comunicazione interna delle scoperte
+    description: |
+      Comunicazione interna dei risultati esplorativi, delle intercettazioni e dello stato di maturazione dei target.
+  BC-4400.60.20:
+    name: Divulgazione pubblica dei risultati esplorativi
+    description: |
+      Divulgazione di intercettazioni e risultati esplorativi ai sensi di JORC, NI 43-101, SAMREC e codici equivalenti.
+  BC-4400.60.30:
+    name: Reporting di joint venture esplorativa
+    description: |
+      Rendicontazione dei progressi, delle spese e dei risultati esplorativi ai partner e agli operatori di joint venture.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-mineral-processing-operations-management.yaml
+++ b/catalogue/i18n/it/L1-mineral-processing-operations-management.yaml
@@ -1,0 +1,141 @@
+# Gestione delle operazioni di trattamento dei minerali (it) — translations for L1-mineral-processing-operations-management.yaml
+locale: it
+source: L1-mineral-processing-operations-management.yaml
+entries:
+  BC-4440:
+    name: Gestione delle operazioni di trattamento dei minerali
+    description: |
+      Operazioni del concentratore e idrometallurgiche che convertono il minerale run-of-mine in concentrati commerciabili o prodotti intermedi tramite comminuzione, arricchimento, lisciviazione e movimentazione del concentrato.
+  BC-4440.10:
+    name: Gestione dello stockpile run-of-mine
+    description: |
+      Gestione degli stockpile run-of-mine tra la miniera e l'impianto di trattamento, incluse la ripresa, la miscelazione e la riconciliazione dell'inventario.
+    in_scope:
+      - Ripresa e miscelazione dello stockpile ROM
+      - Riconciliazione dell'inventario dello stockpile
+    out_of_scope:
+      - Allocazione dei blocchi di minerale in cava (BC-4430.40.40)
+      - Stoccaggio del concentrato (BC-4440.50.30)
+  BC-4440.10.10:
+    name: Ripresa dello stockpile run-of-mine
+    description: |
+      Ripresa degli stockpile run-of-mine all'alimentazione dell'impianto tramite alimentatori a grembiule o pale caricatrici.
+  BC-4440.10.20:
+    name: Miscelazione del minerale
+    description: |
+      Miscelazione del materiale degli stockpile per raggiungere il tenore target e le caratteristiche metallurgiche.
+  BC-4440.10.30:
+    name: Riconciliazione dell'inventario dello stockpile
+    description: |
+      Riconciliazione dei dati di rilievo, dispacciamento e ripresa nei saldi di inventario degli stockpile.
+  BC-4440.20:
+    name: Operazioni di comminuzione
+    description: |
+      Operazioni di frantumazione, macinazione e ottimizzazione del circuito che riducono il minerale alla dimensione di liberazione.
+  BC-4440.20.10:
+    name: Operazioni di frantumazione
+    description: |
+      Operazione di stazioni di frantumazione primaria, secondaria e terziaria.
+  BC-4440.20.20:
+    name: Operazioni di mulino di macinazione
+    description: |
+      Operazione di mulini SAG, AG, a sfere e a barre con relativa classificazione.
+  BC-4440.20.30:
+    name: Ottimizzazione del circuito di comminuzione
+    description: |
+      Ottimizzazione del processo dei circuiti di comminuzione per produzione, P80 e intensità energetica.
+  BC-4440.30:
+    name: Operazioni di arricchimento
+    description: |
+      Concentrazione fisica dei minerali di valore tramite flottazione, gravità, separazione magnetica e a mezzo denso.
+  BC-4440.30.10:
+    name: Operazioni del circuito di flottazione
+    description: |
+      Operazione dei circuiti di flottazione rougher, scavenger e cleaner con dosaggio dei reagenti.
+  BC-4440.30.20:
+    name: Concentrazione gravimetrica
+    description: |
+      Operazione di jigg, spirali e concentratori centrifughi per minerali suscettibili alla gravità.
+  BC-4440.30.30:
+    name: Separazione magnetica
+    description: |
+      Separazione magnetica a bassa e alta intensità per minerali ferromagnetici e paramagnetici.
+  BC-4440.30.40:
+    name: Separazione a mezzo denso
+    description: |
+      Operazione di cicloni e tamburi a mezzo denso per la pre-concentrazione.
+  BC-4440.40:
+    name: Operazioni idrometallurgiche
+    description: |
+      Estrazione acquosa dei metalli tramite lisciviazione su heap, in serbatoio e in vasca, estrazione con solventi e circuiti di adsorbimento.
+  BC-4440.40.10:
+    name: Operazioni di heap leach
+    description: |
+      Operazione di heap leach pad inclusi stacking, irrigazione e raccolta della soluzione pregnante.
+  BC-4440.40.20:
+    name: Operazioni di lisciviazione in serbatoio e in vasca
+    description: |
+      Operazione di circuiti di lisciviazione in serbatoio e in vasca per minerale e concentrato.
+  BC-4440.40.30:
+    name: Operazioni di estrazione con solventi
+    description: |
+      Operazione di circuiti di estrazione con solventi per il trasferimento selettivo del metallo all'elettrolito.
+  BC-4440.40.40:
+    name: Operazioni di adsorbimento su carboni attivi
+    description: |
+      Operazione di circuiti di adsorbimento-eluizione-recupero CIL/CIP e carbon-in-column.
+  BC-4440.50:
+    name: Movimentazione e filtrazione del concentrato
+    description: |
+      Ispessimento, filtrazione e stoccaggio dei concentrati per la spedizione alla fonderia o per la vendita.
+  BC-4440.50.10:
+    name: Operazioni di ispessimento
+    description: |
+      Operazione di ispessitori ad alta velocità e a pasta per la disidratazione di concentrato e residui di lavorazione.
+  BC-4440.50.20:
+    name: Filtrazione e disidratazione
+    description: |
+      Operazione di filtri a pressione, sottovuoto e a nastro per la disidratazione del concentrato.
+  BC-4440.50.30:
+    name: Stoccaggio del concentrato
+    description: |
+      Stoccaggio in ambienti interni ed esterni del concentrato disidratato in attesa della spedizione.
+  BC-4440.60:
+    name: Contabilità metallurgica dell'impianto di trattamento
+    description: |
+      Campionamento, analisi del campione e riconciliazione del bilancio metallico dell'alimentazione, dei prodotti e dei residui di lavorazione dell'impianto.
+  BC-4440.60.10:
+    name: Campionamento e analisi dell'impianto
+    description: |
+      Campionamento trasversale e analisi del campione dell'alimentazione, del concentrato e dei residui di lavorazione dell'impianto.
+  BC-4440.60.20:
+    name: Bilancio metallurgico
+    description: |
+      Riconciliazione periodica del bilancio metallico attraverso il diagramma di flusso dell'impianto.
+  BC-4440.60.30:
+    name: Reporting del recupero
+    description: |
+      Reporting del recupero metallico rispetto al piano e al progetto.
+  BC-4440.60.40:
+    name: Reporting della qualità del concentrato
+    description: |
+      Reporting del tenore del concentrato, degli elementi indesiderati e dell'umidità rispetto alla specifica.
+  BC-4440.70:
+    name: Gestione dei reagenti e dei materiali di consumo del processo
+    description: |
+      Gestione dei reagenti e dei materiali di consumo del processo, inclusi il controllo del dosaggio, l'inventario e la gestione dei reagenti pericolosi.
+  BC-4440.70.10:
+    name: Controllo del dosaggio dei reagenti
+    description: |
+      Controllo in tempo reale del dosaggio dei reagenti nei circuiti di flottazione e idrometallurgici.
+  BC-4440.70.20:
+    name: Gestione dell'inventario dei reagenti
+    description: |
+      Gestione dell'inventario e del consumo di reagenti sfusi e mezzi di macinazione.
+  BC-4440.70.30:
+    name: Gestione responsabile del cianuro
+    description: |
+      Gestione responsabile del cianuro e di altri reagenti pericolosi in linea con l'International Cyanide Management Code.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-mineral-product-marketing-management.yaml
+++ b/catalogue/i18n/it/L1-mineral-product-marketing-management.yaml
@@ -1,0 +1,120 @@
+# Gestione della commercializzazione dei prodotti minerari (it) — translations for L1-mineral-product-marketing-management.yaml
+locale: it
+source: L1-mineral-product-marketing-management.yaml
+entries:
+  BC-4480:
+    name: Gestione della commercializzazione dei prodotti minerari
+    description: |
+      Vendite, accordi di acquisto, negoziazione delle commissioni di trattamento e raffinazione, liquidazione dei prezzi provvisori, coordinamento della logistica e gestione del rischio di trading per concentrati, intermedi e prodotti metallici finiti.
+  BC-4480.10:
+    name: Vendite di concentrato e metallo
+    description: |
+      Esecuzione di vendite spot e a termine e pianificazione dell'allocazione ai clienti per concentrati e metallo finito.
+    in_scope:
+      - Vendite spot a tonnate e contratti a lungo termine
+      - Pianificazione dell'allocazione ai clienti tra miniere e raffinerie
+    out_of_scope:
+      - Calcoli di liquidazione a prezzi provvisori (BC-4480.40)
+  BC-4480.10.10:
+    name: Esecuzione delle vendite spot
+    description: |
+      Esecuzione di vendite spot di concentrati e metalli a trader e clienti finali.
+  BC-4480.10.20:
+    name: Gestione dei contratti a lungo termine
+    description: |
+      Gestione di contratti di vendita a lungo termine pluriennali per concentrati e metalli.
+  BC-4480.10.30:
+    name: Pianificazione dell'allocazione ai clienti
+    description: |
+      Allocazione della produzione disponibile tra clienti e contratti.
+  BC-4480.20:
+    name: Gestione degli accordi di acquisto
+    description: |
+      Negoziazione e amministrazione continuativa degli accordi di acquisto, inclusi gli accordi di streaming e royalty.
+  BC-4480.20.10:
+    name: Negoziazione dei contratti di acquisto
+    description: |
+      Negoziazione commerciale e legale degli accordi di acquisto e di streaming.
+  BC-4480.20.20:
+    name: Nomina dei volumi di acquisto
+    description: |
+      Nomina dei volumi di acquisto rispetto ai diritti contrattuali.
+  BC-4480.20.30:
+    name: Monitoraggio delle prestazioni dell'accordo di acquisto
+    description: |
+      Monitoraggio delle consegne, della qualità e delle prestazioni della controparte nell'accordo di acquisto.
+  BC-4480.30:
+    name: Negoziazione delle commissioni di trattamento e raffinazione
+    description: |
+      Negoziazione annuale di benchmark e bilaterale delle commissioni di trattamento e raffinazione (TC/RC) e dei termini di penale sul concentrato.
+  BC-4480.30.10:
+    name: Negoziazione del benchmark annuale
+    description: |
+      Negoziazione annuale del benchmark delle TC/RC con fonderie e clienti.
+  BC-4480.30.20:
+    name: Monitoraggio della liquidazione delle commissioni di trattamento
+    description: |
+      Monitoraggio della liquidazione delle TC/RC rispetto al benchmark e alle condizioni contrattuali.
+  BC-4480.30.30:
+    name: Gestione degli elementi penalizzanti
+    description: |
+      Gestione dei termini di penale per arsenico, antimonio, fluoro e altri elementi indesiderati.
+  BC-4480.40:
+    name: Prezzi provvisori e liquidazione finale
+    description: |
+      Gestione dei periodi di quotazione, fatturazione provvisoria, calcolo della liquidazione finale e coordinamento della copertura del rischio per il contenuto metallico a prezzo.
+  BC-4480.40.10:
+    name: Gestione dei periodi di quotazione
+    description: |
+      Gestione dei periodi di quotazione che governano il prezzo finale delle spedizioni.
+  BC-4480.40.20:
+    name: Emissione della fattura provvisoria
+    description: |
+      Emissione di fatture provvisorie alla spedizione sulla base di analisi e prezzi presunti.
+  BC-4480.40.30:
+    name: Calcolo della liquidazione finale
+    description: |
+      Liquidazione finale delle spedizioni mediante analisi arbitrali e prezzi medi del periodo di quotazione.
+  BC-4480.40.40:
+    name: Coordinamento della copertura del rischio
+    description: |
+      Coordinamento con i programmi di hedging della tesoreria per l'esposizione al metallo a prezzo provvisorio.
+  BC-4480.50:
+    name: Coordinamento della logistica dei prodotti minerari
+    description: |
+      Nomina delle spedizioni alla rinfusa, gestione dei warrant di magazzino, campionamento allo scarico e conformità normativa del carico alla rinfusa.
+  BC-4480.50.10:
+    name: Nomina delle spedizioni alla rinfusa
+    description: |
+      Nomina di navi, convogli ferroviari e chiatte per le spedizioni di concentrato e minerale.
+  BC-4480.50.20:
+    name: Gestione dei warrant di magazzino
+    description: |
+      Gestione dei warrant di magazzino LME e di altre borse per le scorte di metallo finito.
+  BC-4480.50.30:
+    name: Campionamento del concentrato allo scarico
+    description: |
+      Coordinamento del campionamento e dell'analisi indipendenti nei porti di scarico.
+  BC-4480.50.40:
+    name: Conformità al codice per i carichi solidi alla rinfusa
+    description: |
+      Conformità al codice IMSBC dell'IMO e alla normativa equivalente per i carichi solidi alla rinfusa.
+  BC-4480.60:
+    name: Gestione del rischio di trading dei metalli
+    description: |
+      Gestione dei rischi di prezzo dei metalli, di credito della controparte e di documentazione commerciale nel portafoglio di marketing.
+  BC-4480.60.10:
+    name: Monitoraggio della posizione di rischio prezzo
+    description: |
+      Monitoraggio delle posizioni di metallo a prezzo e non a prezzo nel portafoglio di marketing.
+  BC-4480.60.20:
+    name: Gestione del credito della controparte
+    description: |
+      Valutazione del credito della controparte, limiti e monitoraggio dell'esposizione per i partner commerciali.
+  BC-4480.60.30:
+    name: Conferma e documentazione commerciale
+    description: |
+      Conferma, documentazione e archiviazione dei ticket e dei contratti commerciali.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-mineral-resource-reserve-management.yaml
+++ b/catalogue/i18n/it/L1-mineral-resource-reserve-management.yaml
@@ -1,0 +1,129 @@
+# Gestione della risorsa e riserva mineraria (it) — translations for L1-mineral-resource-reserve-management.yaml
+locale: it
+source: L1-mineral-resource-reserve-management.yaml
+entries:
+  BC-4410:
+    name: Gestione della risorsa e riserva mineraria
+    description: |
+      Modellizzazione geologica, stima geostatistica, classificazione, governance della persona competente e reporting pubblico di risorse minerarie e riserve di minerale ai sensi dei codici della famiglia CRIRSCO.
+  BC-4410.10:
+    name: Modellizzazione geologica
+    description: |
+      Costruzione di modelli geologici tridimensionali di litologia, struttura, alterazione e domini di mineralizzazione come input alla stima delle risorse.
+    in_scope:
+      - Modellizzazione litologica e stratigrafica
+      - Modellizzazione strutturale e delle faglie
+      - Wireframing dei domini di mineralizzazione
+    out_of_scope:
+      - Wireframe di progettazione di cava e stope (BC-4420.40)
+  BC-4410.10.10:
+    name: Modellizzazione litologica
+    description: |
+      Modellizzazione tridimensionale di unità litologiche e stratigrafiche dal carotaggio dei sondaggi.
+  BC-4410.10.20:
+    name: Modellizzazione strutturale
+    description: |
+      Modellizzazione di faglie, pieghe e zone di taglio che controllano la geometria della mineralizzazione.
+  BC-4410.10.30:
+    name: Modellizzazione dei domini di mineralizzazione
+    description: |
+      Wireframing degli inviluppi di mineralizzazione e dei domini di tenore utilizzati come confini di stima.
+  BC-4410.10.40:
+    name: Flussi di lavoro per la modellizzazione implicita
+    description: |
+      Flussi di lavoro di modellizzazione geologica implicita e ad aggiornamento rapido per il perfezionamento iterativo del modello.
+  BC-4410.20:
+    name: Stima delle risorse
+    description: |
+      Stima geostatistica di tenore e tonnellaggio nel modello a blocchi e classificazione del materiale stimato come inferito, indicato o misurato ai sensi dei codici di reporting pubblico.
+  BC-4410.20.10:
+    name: Stima geostatistica
+    description: |
+      Variografia e stima mediante kriging o simulazione del tenore nel modello a blocchi.
+  BC-4410.20.20:
+    name: Costruzione del modello a blocchi
+    description: |
+      Costruzione e popolamento di modelli a blocchi regolarizzati per la pianificazione a valle.
+  BC-4410.20.30:
+    name: Validazione della stima
+    description: |
+      Validazione statistica e visiva dei tenori stimati rispetto ai dati compositi.
+  BC-4410.20.40:
+    name: Classificazione delle risorse
+    description: |
+      Classificazione della mineralizzazione stimata nelle categorie inferito, indicato e misurato.
+  BC-4410.30:
+    name: Stima delle riserve
+    description: |
+      Applicazione dei fattori modificanti minerari, metallurgici, economici e altri per convertire risorse indicate e misurate in riserve di minerale probabili e provate.
+  BC-4410.30.10:
+    name: Applicazione dei fattori modificanti
+    description: |
+      Applicazione di fattori modificanti minerari, metallurgici, infrastrutturali ed economici alle risorse.
+  BC-4410.30.20:
+    name: Determinazione del tenore di cut-off
+    description: |
+      Calcolo dei tenori di cut-off a supporto della definizione delle riserve con prezzi e costi assunti.
+  BC-4410.30.30:
+    name: Modellizzazione del recupero minerario e della diluizione
+    description: |
+      Modellizzazione del recupero minerario, della diluizione e degli effetti di bordo applicati alle risorse in situ.
+  BC-4410.30.40:
+    name: Classificazione delle riserve di minerale
+    description: |
+      Classificazione delle riserve di minerale nelle categorie probabile e provato.
+  BC-4410.40:
+    name: Governance della persona competente
+    description: |
+      Governance delle persone competenti e qualificate responsabili delle dichiarazioni di risorse e riserve ai sensi dei codici di reporting pubblico.
+  BC-4410.40.10:
+    name: Approvazione della persona competente
+    description: |
+      Revisione e approvazione delle dichiarazioni di risorse e riserve da parte di una persona competente o qualificata.
+  BC-4410.40.20:
+    name: Revisione interna delle risorse
+    description: |
+      Revisione interna tra pari e del comitato tecnico delle stime di risorse e riserve.
+  BC-4410.40.30:
+    name: Coordinamento dell'audit esterno delle risorse
+    description: |
+      Coordinamento di audit indipendenti di terze parti su risorse e riserve.
+  BC-4410.50:
+    name: Reporting pubblico di risorse e riserve
+    description: |
+      Preparazione e divulgazione di dichiarazioni pubbliche di risorse minerarie e riserve di minerale richieste dagli organi di vigilanza dei valori mobiliari e dai regolamenti di quotazione.
+  BC-4410.50.10:
+    name: Preparazione della dichiarazione di risorse
+    description: |
+      Preparazione di dichiarazioni pubbliche di risorse minerarie allineate ai codici della famiglia CRIRSCO.
+  BC-4410.50.20:
+    name: Preparazione della dichiarazione di riserve
+    description: |
+      Preparazione di dichiarazioni pubbliche di riserve di minerale allineate ai codici della famiglia CRIRSCO.
+  BC-4410.50.30:
+    name: Aggiornamento annuale della dichiarazione delle riserve
+    description: |
+      Aggiornamento annuale delle dichiarazioni di risorse e riserve che riflette il depauperamento e le nuove stime.
+  BC-4410.50.40:
+    name: Coordinamento della relazione tecnica indipendente
+    description: |
+      Coordinamento delle relazioni tecniche redatte da persone qualificate per mercati dei capitali, transazioni ed eventi di divulgazione.
+  BC-4410.60:
+    name: Riconciliazione delle risorse
+    description: |
+      Riconciliazione delle risorse e riserve stimate con i dati di controllo del tenore, l'alimentazione dell'impianto e la produzione metallica per valutare le prestazioni del modello.
+  BC-4410.60.10:
+    name: Riconciliazione dalla miniera all'impianto
+    description: |
+      Riconciliazione di tonnate e tenore estratti rispetto all'alimentazione dell'impianto e al metallo recuperato.
+  BC-4410.60.20:
+    name: Monitoraggio del depauperamento delle risorse
+    description: |
+      Monitoraggio del depauperamento di risorse e riserve derivante dall'attività mineraria.
+  BC-4410.60.30:
+    name: Analisi delle prestazioni del modello
+    description: |
+      Analisi delle prestazioni del modello di risorsa rispetto ai dati consuntivi per orientare le stime future.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-mining-community-social-performance-management.yaml
+++ b/catalogue/i18n/it/L1-mining-community-social-performance-management.yaml
@@ -1,0 +1,134 @@
+# Gestione della performance sociale e relazioni con le comunità minerarie (it) — translations for L1-mining-community-social-performance-management.yaml
+locale: it
+source: L1-mining-community-social-performance-management.yaml
+entries:
+  BC-4500:
+    name: Gestione della performance sociale e relazioni con le comunità minerarie
+    description: |
+      Mantenimento della licenza sociale tramite il coinvolgimento delle comunità ospitanti, dei popoli indigeni e dei proprietari tradizionali, il reinsediamento e l'accesso ai terreni, gli investimenti nella comunità, il contenuto locale, i diritti umani e il reporting della performance sociale.
+  BC-4500.10:
+    name: Coinvolgimento della comunità ospitante
+    description: |
+      Identificazione, consultazione e gestione dei reclami con le comunità ospitanti interessate dalle operazioni minerarie.
+    in_scope:
+      - Identificazione e mappatura degli stakeholder
+      - Programmi di consultazione della comunità
+      - Meccanismi di reclamo della comunità
+    out_of_scope:
+      - Coinvolgimento specifico delle popolazioni indigene (BC-4500.20)
+      - Reinsediamento (BC-4500.30)
+  BC-4500.10.10:
+    name: Mappatura degli stakeholder della comunità
+    description: |
+      Identificazione e mappatura degli stakeholder nell'area di influenza delle operazioni minerarie.
+  BC-4500.10.20:
+    name: Programma di consultazione della comunità
+    description: |
+      Operazione di forum strutturati di consultazione della comunità e divulgazione delle informazioni.
+  BC-4500.10.30:
+    name: Gestione dei reclami della comunità
+    description: |
+      Meccanismo operativo di reclamo della comunità allineato ai criteri di efficacia dei Principi guida delle Nazioni Unite.
+  BC-4500.20:
+    name: Coinvolgimento dei popoli indigeni e dei proprietari tradizionali
+    description: |
+      Coinvolgimento di gruppi indigeni e proprietari tradizionali, inclusi titolo nativo, patrimonio culturale e accordi di condivisione dei benefici.
+  BC-4500.20.10:
+    name: Coinvolgimento su titolo nativo e diritti fondiari
+    description: |
+      Coinvolgimento sul titolo nativo e sui diritti consuetudinari sui terreni che interessano le operazioni minerarie.
+  BC-4500.20.20:
+    name: Gestione del patrimonio culturale
+    description: |
+      Identificazione, protezione e gestione dei siti e dei valori del patrimonio culturale.
+  BC-4500.20.30:
+    name: Amministrazione degli accordi di uso del territorio con le popolazioni indigene
+    description: |
+      Amministrazione degli accordi di uso del territorio indigeno e di condivisione dei benefici.
+  BC-4500.30:
+    name: Gestione del reinsediamento e dell'accesso ai terreni
+    description: |
+      Acquisizione dei terreni, reinsediamento involontario e ripristino dei mezzi di sussistenza per le persone colpite dal progetto.
+  BC-4500.30.10:
+    name: Negoziazione dell'acquisizione dei terreni
+    description: |
+      Negoziazione di acquisizioni volontarie di terreni per le operazioni minerarie e le infrastrutture associate.
+  BC-4500.30.20:
+    name: Pianificazione del reinsediamento involontario
+    description: |
+      Pianificazione del reinsediamento involontario allineata agli Standard di prestazione IFC e a regimi equivalenti.
+  BC-4500.30.30:
+    name: Attuazione del piano d'azione per il reinsediamento
+    description: |
+      Attuazione dei piani d'azione per il reinsediamento per le famiglie colpite dal progetto.
+  BC-4500.30.40:
+    name: Operazioni del programma di ripristino dei mezzi di sussistenza
+    description: |
+      Operazione di programmi di ripristino dei mezzi di sussistenza per le famiglie dislocate e le comunità ospitanti.
+  BC-4500.40:
+    name: Investimento e sviluppo della comunità
+    description: |
+      Progettazione e realizzazione di programmi di investimento nella comunità e co-investimento in infrastrutture locali e progetti di sviluppo.
+  BC-4500.40.10:
+    name: Progettazione del programma di investimento nella comunità
+    description: |
+      Progettazione di programmi di investimento nella comunità pluriennali allineati ai piani di sviluppo locale.
+  BC-4500.40.20:
+    name: Co-investimento in infrastrutture locali
+    description: |
+      Co-investimento in strade, acqua, energia e infrastrutture sociali condivise con le comunità ospitanti.
+  BC-4500.40.30:
+    name: Realizzazione di progetti di sviluppo della comunità
+    description: |
+      Realizzazione di progetti di sviluppo della comunità nel settore della salute, dell'istruzione e dei mezzi di sussistenza.
+  BC-4500.50:
+    name: Gestione del contenuto e degli approvvigionamenti locali
+    description: |
+      Sviluppo dei fornitori locali, programmi di occupazione locale e reporting rispetto agli impegni di contenuto locale.
+  BC-4500.50.10:
+    name: Sviluppo dei fornitori locali
+    description: |
+      Sviluppo e potenziamento delle capacità dei fornitori locali e di proprietà indigena.
+  BC-4500.50.20:
+    name: Gestione del programma di occupazione locale
+    description: |
+      Gestione dei programmi di occupazione locale, formazione e apprendistato per i lavoratori delle comunità ospitanti.
+  BC-4500.50.30:
+    name: Reporting del contenuto locale
+    description: |
+      Reporting rispetto agli impegni di contenuto locale del governo ospitante e contrattuali.
+  BC-4500.60:
+    name: Gestione dei diritti umani e della sicurezza
+    description: |
+      Due diligence sui diritti umani, allineamento ai Principi volontari sulla sicurezza e i diritti umani e supervisione della condotta dei fornitori di sicurezza.
+  BC-4500.60.10:
+    name: Due diligence sui diritti umani
+    description: |
+      Valutazione dell'impatto sui diritti umani a livello di sito e due diligence ai sensi dei Principi guida delle Nazioni Unite.
+  BC-4500.60.20:
+    name: Conformità ai Principi volontari
+    description: |
+      Conformità ai Principi volontari sulla sicurezza e i diritti umani nelle operazioni di sicurezza.
+  BC-4500.60.30:
+    name: Supervisione della condotta dei fornitori di sicurezza
+    description: |
+      Supervisione della condotta dei fornitori di sicurezza pubblici e privati attorno ai siti minerari.
+  BC-4500.70:
+    name: Reporting della performance sociale
+    description: |
+      Monitoraggio degli indicatori di performance sociale, valutazione dell'impatto sociale e divulgazione esterna della performance sociale.
+  BC-4500.70.10:
+    name: Monitoraggio degli indicatori di performance sociale
+    description: |
+      Monitoraggio degli indicatori di performance sociale nelle operazioni e negli investimenti.
+  BC-4500.70.20:
+    name: Valutazione dell'impatto sociale
+    description: |
+      Valutazione periodica dell'impatto sociale delle operazioni minerarie sulle comunità ospitanti.
+  BC-4500.70.30:
+    name: Divulgazione esterna della performance sociale
+    description: |
+      Divulgazione esterna della performance sociale nei rapporti di sostenibilità e nelle comunicazioni normative.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-mining-tenement-royalty-management.yaml
+++ b/catalogue/i18n/it/L1-mining-tenement-royalty-management.yaml
@@ -1,0 +1,121 @@
+# Gestione delle concessioni minerarie e delle royalty (it) — translations for L1-mining-tenement-royalty-management.yaml
+locale: it
+source: L1-mining-tenement-royalty-management.yaml
+entries:
+  BC-4490:
+    name: Gestione delle concessioni minerarie e delle royalty
+    description: |
+      Acquisizione, conformità e gestione del portafoglio di permessi esplorativi e concessioni minerarie, unitamente al calcolo, al reporting e alla divulgazione degli obblighi di royalty verso governi, privati e popolazioni indigene.
+  BC-4490.10:
+    name: Acquisizione di concessioni
+    description: |
+      Domanda, gara e due diligence di acquisizione per permessi esplorativi, concessioni minerarie e altre titolarità minerarie.
+    in_scope:
+      - Domande di permesso esplorativo in aree vergini
+      - Domande di concessione mineraria e rinnovi
+      - Due diligence di acquisizione di concessioni
+    out_of_scope:
+      - Maturazione dei prospetti in fase di scoperta (BC-4400.20)
+  BC-4490.10.10:
+    name: Domanda di permesso esplorativo
+    description: |
+      Preparazione e deposito di domande di permesso esplorativo in aree vergini e nelle aree di attività esistenti.
+  BC-4490.10.20:
+    name: Domanda di concessione mineraria
+    description: |
+      Preparazione e deposito di domande di concessione mineraria e conversioni dalla titolarità esplorativa.
+  BC-4490.10.30:
+    name: Partecipazione a gare di concessione
+    description: |
+      Partecipazione a gare e aste competitive di concessioni minerarie.
+  BC-4490.10.40:
+    name: Due diligence di acquisizione della concessione
+    description: |
+      Due diligence su titolarità, gravami e obblighi nelle acquisizioni di concessioni.
+  BC-4490.20:
+    name: Conformità e manutenzione della concessione
+    description: |
+      Conformità agli obblighi annuali di spesa, programma di lavoro, canone e rinnovo relativi alle titolarità minerarie.
+  BC-4490.20.10:
+    name: Reporting della spesa annuale
+    description: |
+      Reporting della spesa annuale di esplorazione e sviluppo rispetto agli impegni della concessione.
+  BC-4490.20.20:
+    name: Conformità al programma di lavoro
+    description: |
+      Dimostrazione della conformità ai programmi di lavoro impegnati su concessioni esplorative e minerarie.
+  BC-4490.20.30:
+    name: Pagamento di canoni e diritti statutari
+    description: |
+      Pagamento di canoni annuali, diritti statutari e depositi cauzionali sulle concessioni.
+  BC-4490.20.40:
+    name: Gestione del rinnovo della concessione
+    description: |
+      Gestione delle domande di rinnovo e delle variazioni delle condizioni della concessione.
+  BC-4490.30:
+    name: Gestione del portafoglio di concessioni
+    description: |
+      Manutenzione del registro delle concessioni, cartografia dei confini e decisioni di restituzione nell'intero portafoglio.
+  BC-4490.30.10:
+    name: Gestione del registro delle concessioni
+    description: |
+      Manutenzione del registro aziendale delle concessioni e degli attributi di riferimento.
+  BC-4490.30.20:
+    name: Cartografia dei confini della concessione
+    description: |
+      Mappatura spaziale e riconciliazione dei confini delle concessioni rispetto ai registri governativi.
+  BC-4490.30.30:
+    name: Decisioni di restituzione della concessione
+    description: |
+      Decisioni di restituzione parziale e totale delle concessioni per razionalizzare il portafoglio.
+  BC-4490.40:
+    name: Gestione delle royalty governative
+    description: |
+      Calcolo, deposito e risposta agli audit per le royalty basate sulla produzione e ad valorem dovute ai governi ospitanti.
+  BC-4490.40.10:
+    name: Calcolo delle royalty sulla produzione
+    description: |
+      Calcolo delle royalty basate sulla produzione e ad valorem sulla produzione di minerali.
+  BC-4490.40.20:
+    name: Deposito delle dichiarazioni di royalty
+    description: |
+      Deposito periodico delle dichiarazioni di royalty presso le autorità fiscali del governo ospitante.
+  BC-4490.40.30:
+    name: Risposta agli audit delle royalty
+    description: |
+      Risposta agli audit e agli accertamenti delle royalty governative.
+  BC-4490.50:
+    name: Gestione delle royalty private e indigene
+    description: |
+      Amministrazione dei flussi di royalty privati e degli obblighi di royalty per la condivisione dei benefici con le popolazioni indigene.
+  BC-4490.50.10:
+    name: Amministrazione dei flussi di royalty privati
+    description: |
+      Amministrazione dei diritti a royalty di venditori, finanziatori e società di streaming.
+  BC-4490.50.20:
+    name: Amministrazione delle royalty per la condivisione dei benefici con le popolazioni indigene
+    description: |
+      Amministrazione dei pagamenti di royalty e degli accordi di condivisione dei benefici con gruppi indigeni e proprietari tradizionali.
+  BC-4490.50.30:
+    name: Reporting della divulgazione delle royalty
+    description: |
+      Divulgazione dei pagamenti di royalty a investitori, regolatori e comunità interessate.
+  BC-4490.60:
+    name: Reporting di trasparenza estrattiva
+    description: |
+      Reporting di pagamenti ai governi, EITI e proprietà effettiva ai sensi dei regimi di trasparenza estrattiva.
+  BC-4490.60.10:
+    name: Reporting dei pagamenti ai governi
+    description: |
+      Reporting obbligatorio dei pagamenti ai governi ai sensi della normativa UE e di regimi equivalenti.
+  BC-4490.60.20:
+    name: Divulgazione della trasparenza estrattiva
+    description: |
+      Reporting EITI e di trasparenza volontaria equivalente sui flussi di ricavi.
+  BC-4490.60.30:
+    name: Divulgazione della proprietà effettiva
+    description: |
+      Divulgazione della proprietà effettiva delle entità operative ai sensi dell'EITI e di norme equivalenti.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-mission-management.yaml
+++ b/catalogue/i18n/it/L1-mission-management.yaml
@@ -1,0 +1,103 @@
+# Gestione della missione (it) — translations for L1-mission-management.yaml
+locale: it
+source: L1-mission-management.yaml
+entries:
+  BC-1700:
+    name: Gestione della missione
+    description: |
+      Pianificazione della missione, comando e controllo (C2), condotta della missione e analisi post-azione.
+  BC-1700.10:
+    name: Gestione della pianificazione della missione
+    description: |
+      Obiettivi della missione, percorso, obiettivi tattici e pianificazione delle forze.
+  BC-1700.10.10:
+    name: Definizione degli obiettivi della missione
+    description: |
+      Definizione degli obiettivi della missione e delle intenzioni del comandante.
+  BC-1700.10.20:
+    name: Pianificazione delle forze e delle risorse
+    description: |
+      Pianificazione della composizione delle forze e dell'assegnazione delle risorse.
+  BC-1700.10.30:
+    name: Pianificazione del percorso e degli obiettivi tattici
+    description: |
+      Pianificazione del percorso e selezione degli obiettivi tattici.
+  BC-1700.10.40:
+    name: Valutazione del rischio della missione
+    description: |
+      Valutazione del rischio operativo e conferma delle regole d'ingaggio.
+  BC-1700.10.50:
+    name: Produzione degli ordini di missione
+    description: |
+      Produzione degli ordini di missione e della documentazione di assegnazione compiti.
+  BC-1700.20:
+    name: Gestione delle operazioni di comando e controllo (C2)
+    description: |
+      Operazioni di C2, consapevolezza situazionale e supporto alle decisioni.
+  BC-1700.20.10:
+    name: Gestione del quadro operativo comune
+    description: |
+      Mantenimento del quadro operativo comune (COP).
+  BC-1700.20.20:
+    name: Supporto alle decisioni tattiche
+    description: |
+      Strumenti e raccomandazioni di supporto alle decisioni tattiche.
+  BC-1700.20.30:
+    name: Gestione delle comunicazioni C2
+    description: |
+      Reti di comunicazione C2 e messaggistica tattica.
+  BC-1700.20.40:
+    name: Coordinamento tra echeloni
+    description: |
+      Coordinamento tra echeloni operativi e tattici.
+  BC-1700.30:
+    name: Gestione della condotta della missione
+    description: |
+      Condotta della missione in tempo reale e controllo tattico.
+  BC-1700.30.10:
+    name: Coordinamento dell'esecuzione tattica
+    description: |
+      Coordinamento tattico in tempo reale degli elementi della missione.
+  BC-1700.30.20:
+    name: Riassegnazione dinamica dei compiti
+    description: |
+      Riassegnazione dinamica dei compiti e ripianificazione durante l'esecuzione.
+  BC-1700.30.30:
+    name: Valutazione degli effetti della missione
+    description: |
+      Valutazione in tempo reale e post-azione dei danni da battaglia e degli effetti della missione.
+  BC-1700.40:
+    name: Gestione dell'esercitazione e simulazione della missione
+    description: |
+      Esercitazione della missione e addestramento basato sulla simulazione.
+  BC-1700.40.10:
+    name: Progettazione delle esercitazioni di missione
+    description: |
+      Progettazione delle esercitazioni di addestramento alla missione.
+  BC-1700.40.20:
+    name: Simulazione live, virtuale e costruttiva
+    description: |
+      Gestione dell'ambiente di simulazione LVC (live, virtual, constructive).
+  BC-1700.40.30:
+    name: Valutazione delle prestazioni nelle esercitazioni
+    description: |
+      Valutazione delle prestazioni delle unità durante le esercitazioni.
+  BC-1700.50:
+    name: Gestione del debriefing e delle lezioni apprese della missione
+    description: |
+      Analisi post-azione, debriefing e raccolta delle lezioni apprese.
+  BC-1700.50.10:
+    name: Condotta del debriefing della missione
+    description: |
+      Condotta dei debriefing della missione e delle analisi post-azione.
+  BC-1700.50.20:
+    name: Raccolta delle lezioni apprese
+    description: |
+      Raccolta e codificazione delle lezioni apprese.
+  BC-1700.50.30:
+    name: Monitoraggio dell'attuazione delle lezioni apprese
+    description: |
+      Monitoraggio dell'attuazione dei miglioramenti identificati.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-mobility-services-operations-management.yaml
+++ b/catalogue/i18n/it/L1-mobility-services-operations-management.yaml
@@ -1,0 +1,181 @@
+# Gestione delle operazioni dei servizi di mobilità (it) — translations for L1-mobility-services-operations-management.yaml
+locale: it
+source: L1-mobility-services-operations-management.yaml
+entries:
+  BC-3490:
+    name: Gestione delle operazioni dei servizi di mobilità
+    description: |
+      Operazioni dei servizi di mobilità condivisa e on-demand — ride-hailing,
+      car sharing e micromobilità, e aggregazione MaaS —
+      inclusi catalogo dei servizi, operazioni di viaggio, riequilibrio della flotta,
+      operazioni di conducenti e passeggeri, pricing dinamico, integrazione con i
+      partner e coinvolgimento di città e regolatori.
+  BC-3490.10:
+    name: Gestione del catalogo dei servizi di mobilità
+    description: |
+      Definizione delle tipologie di servizio di mobilità, dei piani tariffari e delle
+      zone di copertura geografica.
+  BC-3490.10.10:
+    name: Definizione delle tipologie di servizio
+    description: |
+      Definizione delle tipologie di servizio quali point-to-point, free-floating,
+      station-based e corse in pool.
+  BC-3490.10.20:
+    name: Configurazione dei piani tariffari dei servizi
+    description: |
+      Configurazione delle tariffe base, del pricing per tempo e distanza e dei
+      piani di abbonamento.
+  BC-3490.10.30:
+    name: Gestione dei geofence e della copertura dei servizi
+    description: |
+      Gestione dei geofence operativi, delle zone vietate e delle aree di
+      copertura.
+  BC-3490.20:
+    name: Operazioni di viaggio e prenotazione
+    description: |
+      Acquisizione, abbinamento, dispatch e gestione del ciclo di vita delle
+      prenotazioni e dei viaggi di mobilità.
+  BC-3490.20.10:
+    name: Acquisizione delle prenotazioni di viaggio
+    description: |
+      Acquisizione delle prenotazioni di viaggio tramite canali app, web e
+      partner.
+  BC-3490.20.20:
+    name: Abbinamento e dispatch del viaggio
+    description: |
+      Abbinamento dei passeggeri a veicoli o conducenti e dispatch dei viaggi
+      confermati.
+  BC-3490.20.30:
+    name: Gestione del ciclo di vita del viaggio
+    description: |
+      Gestione del ciclo di vita dei viaggi in corso, incluse cancellazione,
+      deviazione e completamento.
+  BC-3490.30:
+    name: Operazioni della flotta condivisa
+    description: |
+      Gestione operativa della flotta condivisa, inclusi riequilibrio, manutenzione
+      in loco e controllo dei danni.
+    in_scope:
+      - Riequilibrio dei veicoli tra zone e stazioni
+      - Pulizia, ricarica e rifornimento in strada
+      - Gestione dei danni e delle perdite per i veicoli condivisi
+    out_of_scope:
+      - Contabilità generica degli asset delle flotte aziendali (BC-2430)
+      - Operazioni delle stazioni di ricarica EV (BC-3480)
+  BC-3490.30.10:
+    name: Operazioni di riequilibrio dei veicoli
+    description: |
+      Riequilibrio dei veicoli condivisi tra zone, stazioni e aree ad alta domanda.
+  BC-3490.30.20:
+    name: Coordinamento della pulizia e della ricarica dei veicoli
+    description: |
+      Coordinamento delle attività di pulizia, ricarica e rifornimento dei veicoli
+      in campo.
+  BC-3490.30.30:
+    name: Gestione dei danni e delle perdite dei veicoli
+    description: |
+      Gestione della valutazione dei danni, dell'instradamento alle riparazioni e
+      del recupero delle perdite per i veicoli condivisi.
+  BC-3490.40:
+    name: Operazioni di conducenti e fornitori
+    description: |
+      Onboarding, conformità, regolamento e gestione delle performance di conducenti
+      e altri fornitori di servizi.
+  BC-3490.40.10:
+    name: Onboarding e conformità dei conducenti
+    description: |
+      Onboarding dei conducenti, inclusi controlli della patente, verifiche dei
+      precedenti e conformità continuativa.
+  BC-3490.40.20:
+    name: Guadagni e regolamento dei conducenti
+    description: |
+      Calcolo e pagamento dei guadagni, delle mance e degli incentivi dei
+      conducenti.
+  BC-3490.40.30:
+    name: Gestione delle performance dei conducenti
+    description: |
+      Gestione delle performance dei conducenti, inclusi valutazioni, coaching e
+      disattivazione.
+  BC-3490.50:
+    name: Operazioni passeggeri
+    description: |
+      Onboarding, supporto e operazioni di trust-and-safety per i passeggeri e i
+      clienti finali dei servizi di mobilità.
+  BC-3490.50.10:
+    name: Onboarding e identità del passeggero
+    description: |
+      Onboarding dei passeggeri, inclusi verifica dell'identità, metodo di pagamento
+      e consenso.
+  BC-3490.50.20:
+    name: Operazioni di supporto ai passeggeri
+    description: |
+      Supporto ai passeggeri per problemi pre-viaggio, durante il viaggio e
+      post-viaggio.
+  BC-3490.50.30:
+    name: Gestione della sicurezza e della fiducia dei passeggeri
+    description: |
+      Operazioni di trust-and-safety, inclusa la gestione degli incidenti, la
+      prevenzione degli abusi e le funzioni di sicurezza.
+  BC-3490.60:
+    name: Pricing dinamico e gestione della domanda
+    description: |
+      Previsione della domanda e operatività dei motori di pricing dinamico,
+      surge e promozioni per i servizi di mobilità.
+  BC-3490.60.10:
+    name: Previsione della domanda
+    description: |
+      Previsione della domanda a breve termine per zona, orario e tipologia di
+      servizio.
+  BC-3490.60.20:
+    name: Operazioni del motore di pricing dinamico
+    description: |
+      Operatività dei motori di pricing dinamico e surge, inclusi limiti di prezzo
+      e audit.
+  BC-3490.60.30:
+    name: Operazioni di promozioni e incentivi
+    description: |
+      Operatività di promozioni e incentivi per passeggeri e conducenti nelle
+      campagne.
+  BC-3490.70:
+    name: Aggregazione multimodale e operazioni con i partner
+    description: |
+      Aggregazione dei partner MaaS, composizione di viaggi multimodali e regolamento
+      inter-operatore tra i partner di mobilità.
+  BC-3490.70.10:
+    name: Onboarding dei partner MaaS
+    description: |
+      Onboarding dei partner di trasporto pubblico, ride-hail e micromobilità
+      sulla piattaforma MaaS.
+  BC-3490.70.20:
+    name: Composizione di viaggi multimodali
+    description: |
+      Composizione di viaggi multimodali che combinano trasporto pubblico e
+      mobilità on-demand.
+  BC-3490.70.30:
+    name: Regolamento inter-operatore
+    description: |
+      Regolamento di ricavi e commissioni tra aggregatori MaaS e operatori di
+      mobilità sottostanti.
+  BC-3490.80:
+    name: Operazioni normative e con le città per la mobilità
+    description: |
+      Coinvolgimento di città e regolatori su permessi, condivisione dei dati e
+      operazioni di marciapiede e parcheggio.
+  BC-3490.80.10:
+    name: Gestione dei permessi e delle autorizzazioni per le città
+    description: |
+      Gestione dei permessi operativi delle città, dei tetti al numero di veicoli e
+      delle autorizzazioni nelle giurisdizioni.
+  BC-3490.80.20:
+    name: Condivisione dei dati operativi con le città
+    description: |
+      Condivisione dei dati operativi con le città secondo MDS, GBFS e
+      specifiche equivalenti.
+  BC-3490.80.30:
+    name: Coordinamento del marciapiede e dei parcheggi
+    description: |
+      Coordinamento dell'accesso ai marciapiedi, dei parcheggi e delle zone di
+      attesa con le autorità cittadine.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-omnichannel-order-fulfilment-management.yaml
+++ b/catalogue/i18n/it/L1-omnichannel-order-fulfilment-management.yaml
@@ -1,0 +1,122 @@
+# Gestione degli ordini e dell'evasione omnicanale (it) — translations for L1-omnichannel-order-fulfilment-management.yaml
+locale: it
+source: L1-omnichannel-order-fulfilment-management.yaml
+entries:
+  BC-2330:
+    name: Gestione degli ordini e dell'evasione omnicanale
+    description: |
+      Orchestrazione cross-canale degli ordini del consumatore — acquisizione su
+      qualsiasi canale, promessa da qualsiasi nodo ed evasione tramite punto vendita,
+      centro di distribuzione, marketplace, drop-ship del fornitore o partner per
+      l'ultimo miglio.
+  BC-2330.10:
+    name: Gestione dell'orchestrazione dei canali
+    description: |
+      Visione unica degli ordini del consumatore su tutti i canali, instradamento per
+      mix di canale e stato coerente tra digitale, punto vendita e marketplace.
+    in_scope:
+      - Regole di instradamento per canale e selezione del nodo
+      - Visione unificata degli ordini su tutti i canali
+      - Economie del mix di canale e compromessi sui costi di evasione
+    out_of_scope:
+      - Evasione generica degli ordini (BC-520.40)
+  BC-2330.10.10:
+    name: Gestione delle regole di instradamento per canale
+    description: |
+      Definizione delle regole di instradamento per la selezione del nodo di evasione
+      in base a costo e livello di servizio.
+  BC-2330.10.20:
+    name: Visione cross-canale degli ordini
+    description: |
+      Visione unificata degli ordini, dello stato e della cronologia su tutti i canali.
+  BC-2330.10.30:
+    name: Economie del mix di canale
+    description: |
+      Analisi dell'economia unitaria per canale e percorso di evasione.
+  BC-2330.20:
+    name: Gestione delle operazioni click-and-collect
+    description: |
+      Operazioni di ritiro in negozio, ritiro a bordo strada e ritiro da locker che
+      collegano gli ordini digitali ai punti di ritiro fisici.
+  BC-2330.20.10:
+    name: Operazioni di prelievo e imballaggio in negozio
+    description: |
+      Prelievo e imballaggio degli ordini online da parte degli addetti al punto vendita.
+  BC-2330.20.20:
+    name: Consegna al cliente per il ritiro
+    description: |
+      Passaggio di consegne al cliente per il ritiro, inclusi verifica dell'identità e
+      gestione delle eccezioni.
+  BC-2330.20.30:
+    name: Ritiro a bordo strada e da locker
+    description: |
+      Operazioni di consegna a bordo strada e ritiro tramite locker.
+  BC-2330.30:
+    name: Gestione dell'evasione distribuita degli ordini
+    description: |
+      Evasione tramite spedizione dal negozio, dark store e drop-ship del fornitore
+      da un pool di scorte distribuite verso le destinazioni del consumatore.
+    in_scope:
+      - Operazioni di spedizione dal negozio
+      - Operazioni di dark store e micro-fulfilment centre
+      - Orchestrazione del drop-ship del fornitore
+  BC-2330.30.10:
+    name: Operazioni di spedizione dal negozio
+    description: |
+      Prelievo, imballaggio e spedizione di ordini online dai punti vendita fisici.
+  BC-2330.30.20:
+    name: Operazioni di dark store e micro-fulfilment
+    description: |
+      Operazioni di dark store e micro-fulfilment centre per gli ordini digitali.
+  BC-2330.30.30:
+    name: Orchestrazione del drop-ship del fornitore
+    description: |
+      Orchestrazione del drop-ship del fornitore, inclusi instradamento degli ordini
+      e tracking.
+  BC-2330.40:
+    name: Gestione delle operazioni come venditore su marketplace
+    description: |
+      Gestione degli annunci del retailer come venditore su marketplace di terze parti
+      e gestione dei venditori terzi su un marketplace proprietario.
+  BC-2330.40.10:
+    name: Gestione degli annunci su marketplace
+    description: |
+      Inserimento di articoli su marketplace di terze parti, incluso l'adattamento dei
+      contenuti.
+  BC-2330.40.20:
+    name: Acquisizione degli ordini da marketplace
+    description: |
+      Acquisizione e traduzione degli ordini provenienti da marketplace nel flusso
+      ordini principale.
+  BC-2330.40.30:
+    name: Onboarding dei venditori terzi
+    description: |
+      Onboarding di venditori terzi sul marketplace proprietario del retailer.
+  BC-2330.40.40:
+    name: Gestione delle performance dei venditori terzi
+    description: |
+      Gestione delle performance e della conformità alle policy dei venditori terzi.
+  BC-2330.50:
+    name: Gestione delle fasce orarie di consegna al consumatore
+    description: |
+      Prenotazione delle fasce orarie di consegna rivolte al consumatore, pricing delle
+      finestre temporali e coordinamento del dispacciamento dei corrieri per la consegna
+      a domicilio.
+  BC-2330.50.10:
+    name: Prenotazione della fascia oraria di consegna
+    description: |
+      Prenotazione da parte del consumatore delle fasce orarie di consegna con logica di
+      disponibilità e capacità.
+  BC-2330.50.20:
+    name: Pricing delle finestre temporali
+    description: |
+      Pricing dinamico delle finestre di consegna in base alla domanda e alla densità
+      del percorso.
+  BC-2330.50.30:
+    name: Coordinamento del dispacciamento dei corrieri
+    description: |
+      Coordinamento del dispacciamento con corrieri dell'ultimo miglio propri e di terze
+      parti.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-patient-access-management.yaml
+++ b/catalogue/i18n/it/L1-patient-access-management.yaml
@@ -1,0 +1,139 @@
+# Gestione dell'accesso dei pazienti (it) — translations for L1-patient-access-management.yaml
+locale: it
+source: L1-patient-access-management.yaml
+entries:
+  BC-2800:
+    name: Gestione dell'accesso dei pazienti
+    description: |
+      Accoglienza del paziente prima dell'incontro, pianificazione degli appuntamenti, registrazione,
+      verifica della eleggibilità, consulenza finanziaria, ammissioni, trasferimenti e dimissioni
+      nei contesti di ricovero, ambulatoriale e d'emergenza.
+  BC-2800.10:
+    name: Pianificazione degli appuntamenti e gestione degli accessi
+    description: |
+      Pianificazione delle risorse e dei professionisti sanitari, prenotazione degli appuntamenti,
+      gestione della lista d'attesa e promemoria proattivi per ottimizzare l'utilizzo della capacità.
+  BC-2800.10.10:
+    name: Ottimizzazione dell'agenda dei professionisti
+    description: |
+      Ottimizzazione delle agende di professionisti, sale e attrezzature attraverso modelli e sovrapposizioni.
+  BC-2800.10.20:
+    name: Prenotazione degli appuntamenti
+    description: |
+      Prenotazione degli appuntamenti su iniziativa del paziente o del professionista inviante, attraverso diversi canali.
+  BC-2800.10.30:
+    name: Gestione della lista d'attesa
+    description: |
+      Mantenimento e prioritizzazione delle liste d'attesa per appuntamenti e procedure.
+  BC-2800.10.40:
+    name: Promemoria appuntamenti e riduzione delle mancate presentazioni
+    description: |
+      Promemoria multicanale, conferma degli appuntamenti e interventi per la riduzione delle mancate presentazioni.
+  BC-2800.20:
+    name: Gestione della registrazione del paziente
+    description: |
+      Raccolta e gestione dei dati anagrafici, di identità e di consenso necessari per registrare
+      il paziente in vista di un incontro.
+  BC-2800.20.10:
+    name: Raccolta dei dati anagrafici
+    description: |
+      Raccolta dei dati anagrafici del paziente al momento della registrazione.
+  BC-2800.20.20:
+    name: Verifica dell'identità del paziente
+    description: |
+      Verifica dell'identità del paziente tramite documenti e controlli biometrici.
+  BC-2800.20.30:
+    name: Raccolta dei consensi e delle autorizzazioni
+    description: |
+      Raccolta dei consensi al trattamento, finanziari e di condivisione delle informazioni, e delle relative autorizzazioni.
+  BC-2800.20.40:
+    name: Gestione degli identificativi del paziente
+    description: |
+      Emissione e mantenimento dei numeri di cartella clinica e degli identificativi aziendali del paziente.
+  BC-2800.30:
+    name: Verifica della eleggibilità e dei benefici
+    description: |
+      Verifica della copertura assicurativa, dei benefici e dei requisiti di autorizzazione preventiva
+      prima dell'erogazione del servizio.
+  BC-2800.30.10:
+    name: Verifica della copertura assicurativa
+    description: |
+      Verifica della copertura assicurativa attiva e dei dettagli del piano sanitario.
+  BC-2800.30.20:
+    name: Determinazione dei benefici
+    description: |
+      Determinazione dei benefici del paziente, delle franchigie, dei ticket e dei limiti di copertura.
+  BC-2800.30.30:
+    name: Gestione dell'autorizzazione preventiva
+    description: |
+      Presentazione, monitoraggio e follow-up delle richieste di autorizzazione preventiva ai pagatori.
+  BC-2800.30.40:
+    name: Verifica della eleggibilità in tempo reale
+    description: |
+      Verifica elettronica in tempo reale della eleggibilità e dei benefici presso i sistemi dei pagatori.
+  BC-2800.40:
+    name: Consulenza finanziaria e stima dei costi
+    description: |
+      Consulenza finanziaria rivolta al paziente, stima dei costi a carico del paziente e
+      iscrizione a programmi di assistenza finanziaria o accordi di pagamento diretto.
+  BC-2800.40.10:
+    name: Valutazione finanziaria del paziente
+    description: |
+      Valutazione della capacità finanziaria del paziente e delle opzioni di pagamento.
+  BC-2800.40.20:
+    name: Stima dei costi
+    description: |
+      Generazione di stime dei costi a carico del paziente e dei costi totali per i servizi pianificati.
+  BC-2800.40.30:
+    name: Assistenza di beneficenza e supporto finanziario
+    description: |
+      Determinazione della eleggibilità e iscrizione a programmi di assistenza di beneficenza e di supporto finanziario.
+  BC-2800.40.40:
+    name: Configurazione del pagamento diretto
+    description: |
+      Configurazione di accordi di pagamento diretto, pagamenti anticipati e piani rateali.
+  BC-2800.50:
+    name: Gestione di ammissioni, trasferimenti e dimissioni
+    description: |
+      Gestione operativa delle ammissioni in regime di ricovero, dei trasferimenti inter-struttura,
+      dell'assegnazione del letto e della registrazione della destinazione alla dimissione.
+  BC-2800.50.10:
+    name: Ammissione in regime di ricovero
+    description: |
+      Ammissione di pazienti in servizi di ricovero da fonti programmate e non programmate.
+  BC-2800.50.20:
+    name: Trasferimento inter-struttura
+    description: |
+      Coordinamento dei trasferimenti di pazienti tra strutture e livelli di cura.
+  BC-2800.50.30:
+    name: Assegnazione del letto
+    description: |
+      Assegnazione e riassegnazione dei letti di ricovero in base all'acuità, all'isolamento e alla capacità.
+  BC-2800.50.40:
+    name: Registrazione della destinazione alla dimissione
+    description: |
+      Registrazione della destinazione alla dimissione, del collocamento post-acuto e della struttura di destinazione del trasferimento.
+  BC-2800.60:
+    name: Gestione della preparazione al servizio
+    description: |
+      Autorizzazione pre-procedurale, verifica della documentazione e attività di preparazione del
+      paziente completate prima dell'erogazione del servizio.
+  BC-2800.60.10:
+    name: Autorizzazione pre-procedurale
+    description: |
+      Autorizzazione clinica e anestesiologica per le procedure programmate.
+  BC-2800.60.20:
+    name: Verifica della documentazione richiesta
+    description: |
+      Verifica della completezza di ordini, consensi e documentazione di anamnesi e visita.
+  BC-2800.60.30:
+    name: Contatto preventivo con il paziente
+    description: |
+      Contatto preventivo con il paziente per la compilazione di moduli, la raccolta dell'anamnesi e la pre-registrazione.
+  BC-2800.60.40:
+    name: Istruzioni di preparazione per il paziente
+    description: |
+      Comunicazione al paziente delle istruzioni di preparazione pre-procedurale e pre-visita.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-patient-experience-management.yaml
+++ b/catalogue/i18n/it/L1-patient-experience-management.yaml
@@ -1,0 +1,138 @@
+# Gestione dell'esperienza del paziente (it) — translations for L1-patient-experience-management.yaml
+locale: it
+source: L1-patient-experience-management.yaml
+entries:
+  BC-2910:
+    name: Gestione dell'esperienza del paziente
+    description: |
+      Coinvolgimento del paziente, servizi digitali, misurazione della soddisfazione, tutela
+      e gestione dei reclami, diritti del paziente ed etica, e servizi di volontariato e
+      ausiliari lungo il continuum delle cure.
+  BC-2910.10:
+    name: Coinvolgimento e comunicazione con il paziente
+    description: |
+      Comunicazione multicanale con pazienti e familiari, inclusi educazione
+      e servizi linguistici.
+  BC-2910.10.10:
+    name: Comunicazione multicanale con il paziente
+    description: |
+      Comunicazione coordinata con il paziente tramite telefono, messaggistica sicura, posta e canali digitali.
+  BC-2910.10.20:
+    name: Erogazione dell'educazione sanitaria
+    description: |
+      Erogazione ai pazienti di educazione su malattie, trattamenti e prevenzione.
+  BC-2910.10.30:
+    name: Comunicazione con familiari e caregiver
+    description: |
+      Comunicazione con familiari e caregiver autorizzati durante gli episodi di cura.
+  BC-2910.10.40:
+    name: Servizi di interpretariato linguistico
+    description: |
+      Erogazione di servizi di interpretariato e traduzione linguistica.
+  BC-2910.20:
+    name: Portale del paziente e servizi digitali
+    description: |
+      Gestione dei servizi digitali rivolti ai pazienti, inclusi portale del paziente,
+      applicazioni mobili e strumenti self-service.
+  BC-2910.20.10:
+    name: Operazioni del portale del paziente
+    description: |
+      Gestione dei servizi del portale del paziente, inclusi messaggistica e accesso ai documenti.
+  BC-2910.20.20:
+    name: Operazioni delle applicazioni di salute mobile
+    description: |
+      Gestione delle applicazioni di salute mobile rivolte ai pazienti.
+  BC-2910.20.30:
+    name: Strumenti self-service per il paziente
+    description: |
+      Strumenti self-service per la pianificazione degli appuntamenti, i pagamenti e le attività pre-visita.
+  BC-2910.20.40:
+    name: Gestione dell'identità digitale del paziente
+    description: |
+      Gestione dell'identità digitale, dell'autenticazione e dell'accesso per delega del paziente.
+  BC-2910.30:
+    name: Misurazione della soddisfazione del paziente
+    description: |
+      Misurazione tramite sondaggi e in tempo reale della soddisfazione e
+      dell'esperienza del paziente.
+  BC-2910.30.10:
+    name: Operazioni dei sondaggi sull'esperienza dei ricoverati
+    description: |
+      Gestione dei programmi di sondaggio sull'esperienza dei ricoverati e analisi dei risultati.
+  BC-2910.30.20:
+    name: Sondaggi sull'esperienza ambulatoriale
+    description: |
+      Gestione dei programmi di sondaggio sull'esperienza ambulatoriale e specialistica.
+  BC-2910.30.30:
+    name: Raccolta del feedback in tempo reale
+    description: |
+      Raccolta di feedback in tempo reale e al punto di incontro dai pazienti.
+  BC-2910.30.40:
+    name: Analytics sull'esperienza del paziente
+    description: |
+      Analytics sui driver dell'esperienza, sui temi e sulle opportunità di miglioramento.
+  BC-2910.40:
+    name: Tutela del paziente e gestione dei reclami
+    description: |
+      Tutela del paziente, gestione di reclami e doglianze, e service recovery.
+  BC-2910.40.10:
+    name: Ricezione dei reclami dei pazienti
+    description: |
+      Ricezione dei reclami dei pazienti attraverso i diversi canali.
+  BC-2910.40.20:
+    name: Indagine sulle doglianze
+    description: |
+      Indagine formale e risoluzione delle doglianze dei pazienti.
+  BC-2910.40.30:
+    name: Mediatore per la tutela del paziente
+    description: |
+      Servizi di mediazione per la tutela del paziente durante gli episodi di cura.
+  BC-2910.40.40:
+    name: Service recovery
+    description: |
+      Interventi di service recovery per eventi di mancanza del servizio.
+  BC-2910.50:
+    name: Diritti del paziente ed etica
+    description: |
+      Supervisione dei diritti del paziente, dei processi di consenso informato, delle
+      direttive anticipate e della consulenza etica.
+  BC-2910.50.10:
+    name: Supervisione del processo di consenso informato
+    description: |
+      Supervisione dei processi di consenso informato per il trattamento e la ricerca.
+  BC-2910.50.20:
+    name: Gestione delle direttive anticipate
+    description: |
+      Raccolta, archiviazione e visualizzazione delle direttive anticipate e degli obiettivi di cura.
+  BC-2910.50.30:
+    name: Consulenza etica
+    description: |
+      Servizi di consulenza etica clinica per pazienti, familiari e clinici.
+  BC-2910.50.40:
+    name: Educazione ai diritti del paziente
+    description: |
+      Educazione dei pazienti sui loro diritti e responsabilità.
+  BC-2910.60:
+    name: Servizi di volontariato e ausiliari
+    description: |
+      Gestione dei programmi di volontariato e ausiliari a supporto di pazienti
+      e familiari.
+  BC-2910.60.10:
+    name: Onboarding dei volontari
+    description: |
+      Reclutamento, selezione e onboarding dei volontari.
+  BC-2910.60.20:
+    name: Erogazione dei servizi di volontariato
+    description: |
+      Coordinamento ed erogazione dei servizi di volontariato nei diversi reparti.
+  BC-2910.60.30:
+    name: Programmi ausiliari
+    description: |
+      Gestione dei programmi ausiliari, filantropici e di comunità.
+  BC-2910.60.40:
+    name: Servizi di supporto ai pazienti
+    description: |
+      Servizi di supporto quali navigazione del paziente, assistenza spirituale e sale d'attesa familiari.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-payments-card-management.yaml
+++ b/catalogue/i18n/it/L1-payments-card-management.yaml
@@ -1,0 +1,147 @@
+# Gestione dei pagamenti e delle carte (it) — translations for L1-payments-card-management.yaml
+locale: it
+source: L1-payments-card-management.yaml
+entries:
+  BC-1340:
+    name: Gestione dei pagamenti e delle carte
+    description: |
+      Iniziazione, elaborazione, compensazione e regolamento dei pagamenti, emissione carte ed elaborazione delle transazioni.
+  BC-1340.10:
+    name: Gestione dell'iniziazione dei pagamenti
+    description: |
+      Acquisizione delle disposizioni di pagamento, validazione e autorizzazione.
+  BC-1340.10.10:
+    name: Acquisizione delle disposizioni di pagamento
+    description: |
+      Acquisizione delle disposizioni di pagamento su tutti i canali.
+  BC-1340.10.20:
+    name: Validazione dei pagamenti
+    description: |
+      Validazione delle disposizioni di pagamento e dei dati del beneficiario.
+  BC-1340.10.30:
+    name: Autorizzazione dei pagamenti
+    description: |
+      Autorizzazione, autenticazione e applicazione dell'autenticazione forte (SCA).
+  BC-1340.10.40:
+    name: Pre-notifica dei pagamenti
+    description: |
+      Pre-notifica dei pagamenti e conferma del beneficiario.
+  BC-1340.20:
+    name: Gestione dell'elaborazione dei pagamenti
+    description: |
+      Elaborazione dei pagamenti, routing, formattazione e standard ISO 20022.
+  BC-1340.20.10:
+    name: Arricchimento e formattazione dei messaggi di pagamento
+    description: |
+      Arricchimento e formattazione ISO 20022 dei messaggi di pagamento.
+  BC-1340.20.20:
+    name: Routing dei pagamenti
+    description: |
+      Instradamento dei pagamenti verso i circuiti e i corrispondenti appropriati.
+  BC-1340.20.30:
+    name: Screening delle sanzioni sui pagamenti
+    description: |
+      Screening delle sanzioni e delle parti ristrette sui pagamenti.
+  BC-1340.20.40:
+    name: Gestione delle anomalie sui pagamenti
+    description: |
+      Indagine su pagamenti falliti, respinti e contestati.
+  BC-1340.30:
+    name: Gestione della compensazione e del regolamento
+    description: |
+      Compensazione domestica — ACH, BACS, SEPA, FPS — e regolamento.
+  BC-1340.30.10:
+    name: Compensazione ACH e massiva
+    description: |
+      Gestione dei circuiti ACH, BACS e di compensazione massiva.
+  BC-1340.30.20:
+    name: Operatività della compensazione SEPA
+    description: |
+      Operazioni di bonifico SEPA e addebito diretto SEPA.
+  BC-1340.30.30:
+    name: RTGS e regolamento netto differito
+    description: |
+      Operazioni di regolamento lordo in tempo reale (RTGS) e regolamento netto differito.
+  BC-1340.30.40:
+    name: Riconciliazione nostro e vostro
+    description: |
+      Riconciliazione dei conti nostro/vostro e gestione delle discrepanze.
+  BC-1340.40:
+    name: Gestione dei pagamenti transfrontalieri
+    description: |
+      Pagamenti internazionali, banca corrispondente e conversione valutaria.
+  BC-1340.40.10:
+    name: Gestione della banca corrispondente
+    description: |
+      Relazioni con le banche corrispondenti e gestione delle autorizzazioni RMA.
+  BC-1340.40.20:
+    name: Routing dei pagamenti transfrontalieri
+    description: |
+      Instradamento dei pagamenti transfrontalieri tramite SWIFT e circuiti alternativi.
+  BC-1340.40.30:
+    name: Conversione valutaria per i pagamenti
+    description: |
+      Conversione valutaria, rilevazione del tasso e tariffazione per i pagamenti.
+  BC-1340.40.40:
+    name: Tracciatura SWIFT GPI
+    description: |
+      Tracciatura dello stato SWIFT GPI e trasparenza verso il cliente.
+  BC-1340.50:
+    name: Gestione dei pagamenti in tempo reale
+    description: |
+      Circuiti di pagamento in tempo reale e istantaneo.
+  BC-1340.50.10:
+    name: Operatività dei circuiti di pagamento istantaneo
+    description: |
+      Gestione di FPS, SCT Inst e altri circuiti di pagamento istantaneo.
+  BC-1340.50.20:
+    name: Operatività del request-to-pay
+    description: |
+      Messaggistica request-to-pay e gestione del ciclo di vita.
+  BC-1340.50.30:
+    name: Liquidità per i pagamenti in tempo reale
+    description: |
+      Gestione della liquidità per i circuiti di pagamento istantaneo attivi 24/7.
+  BC-1340.60:
+    name: Gestione dell'emissione carte
+    description: |
+      Produzione, personalizzazione, spedizione e attivazione delle carte.
+  BC-1340.60.10:
+    name: Produzione e personalizzazione delle carte
+    description: |
+      Produzione, goffratura e personalizzazione delle carte.
+  BC-1340.60.20:
+    name: Spedizione e consegna delle carte
+    description: |
+      Spedizione delle carte fisiche e consegna del PIN.
+  BC-1340.60.30:
+    name: Attivazione delle carte
+    description: |
+      Flussi di attivazione delle carte e gestione del PIN.
+  BC-1340.60.40:
+    name: Provisioning di carte digitali e wallet
+    description: |
+      Emissione di carte digitali e provisioning su wallet (tokenizzazione).
+  BC-1340.70:
+    name: Gestione dell'elaborazione delle transazioni con carta
+    description: |
+      Switching, autorizzazione, screening antifrode e gestione dei chargeback.
+  BC-1340.70.10:
+    name: Switching per l'autorizzazione delle carte
+    description: |
+      Switching di autorizzazione in tempo reale e routing.
+  BC-1340.70.20:
+    name: Screening antifrode sulle carte
+    description: |
+      Screening antifrode in tempo reale delle transazioni con carta.
+  BC-1340.70.30:
+    name: Regolamento e interchange delle carte
+    description: |
+      Regolamento, interchange e compensazione con i circuiti carta.
+  BC-1340.70.40:
+    name: Gestione di chargeback e controversie
+    description: |
+      Gestione dei chargeback e risoluzione delle controversie con i circuiti.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-permits-licences-authorisations-management.yaml
+++ b/catalogue/i18n/it/L1-permits-licences-authorisations-management.yaml
@@ -1,0 +1,123 @@
+# Gestione di permessi, licenze e autorizzazioni (it) — translations for L1-permits-licences-authorisations-management.yaml
+locale: it
+source: L1-permits-licences-authorisations-management.yaml
+entries:
+  BC-3240:
+    name: Gestione di permessi, licenze e autorizzazioni
+    description: |
+      Rilascio, rinnovo, sospensione, revoca e manutenzione dei registri di permessi, licenze e autorizzazioni concessi dal governo a persone, imprese e attività, incluse le autorizzazioni professionali, ambientali e operative.
+  BC-3240.10:
+    name: Ricezione e triage delle domande
+    description: |
+      Ricezione, verifica di completezza e triage delle domande di permessi, licenze e autorizzazioni.
+  BC-3240.10.10:
+    name: Presentazione della domanda
+    description: |
+      Presentazione multicanale delle domande di permessi e licenze.
+  BC-3240.10.20:
+    name: Verifica di completezza
+    description: |
+      Verifica che le domande siano complete e soddisfino i requisiti documentali.
+  BC-3240.10.30:
+    name: Instradamento della domanda
+    description: |
+      Instradamento delle domande all'autorità di licenza e al revisore competente.
+  BC-3240.10.40:
+    name: Valutazione e riscossione dei diritti
+    description: |
+      Valutazione e riscossione dei diritti di legge per la domanda e la licenza.
+  BC-3240.20:
+    name: Valutazione dell'eleggibilità e dei requisiti
+    description: |
+      Valutazione dell'idoneità, dei requisiti e dei criteri di legge del richiedente per l'autorizzazione richiesta.
+  BC-3240.20.10:
+    name: Valutazione di idoneità e integrità
+    description: |
+      Valutazione dell'idoneità, dell'integrità e dei precedenti ostativi del richiedente.
+  BC-3240.20.20:
+    name: Verifica dei requisiti
+    description: |
+      Verifica dei titoli, delle competenze e dei prerequisiti per la licenza.
+  BC-3240.20.30:
+    name: Coordinamento dei controlli sui precedenti
+    description: |
+      Coordinamento dei controlli sui precedenti personali, penali e di sicurezza ove richiesto.
+  BC-3240.20.40:
+    name: Valutazione dell'interesse pubblico
+    description: |
+      Valutazione dei criteri di legge in materia di interesse pubblico, ambientale o urbanistico.
+  BC-3240.30:
+    name: Operazioni di rilascio e rinnovo
+    description: |
+      Decisione, rilascio e rinnovo di permessi, licenze e autorizzazioni, incluse condizioni, durata e credenziali.
+  BC-3240.30.10:
+    name: Decisione di licenza
+    description: |
+      Adozione delle decisioni di concessione, diniego o concessione condizionata di permessi e licenze.
+  BC-3240.30.20:
+    name: Emissione delle credenziali
+    description: |
+      Produzione e rilascio di credenziali di licenza fisiche e digitali.
+  BC-3240.30.30:
+    name: Gestione del rinnovo
+    description: |
+      Elaborazione delle domande di rinnovo e verifica della continuità dell'eleggibilità.
+  BC-3240.30.40:
+    name: Gestione di variazioni e integrazioni
+    description: |
+      Elaborazione di variazioni, integrazioni e modifiche delle condizioni.
+  BC-3240.40:
+    name: Ispezione e verifica della conformità
+    description: |
+      Ispezione, audit e verifica della conformità del titolare di licenza alle condizioni del permesso e agli obblighi di legge.
+  BC-3240.40.10:
+    name: Pianificazione delle ispezioni
+    description: |
+      Pianificazione e programmazione basata sul rischio delle ispezioni di conformità.
+  BC-3240.40.20:
+    name: Esecuzione delle ispezioni in loco
+    description: |
+      Esecuzione di ispezioni in loco e raccolta delle prove.
+  BC-3240.40.30:
+    name: Revisione dei rapporti di conformità
+    description: |
+      Revisione dei rapporti di conformità obbligatori e delle autocertificazioni presentate dai titolari di licenza.
+  BC-3240.50:
+    name: Sospensione, revoca e sanzione
+    description: |
+      Azioni esecutive, incluse diffide, sospensioni, revoche, sanzioni pecuniarie e misure sanzionatorie nei confronti dei titolari di licenza non conformi.
+  BC-3240.50.10:
+    name: Indagine sulla non conformità
+    description: |
+      Indagine sulle presunte violazioni delle condizioni della licenza.
+  BC-3240.50.20:
+    name: Decisione sull'azione esecutiva
+    description: |
+      Adozione delle decisioni sulle azioni esecutive, dalla diffida alla revoca.
+  BC-3240.50.30:
+    name: Emissione della sanzione pecuniaria
+    description: |
+      Emissione, registrazione e riscossione delle sanzioni pecuniarie.
+  BC-3240.50.40:
+    name: Esecuzione della sospensione e della revoca
+    description: |
+      Esecuzione dei provvedimenti di sospensione e revoca e ritiro delle credenziali.
+  BC-3240.60:
+    name: Gestione del registro delle licenze
+    description: |
+      Manutenzione e divulgazione pubblica dei registri dei permessi e delle licenze rilasciati, sospesi e revocati.
+  BC-3240.60.10:
+    name: Manutenzione del registro
+    description: |
+      Manutenzione dei registri ufficiali delle licenze e dei permessi.
+  BC-3240.60.20:
+    name: Divulgazione del registro pubblico
+    description: |
+      Pubblicazione dei registri accessibili al pubblico e dei servizi di ricerca.
+  BC-3240.60.30:
+    name: Servizi di verifica del registro
+    description: |
+      Fornitura di servizi di verifica delle credenziali alle parti che vi fanno affidamento.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-petroleum-joint-venture-management.yaml
+++ b/catalogue/i18n/it/L1-petroleum-joint-venture-management.yaml
@@ -1,0 +1,117 @@
+# Gestione delle joint venture nel settore petrolifero (it) — translations for L1-petroleum-joint-venture-management.yaml
+locale: it
+source: L1-petroleum-joint-venture-management.yaml
+entries:
+  BC-3110:
+    name: Gestione delle joint venture nel settore petrolifero
+    description: |
+      Amministrazione dei JOA a monte, concessioni e contratti di production sharing:
+      comitati operativi, approvazioni AFE, fatturazione a interesse comune, cash call,
+      obblighi di licenza, e rendicontazione ai partner e ai governi ospitanti.
+  BC-3110.10:
+    name: Amministrazione del JOA
+    description: |
+      Redazione, amministrazione e governance dei JOA inclusi i processi del comitato
+      operativo e le approvazioni AFE.
+  BC-3110.10.10:
+    name: Redazione e rinegoziazione del JOA
+    description: |
+      Redazione, revisione e rinegoziazione periodica dei JOA.
+  BC-3110.10.20:
+    name: Coordinamento del comitato operativo
+    description: |
+      Coordinamento delle riunioni di OPCOM, TECCOM e sottocomitati.
+  BC-3110.10.30:
+    name: Gestione delle autorizzazioni alle spese
+    description: |
+      Emissione, approvazione e monitoraggio delle autorizzazioni alle spese (AFE).
+  BC-3110.10.40:
+    name: Monitoraggio dei diritti di voto e delle approvazioni
+    description: |
+      Monitoraggio dei diritti di voto dei partner e delle soglie di approvazione del JOA.
+  BC-3110.20:
+    name: Fatturazione a interesse comune
+    description: |
+      Preparazione, audit e risoluzione delle controversie sulle fatture a interesse comune.
+  BC-3110.20.10:
+    name: Preparazione delle fatture a interesse comune
+    description: |
+      Preparazione delle fatture mensili a interesse comune ai partner.
+  BC-3110.20.20:
+    name: Coordinamento dell'audit JV
+    description: |
+      Coordinamento degli audit JV condotti dai partner.
+  BC-3110.20.30:
+    name: Risoluzione delle controversie JIB
+    description: |
+      Indagine e risoluzione delle controversie sulla fatturazione a interesse comune.
+  BC-3110.30:
+    name: Gestione delle cash call e dei finanziamenti
+    description: |
+      Emissione delle cash call, ricezione dei finanziamenti dei partner e gestione
+      delle inadempienze.
+  BC-3110.30.10:
+    name: Emissione delle cash call
+    description: |
+      Emissione di cash call mensili e supplementari ai partner.
+  BC-3110.30.20:
+    name: Ricezione dei finanziamenti dei partner
+    description: |
+      Ricezione e riconciliazione dei finanziamenti delle cash call dei partner.
+  BC-3110.30.30:
+    name: Gestione delle inadempienze di finanziamento
+    description: |
+      Gestione delle posizioni dei partner inadempienti secondo i rimedi del JOA.
+  BC-3110.40:
+    name: Gestione degli obblighi di licenza e concessione
+    description: |
+      Monitoraggio degli impegni del programma di lavoro, delle royalty e degli
+      obblighi di restituzione della licenza.
+  BC-3110.40.10:
+    name: Monitoraggio degli impegni del programma di lavoro
+    description: |
+      Monitoraggio degli obblighi minimi di lavoro e degli impegni esplorativi.
+  BC-3110.40.20:
+    name: Calcolo delle royalty sulla concessione
+    description: |
+      Calcolo delle royalty dovute ai governi ospitanti secondo i termini della concessione.
+  BC-3110.40.30:
+    name: Gestione della restituzione della licenza
+    description: |
+      Gestione della restituzione parziale e totale della licenza.
+  BC-3110.50:
+    name: Rendicontazione al governo ospitante e ai partner
+    description: |
+      Rendicontazione ai governi ospitanti secondo i termini del PSA e ai partner
+      secondo i termini del JOA.
+  BC-3110.50.10:
+    name: Rendicontazione al governo ospitante
+    description: |
+      Rendicontazione di operazioni, costi e produzione ai governi ospitanti.
+  BC-3110.50.20:
+    name: Rendicontazione del contratto di production sharing
+    description: |
+      Rendicontazione del recupero costi, del profit oil e del lifting secondo i termini del PSA.
+  BC-3110.50.30:
+    name: Rendicontazione delle performance dei partner
+    description: |
+      Rendicontazione operativa e finanziaria periodica ai partner JV.
+  BC-3110.60:
+    name: Gestione delle partecipazioni non operate
+    description: |
+      Gestione delle partecipazioni azionarie nelle JV operate da altre parti.
+  BC-3110.60.10:
+    name: Monitoraggio della posizione non operata
+    description: |
+      Monitoraggio delle attività dell'operatore e delle performance JV dal punto di vista non operato.
+  BC-3110.60.20:
+    name: Espressione del voto nelle partecipazioni non operate
+    description: |
+      Revisione interna ed espressione dei voti sui programmi di lavoro proposti dall'operatore.
+  BC-3110.60.30:
+    name: Verifica dei costi della partecipazione non operata
+    description: |
+      Verifica dei costi addebitati dall'operatore rispetto alle procedure contabili del JOA.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-petroleum-process-safety-management.yaml
+++ b/catalogue/i18n/it/L1-petroleum-process-safety-management.yaml
@@ -1,0 +1,156 @@
+# Gestione della sicurezza di processo nel settore petrolifero (it) — translations for L1-petroleum-process-safety-management.yaml
+locale: it
+source: L1-petroleum-process-safety-management.yaml
+entries:
+  BC-3050:
+    name: Gestione della sicurezza di processo nel settore petrolifero
+    description: |
+      Prevenzione dei rischi di incidente grave negli impianti di trattamento
+      di idrocarburi: analisi dei pericoli di processo, integrità meccanica dei
+      sistemi in pressione, assurance degli elementi safety-critical, procedure
+      operative, rendicontazione delle performance e risposta alle emergenze.
+      Distinto dalla gestione HSE cross-industry (BC-730), che include la salute
+      occupazionale, l'ambiente e la sicurezza personale.
+  BC-3050.10:
+    name: Analisi dei pericoli di processo
+    description: |
+      Identificazione e analisi strutturata dei rischi di incidente grave
+      nel ciclo di vita dell'asset.
+    in_scope:
+      - HAZID, HAZOP, LOPA e analisi bow-tie
+      - Valutazione quantitativa del rischio
+    out_of_scope:
+      - Valutazione del rischio per la sicurezza personale (BC-730)
+  BC-3050.10.10:
+    name: Studi HAZOP
+    description: |
+      Studi di pericolo e operabilità su impianti nuovi e modificati.
+  BC-3050.10.20:
+    name: Studi HAZID
+    description: |
+      Studi di identificazione dei pericoli nelle fasi preliminari di concetto e progettazione.
+  BC-3050.10.30:
+    name: Studi LOPA
+    description: |
+      Analisi LOPA per la definizione dei livelli di integrità della sicurezza SIL.
+  BC-3050.10.40:
+    name: Analisi bow-tie
+    description: |
+      Analisi bow-tie per la mappatura delle barriere rispetto agli scenari di incidente grave.
+  BC-3050.20:
+    name: Gestione dell'integrità meccanica
+    description: |
+      Ispezione e gestione dell'integrità delle apparecchiature in pressione
+      e dei dispositivi di sicurezza di scarico.
+  BC-3050.20.10:
+    name: Ispezione dei recipienti in pressione
+    description: |
+      Ispezione basata sul rischio dei recipienti in pressione secondo API 510.
+  BC-3050.20.20:
+    name: Ispezione di tubazioni e pipeline
+    description: |
+      Ispezione di tubazioni di processo e pipeline secondo API 570 e ASME B31G.
+  BC-3050.20.30:
+    name: Ispezione dei serbatoi di stoccaggio
+    description: |
+      Ispezione dei serbatoi di stoccaggio atmosferici e pressurizzati secondo API 653.
+  BC-3050.20.40:
+    name: Gestione dei dispositivi di scarico della pressione
+    description: |
+      Dimensionamento, collaudo e gestione del ciclo di vita delle valvole di sicurezza e dei dischi di rottura.
+  BC-3050.30:
+    name: Gestione degli elementi safety-critical
+    description: |
+      Identificazione e assurance delle performance degli elementi safety-critical
+      e mantenimento del safety case.
+  BC-3050.30.10:
+    name: Identificazione degli elementi safety-critical
+    description: |
+      Identificazione degli SCE dall'analisi dei rischi di incidente grave.
+  BC-3050.30.20:
+    name: Definizione degli standard di performance
+    description: |
+      Definizione degli standard di performance per ogni SCE.
+  BC-3050.30.30:
+    name: Verifica delle performance degli elementi safety-critical
+    description: |
+      Verifica delle performance degli SCE rispetto agli standard definiti.
+  BC-3050.30.40:
+    name: Mantenimento del safety case
+    description: |
+      Mantenimento dei safety case dell'impianto e presentazione alle autorità di regolamentazione.
+  BC-3050.40:
+    name: Procedure operative di sicurezza di processo
+    description: |
+      Redazione, revisione e definizione dell'inviluppo operativo per le procedure
+      critiche per la sicurezza di processo.
+  BC-3050.40.10:
+    name: Redazione delle procedure operative
+    description: |
+      Redazione di procedure operative critiche per la sicurezza di processo.
+  BC-3050.40.20:
+    name: Revisione e aggiornamento delle procedure
+    description: |
+      Revisione e aggiornamento periodici delle procedure di sicurezza di processo.
+  BC-3050.40.30:
+    name: Definizione dell'inviluppo operativo
+    description: |
+      Definizione degli inviluppi operativi sicuri per le unità di processo.
+  BC-3050.50:
+    name: MOC della sicurezza di processo
+    description: |
+      Governance della sicurezza di processo sulle modifiche di impianto, procedurali
+      e di personale, inclusa la revisione pre-avviamento.
+  BC-3050.50.10:
+    name: Revisione delle richieste di modifica PSM
+    description: |
+      Revisione delle richieste di modifica con impatto PSM rispetto agli standard di pericolo.
+  BC-3050.50.20:
+    name: Revisione della sicurezza pre-avviamento
+    description: |
+      Revisioni della sicurezza pre-avviamento per impianti nuovi e modificati.
+  BC-3050.50.30:
+    name: Gestione delle modifiche temporanee
+    description: |
+      Gestione delle modifiche di processo temporanee nell'arco di tempo autorizzato.
+  BC-3050.60:
+    name: Gestione delle performance di sicurezza di processo
+    description: |
+      Monitoraggio e rendicontazione degli indicatori leading e lagging di sicurezza
+      di processo secondo API RP 754 e framework equivalenti.
+  BC-3050.60.10:
+    name: Rendicontazione degli eventi di sicurezza di processo di livello 1 e 2
+    description: |
+      Registrazione e rendicontazione degli eventi di sicurezza di processo di livello 1 e 2.
+  BC-3050.60.20:
+    name: Monitoraggio degli indicatori leading
+    description: |
+      Monitoraggio degli indicatori leading di sicurezza di processo di livello 3 e 4.
+  BC-3050.60.30:
+    name: Rendicontazione dei KPI di sicurezza di processo
+    description: |
+      Rendicontazione interna ed esterna dei KPI di sicurezza di processo.
+  BC-3050.70:
+    name: Preparazione e risposta alle emergenze
+    description: |
+      Pianificazione della risposta alle emergenze, esecuzione di esercitazioni e
+      coordinamento della risposta agli sversamenti per gli scenari di incidente grave.
+  BC-3050.70.10:
+    name: Pianificazione della risposta alle emergenze
+    description: |
+      Mantenimento dei piani di risposta alle emergenze dell'impianto e aziendali.
+  BC-3050.70.20:
+    name: Coordinamento delle esercitazioni
+    description: |
+      Coordinamento delle esercitazioni di emergenza e degli esercizi per incidenti gravi.
+  BC-3050.70.30:
+    name: Coordinamento della risposta agli sversamenti
+    description: |
+      Coordinamento delle operazioni di risposta agli sversamenti di petrolio e prodotti chimici.
+  BC-3050.70.40:
+    name: Coordinamento del mutuo soccorso
+    description: |
+      Coordinamento del mutuo soccorso con le cooperative di risposta del settore.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-pharmaceutical-commercial-management.yaml
+++ b/catalogue/i18n/it/L1-pharmaceutical-commercial-management.yaml
@@ -1,0 +1,111 @@
+# Gestione commerciale farmaceutica (it) — translations for L1-pharmaceutical-commercial-management.yaml
+locale: it
+source: L1-pharmaceutical-commercial-management.yaml
+entries:
+  BC-1590:
+    name: Gestione commerciale farmaceutica
+    description: |
+      Engagement con i professionisti sanitari, campioni, materiale promozionale, forza vendita, brand, engagement del paziente.
+  BC-1590.10:
+    name: Gestione dell'engagement con i professionisti sanitari
+    description: |
+      Programmi di engagement con i professionisti sanitari, interazioni della forza vendita.
+  BC-1590.10.10:
+    name: Targeting e segmentazione dei professionisti sanitari
+    description: |
+      Targeting e segmentazione dei professionisti sanitari.
+  BC-1590.10.20:
+    name: Engagement multicanale dei professionisti sanitari
+    description: |
+      Orchestrazione dell'engagement multicanale con i professionisti sanitari.
+  BC-1590.10.30:
+    name: Reportistica sulla trasparenza verso i professionisti sanitari
+    description: |
+      Reportistica di trasparenza secondo il Sunshine Act e EFPIA.
+  BC-1590.20:
+    name: Gestione dei campioni
+    description: |
+      Distribuzione dei campioni, accountability, conformità regolatoria.
+  BC-1590.20.10:
+    name: Richiesta e distribuzione dei campioni
+    description: |
+      Gestione delle richieste e distribuzione dei campioni ai professionisti sanitari.
+  BC-1590.20.20:
+    name: Accountability e riconciliazione dei campioni
+    description: |
+      Accountability e riconciliazione dei campioni conforme al PDMA.
+  BC-1590.20.30:
+    name: Audit di conformità sui campioni
+    description: |
+      Audit sulle pratiche di distribuzione dei campioni.
+  BC-1590.30:
+    name: Gestione dei materiali promozionali
+    description: |
+      Sviluppo del materiale promozionale, revisione MLR, governance.
+  BC-1590.30.10:
+    name: Redazione del materiale promozionale
+    description: |
+      Redazione di materiale promozionale e contenuti.
+  BC-1590.30.20:
+    name: Revisione medica, legale e regolatoria
+    description: |
+      Flusso di revisione e approvazione MLR dei contenuti promozionali.
+  BC-1590.30.30:
+    name: Distribuzione del materiale promozionale
+    description: |
+      Distribuzione dei materiali promozionali approvati.
+  BC-1590.40:
+    name: Gestione della forza vendita farmaceutica
+    description: |
+      Pianificazione del field force, territorio, targeting, deployment.
+  BC-1590.40.10:
+    name: Dimensionamento della forza vendita
+    description: |
+      Dimensionamento e progettazione della struttura della forza vendita.
+  BC-1590.40.20:
+    name: Progettazione del territorio di vendita
+    description: |
+      Progettazione e allineamento del territorio di vendita farmaceutico.
+  BC-1590.40.30:
+    name: Targeting della forza vendita
+    description: |
+      Targeting e pianificazione delle chiamate per i rappresentanti scientifici.
+  BC-1590.40.40:
+    name: Misurazione dell'efficacia della forza vendita
+    description: |
+      Misurazione e miglioramento dell'efficacia della forza vendita.
+  BC-1590.50:
+    name: Gestione del brand farmaceutico
+    description: |
+      Strategia di brand, posizionamento, ciclo di vita.
+  BC-1590.50.10:
+    name: Strategia del brand farmaceutico
+    description: |
+      Strategia e posizionamento del brand per indicazione.
+  BC-1590.50.20:
+    name: Forecasting del brand
+    description: |
+      Forecasting a livello di brand e demand sensing.
+  BC-1590.50.30:
+    name: Pianificazione del brand nel ciclo di vita
+    description: |
+      Pianificazione del brand nel ciclo di vita, inclusa la perdita di esclusività.
+  BC-1590.60:
+    name: Gestione dell'engagement del paziente
+    description: |
+      Programmi per i pazienti, servizi di supporto, patient advocacy.
+  BC-1590.60.10:
+    name: Operatività dei programmi di supporto al paziente
+    description: |
+      Gestione dei programmi di supporto e aderenza terapeutica per i pazienti.
+  BC-1590.60.20:
+    name: Engagement con le organizzazioni di patient advocacy
+    description: |
+      Engagement con le organizzazioni di patient advocacy.
+  BC-1590.60.30:
+    name: Raccolta degli insight del paziente
+    description: |
+      Raccolta e integrazione degli insight del paziente e dei PRO.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-pharmaceutical-manufacturing-management.yaml
+++ b/catalogue/i18n/it/L1-pharmaceutical-manufacturing-management.yaml
@@ -1,0 +1,139 @@
+# Gestione della produzione farmaceutica (it) — translations for L1-pharmaceutical-manufacturing-management.yaml
+locale: it
+source: L1-pharmaceutical-manufacturing-management.yaml
+entries:
+  BC-1550:
+    name: Gestione della produzione farmaceutica
+    description: |
+      Produzione GMP-conforme di API (principio attivo) e prodotti medicinali.
+  BC-1550.10:
+    name: Gestione della produzione dell'API
+    description: |
+      Produzione del principio attivo farmaceutico (API).
+  BC-1550.10.10:
+    name: Sintesi dell'API small molecule
+    description: |
+      Sintesi di principi attivi farmaceutici (API) di piccola molecola.
+  BC-1550.10.20:
+    name: Produzione dell'API biologico
+    description: |
+      Produzione di API biologici mediante coltura cellulare e fermentazione.
+  BC-1550.10.30:
+    name: Purificazione dell'API
+    description: |
+      Purificazione a valle dei principi attivi farmaceutici.
+  BC-1550.20:
+    name: Gestione della produzione del prodotto medicinale
+    description: |
+      Produzione del prodotto medicinale: compresse, capsule, liquidi, biologici.
+  BC-1550.20.10:
+    name: Produzione di forme farmaceutiche solide
+    description: |
+      Operazioni di produzione di compresse e capsule.
+  BC-1550.20.20:
+    name: Produzione di forme liquide e semi-solide
+    description: |
+      Produzione di forme farmaceutiche liquide, sospensioni e semi-solide.
+  BC-1550.20.30:
+    name: Riempimento e confezionamento del prodotto medicinale biologico
+    description: |
+      Riempimento e confezionamento di prodotti medicinali biologici.
+  BC-1550.20.40:
+    name: Produzione di forme per inalazione e specialistiche
+    description: |
+      Produzione di forme inalatorie, transdermiche e specialistiche.
+  BC-1550.30:
+    name: Gestione della produzione sterile
+    description: |
+      Produzione asettica e con sterilizzazione terminale.
+  BC-1550.30.10:
+    name: Operazioni di riempimento asettico
+    description: |
+      Riempimento asettico secondo i requisiti dell'Annesso 1.
+  BC-1550.30.20:
+    name: Operazioni di sterilizzazione terminale
+    description: |
+      Processi di sterilizzazione terminale.
+  BC-1550.30.30:
+    name: Operazioni in camera bianca
+    description: |
+      Gestione delle camere bianche classificate e monitoraggio ambientale.
+  BC-1550.40:
+    name: Gestione del confezionamento e dell'etichettatura
+    description: |
+      Confezionamento primario e secondario, operazioni di etichettatura.
+  BC-1550.40.10:
+    name: Operazioni di confezionamento primario
+    description: |
+      Confezionamento primario dei prodotti medicinali.
+  BC-1550.40.20:
+    name: Operazioni di confezionamento secondario
+    description: |
+      Confezionamento secondario, inscatolamento e raggruppamento.
+  BC-1550.40.30:
+    name: Applicazione dell'etichettatura
+    description: |
+      Apposizione di etichette e marchi di serializzazione.
+  BC-1550.40.40:
+    name: Personalizzazione tardiva
+    description: |
+      Personalizzazione tardiva e confezionamento specifico per paese.
+  BC-1550.50:
+    name: Gestione della validazione e qualifica
+    description: |
+      Validazione di processo, attrezzature, pulizia e sistemi informatizzati.
+  BC-1550.50.10:
+    name: Validazione del processo
+    description: |
+      Validazione del processo allineata all'ICH Q7.
+  BC-1550.50.20:
+    name: Qualifica delle attrezzature
+    description: |
+      Qualifica IQ, OQ, PQ delle attrezzature GMP.
+  BC-1550.50.30:
+    name: Validazione della pulizia
+    description: |
+      Validazione della pulizia tra i changeover di prodotto.
+  BC-1550.50.40:
+    name: Validazione dei sistemi informatizzati
+    description: |
+      Validazione dei sistemi informatizzati (CSV) secondo GAMP 5 e 21 CFR Part 11.
+  BC-1550.60:
+    name: Gestione del tech transfer
+    description: |
+      Tech transfer tra siti, attività di scale-up.
+  BC-1550.60.10:
+    name: Pianificazione del tech transfer
+    description: |
+      Pianificazione del trasferimento tecnologico tra siti.
+  BC-1550.60.20:
+    name: Scale-up del processo
+    description: |
+      Scale-up dalla scala pilota alla scala di produzione commerciale.
+  BC-1550.60.30:
+    name: Verifica della disponibilità del sito ricevente
+    description: |
+      Verifica della disponibilità del sito ricevente per il tech transfer.
+  BC-1550.70:
+    name: Gestione delle operazioni di produzione GMP
+    description: |
+      Produzione GMP quotidiana, esecuzione della scheda batch.
+  BC-1550.70.10:
+    name: Esecuzione della scheda batch
+    description: |
+      Esecuzione di schede batch cartacee o elettroniche.
+  BC-1550.70.20:
+    name: Campionamento dei controlli in-process
+    description: |
+      Campionamento e analisi dei controlli in-process.
+  BC-1550.70.30:
+    name: Bonifica della linea di produzione
+    description: |
+      Operazioni di bonifica della linea e changeover.
+  BC-1550.70.40:
+    name: Formazione GMP degli operatori
+    description: |
+      Formazione e qualifica GMP degli operatori.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-pharmaceutical-quality-management.yaml
+++ b/catalogue/i18n/it/L1-pharmaceutical-quality-management.yaml
@@ -1,0 +1,143 @@
+# Gestione della qualità farmaceutica (it) — translations for L1-pharmaceutical-quality-management.yaml
+locale: it
+source: L1-pharmaceutical-quality-management.yaml
+entries:
+  BC-1560:
+    name: Gestione della qualità farmaceutica
+    description: |
+      Sistemi di qualità GxP, deviazioni/CAPA, controllo delle modifiche, rilascio del lotto.
+  BC-1560.10:
+    name: Gestione della conformità GMP
+    description: |
+      Framework di conformità GMP, preparazione alle ispezioni regolatorie.
+  BC-1560.10.10:
+    name: QMS GMP
+    description: |
+      Manutenzione del QMS allineato all'ICH Q10.
+  BC-1560.10.20:
+    name: Preparazione alle ispezioni GMP
+    description: |
+      Preparazione alle ispezioni di FDA, EMA e PMDA.
+  BC-1560.10.30:
+    name: Programma di audit GMP
+    description: |
+      Programma di audit GMP interno.
+  BC-1560.20:
+    name: Gestione del controllo qualità GxP
+    description: |
+      Laboratori di controllo qualità (QC), analisi, studio di stabilità.
+  BC-1560.20.10:
+    name: Operazioni del laboratorio QC
+    description: |
+      Gestione dei laboratori QC GMP.
+  BC-1560.20.20:
+    name: Trasferimento del metodo analitico
+    description: |
+      Trasferimento dei metodi analitici ai siti QC.
+  BC-1560.20.30:
+    name: Studio di stabilità
+    description: |
+      Studio di stabilità secondo ICH Q1.
+  BC-1560.20.40:
+    name: Indagine OOS (fuori specifica)
+    description: |
+      Indagine dei risultati OOS (fuori specifica).
+  BC-1560.30:
+    name: Gestione della garanzia della qualità GxP
+    description: |
+      Revisione QA, revisione della scheda batch, supervisione.
+  BC-1560.30.10:
+    name: Revisione della scheda batch
+    description: |
+      Revisione QA delle schede batch eseguite.
+  BC-1560.30.20:
+    name: Gestione documentale GxP
+    description: |
+      Gestione dei documenti controllati GxP.
+  BC-1560.30.30:
+    name: Supervisione QA delle operazioni
+    description: |
+      Supervisione QA in floor delle operazioni produttive.
+  BC-1560.40:
+    name: Gestione delle deviazioni e CAPA
+    description: |
+      Gestione delle deviazioni, CAPA, verifiche di efficacia.
+  BC-1560.40.10:
+    name: Gestione delle deviazioni GxP
+    description: |
+      Rilevazione, indagine e chiusura delle deviazioni GxP.
+  BC-1560.40.20:
+    name: Gestione delle CAPA GxP
+    description: |
+      Gestione delle CAPA con analisi delle cause radice.
+  BC-1560.40.30:
+    name: Verifica dell'efficacia delle CAPA
+    description: |
+      Verifica dell'efficacia delle CAPA implementate.
+  BC-1560.50:
+    name: Gestione del controllo delle modifiche GxP
+    description: |
+      Controllo delle modifiche GxP, valutazione dell'impatto.
+  BC-1560.50.10:
+    name: Rilevazione delle richieste di modifica GxP
+    description: |
+      Rilevazione e classificazione delle richieste di modifica GxP.
+  BC-1560.50.20:
+    name: Valutazione dell'impatto delle modifiche GxP
+    description: |
+      Valutazione dell'impatto delle modifiche GxP sulla qualità del prodotto.
+  BC-1560.50.30:
+    name: Tracciamento dell'implementazione delle modifiche GxP
+    description: |
+      Tracciamento dell'implementazione delle modifiche GxP approvate.
+  BC-1560.60:
+    name: Gestione della qualità dei fornitori farmaceutici
+    description: |
+      Qualifica del fornitore, audit, accordi sulla qualità.
+  BC-1560.60.10:
+    name: Qualifica GMP del fornitore
+    description: |
+      Qualifica dei fornitori di materiali e servizi GMP.
+  BC-1560.60.20:
+    name: Audit GMP del fornitore
+    description: |
+      Audit GMP in loco presso i fornitori.
+  BC-1560.60.30:
+    name: Gestione degli accordi sulla qualità
+    description: |
+      Negoziazione e manutenzione degli accordi sulla qualità.
+  BC-1560.70:
+    name: Gestione del rilascio del lotto
+    description: |
+      Rilascio da parte del QP (qualified person), certificazione del lotto.
+  BC-1560.70.10:
+    name: Decisione di disposizione del lotto
+    description: |
+      Decisione di disposizione sui lotti prodotti.
+  BC-1560.70.20:
+    name: Certificazione del QP (qualified person)
+    description: |
+      Certificazione del QP (qualified person) secondo EU Annesso 16.
+  BC-1560.70.30:
+    name: Coordinamento del rilascio sul mercato
+    description: |
+      Coordinamento del rilascio sul mercato nelle diverse regioni.
+  BC-1560.80:
+    name: Gestione della revisione annuale della qualità del prodotto
+    description: |
+      APQR/APR, analisi dei trend di qualità del prodotto.
+  BC-1560.80.10:
+    name: Produzione dell'APQR
+    description: |
+      Produzione delle revisioni annuali della qualità del prodotto (APQR).
+  BC-1560.80.20:
+    name: Analisi dei trend di qualità del prodotto
+    description: |
+      Analisi dei trend dei dati di qualità del prodotto nel tempo.
+  BC-1560.80.30:
+    name: Tracciamento delle azioni derivanti dall'APQR
+    description: |
+      Tracciamento delle azioni derivanti dalle conclusioni dell'APQR.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-pharmaceutical-supply-chain-management.yaml
+++ b/catalogue/i18n/it/L1-pharmaceutical-supply-chain-management.yaml
@@ -1,0 +1,99 @@
+# Gestione della supply chain farmaceutica (it) — translations for L1-pharmaceutical-supply-chain-management.yaml
+locale: it
+source: L1-pharmaceutical-supply-chain-management.yaml
+entries:
+  BC-1570:
+    name: Gestione della supply chain farmaceutica
+    description: |
+      Catena del freddo, serializzazione, distribuzione farmaceutica, logistica.
+  BC-1570.10:
+    name: Gestione della catena del freddo
+    description: |
+      Supply chain a temperatura controllata, GDP.
+  BC-1570.10.10:
+    name: Progettazione della catena del freddo
+    description: |
+      Progettazione e qualifica delle soluzioni per la catena del freddo.
+  BC-1570.10.20:
+    name: Monitoraggio della temperatura
+    description: |
+      Monitoraggio end-to-end della temperatura lungo la catena del freddo.
+  BC-1570.10.30:
+    name: Gestione delle escursioni termiche
+    description: |
+      Indagine e disposizione delle escursioni termiche.
+  BC-1570.20:
+    name: Gestione della serializzazione e del tracciamento
+    description: |
+      Serializzazione, aggregazione, anti-contraffazione.
+  BC-1570.20.10:
+    name: Gestione dei numeri seriali
+    description: |
+      Generazione e assegnazione dei numeri seriali per mercato.
+  BC-1570.20.20:
+    name: Gestione dell'aggregazione e della gerarchia
+    description: |
+      Aggregazione delle unità serializzate in bundle e pallet.
+  BC-1570.20.30:
+    name: Reportistica regolatoria e verifica
+    description: |
+      Reportistica regolatoria (DSCSA, EU FMD) e verifica alla dispensazione.
+  BC-1570.30:
+    name: Gestione della distribuzione farmaceutica
+    description: |
+      Distribuzione a grossisti, ospedali e farmacie.
+  BC-1570.30.10:
+    name: Operazioni di grossisti e distributori
+    description: |
+      Operazioni di distribuzione a grossisti e distributori.
+  BC-1570.30.20:
+    name: Distribuzione diretta agli ospedali
+    description: |
+      Distribuzione diretta agli ospedali e alle farmacie.
+  BC-1570.30.30:
+    name: Distribuzione specialistica
+    description: |
+      Distribuzione specialistica per prodotti a distribuzione limitata.
+  BC-1570.40:
+    name: Gestione delle scorte farmaceutiche
+    description: |
+      Scorte farmaceutiche, scadenza, allocazione.
+  BC-1570.40.10:
+    name: Pianificazione delle scorte farmaceutiche
+    description: |
+      Pianificazione delle scorte per prodotti farmaceutici.
+  BC-1570.40.20:
+    name: Gestione della scadenza e della shelf-life
+    description: |
+      Gestione FEFO e monitoraggio della shelf-life.
+  BC-1570.40.30:
+    name: Allocazione farmaceutica
+    description: |
+      Allocazione della fornitura vincolata tra i mercati.
+  BC-1570.40.40:
+    name: Coordinamento dei ritiri e delle revoche
+    description: |
+      Coordinamento delle operazioni di ritiro e revoca del prodotto.
+  BC-1570.50:
+    name: Gestione della logistica farmaceutica
+    description: |
+      Trasporto, magazzinaggio, logistica GDP-conforme.
+  BC-1570.50.10:
+    name: Trasporto GDP-conforme
+    description: |
+      Operazioni di trasporto conformi alla GDP.
+  BC-1570.50.20:
+    name: Magazzinaggio GDP-conforme
+    description: |
+      Operazioni di magazzinaggio conformi alla GDP.
+  BC-1570.50.30:
+    name: Operazioni doganali farmaceutiche
+    description: |
+      Operazioni doganali farmaceutiche e di importazione/esportazione.
+  BC-1570.50.40:
+    name: Gestione dei fornitori di servizi logistici
+    description: |
+      Gestione dei fornitori 3PL nella supply chain farmaceutica.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-pharmacovigilance-management.yaml
+++ b/catalogue/i18n/it/L1-pharmacovigilance-management.yaml
@@ -1,0 +1,99 @@
+# Gestione della farmacovigilanza (it) — translations for L1-pharmacovigilance-management.yaml
+locale: it
+source: L1-pharmacovigilance-management.yaml
+entries:
+  BC-1540:
+    name: Gestione della farmacovigilanza
+    description: |
+      Monitoraggio degli eventi avversi, rilevamento dei segnali di rischio, reportistica sulla sicurezza.
+  BC-1540.10:
+    name: Gestione dei casi di eventi avversi
+    description: |
+      Elaborazione degli ICSR, reportistica expedited.
+  BC-1540.10.10:
+    name: Ricezione e triage degli ICSR
+    description: |
+      Ricezione e triage dei report individuali di sicurezza (ICSR).
+  BC-1540.10.20:
+    name: Elaborazione dei casi ICSR
+    description: |
+      Elaborazione, codifica e redazione della narrativa degli ICSR.
+  BC-1540.10.30:
+    name: Reportistica expedited e periodica
+    description: |
+      Reportistica expedited secondo ICH E2D ed EU GVP.
+  BC-1540.10.40:
+    name: Revisione medica e valutazione del nesso causale
+    description: |
+      Revisione medica e valutazione del nesso causale dei casi.
+  BC-1540.20:
+    name: Rilevamento e gestione dei segnali di rischio
+    description: |
+      Rilevamento dei segnali di rischio, valutazione, escalation.
+  BC-1540.20.10:
+    name: Rilevamento dei segnali di rischio
+    description: |
+      Rilevamento quantitativo e qualitativo dei segnali di rischio.
+  BC-1540.20.20:
+    name: Valutazione dei segnali di rischio
+    description: |
+      Valutazione e convalida dei segnali di rischio rilevati.
+  BC-1540.20.30:
+    name: Disposizione e azioni sui segnali di rischio
+    description: |
+      Disposizione dei segnali di rischio in azioni e modifiche all'etichettatura.
+  BC-1540.30:
+    name: Gestione della reportistica periodica sulla sicurezza
+    description: |
+      PSUR/PBRER, DSUR, rapporti periodici.
+  BC-1540.30.10:
+    name: Produzione di PSUR/PBRER
+    description: |
+      Produzione di PSUR e PBRER.
+  BC-1540.30.20:
+    name: Produzione di DSUR
+    description: |
+      Produzione dei Development Safety Update Report (DSUR).
+  BC-1540.30.30:
+    name: Reportistica aggregata sulla sicurezza
+    description: |
+      Produzione di altri rapporti aggregati sulla sicurezza.
+  BC-1540.40:
+    name: Gestione del piano di gestione del rischio
+    description: |
+      RMP, misure di minimizzazione del rischio, REMS.
+  BC-1540.40.10:
+    name: Redazione del piano di gestione del rischio
+    description: |
+      Redazione dei piani di gestione del rischio (RMP) UE e dei documenti REMS.
+  BC-1540.40.20:
+    name: Implementazione della minimizzazione del rischio
+    description: |
+      Implementazione delle misure di minimizzazione del rischio di routine e addizionali.
+  BC-1540.40.30:
+    name: Valutazione dell'efficacia della minimizzazione del rischio
+    description: |
+      Valutazione dell'efficacia delle misure di minimizzazione del rischio.
+  BC-1540.50:
+    name: Gestione degli audit e delle ispezioni di farmacovigilanza
+    description: |
+      Audit PV, ispezioni delle autorità regolatorie, CAPA.
+  BC-1540.50.10:
+    name: Programma di audit del sistema di farmacovigilanza
+    description: |
+      Programma di audit interno del sistema di farmacovigilanza (PV).
+  BC-1540.50.20:
+    name: Preparazione alle ispezioni di farmacovigilanza
+    description: |
+      Preparazione alle ispezioni di farmacovigilanza delle autorità sanitarie.
+  BC-1540.50.30:
+    name: Gestione delle CAPA di farmacovigilanza
+    description: |
+      Gestione delle CAPA derivanti da audit e ispezioni.
+  BC-1540.50.40:
+    name: Manutenzione del PSMF
+    description: |
+      Manutenzione del Pharmacovigilance System Master File (PSMF).
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-pharmacy-medication-management.yaml
+++ b/catalogue/i18n/it/L1-pharmacy-medication-management.yaml
@@ -1,0 +1,139 @@
+# Gestione della farmacia e dei farmaci (it) — translations for L1-pharmacy-medication-management.yaml
+locale: it
+source: L1-pharmacy-medication-management.yaml
+entries:
+  BC-2850:
+    name: Gestione della farmacia e dei farmaci
+    description: |
+      Operazioni farmaceutiche del lato erogatore, inclusi prontuario farmaceutico, dispensazione
+      in regime di ricovero e ambulatoriale, somministrazione e riconciliazione farmacologica,
+      stewardship delle sostanze controllate e servizi di farmacia clinica.
+  BC-2850.10:
+    name: Gestione del prontuario farmaceutico
+    description: |
+      Gestione del prontuario farmaceutico, dell'interscambio terapeutico e
+      della risposta alla carenza di farmaci.
+  BC-2850.10.10:
+    name: Decisioni sul prontuario farmaceutico
+    description: |
+      Decisioni basate sulle prove di efficacia per l'inclusione, l'esclusione e la classificazione in fasce dei farmaci nel prontuario.
+  BC-2850.10.20:
+    name: Interscambio terapeutico
+    description: |
+      Gestione ed esecuzione dei protocolli di interscambio terapeutico.
+  BC-2850.10.30:
+    name: Supporto al comitato farmaceutico e terapeutico
+    description: |
+      Supporto operativo al comitato farmaceutico e terapeutico.
+  BC-2850.10.40:
+    name: Gestione della carenza di farmaci
+    description: |
+      Identificazione, mitigazione e pianificazione della sostituzione in caso di carenza di farmaci.
+  BC-2850.20:
+    name: Operazioni della farmacia ospedaliera
+    description: |
+      Verifica degli ordini, preparazione galenica sterile e non sterile, dispensazione
+      e preparazione di farmaci endovenosi per i servizi in regime di ricovero.
+  BC-2850.20.10:
+    name: Verifica degli ordini farmacologici
+    description: |
+      Verifica farmaceutica degli ordini farmacologici per la sicurezza e l'appropriatezza.
+  BC-2850.20.20:
+    name: Preparazione galenica sterile
+    description: |
+      Operazioni di preparazione galenica sterile, inclusa la preparazione di farmaci pericolosi.
+  BC-2850.20.30:
+    name: Dispensazione in dose unitaria
+    description: |
+      Preparazione e dispensazione in dose unitaria per la somministrazione in regime di ricovero.
+  BC-2850.20.40:
+    name: Preparazione farmaci endovenosi
+    description: |
+      Preparazione di farmaci endovenosi, infusioni e nutrizione parenterale.
+  BC-2850.30:
+    name: Operazioni della farmacia ambulatoriale e specialistica
+    description: |
+      Operazioni di farmacia al dettaglio, specialistica e per corrispondenza, incluse
+      le operazioni dei programmi di distribuzione a prezzo scontato.
+  BC-2850.30.10:
+    name: Dispensazione al dettaglio
+    description: |
+      Dispensazione di ricette al dettaglio nelle farmacie ambulatoriali.
+  BC-2850.30.20:
+    name: Gestione dei farmaci specialistici
+    description: |
+      Operazioni di farmacia specialistica per farmaci ad alto costo e a distribuzione limitata.
+  BC-2850.30.30:
+    name: Evasione degli ordini per corrispondenza
+    description: |
+      Operazioni di evasione e consegna delle ricette per corrispondenza.
+  BC-2850.30.40:
+    name: Operazioni dei programmi di distribuzione a prezzo scontato
+    description: |
+      Operazioni per i programmi statutari di distribuzione di farmaci a prezzo scontato e conformità degli enti qualificati.
+  BC-2850.40:
+    name: Somministrazione e riconciliazione farmacologica
+    description: |
+      Somministrazione dei farmaci al letto del paziente, riconciliazione nelle transizioni
+      e gestione dei farmaci del paziente.
+  BC-2850.40.10:
+    name: Somministrazione dei farmaci al letto del paziente
+    description: |
+      Somministrazione dei farmaci al letto del paziente con verifica tramite codice a barre da parte del personale infermieristico.
+  BC-2850.40.20:
+    name: Riconciliazione farmacologica
+    description: |
+      Riconciliazione dei farmaci domiciliari e prescritti all'ammissione, al trasferimento e alla dimissione.
+  BC-2850.40.30:
+    name: Operazioni della scheda unica di terapia
+    description: |
+      Gestione della scheda unica di terapia elettronica.
+  BC-2850.40.40:
+    name: Gestione dei farmaci del paziente
+    description: |
+      Identificazione, conservazione e somministrazione autorizzata dei farmaci di proprietà del paziente.
+  BC-2850.50:
+    name: Stewardship delle sostanze controllate
+    description: |
+      Conformità normativa, monitoraggio delle deviazioni, gestione delle scorte e smaltimento
+      dei farmaci sotto controllo.
+  BC-2850.50.10:
+    name: Conformità normativa per le sostanze controllate
+    description: |
+      Conformità alle normative sulle sostanze controllate, inclusa la registrazione e la tenuta dei registri.
+  BC-2850.50.20:
+    name: Monitoraggio delle deviazioni
+    description: |
+      Sorveglianza e indagine su presunte deviazioni di farmaci.
+  BC-2850.50.30:
+    name: Scorte di farmaci controllati
+    description: |
+      Inventario perpetuo e riconciliazione delle scorte di farmaci controllati.
+  BC-2850.50.40:
+    name: Smaltimento e distruzione dei farmaci controllati
+    description: |
+      Smaltimento, distruzione in presenza di testimoni e restituzione al circuito inverso dei farmaci controllati.
+  BC-2850.60:
+    name: Servizi di farmacia clinica
+    description: |
+      Servizi di farmacia clinica, inclusi gestione della terapia anticoagulante, stewardship
+      antimicrobica, gestione della terapia farmacologica e monitoraggio terapeutico dei farmaci.
+  BC-2850.60.10:
+    name: Gestione della terapia anticoagulante
+    description: |
+      Servizi di dosaggio e monitoraggio della terapia anticoagulante condotti dal farmacista.
+  BC-2850.60.20:
+    name: Farmacia di stewardship antimicrobica
+    description: |
+      Contributo della farmacia ai programmi di stewardship antimicrobica.
+  BC-2850.60.30:
+    name: Gestione della terapia farmacologica
+    description: |
+      Consulenze di gestione della terapia farmacologica erogate dal farmacista.
+  BC-2850.60.40:
+    name: Monitoraggio terapeutico dei farmaci
+    description: |
+      Servizi di monitoraggio terapeutico dei farmaci e di individualizzazione della dose.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-physical-asset-management.yaml
+++ b/catalogue/i18n/it/L1-physical-asset-management.yaml
@@ -1,0 +1,99 @@
+# Gestione del patrimonio fisico (it) — translations for L1-physical-asset-management.yaml
+locale: it
+source: L1-physical-asset-management.yaml
+entries:
+  BC-1040:
+    name: Gestione del patrimonio fisico
+    description: |
+      Gestione del ciclo di vita di impianti, macchine, flotte e infrastrutture.
+  BC-1040.10:
+    name: Gestione della strategia e del ciclo di vita degli asset
+    description: |
+      Strategia degli asset, ciclo di vita e pianificazione della sostituzione.
+  BC-1040.10.10:
+    name: Strategia per classe di asset
+    description: |
+      Strategia per classe di asset allineata a ISO 55000.
+  BC-1040.10.20:
+    name: Pianificazione del ciclo di vita degli asset
+    description: |
+      Pianificazione dell'intero ciclo di vita degli asset attraverso le fasi di acquisizione, esercizio e dismissione.
+  BC-1040.10.30:
+    name: Pianificazione della sostituzione degli asset
+    description: |
+      Pianificazione della sostituzione basata sulla vita utile attesa e sulle condizioni.
+  BC-1040.10.40:
+    name: Pianificazione del capitale per gli asset
+    description: |
+      Pianificazione del CAPEX per gli investimenti e i rinnovi degli asset.
+  BC-1040.20:
+    name: Gestione delle performance degli asset
+    description: |
+      KPI degli asset, disponibilità e utilizzo.
+  BC-1040.20.10:
+    name: Definizione dei KPI degli asset
+    description: |
+      Definizione dei KPI di performance degli asset e dei target.
+  BC-1040.20.20:
+    name: Monitoraggio della disponibilità degli asset
+    description: |
+      Monitoraggio della disponibilità e dell'uptime degli asset.
+  BC-1040.20.30:
+    name: Reporting dell'utilizzo degli asset
+    description: |
+      Reporting sull'utilizzo e sulle performance degli asset.
+  BC-1040.20.40:
+    name: Gestione dell'indice di salute degli asset
+    description: |
+      Indici di salute compositi e scoring delle condizioni degli asset.
+  BC-1040.30:
+    name: Gestione del rischio e della criticità degli asset
+    description: |
+      Classificazione della criticità e prioritizzazione basata sul rischio.
+  BC-1040.30.10:
+    name: Classificazione della criticità degli asset
+    description: |
+      Classificazione della criticità degli asset per impatto.
+  BC-1040.30.20:
+    name: Valutazione del rischio degli asset
+    description: |
+      Valutazione del rischio degli asset incluse le conseguenze dei guasti.
+  BC-1040.30.30:
+    name: Prioritizzazione della manutenzione basata sul rischio
+    description: |
+      Prioritizzazione basata sul rischio delle azioni di manutenzione e di capitale.
+  BC-1040.40:
+    name: Gestione delle informazioni sugli asset
+    description: |
+      Dati master degli asset e documentazione tecnica.
+  BC-1040.40.10:
+    name: Gestione dei dati master degli asset
+    description: |
+      Dati master degli asset, gerarchie e registri delle macchine.
+  BC-1040.40.20:
+    name: Documentazione tecnica degli asset
+    description: |
+      Fascicoli tecnici, disegni e documentazione OEM.
+  BC-1040.40.30:
+    name: Gestione del digital twin degli asset
+    description: |
+      Modelli di digital twin per le operazioni e l'analytics degli asset.
+  BC-1040.50:
+    name: Gestione del decommissioning e della dismissione degli asset
+    description: |
+      Decommissioning, dismissione e ritiro degli asset.
+  BC-1040.50.10:
+    name: Pianificazione del decommissioning
+    description: |
+      Pianificazione del decommissioning degli asset inclusi gli aspetti HSE.
+  BC-1040.50.20:
+    name: Esecuzione della rimozione degli asset
+    description: |
+      Rimozione fisica e smantellamento degli asset dismessi.
+  BC-1040.50.30:
+    name: Dismissione e rivendita degli asset
+    description: |
+      Rivendita, rottamazione e riciclo degli asset dismessi.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-pipeline-operations-management.yaml
+++ b/catalogue/i18n/it/L1-pipeline-operations-management.yaml
@@ -1,0 +1,121 @@
+# Gestione delle operazioni di oleodotto/gasdotto (it) — translations for L1-pipeline-operations-management.yaml
+locale: it
+source: L1-pipeline-operations-management.yaml
+entries:
+  BC-3060:
+    name: Gestione delle operazioni di oleodotto/gasdotto
+    description: |
+      Operazione, integrità e gestione commerciale degli oleodotti e gasdotti di raccolta
+      e trasmissione di idrocarburi: dispacciamento dalla sala controllo, ispezione in-line,
+      rilevamento perdite, programmazione e nomine, e amministrazione delle tariffe.
+  BC-3060.10:
+    name: Operazioni di controllo del pipeline
+    description: |
+      Dispacciamento dalla sala controllo e operazione SCADA di pipeline liquidi e gas.
+  BC-3060.10.10:
+    name: Dispacciamento e controllo del pipeline
+    description: |
+      Dispacciamento 24/7 dalla sala controllo delle operazioni di pipeline.
+  BC-3060.10.20:
+    name: Operazioni SCADA
+    description: |
+      Operazione dei sistemi SCADA di pipeline e della telemetria di campo.
+  BC-3060.10.30:
+    name: Modellizzazione idraulica del pipeline
+    description: |
+      Modellizzazione idraulica in tempo reale e offline dei regimi di flusso del pipeline.
+  BC-3060.10.40:
+    name: Gestione del simulatore di addestramento operatori
+    description: |
+      Mantenimento dei simulatori di addestramento per i controllori di pipeline secondo i requisiti normativi.
+  BC-3060.20:
+    name: Gestione dell'integrità del pipeline
+    description: |
+      Ispezione in-line, protezione catodica e valutazione dei difetti per l'assurance
+      dell'integrità del pipeline.
+  BC-3060.20.10:
+    name: Ispezione in-line
+    description: |
+      Campagne di ispezione in-line con smart-pig per l'integrità del pipeline.
+  BC-3060.20.20:
+    name: Gestione della protezione catodica
+    description: |
+      Progettazione, operazione e rilievo della protezione catodica dei pipeline.
+  BC-3060.20.30:
+    name: Valutazione dei difetti del pipeline
+    description: |
+      Valutazione critica ingegneristica dei difetti di perdita di metallo e di tipo crack.
+  BC-3060.20.40:
+    name: Pattugliamento del diritto di passaggio
+    description: |
+      Pattugliamento aereo e a terra dei diritti di passaggio del pipeline.
+  BC-3060.30:
+    name: Rilevamento perdite e sorveglianza del pipeline
+    description: |
+      Sistemi computazionali ed esterni di rilevamento perdite e sorveglianza del pipeline.
+  BC-3060.30.10:
+    name: Rilevamento computazionale delle perdite
+    description: |
+      Sistemi di rilevamento perdite in tempo reale basati su modelli transienti e statistici.
+  BC-3060.30.20:
+    name: Rilevamento esterno delle perdite
+    description: |
+      Rilevamento esterno delle perdite tramite fibra ottica, acustica e sensori di vapore.
+  BC-3060.30.30:
+    name: Rilievo aereo e a piedi
+    description: |
+      Rilievi aerei e a piedi di routine dei corridoi del pipeline.
+  BC-3060.40:
+    name: Programmazione e nomine del pipeline
+    description: |
+      Gestione delle nomine di capacità, sequenziamento dei batch e gestione
+      del linefill per i volumi trasportati.
+  BC-3060.40.10:
+    name: Gestione delle nomine di capacità
+    description: |
+      Ricezione, conferma e programmazione delle nomine degli shipper.
+  BC-3060.40.20:
+    name: Sequenziamento dei batch
+    description: |
+      Sequenziamento dei batch multiprodotto nei pipeline di liquidi.
+  BC-3060.40.30:
+    name: Gestione del linefill
+    description: |
+      Gestione della proprietà del linefill e delle posizioni di inventario dei pipeline.
+  BC-3060.50:
+    name: Gestione della tariffa del pipeline
+    description: |
+      Deposito e amministrazione di tariffe pipeline regolamentate e contrattuali,
+      fatturazione degli shipper e regolamento degli squilibri.
+  BC-3060.50.10:
+    name: Deposito e mantenimento della tariffa
+    description: |
+      Deposito e mantenimento delle tariffe pipeline presso le autorità di regolamentazione.
+  BC-3060.50.20:
+    name: Fatturazione agli shipper
+    description: |
+      Calcolo e emissione delle fatture di trasporto agli shipper.
+  BC-3060.50.30:
+    name: Regolamento degli squilibri
+    description: |
+      Regolamento degli squilibri operativi tra gli shipper.
+  BC-3060.60:
+    name: Operazioni di costruzione e riparazione del pipeline
+    description: |
+      Riparazioni in servizio, operazioni di hot-tap e coordinamento delle sostituzioni
+      per pipeline di trasmissione e raccolta.
+  BC-3060.60.10:
+    name: Coordinamento della sostituzione del pipeline
+    description: |
+      Coordinamento della sostituzione e del re-routing dei segmenti di pipeline.
+  BC-3060.60.20:
+    name: Operazioni di riparazione in servizio
+    description: |
+      Riparazioni con compositi, manicotti e overlay di saldatura su pipeline in servizio.
+  BC-3060.60.30:
+    name: Operazioni di hot-tap
+    description: |
+      Operazioni di hot-tap e stopple per gli allacciamenti su pipeline in pressione.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-plant-maintenance-management.yaml
+++ b/catalogue/i18n/it/L1-plant-maintenance-management.yaml
@@ -1,0 +1,131 @@
+# Gestione della manutenzione degli impianti (it) — translations for L1-plant-maintenance-management.yaml
+locale: it
+source: L1-plant-maintenance-management.yaml
+entries:
+  BC-1030:
+    name: Gestione della manutenzione degli impianti
+    description: |
+      Manutenzione preventiva, predittiva e correttiva degli impianti e delle macchine.
+  BC-1030.10:
+    name: Gestione della strategia di manutenzione
+    description: |
+      Strategia di manutenzione per classe di asset e RCM.
+  BC-1030.10.10:
+    name: Analisi della manutenzione centrata sull'affidabilità
+    description: |
+      Analisi RCM per definire le strategie di manutenzione per classe di asset.
+  BC-1030.10.20:
+    name: Definizione del piano di manutenzione
+    description: |
+      Definizione dei piani di manutenzione, delle attività e degli intervalli.
+  BC-1030.10.30:
+    name: Gestione degli standard di manutenzione
+    description: |
+      Procedure, standard e best practice di manutenzione.
+  BC-1030.20:
+    name: Gestione della manutenzione preventiva
+    description: |
+      Piani di manutenzione preventiva, schedulazione ed esecuzione.
+  BC-1030.20.10:
+    name: Gestione della schedulazione della manutenzione preventiva
+    description: |
+      Generazione e gestione delle schedulazioni di manutenzione preventiva.
+  BC-1030.20.20:
+    name: Esecuzione della manutenzione preventiva
+    description: |
+      Esecuzione delle attività di manutenzione preventiva e verifica del completamento.
+  BC-1030.20.30:
+    name: Monitoraggio della conformità della manutenzione preventiva
+    description: |
+      Monitoraggio della conformità e delle attività in ritardo della manutenzione preventiva.
+  BC-1030.30:
+    name: Gestione della manutenzione correttiva
+    description: |
+      Risposta ai guasti e riparazioni.
+  BC-1030.30.10:
+    name: Risposta ai guasti
+    description: |
+      Prima risposta ai guasti delle macchine e agli eventi non pianificati.
+  BC-1030.30.20:
+    name: Esecuzione delle riparazioni delle macchine
+    description: |
+      Esecuzione delle riparazioni correttive e verifica.
+  BC-1030.30.30:
+    name: Analisi dei guasti e reporting
+    description: |
+      Analisi delle cause radice e reporting dei guasti dopo gli interventi correttivi.
+  BC-1030.40:
+    name: Gestione della manutenzione predittiva
+    description: |
+      Manutenzione basata sulle condizioni e su analytics predittive.
+  BC-1030.40.10:
+    name: Monitoraggio delle condizioni
+    description: |
+      Monitoraggio delle condizioni tramite vibrazione, termografia, analisi olio e acustica.
+  BC-1030.40.20:
+    name: Modellazione con analytics predittive
+    description: |
+      Previsione dei guasti basata su machine learning.
+  BC-1030.40.30:
+    name: Azioni di manutenzione prescrittiva
+    description: |
+      Generazione di azioni di manutenzione prescrittiva dalle previsioni.
+  BC-1030.50:
+    name: Gestione degli ordini di lavoro di manutenzione
+    description: |
+      Ciclo di vita degli ordini di lavoro di manutenzione.
+  BC-1030.50.10:
+    name: Raccolta delle notifiche di manutenzione
+    description: |
+      Raccolta delle notifiche e delle richieste di manutenzione.
+  BC-1030.50.20:
+    name: Pianificazione degli ordini di lavoro di manutenzione
+    description: |
+      Pianificazione degli ordini di lavoro incluse risorse e ricambi.
+  BC-1030.50.30:
+    name: Esecuzione degli ordini di lavoro di manutenzione
+    description: |
+      Esecuzione e conferma degli ordini di lavoro di manutenzione.
+  BC-1030.50.40:
+    name: Chiusura degli ordini di lavoro di manutenzione
+    description: |
+      Chiusura, liquidazione e registrazioni degli ordini di lavoro di manutenzione.
+  BC-1030.60:
+    name: Gestione dell'inventario dei ricambi di manutenzione
+    description: |
+      Stoccaggio e utilizzo dei ricambi MRO.
+  BC-1030.60.10:
+    name: Strategia di stock MRO
+    description: |
+      Strategia e livelli di stoccaggio per i ricambi MRO.
+  BC-1030.60.20:
+    name: Approvvigionamento di ricambi MRO
+    description: |
+      Approvvigionamento di ricambi e materiali di consumo MRO.
+  BC-1030.60.30:
+    name: Operatività del magazzino MRO
+    description: |
+      Operatività del magazzino MRO incluse emissione e reso dei ricambi.
+  BC-1030.60.40:
+    name: Gestione dei ricambi critici
+    description: |
+      Identificazione e gestione dei ricambi critici e di emergenza.
+  BC-1030.70:
+    name: Gestione dell'affidabilità delle macchine
+    description: |
+      Ingegneria dell'affidabilità, analisi dei guasti, MTBF/MTTR.
+  BC-1030.70.10:
+    name: Analisi di ingegneria dell'affidabilità
+    description: |
+      Analisi dell'affidabilità (FMEA, FTA, RBD) degli asset critici.
+  BC-1030.70.20:
+    name: Monitoraggio di MTBF e MTTR
+    description: |
+      Monitoraggio del tempo medio tra i guasti e dei tempi di riparazione.
+  BC-1030.70.30:
+    name: Programmi di miglioramento dell'affidabilità
+    description: |
+      Programmi per migliorare l'affidabilità degli asset ad alta frequenza di guasto.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-point-of-sale-operations-management.yaml
+++ b/catalogue/i18n/it/L1-point-of-sale-operations-management.yaml
@@ -1,0 +1,166 @@
+# Gestione delle operazioni al punto vendita (it) — translations for L1-point-of-sale-operations-management.yaml
+locale: it
+source: L1-point-of-sale-operations-management.yaml
+entries:
+  BC-2320:
+    name: Gestione delle operazioni al punto vendita
+    description: |
+      Strato transazionale rivolto al cliente nel retail — registrazione delle vendite,
+      accettazione dei pagamenti, resi e rimborsi, gestione del contante, configurazione
+      del POS e continuità della vendita durante le interruzioni di sistema.
+  BC-2320.10:
+    name: Gestione delle transazioni di vendita
+    description: |
+      Registrazione delle transazioni di vendita al consumatore, inclusi la composizione
+      del carrello, la scansione, l'applicazione delle promozioni, la gestione fiscale e
+      le ricevute digitali.
+    in_scope:
+      - Composizione del carrello e scansione degli articoli
+      - Applicazione di promozioni e loyalty alla cassa
+      - Calcolo delle imposte e ricevute digitali o cartacee
+    out_of_scope:
+      - Progettazione delle promozioni (BC-440.30)
+      - Cassa e-commerce (BC-2330)
+  BC-2320.10.10:
+    name: Scansione degli articoli e composizione del carrello
+    description: |
+      Scansione degli articoli e assemblaggio del carrello alla cassa, inclusi gli
+      articoli a peso.
+  BC-2320.10.20:
+    name: Applicazione di promozioni e loyalty
+    description: |
+      Applicazione di promozioni, coupon e riscatto punti loyalty durante la vendita.
+  BC-2320.10.30:
+    name: Gestione di imposte e IVA
+    description: |
+      Calcolo delle imposte sulle vendite, dell'IVA e delle regole giurisdizionali alla
+      cassa.
+  BC-2320.10.40:
+    name: Emissione di ricevute cartacee e digitali
+    description: |
+      Emissione di ricevute cartacee e digitali con possibilità di collegamento al profilo
+      del consumatore.
+  BC-2320.20:
+    name: Gestione dell'accettazione dei pagamenti
+    description: |
+      Accettazione dei pagamenti alla cassa, inclusi EMV, contactless, wallet digitali,
+      gift card e metodi di pagamento alternativi, con conformità PCI-DSS.
+  BC-2320.20.10:
+    name: Accettazione di pagamenti con carta e contactless
+    description: |
+      Accettazione di pagamenti EMV, contactless e tramite wallet digitale alle casse
+      retail.
+  BC-2320.20.20:
+    name: Accettazione di contanti e assegni
+    description: |
+      Accettazione di contanti, monete e assegni, inclusa la gestione delle
+      denominazioni.
+  BC-2320.20.30:
+    name: Accettazione di gift card e strumenti a valore memorizzato
+    description: |
+      Accettazione ed emissione di gift card e strumenti a valore memorizzato.
+  BC-2320.20.40:
+    name: Accettazione di metodi di pagamento alternativi
+    description: |
+      Accettazione di pagamenti buy-now-pay-later, QR e altri metodi alternativi.
+  BC-2320.20.50:
+    name: Operazioni di conformità PCI-DSS
+    description: |
+      Gestione dei dati del titolare di carta conforme agli standard PCI-DSS al punto
+      vendita.
+  BC-2320.30:
+    name: Gestione di resi, rimborsi e cambi
+    description: |
+      Elaborazione in negozio di resi, rimborsi e cambi del consumatore, inclusi i casi
+      di rimborso sul mezzo di pagamento originale, credito negozio e resi cross-canale.
+    in_scope:
+      - Resi e rimborsi del consumatore in negozio
+      - Gestione di credito negozio e cambi
+      - Resi in negozio di ordini online (cross-canale)
+    out_of_scope:
+      - Logistica inversa verso il centro di distribuzione (BC-520.40.40)
+  BC-2320.30.10:
+    name: Accettazione dei resi del consumatore
+    description: |
+      Accettazione dei resi del consumatore alla cassa nel rispetto della politica di
+      reso.
+  BC-2320.30.20:
+    name: Emissione di rimborsi e crediti negozio
+    description: |
+      Emissione di rimborsi sul mezzo di pagamento originale o tramite credito negozio.
+  BC-2320.30.30:
+    name: Gestione delle transazioni di cambio
+    description: |
+      Transazioni di cambio in pari e non in pari, inclusa la riconciliazione del prezzo.
+  BC-2320.30.40:
+    name: Elaborazione dei resi cross-canale
+    description: |
+      Accettazione in negozio di ordini provenienti da altri canali per la restituzione.
+  BC-2320.40:
+    name: Gestione del contante e dei pagamenti al POS
+    description: |
+      Processi di gestione del cassetto del denaro, della cassaforte, del versamento e
+      della riconciliazione dei pagamenti di fine giornata a tutela degli incassi.
+  BC-2320.40.10:
+    name: Gestione del cassetto del denaro
+    description: |
+      Apertura, monitoraggio e riconciliazione dei cassetti del denaro alla cassa.
+  BC-2320.40.20:
+    name: Operazioni di cassaforte e prelievi
+    description: |
+      Gestione della cassaforte, prelievi a metà giornata e preparazione per il trasporto
+      valori.
+  BC-2320.40.30:
+    name: Riconciliazione dei pagamenti di fine giornata
+    description: |
+      Riconciliazione di tutti i mezzi di pagamento rispetto ai registri di vendita POS
+      a fine giornata.
+  BC-2320.40.40:
+    name: Preparazione del versamento bancario
+    description: |
+      Preparazione dei versamenti bancari e consegna al servizio di trasporto valori.
+  BC-2320.50:
+    name: Gestione della configurazione del POS
+    description: |
+      Configurazione dei tipi di pagamento, delle regole fiscali, della logica
+      promozionale, delle periferiche e del comportamento della cassa in tutti i punti
+      vendita.
+  BC-2320.50.10:
+    name: Configurazione dei pagamenti e dei mezzi di pagamento
+    description: |
+      Configurazione dei mezzi di pagamento accettati, dei limiti e dell'instradamento
+      per punto vendita.
+  BC-2320.50.20:
+    name: Configurazione delle regole fiscali
+    description: |
+      Configurazione delle regole fiscali e delle deroghe giurisdizionali per punto
+      vendita.
+  BC-2320.50.30:
+    name: Configurazione del motore promozionale
+    description: |
+      Configurazione del motore promozionale del POS e delle regole di prioritizzazione
+      delle offerte.
+  BC-2320.50.40:
+    name: Configurazione delle periferiche POS
+    description: |
+      Configurazione di bilance, scanner, stampanti e pin pad alla cassa.
+  BC-2320.60:
+    name: Resilienza del POS e operazioni offline
+    description: |
+      Continuità della vendita durante interruzioni di connettività o di sistema, inclusi
+      POS offline, store-and-forward e gestione delle code.
+  BC-2320.60.10:
+    name: Operatività del POS offline
+    description: |
+      Operatività continuata del POS in caso di perdita di connettività.
+  BC-2320.60.20:
+    name: Gestione delle transazioni store-and-forward
+    description: |
+      Memorizzazione e inoltro delle transazioni offline al ripristino della connessione.
+  BC-2320.60.30:
+    name: Gestione delle code in caso di interruzione
+    description: |
+      Gestione delle code dei clienti durante le interruzioni del sistema di cassa.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-policy-administration-management.yaml
+++ b/catalogue/i18n/it/L1-policy-administration-management.yaml
@@ -1,0 +1,115 @@
+# Gestione delle polizze (it) — translations for L1-policy-administration-management.yaml
+locale: it
+source: L1-policy-administration-management.yaml
+entries:
+  BC-2140:
+    name: Gestione delle polizze
+    description: |
+      Emissione della polizza, appendici, modifiche infrannuali, rinnovi, disdette, decadenze, ripristini, gestione documentale e amministrazione delle polizze collettive e polizze madre dei contratti assicurativi in vigore.
+  BC-2140.10:
+    name: Gestione dell'emissione della polizza
+    description: |
+      Generazione, assemblaggio e attivazione di nuovi contratti di polizza e dei documenti di supporto.
+  BC-2140.10.10:
+    name: Generazione del documento di polizza
+    description: |
+      Generazione dei documenti di polizza dai modelli di prodotto e dai termini accettati.
+  BC-2140.10.20:
+    name: Assemblaggio del piano e delle condizioni di polizza
+    description: |
+      Assemblaggio del piano della polizza, delle condizioni e delle appendici nel contratto.
+  BC-2140.10.30:
+    name: Attivazione della polizza
+    description: |
+      Attivazione delle nuove polizze e notifica ai sistemi a valle.
+  BC-2140.20:
+    name: Gestione delle appendici e delle modifiche infrannuali
+    description: |
+      Acquisizione, tariffazione del rischio, approvazione ed emissione delle appendici e delle modifiche infrannuali.
+  BC-2140.20.10:
+    name: Acquisizione della richiesta di appendice
+    description: |
+      Acquisizione delle richieste di appendice dai contraenti e dai produttori.
+  BC-2140.20.20:
+    name: Tariffazione e approvazione dell'appendice
+    description: |
+      Tariffazione delle appendici e approvazione in sottoscrizione ove necessario.
+  BC-2140.20.30:
+    name: Emissione e comunicazione dell'appendice
+    description: |
+      Emissione dei documenti di appendice e comunicazione al contraente.
+  BC-2140.30:
+    name: Gestione del rinnovo della polizza
+    description: |
+      Eleggibilità al rinnovo, nuovo pricing, generazione dell'offerta e gestione del mancato rinnovo.
+  BC-2140.30.10:
+    name: Valutazione dell'eleggibilità al rinnovo
+    description: |
+      Valutazione dell'eleggibilità al rinnovo in base all'esperienza sinistri e alle regole di sottoscrizione.
+  BC-2140.30.20:
+    name: Nuovo pricing al rinnovo
+    description: |
+      Nuovo pricing delle polizze in rinnovo in base alle tariffe depositate correnti e all'esperienza.
+  BC-2140.30.30:
+    name: Generazione dell'offerta di rinnovo
+    description: |
+      Generazione e invio delle offerte di rinnovo ai contraenti.
+  BC-2140.30.40:
+    name: Gestione del mancato rinnovo
+    description: |
+      Gestione dei mancati rinnovi, inclusi i periodi di preavviso e le comunicazioni normative.
+  BC-2140.40:
+    name: Gestione della disdetta e della decadenza della polizza
+    description: |
+      Elaborazione della disdetta, adeguamento del premio, decadenza e ripristino.
+  BC-2140.40.10:
+    name: Elaborazione della richiesta di disdetta
+    description: |
+      Elaborazione delle richieste di disdetta da parte dei contraenti, dei produttori o della compagnia.
+  BC-2140.40.20:
+    name: Calcolo del pro-rata e del rateo breve
+    description: |
+      Calcolo degli adeguamenti del premio pro-rata e a rateo breve in caso di disdetta.
+  BC-2140.40.30:
+    name: Gestione della decadenza
+    description: |
+      Elaborazione della decadenza per mancato pagamento e notifica al contraente.
+  BC-2140.40.40:
+    name: Elaborazione del ripristino
+    description: |
+      Ripristino delle polizze decadute o disdette previo controllo in sottoscrizione.
+  BC-2140.50:
+    name: Gestione dei documenti e degli archivi di polizza
+    description: |
+      Archivio dei documenti di polizza, conservazione dei registri normativi e audit trail delle polizze.
+  BC-2140.50.10:
+    name: Archivio dei documenti di polizza
+    description: |
+      Archivio dei documenti di polizza e della corrispondenza di supporto.
+  BC-2140.50.20:
+    name: Conservazione dei registri normativi
+    description: |
+      Conservazione dei registri di polizza in conformità ai requisiti normativi assicurativi.
+  BC-2140.50.30:
+    name: Manutenzione dell'audit trail della polizza
+    description: |
+      Manutenzione degli audit trail immutabili sulle modifiche e sulle decisioni di polizza.
+  BC-2140.60:
+    name: Amministrazione delle polizze collettive e polizze madre
+    description: |
+      Configurazione delle polizze collettive, manutenzione dei certificati e cicli di rinnovo di gruppo.
+  BC-2140.60.10:
+    name: Configurazione della polizza collettiva
+    description: |
+      Configurazione dei contratti di polizza collettiva e polizza madre per schemi aziendali e di affinità.
+  BC-2140.60.20:
+    name: Manutenzione dei membri e dei certificati
+    description: |
+      Manutenzione dei membri del gruppo, dei certificati e dei dipendenti.
+  BC-2140.60.30:
+    name: Gestione del ciclo di rinnovo del gruppo
+    description: |
+      Gestione dei cicli di rinnovo del gruppo, del nuovo pricing e della re-iscrizione dei membri.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-population-health-management.yaml
+++ b/catalogue/i18n/it/L1-population-health-management.yaml
@@ -1,0 +1,137 @@
+# Gestione della salute della popolazione (it) — translations for L1-population-health-management.yaml
+locale: it
+source: L1-population-health-management.yaml
+entries:
+  BC-2880:
+    name: Gestione della salute della popolazione
+    description: |
+      Stratificazione del rischio, cure preventive, gestione delle malattie croniche,
+      operazioni di VBC (value-based care), gestione dei panel e dell'attribuzione, e
+      analytics per la salute della popolazione attribuita e a rischio.
+  BC-2880.10:
+    name: Stratificazione e identificazione del rischio
+    description: |
+      Modellizzazione predittiva e identificazione delle popolazioni a rischio crescente
+      e con gap nell'assistenza.
+  BC-2880.10.10:
+    name: Modellizzazione predittiva del rischio
+    description: |
+      Sviluppo e gestione di modelli di rischio predittivo per costi ed esiti clinici.
+  BC-2880.10.20:
+    name: Identificazione dei pazienti a rischio crescente
+    description: |
+      Identificazione dei pazienti a rischio crescente per interventi precoci.
+  BC-2880.10.30:
+    name: Definizione delle coorti
+    description: |
+      Definizione e manutenzione delle coorti cliniche per i programmi di salute della popolazione.
+  BC-2880.10.40:
+    name: Identificazione dei gap nell'assistenza
+    description: |
+      Identificazione dei gap nell'assistenza basati sulle prove di efficacia nelle popolazioni.
+  BC-2880.20:
+    name: Cure preventive e benessere
+    description: |
+      Programmi di screening, vaccinazione, valutazione del rischio sanitario e coaching per il benessere.
+  BC-2880.20.10:
+    name: Outreach per i programmi di screening
+    description: |
+      Outreach per gli screening preventivi basati sulle prove di efficacia.
+  BC-2880.20.20:
+    name: Programmi di vaccinazione
+    description: |
+      Erogazione di programmi di vaccinazione per adulti e bambini.
+  BC-2880.20.30:
+    name: Valutazione del rischio sanitario
+    description: |
+      Erogazione della valutazione del rischio sanitario e follow-up.
+  BC-2880.20.40:
+    name: Coaching per il benessere
+    description: |
+      Erogazione di programmi di coaching per lo stile di vita e il benessere.
+  BC-2880.30:
+    name: Gestione delle malattie croniche
+    description: |
+      Programmi di gestione delle malattie specifici per le principali patologie croniche.
+  BC-2880.30.10:
+    name: Programmi per il diabete
+    description: |
+      Programmi di gestione del diabete, inclusi educazione e monitoraggio remoto.
+  BC-2880.30.20:
+    name: Programmi per le malattie cardiovascolari
+    description: |
+      Programmi di gestione delle malattie cardiovascolari e dell'ipertensione.
+  BC-2880.30.30:
+    name: Integrazione della salute mentale
+    description: |
+      Integrazione della salute mentale nelle cure primarie e nella gestione delle malattie croniche.
+  BC-2880.30.40:
+    name: Programmi per le malattie respiratorie
+    description: |
+      Programmi per l'asma, la broncopneumopatia cronica ostruttiva e le malattie respiratorie.
+  BC-2880.40:
+    name: Operazioni di VBC (value-based care)
+    description: |
+      Operazioni a supporto dell'assistenza responsabile, del pagamento per episodio e dei
+      programmi contrattuali basati sul valore.
+  BC-2880.40.10:
+    name: Operazioni delle organizzazioni di assistenza responsabile (ACO)
+    description: |
+      Operazioni delle ACO (organizzazioni di assistenza responsabile) e dei programmi di risparmio condiviso.
+  BC-2880.40.20:
+    name: Operazioni dei programmi di pagamento per episodio
+    description: |
+      Operazioni a supporto dei programmi di pagamento per episodio.
+  BC-2880.40.30:
+    name: Monitoraggio delle performance di qualità
+    description: |
+      Monitoraggio delle performance di qualità rispetto ai requisiti dei programmi basati sul valore.
+  BC-2880.40.40:
+    name: Riconciliazione del risparmio condiviso
+    description: |
+      Riconciliazione degli accordi di risparmio condiviso e di condivisione del rischio con i pagatori.
+  BC-2880.50:
+    name: Gestione del panel e dell'attribuzione
+    description: |
+      Attribuzione dei pazienti ai professionisti, dimensionamento del panel, monitoraggio della
+      continuità e riconciliazione dell'attribuzione.
+  BC-2880.50.10:
+    name: Attribuzione paziente-professionista
+    description: |
+      Assegnazione dei pazienti ai professionisti di cure primarie e ai team di cura.
+  BC-2880.50.20:
+    name: Gestione delle dimensioni del panel
+    description: |
+      Gestione delle dimensioni, della composizione e della capacità del panel.
+  BC-2880.50.30:
+    name: Monitoraggio della continuità delle cure
+    description: |
+      Monitoraggio delle metriche di continuità delle cure nei panel.
+  BC-2880.50.40:
+    name: Riconciliazione dell'attribuzione
+    description: |
+      Riconciliazione delle liste di attribuzione dei pagatori con i dati interni del panel.
+  BC-2880.60:
+    name: Analytics e reportistica per la salute della popolazione
+    description: |
+      Analytics a livello di popolazione su equità, performance dei programmi di qualità,
+      costi, utilizzo e benchmarking degli esiti.
+  BC-2880.60.10:
+    name: Analytics sull'equità sanitaria
+    description: |
+      Analytics su disparità, determinanti sociali della salute ed esiti di equità.
+  BC-2880.60.20:
+    name: Reportistica dei programmi di qualità
+    description: |
+      Reportistica rispetto ai programmi di qualità quali star rating e misure di qualità.
+  BC-2880.60.30:
+    name: Analytics su costi e utilizzo
+    description: |
+      Analytics su costi, utilizzo e spesa evitabile.
+  BC-2880.60.40:
+    name: Benchmarking degli esiti
+    description: |
+      Benchmarking degli esiti clinici rispetto a dataset nazionali e di confronto tra pari.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-power-generation-operations-management.yaml
+++ b/catalogue/i18n/it/L1-power-generation-operations-management.yaml
@@ -1,0 +1,182 @@
+# Gestione delle operazioni di generazione di energia elettrica (it) — translations for L1-power-generation-operations-management.yaml
+locale: it
+source: L1-power-generation-operations-management.yaml
+entries:
+  BC-3800:
+    name: Gestione delle operazioni di generazione di energia elettrica
+    description: |
+      Operazione del parco di generazione su asset termoelettrici, nucleari, idroelettrici,
+      eolici, fotovoltaici e di stoccaggio — comprende dispacciamento e programmazione,
+      operazione degli impianti per tecnologia, gestione del combustibile e delle emissioni,
+      e gestione delle prestazioni a livello di parco.
+  BC-3800.10:
+    name: Dispacciamento e programmazione della generazione
+    description: |
+      Impegno delle unità, istruzioni di dispacciamento e programmi a breve termine
+      per il parco di generazione in funzione delle nomine del gestore del sistema
+      e delle posizioni di mercato.
+  BC-3800.10.10:
+    name: Impegno delle unità
+    description: |
+      Selezione giornaliera e infragiornaliera delle unità di generazione per il servizio.
+  BC-3800.10.20:
+    name: Dispacciamento economico
+    description: |
+      Dispacciamento in tempo reale delle unità impegnate secondo l'ordine di merito rispetto al carico.
+  BC-3800.10.30:
+    name: Coordinamento delle fermate
+    description: |
+      Coordinamento delle fermate programmate e forzate delle unità con il gestore del sistema e i programmi di mercato.
+  BC-3800.20:
+    name: Operazioni degli impianti termoelettrici
+    description: |
+      Operazione quotidiana delle centrali alimentate a carbone, gas e olio,
+      inclusi impianti a ciclo combinato e di cogenerazione.
+    in_scope:
+      - Operazione di caldaie e turbine
+      - Sorveglianza del rendimento termico e del heat rate
+      - Controllo della combustione
+    out_of_scope:
+      - Operazione degli impianti nucleari (BC-3800.40)
+      - Operazione degli impianti rinnovabili (BC-3800.50)
+  BC-3800.20.10:
+    name: Operazioni delle caldaie
+    description: |
+      Operazione degli impianti di produzione del vapore e controllo della combustione.
+  BC-3800.20.20:
+    name: Operazioni delle turbine a vapore
+    description: |
+      Operazione delle turbine a vapore e dei sistemi condensato-acqua di alimento.
+  BC-3800.20.30:
+    name: Operazioni delle turbine a gas
+    description: |
+      Operazione delle turbine a gas in ciclo aperto e a ciclo combinato.
+  BC-3800.20.40:
+    name: Operazioni di cogenerazione
+    description: |
+      Operazione degli impianti di cogenerazione che forniscono energia elettrica e calore di processo o teleriscaldamento.
+  BC-3800.30:
+    name: Operazioni degli impianti idroelettrici
+    description: |
+      Operazione di centrali idroelettriche convenzionali, di pompaggio e ad acqua fluente,
+      inclusa la gestione delle dighe e dei canali di adduzione.
+  BC-3800.30.10:
+    name: Operazioni delle unità idroelettriche
+    description: |
+      Avviamento, arresto, regolazione e controllo del carico delle unità di generazione idroelettrica.
+  BC-3800.30.20:
+    name: Gestione del livello del serbatoio
+    description: |
+      Programmazione del livello del serbatoio in funzione degli obiettivi energetici, idraulici e ambientali.
+  BC-3800.30.30:
+    name: Operazioni di ciclo del pompaggio
+    description: |
+      Cicli di pompaggio e generazione degli impianti idroelettrici di pompaggio.
+  BC-3800.30.40:
+    name: Sorveglianza della sicurezza delle dighe
+    description: |
+      Sorveglianza del comportamento strutturale e dei drenaggi delle dighe rispetto ai criteri di sicurezza.
+  BC-3800.40:
+    name: Operazioni degli impianti nucleari
+    description: |
+      Operazione delle centrali nucleari — controllo del reattore, fermate per ricarica del combustibile
+      e sorveglianza della sicurezza radiologica nel rispetto delle condizioni della licenza dell'autorità di regolamentazione nucleare.
+  BC-3800.40.10:
+    name: Operazioni del reattore
+    description: |
+      Controllo del reattore, gestione della reattività e operazioni di inseguimento del carico.
+  BC-3800.40.20:
+    name: Operazioni di fermata per ricarica
+    description: |
+      Pianificazione ed esecuzione delle fermate per ricarica del combustibile e per manutenzione maggiore.
+  BC-3800.40.30:
+    name: Sorveglianza radiologica
+    description: |
+      Sorveglianza dei rilasci radiologici e delle dosi ai lavoratori rispetto ai limiti normativi.
+  BC-3800.40.40:
+    name: Operazioni della piscina del combustibile esausto
+    description: |
+      Operazione e sorveglianza del raffreddamento e dell'inventario della piscina del combustibile esausto.
+  BC-3800.50:
+    name: Operazioni della generazione da rinnovabili
+    description: |
+      Operazione di asset eolici, fotovoltaici e di altre fonti rinnovabili variabili,
+      inclusi curtailment e previsione della produzione.
+  BC-3800.50.10:
+    name: Operazioni dei parchi eolici
+    description: |
+      Operazione di parchi eolici onshore e offshore e gestione della disponibilità delle turbine.
+  BC-3800.50.20:
+    name: Operazioni degli impianti fotovoltaici
+    description: |
+      Operazione di impianti fotovoltaici utility-scale e monitoraggio degli string.
+  BC-3800.50.30:
+    name: Operazioni di curtailment delle rinnovabili
+    description: |
+      Esecuzione delle istruzioni di curtailment dei gestori del sistema sulle fonti rinnovabili variabili.
+  BC-3800.50.40:
+    name: Previsione della generazione da rinnovabili
+    description: |
+      Previsione a breve termine della produzione eolica e fotovoltaica per il dispacciamento e le attività di trading.
+  BC-3800.60:
+    name: Operazioni dello stoccaggio energetico
+    description: |
+      Operazione di accumulo a batteria su scala di rete e di altri asset di stoccaggio energetico,
+      inclusa la gestione dello stato di carica e dei cicli in funzione delle posizioni di mercato e di servizio ancillare.
+  BC-3800.60.10:
+    name: Operazioni dell'accumulo a batteria
+    description: |
+      Operazione e gestione dello stato di carica degli impianti di accumulo a batteria su scala di rete.
+  BC-3800.60.20:
+    name: Ottimizzazione dei cicli di stoccaggio
+    description: |
+      Ottimizzazione dei cicli di carica e scarica rispetto ai valori dell'energia e dei servizi ancillari.
+  BC-3800.60.30:
+    name: Monitoraggio del degrado dello stoccaggio
+    description: |
+      Monitoraggio dell'efficienza round-trip e della perdita di capacità degli asset a batteria.
+  BC-3800.70:
+    name: Gestione delle prestazioni della generazione
+    description: |
+      Sorveglianza a livello di parco della disponibilità, del heat rate, del fattore di capacità
+      e del tasso di fermata forzata per le diverse tecnologie di generazione.
+  BC-3800.70.10:
+    name: Rendicontazione della disponibilità e affidabilità
+    description: |
+      Rendicontazione allineata GADS della disponibilità equivalente e delle statistiche sulle fermate forzate.
+  BC-3800.70.20:
+    name: Monitoraggio del heat rate e del rendimento
+    description: |
+      Monitoraggio del heat rate e del rendimento termico rispetto agli obiettivi di progetto e contrattuali.
+  BC-3800.70.30:
+    name: Monitoraggio delle prestazioni di capacità
+    description: |
+      Monitoraggio del fattore di capacità e delle valutazioni di capacità affidabile.
+  BC-3800.80:
+    name: Gestione del combustibile e delle emissioni
+    description: |
+      Approvvigionamento del combustibile, gestione delle scorte e dei sottoprodotti della combustione
+      per il parco di generazione, inclusa la sorveglianza delle emissioni atmosferiche e della CO2.
+  BC-3800.80.10:
+    name: Operazioni delle scorte di combustibile
+    description: |
+      Operazioni di piazzale per carbone, olio e biomassa e controllo delle scorte.
+  BC-3800.80.20:
+    name: Nomine di fornitura del gas
+    description: |
+      Nomine del gas su gasdotto e bilanciamento per la generazione a gas.
+  BC-3800.80.30:
+    name: Monitoraggio delle emissioni atmosferiche
+    description: |
+      Monitoraggio continuo delle emissioni di NOx, SOx, polveri e relativa rendicontazione.
+  BC-3800.80.40:
+    name: Riconciliazione CO2 e quote di emissione
+    description: |
+      Riconciliazione delle emissioni di CO2 con le quote restituite nell'ambito dei regimi cap-and-trade.
+  BC-3800.80.50:
+    name: Operazioni di gestione delle ceneri e dei residui di combustione
+    description: |
+      Gestione e smaltimento di ceneri volanti, ceneri pesanti e residui del desolforatore.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-practice-pursuit-and-proposal-management.yaml
+++ b/catalogue/i18n/it/L1-practice-pursuit-and-proposal-management.yaml
@@ -1,0 +1,141 @@
+# Gestione dello sviluppo del business e delle proposte (it) — translations for L1-practice-pursuit-and-proposal-management.yaml
+locale: it
+source: L1-practice-pursuit-and-proposal-management.yaml
+entries:
+  BC-4360:
+    name: Gestione dello sviluppo del business e delle proposte
+    description: |
+      Attività nella fase di pursuit per gli studi di servizi professionali — qualifica delle opportunità,
+      strategia di pursuit, sviluppo di proposte e presentazioni, modellazione degli onorari
+      e analisi win/loss — distinte dalla gestione delle vendite generica.
+  BC-4360.10:
+    name: Gestione della qualifica delle opportunità
+    description: |
+      Qualifica delle opportunità inbound e outbound per adeguatezza strategica,
+      realizzabilità e attrattività commerciale.
+  BC-4360.10.10:
+    name: Acquisizione delle opportunità
+    description: |
+      Acquisizione delle opportunità di pursuit da RFP,
+      referral e origination basata sulle relazioni.
+  BC-4360.10.20:
+    name: Scoring della qualifica delle opportunità
+    description: |
+      Scoring delle opportunità rispetto a criteri di adeguatezza strategica,
+      capacità e commerciali.
+  BC-4360.10.30:
+    name: Coordinamento della pre-clearance del pursuit
+    description: |
+      Pre-clearance delle opportunità tramite verifiche indicative di indipendenza
+      e conflitti prima dell'investimento formale nel pursuit.
+  BC-4360.20:
+    name: Gestione della strategia di pursuit
+    description: |
+      Definizione della strategia di pursuit, del piano di aggiudicazione,
+      della composizione del team e del posizionamento competitivo per le opportunità qualificate.
+  BC-4360.20.10:
+    name: Sviluppo del piano di aggiudicazione
+    description: |
+      Sviluppo del piano di aggiudicazione del pursuit, inclusi messaggi chiave,
+      elementi differenzianti e mappatura degli stakeholder.
+  BC-4360.20.20:
+    name: Composizione del team di pursuit
+    description: |
+      Composizione del team di pursuit, inclusi responsabile del pursuit,
+      esperti di materia e supporto al pricing.
+  BC-4360.20.30:
+    name: Sintesi dell'intelligence competitiva
+    description: |
+      Sintesi dell'intelligence competitiva sugli studi rivali
+      che si prevede partecipino alla stessa opportunità.
+  BC-4360.30:
+    name: Gestione dello sviluppo della proposta
+    description: |
+      Bozza, revisione e invio di proposte scritte e risposte a RFP
+      secondo le specifiche del cliente.
+  BC-4360.30.10:
+    name: Bozza della proposta
+    description: |
+      Bozza delle sezioni della proposta, inclusi approccio,
+      team ed esperienze rilevanti.
+  BC-4360.30.20:
+    name: Revisione e approvazione della proposta
+    description: |
+      Revisione e approvazione interna dei contenuti, delle affermazioni
+      e degli impegni commerciali della proposta.
+  BC-4360.30.30:
+    name: Gestione dell'invio della proposta
+    description: |
+      Invio della proposta nel formato e nel canale richiesti dal cliente,
+      con audit trail dell'invio.
+  BC-4360.30.40:
+    name: Riutilizzo degli asset della proposta
+    description: |
+      Riutilizzo e tagging di contenuti della proposta, case study
+      e credenziali tra i pursuit.
+  BC-4360.40:
+    name: Gestione della presentazione e del pitch
+    description: |
+      Preparazione ed erogazione di pitch, beauty parade e presentazioni orali
+      nell'ambito dei pursuit competitivi.
+  BC-4360.40.10:
+    name: Preparazione dei materiali di pitch
+    description: |
+      Preparazione di deck per il pitch, asset dimostrativi
+      e materiali di supporto per le presentazioni orali.
+  BC-4360.40.20:
+    name: Prova e coaching del pitch
+    description: |
+      Prove del team di pitch e coaching su messaggi,
+      dinamiche di gruppo e gestione delle domande.
+  BC-4360.40.30:
+    name: Gestione dell'erogazione del pitch
+    description: |
+      Erogazione di pitch e beauty parade, inclusi logistica
+      e materiali di follow-up.
+  BC-4360.50:
+    name: Modellazione degli onorari e pricing del pursuit
+    description: |
+      Progettazione della struttura degli onorari e modellazione del pricing
+      per le opportunità di pursuit, inclusi accordi economici alternativi e strutture di risk-sharing.
+    out_of_scope:
+      - Gestione degli onorari nella fase di incarico (BC-4330.40)
+      - Strategia di pricing a livello di studio (BC-290)
+  BC-4360.50.10:
+    name: Progettazione della struttura degli onorari del pursuit
+    description: |
+      Progettazione delle strutture degli onorari tra opzioni orarie,
+      a tariffa fissa, con massimale, contingency e basate sugli outcome.
+  BC-4360.50.20:
+    name: Modellazione della redditività del pursuit
+    description: |
+      Modellazione della redditività del pursuit in diversi scenari
+      di staffing, onorari e rischio.
+  BC-4360.50.30:
+    name: Approvazione del pricing del pursuit
+    description: |
+      Approvazione interna del pricing del pursuit rispetto a soglie
+      di sconto, margine e rischio.
+  BC-4360.60:
+    name: Analisi win/loss del pursuit
+    description: |
+      Debriefing strutturato degli esiti del pursuit, analytics del tasso di aggiudicazione
+      e raccolta di insight nelle pratiche di pursuit e proposta.
+  BC-4360.60.10:
+    name: Debriefing degli esiti del pursuit
+    description: |
+      Debriefing interni e rivolti al cliente degli esiti del pursuit,
+      inclusa la valutazione dei competitor.
+  BC-4360.60.20:
+    name: Analytics del tasso di aggiudicazione
+    description: |
+      Analytics del tasso di aggiudicazione segmentate per practice, cliente,
+      tipologia di opportunità e responsabile del pursuit.
+  BC-4360.60.30:
+    name: Raccolta delle lezioni del pursuit
+    description: |
+      Raccolta delle lezioni del pursuit e del feedback
+      nei playbook e nella formazione.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-premium-accounting-management.yaml
+++ b/catalogue/i18n/it/L1-premium-accounting-management.yaml
@@ -1,0 +1,119 @@
+# Gestione della contabilità premi (it) — translations for L1-premium-accounting-management.yaml
+locale: it
+source: L1-premium-accounting-management.yaml
+entries:
+  BC-2150:
+    name: Gestione della contabilità premi
+    description: |
+      Fatturazione del premio, incasso, regolamento dei conti broker e delle provvigioni, meccaniche di riserva premi e riconoscimento del premio di competenza, gestione degli insoluti e contabilità dell'imposta sui premi assicurativi.
+  BC-2150.10:
+    name: Gestione della fatturazione del premio
+    description: |
+      Generazione delle fatture, pianificazione delle rate, instradamento della fatturazione e rettifiche.
+  BC-2150.10.10:
+    name: Generazione della fattura del premio
+    description: |
+      Generazione delle fatture e degli estratti conto del premio per ciclo di fatturazione.
+  BC-2150.10.20:
+    name: Configurazione del piano di rateazione
+    description: |
+      Configurazione dei piani di rateazione del premio e degli oneri finanziari.
+  BC-2150.10.30:
+    name: Instradamento della fatturazione diretta e tramite agenzia
+    description: |
+      Instradamento della fatturazione tra modalità di pagamento diretto e tramite agenzia.
+  BC-2150.10.40:
+    name: Rettifica della fatturazione e nota di credito
+    description: |
+      Emissione di rettifiche alla fatturazione e note di credito a seguito di appendici e disdette.
+  BC-2150.20:
+    name: Gestione dell'incasso dei premi
+    description: |
+      Ricezione e applicazione dei pagamenti, operazioni di pagamento ricorrente, rimborsi e lockbox.
+  BC-2150.20.10:
+    name: Ricezione e applicazione del pagamento
+    description: |
+      Ricezione dei pagamenti del premio e imputazione ai conti di polizza.
+  BC-2150.20.20:
+    name: Operatività dell'addebito diretto e del pagamento ricorrente
+    description: |
+      Operatività degli schemi di addebito diretto, carte ricorrenti e ordini permanenti.
+  BC-2150.20.30:
+    name: Elaborazione del rimborso del premio
+    description: |
+      Elaborazione dei rimborsi del premio a seguito di appendici e disdette.
+  BC-2150.20.40:
+    name: Lockbox e allocazione della cassa
+    description: |
+      Ricezione lockbox, allocazione della cassa e gestione delle eccezioni.
+  BC-2150.30:
+    name: Regolamento del conto broker e del produttore
+    description: |
+      Estratti conto del produttore, regolamento del premio al netto delle provvigioni e riconciliazione del conto fiduciario.
+  BC-2150.30.10:
+    name: Generazione dell'estratto conto del produttore
+    description: |
+      Generazione degli estratti conto di premio e provvigione per i produttori.
+  BC-2150.30.20:
+    name: Regolamento del premio al netto delle provvigioni
+    description: |
+      Regolamento del premio al netto delle provvigioni verso e dai produttori.
+  BC-2150.30.30:
+    name: Riconciliazione del conto fiduciario premi del produttore
+    description: |
+      Riconciliazione dei conti fiduciari premi e dei saldi IBA del produttore.
+  BC-2150.40:
+    name: Gestione della riserva premi e del premio di competenza
+    description: |
+      Calcolo della riserva premi, riconoscimento del premio di competenza e monitoraggio dei costi di acquisizione differiti.
+  BC-2150.40.10:
+    name: Calcolo della riserva premi
+    description: |
+      Calcolo delle riserve premi sulle polizze in vigore.
+  BC-2150.40.20:
+    name: Riconoscimento del premio di competenza
+    description: |
+      Riconoscimento del premio di competenza per periodo contabile.
+  BC-2150.40.30:
+    name: Monitoraggio dei costi di acquisizione differiti
+    description: |
+      Monitoraggio dei costi di acquisizione differiti (DAC) per coorti di prodotto.
+  BC-2150.50:
+    name: Gestione degli incassi e degli insoluti
+    description: |
+      Monitoraggio dei crediti scaduti, operazioni di sollecito, disdetta per mancato pagamento e svalutazione dei crediti inesigibili.
+  BC-2150.50.10:
+    name: Monitoraggio dei crediti scaduti
+    description: |
+      Monitoraggio dei crediti premi scaduti verso contraenti e produttori.
+  BC-2150.50.20:
+    name: Operazioni di sollecito e promemoria
+    description: |
+      Avvisi di sollecito, promemoria e comunicazioni sugli arretrati.
+  BC-2150.50.30:
+    name: Gestione della disdetta per mancato pagamento
+    description: |
+      Attivazione dei processi di disdetta per mancato pagamento del premio.
+  BC-2150.50.40:
+    name: Svalutazione dei crediti inesigibili
+    description: |
+      Approvazione e contabilizzazione delle svalutazioni dei crediti inesigibili sul premio non riscosso.
+  BC-2150.60:
+    name: Contabilità delle imposte e dei prelievi
+    description: |
+      Calcolo dell'imposta sui premi assicurativi, riscossione dell'imposta di bollo e dei prelievi, e supporto al deposito delle dichiarazioni fiscali sui premi.
+  BC-2150.60.10:
+    name: Calcolo dell'imposta sui premi assicurativi
+    description: |
+      Calcolo dell'imposta sui premi assicurativi nelle varie giurisdizioni e tipologie di prodotto.
+  BC-2150.60.20:
+    name: Riscossione dell'imposta di bollo e dei prelievi
+    description: |
+      Riscossione e versamento delle imposte di bollo e dei prelievi obbligatori.
+  BC-2150.60.30:
+    name: Supporto al deposito delle dichiarazioni fiscali sui premi
+    description: |
+      Produzione dei dati di base e delle riconciliazioni per i depositi delle dichiarazioni fiscali sui premi.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-pricing-management.yaml
+++ b/catalogue/i18n/it/L1-pricing-management.yaml
@@ -1,0 +1,87 @@
+# Gestione della tariffazione (it) — translations for L1-pricing-management.yaml
+locale: it
+source: L1-pricing-management.yaml
+entries:
+  BC-440:
+    name: Gestione della tariffazione
+    description: |
+      Definizione dei prezzi, struttura, sconti, promozioni.
+  BC-440.10:
+    name: Gestione della strategia di pricing
+    description: |
+      Modelli di pricing, pricing basato sul valore, pricing per segmento.
+  BC-440.10.10:
+    name: Definizione del modello di pricing
+    description: |
+      Definizione dei modelli di pricing (cost-plus, basato sul valore, a sottoscrizione).
+  BC-440.10.20:
+    name: Pricing basato sul valore
+    description: |
+      Analisi del valore per il cliente e della disponibilità a pagare per informare il prezzo.
+  BC-440.10.30:
+    name: Benchmarking competitivo dei prezzi
+    description: |
+      Benchmarking dei prezzi della concorrenza e posizionamento dei prezzi.
+  BC-440.10.40:
+    name: Pricing per segmento e area geografica
+    description: |
+      Differenziazione dei prezzi per segmento, canale e area geografica.
+  BC-440.20:
+    name: Gestione del listino prezzi
+    description: |
+      Prezzi di listino, prezzi regionali, manutenzione del listino.
+  BC-440.20.10:
+    name: Manutenzione del listino prezzi
+    description: |
+      Manutenzione dei listini prezzi, dei prezzi di listino e delle varianti valutarie.
+  BC-440.20.20:
+    name: Gestione delle modifiche ai prezzi
+    description: |
+      Approvazione, comunicazione e implementazione delle variazioni di prezzo.
+  BC-440.20.30:
+    name: Governance del master data dei prezzi
+    description: |
+      Governance della qualità e della lineage del master data dei prezzi.
+  BC-440.30:
+    name: Gestione degli sconti e delle promozioni
+    description: |
+      Politiche di sconto, offerte promozionali, rimborsi.
+  BC-440.30.10:
+    name: Gestione della politica degli sconti
+    description: |
+      Definizione dei livelli di sconto, delle regole e delle soglie di approvazione.
+  BC-440.30.20:
+    name: Pianificazione ed esecuzione delle promozioni
+    description: |
+      Calendario promozionale, configurazione delle offerte ed esecuzione.
+  BC-440.30.30:
+    name: Gestione dei rimborsi e degli allowance commerciali
+    description: |
+      Accantonamenti per rimborsi, richieste e liquidazione con clienti e canali.
+  BC-440.30.40:
+    name: Analisi dell'efficacia delle promozioni
+    description: |
+      Misurazione del ROI promozionale, del lift e della cannibalizzazione.
+  BC-440.40:
+    name: Gestione della realizzazione dei prezzi e della conformità
+    description: |
+      Gestione delle eccezioni di prezzo, analisi delle perdite di ricavo.
+  BC-440.40.10:
+    name: Approvazione delle eccezioni di prezzo
+    description: |
+      Flusso e approvazione delle eccezioni di pricing fuori policy.
+  BC-440.40.20:
+    name: Analisi del prezzo netto e del margine
+    description: |
+      Analisi del prezzo netto realizzato e del margine per transazione.
+  BC-440.40.30:
+    name: Indagine sulle perdite di prezzo
+    description: |
+      Identificazione e correzione delle perdite di prezzo e di sconto.
+  BC-440.40.40:
+    name: Monitoraggio della conformità dei prezzi
+    description: |
+      Conformità alla politica dei prezzi, alle normative antitrust e alle regole del commercio equo.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-procurement-management.yaml
+++ b/catalogue/i18n/it/L1-procurement-management.yaml
@@ -1,0 +1,139 @@
+# Gestione dell'approvvigionamento (it) — translations for L1-procurement-management.yaml
+locale: it
+source: L1-procurement-management.yaml
+entries:
+  BC-500:
+    name: Gestione dell'approvvigionamento
+    description: |
+      Sourcing, contrattualizzazione, acquisti, operazioni procure-to-pay.
+  BC-500.10:
+    name: Gestione del sourcing
+    description: |
+      Sourcing strategico, RFx, selezione dei fornitori.
+  BC-500.10.10:
+    name: Definizione della strategia di sourcing
+    description: |
+      Definizione della strategia di sourcing per categoria merceologica e mercato.
+  BC-500.10.20:
+    name: Esecuzione delle RFx
+    description: |
+      Preparazione, emissione e valutazione di RFI, RFQ ed RFP.
+  BC-500.10.30:
+    name: Negoziazione con i fornitori
+    description: |
+      Negoziazione commerciale e contrattuale con i fornitori selezionati.
+  BC-500.10.40:
+    name: Selezione e aggiudicazione ai fornitori
+    description: |
+      Selezione finale del fornitore, decisione di aggiudicazione e notifica.
+  BC-500.10.50:
+    name: Operazioni di asta inversa
+    description: |
+      Configurazione, svolgimento e aggiudicazione di e-auction per lotti competitivi.
+  BC-500.20:
+    name: Gestione dei contratti di approvvigionamento
+    description: |
+      Contratti di approvvigionamento, condizioni, ciclo di vita.
+  BC-500.20.10:
+    name: Redazione e modelli di contratto
+    description: |
+      Modelli di contratto di approvvigionamento, clausole e playbook.
+  BC-500.20.20:
+    name: Approvazione e stipula del contratto
+    description: |
+      Flusso di approvazione, firma e stipula dei contratti di approvvigionamento.
+  BC-500.20.30:
+    name: Monitoraggio della conformità contrattuale
+    description: |
+      Monitoraggio degli acquisti rispetto ai fornitori e ai prezzi contrattualizzati.
+  BC-500.20.40:
+    name: Rinnovo e rinegoziazione dei contratti
+    description: |
+      Gestione del ciclo di rinnovo e rinegoziazione dei contratti di approvvigionamento.
+  BC-500.30:
+    name: Gestione degli ordini di acquisto
+    description: |
+      Creazione, approvazione ed esecuzione degli ordini di acquisto.
+  BC-500.30.10:
+    name: Creazione degli ordini di acquisto
+    description: |
+      Generazione di ordini di acquisto da richieste, contratti o cataloghi.
+  BC-500.30.20:
+    name: Approvazione degli ordini di acquisto
+    description: |
+      Flussi di approvazione basati su soglie per gli ordini di acquisto.
+  BC-500.30.30:
+    name: Conferma e modifica degli ordini di acquisto
+    description: |
+      Conferma del fornitore e gestione degli ordini di modifica.
+  BC-500.30.40:
+    name: Chiusura degli ordini di acquisto
+    description: |
+      Completamento della ricezione, abbinamento delle fatture e chiusura dell'ordine di acquisto.
+  BC-500.40:
+    name: Gestione delle operazioni procure-to-pay
+    description: |
+      Operazioni P2P quotidiane, richieste d'acquisto, ricevimenti.
+  BC-500.40.10:
+    name: Gestione delle richieste d'acquisto
+    description: |
+      Raccolta, approvazione e conversione delle richieste d'acquisto.
+  BC-500.40.20:
+    name: Gestione del catalogo e del punch-out
+    description: |
+      Cataloghi interni e punch-out del fornitore per gli acquisti self-service.
+  BC-500.40.30:
+    name: Ricezione merci e accettazione servizi
+    description: |
+      Registrazione dei ricevimenti merci e delle schede di accettazione servizi.
+  BC-500.40.40:
+    name: Abbinamento e riconciliazione delle fatture
+    description: |
+      Abbinamento a due e tre vie delle fatture con ordini di acquisto e ricevimenti.
+  BC-500.40.50:
+    name: Helpdesk P2P e supporto agli acquirenti
+    description: |
+      Supporto a compratori e fornitori per le transazioni P2P.
+  BC-500.50:
+    name: Gestione delle categorie merceologiche
+    description: |
+      Strategia di categoria, analisi della spesa per categoria.
+  BC-500.50.10:
+    name: Sviluppo della strategia di categoria
+    description: |
+      Strategia di categoria pluriennale e valutazione del mercato di fornitura.
+  BC-500.50.20:
+    name: Gestione della performance di categoria
+    description: |
+      Monitoraggio dei KPI, dei risparmi e della creazione di valore per categoria.
+  BC-500.50.30:
+    name: Aggregazione e standardizzazione della domanda
+    description: |
+      Consolidamento della domanda e standardizzazione delle specifiche tra le business unit.
+  BC-500.50.40:
+    name: Sourcing di innovazione di categoria
+    description: |
+      Identificazione dell'innovazione attraverso i mercati dei fornitori.
+  BC-500.60:
+    name: Gestione dell'analisi della spesa in approvvigionamento
+    description: |
+      Visibilità della spesa, reporting, monitoraggio dei risparmi.
+  BC-500.60.10:
+    name: Aggregazione e pulizia dei dati di spesa
+    description: |
+      Aggregazione, pulizia e classificazione dei dati di spesa aziendale.
+  BC-500.60.20:
+    name: Reporting e analytics della spesa
+    description: |
+      Analytics della spesa, dashboard e identificazione della spesa indirizzabile.
+  BC-500.60.30:
+    name: Monitoraggio e validazione dei risparmi
+    description: |
+      Raccolta, validazione e reporting dei risparmi in approvvigionamento.
+  BC-500.60.40:
+    name: Gestione della spesa di coda
+    description: |
+      Identificazione e razionalizzazione della spesa di coda.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-product-information-management.yaml
+++ b/catalogue/i18n/it/L1-product-information-management.yaml
@@ -1,0 +1,117 @@
+# Gestione delle informazioni di prodotto (it) — translations for L1-product-information-management.yaml
+locale: it
+source: L1-product-information-management.yaml
+entries:
+  BC-2370:
+    name: Gestione delle informazioni di prodotto
+    description: |
+      Attributi autorevoli degli articoli, contenuti di marketing e dati di prodotto
+      pronti per il canale — dalla creazione dell'articolo alla sincronizzazione
+      GS1/GDSN fino alla sindacazione multicanale e alla prontezza dei contenuti.
+  BC-2370.10:
+    name: Gestione dei dati master degli articoli
+    description: |
+      Attributi master degli articoli, GTIN, gerarchie e tassonomia che costituiscono
+      il record canonico del prodotto nell'intera organizzazione.
+    in_scope:
+      - Creazione degli articoli e manutenzione degli attributi
+      - Identificazione tramite GTIN, GLN e livelli di imballaggio
+      - Tassonomia e classificazione dei prodotti (es. GS1 GPC)
+    out_of_scope:
+      - Governance generica dei dati master (BC-610)
+  BC-2370.10.10:
+    name: Creazione degli articoli e attribuzione
+    description: |
+      Creazione dei record degli articoli e compilazione dei valori degli attributi.
+  BC-2370.10.20:
+    name: Allocazione di GTIN e identificatori
+    description: |
+      Allocazione di GTIN e identificatori di livello imballaggio secondo le regole GS1.
+  BC-2370.10.30:
+    name: Gerarchia e tassonomia dei prodotti
+    description: |
+      Manutenzione della gerarchia e della tassonomia dei prodotti (es. GS1 GPC).
+  BC-2370.10.40:
+    name: Stato degli articoli e fase del ciclo di vita
+    description: |
+      Tracciamento delle fasi del ciclo di vita degli articoli dalla progettazione alla
+      discontinuazione.
+  BC-2370.20:
+    name: Gestione dell'authoring dei contenuti di prodotto
+    description: |
+      Authoring di testi di marketing, fotografie, video e rich media che trasformano
+      il record di un articolo in un prodotto vendibile rivolto al consumatore.
+  BC-2370.20.10:
+    name: Authoring dei testi di marketing
+    description: |
+      Authoring di titoli, descrizioni e testi di vendita per canale.
+  BC-2370.20.20:
+    name: Produzione di fotografie e video di prodotto
+    description: |
+      Produzione di fotografie di prodotto, immagini lifestyle e video.
+  BC-2370.20.30:
+    name: Produzione di rich media e asset 3D
+    description: |
+      Produzione di asset di prodotto a 360 gradi, in AR e in 3D.
+  BC-2370.20.40:
+    name: Traduzione e localizzazione
+    description: |
+      Traduzione e localizzazione dei contenuti di prodotto per i mercati di destinazione.
+  BC-2370.30:
+    name: Gestione della sindacazione per canale
+    description: |
+      Pubblicazione dei contenuti di prodotto sui canali propri, nei feed per il
+      retailer, sui marketplace e con i partner commerciali, con adattamento specifico
+      per canale.
+  BC-2370.30.10:
+    name: Pubblicazione sui canali propri
+    description: |
+      Pubblicazione dei contenuti sui canali web, mobile e punti vendita di proprietà.
+  BC-2370.30.20:
+    name: Sindacazione dei feed per marketplace
+    description: |
+      Sindacazione dei feed verso marketplace di terze parti e aggregatori.
+  BC-2370.30.30:
+    name: Feed per il retailer e catalogo EDI 832
+    description: |
+      Fornitura di cataloghi prodotto EDI 832 ai partner commerciali retail.
+  BC-2370.40:
+    name: Gestione della sincronizzazione GS1/GDSN
+    description: |
+      Sincronizzazione dei dati master di prodotto con i partner commerciali tramite
+      data pool GDSN, registrazione delle parti e sottoscrizioni dei destinatari.
+  BC-2370.40.10:
+    name: Operazioni del data pool GDSN
+    description: |
+      Gestione del rapporto con il data pool GDSN e delle sottomissioni dei dati.
+  BC-2370.40.20:
+    name: Registrazione delle parti e dei destinatari
+    description: |
+      Registrazione delle parti e delle sottoscrizioni dei destinatari nel GDSN.
+  BC-2370.40.30:
+    name: Gestione delle eccezioni di sincronizzazione GDSN
+    description: |
+      Gestione delle eccezioni di sincronizzazione GDSN e delle discrepanze con i
+      partner commerciali.
+  BC-2370.50:
+    name: Gestione della qualità dei contenuti di prodotto
+    description: |
+      Scoring della prontezza dei contenuti, misurazione della completezza e validazione
+      rispetto agli standard di qualità specifici per canale.
+  BC-2370.50.10:
+    name: Scoring della completezza dei contenuti
+    description: |
+      Scoring della completezza dei contenuti rispetto ai requisiti di prontezza per
+      canale.
+  BC-2370.50.20:
+    name: Validazione e conformità dei contenuti
+    description: |
+      Validazione dei contenuti rispetto alle regole normative e di canale.
+  BC-2370.50.30:
+    name: Remediation della qualità dei contenuti
+    description: |
+      Flusso di remediation per gli articoli che non superano i controlli di qualità
+      dei contenuti.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-product-lifecycle-management.yaml
+++ b/catalogue/i18n/it/L1-product-lifecycle-management.yaml
@@ -1,0 +1,143 @@
+# Gestione del ciclo di vita del prodotto (it) — translations for L1-product-lifecycle-management.yaml
+locale: it
+source: L1-product-lifecycle-management.yaml
+entries:
+  BC-820:
+    name: Gestione del ciclo di vita del prodotto
+    description: |
+      Gestione end-to-end dei prodotti dal concept al ritiro.
+  BC-820.10:
+    name: Gestione del concept di prodotto
+    description: |
+      Sviluppo del concept, ideazione e validazione di mercato.
+  BC-820.10.10:
+    name: Ideazione del prodotto
+    description: |
+      Generazione di nuovi concept di prodotto a partire dalle analisi di mercato e dei clienti.
+  BC-820.10.20:
+    name: Validazione del concept
+    description: |
+      Validazione dei concept di prodotto attraverso test con clienti e sul mercato.
+  BC-820.10.30:
+    name: Definizione del business case
+    description: |
+      Business case e giustificazione economica per i nuovi prodotti.
+  BC-820.20:
+    name: Gestione della progettazione del prodotto
+    description: |
+      Progettazione del prodotto, engineering e revisioni di progetto.
+  BC-820.20.10:
+    name: Ingegneria di progettazione del prodotto
+    description: |
+      Progettazione dettagliata del prodotto e analisi ingegneristica.
+  BC-820.20.20:
+    name: Revisione e approvazione del progetto
+    description: |
+      Revisioni formali del progetto e gate di approvazione.
+  BC-820.20.30:
+    name: Design for X
+    description: |
+      Design orientato alla producibilità, alla sostenibilità, alla manutenibilità e al costo.
+  BC-820.20.40:
+    name: Verifica e validazione del progetto
+    description: |
+      Verifica e validazione del progetto rispetto ai requisiti.
+  BC-820.30:
+    name: Gestione delle specifiche di prodotto
+    description: |
+      Specifiche di prodotto, requisiti e definizione della distinta base.
+  BC-820.30.10:
+    name: Gestione dei requisiti di prodotto
+    description: |
+      Raccolta e tracciabilità dei requisiti di prodotto.
+  BC-820.30.20:
+    name: Redazione delle specifiche di prodotto
+    description: |
+      Redazione delle specifiche di prodotto e della documentazione tecnica.
+  BC-820.30.30:
+    name: Definizione della distinta base del prodotto
+    description: |
+      Definizione delle strutture della distinta base del prodotto e delle revisioni.
+  BC-820.30.40:
+    name: Gestione dei dati di prodotto
+    description: |
+      PDM per dati di prodotto, disegni e assiemi CAD.
+  BC-820.40:
+    name: Gestione della configurazione e delle varianti del prodotto
+    description: |
+      Configurazioni, varianti, opzioni e bundle.
+  BC-820.40.10:
+    name: Modellazione della configurazione del prodotto
+    description: |
+      Modelli di configurazione, opzioni e regole di configurabilità.
+  BC-820.40.20:
+    name: Gestione delle varianti
+    description: |
+      Gestione delle varianti di prodotto e delle piattaforme.
+  BC-820.40.30:
+    name: Definizione di bundle e soluzioni
+    description: |
+      Definizione di bundle, kit e soluzioni combinate.
+  BC-820.50:
+    name: Gestione del rilascio e del lancio del prodotto
+    description: |
+      Pianificazione del rilascio, esecuzione del lancio e ramp-up.
+  BC-820.50.10:
+    name: Pianificazione del rilascio
+    description: |
+      Pianificazione del rilascio e definizione del perimetro del contenuto.
+  BC-820.50.20:
+    name: Esecuzione del lancio
+    description: |
+      Esecuzione cross-funzionale del lancio e verifica della readiness.
+  BC-820.50.30:
+    name: Ramp-up produttivo
+    description: |
+      Ramp-up produttivo e readiness della catena di fornitura post-lancio.
+  BC-820.50.40:
+    name: Monitoraggio delle performance del lancio
+    description: |
+      Monitoraggio dei KPI di lancio e azioni correttive post-lancio.
+  BC-820.60:
+    name: Gestione delle performance e del feedback del prodotto
+    description: |
+      Performance in vita, feedback dei clienti e analytics di prodotto.
+  BC-820.60.10:
+    name: Monitoraggio delle performance del prodotto in vita
+    description: |
+      Monitoraggio delle performance del prodotto attraverso metriche in vita.
+  BC-820.60.20:
+    name: Sintesi del feedback dei clienti
+    description: |
+      Sintesi del feedback dei clienti per alimentare la roadmap di prodotto.
+  BC-820.60.30:
+    name: Gestione della roadmap di prodotto
+    description: |
+      Definizione e aggiornamento della roadmap di prodotto.
+  BC-820.60.40:
+    name: Analytics di prodotto
+    description: |
+      Analytics di utilizzo, telemetria e strumentazione del prodotto.
+  BC-820.70:
+    name: Gestione del fine vita del prodotto
+    description: |
+      Pianificazione EOL, ritiro e strategie di sostituzione.
+  BC-820.70.10:
+    name: Pianificazione del fine vita
+    description: |
+      Pianificazione EOL, dipendenze e tempistiche.
+  BC-820.70.20:
+    name: Strategia di migrazione e sostituzione
+    description: |
+      Migrazione dei clienti verso prodotti successori e sostitutivi.
+  BC-820.70.30:
+    name: Ultimo ordine e gestione del supporto
+    description: |
+      Gestione dell'ultimo ordine, dei ricambi e del supporto EOL.
+  BC-820.70.40:
+    name: Comunicazioni di ritiro del prodotto
+    description: |
+      Comunicazione del ritiro del prodotto ai clienti e ai canali di vendita.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-product-substance-circularity-management.yaml
+++ b/catalogue/i18n/it/L1-product-substance-circularity-management.yaml
@@ -1,0 +1,144 @@
+# Gestione delle sostanze nel prodotto e della circolarità (it) — translations for L1-product-substance-circularity-management.yaml
+locale: it
+source: L1-product-substance-circularity-management.yaml
+entries:
+  BC-1980:
+    name: Gestione delle sostanze nel prodotto e della circolarità
+    description: |
+      Restrizioni sulle sostanze, ritiro e restituzione a fine vita, riparazione, ricondizionamento,
+      remanufacturing e divulgazione dell'impronta ambientale per prodotti elettrici.
+  BC-1980.10:
+    name: Gestione della conformità alle sostanze soggette a restrizioni
+    description: |
+      Conformità ai regimi di restrizione delle sostanze quali RoHS, REACH SVHC e Proposizione 65.
+  BC-1980.10.10:
+    name: Verifica della conformità RoHS
+    description: |
+      Verifica dei prodotti rispetto ai limiti di sostanza RoHS.
+  BC-1980.10.20:
+    name: Conformità REACH alle sostanze SVHC
+    description: |
+      Conformità agli obblighi REACH relativi alle sostanze estremamente preoccupanti.
+  BC-1980.10.30:
+    name: Conformità halogen-free
+    description: |
+      Verifica delle dichiarazioni di prodotto halogen-free.
+  BC-1980.10.40:
+    name: Conformità alla Proposizione 65
+    description: |
+      Conformità agli obblighi di avvertenza della Proposizione 65 della California.
+  BC-1980.20:
+    name: Gestione dei dati di dichiarazione delle sostanze
+    description: |
+      Raccolta e gestione dei dati di dichiarazione delle sostanze nell'intera distinta base.
+  BC-1980.20.10:
+    name: Raccolta delle dichiarazioni sui materiali
+    description: |
+      Raccolta delle dichiarazioni complete sui materiali dai fornitori.
+  BC-1980.20.20:
+    name: Manutenzione del database di conformità alle sostanze
+    description: |
+      Manutenzione del database principale di conformità alle sostanze.
+  BC-1980.20.30:
+    name: Divulgazione delle sostanze ai clienti
+    description: |
+      Fornitura di informazioni sulle sostanze a clienti e autorità.
+  BC-1980.30:
+    name: Due diligence sui minerali provenienti da zone di conflitto
+    description: |
+      Due diligence sulle fonti di stagno, tungsteno, tantalio e oro secondo i regimi allineati all'OCSE.
+  BC-1980.30.10:
+    name: Mappatura di fonderie e affinatori
+    description: |
+      Mappatura delle fonderie e degli affinatori che alimentano la catena di fornitura.
+  BC-1980.30.20:
+    name: Indagine sul paese di origine
+    description: |
+      Ragionevole indagine sul paese di origine per i minerali soggetti a regolamentazione.
+  BC-1980.30.30:
+    name: Rendicontazione sui minerali provenienti da zone di conflitto
+    description: |
+      Rendicontazione statutaria e verso i clienti sui minerali provenienti da zone di conflitto.
+  BC-1980.40:
+    name: Gestione della conformità per batterie e imballaggi
+    description: |
+      Conformità ai regimi per batterie e imballaggi, incluso il Regolamento UE sulle batterie.
+  BC-1980.40.10:
+    name: Conformità al regolamento sulle batterie
+    description: |
+      Conformità al Regolamento UE sulle batterie e agli strumenti equivalenti.
+  BC-1980.40.20:
+    name: Gestione dei dati del passaporto della batteria
+    description: |
+      Redazione e manutenzione dei dati del passaporto della batteria.
+  BC-1980.40.30:
+    name: Conformità per gli imballaggi e i rifiuti di imballaggio
+    description: |
+      Conformità agli obblighi in materia di imballaggi e rifiuti di imballaggio.
+  BC-1980.50:
+    name: Operazioni di ritiro a fine vita
+    description: |
+      Ritiro, logistica inversa e rendicontazione della responsabilità del produttore per prodotti elettrici.
+  BC-1980.50.10:
+    name: Operazioni dello schema di ritiro WEEE
+    description: |
+      Gestione degli accordi con lo schema di conformità del produttore WEEE.
+  BC-1980.50.20:
+    name: Rendicontazione della responsabilità del produttore
+    description: |
+      Rendicontazione delle tonnellate immesse sul mercato e recuperate.
+  BC-1980.50.30:
+    name: Operazioni di logistica inversa
+    description: |
+      Logistica inversa per prodotti e componenti a fine vita.
+  BC-1980.60:
+    name: Operazioni di riparazione e ricondizionamento
+    description: |
+      Rete di assistenza per la riparazione e documentazione sul diritto alla riparazione.
+  BC-1980.60.10:
+    name: Operazioni della rete di assistenza per la riparazione
+    description: |
+      Gestione delle reti di assistenza per la riparazione autorizzate.
+  BC-1980.60.20:
+    name: Documentazione per il diritto alla riparazione
+    description: |
+      Fornitura della documentazione di riparazione secondo i regimi del diritto alla riparazione.
+  BC-1980.60.30:
+    name: Operazioni del processo di ricondizionamento
+    description: |
+      Ricondizionamento dei prodotti restituiti per riportarli in condizione di rivendita.
+  BC-1980.70:
+    name: Operazioni di remanufacturing e riutilizzo
+    description: |
+      Remanufacturing e riutilizzo di nuclei e componenti in nuove costruzioni.
+  BC-1980.70.10:
+    name: Recupero e smontaggio del nucleo
+    description: |
+      Recupero e smontaggio dei nuclei restituiti.
+  BC-1980.70.20:
+    name: Esecuzione del processo di remanufacturing
+    description: |
+      Esecuzione dei processi di remanufacturing sui nuclei recuperati.
+  BC-1980.70.30:
+    name: Tracciabilità dei componenti riutilizzati
+    description: |
+      Tracciabilità dei componenti riutilizzati nella produzione di nuovi prodotti.
+  BC-1980.80:
+    name: Rendicontazione dell'impronta ambientale del prodotto
+    description: |
+      Redazione e divulgazione dei dati sull'impronta ambientale a livello di prodotto.
+  BC-1980.80.10:
+    name: Calcolo dell'impronta di carbonio del prodotto
+    description: |
+      Calcolo delle impronte di carbonio a livello di prodotto.
+  BC-1980.80.20:
+    name: Dichiarazione ambientale di prodotto
+    description: |
+      Redazione di dichiarazioni ambientali di prodotto EPD.
+  BC-1980.80.30:
+    name: Operazioni del passaporto digitale del prodotto
+    description: |
+      Gestione dei passaporti digitali del prodotto secondo la normativa emergente.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-product-telemetry-experimentation-management.yaml
+++ b/catalogue/i18n/it/L1-product-telemetry-experimentation-management.yaml
@@ -1,0 +1,133 @@
+# Gestione della telemetria di prodotto e sperimentazione (it) — translations for L1-product-telemetry-experimentation-management.yaml
+locale: it
+source: L1-product-telemetry-experimentation-management.yaml
+entries:
+  BC-4280:
+    name: Gestione della telemetria di prodotto e sperimentazione
+    description: |
+      Strumentazione, governance e analisi della telemetria di utilizzo del prodotto,
+      nonché progettazione ed esecuzione di esperimenti sulle funzionalità
+      che guidano le decisioni di prodotto.
+  BC-4280.10:
+    name: Strumentazione della telemetria di prodotto
+    description: |
+      Acquisizione degli eventi di utilizzo del prodotto dai runtime client e server
+      rispetto a schemi di eventi definiti.
+  BC-4280.10.10:
+    name: Definizione degli schemi degli eventi
+    description: |
+      Definizione degli schemi degli eventi di prodotto, incluse
+      le proprietà obbligatorie e facoltative.
+  BC-4280.10.20:
+    name: Strumentazione della telemetria client
+    description: |
+      Strumentazione dei runtime client
+      per l'emissione di eventi di prodotto.
+  BC-4280.10.30:
+    name: Strumentazione della telemetria server
+    description: |
+      Strumentazione dei runtime server
+      per l'emissione di eventi di prodotto.
+  BC-4280.20:
+    name: Qualità e governance della telemetria
+    description: |
+      Governance degli schemi, monitoraggio della qualità della pipeline
+      e filtraggio per la privacy della telemetria di prodotto.
+  BC-4280.20.10:
+    name: Governance degli schemi di telemetria
+    description: |
+      Governance degli schemi degli eventi di prodotto
+      su tutte le superfici di prodotto.
+  BC-4280.20.20:
+    name: Monitoraggio della qualità della pipeline di telemetria
+    description: |
+      Monitoraggio della correttezza, completezza
+      e freschezza della pipeline di telemetria.
+  BC-4280.20.30:
+    name: Filtraggio per la privacy della telemetria
+    description: |
+      Filtraggio, redazione e minimizzazione della telemetria
+      in linea con gli impegni di privacy.
+  BC-4280.30:
+    name: Analytics d'utilizzo del prodotto
+    description: |
+      Viste analitiche dell'utilizzo del prodotto, inclusi funnel,
+      coorti di retention ed engagement sulle funzionalità.
+  BC-4280.30.10:
+    name: Analytics del funnel
+    description: |
+      Analisi del funnel di conversione e abbandono
+      nei percorsi di prodotto.
+  BC-4280.30.20:
+    name: Analytics per coorte della retention
+    description: |
+      Analisi per coorte della retention degli utenti
+      nel tempo.
+  BC-4280.30.30:
+    name: Report sull'engagement delle funzionalità
+    description: |
+      Report sull'engagement con funzionalità specifiche
+      nell'intera base utenti.
+  BC-4280.40:
+    name: Gestione del programma di sperimentazione
+    description: |
+      Metodologia, revisione del design e aggiudicazione degli esperimenti
+      che guidano le decisioni di prodotto.
+  BC-4280.40.10:
+    name: Standard di metodologia di sperimentazione
+    description: |
+      Standard per una metodologia di sperimentazione valida
+      nei team di prodotto.
+  BC-4280.40.20:
+    name: Revisione del design degli esperimenti
+    description: |
+      Revisione dei design degli esperimenti rispetto agli standard
+      di metodologia ed etica.
+  BC-4280.40.30:
+    name: Aggiudicazione dei risultati degli esperimenti
+    description: |
+      Aggiudicazione degli esiti degli esperimenti
+      e conseguenti decisioni di prodotto.
+  BC-4280.50:
+    name: Esecuzione degli A/B test
+    description: |
+      Configurazione, targeting e monitoraggio degli A/B test
+      e dei test multivariati in corso.
+  BC-4280.50.10:
+    name: Configurazione degli esperimenti
+    description: |
+      Configurazione delle varianti degli esperimenti
+      e delle regole di assegnazione.
+  BC-4280.50.20:
+    name: Targeting degli esperimenti
+    description: |
+      Targeting delle coorti degli esperimenti
+      verso i pubblici appropriati.
+  BC-4280.50.30:
+    name: Monitoraggio degli esperimenti
+    description: |
+      Monitoraggio degli esperimenti in corso per guardrail
+      e interruzione anticipata.
+  BC-4280.60:
+    name: Sintesi degli insight sui clienti
+    description: |
+      Sintesi dei segnali quantitativi e qualitativi in decisioni
+      di prodotto e memo decisionali.
+  BC-4280.60.10:
+    name: Sintesi degli insight quantitativi
+    description: |
+      Sintesi dei risultati quantitativi da telemetria
+      e sperimentazione.
+  BC-4280.60.20:
+    name: Sintesi degli insight qualitativi
+    description: |
+      Sintesi dei risultati della ricerca qualitativa
+      in insight di prodotto.
+  BC-4280.60.30:
+    name: Redazione dei memo decisionali
+    description: |
+      Redazione di memo decisionali che documentano evidenze,
+      scelte e ragionamenti.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-production-management.yaml
+++ b/catalogue/i18n/it/L1-production-management.yaml
@@ -1,0 +1,127 @@
+# Gestione della produzione (it) — translations for L1-production-management.yaml
+locale: it
+source: L1-production-management.yaml
+entries:
+  BC-1000:
+    name: Gestione della produzione
+    description: |
+      Produzione di beni fisici: pianificazione, programmazione ed esecuzione a livello aziendale.
+  BC-1000.10:
+    name: Gestione della strategia produttiva
+    description: |
+      Footprint produttivo, make/buy e strategia di capacità.
+  BC-1000.10.10:
+    name: Strategia del footprint produttivo
+    description: |
+      Definizione del footprint produttivo di lungo periodo e del ruolo di ciascuno stabilimento.
+  BC-1000.10.20:
+    name: Strategia make-or-buy
+    description: |
+      Strategia make-or-buy e di outsourcing per linea di prodotto.
+  BC-1000.10.30:
+    name: Strategia di capacità
+    description: |
+      Strategia di capacità di lungo termine e pianificazione dell'espansione del capitale.
+  BC-1000.10.40:
+    name: Progettazione del modello operativo produttivo
+    description: |
+      Design del modello operativo e della governance della produzione manifatturiera.
+  BC-1000.20:
+    name: Gestione della pianificazione della produzione
+    description: |
+      Piano di produzione principale, pianificazione a medio termine (settimane-mesi).
+  BC-1000.20.10:
+    name: Schedulazione del piano di produzione principale
+    description: |
+      Generazione del piano di produzione principale su tutti gli stabilimenti.
+  BC-1000.20.20:
+    name: Pianificazione della capacità a grandi linee
+    description: |
+      Verifica della capacità a grandi linee rispetto al piano di produzione principale.
+  BC-1000.20.30:
+    name: Pianificazione della produzione a medio termine
+    description: |
+      Pianificazione della produzione settimanale e mensile per linea produttiva.
+  BC-1000.20.40:
+    name: Riconciliazione del piano di produzione
+    description: |
+      Riconciliazione del piano di produzione con l'offerta e la domanda.
+  BC-1000.30:
+    name: Gestione della schedulazione della produzione
+    description: |
+      Schedulazione dettagliata e sequenziamento (ore-giorni).
+  BC-1000.30.10:
+    name: Schedulazione dettagliata a capacità finita
+    description: |
+      Schedulazione a capacità finita a livello di macchina e linea produttiva.
+  BC-1000.30.20:
+    name: Ottimizzazione della sequenza
+    description: |
+      Ottimizzazione della sequenza per minimizzare i changeover e gli sprechi.
+  BC-1000.30.30:
+    name: Monitoraggio del rispetto della pianificazione
+    description: |
+      Monitoraggio del rispetto della pianificazione e ripianificazione.
+  BC-1000.30.40:
+    name: Rilascio degli ordini di produzione
+    description: |
+      Rilascio degli ordini di produzione al reparto produttivo.
+  BC-1000.40:
+    name: Gestione dell'esecuzione della produzione
+    description: |
+      Supervisione dell'esecuzione, dispatching e controllo in tempo reale.
+  BC-1000.40.10:
+    name: Dispatching degli ordini di produzione
+    description: |
+      Dispatching degli ordini ai centri di lavoro.
+  BC-1000.40.20:
+    name: Monitoraggio dello stato della produzione
+    description: |
+      Monitoraggio in tempo reale dello stato degli ordini di produzione.
+  BC-1000.40.30:
+    name: Gestione delle eccezioni di produzione
+    description: |
+      Gestione delle eccezioni di produzione e delle escalation.
+  BC-1000.40.40:
+    name: Chiusura degli ordini di produzione
+    description: |
+      Conferma, liquidazione e chiusura degli ordini di produzione.
+  BC-1000.50:
+    name: Gestione delle performance produttive
+    description: |
+      OEE, throughput, resa produttiva e KPI di produzione.
+  BC-1000.50.10:
+    name: Misurazione dell'OEE
+    description: |
+      Misurazione e reporting dell'OEE (Overall Equipment Effectiveness).
+  BC-1000.50.20:
+    name: Analisi del throughput e della resa
+    description: |
+      Analisi del throughput, della resa produttiva e del first-pass yield.
+  BC-1000.50.30:
+    name: Analisi dei fermi macchina e delle perdite
+    description: |
+      Classificazione dei fermi macchina e analisi dell'albero delle perdite.
+  BC-1000.50.40:
+    name: Reporting delle performance produttive
+    description: |
+      Reporting delle performance dello stabilimento e benchmarking.
+  BC-1000.60:
+    name: Gestione dei costi di produzione
+    description: |
+      Costi standard, varianze di produzione e analisi dei costi.
+  BC-1000.60.10:
+    name: Definizione dei costi standard
+    description: |
+      Definizione e rivalutazione dei costi standard per gli articoli prodotti.
+  BC-1000.60.20:
+    name: Analisi delle varianze di produzione
+    description: |
+      Analisi delle varianze di materiali, manodopera e costi generali.
+  BC-1000.60.30:
+    name: Reporting dei costi di produzione
+    description: |
+      Reporting periodico dei costi di produzione e benchmarking.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-professional-licensing-and-standards-management.yaml
+++ b/catalogue/i18n/it/L1-professional-licensing-and-standards-management.yaml
@@ -1,0 +1,142 @@
+# Gestione dell'abilitazione professionale e degli standard (it) — translations for L1-professional-licensing-and-standards-management.yaml
+locale: it
+source: L1-professional-licensing-and-standards-management.yaml
+entries:
+  BC-4380:
+    name: Gestione dell'abilitazione professionale e degli standard
+    description: |
+      Licenze e registrazioni dello studio e individuali, comunicazioni agli ordini professionali,
+      CPD (sviluppo professionale continuo), adozione di nuovi standard professionali
+      e gestione delle indagini disciplinari tipiche degli studi di servizi professionali.
+  BC-4380.10:
+    name: Gestione delle licenze e delle registrazioni dello studio
+    description: |
+      Manutenzione delle licenze e delle registrazioni professionali dello studio
+      presso organismi di vigilanza sulla revisione, ordini forensi e autorità equivalenti
+      nelle diverse giurisdizioni.
+  BC-4380.10.10:
+    name: Manutenzione delle registrazioni dello studio
+    description: |
+      Manutenzione delle registrazioni dello studio quali PCAOB, FRC RSB, registrazione
+      ICAEW, SRA recognised body e autorizzazioni ABS.
+  BC-4380.10.20:
+    name: Gestione del rinnovo delle licenze dello studio
+    description: |
+      Rinnovi periodici, pagamenti di quote e dichiarazioni
+      di supporto per le licenze dello studio.
+  BC-4380.10.30:
+    name: Coordinamento delle licenze multi-giurisdizionale
+    description: |
+      Coordinamento delle licenze dello studio nelle reti di member firm
+      e nelle giurisdizioni.
+  BC-4380.20:
+    name: Gestione dei certificati di esercizio individuali
+    description: |
+      Acquisizione e manutenzione dei certificati di esercizio individuali,
+      delle abilitazioni forensi, delle qualifiche di revisore e di altre licenze personali
+      detenute dai professionisti.
+  BC-4380.20.10:
+    name: Acquisizione dei certificati di esercizio
+    description: |
+      Acquisizione e verifica dei certificati di esercizio individuali
+      e delle qualifiche.
+  BC-4380.20.20:
+    name: Monitoraggio del rinnovo dei certificati di esercizio
+    description: |
+      Monitoraggio dei cicli di rinnovo e dei prerequisiti
+      per i certificati di esercizio individuali.
+  BC-4380.20.30:
+    name: Gestione dell'abilitazione transfrontaliera
+    description: |
+      Gestione dell'abilitazione transfrontaliera, dello status di avvocato straniero registrato
+      e degli accordi di equivalenza.
+  BC-4380.30:
+    name: Gestione del CPD
+    description: |
+      Pianificazione, erogazione e documentazione delle ore di sviluppo professionale continuo
+      richieste dagli ordini professionali e dalla policy dello studio.
+    in_scope:
+      - Pianificazione del curriculum CPD
+      - Erogazione e registrazione dei corsi CPD
+      - Evidenza CPD e rimediazione dei deficit
+    out_of_scope:
+      - Formazione e sviluppo generici (BC-300)
+  BC-4380.30.10:
+    name: Monitoraggio dei requisiti CPD
+    description: |
+      Monitoraggio dei requisiti di ore CPD per professionista,
+      qualifica e giurisdizione.
+  BC-4380.30.20:
+    name: Erogazione e registrazione dei corsi CPD
+    description: |
+      Erogazione di corsi CPD accreditati e registrazione
+      della partecipazione e dell'evidenza di completamento.
+  BC-4380.30.30:
+    name: Rimediazione dei deficit di CPD
+    description: |
+      Identificazione e rimediazione dei professionisti a rischio
+      di deficit di CPD prima delle scadenze di reporting.
+  BC-4380.40:
+    name: Reporting agli ordini professionali
+    description: |
+      Comunicazioni periodiche e notifiche agli ordini professionali, alle autorità di vigilanza
+      e ai regolatori su questioni dello studio e individuali.
+  BC-4380.40.10:
+    name: Preparazione delle comunicazioni annuali
+    description: |
+      Preparazione delle comunicazioni annuali e delle statistiche
+      agli ordini professionali e alle autorità di vigilanza.
+  BC-4380.40.20:
+    name: Segnalazione di eventi notificabili
+    description: |
+      Segnalazione di eventi notificabili quali dimissioni,
+      cambi di leadership e violazioni significative.
+  BC-4380.40.30:
+    name: Produzione del rapporto di trasparenza
+    description: |
+      Produzione di rapporti di trasparenza statutari o volontari
+      richiesti agli studi di revisione e ad altri studi regolamentati.
+  BC-4380.50:
+    name: Gestione dell'adozione degli standard professionali
+    description: |
+      Adozione di standard professionali nuovi e rivisti nella metodologia,
+      nelle policy e nell'esecuzione degli incarichi dello studio.
+  BC-4380.50.10:
+    name: Monitoraggio dell'orizzonte degli standard
+    description: |
+      Monitoraggio dei cambiamenti imminenti agli standard professionali e normativi
+      rilevanti per le practice dello studio.
+  BC-4380.50.20:
+    name: Valutazione dell'impatto degli standard
+    description: |
+      Valutazione dell'impatto su metodologia, formazione e strumenti
+      derivante da standard nuovi o rivisti.
+  BC-4380.50.30:
+    name: Rollout dell'adozione degli standard
+    description: |
+      Rollout degli aggiornamenti a metodologia, policy e strumenti
+      che recepiscono gli standard adottati.
+  BC-4380.60:
+    name: Gestione delle indagini sulla condotta professionale
+    description: |
+      Indagini interne, risposta alle indagini degli ordini professionali
+      e gestione delle richieste di risarcimento per responsabilità professionale
+      relative a presunti illeciti professionali.
+  BC-4380.60.10:
+    name: Indagine interna sulla condotta
+    description: |
+      Indagine interna su presunte violazioni degli standard professionali
+      o della policy di condotta dello studio.
+  BC-4380.60.20:
+    name: Risposta alle indagini degli ordini professionali
+    description: |
+      Coordinamento delle risposte dello studio alle indagini
+      degli ordini professionali e dei tribunali disciplinari.
+  BC-4380.60.30:
+    name: Gestione delle richieste di risarcimento per responsabilità professionale
+    description: |
+      Gestione delle richieste di risarcimento per responsabilità professionale
+      e delle notifiche agli assicuratori derivanti dal lavoro degli incarichi.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-professional-practice-knowledge-management.yaml
+++ b/catalogue/i18n/it/L1-professional-practice-knowledge-management.yaml
@@ -1,0 +1,133 @@
+# Gestione della conoscenza professionale (it) — translations for L1-professional-practice-knowledge-management.yaml
+locale: it
+source: L1-professional-practice-knowledge-management.yaml
+entries:
+  BC-4370:
+    name: Gestione della conoscenza professionale
+    description: |
+      Manutenzione e riutilizzo di precedenti della practice, asset metodologici,
+      thought leadership, template di deliverable e biblioteche di ricerca
+      che sostengono l'erogazione degli incarichi negli studi di servizi professionali.
+  BC-4370.10:
+    name: Gestione dei precedenti e dei template
+    description: |
+      Cura, versioning e controllo degli accessi a precedenti legali,
+      template contrattuali e prodotti di lavoro standard disponibili per il riutilizzo.
+  BC-4370.10.10:
+    name: Cura dei precedenti
+    description: |
+      Selezione, redazione e cura degli output di alta qualità degli incarichi
+      nella biblioteca dei precedenti dello studio.
+  BC-4370.10.20:
+    name: Manutenzione dei template
+    description: |
+      Manutenzione e controllo delle versioni di template contrattuali,
+      schemi di pareri e template standard di deliverable.
+  BC-4370.10.30:
+    name: Governance degli accessi ai precedenti
+    description: |
+      Governance degli accessi ai precedenti per bilanciare il riutilizzo
+      con la riservatezza del cliente e i vincoli delle barriere informative.
+  BC-4370.20:
+    name: Gestione della metodologia e degli strumenti
+    description: |
+      Definizione, evoluzione e rollout della metodologia degli incarichi,
+      dei framework analitici e degli strumenti proprietari utilizzati negli incarichi.
+  BC-4370.20.10:
+    name: Definizione della metodologia
+    description: |
+      Definizione delle metodologie di revisione, advisory e legali
+      allineate agli standard professionali e alla policy dello studio.
+  BC-4370.20.20:
+    name: Versioning e rilascio della metodologia
+    description: |
+      Versioning, gestione dei rilasci e deprecazione della metodologia
+      e dei componenti acceleratori.
+  BC-4370.20.30:
+    name: Rollout e formazione sulla metodologia
+    description: |
+      Rollout dei nuovi rilasci metodologici, inclusi formazione,
+      FAQ e monitoraggio dell'adozione.
+  BC-4370.30:
+    name: Gestione degli insight e del thought leadership della practice
+    description: |
+      Produzione e distribuzione di punti di vista, alert, survey
+      e pubblicazioni di thought leadership della practice.
+  BC-4370.30.10:
+    name: Pianificazione dei temi degli insight
+    description: |
+      Pianificazione dei temi di insight e thought leadership
+      allineati alla strategia della practice e agli interessi dei clienti.
+  BC-4370.30.20:
+    name: Produzione degli insight
+    description: |
+      Produzione di articoli, alert, punti di vista
+      e rapporti di survey.
+  BC-4370.30.30:
+    name: Distribuzione degli insight e monitoraggio dell'engagement
+    description: |
+      Distribuzione degli insight a clienti e prospect
+      e monitoraggio dell'engagement.
+  BC-4370.40:
+    name: Gestione del riutilizzo degli asset degli incarichi
+    description: |
+      Identificazione, raccolta e tagging degli output di alto valore degli incarichi
+      come asset riutilizzabili, bilanciati con la riservatezza del cliente.
+  BC-4370.40.10:
+    name: Identificazione degli asset riutilizzabili
+    description: |
+      Identificazione degli output degli incarichi con valore di riutilizzo
+      oltre l'incarico originante.
+  BC-4370.40.20:
+    name: Sanificazione e redazione degli asset
+    description: |
+      Sanificazione e redazione degli asset degli incarichi per rimuovere
+      le informazioni riservate del cliente prima del riutilizzo.
+  BC-4370.40.30:
+    name: Tagging e reperibilità degli asset
+    description: |
+      Tagging e arricchimento dei metadati degli asset riutilizzabili
+      per favorire la scoperta tra le practice.
+  BC-4370.50:
+    name: Gestione della biblioteca della practice
+    description: |
+      Cura e licenza di database di ricerca esterni, biblioteche legali e fiscali
+      e contenuti in abbonamento utilizzati dai professionisti.
+  BC-4370.50.10:
+    name: Gestione degli abbonamenti alla ricerca esterna
+    description: |
+      Acquisizione e rinnovo degli abbonamenti a database legali,
+      fiscali e di ricerca esterni.
+  BC-4370.50.20:
+    name: Catalogo e ricerca della biblioteca
+    description: |
+      Catalogo e ricerca federata su fonti di ricerca
+      interne ed esterne.
+  BC-4370.50.30:
+    name: Analytics sull'utilizzo della biblioteca
+    description: |
+      Analytics sull'utilizzo dei database di ricerca
+      per informare le decisioni di rinnovo e razionalizzazione.
+  BC-4370.60:
+    name: Gestione della community della practice
+    description: |
+      Gestione dei gruppi di practice, delle community of practice
+      e delle reti tematiche che condividono conoscenze nello studio.
+  BC-4370.60.10:
+    name: Gestione dei gruppi di practice
+    description: |
+      Gestione dei gruppi di practice, inclusi membership,
+      leadership e cadenza dei forum.
+  BC-4370.60.20:
+    name: Facilitazione delle community of practice
+    description: |
+      Facilitazione di community of practice trasversali
+      su temi emergenti e metodi.
+  BC-4370.60.30:
+    name: Rete dei knowledge champion
+    description: |
+      Gestione di una rete di knowledge champion distribuita
+      tra practice e uffici.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-professional-services-delivery-management.yaml
+++ b/catalogue/i18n/it/L1-professional-services-delivery-management.yaml
@@ -1,0 +1,171 @@
+# Gestione dell'erogazione dei servizi professionali (it) — translations for L1-professional-services-delivery-management.yaml
+locale: it
+source: L1-professional-services-delivery-management.yaml
+entries:
+  BC-4310:
+    name: Gestione dell'erogazione dei servizi professionali
+    description: |
+      Esecuzione di incarichi advisory, legali, di revisione e di consulenza — pianificazione
+      del lavoro, attività sul campo, produzione dei deliverable, revisione interna
+      e reporting dell'incarico nell'ambito concordato.
+  BC-4310.10:
+    name: Gestione della pianificazione dell'incarico
+    description: |
+      Pianificazione dettagliata del lavoro, delle milestone, della struttura dei deliverable
+      e delle procedure commisurate al rischio in linea con gli standard professionali applicabili.
+  BC-4310.10.10:
+    name: Definizione del piano di lavoro dell'incarico
+    description: |
+      Definizione della scomposizione del lavoro, delle milestone
+      e delle dipendenze per l'incarico.
+  BC-4310.10.20:
+    name: Personalizzazione delle procedure basata sul rischio
+    description: |
+      Personalizzazione delle procedure di revisione, analisi advisory
+      o fasi legali in base al rischio e alla rilevanza specifici dell'incarico.
+  BC-4310.10.30:
+    name: Definizione del piano dei deliverable
+    description: |
+      Definizione della struttura, del formato e dei punti
+      di revisione dei deliverable.
+  BC-4310.10.40:
+    name: Gestione del calendario dell'incarico
+    description: |
+      Pianificazione giornaliera delle attività dell'incarico
+      e della disponibilità delle risorse rispetto al piano di lavoro.
+  BC-4310.20:
+    name: Gestione dell'esecuzione dell'incarico
+    description: |
+      Erogazione quotidiana del lavoro — attività sul campo, analisi advisory,
+      testing di revisione, bozze e interazione con il cliente.
+  BC-4310.20.10:
+    name: Esecuzione delle procedure di revisione
+    description: |
+      Svolgimento delle procedure di revisione e assurance, inclusi
+      test sostanziali, testing dei controlli e procedure analitiche.
+  BC-4310.20.20:
+    name: Esecuzione delle analisi advisory
+    description: |
+      Svolgimento di analisi di consulenza, modellazione, benchmarking
+      e sviluppo di raccomandazioni.
+  BC-4310.20.30:
+    name: Esecuzione della materia legale
+    description: |
+      Lavoro legale sostanziale, inclusi bozze, pareri, atti giudiziari,
+      esecuzione di operazioni e consulenza.
+  BC-4310.20.40:
+    name: Gestione dell'interazione con il cliente
+    description: |
+      Interazione quotidiana con il cliente durante l'esecuzione — interviste,
+      richieste di informazioni, aggiornamenti e workshop con gli stakeholder.
+  BC-4310.30:
+    name: Gestione dei deliverable dell'incarico
+    description: |
+      Bozza, controllo delle versioni e finalizzazione dei deliverable,
+      quali report di revisione, pareri, report advisory e documentazione di operazioni.
+  BC-4310.30.10:
+    name: Bozza dei deliverable
+    description: |
+      Produzione delle bozze dei deliverable utilizzando template,
+      metodologia e risultanze dello studio.
+  BC-4310.30.20:
+    name: Controllo delle versioni dei deliverable
+    description: |
+      Versioning, branching e audit trail delle bozze dei deliverable
+      nel corso dei cicli di revisione.
+  BC-4310.30.30:
+    name: Finalizzazione dei deliverable
+    description: |
+      Formattazione finale, blocchi firma e packaging per il rilascio
+      dei deliverable completati.
+  BC-4310.40:
+    name: Gestione della documentazione di lavoro dell'incarico
+    description: |
+      Acquisizione, organizzazione e conservazione della documentazione di lavoro
+      e delle evidenze a supporto dei deliverable e delle conclusioni.
+    in_scope:
+      - Documenti di lavoro del fascicolo dell'incarico
+      - Indicizzazione e cross-referencing delle evidenze
+      - Assemblaggio e blocco del fascicolo
+    out_of_scope:
+      - Asset metodologici e precedenti riutilizzabili (BC-4370)
+  BC-4310.40.10:
+    name: Acquisizione della documentazione di lavoro
+    description: |
+      Acquisizione di evidenze, analisi e note
+      nel fascicolo della documentazione di lavoro.
+  BC-4310.40.20:
+    name: Indicizzazione e cross-referencing della documentazione
+    description: |
+      Indicizzazione e cross-referencing della documentazione di lavoro
+      rispetto alle asserzioni dei deliverable e alle fasi delle procedure.
+  BC-4310.40.30:
+    name: Assemblaggio e blocco del fascicolo
+    description: |
+      Assemblaggio del fascicolo definitivo dell'incarico e blocco per impedire
+      modifiche post-emissione al di fuori dei controlli previsti.
+  BC-4310.50:
+    name: Gestione della revisione interna dell'incarico
+    description: |
+      Cicli di revisione all'interno dell'incarico da parte di revisori, manager e partner
+      prima del rilascio dei deliverable; distinti dal monitoraggio della qualità a livello di studio.
+    out_of_scope:
+      - Monitoraggio della qualità a livello di studio ed EQR (BC-4340)
+  BC-4310.50.10:
+    name: Revisione dei documenti di lavoro da parte del manager
+    description: |
+      Revisione da parte del manager dei documenti di lavoro
+      e delle conclusioni prima della firma del partner.
+  BC-4310.50.20:
+    name: Revisione e firma del partner
+    description: |
+      Revisione e firma del partner responsabile
+      su deliverable e pareri.
+  BC-4310.50.30:
+    name: Revisione tecnica specialistica
+    description: |
+      Revisione da parte di specialisti tecnici (fiscalità, valutazione, IT, attuariale)
+      nelle aree che richiedono input specializzati.
+  BC-4310.60:
+    name: Gestione del coinvolgimento di specialisti esterni
+    description: |
+      Coinvolgimento di co-counsel, testimoni esperti, sub-appaltatori
+      e specialisti terzi nell'ambito di un incarico.
+  BC-4310.60.10:
+    name: Coinvolgimento di co-counsel e sub-appaltatori
+    description: |
+      Selezione e coinvolgimento di co-counsel, local counsel
+      o sub-appaltatori di consulenza.
+  BC-4310.60.20:
+    name: Coinvolgimento di testimoni esperti
+    description: |
+      Identificazione, coinvolgimento e gestione di testimoni esperti
+      ed esperti esterni.
+  BC-4310.60.30:
+    name: Supervisione della qualità degli specialisti esterni
+    description: |
+      Supervisione del prodotto di lavoro degli specialisti esterni
+      e valutazione dell'affidabilità per le conclusioni dell'incarico.
+  BC-4310.70:
+    name: Reporting e comunicazione dell'incarico
+    description: |
+      Reporting sullo stato, comunicazioni intermedie e reporting finale al cliente
+      e alla leadership dell'incarico durante l'esecuzione.
+  BC-4310.70.10:
+    name: Reporting sullo stato dell'incarico
+    description: |
+      Aggiornamenti periodici sullo stato alla leadership dell'incarico e al cliente,
+      inclusi avanzamento, rischi e problematiche.
+  BC-4310.70.20:
+    name: Comunicazione dei risultati preliminari
+    description: |
+      Comunicazione intermedia di risultati preliminari, osservazioni
+      e problematiche significative al cliente durante l'esecuzione.
+  BC-4310.70.30:
+    name: Reporting finale dell'incarico
+    description: |
+      Emissione di report finali, pareri e management letter
+      nell'ambito della chiusura dell'incarico.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-professional-workforce-resourcing-management.yaml
+++ b/catalogue/i18n/it/L1-professional-workforce-resourcing-management.yaml
@@ -1,0 +1,153 @@
+# Gestione delle risorse professionali (it) — translations for L1-professional-workforce-resourcing-management.yaml
+locale: it
+source: L1-professional-workforce-resourcing-management.yaml
+entries:
+  BC-4320:
+    name: Gestione delle risorse professionali
+    description: |
+      Allocazione, tasso di utilizzo, leva e gestione del bench dei professionisti fatturabili
+      nel portafoglio di incarichi. Distinta dalla gestione del capitale umano generica —
+      focalizzata sulla forza lavoro fatturabile come principale risorsa di erogazione dello studio.
+  BC-4320.10:
+    name: Previsione della domanda di risorse
+    description: |
+      Previsione della domanda di risorse fatturabili dalla pipeline di incarichi,
+      dagli incarichi confermati e dalle ipotesi di crescita.
+  BC-4320.10.10:
+    name: Previsione della domanda basata sulla pipeline
+    description: |
+      Previsione della domanda di risorse derivata dalla pipeline di opportunità,
+      ponderata per la probabilità di aggiudicazione.
+  BC-4320.10.20:
+    name: Pianificazione della domanda per incarichi confermati
+    description: |
+      Pianificazione della domanda di risorse dagli incarichi accettati
+      con ambito e tempistiche confermati.
+  BC-4320.10.30:
+    name: Aggregazione della domanda per competenza
+    description: |
+      Aggregazione della domanda prevista per competenza, specialismo,
+      lingua e abilitazione.
+  BC-4320.20:
+    name: Gestione dello staffing degli incarichi
+    description: |
+      Allocazione di professionisti nominativi ai ruoli dell'incarico, bilanciando
+      le esigenze dell'incarico, lo sviluppo individuale e gli obiettivi di utilizzo.
+  BC-4320.20.10:
+    name: Gestione delle richieste di risorse per l'incarico
+    description: |
+      Raccolta e triage delle richieste di risorse lato incarico
+      rispetto ai professionisti disponibili.
+  BC-4320.20.20:
+    name: Gestione delle decisioni di staffing
+    description: |
+      Processo decisionale sull'allocazione che bilancia l'idoneità all'incarico,
+      le esigenze di sviluppo e le preferenze del partner.
+  BC-4320.20.30:
+    name: Conferma e notifica dello staffing
+    description: |
+      Conferma delle decisioni di staffing alla leadership dell'incarico
+      e ai professionisti assegnati.
+  BC-4320.30:
+    name: Abbinamento di competenze e specialismi
+    description: |
+      Manutenzione dei profili di competenza dei professionisti e abbinamento
+      dei profili ai requisiti di competenza degli incarichi.
+  BC-4320.30.10:
+    name: Manutenzione del profilo di competenza del professionista
+    description: |
+      Raccolta e aggiornamento di competenze, qualifiche, lingue
+      ed esperienza settoriale per ciascun professionista.
+  BC-4320.30.20:
+    name: Definizione dei requisiti di competenza dell'incarico
+    description: |
+      Definizione dei requisiti di competenza, specialismo
+      e abilitazione per ruolo nell'incarico.
+  BC-4320.30.30:
+    name: Abbinamento basato sulle competenze
+    description: |
+      Abbinamento dei professionisti ai ruoli dell'incarico
+      sulla base di competenza, specialismo e disponibilità.
+  BC-4320.40:
+    name: Gestione del tasso di utilizzo
+    description: |
+      Monitoraggio e orientamento dell'addebitabilità rispetto agli obiettivi
+      dello studio e individuali, incluse le analytics di produttività.
+  BC-4320.40.10:
+    name: Definizione degli obiettivi di utilizzo
+    description: |
+      Definizione degli obiettivi di utilizzo addebitabile
+      per livello professionale, practice e professionista.
+  BC-4320.40.20:
+    name: Monitoraggio del tasso di utilizzo
+    description: |
+      Monitoraggio giornaliero delle ore addebitabili,
+      delle ore non addebitabili e delle assenze.
+  BC-4320.40.30:
+    name: Azioni sulle scostanze di utilizzo
+    description: |
+      Identificazione e rimediazione dei professionisti al di sotto
+      o significativamente al di sopra degli obiettivi di utilizzo.
+  BC-4320.50:
+    name: Gestione del bench
+    description: |
+      Gestione della capacità fatturabile non allocata, incluse la pianificazione della rampa,
+      l'utilizzo del bench per attività non fatturabili e il reimpiego proattivo.
+  BC-4320.50.10:
+    name: Gestione della visibilità del bench
+    description: |
+      Visibilità della capacità disponibile per livello professionale,
+      competenza e sede.
+  BC-4320.50.20:
+    name: Allocazione delle attività sul bench
+    description: |
+      Allocazione del tempo sul bench a sviluppo, supporto alle proposte,
+      lavoro metodologico o formazione.
+  BC-4320.50.30:
+    name: Azioni di riduzione del bench
+    description: |
+      Reimpiego proattivo, distacco o adeguamento della capacità
+      quando il bench supera il target.
+  BC-4320.60:
+    name: Gestione delle risorse cross-office e transfrontaliera
+    description: |
+      Coordinamento della condivisione delle risorse tra uffici, practice e confini,
+      inclusi distacchi e mobilità internazionale per i professionisti fatturabili.
+  BC-4320.60.10:
+    name: Prestito di risorse tra uffici
+    description: |
+      Prestito e concessione in prestito di professionisti tra uffici
+      su base temporanea.
+  BC-4320.60.20:
+    name: Gestione dei distacchi internazionali
+    description: |
+      Distacchi internazionali di lungo periodo di professionisti
+      tra gli uffici dello studio o nelle giurisdizioni della rete.
+  BC-4320.60.30:
+    name: Addebito e liquidazione inter-ufficio
+    description: |
+      Liquidazione operativa degli addebiti di tempo e costi
+      tra uffici su incarichi condivisi.
+  BC-4320.70:
+    name: Gestione della leva dell'incarico
+    description: |
+      Gestione del rapporto leva partner/staff negli incarichi,
+      bilanciando aspetti economici, qualità e sviluppo.
+  BC-4320.70.10:
+    name: Modellazione della leva dell'incarico
+    description: |
+      Modellazione del mix di partner, manager, senior e junior
+      per tipologia di incarico.
+  BC-4320.70.20:
+    name: Monitoraggio degli scostamenti di leva
+    description: |
+      Monitoraggio della leva effettiva rispetto al target
+      e analisi delle cause radice degli scostamenti.
+  BC-4320.70.30:
+    name: Analytics sulla salute della piramide professionale
+    description: |
+      Analytics sulla salute della piramide per livello professionale,
+      velocità di promozione e impatto dell'attrition sulla leva.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-programming-scheduling-management.yaml
+++ b/catalogue/i18n/it/L1-programming-scheduling-management.yaml
@@ -1,0 +1,113 @@
+# Programmazione e palinsesto (it) — translations for L1-programming-scheduling-management.yaml
+locale: it
+source: L1-programming-scheduling-management.yaml
+entries:
+  BC-3730:
+    name: Programmazione e palinsesto
+    description: |
+      Pianificazione del palinsesto lineare, gestione dell'EPG, curazione del
+      catalogo on-demand, playlist di trasmissione e continuità, e riconciliazione
+      della domanda di programmazione con i diritti e le pipeline di acquisizione.
+  BC-3730.10:
+    name: Pianificazione del palinsesto lineare
+    description: |
+      Pianificazione del palinsesto a lungo termine, tattica e in modifica
+      per canali lineari e stream.
+  BC-3730.10.10:
+    name: Pianificazione del palinsesto a lungo termine
+    description: |
+      Piani di palinsesto multi-trimestrale e stagionale allineati alle
+      finestre di diritti e alla strategia di audience.
+  BC-3730.10.20:
+    name: Costruzione del palinsesto tattico
+    description: |
+      Costruzione del palinsesto della settimana di messa in onda fino
+      al livello di programma e interruzione pubblicitaria.
+  BC-3730.10.30:
+    name: Gestione delle variazioni di palinsesto
+    description: |
+      Gestione controllata delle variazioni di palinsesto urgenti ed
+      emergenziali con notifica downstream.
+  BC-3730.20:
+    name: Gestione dell'EPG
+    description: |
+      Redazione, distribuzione e aggiornamento dei dati EPG verso
+      gli operatori e i dispositivi consumer.
+  BC-3730.20.10:
+    name: Redazione dei dati EPG
+    description: |
+      Redazione di titoli, sinossi, classificazioni e metadati degli eventi
+      EPG per la pubblicazione.
+  BC-3730.20.20:
+    name: Distribuzione dell'EPG agli operatori
+    description: |
+      Distribuzione dei feed EPG agli operatori di piattaforma, aggregatori
+      e piattaforme per dispositivi consumer.
+  BC-3730.20.30:
+    name: Gestione degli aggiornamenti in tempo reale dell'EPG
+    description: |
+      Aggiornamenti in tempo reale dei dati EPG per sforamenti di dirette,
+      sport e notizie dell'ultima ora.
+  BC-3730.30:
+    name: Curazione del catalogo on-demand
+    description: |
+      Curazione di titoli, collezioni e regole di personalizzazione
+      sulle superfici on-demand e streaming.
+  BC-3730.30.10:
+    name: Selezione e curazione dei titoli
+    description: |
+      Selezione e inquadratura editoriale dei titoli nel catalogo on-demand,
+      compresa la disponibilità territoriale.
+  BC-3730.30.20:
+    name: Gestione delle collezioni editoriali
+    description: |
+      Redazione e ciclo di vita di collezioni editoriali, tematiche
+      e righe presentate agli spettatori.
+  BC-3730.30.30:
+    name: Redazione delle regole di personalizzazione
+    description: |
+      Redazione di regole di business che governano la personalizzazione
+      in abbinamento alle raccomandazioni di machine learning.
+  BC-3730.40:
+    name: Gestione della playlist e della continuità
+    description: |
+      Costruzione delle playlist di trasmissione e della continuità on-air
+      per canali lineari e streaming 24/7.
+  BC-3730.40.10:
+    name: Costruzione della playlist di trasmissione
+    description: |
+      Costruzione delle playlist di trasmissione temporizzate per il playout,
+      comprensive di interruzioni pubblicitarie ed elementi interstitial.
+  BC-3730.40.20:
+    name: Gestione della continuità e dei giunti di palinsesto
+    description: |
+      Redazione e gestione degli annunci di continuità, ident e pacchetti
+      di giunzione.
+  BC-3730.40.30:
+    name: Gestione dei tagli di conformità e degli inserti
+    description: |
+      Applicazione dei tagli di conformità e degli inserti di versione
+      richiesti per il canale e lo slot target.
+  BC-3730.50:
+    name: Pianificazione degli slot di acquisizione di programmi
+    description: |
+      Traduzione della domanda degli slot di programmazione in wishlist di
+      acquisizione e riconciliazione dei diritti acquisiti con le esigenze di palinsesto.
+  BC-3730.50.10:
+    name: Pianificazione della domanda di slot
+    description: |
+      Quantificazione della domanda di slot per genere, fascia oraria e
+      target di audience sull'orizzonte di palinsesto.
+  BC-3730.50.20:
+    name: Gestione della wishlist di acquisizione
+    description: |
+      Wishlist di titoli, format e pacchetti prioritari per l'acquisizione
+      a copertura degli slot identificati.
+  BC-3730.50.30:
+    name: Riconciliazione programmazione-diritti
+    description: |
+      Riconciliazione delle trasmissioni programmate rispetto ai diritti
+      detenuti, ai passaggi e al consumo delle finestre.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-project-engineering-management.yaml
+++ b/catalogue/i18n/it/L1-project-engineering-management.yaml
@@ -1,0 +1,127 @@
+# Gestione dell'ingegneria di progetto (it) — translations for L1-project-engineering-management.yaml
+locale: it
+source: L1-project-engineering-management.yaml
+entries:
+  BC-1110:
+    name: Gestione dell'ingegneria di progetto
+    description: |
+      Ingegneria di progetto dal FEED fino alla consegna.
+  BC-1110.10:
+    name: Gestione della pianificazione dell'ingegneria di progetto
+    description: |
+      Struttura di scomposizione delle attività di ingegneria, piani degli elaborati e scheduling ingegneristico.
+  BC-1110.10.10:
+    name: Definizione della struttura di scomposizione delle attività di ingegneria
+    description: |
+      WBS di ingegneria e scomposizione per disciplina.
+  BC-1110.10.20:
+    name: Registro degli elaborati di ingegneria
+    description: |
+      Registro degli elaborati, responsabili e date obiettivo.
+  BC-1110.10.30:
+    name: Sviluppo del programma di ingegneria
+    description: |
+      Programma di ingegneria con le interdipendenze tra discipline.
+  BC-1110.10.40:
+    name: Caricamento delle risorse di ingegneria
+    description: |
+      Previsione delle ore di ingegneria e caricamento delle risorse.
+  BC-1110.20:
+    name: Gestione dell'esecuzione dell'ingegneria di progetto
+    description: |
+      Supervisione e reportistica dell'esecuzione ingegneristica multidisciplinare.
+  BC-1110.20.10:
+    name: Misurazione dell'avanzamento dell'ingegneria
+    description: |
+      Misurazione dell'avanzamento degli elaborati di ingegneria e valore guadagnato.
+  BC-1110.20.20:
+    name: Controllo delle ore-uomo di ingegneria
+    description: |
+      Monitoraggio e previsione del consumo di ore-uomo di ingegneria.
+  BC-1110.20.30:
+    name: Riunioni di coordinamento dell'ingegneria
+    description: |
+      Coordinamento ingegneristico interdisciplinare e reportistica settimanale.
+  BC-1110.20.40:
+    name: Miglioramento della produttività dell'ingegneria
+    description: |
+      Iniziative di produttività quali l'automazione della progettazione e il riutilizzo.
+  BC-1110.30:
+    name: Gestione delle modifiche tecniche
+    description: |
+      Richieste di modifica, valutazione dell'impatto tecnico e controllo della baseline.
+  BC-1110.30.10:
+    name: Acquisizione delle richieste di modifica tecnica
+    description: |
+      Acquisizione e classificazione delle richieste di modifica tecnica.
+  BC-1110.30.20:
+    name: Valutazione dell'impatto tecnico
+    description: |
+      Valutazione dell'impatto tecnico multidisciplinare delle modifiche.
+  BC-1110.30.30:
+    name: Controllo della baseline di ingegneria
+    description: |
+      Controllo delle baseline di ingegneria e degli elementi di configurazione.
+  BC-1110.30.40:
+    name: Approvazione e attuazione delle modifiche tecniche
+    description: |
+      Commissioni di approvazione delle modifiche e monitoraggio dell'attuazione.
+  BC-1110.40:
+    name: Gestione delle interfacce tecniche
+    description: |
+      Interfacce tecniche interne ed esterne, coordinamento con gli stakeholder.
+  BC-1110.40.10:
+    name: Identificazione e registrazione delle interfacce tecniche
+    description: |
+      Identificazione e registrazione delle interfacce tecniche.
+  BC-1110.40.20:
+    name: Gestione degli accordi di interfaccia
+    description: |
+      Accordi di interfaccia con le parti e criteri di accettazione.
+  BC-1110.40.30:
+    name: Monitoraggio e chiusura delle interfacce tecniche
+    description: |
+      Monitoraggio degli elaborati di interfaccia e chiusura formale.
+  BC-1110.50:
+    name: Gestione della qualità dell'ingegneria di progetto
+    description: |
+      QA/QC dell'ingegneria, assurance tecnica, revisioni tra pari e audit.
+  BC-1110.50.10:
+    name: Gestione del programma QA dell'ingegneria
+    description: |
+      Allineamento del programma QA dell'ingegneria con ISO 9001.
+  BC-1110.50.20:
+    name: Revisione tra pari disciplinare
+    description: |
+      Revisione tra pari degli elaborati di ingegneria per disciplina.
+  BC-1110.50.30:
+    name: Audit tecnico dell'ingegneria
+    description: |
+      Audit tecnici indipendenti e revisioni di assurance.
+  BC-1110.50.40:
+    name: Lezioni apprese dell'ingegneria
+    description: |
+      Acquisizione e diffusione delle lezioni apprese dell'ingegneria.
+  BC-1110.60:
+    name: Gestione dei rischi e delle problematiche tecniche di progetto
+    description: |
+      Rischi tecnici, problematiche tecniche e monitoraggio delle azioni di mitigazione.
+  BC-1110.60.10:
+    name: Identificazione dei rischi tecnici
+    description: |
+      Identificazione dei rischi tecnici e ingegneristici.
+  BC-1110.60.20:
+    name: Valutazione dei rischi tecnici
+    description: |
+      Valutazione della probabilità e dell'impatto dei rischi tecnici.
+  BC-1110.60.30:
+    name: Risoluzione delle problematiche tecniche
+    description: |
+      Monitoraggio e risoluzione delle problematiche tecniche con i responsabili.
+  BC-1110.60.40:
+    name: Monitoraggio delle azioni di mitigazione tecnica
+    description: |
+      Monitoraggio delle azioni di mitigazione e del rischio residuo.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-project-portfolio-management.yaml
+++ b/catalogue/i18n/it/L1-project-portfolio-management.yaml
@@ -1,0 +1,135 @@
+# Gestione del portafoglio progetti (it) — translations for L1-project-portfolio-management.yaml
+locale: it
+source: L1-project-portfolio-management.yaml
+entries:
+  BC-900:
+    name: Gestione del portafoglio progetti
+    description: |
+      Esecuzione dei progetti, prioritizzazione del portafoglio e PMO.
+  BC-900.10:
+    name: Gestione del portafoglio
+    description: |
+      Composizione, prioritizzazione e bilanciamento del portafoglio.
+  BC-900.10.10:
+    name: Definizione della composizione del portafoglio
+    description: |
+      Composizione del portafoglio per tema strategico, tipologia e rischio.
+  BC-900.10.20:
+    name: Prioritizzazione e selezione del portafoglio
+    description: |
+      Valutazione e selezione delle iniziative da includere nel portafoglio.
+  BC-900.10.30:
+    name: Bilanciamento del portafoglio
+    description: |
+      Bilanciamento del portafoglio per orizzonti temporali, rischio e rendimento.
+  BC-900.10.40:
+    name: Reporting delle performance del portafoglio
+    description: |
+      Dashboard di portafoglio, stato avanzamento e reporting dei benefici.
+  BC-900.20:
+    name: Gestione del programma
+    description: |
+      Pianificazione, esecuzione e governance del programma.
+  BC-900.20.10:
+    name: Definizione e mobilizzazione del programma
+    description: |
+      Blueprint del programma, mandato e mobilizzazione.
+  BC-900.20.20:
+    name: Integrazione del piano di programma
+    description: |
+      Integrazione dei piani di progetto, delle dipendenze e delle milestone.
+  BC-900.20.30:
+    name: Gestione dei rischi e delle problematiche del programma
+    description: |
+      Gestione dei rischi, delle problematiche e delle dipendenze a livello di programma.
+  BC-900.20.40:
+    name: Chiusura del programma
+    description: |
+      Chiusura del programma, handover e lezioni apprese.
+  BC-900.30:
+    name: Gestione dei progetti
+    description: |
+      Esecuzione, pianificazione e monitoraggio dei progetti.
+  BC-900.30.10:
+    name: Pianificazione del progetto
+    description: |
+      Pianificazione di ambito, tempi, costi e risorse del progetto.
+  BC-900.30.20:
+    name: Esecuzione e monitoraggio del progetto
+    description: |
+      Esecuzione quotidiana del progetto e monitoraggio dell'avanzamento.
+  BC-900.30.30:
+    name: Gestione dei rischi e delle problematiche del progetto
+    description: |
+      Gestione di rischi, problematiche e decisioni a livello di progetto.
+  BC-900.30.40:
+    name: Gestione della qualità del progetto
+    description: |
+      Qualità e accettazione dei deliverable del progetto.
+  BC-900.30.50:
+    name: Chiusura e handover del progetto
+    description: |
+      Chiusura del progetto, handover alle operations e revisione post-implementazione.
+  BC-900.40:
+    name: Gestione della governance di progetto
+    description: |
+      Stage gate, comitati di steering e assurance.
+  BC-900.40.10:
+    name: Governance stage gate
+    description: |
+      Definizione degli stage gate, criteri e approvazioni.
+  BC-900.40.20:
+    name: Operatività del comitato di steering
+    description: |
+      Termini di riferimento, ordini del giorno e decisioni del comitato di steering.
+  BC-900.40.30:
+    name: Revisioni di assurance del progetto
+    description: |
+      Revisioni di assurance indipendenti e gateway review.
+  BC-900.40.40:
+    name: Audit di progetto e lezioni apprese
+    description: |
+      Audit post-progetto, raccolta e disseminazione delle lezioni apprese.
+  BC-900.50:
+    name: Gestione operativa del PMO
+    description: |
+      Servizi, metodologie e strumenti del PMO.
+  BC-900.50.10:
+    name: Metodologia e standard del PMO
+    description: |
+      Metodologie di project management, template e standard (PRINCE2, PMI, agile).
+  BC-900.50.20:
+    name: Strumenti e reporting del PMO
+    description: |
+      Strumenti di project management, dashboard e reporting.
+  BC-900.50.30:
+    name: Sviluppo delle competenze del PMO
+    description: |
+      Sviluppo delle competenze dei project manager e certificazioni.
+  BC-900.50.40:
+    name: Gestione delle performance del PMO
+    description: |
+      Scorecard, valore e monitoraggio delle performance del PMO.
+  BC-900.60:
+    name: Gestione della domanda e della capacità
+    description: |
+      Intake della domanda di progetti e pianificazione della capacità delle risorse.
+  BC-900.60.10:
+    name: Intake della domanda di progetti
+    description: |
+      Raccolta, qualificazione e approvazione delle nuove richieste di progetto.
+  BC-900.60.20:
+    name: Pianificazione della capacità delle risorse
+    description: |
+      Pianificazione della capacità tra i team di delivery e per competenza.
+  BC-900.60.30:
+    name: Allocazione e livellamento delle risorse
+    description: |
+      Allocazione delle risorse tra i progetti e risoluzione dei conflitti.
+  BC-900.60.40:
+    name: Reporting dell'utilizzo delle risorse
+    description: |
+      Utilizzo delle risorse, ore fatturabili e reporting delle previsioni di domanda.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-property-management-operations.yaml
+++ b/catalogue/i18n/it/L1-property-management-operations.yaml
@@ -1,0 +1,167 @@
+# Operazioni di gestione della proprietà (it) — translations for L1-property-management-operations.yaml
+locale: it
+source: L1-property-management-operations.yaml
+entries:
+  BC-4940:
+    name: Operazioni di gestione della proprietà
+    description: |
+      Gestione lato locatore e property manager di edifici commerciali, retail e residenziali multifamiliare — servizi edilizi, gestione dei fornitori e dei contratti, ordini di lavoro, servizi ai conduttori in fase di occupazione, sicurezza e sistemi antincendio, energia e sostenibilità, e contabilità immobiliare inclusa la riconciliazione CAM. Distinto dalla gestione operativa degli hotel (BC-4060) e dagli immobili strumentali aziendali (BC-700).
+  BC-4940.10:
+    name: Gestione delle operazioni edilizie
+    description: |
+      Gestione quotidiana dei servizi edilizi, dei sistemi di building management, delle aree comuni, della reception e dei turni operativi per asset commerciali, retail e residenziali multifamiliare.
+  BC-4940.10.10:
+    name: Operazioni delle aree comuni
+    description: |
+      Gestione delle aree comuni, inclusi atrii, corridoi e spazi condivisi.
+  BC-4940.10.20:
+    name: Operazioni del sistema di building management
+    description: |
+      Gestione dei sistemi di building management, inclusi HVAC, illuminazione e controlli di accesso.
+  BC-4940.10.30:
+    name: Operazioni di reception e controllo accessi
+    description: |
+      Reception, portineria e operazioni di controllo accessi per conduttori e visitatori presso la proprietà.
+  BC-4940.10.40:
+    name: Gestione degli orari e dei turni operativi
+    description: |
+      Gestione degli orari di apertura, delle richieste fuori orario e dei turni festivi.
+  BC-4940.20:
+    name: Manutenzione della proprietà e gestione degli ordini di lavoro
+    description: |
+      Manutenzione preventiva, reattiva e normativa dei sistemi edilizi e degli asset rivolti ai conduttori tramite flussi di ordini di lavoro.
+  BC-4940.20.10:
+    name: Operazioni di manutenzione preventiva
+    description: |
+      Esecuzione della manutenzione preventiva secondo il piano e i dati sulle condizioni degli asset.
+  BC-4940.20.20:
+    name: Manutenzione reattiva e ordini di lavoro
+    description: |
+      Gestione della manutenzione reattiva innescata da richieste dei conduttori e da ispezioni.
+  BC-4940.20.30:
+    name: Ispezioni normative e di conformità
+    description: |
+      Ispezioni normative e di conformità su ascensori, impianti antincendio, gas e impianti in pressione.
+  BC-4940.20.40:
+    name: Reporting della manutenzione
+    description: |
+      Reporting delle attività di manutenzione, degli arretrati e della performance SLA a proprietari e conduttori.
+  BC-4940.30:
+    name: Gestione dei fornitori e dei contratti di servizio
+    description: |
+      Onboarding e gestione dei fornitori di servizi e dei contratti a livello di proprietà per pulizie, sicurezza, verde e fornitura di utenze.
+  BC-4940.30.10:
+    name: Onboarding dei contratti di servizio
+    description: |
+      Onboarding dei contratti di servizio e dei fornitori a livello di proprietà.
+  BC-4940.30.20:
+    name: Gestione della performance dei fornitori
+    description: |
+      Gestione della performance dei fornitori della proprietà rispetto a SLA e KPI.
+  BC-4940.30.30:
+    name: Definizione delle specifiche di servizio e dei SLA
+    description: |
+      Definizione delle specifiche di servizio, degli scope e dei SLA per i servizi di proprietà in appalto.
+  BC-4940.40:
+    name: Servizi ai conduttori e coordinamento degli spostamenti
+    description: |
+      Coordinamento dell'onboarding dei conduttori, degli ingressi e delle uscite, degli allestimenti e della gestione continuativa delle richieste di servizio sulla proprietà.
+  BC-4940.40.10:
+    name: Coordinamento dell'ingresso del conduttore
+    description: |
+      Coordinamento dell'ingresso del conduttore, incluso l'accesso, la segnaletica e l'orientamento.
+  BC-4940.40.20:
+    name: Coordinamento dei lavori di allestimento del conduttore
+    description: |
+      Coordinamento dei lavori di allestimento del conduttore, dell'accesso degli appaltatori e delle approvazioni del locatore.
+  BC-4940.40.30:
+    name: Uscita del conduttore e ripristino dei locali
+    description: |
+      Coordinamento dell'uscita del conduttore e del ripristino delle aree in locazione.
+  BC-4940.40.40:
+    name: Gestione delle richieste di servizio del conduttore
+    description: |
+      Gestione delle richieste di servizio del conduttore durante il periodo di occupazione su tutti i canali.
+  BC-4940.50:
+    name: Operazioni di sicurezza e sistemi di salvaguardia della vita
+    description: |
+      Gestione di videosorveglianza, sistemi antincendio e di salvaguardia della vita, risposta agli incidenti ed evacuazione di emergenza presso la proprietà.
+  BC-4940.50.10:
+    name: Operazioni di videosorveglianza
+    description: |
+      Gestione del sistema CCTV e di sorveglianza nelle aree comuni e di servizio.
+  BC-4940.50.20:
+    name: Operazioni dei sistemi antincendio e di salvaguardia della vita
+    description: |
+      Gestione dei sistemi di rilevazione incendio, soppressione e salvaguardia della vita, incluse le esercitazioni.
+  BC-4940.50.30:
+    name: Risposta agli incidenti sulla proprietà
+    description: |
+      Gestione degli incidenti a livello di proprietà relativi a sicurezza, furto ed eventi di ordine pubblico.
+  BC-4940.50.40:
+    name: Operazioni di evacuazione di emergenza
+    description: |
+      Esecuzione dei piani di evacuazione di emergenza e comando degli incidenti sulla proprietà.
+  BC-4940.60:
+    name: Operazioni di energia e sostenibilità della proprietà
+    description: |
+      Gestione operativa di energia, acqua, rifiuti, qualità ambientale interna e programmi di sub-metering dei conduttori a livello di proprietà.
+  BC-4940.60.10:
+    name: Operazioni energetiche della proprietà
+    description: |
+      Gestione dei sistemi energetici della proprietà e monitoraggio dei consumi rispetto agli obiettivi.
+  BC-4940.60.20:
+    name: Operazioni acqua e rifiuti
+    description: |
+      Gestione dei programmi di acque reflue, rifiuti e raccolta differenziata della proprietà.
+  BC-4940.60.30:
+    name: Operazioni di qualità ambientale interna
+    description: |
+      Gestione dei programmi di qualità dell'aria interna, illuminazione e comfort acustico.
+  BC-4940.60.40:
+    name: Sub-metering e allocazione ai conduttori
+    description: |
+      Gestione del sub-metering e dell'allocazione del consumo di utenze ai conduttori.
+  BC-4940.70:
+    name: Contabilità immobiliare e reporting operativo
+    description: |
+      Contabilità generale a livello di proprietà, fatturazione e crediti dei conduttori, debiti verso fornitori e reporting al proprietario.
+  BC-4940.70.10:
+    name: Operazioni di contabilità generale della proprietà
+    description: |
+      Gestione della contabilità generale e del bilancio di verifica a livello di proprietà.
+  BC-4940.70.20:
+    name: Fatturazione e crediti dei conduttori
+    description: |
+      Fatturazione di canoni, recuperi e addebiti accessori e riscossione dei crediti.
+  BC-4940.70.30:
+    name: Operazioni di contabilità fornitori della proprietà
+    description: |
+      Gestione dei debiti verso fornitori di utenze, service provider e appaltatori a livello di proprietà.
+  BC-4940.70.40:
+    name: Pacchetto di reporting al proprietario
+    description: |
+      Pacchetti di reporting periodico al proprietario sulla performance operativa e sugli scostamenti.
+  BC-4940.80:
+    name: Riconciliazione delle spese comuni
+    description: |
+      Ciclo contabile specifico del rapporto locatore-conduttore che comprende budgeting, rilevazione, riconciliazione e risposta agli audit CAM e sugli oneri di servizio.
+  BC-4940.80.10:
+    name: Definizione del budget e delle stime CAM
+    description: |
+      Definizione dei budget CAM e degli oneri di servizio e delle stime per i conduttori per l'anno.
+  BC-4940.80.20:
+    name: Rilevazione delle spese effettive CAM
+    description: |
+      Rilevazione delle spese effettive rimborsabili nelle categorie CAM e degli oneri di servizio.
+  BC-4940.80.30:
+    name: Riconciliazione e regolamento CAM
+    description: |
+      Riconciliazione dei consuntivi CAM rispetto alle stime e regolamento degli importi di conguaglio con i conduttori.
+  BC-4940.80.40:
+    name: Risposta all'audit CAM dei conduttori
+    description: |
+      Risposta alle richieste di audit e ispezione dei conduttori sui diritti CAM e sugli oneri di servizio.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-property-operations-management.yaml
+++ b/catalogue/i18n/it/L1-property-operations-management.yaml
@@ -1,0 +1,210 @@
+# Gestione operativa della struttura ricettiva (it) — translations for L1-property-operations-management.yaml
+locale: it
+source: L1-property-operations-management.yaml
+entries:
+  BC-4060:
+    name: Gestione operativa della struttura ricettiva
+    description: |
+      Operatività quotidiana di hotel, resort e strutture ricettive di servizio —
+      front office, housekeeping, ingegneria, concierge, sicurezza, sostenibilità
+      e conformità agli standard di brand e di qualità.
+    in_scope:
+      - Operazioni di front office e check-in / check-out
+      - Housekeeping e oggetti smarriti
+      - Ingegneria e manutenzione della struttura
+      - Concierge, portabagagli, valet e trasporto degli ospiti
+      - Sicurezza della struttura, sistemi antincendio e gestione degli incidenti
+      - Operazioni di sostenibilità a livello di struttura
+      - Audit degli standard di brand e conformità alla qualità
+    out_of_scope:
+      - Operazioni di ristorazione (BC-4070)
+      - Esecuzione di blocchi di gruppo ed eventi (BC-4110)
+      - Strategia di sostenibilità aziendale (BC-740)
+  BC-4060.10:
+    name: Operazioni di front office
+    description: |
+      Operazioni del front office, incluse la preparazione pre-arrivo, il check-in,
+      l'assegnazione della camera, il check-out, la liquidazione del conto
+      e l'emissione delle chiavi.
+  BC-4060.10.10:
+    name: Preparazione pre-arrivo
+    description: |
+      Attività di preparazione prima dell'arrivo, inclusi i report di arrivo,
+      l'assegnazione delle camere e la preparazione dei servizi di accoglienza.
+  BC-4060.10.20:
+    name: Operazioni di check-in
+    description: |
+      Operazioni di check-in degli ospiti attraverso i canali
+      di reception, mobile e chiosco.
+  BC-4060.10.30:
+    name: Assegnazione della camera e upgrade
+    description: |
+      Assegnazione delle camere ed esecuzione delle decisioni di upgrade,
+      inclusi upgrade a pagamento e gratuiti.
+  BC-4060.10.40:
+    name: Check-out e liquidazione del conto
+    description: |
+      Operazioni di check-out degli ospiti e liquidazione del conto della struttura.
+  BC-4060.10.50:
+    name: Emissione di chiavi e credenziali di accesso
+    description: |
+      Emissione e revoca di chiavi di camera fisiche e digitali
+      e credenziali di accesso.
+  BC-4060.20:
+    name: Operazioni di housekeeping
+    description: |
+      Operazioni di pulizia delle camere, servizio di cambio letto, pulizia
+      approfondita e gestione degli oggetti smarriti in tutta la struttura.
+  BC-4060.20.10:
+    name: Operazioni di pulizia giornaliera
+    description: |
+      Pulizia giornaliera delle camere in soggiorno e in partenza
+      secondo gli standard della struttura.
+  BC-4060.20.20:
+    name: Servizio di cambio letto e camera in soggiorno
+    description: |
+      Servizi di cambio letto e di camera in soggiorno per gli ospiti presenti.
+  BC-4060.20.30:
+    name: Pulizia approfondita e gestione delle camere fuori servizio
+    description: |
+      Esecuzione dei cicli di pulizia approfondita e gestione delle camere
+      fuori ordine e fuori servizio.
+  BC-4060.20.40:
+    name: Operazioni oggetti smarriti
+    description: |
+      Registrazione, conservazione e restituzione agli ospiti degli oggetti
+      smarriti nella struttura.
+  BC-4060.30:
+    name: Ingegneria e manutenzione della struttura
+    description: |
+      Operazioni di ingegneria e manutenzione, inclusi interventi preventivi,
+      reattivi, di ristrutturazione e ispezioni di conformità.
+  BC-4060.30.10:
+    name: Operazioni di manutenzione preventiva
+    description: |
+      Esecuzione della manutenzione preventiva secondo il piano
+      e i dati sullo stato degli impianti.
+  BC-4060.30.20:
+    name: Operazioni di manutenzione reattiva
+    description: |
+      Esecuzione della manutenzione reattiva attivata da segnalazioni
+      degli ospiti e risultanze delle ispezioni.
+  BC-4060.30.30:
+    name: Sostituzione e ristrutturazione degli asset
+    description: |
+      Sostituzione e ristrutturazione degli asset della struttura in camere,
+      spazi comuni e aree di servizio.
+  BC-4060.30.40:
+    name: Ispezioni di conformità tecnica
+    description: |
+      Ispezioni di conformità relative ai sistemi antincendio, ai sistemi
+      di sicurezza, agli ascensori e agli impianti a pressione.
+  BC-4060.40:
+    name: Concierge e servizi agli ospiti
+    description: |
+      Servizi di concierge, portabagagli, valet e trasporto degli ospiti
+      erogati lungo il percorso del soggiorno.
+  BC-4060.40.10:
+    name: Servizi di informazione e prenotazione del concierge
+    description: |
+      Servizi di concierge relativi a informazioni sulla destinazione,
+      prenotazioni di ristoranti e attività.
+  BC-4060.40.20:
+    name: Operazioni di portabagagli e gestione del bagaglio
+    description: |
+      Operazioni di portabagagli e gestione del bagaglio,
+      inclusi deposito e consegna.
+  BC-4060.40.30:
+    name: Operazioni di valet parking
+    description: |
+      Servizi di valet parking e gestione dei veicoli
+      agli ingressi della struttura.
+  BC-4060.40.40:
+    name: Coordinamento del trasporto degli ospiti
+    description: |
+      Coordinamento del trasporto terrestre degli ospiti, inclusi
+      navette e servizi auto della struttura.
+  BC-4060.50:
+    name: Operazioni di sicurezza e protezione della struttura
+    description: |
+      Operazioni di sorveglianza della struttura, sistemi antincendio,
+      evacuazione e gestione degli incidenti.
+  BC-4060.50.10:
+    name: Operazioni di sorveglianza della struttura
+    description: |
+      Sorveglianza degli spazi pubblici e operativi,
+      inclusi monitoraggio e revisione.
+  BC-4060.50.20:
+    name: Operazioni antincendio e di sicurezza
+    description: |
+      Operazione dei sistemi antincendio e di sicurezza,
+      incluse esercitazioni e prontezza delle attrezzature.
+  BC-4060.50.30:
+    name: Operazioni di evacuazione di emergenza
+    description: |
+      Esecuzione dell'evacuazione di emergenza e delle operazioni
+      di incident command nella struttura.
+  BC-4060.50.40:
+    name: Gestione degli incidenti degli ospiti
+    description: |
+      Gestione degli incidenti di sicurezza, furto e protezione
+      degli ospiti nella struttura.
+  BC-4060.60:
+    name: Operazioni di sostenibilità della struttura
+    description: |
+      Operatività a livello di struttura dei programmi di energia, acqua,
+      rifiuti e riutilizzo della biancheria, coerentemente con gli impegni
+      di brand e certificazione.
+    in_scope:
+      - Misurazione e monitoraggio dei consumi della struttura
+      - Programmi di riutilizzo e gestione dei rifiuti a livello di struttura
+    out_of_scope:
+      - Strategia di sostenibilità aziendale (BC-740)
+  BC-4060.60.10:
+    name: Operazioni energetiche della struttura
+    description: |
+      Operazione degli impianti energetici della struttura e monitoraggio
+      dei consumi rispetto agli obiettivi.
+  BC-4060.60.20:
+    name: Operazioni di gestione idrica
+    description: |
+      Gestione del consumo idrico della struttura, inclusi il rilevamento
+      di perdite e le misure di riutilizzo.
+  BC-4060.60.30:
+    name: Operazioni di gestione dei rifiuti e del riciclaggio
+    description: |
+      Operazione dei programmi di raccolta differenziata, riciclaggio
+      e gestione degli sprechi alimentari della struttura.
+  BC-4060.60.40:
+    name: Programmi di riutilizzo della biancheria e degli asciugamani
+    description: |
+      Operazione dei programmi di riutilizzo della biancheria e degli asciugamani
+      e delle modalità di opt-in per gli ospiti.
+  BC-4060.70:
+    name: Audit della qualità della struttura e standard di brand
+    description: |
+      Audit della conformità della struttura agli standard di brand e operativi,
+      programmi di mystery guest e operazioni di service recovery.
+  BC-4060.70.10:
+    name: Operazioni di audit degli standard di brand
+    description: |
+      Audit della conformità della struttura agli standard
+      di brand e operativi.
+  BC-4060.70.20:
+    name: Operazioni del programma mystery guest
+    description: |
+      Operazione dei programmi di mystery guest per la valutazione
+      dell'esperienza degli ospiti rispetto a percorsi predefiniti.
+  BC-4060.70.30:
+    name: Registrazione del service recovery
+    description: |
+      Registrazione delle azioni di service recovery intraprese nella struttura,
+      inclusi risarcimenti e azioni di follow-up.
+  BC-4060.70.40:
+    name: Chiusura dei piani di miglioramento della qualità
+    description: |
+      Chiusura dei rilievi di audit e di feedback rispetto
+      ai piani di miglioramento della qualità.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-public-benefits-entitlements-management.yaml
+++ b/catalogue/i18n/it/L1-public-benefits-entitlements-management.yaml
@@ -1,0 +1,137 @@
+# Gestione delle prestazioni pubbliche e dei diritti (it) — translations for L1-public-benefits-entitlements-management.yaml
+locale: it
+source: L1-public-benefits-entitlements-management.yaml
+entries:
+  BC-3230:
+    name: Gestione delle prestazioni pubbliche e dei diritti
+    description: |
+      Progettazione, determinazione dell'eleggibilità, calcolo, erogazione, monitoraggio e recupero delle prestazioni di protezione sociale e dei diritti di legge, incluse pensioni, disoccupazione, invalidità, famiglia e assistenza alimentare.
+  BC-3230.10:
+    name: Progettazione e configurazione dei programmi di prestazioni
+    description: |
+      Configurazione dei programmi di prestazioni di legge, incluse le regole di eleggibilità, le formule per le prestazioni e i parametri operativi.
+    in_scope:
+      - Configurazione delle regole di eleggibilità
+      - Definizione della formula e delle tariffe delle prestazioni
+      - Gestione dei parametri e dell'indicizzazione del programma
+    out_of_scope:
+      - Redazione della legislazione abilitante (coperta dalla Gestione della redazione legislativa e normativa)
+  BC-3230.10.10:
+    name: Configurazione delle regole di eleggibilità
+    description: |
+      Codificazione delle regole di eleggibilità di legge in forma eseguibile da macchina.
+  BC-3230.10.20:
+    name: Configurazione della formula e delle tariffe delle prestazioni
+    description: |
+      Configurazione delle formule di calcolo delle prestazioni, delle tariffe e dei massimali.
+  BC-3230.10.30:
+    name: Indicizzazione dei parametri del programma
+    description: |
+      Indicizzazione e aggiornamento periodico dei parametri del programma all'inflazione o alle variazioni salariali.
+  BC-3230.20:
+    name: Determinazione dell'eleggibilità
+    description: |
+      Determinazione dell'eleggibilità del richiedente alle prestazioni, incluse la prova dei mezzi, l'eleggibilità categoriale e la composizione del nucleo familiare.
+  BC-3230.20.10:
+    name: Ricezione delle domande
+    description: |
+      Ricezione delle domande di prestazioni su tutti i canali, tra cui digitale, fisico e assistito.
+  BC-3230.20.20:
+    name: Prova dei mezzi
+    description: |
+      Verifica del reddito, del patrimonio e delle condizioni del nucleo familiare rispetto alle soglie del programma.
+  BC-3230.20.30:
+    name: Verifica dell'eleggibilità categoriale
+    description: |
+      Verifica dell'eleggibilità categoriale, come l'età, l'invalidità o lo stato familiare.
+  BC-3230.20.40:
+    name: Decisione e notifica dell'eleggibilità
+    description: |
+      Registrazione della decisione e notifica al richiedente degli esiti dell'eleggibilità.
+  BC-3230.30:
+    name: Calcolo e concessione delle prestazioni
+    description: |
+      Calcolo degli importi della prestazione, valutazione dei contributi e emissione della concessione delle prestazioni.
+  BC-3230.30.10:
+    name: Valutazione dei contributi
+    description: |
+      Valutazione dei contributi versati per le prestazioni contributive quali pensioni e indennità di disoccupazione.
+  BC-3230.30.20:
+    name: Calcolo della prestazione
+    description: |
+      Calcolo degli importi della prestazione, inclusi supplementi, detrazioni e riduzione progressiva.
+  BC-3230.30.30:
+    name: Emissione della concessione
+    description: |
+      Emissione e registrazione delle concessioni di prestazioni e delle relative lettere di comunicazione.
+  BC-3230.40:
+    name: Operazioni di erogazione delle prestazioni
+    description: |
+      Erogazione periodica delle prestazioni su tutti i canali di pagamento e riconciliazione con le concessioni.
+  BC-3230.40.10:
+    name: Gestione dei calendari di pagamento
+    description: |
+      Gestione dei calendari di pagamento, delle frequenze e dei calendari delle elaborazioni.
+  BC-3230.40.20:
+    name: Esecuzione del pagamento
+    description: |
+      Esecuzione delle elaborazioni di pagamento su canali bancari, carte prepagate, assegni e in natura.
+  BC-3230.40.30:
+    name: Riconciliazione dei pagamenti
+    description: |
+      Riconciliazione delle erogazioni con le concessioni e le conferme bancarie.
+  BC-3230.40.40:
+    name: Distribuzione di prestazioni in natura
+    description: |
+      Distribuzione di prestazioni in natura, quali buoni per l'assistenza alimentare e trasferimento elettronico di benefici.
+  BC-3230.50:
+    name: Monitoraggio dei beneficiari e continuità dell'eleggibilità
+    description: |
+      Monitoraggio continuativo delle condizioni dei beneficiari e rideterminazione periodica della continuità dell'eleggibilità.
+  BC-3230.50.10:
+    name: Acquisizione dei cambiamenti di circostanze
+    description: |
+      Acquisizione e gestione dei cambiamenti di circostanze segnalati dai beneficiari o rilevati automaticamente.
+  BC-3230.50.20:
+    name: Rideterminazione periodica
+    description: |
+      Rideterminazione periodica dell'eleggibilità e del livello della prestazione.
+  BC-3230.50.30:
+    name: Monitoraggio della condizionalità e della conformità
+    description: |
+      Monitoraggio del rispetto da parte del beneficiario delle condizioni, quali la ricerca attiva di lavoro o i requisiti di formazione.
+  BC-3230.60:
+    name: Gestione dei pagamenti in eccesso e del recupero
+    description: |
+      Rilevamento, calcolo e recupero dei pagamenti in eccesso e dei pagamenti non dovuti.
+  BC-3230.60.10:
+    name: Rilevamento dei pagamenti in eccesso
+    description: |
+      Rilevamento dei pagamenti in eccesso tramite riconciliazione, corrispondenza dei dati e revisioni.
+  BC-3230.60.20:
+    name: Definizione del piano di recupero
+    description: |
+      Definizione dei piani di recupero, incluse rate, detrazioni e cancellazione del debito.
+  BC-3230.60.30:
+    name: Operazioni di riscossione del debito
+    description: |
+      Riscossione dei debiti recuperabili tramite detrazioni, azioni civili e compensazioni.
+  BC-3230.70:
+    name: Indagine sulle frodi alle prestazioni
+    description: |
+      Rilevamento, indagine e gestione dei casi di frode alle prestazioni.
+  BC-3230.70.10:
+    name: Rilevamento del rischio di frode
+    description: |
+      Rilevamento basato sul rischio di presunte frodi tramite analisi e intelligence.
+  BC-3230.70.20:
+    name: Indagine sui casi di frode
+    description: |
+      Indagine sui presunti casi di frode, inclusa la raccolta delle prove e le interviste.
+  BC-3230.70.30:
+    name: Sanzione per frode e segnalazione
+    description: |
+      Irrogazione di sanzioni per frode accertata e segnalazione all'autorità giudiziaria ove applicabile.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-public-finance-budget-management.yaml
+++ b/catalogue/i18n/it/L1-public-finance-budget-management.yaml
@@ -1,0 +1,133 @@
+# Gestione della finanza pubblica e del bilancio (it) — translations for L1-public-finance-budget-management.yaml
+locale: it
+source: L1-public-finance-budget-management.yaml
+entries:
+  BC-3280:
+    name: Gestione della finanza pubblica e del bilancio
+    description: |
+      Formulazione del bilancio pubblico, esecuzione degli stanziamenti, contabilità dei fondi pubblici, gestione del debito, operazioni di tesoreria e rendicontazione e comunicazione fiscale in linea con IPSAS.
+  BC-3280.10:
+    name: Formulazione del bilancio
+    description: |
+      Predisposizione dei bilanci annuali e pluriennali, inclusi tetti di spesa, bilancio per programmi e presentazione all'organo legislativo.
+    in_scope:
+      - Previsione macro-fiscale
+      - Bilancio per programmi e bilancio a base zero
+      - Presentazione del bilancio al Parlamento
+    out_of_scope:
+      - Pianificazione finanziaria e contabilità gestionale aziendale (coperta dalla Pianificazione e analisi finanziaria)
+  BC-3280.10.10:
+    name: Previsione macro-fiscale
+    description: |
+      Previsione degli aggregati di entrate e spese e degli scenari macro-fiscali.
+  BC-3280.10.20:
+    name: Definizione dei tetti di bilancio
+    description: |
+      Definizione dei tetti di bilancio per agenzie e programmi nell'ambito del quadro fiscale.
+  BC-3280.10.30:
+    name: Preparazione del bilancio per programmi
+    description: |
+      Predisposizione dei bilanci per programmi e per la performance da parte delle agenzie di spesa.
+  BC-3280.10.40:
+    name: Presentazione del bilancio al Parlamento
+    description: |
+      Compilazione e presentazione del bilancio dell'esecutivo al Parlamento.
+  BC-3280.20:
+    name: Esecuzione degli stanziamenti
+    description: |
+      Ripartizione, assegnazione, impegno, obbligazione e liquidazione dei fondi stanziati in linea con la legge di bilancio.
+  BC-3280.20.10:
+    name: Ripartizione e assegnazione
+    description: |
+      Ripartizione e assegnazione degli stanziamenti alle agenzie di spesa.
+  BC-3280.20.20:
+    name: Registrazione degli impegni e delle obbligazioni
+    description: |
+      Registrazione degli impegni e delle obbligazioni a carico degli stanziamenti.
+  BC-3280.20.30:
+    name: Elaborazione delle spese e dei pagamenti
+    description: |
+      Elaborazione delle spese e dei pagamenti a valere sui fondi impegnati.
+  BC-3280.20.40:
+    name: Autorizzazione alle riprogrammazioni e ai trasferimenti
+    description: |
+      Gestione delle riprogrammazioni, dei trasferimenti e delle modifiche all'autorizzazione di legge.
+  BC-3280.30:
+    name: Contabilità dei fondi pubblici
+    description: |
+      Contabilizzazione dei fondi pubblici, inclusi fondo generale, fondi speciali, fondi fiduciari e fondi rotativi, secondo IPSAS o equivalenti nazionali.
+  BC-3280.30.10:
+    name: Manutenzione della struttura dei fondi
+    description: |
+      Manutenzione della struttura dei fondi pubblici e del piano dei conti.
+  BC-3280.30.20:
+    name: Contabilità per fondo
+    description: |
+      Registrazione e riconciliazione delle operazioni sui fondi generali, speciali, fiduciari e rotativi.
+  BC-3280.30.30:
+    name: Regolamento interistituzionale
+    description: |
+      Regolamento e riconciliazione dei trasferimenti interistituzionali e degli accordi rimborsabili.
+  BC-3280.40:
+    name: Gestione del debito pubblico
+    description: |
+      Emissione, servizio e gestione del rischio degli strumenti di debito sovrano e sub-sovrano.
+  BC-3280.40.10:
+    name: Strategia e pianificazione delle emissioni di debito
+    description: |
+      Definizione della strategia del debito e dei calendari di emissione per strumenti e scadenze.
+  BC-3280.40.20:
+    name: Operazioni di emissione del debito
+    description: |
+      Asta, sindacazione ed emissione diretta di strumenti di debito pubblico.
+  BC-3280.40.30:
+    name: Servizio del debito
+    description: |
+      Pagamento di cedole, interessi e quota capitale ai detentori del debito.
+  BC-3280.40.40:
+    name: Gestione del rischio del portafoglio del debito
+    description: |
+      Gestione del rischio di cambio, di tasso di interesse e di rifinanziamento nel portafoglio del debito.
+  BC-3280.50:
+    name: Operazioni di cassa e tesoreria
+    description: |
+      Gestione della liquidità pubblica, operazioni del conto unico di tesoreria ed elaborazione di pagamenti e incassi per conto delle agenzie.
+  BC-3280.50.10:
+    name: Previsione di cassa
+    description: |
+      Previsione giornaliera e periodica dei flussi di cassa pubblici.
+  BC-3280.50.20:
+    name: Operazioni del conto unico di tesoreria
+    description: |
+      Gestione del conto unico di tesoreria e degli accordi bancari consolidati.
+  BC-3280.50.30:
+    name: Operazioni di pagamento pubblico
+    description: |
+      Esecuzione dei pagamenti pubblici per conto delle agenzie di spesa.
+  BC-3280.50.40:
+    name: Elaborazione degli incassi pubblici
+    description: |
+      Elaborazione degli incassi pubblici in entrata e accreditamento alle agenzie.
+  BC-3280.60:
+    name: Rendicontazione e trasparenza fiscale
+    description: |
+      Rapporti fiscali infrannuali e annuali, rendiconti finanziari IPSAS e rendicontazione statistica COFOG/GFSM.
+  BC-3280.60.10:
+    name: Rendicontazione fiscale infrannuale
+    description: |
+      Produzione di rapporti fiscali mensili e trimestrali rispetto al bilancio.
+  BC-3280.60.20:
+    name: Redazione dei rendiconti finanziari IPSAS
+    description: |
+      Predisposizione dei rendiconti finanziari consolidati e di entità ai sensi di IPSAS.
+  BC-3280.60.30:
+    name: Rendicontazione statistica GFSM e COFOG
+    description: |
+      Compilazione delle statistiche di finanza pubblica secondo le classificazioni FMI GFSM e COFOG.
+  BC-3280.60.40:
+    name: Divulgazione della spesa pubblica in open data
+    description: |
+      Pubblicazione in open data di spese, operazioni ed esecuzione del bilancio.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-public-policy-management.yaml
+++ b/catalogue/i18n/it/L1-public-policy-management.yaml
@@ -1,0 +1,129 @@
+# Gestione delle politiche pubbliche (it) — translations for L1-public-policy-management.yaml
+locale: it
+source: L1-public-policy-management.yaml
+entries:
+  BC-3200:
+    name: Gestione delle politiche pubbliche
+    description: |
+      Formulazione, analisi, supporto alle decisioni, coordinamento dell'attuazione e valutazione delle politiche pubbliche lungo l'intero ciclo delle politiche, ancorati a prove, consultazione pubblica e analisi dell'impatto.
+  BC-3200.10:
+    name: Definizione dell'agenda delle politiche
+    description: |
+      Identificazione, prioritizzazione e acquisizione dei mandati relativi alle questioni di politica pubblica che richiedono l'attenzione del governo.
+    in_scope:
+      - Identificazione delle questioni e analisi prospettica
+      - Acquisizione dei mandati ministeriali e politici
+      - Prioritizzazione delle politiche e gestione dell'agenda
+    out_of_scope:
+      - Redazione di leggi o regolamenti (coperta dalla Gestione della redazione legislativa e normativa)
+      - Esecuzione delle decisioni del Consiglio dei ministri (coperta dal Supporto alle decisioni sulle politiche)
+  BC-3200.10.10:
+    name: Identificazione delle questioni di politica
+    description: |
+      Identificazione delle questioni emergenti e dei problemi di politica pubblica attraverso l'analisi prospettica e i segnali delle parti interessate.
+  BC-3200.10.20:
+    name: Acquisizione dei mandati politici
+    description: |
+      Raccolta e strutturazione dei mandati politici e ministeriali in programmi di lavoro sulle politiche.
+  BC-3200.10.30:
+    name: Prioritizzazione delle politiche
+    description: |
+      Prioritizzazione delle questioni di politica pubblica concorrenti in base alle capacità, all'urgenza e agli impegni del governo.
+  BC-3200.20:
+    name: Analisi delle opzioni di politica
+    description: |
+      Revisione delle prove, modellazione e analisi comparativa delle opzioni di politica, inclusi costi, impatto e fattibilità.
+    in_scope:
+      - Revisione delle prove e della letteratura
+      - Analisi costi-benefici e modellazione economica
+      - Valutazione comparativa delle opzioni
+      - Analisi distributiva e di equità
+    out_of_scope:
+      - Analisi dell'impatto regolatorio per gli strumenti in bozza (coperta dalla Gestione della redazione legislativa e normativa)
+  BC-3200.20.10:
+    name: Revisione delle prove e della letteratura
+    description: |
+      Raccolta sistematica e sintesi delle prove a supporto delle opzioni di politica pubblica.
+  BC-3200.20.20:
+    name: Modellazione e previsione delle politiche
+    description: |
+      Modellazione quantitativa, microsimulazione e previsione degli esiti delle politiche.
+  BC-3200.20.30:
+    name: Valutazione comparativa delle opzioni
+    description: |
+      Valutazione comparativa delle opzioni di politica rispetto agli obiettivi e ai vincoli.
+  BC-3200.20.40:
+    name: Analisi distributiva e di equità
+    description: |
+      Analisi degli effetti distributivi e degli impatti sull'equità tra i gruppi della popolazione.
+  BC-3200.30:
+    name: Consultazione pubblica e delle parti interessate
+    description: |
+      Progettazione, attuazione e analisi delle consultazioni con le parti interessate, il pubblico e i partner interistituzionali sulle proposte di politica.
+  BC-3200.30.10:
+    name: Progettazione della consultazione
+    description: |
+      Progettazione delle strategie di consultazione, degli strumenti e dei piani di diffusione.
+  BC-3200.30.20:
+    name: Conduzione della consultazione
+    description: |
+      Gestione dei canali di consultazione, tra cui portali online, audizioni e workshop.
+  BC-3200.30.30:
+    name: Analisi delle risposte alla consultazione
+    description: |
+      Codifica, analisi e sintesi delle risposte alla consultazione pubblica.
+  BC-3200.30.40:
+    name: Coordinamento interistituzionale
+    description: |
+      Coordinamento con i partner sub-nazionali e internazionali su politiche condivise.
+  BC-3200.40:
+    name: Supporto alle decisioni sulle politiche
+    description: |
+      Preparazione degli elaborati decisionali per il Consiglio dei ministri, i ministeri e gli organi esecutivi, inclusi briefing, note decisionali e raccomandazioni.
+  BC-3200.40.10:
+    name: Preparazione dei briefing
+    description: |
+      Preparazione di briefing ministeriali ed esecutivi su questioni di politica pubblica.
+  BC-3200.40.20:
+    name: Gestione delle proposte al Consiglio dei ministri
+    description: |
+      Redazione e coordinamento delle proposte al Consiglio dei ministri, all'esecutivo o al consiglio.
+  BC-3200.40.30:
+    name: Registrazione e comunicazione delle decisioni
+    description: |
+      Registrazione delle decisioni, diffusione degli esiti e assegnazione dei compiti alle entità attuatrici.
+  BC-3200.50:
+    name: Coordinamento dell'attuazione delle politiche
+    description: |
+      Coordinamento dell'attuazione delle politiche tra agenzie, inclusi la progettazione dei programmi, la sequenza e la supervisione dell'erogazione.
+  BC-3200.50.10:
+    name: Pianificazione dell'attuazione
+    description: |
+      Trasformazione delle decisioni di politica in piani di attuazione, tappe fondamentali e responsabilità.
+  BC-3200.50.20:
+    name: Coordinamento inter-agenzia
+    description: |
+      Coordinamento delle agenzie attuatrici e degli accordi di erogazione congiunta.
+  BC-3200.50.30:
+    name: Monitoraggio dell'attuazione
+    description: |
+      Monitoraggio dei progressi nell'attuazione delle politiche rispetto agli impegni e alle scadenze.
+  BC-3200.60:
+    name: Valutazione e revisione delle politiche
+    description: |
+      Valutazione ex-post, revisioni di tramonto e post-attuazione, e feedback nel ciclo delle politiche.
+  BC-3200.60.10:
+    name: Valutazione dei risultati e degli impatti
+    description: |
+      Valutazione dei risultati e degli impatti delle politiche rispetto agli obiettivi previsti.
+  BC-3200.60.20:
+    name: Revisione di tramonto e post-attuazione
+    description: |
+      Revisioni statutarie e discrezionali delle politiche e degli strumenti a intervalli definiti.
+  BC-3200.60.30:
+    name: Raccolta delle lezioni apprese
+    description: |
+      Raccolta e diffusione delle lezioni apprese per i futuri cicli delle politiche.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-public-procurement-contracting-management.yaml
+++ b/catalogue/i18n/it/L1-public-procurement-contracting-management.yaml
@@ -1,0 +1,161 @@
+# Gestione degli appalti pubblici e della contrattualistica (it) — translations for L1-public-procurement-contracting-management.yaml
+locale: it
+source: L1-public-procurement-contracting-management.yaml
+entries:
+  BC-3270:
+    name: Gestione degli appalti pubblici e della contrattualistica
+    description: |
+      Approvvigionamento e contrattualistica del settore pubblico ai sensi dei regimi FAR/DFARS e delle direttive europee sugli appalti, inclusi pianificazione degli acquisti, pubblicazione della gara, selezione della fonte, aggiudicazione e gestione del contratto, valutazione dei fornitori, ricorsi e programmi socioeconomici.
+  BC-3270.10:
+    name: Pianificazione degli acquisti
+    description: |
+      Formulazione della strategia di acquisizione, ricerche di mercato e pianificazione degli appalti pubblici.
+    in_scope:
+      - Ricerche di mercato e consolidamento della domanda
+      - Strategia di acquisizione e selezione del metodo
+      - Preparazione delle stime di costo indipendenti
+    out_of_scope:
+      - Strategia di approvvigionamento per acquisti non governativi (coperta dalla Gestione degli acquisti)
+  BC-3270.10.10:
+    name: Ricerca di mercato
+    description: |
+      Ricerca di mercato sull'offerta, sulle capacità e sui prezzi per il fabbisogno.
+  BC-3270.10.20:
+    name: Strategia di acquisizione
+    description: |
+      Selezione del metodo contrattuale, dello strumento e dell'approccio concorrenziale.
+  BC-3270.10.30:
+    name: Stima di costo indipendente
+    description: |
+      Preparazione delle stime di costo indipendenti e delle prenotazioni di bilancio.
+  BC-3270.10.40:
+    name: Sviluppo di specifiche tecniche e capitolato
+    description: |
+      Sviluppo di specifiche tecniche, capitolati e dichiarazioni di lavoro per la performance.
+  BC-3270.20:
+    name: Gestione della gara
+    description: |
+      Pubblicazione delle gare, inclusi documenti RFP, IFB e RFQ, varianti e domande degli offerenti.
+  BC-3270.20.10:
+    name: Redazione della documentazione di gara
+    description: |
+      Redazione di RFP, IFB, RFQ e documentazione di gara.
+  BC-3270.20.20:
+    name: Pubblicazione della gara
+    description: |
+      Pubblicazione delle gare sui sistemi di avviso ufficiali e sugli equivalenti di OJEU/SAM.gov.
+  BC-3270.20.30:
+    name: Gestione delle domande degli offerenti
+    description: |
+      Gestione delle domande, delle varianti e dei chiarimenti degli offerenti durante la gara.
+  BC-3270.20.40:
+    name: Conferenza pre-offerta
+    description: |
+      Conduzione di conferenze pre-offerta e sopralluoghi.
+  BC-3270.30:
+    name: Selezione della fonte e valutazione
+    description: |
+      Ricezione, valutazione e selezione delle offerte e delle proposte rispetto ai criteri pubblicati.
+  BC-3270.30.10:
+    name: Ricezione di offerte e proposte
+    description: |
+      Ricezione, registrazione e custodia delle offerte e delle proposte.
+  BC-3270.30.20:
+    name: Valutazione tecnica
+    description: |
+      Valutazione tecnica delle proposte rispetto ai criteri indicati.
+  BC-3270.30.30:
+    name: Analisi dei prezzi e dei costi
+    description: |
+      Analisi della ragionevolezza del prezzo e della realismo dei costi delle offerte.
+  BC-3270.30.40:
+    name: Determinazione della responsabilità del contraente
+    description: |
+      Determinazione della responsabilità, della capacità finanziaria e dell'integrità del contraente.
+  BC-3270.40:
+    name: Aggiudicazione e formazione del contratto
+    description: |
+      Decisione di selezione, notifica dell'aggiudicazione, debriefing e formazione del contratto, inclusa la firma.
+  BC-3270.40.10:
+    name: Decisione di selezione
+    description: |
+      Decisione di aggiudicazione e documentazione della decisione di selezione della fonte.
+  BC-3270.40.20:
+    name: Avviso di aggiudicazione e debriefing
+    description: |
+      Avviso di aggiudicazione, notifica agli offerenti non aggiudicatari e debriefing.
+  BC-3270.40.30:
+    name: Firma del contratto e impegno dei fondi
+    description: |
+      Sottoscrizione dei documenti contrattuali e impegno dei fondi.
+  BC-3270.50:
+    name: Gestione e modifica del contratto
+    description: |
+      Gestione contrattuale quotidiana, incluse modifiche, rivendicazioni e supervisione del responsabile del contratto.
+  BC-3270.50.10:
+    name: Accettazione dei prodotti
+    description: |
+      Ispezione e accettazione dei prodotti rispetto ai requisiti contrattuali.
+  BC-3270.50.20:
+    name: Modifica del contratto
+    description: |
+      Emissione di modifiche contrattuali, ordini di variazione ed esercizio di opzioni.
+  BC-3270.50.30:
+    name: Gestione dei reclami contrattuali
+    description: |
+      Ricezione e risoluzione dei reclami del contraente e degli adeguamenti equitativi.
+  BC-3270.50.40:
+    name: Chiusura del contratto
+    description: |
+      Accettazione finale, disimpegno dei fondi e chiusura fisica e amministrativa.
+  BC-3270.60:
+    name: Gestione della performance dei fornitori
+    description: |
+      Registrazione delle performance precedenti, esclusione e sospensione e monitoraggio della responsabilità del contraente.
+  BC-3270.60.10:
+    name: Registrazione delle performance precedenti
+    description: |
+      Registrazione delle valutazioni delle performance precedenti dei contraenti nelle banche dati pubbliche.
+  BC-3270.60.20:
+    name: Gestione della sospensione e dell'esclusione
+    description: |
+      Gestione dei procedimenti di sospensione ed esclusione nei confronti dei contraenti.
+  BC-3270.60.30:
+    name: Monitoraggio della responsabilità del contraente
+    description: |
+      Monitoraggio continuativo della responsabilità e della capacità finanziaria del contraente.
+  BC-3270.70:
+    name: Gestione di ricorsi e controversie
+    description: |
+      Ricezione e gestione dei ricorsi sulle gare e delle controversie contrattuali attraverso canali amministrativi e giuridici.
+  BC-3270.70.10:
+    name: Gestione dei ricorsi sulle gare
+    description: |
+      Gestione dei ricorsi pre-aggiudicazione e post-aggiudicazione sulle gare.
+  BC-3270.70.20:
+    name: Risoluzione delle controversie contrattuali
+    description: |
+      Risoluzione amministrativa e giudiziaria delle controversie contrattuali.
+  BC-3270.70.30:
+    name: Risoluzione alternativa delle controversie
+    description: |
+      Mediazione, arbitrato e procedure ADR per le controversie contrattuali.
+  BC-3270.80:
+    name: Gestione delle riserve e dei programmi socioeconomici
+    description: |
+      Gestione delle riserve per le piccole imprese, le minoranze, le imprese femminili e delle altre preferenze e obiettivi di appalto socioeconomici.
+  BC-3270.80.10:
+    name: Determinazione delle riserve
+    description: |
+      Determinazione dell'applicabilità delle riserve per le piccole imprese e degli obiettivi socioeconomici.
+  BC-3270.80.20:
+    name: Supervisione dei piani di subappalto
+    description: |
+      Supervisione dei piani e dei rapporti di subappalto alle piccole imprese.
+  BC-3270.80.30:
+    name: Rendicontazione degli obiettivi socioeconomici
+    description: |
+      Monitoraggio e rendicontazione degli obiettivi e dei risultati degli appalti socioeconomici.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-public-safety-emergency-operations-management.yaml
+++ b/catalogue/i18n/it/L1-public-safety-emergency-operations-management.yaml
@@ -1,0 +1,153 @@
+# Gestione della sicurezza pubblica e delle operazioni di emergenza (it) — translations for L1-public-safety-emergency-operations-management.yaml
+locale: it
+source: L1-public-safety-emergency-operations-management.yaml
+entries:
+  BC-3310:
+    name: Gestione della sicurezza pubblica e delle operazioni di emergenza
+    description: |
+      Sicurezza pubblica e operazioni di emergenza, incluse comunicazioni e dispacciamento di emergenza, intervento in campo di polizia, vigili del fuoco e servizi di emergenza medica, comando degli incidenti secondo NIMS, preparazione e ripresa post-disastro, indagini sulla sicurezza pubblica e coordinamento della mutua assistenza.
+  BC-3310.10:
+    name: Comunicazioni e dispacciamento di emergenza
+    description: |
+      Ricezione delle chiamate di emergenza, dispacciamento assistito da computer e comunicazioni radio sul campo per i soccorritori di polizia, vigili del fuoco e servizi di emergenza medica.
+    in_scope:
+      - Ricezione delle chiamate 911/112/999
+      - Dispacciamento assistito da computer
+      - Operazioni radio della sicurezza pubblica
+    out_of_scope:
+      - Regimi di servizio universale delle telecomunicazioni (coperti dalla Gestione della conformità normativa delle telecomunicazioni)
+  BC-3310.10.10:
+    name: Ricezione delle chiamate di emergenza
+    description: |
+      Ricezione e triage delle chiamate di emergenza e dei messaggi di testo al numero di emergenza.
+  BC-3310.10.20:
+    name: Dispacciamento assistito da computer
+    description: |
+      Dispacciamento tramite CAD di unità di polizia, vigili del fuoco e servizi di emergenza medica verso gli incidenti.
+  BC-3310.10.30:
+    name: Operazioni radio della sicurezza pubblica
+    description: |
+      Gestione delle reti radio mobili terrestri e della banda larga equivalente a FirstNet per la sicurezza pubblica.
+  BC-3310.10.40:
+    name: Allerta e avvertimento pubblico
+    description: |
+      Emissione di allerte pubbliche tramite WEA, Cell Broadcast, EAS, sirene e altri canali.
+  BC-3310.20:
+    name: Operazioni di intervento sul campo
+    description: |
+      Operazioni quotidiane sul campo di polizia, vigili del fuoco e primo soccorso dei servizi di emergenza medica.
+  BC-3310.20.10:
+    name: Pattugliamento delle forze dell'ordine
+    description: |
+      Pattugliamento di routine e proattivo delle forze dell'ordine e risposta agli incidenti.
+  BC-3310.20.20:
+    name: Spegnimento degli incendi e operazioni di soccorso
+    description: |
+      Spegnimento degli incendi, operazioni di soccorso e risposta alle sostanze pericolose.
+  BC-3310.20.30:
+    name: Risposta dei servizi di emergenza medica
+    description: |
+      Valutazione medica d'urgenza pre-ospedaliera, trattamento e trasporto.
+  BC-3310.20.40:
+    name: Risposta tattica specialistica
+    description: |
+      Operazioni tattiche specialistiche, di disinnesco ordigni esplosivi e risposta ai materiali pericolosi.
+  BC-3310.30:
+    name: Comando e coordinamento degli incidenti
+    description: |
+      Comando degli incidenti allineato a NIMS/ICS, coordinamento multi-agenzia e operazioni dei centri operativi di emergenza.
+  BC-3310.30.10:
+    name: Istituzione del comando degli incidenti
+    description: |
+      Istituzione del comando degli incidenti, del comando unificato e delle strutture ICS.
+  BC-3310.30.20:
+    name: Coordinamento multi-agenzia
+    description: |
+      Coordinamento tra le agenzie e le giurisdizioni di intervento durante gli incidenti.
+  BC-3310.30.30:
+    name: Operazioni del centro operativo di emergenza
+    description: |
+      Gestione dei centri operativi di emergenza a livello locale, regionale e nazionale durante le emergenze.
+  BC-3310.30.40:
+    name: Manutenzione del quadro operativo comune
+    description: |
+      Manutenzione di un quadro operativo comune condiviso tra le agenzie.
+  BC-3310.40:
+    name: Preparazione e mitigazione dei disastri
+    description: |
+      Analisi dei rischi, pianificazione, esercitazioni, formazione e attività di mitigazione per la preparazione ai disastri nell'ambito del Quadro di Sendai.
+  BC-3310.40.10:
+    name: Analisi dei pericoli e dei rischi
+    description: |
+      Identificazione e valutazione dei pericoli naturali e di origine umana e dei relativi rischi.
+  BC-3310.40.20:
+    name: Pianificazione delle emergenze
+    description: |
+      Predisposizione di piani operativi di emergenza, piani specifici per pericolo e disposizioni di continuità operativa.
+  BC-3310.40.30:
+    name: Esercitazioni e formazione
+    description: |
+      Esercitazioni da tavolo, funzionali e su scala reale e programmi di formazione per i soccorritori.
+  BC-3310.40.40:
+    name: Gestione dei programmi di mitigazione
+    description: |
+      Gestione dei programmi di mitigazione strutturale e non strutturale dei disastri.
+  BC-3310.50:
+    name: Risposta e ripresa post-disastro
+    description: |
+      Dichiarazione di disastro, operazioni di risposta, assistenza individuale e pubblica e coordinamento della ripresa a lungo termine.
+  BC-3310.50.10:
+    name: Dichiarazione di disastro e attivazione
+    description: |
+      Dichiarazione degli stati di emergenza e attivazione delle autorità di risposta.
+  BC-3310.50.20:
+    name: Gestione dell'assistenza individuale
+    description: |
+      Gestione dell'assistenza ai disastri per individui e famiglie colpite.
+  BC-3310.50.30:
+    name: Gestione dell'assistenza pubblica
+    description: |
+      Gestione dei contributi di assistenza pubblica per la rimozione di detriti, infrastrutture e lavori di emergenza.
+  BC-3310.50.40:
+    name: Coordinamento della ripresa a lungo termine
+    description: |
+      Coordinamento delle attività di ripresa a lungo termine e di ricostruzione migliorativa.
+  BC-3310.60:
+    name: Indagini sulla sicurezza pubblica
+    description: |
+      Indagini penali e sulla sicurezza pubblica, inclusi gestione delle prove, intelligence e preparazione dei fascicoli processuali.
+  BC-3310.60.10:
+    name: Indagine sulla scena del crimine
+    description: |
+      Esame della scena del crimine e raccolta di prove forensi.
+  BC-3310.60.20:
+    name: Gestione dei fascicoli investigativi
+    description: |
+      Gestione dei fascicoli investigativi, monitoraggio dei sospetti e preparazione dei fascicoli per il pubblico ministero.
+  BC-3310.60.30:
+    name: Operazioni di intelligence della polizia
+    description: |
+      Raccolta, analisi e diffusione dell'intelligence della polizia nell'ambito del poliziotto basato sull'intelligence.
+  BC-3310.60.40:
+    name: Gestione delle prove e dei beni sequestrati
+    description: |
+      Custodia, catena di custodia e gestione delle prove sequestrate e dei beni.
+  BC-3310.70:
+    name: Gestione delle risorse di emergenza e della mutua assistenza
+    description: |
+      Classificazione, dispiegamento delle risorse di emergenza e accordi di mutua assistenza tra giurisdizioni.
+  BC-3310.70.10:
+    name: Classificazione e inventario delle risorse
+    description: |
+      Classificazione delle risorse allineata a NIMS e inventario delle risorse di emergenza.
+  BC-3310.70.20:
+    name: Gestione degli accordi di mutua assistenza
+    description: |
+      Gestione degli accordi di mutua assistenza intra- e inter-giurisdizionali.
+  BC-3310.70.30:
+    name: Dispiegamento e smobilitazione delle risorse
+    description: |
+      Dispiegamento, monitoraggio e smobilitazione delle risorse di emergenza verso gli incidenti.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-quality-management.yaml
+++ b/catalogue/i18n/it/L1-quality-management.yaml
@@ -1,0 +1,131 @@
+# Gestione della qualità (it) — translations for L1-quality-management.yaml
+locale: it
+source: L1-quality-management.yaml
+entries:
+  BC-720:
+    name: Gestione della qualità
+    description: |
+      Strategia, assicurazione e controllo qualità su tutti gli output aziendali.
+  BC-720.10:
+    name: Gestione della strategia e della politica della qualità
+    description: |
+      Politica della qualità, standard e framework di riferimento.
+  BC-720.10.10:
+    name: Gestione del manuale e della politica della qualità
+    description: |
+      Manuale della qualità e politiche allineate a ISO 9001 e agli standard di settore.
+  BC-720.10.20:
+    name: Definizione degli obiettivi di qualità
+    description: |
+      Definizione degli obiettivi di qualità, KPI e target aziendali.
+  BC-720.10.30:
+    name: Governance del sistema di gestione della qualità
+    description: |
+      Governance dell'ambito, della struttura e delle responsabilità del SGQ.
+  BC-720.10.40:
+    name: Gestione del rischio di qualità
+    description: |
+      Identificazione, valutazione e trattamento dei rischi di qualità.
+  BC-720.20:
+    name: Gestione dell'assicurazione della qualità
+    description: |
+      Sistemi di qualità, audit e certificazione (ISO 9001, ecc.).
+  BC-720.20.10:
+    name: Audit interni della qualità
+    description: |
+      Pianificazione ed esecuzione degli audit interni della qualità.
+  BC-720.20.20:
+    name: Gestione delle certificazioni esterne
+    description: |
+      Gestione delle certificazioni ISO 9001 e di altri schemi di certificazione e sorveglianza.
+  BC-720.20.30:
+    name: Validazione e qualifica dei processi
+    description: |
+      Validazione e qualifica di processi e attrezzature produttive.
+  BC-720.20.40:
+    name: Controllo dei documenti e delle registrazioni
+    description: |
+      Documenti controllati, registrazioni e archivio della qualità.
+  BC-720.30:
+    name: Gestione del controllo qualità
+    description: |
+      Ispezioni, collaudi e criteri di accettazione.
+  BC-720.30.10:
+    name: Pianificazione delle ispezioni
+    description: |
+      Piani di ispezione, piani di campionamento e criteri di accettazione.
+  BC-720.30.20:
+    name: Controllo qualità in processo
+    description: |
+      Controllo in processo, misurazione e controllo statistico di processo.
+  BC-720.30.30:
+    name: Ispezione finale e rilascio
+    description: |
+      Ispezione finale, rilascio dei lotti e emissione dei certificati.
+  BC-720.30.40:
+    name: Gestione della taratura
+    description: |
+      Taratura degli strumenti di misura e delle attrezzature di prova.
+  BC-720.40:
+    name: Gestione delle non conformità
+    description: |
+      Rapporti di non conformità, deroghe e azioni correttive e preventive.
+  BC-720.40.10:
+    name: Segnalazione delle non conformità
+    description: |
+      Registrazione e classificazione delle non conformità e delle deroghe.
+  BC-720.40.20:
+    name: Disposizione e contenimento
+    description: |
+      Gestione del materiale non conforme e azioni di contenimento.
+  BC-720.40.30:
+    name: Azione correttiva e preventiva
+    description: |
+      Processo CAPA comprensivo di analisi delle cause radice e verifica dell'efficacia.
+  BC-720.40.40:
+    name: Controllo delle modifiche
+    description: |
+      Controllo delle modifiche che impattano sulla qualità dei prodotti e dei processi.
+  BC-720.50:
+    name: Gestione del miglioramento continuo
+    description: |
+      Programmi lean, Six Sigma, kaizen e di miglioramento continuo.
+  BC-720.50.10:
+    name: Gestione delle idee di miglioramento
+    description: |
+      Raccolta, valutazione e prioritizzazione delle idee di miglioramento.
+  BC-720.50.20:
+    name: Realizzazione di progetti lean e Six Sigma
+    description: |
+      Metodologia e realizzazione di progetti lean e Six Sigma.
+  BC-720.50.30:
+    name: Coaching per il miglioramento continuo
+    description: |
+      Coaching e sviluppo delle competenze nei metodi di miglioramento continuo.
+  BC-720.50.40:
+    name: Monitoraggio della realizzazione dei benefici
+    description: |
+      Monitoraggio e verifica dei benefici dei progetti di miglioramento continuo.
+  BC-720.60:
+    name: Gestione della qualità per il cliente
+    description: |
+      Reclami del cliente sulla qualità, resi e qualità sul campo.
+  BC-720.60.10:
+    name: Gestione dei reclami del cliente sulla qualità
+    description: |
+      Raccolta, analisi e risposta ai reclami del cliente sulla qualità.
+  BC-720.60.20:
+    name: Analisi dei guasti sul campo
+    description: |
+      Analisi dei guasti sul campo e dei resi in garanzia.
+  BC-720.60.30:
+    name: Richiamo del prodotto e notifica al cliente
+    description: |
+      Coordinamento dei richiami del prodotto e delle notifiche ai clienti.
+  BC-720.60.40:
+    name: Reporting della qualità al cliente
+    description: |
+      Reporting e scorecard della qualità per i clienti.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-real-estate-acquisition-disposition-management.yaml
+++ b/catalogue/i18n/it/L1-real-estate-acquisition-disposition-management.yaml
@@ -1,0 +1,139 @@
+# Gestione dell'acquisizione e cessione immobiliare (it) — translations for L1-real-estate-acquisition-disposition-management.yaml
+locale: it
+source: L1-real-estate-acquisition-disposition-management.yaml
+entries:
+  BC-4930:
+    name: Gestione dell'acquisizione e cessione immobiliare
+    description: |
+      Disciplina transazionale che comprende sourcing, underwriting, due diligence, strutturazione, negoziazione, closing e onboarding post-closing per acquisizioni e cessioni immobiliari dirette, di portafoglio e a livello di entità.
+  BC-4930.10:
+    name: Sourcing e screening delle acquisizioni
+    description: |
+      Sourcing di opportunità di acquisizione tramite broker, controparti dirette e canali proprietari, con screening iniziale rispetto ai criteri di investimento.
+  BC-4930.10.10:
+    name: Sourcing dei lead di acquisizione
+    description: |
+      Sourcing di lead di acquisizione attraverso canali diretti, broker e fuori mercato.
+  BC-4930.10.20:
+    name: Gestione dei broker e degli intermediari
+    description: |
+      Gestione delle relazioni con broker e intermediari che forniscono opportunità di acquisizione.
+  BC-4930.10.30:
+    name: Screening iniziale e decisioni di offerta
+    description: |
+      Screening iniziale delle opportunità e decisioni di presentare o rinunciare all'offerta.
+  BC-4930.20:
+    name: Underwriting delle acquisizioni
+    description: |
+      Underwriting finanziario, di mercato e di rischio degli asset target per determinare il prezzo di offerta e le aspettative di rendimento.
+  BC-4930.20.10:
+    name: Underwriting dei flussi di cassa e DCF
+    description: |
+      Costruzione di modelli di flusso di cassa dell'asset e di underwriting con flussi di cassa attualizzati.
+  BC-4930.20.20:
+    name: Analisi delle vendite comparabili e del tasso di capitalizzazione
+    description: |
+      Analisi delle vendite comparabili e dei tassi di capitalizzazione prevalenti per calibrare il valore.
+  BC-4930.20.30:
+    name: Modellazione delle sensitivity e degli scenari
+    description: |
+      Modellazione di sensitivity e scenari dei rendimenti sotto diverse ipotesi di canone, vacancy e uscita.
+  BC-4930.30:
+    name: Gestione della due diligence
+    description: |
+      Coordinamento ed esecuzione della due diligence multidisciplinare sulle acquisizioni target, inclusi i workstream fisici, ambientali, legali, locativi e finanziari.
+  BC-4930.30.10:
+    name: Due diligence fisica e strutturale
+    description: |
+      Valutazioni delle condizioni fisiche e due diligence strutturale sugli asset target.
+  BC-4930.30.20:
+    name: Due diligence ambientale (Fase I / II)
+    description: |
+      Due diligence ambientale incluse le valutazioni ASTM Phase I e Phase II.
+  BC-4930.30.30:
+    name: Due diligence su titolo, rilievo e zonizzazione
+    description: |
+      Due diligence su titolo di proprietà, rilievi, servitù e conformità urbanistica.
+  BC-4930.30.40:
+    name: Due diligence su contratti di locazione e conduttori
+    description: |
+      Revisione degli abstract dei contratti di locazione, raccolta dei certificati estoppel e colloqui con i conduttori.
+  BC-4930.30.50:
+    name: Due diligence finanziaria e fiscale
+    description: |
+      Due diligence finanziaria e fiscale sui rendiconti operativi, le spese operative e gli accertamenti fiscali storici.
+  BC-4930.40:
+    name: Strutturazione e negoziazione della transazione
+    description: |
+      Strategia di offerta, strutturazione dell'operazione e negoziazione dei documenti vincolanti della transazione.
+  BC-4930.40.10:
+    name: Strategia di offerta e proposta
+    description: |
+      Definizione della strategia di offerta e proposta, incluso il prezzo e il posizionamento delle condizioni.
+  BC-4930.40.20:
+    name: Negoziazione della lettera di intenti
+    description: |
+      Negoziazione delle lettere di intenti e dei periodi di esclusiva.
+  BC-4930.40.30:
+    name: Negoziazione del contratto preliminare di acquisto
+    description: |
+      Negoziazione e sottoscrizione dei contratti preliminari di acquisto, incluse dichiarazioni e garanzie.
+  BC-4930.40.40:
+    name: Strutturazione fiscale e del veicolo
+    description: |
+      Strutturazione dei veicoli di acquisizione per l'efficienza fiscale, inclusi scambi 1031 e wrapper societari.
+  BC-4930.50:
+    name: Gestione del closing e del regolamento
+    description: |
+      Gestione del deposito fiduciario, delle condizioni di closing, del finanziamento del regolamento e della registrazione per le transazioni chiuse.
+  BC-4930.50.10:
+    name: Deposito fiduciario e condizioni di closing
+    description: |
+      Gestione dei conti di deposito fiduciario e monitoraggio delle condizioni di closing fino alla loro soddisfazione.
+  BC-4930.50.20:
+    name: Fondi di closing e dichiarazione di regolamento
+    description: |
+      Coordinamento dei fondi di closing e riconciliazione rispetto alla dichiarazione di regolamento.
+  BC-4930.50.30:
+    name: Assicurazione del titolo e registrazione
+    description: |
+      Emissione dell'assicurazione del titolo di proprietà e registrazione di rogiti e ipoteche.
+  BC-4930.60:
+    name: Gestione della cessione e dell'uscita
+    description: |
+      Disciplina lato venditore che comprende definizione del prezzo di cessione, marketing, selezione dell'acquirente e obblighi post-closing.
+  BC-4930.60.10:
+    name: Strategia di cessione e pricing
+    description: |
+      Definizione della strategia di cessione, del prezzo e dei pool di acquirenti target.
+  BC-4930.60.20:
+    name: Marketing delle vendite e visite degli acquirenti
+    description: |
+      Marketing lato venditore, incluso memorandum di offerta, data room e visite degli acquirenti.
+  BC-4930.60.30:
+    name: Selezione dell'acquirente e processo di offerta
+    description: |
+      Selezione dell'acquirente attraverso procedure di call for offer, best-and-final o asta strutturata.
+  BC-4930.60.40:
+    name: Obblighi post-closing
+    description: |
+      Monitoraggio degli obblighi post-closing, inclusi trattenute, earnout e richieste di indennizzo.
+  BC-4930.70:
+    name: Onboarding post-acquisizione
+    description: |
+      Passaggio degli asset di nuova acquisizione dal team transazionale alla gestione patrimoniale e della proprietà, incluso l'onboarding di dati e contratti.
+  BC-4930.70.10:
+    name: Migrazione dei dati dell'asset
+    description: |
+      Migrazione dei dati dell'asset, degli elaborati grafici e dei registri operativi nei sistemi del proprietario.
+  BC-4930.70.20:
+    name: Onboarding dei dati di contratti di locazione e conduttori
+    description: |
+      Onboarding degli abstract dei contratti di locazione e dei dati dei conduttori nei sistemi del locatore.
+  BC-4930.70.30:
+    name: Cessione dei contratti con i fornitori
+    description: |
+      Cessione o sostituzione dei contratti di fornitura e servizi in essere al nuovo proprietario.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-real-estate-asset-management.yaml
+++ b/catalogue/i18n/it/L1-real-estate-asset-management.yaml
@@ -1,0 +1,143 @@
+# Gestione del patrimonio immobiliare (it) — translations for L1-real-estate-asset-management.yaml
+locale: it
+source: L1-real-estate-asset-management.yaml
+entries:
+  BC-4920:
+    name: Gestione del patrimonio immobiliare
+    description: |
+      Presidio lato proprietario degli asset immobiliari nel corso del periodo di detenzione — esecuzione del business plan, monitoraggio della performance, prioritizzazione del capex, riposizionamento, percorso di sostenibilità, rischio degli asset e ottimizzazione delle imposte sulla proprietà e delle spese operative. Collega la visione dell'investitore (BC-4910) con la gestione operativa della proprietà (BC-4940).
+  BC-4920.10:
+    name: Gestione del business plan dell'asset
+    description: |
+      Definizione e aggiornamento dei business plan per singolo asset in linea con il mandato del fondo, l'orizzonte di detenzione e la thesis di creazione di valore.
+  BC-4920.10.10:
+    name: Definizione del business plan dell'asset
+    description: |
+      Definizione dei business plan per singolo asset, includendo thesis, driver di valore e orizzonte di detenzione.
+  BC-4920.10.20:
+    name: Analisi hold/sell
+    description: |
+      Analisi dell'economia di detenzione versus cessione e raccomandazione al comitato d'investimento.
+  BC-4920.10.30:
+    name: Aggiornamento annuale del piano
+    description: |
+      Aggiornamento annuale dei business plan degli asset rispetto ai consuntivi e alle nuove previsioni di mercato.
+  BC-4920.20:
+    name: Monitoraggio della performance dell'asset
+    description: |
+      Monitoraggio della performance finanziaria, locativa e operativa a livello di asset rispetto al business plan.
+  BC-4920.20.10:
+    name: Monitoraggio della performance finanziaria dell'asset
+    description: |
+      Monitoraggio del NOI, del flusso di cassa e del rendimento rispetto al budget e al business plan.
+  BC-4920.20.20:
+    name: Monitoraggio della performance locativa e dell'occupancy
+    description: |
+      Monitoraggio dell'occupancy, della percentuale locata, della durata media ponderata dei contratti e del canone rispetto al mercato.
+  BC-4920.20.30:
+    name: Monitoraggio dei KPI operativi
+    description: |
+      Monitoraggio dei KPI operativi relativi a disponibilità degli impianti, reclami, intensità energetica e conteggio visitatori.
+  BC-4920.20.40:
+    name: Analisi degli scostamenti e revisione delle previsioni
+    description: |
+      Analisi degli scostamenti dei consuntivi rispetto al piano e revisione delle previsioni e delle ipotesi di uscita.
+  BC-4920.30:
+    name: Gestione del programma di spese in conto capitale
+    description: |
+      Pianificazione, prioritizzazione e supervisione dell'esecuzione dei programmi di capex per asset e portafoglio.
+  BC-4920.30.10:
+    name: Pianificazione del programma di capex
+    description: |
+      Pianificazione pluriennale del programma di capex per asset e portafoglio.
+  BC-4920.30.20:
+    name: Prioritizzazione e approvazione del capex
+    description: |
+      Prioritizzazione e approvazione dei progetti di capex rispetto ai criteri di ROI e rischio.
+  BC-4920.30.30:
+    name: Supervisione dell'esecuzione del capex
+    description: |
+      Supervisione dell'esecuzione dei progetti di capex, inclusi acconti e consegna dei milestone.
+  BC-4920.30.40:
+    name: Riconciliazione della performance del capex
+    description: |
+      Riconciliazione della performance del capex rispetto all'incremento di valore e al miglioramento del NOI sottoscritti in fase di investimento.
+  BC-4920.40:
+    name: Gestione del riposizionamento e del value-add dell'asset
+    description: |
+      Definizione ed esecuzione di strategie di riposizionamento, conversione e mix dei conduttori che modificano l'uso o il profilo reddituale dell'asset.
+  BC-4920.40.10:
+    name: Definizione della strategia di riposizionamento
+    description: |
+      Definizione della strategia di riposizionamento, incluso il mercato target e la value proposition.
+  BC-4920.40.20:
+    name: Programmi di conversione e riutilizzo
+    description: |
+      Programmi di conversione degli asset tra destinazioni d'uso (uffici in residenziale, retail in uso misto).
+  BC-4920.40.30:
+    name: Strategia del mix dei conduttori e del merchandising
+    description: |
+      Definizione ed esecuzione della strategia di mix dei conduttori e di merchandising per asset retail e a uso misto.
+  BC-4920.50:
+    name: Gestione della sostenibilità e ESG a livello di asset
+    description: |
+      Percorso di decarbonizzazione dell'asset, gestione dell'intensità energetica, certificazioni e invio alla valutazione GRESB.
+  BC-4920.50.10:
+    name: Percorso di decarbonizzazione dell'asset
+    description: |
+      Definizione del percorso di decarbonizzazione dell'asset in linea con le linee guida CRREM e SBTi per gli edifici.
+  BC-4920.50.20:
+    name: Gestione dell'intensità energetica e idrica
+    description: |
+      Gestione dell'intensità energetica e idrica dell'asset rispetto agli obiettivi.
+  BC-4920.50.30:
+    name: Certificazione ESG dell'asset (LEED / BREEAM / WELL)
+    description: |
+      Ottenimento e mantenimento delle certificazioni a livello di asset, incluse LEED, BREEAM, WELL e Fitwel.
+  BC-4920.50.40:
+    name: Invio dati GRESB per l'asset
+    description: |
+      Preparazione e invio dei dati a livello di asset alla valutazione GRESB.
+  BC-4920.60:
+    name: Gestione del rischio dell'asset
+    description: |
+      Monitoraggio a livello di asset dei rischi fisici, climatici, di mercato e di credito dei conduttori e dell'adeguatezza assicurativa.
+  BC-4920.60.10:
+    name: Valutazione del rischio fisico e climatico
+    description: |
+      Valutazione dei rischi fisici e climatici dell'asset, inclusa l'esposizione ad alluvioni, incendi boschivi e calore.
+  BC-4920.60.20:
+    name: Monitoraggio del rischio di credito dei conduttori
+    description: |
+      Monitoraggio del credito dei conduttori e del rischio di riscossione dei canoni per asset e portafoglio.
+  BC-4920.60.30:
+    name: Monitoraggio del rischio di mercato
+    description: |
+      Monitoraggio dei driver di rischio di mercato, inclusi movimenti del tasso di capitalizzazione, pipeline dell'offerta e trend dei canoni.
+  BC-4920.60.40:
+    name: Revisione dell'adeguatezza assicurativa
+    description: |
+      Revisione periodica dell'adeguatezza della copertura assicurativa per property e responsabilità civile rispetto al valore e all'esposizione dell'asset.
+  BC-4920.70:
+    name: Ottimizzazione delle imposte e dei costi operativi
+    description: |
+      Gestione delle valutazioni fiscali sulla proprietà, revisione delle spese operative, audit sul recupero CAM e ottimizzazione delle tariffe utenze specifici degli asset immobiliari.
+  BC-4920.70.10:
+    name: Valutazione e ricorso sull'imposta sulla proprietà
+    description: |
+      Revisione e contestazione delle valutazioni dell'imposta sulla proprietà rispetto alle evidenze comparabili.
+  BC-4920.70.20:
+    name: Revisione delle spese operative
+    description: |
+      Revisione periodica delle spese operative a fini di benchmark e identificazione di opportunità di risparmio.
+  BC-4920.70.30:
+    name: Audit sul recupero CAM
+    description: |
+      Audit del recupero di CAM e oneri di servizio dai conduttori rispetto ai diritti contrattuali.
+  BC-4920.70.40:
+    name: Ottimizzazione delle tariffe utenze
+    description: |
+      Ottimizzazione dell'approvvigionamento di utenze, delle tariffe e degli oneri di domanda su tutto il portafoglio.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-real-estate-brokerage-management.yaml
+++ b/catalogue/i18n/it/L1-real-estate-brokerage-management.yaml
@@ -1,0 +1,163 @@
+# Gestione dell'intermediazione immobiliare (it) — translations for L1-real-estate-brokerage-management.yaml
+locale: it
+source: L1-real-estate-brokerage-management.yaml
+entries:
+  BC-4960:
+    name: Gestione dell'intermediazione immobiliare
+    description: |
+      Intermediazione e agenzia come linea di servizio per il settore immobiliare commerciale e residenziale — acquisizione di mandati di vendita, rappresentanza di acquirenti e conduttori, gestione dei dati MLS, analisi comparativa, operazioni di visite, negoziazione delle offerte, coordinamento del closing, liquidazione delle provvigioni e dei broker cooperanti, e gestione della produttività e del roster degli agenti.
+  BC-4960.10:
+    name: Acquisizione e gestione dei mandati di vendita
+    description: |
+      Acquisizione e conversione dei mandati di vendita e locazione lato venditore e locatore, ed esecuzione del piano di marketing previsto nel contratto di incarico.
+  BC-4960.10.10:
+    name: Pitching e acquisizione del mandato
+    description: |
+      Presentazione per l'acquisizione di mandati di vendita, inclusa CMA, proposta di marketing e presentazione al cliente.
+  BC-4960.10.20:
+    name: Gestione del contratto di incarico
+    description: |
+      Gestione dei contratti di incarico, incluse esclusiva, durata e condizioni di provvigione.
+  BC-4960.10.30:
+    name: Piano di marketing del mandato
+    description: |
+      Definizione ed esecuzione del piano di marketing previsto nel contratto di incarico.
+  BC-4960.20:
+    name: Rappresentanza di acquirenti e conduttori
+    description: |
+      Gestione ed esecuzione dei mandati di rappresentanza lato acquirente e conduttore, incluse ricerca e selezione.
+  BC-4960.20.10:
+    name: Coinvolgimento dell'acquirente o del conduttore
+    description: |
+      Coinvolgimento dei clienti acquirenti e conduttori, inclusi accordi di agenzia e informative.
+  BC-4960.20.20:
+    name: Definizione dei requisiti e del brief
+    description: |
+      Definizione del brief dei requisiti del cliente, inclusi uso, dimensioni, localizzazione e budget.
+  BC-4960.20.30:
+    name: Ricerca e selezione degli immobili
+    description: |
+      Ricerca, selezione e presentazione degli immobili candidati al cliente.
+  BC-4960.30:
+    name: Gestione dei dati di annuncio e MLS
+    description: |
+      Gestione dei dati degli annunci MLS e di portale, inclusi acquisizione, contenuti multimediali, distribuzione e conformità agli standard dati RESO.
+  BC-4960.30.10:
+    name: Acquisizione degli annunci MLS
+    description: |
+      Acquisizione degli annunci MLS rispetto ai campi e alle regole del dizionario dati RESO.
+  BC-4960.30.20:
+    name: Contenuti multimediali degli annunci
+    description: |
+      Produzione e gestione dei contenuti multimediali degli annunci, inclusi fotografia, video e tour 3D.
+  BC-4960.30.30:
+    name: Distribuzione su portali e aggregatori
+    description: |
+      Distribuzione degli annunci su portali, siti partner e aggregatori.
+  BC-4960.30.40:
+    name: Conformità degli annunci e gestione dei ritiri
+    description: |
+      Gestione della conformità degli annunci per accuratezza dei contenuti, aggiornamenti di stato e ritiri.
+  BC-4960.40:
+    name: Analisi comparativa di mercato
+    description: |
+      Produzione di analisi comparative di mercato, broker opinion of value e posizionamento del prezzo per mandati di vendita e acquirente.
+  BC-4960.40.10:
+    name: Raccolta delle vendite comparabili
+    description: |
+      Raccolta delle evidenze di vendite comparabili da MLS e registri pubblici.
+  BC-4960.40.20:
+    name: Produzione del report CMA
+    description: |
+      Produzione dei report di analisi comparativa di mercato per la presentazione al cliente.
+  BC-4960.40.30:
+    name: Broker opinion of value
+    description: |
+      Emissione di broker opinion of value per clienti e mandanti istituzionali.
+  BC-4960.50:
+    name: Operazioni di visite e open house
+    description: |
+      Gestione degli appuntamenti per le visite, degli open house e dell'accesso fisico e digitale per i prospect e gli agenti cooperanti.
+  BC-4960.50.10:
+    name: Gestione degli appuntamenti per le visite
+    description: |
+      Gestione degli appuntamenti per le visite e delle richieste di accesso degli agenti cooperanti.
+  BC-4960.50.20:
+    name: Operazioni di open house
+    description: |
+      Organizzazione degli open house, inclusi registrazione e follow-up.
+  BC-4960.50.30:
+    name: Gestione delle cassette di sicurezza e del controllo accessi
+    description: |
+      Gestione delle cassette di sicurezza e delle credenziali di accesso digitale per gli immobili in portafoglio.
+  BC-4960.60:
+    name: Gestione delle offerte e della negoziazione
+    description: |
+      Redazione e negoziazione di offerte, contro-offerte e scenari con offerte multiple per conto della parte rappresentata.
+  BC-4960.60.10:
+    name: Redazione dell'offerta
+    description: |
+      Redazione delle offerte e degli addendum di supporto per conto della parte rappresentata.
+  BC-4960.60.20:
+    name: Gestione delle contro-offerte e delle offerte multiple
+    description: |
+      Gestione delle contro-offerte e dei processi con offerte multiple, incluse le chiamate best-and-final.
+  BC-4960.60.30:
+    name: Accettazione e conferma del contratto vincolante
+    description: |
+      Conferma dell'accettazione dell'offerta e della formazione del contratto vincolante.
+  BC-4960.70:
+    name: Coordinamento del closing di intermediazione
+    description: |
+      Coordinamento di contingenze, deposito fiduciario e atti notarili fino al closing per le transazioni intermediate.
+  BC-4960.70.10:
+    name: Monitoraggio delle condizioni sospensive
+    description: |
+      Monitoraggio delle condizioni sospensive di ispezione, finanziamento e altre fino alla soddisfazione o rinuncia.
+  BC-4960.70.20:
+    name: Coordinamento del deposito fiduciario e dell'atto notarile
+    description: |
+      Coordinamento con le parti di deposito fiduciario e atto notarile per la documentazione e i fondi di closing.
+  BC-4960.70.30:
+    name: Coordinamento del giorno di closing
+    description: |
+      Coordinamento di firma, consegna delle chiavi e logistica del giorno di closing.
+  BC-4960.80:
+    name: Gestione delle provvigioni e dei broker cooperanti
+    description: |
+      Raccolta delle condizioni di provvigione e liquidazione delle provvigioni dei broker cooperanti e delle commissioni di referral.
+  BC-4960.80.10:
+    name: Acquisizione dell'accordo di provvigione
+    description: |
+      Acquisizione degli accordi di provvigione, incluse ripartizioni e condizioni.
+  BC-4960.80.20:
+    name: Liquidazione del broker cooperante
+    description: |
+      Liquidazione delle provvigioni dovute ai broker cooperanti sulle transazioni concluse.
+  BC-4960.80.30:
+    name: Erogazione delle provvigioni
+    description: |
+      Erogazione delle provvigioni alla mediazione e agli agenti al netto delle trattenute.
+  BC-4960.80.40:
+    name: Gestione delle commissioni di referral
+    description: |
+      Gestione degli accordi di commissione di referral con broker e partner segnalatori.
+  BC-4960.90:
+    name: Gestione della produttività e del roster degli agenti
+    description: |
+      Gestione della sponsorizzazione delle licenze degli agenti, della performance e dell'amministrazione dei piani di provvigione su tutto il roster della mediazione.
+  BC-4960.90.10:
+    name: Monitoraggio delle licenze e degli accordi di sponsorizzazione degli agenti
+    description: |
+      Monitoraggio dello stato delle licenze degli agenti e degli accordi di sponsorizzazione con la mediazione.
+  BC-4960.90.20:
+    name: Gestione della performance degli agenti
+    description: |
+      Gestione della performance degli agenti rispetto agli obiettivi di produzione e agli standard.
+  BC-4960.90.30:
+    name: Amministrazione dei piani di provvigione degli agenti
+    description: |
+      Amministrazione dei piani di provvigione, delle ripartizioni e dei cap degli agenti.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-real-estate-capital-markets-management.yaml
+++ b/catalogue/i18n/it/L1-real-estate-capital-markets-management.yaml
@@ -1,0 +1,143 @@
+# Gestione dei mercati dei capitali immobiliari (it) — translations for L1-real-estate-capital-markets-management.yaml
+locale: it
+source: L1-real-estate-capital-markets-management.yaml
+entries:
+  BC-4980:
+    name: Gestione dei mercati dei capitali immobiliari
+    description: |
+      Disciplina specifica del settore immobiliare per i mercati dei capitali di debito e azionario — origination di debito senior, mezzanino, costruttivo e bridge; servicing dei finanziamenti e asset management; strutturazione di CMBS e CRE CLO; programmi di equity in joint venture; raccolta di capitale pubblico REIT; rifinanziamento e ricapitalizzazione; e gestione del rischio del portafoglio prestiti CRE.
+  BC-4980.10:
+    name: Origination del debito immobiliare
+    description: |
+      Origination di debito immobiliare senior, mezzanino, costruttivo e bridge basata sull'underwriting dell'asset e dello sponsor.
+  BC-4980.10.10:
+    name: Origination del mutuo ipotecario senior
+    description: |
+      Origination di mutui ipotecari senior su asset consolidati.
+  BC-4980.10.20:
+    name: Origination di finanziamenti costruttivi e bridge
+    description: |
+      Origination di finanziamenti costruttivi e bridge per asset in sviluppo e in transizione.
+  BC-4980.10.30:
+    name: Origination di debito mezzanino e equity privilegiata
+    description: |
+      Origination di debito mezzanino e equity privilegiata nella struttura del capitale.
+  BC-4980.10.40:
+    name: Negoziazione di term sheet e lettere d'impegno
+    description: |
+      Negoziazione di term sheet e lettere d'impegno con mutuatari e sponsor.
+  BC-4980.20:
+    name: Servicing e asset management del debito immobiliare
+    description: |
+      Boarding e servicing dei prestiti CRE e monitoraggio proattivo, modifica e workout ove necessario.
+  BC-4980.20.10:
+    name: Boarding del prestito e setup del servicing
+    description: |
+      Boarding dei nuovi prestiti CRE nella piattaforma di servicing e configurazione dei flussi di pagamento e reporting.
+  BC-4980.20.20:
+    name: Monitoraggio dei covenant e del DSCR
+    description: |
+      Monitoraggio continuativo dei covenant del prestito, del DSCR e del LTV rispetto ai trigger del contratto di finanziamento.
+  BC-4980.20.30:
+    name: Modifica e workout del prestito
+    description: |
+      Negoziazione di modifiche ai finanziamenti e workout su asset in difficoltà.
+  BC-4980.20.40:
+    name: Coordinamento del special servicing
+    description: |
+      Coordinamento con i special servicer su prestiti in default o prossimi al default nelle cartolarizzazioni.
+  BC-4980.30:
+    name: Gestione di CMBS e cartolarizzazione
+    description: |
+      Aggregazione dei pool di prestiti, strutturazione di operazioni CMBS e CRE CLO e reporting IRP periodico agli investitori.
+  BC-4980.30.10:
+    name: Aggregazione del pool di prestiti
+    description: |
+      Aggregazione dei pool di prestiti idonei alla cartolarizzazione.
+  BC-4980.30.20:
+    name: Strutturazione della cartolarizzazione
+    description: |
+      Strutturazione di operazioni CMBS e CRE CLO, incluse tranching e rating.
+  BC-4980.30.30:
+    name: Reporting IRP agli investitori
+    description: |
+      Reporting agli investitori nell'ambito del CREFC Investor Reporting Package.
+  BC-4980.30.40:
+    name: Coordinamento con trustee e servicer
+    description: |
+      Coordinamento con trustee, master servicer e agenzie di rating sulle operazioni in essere.
+  BC-4980.40:
+    name: Gestione delle joint venture e dei partner azionari
+    description: |
+      Sourcing di equity in joint venture, strutturazione del promote e degli accordi di waterfall, reporting periodico e distribuzioni ai partner.
+  BC-4980.40.10:
+    name: Sourcing dell'equity in joint venture
+    description: |
+      Sourcing di equity per joint venture da partner istituzionali e HNW.
+  BC-4980.40.20:
+    name: Strutturazione del promote e del waterfall
+    description: |
+      Strutturazione di promote, hurdle e waterfall negli accordi di partnership in joint venture.
+  BC-4980.40.30:
+    name: Reporting e distribuzioni ai partner JV
+    description: |
+      Reporting ai partner di joint venture ed esecuzione delle distribuzioni contrattuali.
+  BC-4980.50:
+    name: Gestione dei mercati dei capitali REIT
+    description: |
+      Emissione di equity e debito REIT pubblico e privato, programmi ATM e gestione della politica dei dividendi.
+  BC-4980.50.10:
+    name: Emissione di equity REIT pubblica
+    description: |
+      Emissione di equity REIT attraverso offerte successive e collocamenti privati.
+  BC-4980.50.20:
+    name: Emissione di debito e obbligazioni REIT
+    description: |
+      Emissione di debito non garantito REIT, obbligazioni e note convertibili.
+  BC-4980.50.30:
+    name: Gestione del programma ATM
+    description: |
+      Gestione dei programmi di equity at-the-market, inclusi pacing e disclosure.
+  BC-4980.50.40:
+    name: Gestione della politica dei dividendi
+    description: |
+      Gestione della politica dei dividendi del REIT in linea con i requisiti di distribuzione REIT e l'AFFO.
+  BC-4980.60:
+    name: Gestione del rifinanziamento e della ricapitalizzazione
+    description: |
+      Rifinanziamento e ricapitalizzazione proattivi delle strutture del capitale degli asset consolidati nel corso del periodo di detenzione.
+  BC-4980.60.10:
+    name: Strategia di rifinanziamento e pacing delle scadenze
+    description: |
+      Definizione della strategia di rifinanziamento e gestione del pacing delle scadenze su tutto il portafoglio.
+  BC-4980.60.20:
+    name: Esecuzione del rifinanziamento
+    description: |
+      Esecuzione delle operazioni di rifinanziamento su singoli asset e pool.
+  BC-4980.60.30:
+    name: Ristrutturazione della ricapitalizzazione
+    description: |
+      Ristrutturazione delle strutture del capitale attraverso ricapitalizzazioni tra partner o iniezioni di equity.
+  BC-4980.70:
+    name: Gestione del rischio del portafoglio prestiti immobiliari
+    description: |
+      Monitoraggio della concentrazione, stress testing, accantonamento per perdite e gestione della watchlist per i portafogli di prestiti CRE.
+  BC-4980.70.10:
+    name: Monitoraggio della concentrazione LTV e DSCR
+    description: |
+      Monitoraggio della concentrazione di LTV e DSCR su tutto il portafoglio di prestiti CRE.
+  BC-4980.70.20:
+    name: Stress testing del portafoglio prestiti CRE
+    description: |
+      Stress testing del portafoglio di prestiti CRE rispetto a shock di tasso, vacancy e valore degli immobili.
+  BC-4980.70.30:
+    name: Accantonamento per perdite CECL / IFRS 9 (CRE)
+    description: |
+      Accantonamento per perdite sul portafoglio CRE nell'ambito dei framework di expected credit loss CECL e IFRS 9.
+  BC-4980.70.40:
+    name: Gestione della watchlist e dei default
+    description: |
+      Aggiornamento della watchlist e monitoraggio dei prestiti in default su tutto il portafoglio.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-real-estate-compliance-regulatory-management.yaml
+++ b/catalogue/i18n/it/L1-real-estate-compliance-regulatory-management.yaml
@@ -1,0 +1,171 @@
+# Gestione della conformità normativa immobiliare (it) — translations for L1-real-estate-compliance-regulatory-management.yaml
+locale: it
+source: L1-real-estate-compliance-regulatory-management.yaml
+entries:
+  BC-4990:
+    name: Gestione della conformità normativa immobiliare
+    description: |
+      Disciplina di conformità per i regimi normativi specifici del settore immobiliare — licenze di intermediazione e agenti, parità di accesso all'alloggio e antidiscriminazione, AML immobiliare e titolarità effettiva, disclosure per rogiti e mutui (RESPA / TRID), performance energetica degli edifici, regolamentazione dei contratti di locazione e dei canoni, regolamentazione di condomini e HOA, e regolamentazione di fondi e gestori.
+  BC-4990.10:
+    name: Conformità delle licenze di mediazione e agenti
+    description: |
+      Conformità con i regimi di licenza per mediatori e agenti, incluso il mantenimento delle licenze aziendali, la formazione continua e la supervisione del mediatore designato.
+  BC-4990.10.10:
+    name: Mantenimento delle licenze aziendali
+    description: |
+      Mantenimento delle licenze delle agenzie di intermediazione nelle regioni di operatività.
+  BC-4990.10.20:
+    name: Licenze degli agenti e formazione continua
+    description: |
+      Monitoraggio delle licenze individuali degli agenti e dei requisiti di formazione continua.
+  BC-4990.10.30:
+    name: Supervisione del mediatore designato
+    description: |
+      Supervisione del mediatore designato sull'attività regolamentata dell'agenzia.
+  BC-4990.10.40:
+    name: Rinnovo delle licenze e risposta agli audit
+    description: |
+      Rinnovo delle licenze e risposta agli audit e alle ispezioni delle autorità di vigilanza.
+  BC-4990.20:
+    name: Conformità alla parità di accesso e antidiscriminazione
+    description: |
+      Conformità con il Fair Housing Act, l'Equality Act, ECOA e regimi antidiscriminazione equivalenti nei processi di locazione, vendita e concessione del credito.
+  BC-4990.20.10:
+    name: Manutenzione della policy sulla parità di accesso
+    description: |
+      Manutenzione delle policy sulla parità di accesso all'alloggio e delle procedure operative standard.
+  BC-4990.20.20:
+    name: Screening di messaggi pubblicitari e fonti di finanziamento
+    description: |
+      Verifica dei contenuti pubblicitari e delle norme sulle fonti di finanziamento per la conformità con i divieti relativi alle categorie protette.
+  BC-4990.20.30:
+    name: Gestione dei reclami per discriminazione
+    description: |
+      Gestione dei reclami per discriminazione abitativa e delle richieste delle autorità di vigilanza.
+  BC-4990.20.40:
+    name: Formazione e attestazione sulla parità di accesso
+    description: |
+      Formazione e attestazione di agenti e collaboratori sugli obblighi in materia di parità di accesso all'alloggio.
+  BC-4990.30:
+    name: Conformità AML e alle sanzioni nel settore immobiliare
+    description: |
+      Conformità con le norme AML specifiche del settore immobiliare, incluse le GTO FinCEN, la FinCEN Residential Real Estate Rule, gli obblighi AMLD 5/6 per le DNFBP e la comunicazione della titolarità effettiva.
+  BC-4990.30.10:
+    name: Acquisizione della titolarità effettiva
+    description: |
+      Acquisizione e verifica della titolarità effettiva per le parti delle transazioni immobiliari.
+  BC-4990.30.20:
+    name: Screening di sanzioni e PEP nel settore immobiliare
+    description: |
+      Screening delle parti della transazione rispetto a liste di sanzioni, PEP e media avversi.
+  BC-4990.30.30:
+    name: Segnalazione di operazioni sospette (RE)
+    description: |
+      Presentazione di segnalazioni di operazioni sospette per le transazioni immobiliari rientranti nell'ambito di applicazione.
+  BC-4990.30.40:
+    name: Audit AML e ispezioni delle autorità
+    description: |
+      Risposta agli audit AML e alle ispezioni delle autorità di vigilanza sui programmi AML del settore immobiliare.
+  BC-4990.40:
+    name: Conformità alle disclosure per rogiti e mutui
+    description: |
+      Conformità con le norme statunitensi RESPA e TRID sulle disclosure per rogiti e mutui e con i regimi regionali equivalenti.
+  BC-4990.40.10:
+    name: Produzione del Loan Estimate e della Closing Disclosure
+    description: |
+      Produzione dei documenti TRID Loan Estimate e Closing Disclosure nel rispetto dei tempi previsti dalla normativa.
+  BC-4990.40.20:
+    name: Disclosure degli accordi con soggetti collegati
+    description: |
+      Disclosure degli accordi con soggetti collegati nei punti previsti dalla transazione.
+  BC-4990.40.30:
+    name: Conformità dei fornitori di servizi di regolamento
+    description: |
+      Conformità con le norme sui referral dei fornitori di servizi di regolamento e i divieti della Sezione 8.
+  BC-4990.40.40:
+    name: Risposta agli audit RESPA
+    description: |
+      Risposta alle ispezioni del CFPB e delle autorità statali sulla conformità RESPA.
+  BC-4990.50:
+    name: Conformità alla performance energetica degli edifici
+    description: |
+      Conformità con EPC, MEES, standard di performance degli edifici e normative di benchmarking (es. Local Law 97, recepimenti EPBD).
+  BC-4990.50.10:
+    name: Conformità alla certificazione energetica degli edifici
+    description: |
+      Acquisizione e deposito degli attestati di prestazione energetica (APE) e equivalenti.
+  BC-4990.50.20:
+    name: Conformità agli standard minimi di efficienza energetica (MEES)
+    description: |
+      Conformità agli standard minimi di efficienza energetica per gli immobili locati e venduti.
+  BC-4990.50.30:
+    name: Disclosure energetica per benchmark (LL97 / BPS)
+    description: |
+      Disclosure ai sensi delle ordinanze comunali di benchmarking energetico e degli standard di performance degli edifici.
+  BC-4990.50.40:
+    name: Conformità al reporting EPBD dell'UE
+    description: |
+      Conformità agli obblighi di reporting e certificazione della Direttiva UE sulla performance energetica degli edifici (EPBD).
+  BC-4990.60:
+    name: Conformità alla normativa sui contratti di locazione e sui canoni
+    description: |
+      Conformità con i regimi di blocco e stabilizzazione dei canoni, gli avvisi di sfratto, la gestione normativa dei depositi cauzionali e la registrazione degli affitti brevi.
+  BC-4990.60.10:
+    name: Conformità al blocco e alla stabilizzazione dei canoni
+    description: |
+      Conformità con i regimi di blocco e stabilizzazione dei canoni per le unità soggette a regolamentazione.
+  BC-4990.60.20:
+    name: Conformità agli avvisi e alle procedure di sfratto
+    description: |
+      Conformità con i requisiti di legge per l'avviso e la procedura di sfratto.
+  BC-4990.60.30:
+    name: Gestione normativa dei depositi cauzionali
+    description: |
+      Gestione normativa dei depositi cauzionali, incluse le norme su deposito fiduciario, interessi e restituzione.
+  BC-4990.60.40:
+    name: Conformità alla registrazione degli affitti brevi
+    description: |
+      Conformità con i requisiti di registrazione e le norme operative per gli affitti brevi nelle città regolamentate.
+  BC-4990.70:
+    name: Conformità alla normativa su condomini, HOA e strata
+    description: |
+      Conformità con i regimi normativi su condomini, HOA, body corporate e strata, incluse le disclosure dello sponsor e le norme sul fondo di riserva.
+  BC-4990.70.10:
+    name: Disclosure dello sponsor condominio e strata
+    description: |
+      Obblighi di disclosure dello sponsor ai sensi della normativa su condomini e strata.
+  BC-4990.70.20:
+    name: Registrazione di HOA e body corporate
+    description: |
+      Registrazione e adempimenti periodici per entità HOA e body corporate.
+  BC-4990.70.30:
+    name: Conformità alla disclosure sul fondo di riserva
+    description: |
+      Conformità con i requisiti di studio e disclosure sul fondo di riserva.
+  BC-4990.70.40:
+    name: Conformità al certificato di rivendita
+    description: |
+      Emissione dei certificati di rivendita e delle relative disclosure sulle vendite di unità in condominio e HOA.
+  BC-4990.80:
+    name: Conformità di fondi e gestori immobiliari
+    description: |
+      Conformità con AIFMD, ELTIF, US Investment Advisers Act e regimi equivalenti di fondo e gestore che disciplinano i gestori di fondi immobiliari.
+  BC-4990.80.10:
+    name: Registrazione del gestore del fondo
+    description: |
+      Mantenimento delle registrazioni e delle autorizzazioni di gestori di fondi e asset manager.
+  BC-4990.80.20:
+    name: Conformità al reporting AIFMD e ELTIF
+    description: |
+      Conformità agli obblighi di reporting di cui all'Allegato IV dell'AIFMD e alle disposizioni ELTIF.
+  BC-4990.80.30:
+    name: Marketing e notifiche transfrontaliere
+    description: |
+      Conformità con i regimi di notifica per il marketing transfrontaliero dei fondi.
+  BC-4990.80.40:
+    name: Risposta agli audit e alle ispezioni del fondo
+    description: |
+      Risposta agli audit e alle ispezioni delle autorità di vigilanza sui fondi in tutte le giurisdizioni.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-real-estate-development-management.yaml
+++ b/catalogue/i18n/it/L1-real-estate-development-management.yaml
@@ -1,0 +1,175 @@
+# Gestione dello sviluppo immobiliare (it) — translations for L1-real-estate-development-management.yaml
+locale: it
+source: L1-real-estate-development-management.yaml
+entries:
+  BC-4900:
+    name: Gestione dello sviluppo immobiliare
+    description: |
+      Origination, studio di fattibilità, titoli edilizi, finanziamento e supervisione della consegna per progetti di nuova costruzione e riqualificazione significativa nel settore commerciale e residenziale. Disciplina lato proprietario che collega l'esecuzione costruttiva generica con le attività a monte (sito, titoli, programma, finanza di sviluppo) e a valle (locazione iniziale, stabilizzazione) specifiche dello sviluppo immobiliare.
+  BC-4900.10:
+    name: Pipeline di sviluppo e selezione dei siti
+    description: |
+      Origination di opportunità di sviluppo attraverso analisi di mercato, selezione diretta dei siti, generazione di contatti fuori mercato e monitoraggio della pipeline rispetto ai criteri di investimento.
+  BC-4900.10.10:
+    name: Analisi di mercato e sottomercato
+    description: |
+      Analisi delle dinamiche metropolitane, di sottomercato e micro-localizzazione per orientare l'attività di sviluppo.
+  BC-4900.10.20:
+    name: Identificazione e selezione dei siti
+    description: |
+      Identificazione di siti candidati allo sviluppo attraverso canali di annunci, reti di broker e screening dei dati catastali.
+  BC-4900.10.30:
+    name: Origination fuori mercato
+    description: |
+      Sviluppo di opportunità fuori mercato attraverso il contatto diretto con i proprietari terrieri e reti proprietarie.
+  BC-4900.10.40:
+    name: Monitoraggio della pipeline
+    description: |
+      Monitoraggio delle opportunità di sviluppo attraverso gate di fase e filtri sui criteri di investimento.
+  BC-4900.20:
+    name: Analisi di fattibilità dello sviluppo
+    description: |
+      Valutazione della fattibilità delle opportunità di sviluppo candidate nelle dimensioni del sito, del programma e finanziaria.
+  BC-4900.20.10:
+    name: Analisi del massimo e miglior uso
+    description: |
+      Analisi degli usi legalmente ammissibili, fisicamente possibili e finanziariamente fattibili per un sito candidato.
+  BC-4900.20.20:
+    name: Studi di programma e sagoma edilizia
+    description: |
+      Studi sul mix funzionale e sulla sagoma degli edifici per verificare la capacità edificatoria e i rendimenti dello sviluppo.
+  BC-4900.20.30:
+    name: Modellazione del proforma di sviluppo
+    description: |
+      Costruzione del proforma di sviluppo che include costi, ricavi e rendimenti levered e unlevered.
+  BC-4900.20.40:
+    name: Underwriting dell'acquisizione del terreno
+    description: |
+      Underwriting del prezzo e della struttura dell'acquisizione del terreno rispetto ai risultati di fattibilità.
+  BC-4900.30:
+    name: Titoli edilizi e permessi di costruzione
+    description: |
+      Ottenimento dei diritti di uso del suolo, del permesso urbanistico, delle autorizzazioni ambientali e dei permessi di costruzione necessari.
+  BC-4900.30.10:
+    name: Strategia di zonizzazione e uso del suolo
+    description: |
+      Strategia ed esecuzione per variazioni di destinazione urbanistica, modifiche alle mappe d'uso del suolo e bonus di densità.
+  BC-4900.30.20:
+    name: Permesso urbanistico e varianti
+    description: |
+      Ottenimento del permesso urbanistico, di varianti e di permessi per usi speciali presso le autorità competenti.
+  BC-4900.30.30:
+    name: Valutazione ambientale (NEPA / VIA)
+    description: |
+      Revisione ambientale ai sensi di NEPA, VIA o regimi regionali equivalenti, inclusa la valutazione degli impatti e le misure di mitigazione.
+  BC-4900.30.40:
+    name: Permessi di costruzione e autorizzazioni
+    description: |
+      Presentazione e ottenimento dei permessi di costruzione e delle autorizzazioni necessarie per avviare i lavori.
+  BC-4900.30.50:
+    name: Coinvolgimento della comunità e degli stakeholder
+    description: |
+      Dialogo con organi di quartiere, vicini e stakeholder politici a supporto del processo di titolazione.
+  BC-4900.40:
+    name: Gestione del programma di sviluppo
+    description: |
+      Governance a livello di programma di pianificazione, budget, rischio e reporting agli stakeholder lungo l'intero ciclo di vita dello sviluppo.
+  BC-4900.40.10:
+    name: Gestione del cronoprogramma di sviluppo
+    description: |
+      Definizione e monitoraggio del cronoprogramma principale dello sviluppo, dall'acquisizione del terreno alla stabilizzazione.
+  BC-4900.40.20:
+    name: Controllo del budget di sviluppo
+    description: |
+      Controllo del budget totale dei costi di sviluppo, incluse componenti di lavori, oneri accessori, finanziamento e contingency.
+  BC-4900.40.30:
+    name: Gestione del rischio e delle contingency di sviluppo
+    description: |
+      Identificazione, quantificazione e gestione dei rischi di programma e dell'utilizzo della contingency.
+  BC-4900.40.40:
+    name: Reporting agli stakeholder
+    description: |
+      Reporting sull'avanzamento dello sviluppo a investitori, finanziatori e organi di governance interni.
+  BC-4900.50:
+    name: Gestione della pianificazione generale e del concept design
+    description: |
+      Definizione di piani generali di lungo periodo e supervisione delle fasi di concept e progettazione schematica rispetto alle intenzioni del promotore.
+  BC-4900.50.10:
+    name: Definizione del piano generale
+    description: |
+      Definizione dei piani generali per sviluppi multifase o multi-lotto, inclusa la pianificazione delle fasi.
+  BC-4900.50.20:
+    name: Supervisione del concept e della progettazione schematica
+    description: |
+      Supervisione lato proprietario degli elaborati di concept e progettazione schematica dell'architetto rispetto al brief.
+  BC-4900.50.30:
+    name: Presidio degli standard di progettazione
+    description: |
+      Presidio degli standard di progettazione e di brand del promotore attraverso i team di consulenza.
+  BC-4900.50.40:
+    name: Definizione del brief di sostenibilità
+    description: |
+      Definizione dei brief di sostenibilità e di certificazione (LEED, BREEAM, WELL, NABERS) per lo sviluppo.
+  BC-4900.60:
+    name: Strutturazione della finanza di sviluppo
+    description: |
+      Strutturazione del capitale azionario, del debito e degli incentivi necessari a finanziare lo sviluppo fino al completamento.
+  BC-4900.60.10:
+    name: Capitalizzazione azionaria
+    description: |
+      Reperimento e closing del capitale di sponsor e limited partner per il progetto di sviluppo.
+  BC-4900.60.20:
+    name: Origination del finanziamento costruttivo
+    description: |
+      Origination di finanziamenti costruttivi e bridge rispetto al proforma di sviluppo.
+  BC-4900.60.30:
+    name: Incentivi pubblici e crediti d'imposta
+    description: |
+      Richiesta di incentivi pubblici quali TIF, PILOT, LIHTC e programmi di credito d'imposta storico.
+  BC-4900.60.40:
+    name: Strutturazione della joint venture
+    description: |
+      Strutturazione di veicoli di joint venture, promote e condizioni di waterfall per i partner di sviluppo.
+  BC-4900.70:
+    name: Supervisione della consegna costruttiva
+    description: |
+      Supervisione lato proprietario della costruzione da parte di appaltatori generali e imprese, lasciando l'esecuzione alla capability costruttiva (BC-1150).
+  BC-4900.70.10:
+    name: Selezione e aggiudicazione degli appaltatori
+    description: |
+      Selezione e aggiudicazione degli appaltatori generali e dei principali contratti d'opera per lo sviluppo.
+  BC-4900.70.20:
+    name: Monitoraggio costruttivo lato proprietario
+    description: |
+      Monitoraggio lato proprietario dell'avanzamento dei lavori, degli acconti e della qualità durante l'esecuzione.
+  BC-4900.70.30:
+    name: Governance delle varianti
+    description: |
+      Governance delle varianti, delle modifiche allo scope e dell'utilizzo della contingency rispetto al budget.
+  BC-4900.70.40:
+    name: Supervisione della qualità e della sicurezza
+    description: |
+      Supervisione della qualità costruttiva e della performance in materia di sicurezza rispetto alle aspettative del promotore e alle normative.
+  BC-4900.80:
+    name: Gestione del lease-up e della stabilizzazione
+    description: |
+      Pre-locazione, coordinamento dell'apertura e avvio dell'asset completato verso la piena occupazione e la performance stabilizzata.
+  BC-4900.80.10:
+    name: Coordinamento della pre-locazione
+    description: |
+      Coordinamento delle campagne di pre-locazione in anticipo rispetto al completamento dell'edificio.
+  BC-4900.80.20:
+    name: Coordinamento dell'apertura e dei primi ingressi
+    description: |
+      Coordinamento dell'apertura dell'edificio, dei primi ingressi dei conduttori e del passaggio operativo.
+  BC-4900.80.30:
+    name: Monitoraggio della performance di stabilizzazione
+    description: |
+      Monitoraggio della velocità di lease-up e della performance operativa rispetto al proforma di stabilizzazione.
+  BC-4900.80.40:
+    name: Chiusura delle punch list e dei difetti
+    description: |
+      Chiusura delle voci di punch list, dei difetti latenti e delle richieste di garanzia agli appaltatori dopo il collaudo.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-real-estate-investment-management.yaml
+++ b/catalogue/i18n/it/L1-real-estate-investment-management.yaml
@@ -1,0 +1,139 @@
+# Gestione degli investimenti immobiliari (it) — translations for L1-real-estate-investment-management.yaml
+locale: it
+source: L1-real-estate-investment-management.yaml
+entries:
+  BC-4910:
+    name: Gestione degli investimenti immobiliari
+    description: |
+      Disciplina di casa d'investimento e di fondo per strategia, raccolta di capitali, pipeline, governance delle decisioni, costruzione del portafoglio, relazioni con gli investitori e performance a livello di fondo per veicoli d'investimento immobiliare inclusi REIT, fondi non quotati, mandati separati e programmi di joint venture.
+  BC-4910.10:
+    name: Gestione della strategia e del mandato d'investimento
+    description: |
+      Definizione e presidio della strategia d'investimento, dei mandati di fondo, della focalizzazione settoriale e geografica e degli obiettivi di rischio-rendimento per i veicoli in gestione.
+  BC-4910.10.10:
+    name: Definizione del fondo e del mandato
+    description: |
+      Definizione dei mandati di fondo o di conto separato, inclusi settore, geografia, stile e vincoli.
+  BC-4910.10.20:
+    name: Allocazione settoriale e geografica
+    description: |
+      Definizione e revisione degli obiettivi di allocazione settoriale e geografica tra i veicoli.
+  BC-4910.10.30:
+    name: Targeting del profilo rischio-rendimento
+    description: |
+      Definizione dei profili di rischio-rendimento per stile (core, core-plus, value-add, opportunistico) e benchmark.
+  BC-4910.10.40:
+    name: Manutenzione della policy d'investimento
+    description: |
+      Aggiornamento delle dichiarazioni di policy d'investimento, delle eccezioni e dei consensi degli investitori.
+  BC-4910.20:
+    name: Raccolta di capitali e costituzione del fondo
+    description: |
+      Costituzione di veicoli d'investimento e raccolta di capitali dagli investitori, incluse strutturazione, marketing e closing.
+  BC-4910.20.10:
+    name: Strutturazione del fondo e setup del veicolo
+    description: |
+      Strutturazione e setup di veicoli di fondo, feeder, blocker e strutture di detenzione fiscalmente efficienti.
+  BC-4910.20.20:
+    name: Targeting degli investitori e sottoscrizione
+    description: |
+      Targeting dei segmenti di investitori, risposta alla due diligence e lavorazione delle sottoscrizioni.
+  BC-4910.20.30:
+    name: Gestione del closing del fondo
+    description: |
+      Gestione dei closing iniziali, intermedi e finali, inclusa la perequazione degli investitori tardivi.
+  BC-4910.20.40:
+    name: Gestione del co-investimento e dei sidecar
+    description: |
+      Origination e gestione di offerte di co-investimento e veicoli sidecar.
+  BC-4910.30:
+    name: Pipeline d'investimento e selezione delle operazioni
+    description: |
+      Origination e triage di opportunità d'investimento attraverso canali di acquisizione diretta, interessi indiretti e joint venture per i fondi.
+  BC-4910.30.10:
+    name: Origination diretta delle operazioni
+    description: |
+      Origination di opportunità d'investimento diretto su asset e portafoglio in linea con i mandati.
+  BC-4910.30.20:
+    name: Sourcing indiretto e di co-investimento
+    description: |
+      Sourcing di interessi indiretti, inclusi secondari, quote di fondo e co-investimenti.
+  BC-4910.30.30:
+    name: Pacing della pipeline e allocazione
+    description: |
+      Calibrazione della pipeline rispetto ai piani di deployment del fondo e allocazione tra i veicoli.
+  BC-4910.40:
+    name: Gestione delle decisioni e delle approvazioni d'investimento
+    description: |
+      Governance del comitato d'investimento, flussi di approvazione e monitoraggio delle condizioni di approvazione per i nuovi investimenti.
+  BC-4910.40.10:
+    name: Preparazione del memorandum d'investimento
+    description: |
+      Predisposizione dei memoranda d'investimento per la revisione del comitato, con thesis, condizioni e rischi.
+  BC-4910.40.20:
+    name: Governance del comitato d'investimento
+    description: |
+      Governance del processo del comitato d'investimento, del quorum e della registrazione delle decisioni.
+  BC-4910.40.30:
+    name: Monitoraggio delle condizioni di approvazione
+    description: |
+      Monitoraggio delle condizioni precedenti e successive alle approvazioni d'investimento.
+  BC-4910.50:
+    name: Costruzione e allocazione del portafoglio
+    description: |
+      Costruzione e ribilanciamento continuo dei portafogli di fondo rispetto ai target di mandato, leva e rischio.
+  BC-4910.50.10:
+    name: Modellazione del portafoglio
+    description: |
+      Modellazione della composizione del portafoglio, della diversificazione per vintage e della performance attesa.
+  BC-4910.50.20:
+    name: Ribilanciamento settoriale e geografico
+    description: |
+      Ribilanciamento del mix settoriale e geografico del portafoglio attraverso acquisizioni e cessioni.
+  BC-4910.50.30:
+    name: Targeting della leva e della copertura
+    description: |
+      Definizione e monitoraggio della leva del portafoglio e delle politiche di copertura FX e tassi.
+  BC-4910.60:
+    name: Relazioni con gli investitori e reporting
+    description: |
+      Comunicazione con i limited partner e gli investitori quotati, esecuzione dei capital call e delle distribuzioni e invio ai benchmark di settore.
+  BC-4910.60.10:
+    name: Capital call e distribuzioni
+    description: |
+      Emissione di capital call ed esecuzione delle distribuzioni, incluso il rimborso del capitale.
+  BC-4910.60.20:
+    name: Reporting e disclosure ai limited partner
+    description: |
+      Reporting trimestrale e annuale ai limited partner su performance, NAV e disclosure.
+  BC-4910.60.30:
+    name: Invio a indici e benchmark
+    description: |
+      Invio a NCREIF, INREV, EPRA e benchmark regionali per la comparabilità della performance.
+  BC-4910.60.40:
+    name: Assemblee annuali degli investitori
+    description: |
+      Organizzazione delle assemblee annuali degli investitori, dei comitati consultivi e degli investor day.
+  BC-4910.70:
+    name: Gestione della performance del fondo e del NAV
+    description: |
+      Calcolo del NAV del fondo, attribuzione della performance e calcolo delle commissioni di gestione e performance, inclusa la cristallizzazione del carried interest.
+  BC-4910.70.10:
+    name: NAV e pricing delle quote
+    description: |
+      Calcolo del NAV del fondo e del pricing delle quote nel ciclo di valutazione periodica.
+  BC-4910.70.20:
+    name: Attribuzione della performance
+    description: |
+      Attribuzione della performance del fondo per contributi da asset, settore, geografia e valuta.
+  BC-4910.70.30:
+    name: Calcolo di commissioni e carried interest
+    description: |
+      Calcolo delle commissioni di gestione e del carried interest in linea con i termini economici dell'LPA.
+  BC-4910.70.40:
+    name: Calcolo di hurdle e waterfall
+    description: |
+      Calcolo degli hurdle di rendimento preferenziale e delle waterfall di distribuzione per ciascun veicolo.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-real-estate-leasing-management.yaml
+++ b/catalogue/i18n/it/L1-real-estate-leasing-management.yaml
@@ -1,0 +1,155 @@
+# Gestione delle locazioni immobiliari (it) — translations for L1-real-estate-leasing-management.yaml
+locale: it
+source: L1-real-estate-leasing-management.yaml
+entries:
+  BC-4950:
+    name: Gestione delle locazioni immobiliari
+    description: |
+      Locazione lato locatore di spazi commerciali, retail e residenziali lungo l'intero ciclo di vita del contratto — pricing, marketing, gestione dei prospect, screening delle domande, negoziazione ed esecuzione, amministrazione del contratto, rinnovo e fidelizzazione, e fine del rapporto locatizio. Distinto dalla locazione del conduttore aziendale (BC-710) e dall'intermediazione come linea di servizio (BC-4960).
+  BC-4950.10:
+    name: Strategia di locazione e pricing
+    description: |
+      Definizione della strategia di canone richiesto, dei pacchetti di agevolazioni, del mix target dei conduttori e del benchmark del canone dell'asset rispetto al mercato.
+  BC-4950.10.10:
+    name: Strategia di canone richiesto e agevolazioni
+    description: |
+      Definizione dei livelli di canone richiesto e dei pacchetti di agevolazioni per asset e tipologia di unità.
+  BC-4950.10.20:
+    name: Strategia del mix target dei conduttori
+    description: |
+      Definizione del mix target di conduttori e del merito creditizio per l'asset.
+  BC-4950.10.30:
+    name: Benchmark del canone di mercato
+    description: |
+      Benchmark periodico dei canoni in essere e richiesti rispetto alle evidenze di mercato.
+  BC-4950.20:
+    name: Marketing degli spazi liberi e gestione degli annunci
+    description: |
+      Marketing degli spazi disponibili tramite contenuti di annuncio, distribuzione sui canali e visite in loco.
+  BC-4950.20.10:
+    name: Produzione dei contenuti dell'annuncio
+    description: |
+      Produzione dei contenuti dell'annuncio, inclusi fotografie, planimetrie e tour virtuali.
+  BC-4950.20.20:
+    name: Gestione dei canali di pubblicazione e distribuzione
+    description: |
+      Gestione della distribuzione degli annunci su portali, MLS e canali partner.
+  BC-4950.20.30:
+    name: Operazioni di visite agli spazi liberi
+    description: |
+      Gestione delle visite alle unità libere e dei tour autonomi presso la proprietà.
+  BC-4950.30:
+    name: Gestione dei prospect e delle richieste
+    description: |
+      Acquisizione, qualificazione e follow-up delle richieste di locazione in entrata e dei prospect.
+  BC-4950.30.10:
+    name: Acquisizione e instradamento delle richieste
+    description: |
+      Acquisizione delle richieste di locazione su tutti i canali e instradamento al team dell'asset appropriato.
+  BC-4950.30.20:
+    name: Qualificazione dei prospect
+    description: |
+      Qualificazione dei prospect rispetto all'uso target, al merito creditizio e all'idoneità dell'unità.
+  BC-4950.30.30:
+    name: Pianificazione delle visite e follow-up
+    description: |
+      Pianificazione delle visite e follow-up post-visita con i prospect.
+  BC-4950.40:
+    name: Domanda e screening del conduttore
+    description: |
+      Acquisizione delle domande di locazione ed esecuzione di verifiche di credito, identità e referenze nel rispetto delle norme di parità di accesso all'alloggio.
+  BC-4950.40.10:
+    name: Acquisizione della domanda
+    description: |
+      Acquisizione delle domande di locazione e della documentazione di supporto.
+  BC-4950.40.20:
+    name: Verifiche creditizie e di referenze
+    description: |
+      Esecuzione di verifiche creditizie e referenze da parte di locatori e datori di lavoro sui richiedenti.
+  BC-4950.40.30:
+    name: Verifica dell'identità e del diritto di occupazione
+    description: |
+      Verifica dell'identità e del diritto di affittare o occupare un immobile come richiesto dalla giurisdizione competente.
+  BC-4950.40.40:
+    name: Gestione del diniego in conformità alla parità di accesso
+    description: |
+      Gestione delle decisioni di rifiuto della domanda nel rispetto delle norme sulla parità di accesso all'alloggio e sull'avviso di diniego.
+  BC-4950.50:
+    name: Negoziazione ed esecuzione del contratto di locazione
+    description: |
+      Negoziazione delle term sheet, redazione, gestione delle revisioni, esecuzione e raccolta dei depositi cauzionali e delle garanzie.
+  BC-4950.50.10:
+    name: Negoziazione della term sheet
+    description: |
+      Negoziazione delle term sheet del contratto di locazione, inclusi canone, durata, opzioni e incentivi.
+  BC-4950.50.20:
+    name: Redazione del contratto e gestione delle revisioni
+    description: |
+      Redazione dei documenti contrattuali e gestione dei cicli di revisione con i legali del conduttore.
+  BC-4950.50.30:
+    name: Firma ed esecuzione del contratto
+    description: |
+      Firma ed esecuzione del contratto di locazione e dei documenti accessori.
+  BC-4950.50.40:
+    name: Raccolta del deposito cauzionale e delle garanzie
+    description: |
+      Raccolta dei depositi cauzionali, delle lettere di credito e delle garanzie personali o societarie.
+  BC-4950.60:
+    name: Amministrazione del contratto di locazione (lato locatore)
+    description: |
+      Amministrazione lato locatore degli abstract contrattuali, dell'indicizzazione dei canoni, del monitoraggio delle opzioni e della conformità contrattuale durante la durata del rapporto.
+  BC-4950.60.10:
+    name: Abstract del contratto di locazione
+    description: |
+      Estrazione dei termini chiave dai contratti di locazione in registri strutturati.
+  BC-4950.60.20:
+    name: Indicizzazione e monitoraggio degli adeguamenti del canone
+    description: |
+      Monitoraggio e attivazione degli adeguamenti del canone, incluse le clausole indicizzate e a gradini.
+  BC-4950.60.30:
+    name: Monitoraggio di opzioni, recessi e rinnovi
+    description: |
+      Monitoraggio delle opzioni del conduttore e del locatore, delle date di recesso e delle finestre di rinnovo.
+  BC-4950.60.40:
+    name: Monitoraggio della conformità contrattuale
+    description: |
+      Monitoraggio della conformità del conduttore ai covenant contrattuali, inclusi uso, lavori e obblighi di rendicontazione.
+  BC-4950.70:
+    name: Gestione del rinnovo e della fidelizzazione
+    description: |
+      Gestione proattiva della pipeline dei rinnovi, negoziazione delle condizioni e programmi di fidelizzazione dei conduttori in essere.
+  BC-4950.70.10:
+    name: Gestione della pipeline dei rinnovi
+    description: |
+      Gestione della pipeline dei rinnovi rispetto al calendario delle scadenze e agli obiettivi di fidelizzazione.
+  BC-4950.70.20:
+    name: Negoziazione delle condizioni di rinnovo
+    description: |
+      Negoziazione delle condizioni di rinnovo, inclusi canone, durata e incentivi.
+  BC-4950.70.30:
+    name: Operazioni dei programmi di fidelizzazione
+    description: |
+      Gestione dei programmi di fidelizzazione, incluso il contatto con i conduttori e le offerte di incentivo.
+  BC-4950.80:
+    name: Gestione dell'uscita e della risoluzione del contratto
+    description: |
+      Gestione del preavviso del conduttore, della restituzione dei locali, dei danni, del ripristino, del rimborso del deposito e della contabilità finale al termine del rapporto locatizio.
+  BC-4950.80.10:
+    name: Lavorazione del preavviso e della restituzione dei locali
+    description: |
+      Lavorazione degli avvisi di recesso e della restituzione dei locali.
+  BC-4950.80.20:
+    name: Valutazione dei danni e degli obblighi di ripristino
+    description: |
+      Valutazione dei danni e degli obblighi di ripristino del conduttore rispetto al contratto.
+  BC-4950.80.30:
+    name: Rimborso del deposito cauzionale
+    description: |
+      Rimborso dei depositi cauzionali al netto di eventuali trattenute in conformità alla normativa e al contratto.
+  BC-4950.80.40:
+    name: Contabilità finale a fine locazione
+    description: |
+      Contabilità finale di canoni, recuperi e crediti al termine del rapporto locatizio.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-real-estate-valuation-appraisal-management.yaml
+++ b/catalogue/i18n/it/L1-real-estate-valuation-appraisal-management.yaml
@@ -1,0 +1,127 @@
+# Gestione della valutazione e perizia immobiliare (it) — translations for L1-real-estate-valuation-appraisal-management.yaml
+locale: it
+source: L1-real-estate-valuation-appraisal-management.yaml
+entries:
+  BC-4970:
+    name: Gestione della valutazione e perizia immobiliare
+    description: |
+      Disciplina di perizia e valutazione per asset e portafogli immobiliari — acquisizione dell'incarico, ispezione dell'immobile, raccolta dei dati comparabili, applicazione degli approcci di confronto, reddituale e del costo, redazione e firma del report, rivalutazione periodica del portafoglio e quality assurance in conformità con USPAP, RICS Red Book e IVS.
+  BC-4970.10:
+    name: Gestione dell'incarico di valutazione
+    description: |
+      Acquisizione dell'incarico, definizione dello scope, verifiche dei conflitti e lettere di incarico per le valutazioni commissionate da clienti e finanziatori.
+  BC-4970.10.10:
+    name: Acquisizione e definizione dello scope dell'incarico
+    description: |
+      Acquisizione degli incarichi di valutazione e definizione dello scope e della finalità della valutazione.
+  BC-4970.10.20:
+    name: Verifica dei conflitti d'interesse e dell'indipendenza
+    description: |
+      Verifica dei conflitti d'interesse e dell'indipendenza del valutatore per i nuovi incarichi.
+  BC-4970.10.30:
+    name: Definizione degli onorari e emissione della lettera d'incarico
+    description: |
+      Definizione e trasmissione degli onorari e delle lettere d'incarico ai clienti.
+  BC-4970.20:
+    name: Ispezione dell'immobile e raccolta dei dati
+    description: |
+      Sopralluoghi, misurazione dell'edificio conforme IPMS e raccolta dei dati sulle condizioni e sui difetti dell'immobile.
+  BC-4970.20.10:
+    name: Operazioni di ispezione dell'immobile
+    description: |
+      Esecuzione dei sopralluoghi sull'immobile da parte di valutatori qualificati.
+  BC-4970.20.20:
+    name: Misurazione dell'edificio (IPMS)
+    description: |
+      Misurazione degli edifici e delle unità locative in conformità con IPMS e gli standard di misura locali.
+  BC-4970.20.30:
+    name: Rilevazione delle condizioni e dei difetti
+    description: |
+      Rilevazione delle condizioni dell'edificio e dei difetti osservati durante il sopralluogo.
+  BC-4970.30:
+    name: Raccolta dei dati di mercato e dei comparabili
+    description: |
+      Sourcing e raccolta di transazioni comparabili, indici di mercato e benchmark dei rendimenti a supporto delle conclusioni di valutazione.
+  BC-4970.30.10:
+    name: Acquisizione delle transazioni comparabili
+    description: |
+      Acquisizione delle transazioni comparabili da fonti di mercato e database interni.
+  BC-4970.30.20:
+    name: Indici di mercato e benchmark dei rendimenti
+    description: |
+      Aggiornamento degli indici di mercato e dei benchmark dei rendimenti per settore e area geografica.
+  BC-4970.30.30:
+    name: Gestione degli aggiustamenti sui comparabili
+    description: |
+      Gestione degli aggiustamenti sui comparabili per differenze di data, localizzazione, condizione e qualità.
+  BC-4970.40:
+    name: Applicazione degli approcci di valutazione
+    description: |
+      Applicazione degli approcci di valutazione riconosciuti — confronto delle vendite, capitalizzazione del reddito, DCF e costo — all'immobile oggetto di perizia.
+  BC-4970.40.10:
+    name: Approccio del confronto delle vendite
+    description: |
+      Applicazione dell'approccio del confronto delle vendite mediante evidenze di transazioni comparabili.
+  BC-4970.40.20:
+    name: Approccio della capitalizzazione del reddito
+    description: |
+      Applicazione dell'approccio della capitalizzazione del reddito utilizzando NOI ed evidenze di rendimento.
+  BC-4970.40.30:
+    name: Approccio dei flussi di cassa attualizzati
+    description: |
+      Applicazione dell'approccio DCF per immobili a reddito con previsioni pluriennali.
+  BC-4970.40.40:
+    name: Approccio del costo
+    description: |
+      Applicazione dell'approccio del costo basato sul costo di sostituzione e sull'analisi del deprezzamento.
+  BC-4970.50:
+    name: Redazione e firma del report di valutazione
+    description: |
+      Redazione, revisione interna e firma dei report di valutazione in conformità con gli standard USPAP, Red Book e IVS.
+  BC-4970.50.10:
+    name: Redazione del report di valutazione
+    description: |
+      Redazione dei report di valutazione rispetto allo scope e alla finalità dell'incarico.
+  BC-4970.50.20:
+    name: Firma del revisore e controllo qualità
+    description: |
+      Firma del revisore e controllo qualità dei report di valutazione prima dell'emissione.
+  BC-4970.50.30:
+    name: Emissione del report e gestione delle revisioni
+    description: |
+      Emissione dei report di valutazione e gestione delle revisioni e degli addendum.
+  BC-4970.60:
+    name: Rivalutazione del portafoglio e valutazione per indici
+    description: |
+      Rivalutazione periodica dei portafogli per fondi e finanziatori e invio dei dati di valutazione a indici e benchmark.
+  BC-4970.60.10:
+    name: Rivalutazione periodica del portafoglio
+    description: |
+      Rivalutazione periodica dei portafogli di fondi e proprietari sul ciclo contrattuale stabilito.
+  BC-4970.60.20:
+    name: Rivalutazione del collaterale per i finanziatori
+    description: |
+      Rivalutazione del collaterale dei finanziatori, inclusi i trigger di covenant e stress test.
+  BC-4970.60.30:
+    name: Reporting a indici e benchmark
+    description: |
+      Trasmissione dei dati di valutazione a NCREIF, MSCI e altri indici di performance.
+  BC-4970.70:
+    name: Quality assurance e audit delle valutazioni
+    description: |
+      Campionamento QA interno, peer review e risposta agli audit di clienti e autorità di vigilanza sulle valutazioni emesse.
+  BC-4970.70.10:
+    name: Campionamento QA interno
+    description: |
+      Campionamento delle valutazioni emesse per la revisione interna della quality assurance.
+  BC-4970.70.20:
+    name: Operazioni di peer review
+    description: |
+      Esecuzione della peer review per valutazioni complesse o di elevato valore.
+  BC-4970.70.30:
+    name: Risposta agli audit di autorità e clienti
+    description: |
+      Risposta alle richieste di audit da parte delle autorità di vigilanza e dei clienti sulle valutazioni emesse.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-refining-operations-management.yaml
+++ b/catalogue/i18n/it/L1-refining-operations-management.yaml
@@ -1,0 +1,141 @@
+# Gestione delle operazioni di raffinazione (it) — translations for L1-refining-operations-management.yaml
+locale: it
+source: L1-refining-operations-management.yaml
+entries:
+  BC-3080:
+    name: Gestione delle operazioni di raffinazione
+    description: |
+      Operazione delle raffinerie di petrolio greggio: distillazione, conversione,
+      trattamento, miscelazione, economia della raffineria, gestione dei catalizzatori
+      e coordinamento dei turnaround.
+  BC-3080.10:
+    name: Operazioni di distillazione del greggio
+    description: |
+      Operazione delle unità di distillazione atmosferica e a vuoto del greggio
+      e transizioni dello schema di raffinazione.
+  BC-3080.10.10:
+    name: Operazioni di distillazione atmosferica
+    description: |
+      Operazione delle colonne di distillazione atmosferica del greggio e dei pre-flash train.
+  BC-3080.10.20:
+    name: Operazioni di distillazione a vuoto
+    description: |
+      Operazione delle colonne di distillazione a vuoto e dei sistemi di testa.
+  BC-3080.10.30:
+    name: Cambio dello schema di raffinazione
+    description: |
+      Gestione operativa dei cambi di qualità del greggio e delle transizioni dello schema.
+  BC-3080.20:
+    name: Operazioni delle unità di conversione
+    description: |
+      Operazione delle unità di cracking catalitico, idrocracking, coking e reforming.
+  BC-3080.20.10:
+    name: Operazioni del fluid catalytic cracking
+    description: |
+      Operazione delle unità FCC e dei rigeneratori.
+  BC-3080.20.20:
+    name: Operazioni di idrocracking
+    description: |
+      Operazione degli idrocracker a stadio singolo e a due stadi.
+  BC-3080.20.30:
+    name: Operazioni di coking
+    description: |
+      Operazione delle unità di delayed coker, fluid coker e flexicoker.
+  BC-3080.20.40:
+    name: Operazioni di reforming
+    description: |
+      Operazione dei reformer catalitici per la produzione di ottano e aromatici.
+  BC-3080.30:
+    name: Operazioni di trattamento e idrodesolforazione
+    description: |
+      Operazione delle unità di idrodesolforazione, recupero dello zolfo e sweetening dei prodotti.
+  BC-3080.30.10:
+    name: Operazioni di idrodesolforazione
+    description: |
+      Operazione degli idrodesolforatori di nafta, distillato e gasolio.
+  BC-3080.30.20:
+    name: Operazioni di recupero dello zolfo e trattamento del tail gas
+    description: |
+      Operazione delle unità di recupero dello zolfo e trattamento del tail gas.
+  BC-3080.30.30:
+    name: Operazioni di sweetening
+    description: |
+      Operazione del sweetening dei prodotti a base caustica e ad adsorbente.
+  BC-3080.40:
+    name: Operazioni di miscelazione dei prodotti
+    description: |
+      Miscelazione in linea e in serbatoio dei prodotti finiti alle specifiche.
+  BC-3080.40.10:
+    name: Miscelazione della benzina
+    description: |
+      Miscelazione multicomponente della benzina alle specifiche di grado.
+  BC-3080.40.20:
+    name: Miscelazione dei distillati
+    description: |
+      Miscelazione di diesel e cherosene inclusa l'incorporazione di biocarburanti.
+  BC-3080.40.30:
+    name: Miscelazione del bunker fuel
+    description: |
+      Miscelazione del bunker fuel marino alle specifiche ISO 8217.
+  BC-3080.40.40:
+    name: Miscelazione di conformità alle specifiche
+    description: |
+      Ottimizzazione in tempo reale delle specifiche e emissione del certificato di qualità.
+  BC-3080.50:
+    name: Pianificazione ed economia della raffineria
+    description: |
+      Selezione del greggio basata su modello di programmazione lineare, ottimizzazione
+      del margine e rendicontazione delle rese della raffineria.
+  BC-3080.50.10:
+    name: Modellazione con programmazione lineare
+    description: |
+      Mantenimento e utilizzo dei modelli LP della raffineria per la pianificazione e l'economia.
+  BC-3080.50.20:
+    name: Economia della selezione del greggio
+    description: |
+      Valutazione economica degli acquisti di greggio candidati e delle opzioni dello schema.
+  BC-3080.50.30:
+    name: Ottimizzazione del margine
+    description: |
+      Ottimizzazione del margine operativo a breve termine e ripianificazione.
+  BC-3080.50.40:
+    name: Rendicontazione delle rese della raffineria
+    description: |
+      Rendicontazione delle rese effettive rispetto al piano e al benchmark.
+  BC-3080.60:
+    name: Gestione dei catalizzatori e dei prodotti chimici della raffineria
+    description: |
+      Gestione del ciclo di vita dei catalizzatori di processo e dell'inventario dei
+      prodotti chimici della raffineria.
+  BC-3080.60.10:
+    name: Gestione del ciclo di vita del catalizzatore
+    description: |
+      Pianificazione del carico del catalizzatore, sorveglianza in servizio e sostituzione.
+  BC-3080.60.20:
+    name: Coordinamento della rigenerazione del catalizzatore
+    description: |
+      Coordinamento delle campagne di rigenerazione in situ e ex situ del catalizzatore.
+  BC-3080.60.30:
+    name: Gestione dell'inventario dei prodotti chimici della raffineria
+    description: |
+      Gestione dell'inventario e del consumo dei prodotti chimici di processo.
+  BC-3080.70:
+    name: Coordinamento del turnaround e della manutenzione principale
+    description: |
+      Coordinamento di ambito, pianificazione ed esecuzione dei principali turnaround
+      della raffineria.
+  BC-3080.70.10:
+    name: Gestione dell'ambito del turnaround
+    description: |
+      Definizione e congelamento dell'ambito del turnaround incluso il processo di verifica.
+  BC-3080.70.20:
+    name: Gestione della pianificazione del turnaround
+    description: |
+      Pianificazione dettagliata del turnaround e controllo dell'avanzamento.
+  BC-3080.70.30:
+    name: Coordinamento della fermata e del riavvio
+    description: |
+      Coordinamento sequenziale della fermata dell'unità, decontaminazione e riavvio.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-refrigerant-lifecycle-management.yaml
+++ b/catalogue/i18n/it/L1-refrigerant-lifecycle-management.yaml
@@ -1,0 +1,199 @@
+# Gestione del ciclo di vita del refrigerante (it) — translations for L1-refrigerant-lifecycle-management.yaml
+locale: it
+source: L1-refrigerant-lifecycle-management.yaml
+entries:
+  BC-2040:
+    name: Gestione del ciclo di vita del refrigerante
+    description: |
+      Ciclo di vita operativo dei refrigeranti nell'intera base installata — approvvigionamento
+      e inventario, contabilità della carica, recupero e rigenerazione, gestione delle perdite,
+      reporting normativo ai sensi del regolamento F-gas / EPA Section 608 / Emendamento di
+      Kigali, certificazione dei tecnici, transizioni di phase-out e smaltimento a fine vita.
+    in_scope:
+      - Approvvigionamento, allocazione e stoccaggio dei refrigeranti
+      - Contabilità della carica per singola risorsa e riconciliazione del bilancio di massa
+      - Recupero sul campo, rigenerazione e controllo qualità del refrigerante riciclato
+      - Rilevamento delle perdite, riparazione e reporting del tasso normativo
+      - Certificazione di gestione dei tecnici e tracciamento delle competenze
+      - Roadmap di transizione e phase-out dei refrigeranti
+      - Distruzione a fine vita e smaltimento certificato
+    out_of_scope:
+      - Approvazioni del refrigerante a livello di prodotto durante la certificazione (BC-2030)
+      - Ciclo e selezione del refrigerante durante la progettazione delle apparecchiature (BC-2000)
+      - Conformità ambientale generale non specifica dei refrigeranti (BC-740)
+
+  BC-2040.10:
+    name: Approvvigionamento e gestione dell'inventario del refrigerante
+    description: |
+      Approvvigionamento, allocazione, stoccaggio e riconciliazione delle scorte di refrigerante
+      nelle operazioni.
+
+  BC-2040.10.10:
+    name: Approvvigionamento del refrigerante
+    description: Approvvigionamento di refrigeranti da fornitori approvati.
+
+  BC-2040.10.20:
+    name: Gestione dell'allocazione delle quote
+    description: Allocazione delle quote normative tra le unità aziendali e i mercati.
+
+  BC-2040.10.30:
+    name: Stoccaggio e gestione del refrigerante
+    description: Stoccaggio e movimentazione delle bombole di refrigerante nel rispetto delle norme di sicurezza e ambientali.
+
+  BC-2040.10.40:
+    name: Riconciliazione dell'inventario del refrigerante
+    description: Riconciliazione periodica dell'inventario del refrigerante tra i siti e le scorte sul campo.
+
+  BC-2040.20:
+    name: Contabilità della carica del refrigerante
+    description: |
+      Contabilità a livello di risorsa della carica di refrigerante, delle reintegrazioni e
+      del bilancio di audit.
+
+  BC-2040.20.10:
+    name: Registrazioni della carica per risorsa
+    description: Registrazioni della carica di refrigerante installata per risorsa apparecchiatura.
+
+  BC-2040.20.20:
+    name: Registrazione delle reintegrazioni e delle ricariche
+    description: Registrazione delle reintegrazioni e delle ricariche rispetto agli eventi di assistenza delle apparecchiature.
+
+  BC-2040.20.30:
+    name: Audit dell'accuratezza della carica
+    description: Audit dell'accuratezza della contabilità della carica nell'intera base installata.
+
+  BC-2040.20.40:
+    name: Riconciliazione del bilancio di massa
+    description: Riconciliazione del bilancio di massa del refrigerante approvvigionato, utilizzato, recuperato e smaltito.
+
+  BC-2040.30:
+    name: Operazioni di recupero e rigenerazione del refrigerante
+    description: |
+      Recupero sul campo e rigenerazione a valle del refrigerante recuperato per il riutilizzo.
+
+  BC-2040.30.10:
+    name: Operazioni di recupero sul campo
+    description: Recupero in situ del refrigerante dalle apparecchiature in assistenza.
+
+  BC-2040.30.20:
+    name: Rigenerazione del refrigerante
+    description: Lavorazione di rigenerazione del refrigerante recuperato alle specifiche del prodotto vergine.
+
+  BC-2040.30.30:
+    name: Verifica della qualità del refrigerante riciclato
+    description: Verifica della qualità del refrigerante riciclato prima del riutilizzo.
+
+  BC-2040.30.40:
+    name: Gestione della banca del refrigerante recuperato
+    description: Gestione delle banche di refrigerante contenenti il prodotto rigenerato per il riutilizzo.
+
+  BC-2040.40:
+    name: Gestione delle perdite di refrigerante
+    description: |
+      Rilevamento, riparazione e reporting delle perdite di refrigerante nell'intera base installata.
+
+  BC-2040.40.10:
+    name: Monitoraggio del rilevamento delle perdite
+    description: Monitoraggio continuo e periodico del rilevamento delle perdite sulle apparecchiature.
+
+  BC-2040.40.20:
+    name: Workflow di riparazione delle perdite
+    description: Workflow per la diagnosi e la riparazione delle perdite identificate.
+
+  BC-2040.40.30:
+    name: Reporting del tasso di perdita
+    description: Reporting dei tassi di perdita rispetto alle soglie normative.
+
+  BC-2040.40.40:
+    name: Analisi dei punti caldi delle perdite
+    description: Analisi dei punti caldi ricorrenti delle perdite per guidare modifiche alle apparecchiature o ai processi.
+
+  BC-2040.50:
+    name: Reporting normativo del refrigerante
+    description: |
+      Reporting normativo sull'utilizzo del refrigerante, le perdite, il recupero e le
+      divulgazioni sulle sostanze.
+
+  BC-2040.50.10:
+    name: Reporting annuale F-gas
+    description: Reporting annuale ai sensi del regolamento F-gas UE.
+
+  BC-2040.50.20:
+    name: Reporting nazionale del refrigerante
+    description: Reporting ai sensi dei programmi nazionali sui refrigeranti (ad es. reporting EPA negli USA).
+
+  BC-2040.50.30:
+    name: Reporting Kigali e Protocollo di Montreal
+    description: Reporting ai sensi degli obblighi dell'Emendamento di Kigali e del Protocollo di Montreal.
+
+  BC-2040.50.40:
+    name: Divulgazione dell'inventario delle sostanze
+    description: Divulgazione dell'inventario delle sostanze a regolatori e stakeholder.
+
+  BC-2040.60:
+    name: Gestione della certificazione del tecnico per il refrigerante
+    description: |
+      Gestione delle certificazioni, delle licenze e delle competenze dei tecnici per la
+      gestione del refrigerante.
+
+  BC-2040.60.10:
+    name: Registrazioni delle certificazioni dei tecnici
+    description: Registrazioni delle certificazioni dei tecnici per la gestione del refrigerante.
+
+  BC-2040.60.20:
+    name: Tracciamento del rinnovo delle certificazioni
+    description: Tracciamento dei prossimi rinnovi delle certificazioni.
+
+  BC-2040.60.30:
+    name: Licenze nazionali per la gestione del refrigerante
+    description: Gestione delle licenze nazionali per la gestione del refrigerante (EPA Section 608, categorie F-gas).
+
+  BC-2040.60.40:
+    name: Verifica delle competenze
+    description: Verifica periodica delle competenze dei tecnici che gestiscono i refrigeranti.
+
+  BC-2040.70:
+    name: Gestione del phase-out e della transizione del refrigerante
+    description: |
+      Gestione strategica dei phase-out dei refrigeranti e delle roadmap di transizione per i clienti.
+
+  BC-2040.70.10:
+    name: Roadmap di sostituzione del refrigerante
+    description: Roadmap per la sostituzione dei refrigeranti in fase di riduzione graduale con alternative a GWP inferiore.
+
+  BC-2040.70.20:
+    name: Pianificazione della conversione in retrofit
+    description: Pianificazione delle conversioni in retrofit a refrigeranti alternativi nella base installata.
+
+  BC-2040.70.30:
+    name: Comunicazioni di transizione ai clienti
+    description: Comunicazioni ai clienti riguardanti le transizioni dei refrigeranti e le tempistiche.
+
+  BC-2040.70.40:
+    name: Gestione del rischio di phase-out
+    description: Gestione dei rischi di approvvigionamento, normativi e reputazionali nelle finestre di phase-out.
+
+  BC-2040.80:
+    name: Smaltimento e fine vita del refrigerante
+    description: |
+      Distruzione a fine vita e smaltimento certificato dei refrigeranti non più idonei al riutilizzo.
+
+  BC-2040.80.10:
+    name: Coordinamento della distruzione
+    description: Coordinamento con gli impianti di distruzione approvati.
+
+  BC-2040.80.20:
+    name: Traccia di audit dello smaltimento certificato
+    description: Mantenimento della traccia di audit che attesta lo smaltimento certificato.
+
+  BC-2040.80.30:
+    name: Recupero delle risorse a fine vita
+    description: Recupero del refrigerante dalle risorse a fine vita prima dello smaltimento.
+
+  BC-2040.80.40:
+    name: Gestione dei fornitori di smaltimento
+    description: Gestione dei fornitori di smaltimento approvati e del programma di audit.
+
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-regulatory-affairs-management.yaml
+++ b/catalogue/i18n/it/L1-regulatory-affairs-management.yaml
@@ -1,0 +1,119 @@
+# Gestione degli affari regolatori (it) — translations for L1-regulatory-affairs-management.yaml
+locale: it
+source: L1-regulatory-affairs-management.yaml
+entries:
+  BC-1530:
+    name: Gestione degli affari regolatori
+    description: |
+      Presentazioni della domanda, approvazioni e interazioni con le autorità regolatorie nel ciclo di vita.
+  BC-1530.10:
+    name: Gestione della strategia regolatoria
+    description: |
+      Strategia regolatoria, valutazione del rischio regolatorio.
+  BC-1530.10.10:
+    name: Strategia regolatoria globale
+    description: |
+      Strategia regolatoria multi-regione e selezione del percorso autorizzativo.
+  BC-1530.10.20:
+    name: Valutazione del rischio regolatorio
+    description: |
+      Valutazione dei rischi regolatori e delle contingenze.
+  BC-1530.10.30:
+    name: Gestione del profilo del prodotto target
+    description: |
+      Definizione e mantenimento del profilo del prodotto target.
+  BC-1530.20:
+    name: Gestione delle presentazioni regolatore
+    description: |
+      Preparazione e presentazione di IND, NDA, MAA, BLA.
+  BC-1530.20.10:
+    name: Pianificazione della presentazione della domanda
+    description: |
+      Pianificazione della presentazione della domanda e programmazione dei contenuti.
+  BC-1530.20.20:
+    name: Compilazione eCTD
+    description: |
+      Compilazione delle presentazioni in formato eCTD.
+  BC-1530.20.30:
+    name: Redazione e revisione della domanda
+    description: |
+      Redazione e revisione dei documenti per la presentazione della domanda regolatoria.
+  BC-1530.20.40:
+    name: Protocollo e tracciamento della domanda
+    description: |
+      Protocollazione e tracciamento della domanda durante la revisione dell'agenzia.
+  BC-1530.30:
+    name: Gestione dell'intelligence regolatoria
+    description: |
+      Intelligence regolatoria, monitoraggio delle linee guida.
+  BC-1530.30.10:
+    name: Monitoraggio delle linee guida regolatorie
+    description: |
+      Monitoraggio dei documenti di linea guida e delle modifiche normative.
+  BC-1530.30.20:
+    name: Intelligence regolatoria competitiva
+    description: |
+      Intelligence sull'attività regolatoria dei concorrenti.
+  BC-1530.30.30:
+    name: Repository della conoscenza regolatoria
+    description: |
+      Manutenzione del repository della conoscenza regolatoria.
+  BC-1530.40:
+    name: Gestione del mantenimento regolatorio nel ciclo di vita
+    description: |
+      Variazioni, rinnovi, modifiche post-approvazione.
+  BC-1530.40.10:
+    name: Presentazione delle variazioni
+    description: |
+      Presentazione delle variazioni di Tipo IA, IB e II.
+  BC-1530.40.20:
+    name: Presentazione dei rinnovi
+    description: |
+      Presentazione dei rinnovi dell'autorizzazione all'immissione in commercio.
+  BC-1530.40.30:
+    name: Gestione delle modifiche post-approvazione
+    description: |
+      Gestione delle modifiche post-approvazione di CMC ed etichettatura.
+  BC-1530.40.40:
+    name: Pianificazione delle presentazioni nel ciclo di vita
+    description: |
+      Pianificazione delle attività di presentazione della domanda nel ciclo di vita per prodotto.
+  BC-1530.50:
+    name: Gestione delle interazioni con le autorità regolatorie
+    description: |
+      Incontri con FDA/EMA/PMDA, consulenza scientifica.
+  BC-1530.50.10:
+    name: Richieste di consulenza scientifica
+    description: |
+      Richieste di consulenza scientifica alle autorità sanitarie.
+  BC-1530.50.20:
+    name: Gestione degli incontri con le autorità sanitarie
+    description: |
+      Preparazione e conduzione degli incontri con le agenzie regolatorie.
+  BC-1530.50.30:
+    name: Risposta alle richieste delle autorità sanitarie
+    description: |
+      Risposta alle richieste di informazioni delle autorità sanitarie.
+  BC-1530.60:
+    name: Gestione dell'etichettatura
+    description: |
+      SmPC (scheda tecnica)/USPI, foglio illustrativo, modifiche dell'etichettatura.
+  BC-1530.60.10:
+    name: Gestione dell'etichettatura core
+    description: |
+      Gestione della scheda tecnica core e dell'etichettatura core.
+  BC-1530.60.20:
+    name: Adattamento locale dell'etichettatura
+    description: |
+      Adattamento locale e traduzione di SmPC (scheda tecnica)/USPI.
+  BC-1530.60.30:
+    name: Implementazione delle modifiche all'etichettatura
+    description: |
+      Implementazione delle modifiche all'etichettatura nei diversi mercati.
+  BC-1530.60.40:
+    name: Gestione dell'artwork
+    description: |
+      Gestione e proofreading dell'artwork del confezionamento.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-reinsurance-management.yaml
+++ b/catalogue/i18n/it/L1-reinsurance-management.yaml
@@ -1,0 +1,123 @@
+# Gestione della riassicurazione (it) — translations for L1-reinsurance-management.yaml
+locale: it
+source: L1-reinsurance-management.yaml
+entries:
+  BC-2170:
+    name: Gestione della riassicurazione
+    description: |
+      Riassicurazione ceded e assumed: strutturazione del trattato, collocamenti facoltativi, bordereau, recuperi sinistri, contabilità e gestione dell'esposizione verso le controparti riassicurative.
+  BC-2170.10:
+    name: Strutturazione del programma di riassicurazione ceduta
+    description: |
+      Analisi del fabbisogno riassicurativo, strutturazione del programma e coordinamento con i broker di riassicurazione.
+  BC-2170.10.10:
+    name: Analisi del fabbisogno riassicurativo
+    description: |
+      Analisi del fabbisogno riassicurativo in base al portafoglio, alla propensione al rischio assicurativo e ai vincoli di capitale.
+  BC-2170.10.20:
+    name: Strategia in trattato e facoltativa
+    description: |
+      Strategia sulle cessioni in trattato vs facoltative e sulle strutture proporzionali vs non proporzionali.
+  BC-2170.10.30:
+    name: Strutturazione del programma
+    description: |
+      Strutturazione dei programmi di riassicurazione, degli strati e delle ritenzioni.
+  BC-2170.10.40:
+    name: Coordinamento con i broker di riassicurazione
+    description: |
+      Coordinamento con i broker di riassicurazione per il collocamento e il rinnovo.
+  BC-2170.20:
+    name: Amministrazione della riassicurazione in trattato
+    description: |
+      Onboarding del trattato, calcolo del premio ceduto, produzione del bordereau e recupero sinistri in trattato.
+  BC-2170.20.10:
+    name: Onboarding e rinnovo del trattato
+    description: |
+      Onboarding e rinnovo dei trattati di riassicurazione e collocamento dello slip.
+  BC-2170.20.20:
+    name: Calcolo del premio di trattato e cessione
+    description: |
+      Calcolo dei premi di trattato e cessione ai riassicuratori partecipanti.
+  BC-2170.20.30:
+    name: Produzione del bordereau di trattato
+    description: |
+      Produzione del bordereau di premio e sinistro del trattato in conformità alla prassi di mercato.
+  BC-2170.20.40:
+    name: Recupero sinistri in trattato
+    description: |
+      Recupero dei pagamenti dei sinistri di trattato dai riassicuratori.
+  BC-2170.30:
+    name: Amministrazione della riassicurazione facoltativa
+    description: |
+      Presentazione facoltativa, monitoraggio del collocamento e regolamento del premio e dei sinistri.
+  BC-2170.30.10:
+    name: Presentazione del rischio facoltativo
+    description: |
+      Presentazione di singoli rischi per il collocamento facoltativo.
+  BC-2170.30.20:
+    name: Monitoraggio del collocamento facoltativo
+    description: |
+      Monitoraggio delle firme del collocamento facoltativo e delle quote tra i riassicuratori.
+  BC-2170.30.30:
+    name: Regolamento del premio e dei sinistri facoltativi
+    description: |
+      Regolamento del premio facoltativo e dei recuperi sinistri.
+  BC-2170.40:
+    name: Gestione della riassicurazione assunta
+    description: |
+      Sottoscrizione in entrata, contabilizzazione del premio, liquidazione dei sinistri e coordinamento della retrocessione.
+  BC-2170.40.10:
+    name: Sottoscrizione delle proposte in entrata
+    description: |
+      Sottoscrizione delle proposte di riassicurazione in entrata e accettazione del rischio.
+  BC-2170.40.20:
+    name: Contabilizzazione del premio in entrata
+    description: |
+      Contabilizzazione del premio di riassicurazione in entrata e delle rettifiche.
+  BC-2170.40.30:
+    name: Liquidazione dei sinistri in entrata
+    description: |
+      Liquidazione dei sinistri di riassicurazione in entrata e dei recuperi.
+  BC-2170.40.40:
+    name: Coordinamento della retrocessione
+    description: |
+      Coordinamento della retrocessione verso i riassicuratori di secondo livello.
+  BC-2170.50:
+    name: Contabilità e regolamento della riassicurazione
+    description: |
+      Contabilità di cessione, monitoraggio dei recuperabili, riconciliazione degli estratti conto e garanzie collaterali della controparte.
+  BC-2170.50.10:
+    name: Contabilità della cessione e del premio
+    description: |
+      Contabilizzazione del premio ceduto, delle provvigioni e delle rettifiche.
+  BC-2170.50.20:
+    name: Monitoraggio dei recuperabili di riassicurazione
+    description: |
+      Monitoraggio dei recuperabili di riassicurazione su sinistri pagati e in sospeso.
+  BC-2170.50.30:
+    name: Riconciliazione degli estratti conto del riassicuratore
+    description: |
+      Riconciliazione degli estratti conto del riassicuratore e risoluzione delle controversie.
+  BC-2170.50.40:
+    name: Gestione delle garanzie collaterali della controparte
+    description: |
+      Gestione delle lettere di credito, dei fondi fiduciari e delle garanzie collaterali dei riassicuratori.
+  BC-2170.60:
+    name: Gestione del rischio di credito della controparte riassicurativa
+    description: |
+      Valutazione del credito del riassicuratore, monitoraggio dei limiti di controparte e mitigazione del default.
+  BC-2170.60.10:
+    name: Valutazione del credito del riassicuratore
+    description: |
+      Valutazione del credito e della solidità finanziaria delle controparti riassicurative.
+  BC-2170.60.20:
+    name: Monitoraggio della concentrazione e dei limiti di controparte
+    description: |
+      Monitoraggio dei limiti di concentrazione e di esposizione verso le controparti.
+  BC-2170.60.30:
+    name: Mitigazione del default del riassicuratore
+    description: |
+      Azioni di mitigazione in caso di downgrade o default del riassicuratore.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-research-development-management.yaml
+++ b/catalogue/i18n/it/L1-research-development-management.yaml
@@ -1,0 +1,107 @@
+# Gestione della ricerca e sviluppo (it) — translations for L1-research-development-management.yaml
+locale: it
+source: L1-research-development-management.yaml
+entries:
+  BC-810:
+    name: Gestione della ricerca e sviluppo
+    description: |
+      Ricerca di base, sviluppo applicato e sperimentazione.
+  BC-810.10:
+    name: Gestione della ricerca
+    description: |
+      Ricerca fondamentale ed esplorativa.
+  BC-810.10.10:
+    name: Definizione del programma di ricerca
+    description: |
+      Definizione dei programmi e dei filoni di ricerca.
+  BC-810.10.20:
+    name: Revisione della letteratura e dei brevetti
+    description: |
+      Revisione sistematica della letteratura scientifica e del panorama brevettuale.
+  BC-810.10.30:
+    name: Esecuzione dei progetti di ricerca
+    description: |
+      Esecuzione dei progetti di ricerca con milestone e revisioni intermedie.
+  BC-810.10.40:
+    name: Pubblicazione dei risultati della ricerca
+    description: |
+      Pubblicazione, partecipazione a convegni e disseminazione dei risultati della ricerca.
+  BC-810.20:
+    name: Gestione dello sviluppo applicato
+    description: |
+      Sviluppo applicato e sviluppo tecnologico.
+  BC-810.20.10:
+    name: Realizzazione di progetti di sviluppo applicato
+    description: |
+      Realizzazione di progetti di sviluppo applicato fino ai livelli TRL previsti.
+  BC-810.20.20:
+    name: Maturazione tecnologica
+    description: |
+      Avanzamento della maturità tecnologica dal concept alla messa in produzione.
+  BC-810.20.30:
+    name: Strumenti e metodi di sviluppo
+    description: |
+      Strumenti di sviluppo standardizzati, metodi e toolchain.
+  BC-810.30:
+    name: Gestione della sperimentazione e della prototipazione
+    description: |
+      Attività di laboratorio, prototipi e prove di concetto.
+  BC-810.30.10:
+    name: Operatività dei laboratori
+    description: |
+      Gestione operativa dei laboratori di ricerca e sviluppo.
+  BC-810.30.20:
+    name: Costruzione del prototipo
+    description: |
+      Costruzione e assemblaggio di prototipi fisici e digitali.
+  BC-810.30.30:
+    name: Esecuzione della prova di concetto
+    description: |
+      Esecuzione di prove di concetto e pilot basati su ipotesi.
+  BC-810.30.40:
+    name: Test e validazione
+    description: |
+      Piani di test, raccolta dei dati e validazione rispetto ai criteri di accettazione.
+  BC-810.40:
+    name: Gestione del portafoglio di ricerca e sviluppo
+    description: |
+      Portafoglio dei progetti di ricerca e sviluppo, finanziamenti e prioritizzazione.
+  BC-810.40.10:
+    name: Selezione dei progetti di ricerca e sviluppo
+    description: |
+      Selezione e prioritizzazione dei progetti di ricerca e sviluppo.
+  BC-810.40.20:
+    name: Allocazione delle risorse di ricerca e sviluppo
+    description: |
+      Allocazione di ricercatori, laboratori e capitali tra i progetti.
+  BC-810.40.30:
+    name: Monitoraggio delle performance di ricerca e sviluppo
+    description: |
+      Monitoraggio delle performance del portafoglio di ricerca e sviluppo e decisioni stage gate.
+  BC-810.40.40:
+    name: Gestione dei crediti fiscali e dei contributi per la ricerca e sviluppo
+    description: |
+      Identificazione e documentazione dei crediti fiscali e dei contributi per la ricerca e sviluppo.
+  BC-810.50:
+    name: Gestione della roadmap tecnologica
+    description: |
+      Technology scouting, roadmap tecnologiche e strategia tecnologica.
+  BC-810.50.10:
+    name: Technology scouting
+    description: |
+      Scouting continuo di tecnologie emergenti e dirompenti.
+  BC-810.50.20:
+    name: Sviluppo della roadmap tecnologica
+    description: |
+      Roadmap pluriennali che collegano le tecnologie a prodotti e mercati.
+  BC-810.50.30:
+    name: Definizione della strategia tecnologica
+    description: |
+      Strategia tecnologica e decisioni sulle piattaforme.
+  BC-810.50.40:
+    name: Decisioni make-or-buy tecnologiche
+    description: |
+      Decisioni di sviluppo interno, partnership o acquisizione per la tecnologia.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-research-scholarship-management.yaml
+++ b/catalogue/i18n/it/L1-research-scholarship-management.yaml
@@ -1,0 +1,151 @@
+# Gestione della ricerca e delle borse di studio (it) — translations for L1-research-scholarship-management.yaml
+locale: it
+source: L1-research-scholarship-management.yaml
+entries:
+  BC-4780:
+    name: Gestione della ricerca e delle borse di studio
+    description: |
+      Gestione della missione di ricerca nell'istruzione superiore, che comprende la strategia
+      del portfolio, il ciclo di vita dei finanziamenti, la supervisione dell'etica e dell'integrità,
+      la produzione scientifica, la collaborazione nella ricerca e la valutazione dell'impatto.
+  BC-4780.10:
+    name: Portfolio e strategia della ricerca
+    description: |
+      Definizione strategica del portfolio di ricerca dell'istituzione attraverso temi,
+      centri e investimenti nelle capacità di ricerca.
+    in_scope:
+      - Strategia dei temi e dei centri di ricerca
+      - Pianificazione degli investimenti nelle capacità di ricerca
+      - Rendicontazione delle prestazioni della ricerca
+    out_of_scope:
+      - Gestione generica del portfolio di progetti (trattata in Gestione del portfolio di progetti)
+  BC-4780.10.10:
+    name: Strategia dei temi e dei centri di ricerca
+    description: |
+      Strategia per i temi, i centri e gli istituti di ricerca.
+  BC-4780.10.20:
+    name: Pianificazione degli investimenti nelle capacità di ricerca
+    description: |
+      Pianificazione degli investimenti nelle capacità di ricerca, incluse infrastrutture e personale.
+  BC-4780.10.30:
+    name: Rendicontazione delle prestazioni della ricerca
+    description: |
+      Rendicontazione interna ed esterna delle prestazioni della ricerca.
+  BC-4780.20:
+    name: Gestione dei finanziamenti per la ricerca
+    description: |
+      Gestione end-to-end dei finanziamenti e dei contratti di ricerca,
+      dall'identificazione delle opportunità all'amministrazione post-assegnazione.
+    in_scope:
+      - Identificazione delle opportunità di finanziamento
+      - Sviluppo delle proposte pre-assegnazione
+      - Amministrazione dei finanziamenti post-assegnazione
+    out_of_scope:
+      - Gestione finanziaria generale (trattata in Gestione finanziaria)
+  BC-4780.20.10:
+    name: Identificazione delle opportunità di finanziamento
+    description: |
+      Identificazione di opportunità di finanziamento e borse di ricerca per i ricercatori.
+  BC-4780.20.20:
+    name: Sviluppo delle proposte pre-assegnazione
+    description: |
+      Sviluppo delle proposte di ricerca, dei costi e dei pacchetti di presentazione.
+  BC-4780.20.30:
+    name: Amministrazione dei finanziamenti post-assegnazione
+    description: |
+      Amministrazione post-assegnazione dei finanziamenti assegnati, incluse la rendicontazione e la conformità.
+  BC-4780.30:
+    name: Supervisione dell'etica e dell'integrità della ricerca
+    description: |
+      Supervisione indipendente dell'etica e dell'integrità della ricerca, inclusa
+      la revisione della ricerca su esseri umani e animali e l'indagine su violazioni dell'integrità.
+    in_scope:
+      - Revisione della ricerca su soggetti umani (IRB/REC)
+      - Supervisione della ricerca sugli animali (IACUC/AWERB)
+      - Indagine su violazioni dell'integrità della ricerca
+    out_of_scope:
+      - Casi di violazione dell'integrità accademica nelle valutazioni (trattati in Gestione della valutazione e degli esami)
+  BC-4780.30.10:
+    name: Revisione della ricerca su soggetti umani
+    description: |
+      Revisione indipendente della ricerca che coinvolge soggetti umani.
+  BC-4780.30.20:
+    name: Supervisione della ricerca sugli animali
+    description: |
+      Supervisione della ricerca che coinvolge soggetti animali.
+  BC-4780.30.30:
+    name: Indagine su violazioni dell'integrità della ricerca
+    description: |
+      Indagine sulle accuse di violazione dell'integrità della ricerca.
+  BC-4780.40:
+    name: Gestione della produzione scientifica e delle pubblicazioni
+    description: |
+      Monitoraggio e gestione della produzione scientifica, incluse le pubblicazioni,
+      l'accesso aperto e gli identificativi persistenti.
+    in_scope:
+      - Monitoraggio delle pubblicazioni
+      - Gestione dell'accesso aperto e dei repository
+      - Gestione degli identificativi persistenti (ORCID, DOI)
+    out_of_scope:
+      - Commercializzazione della proprietà intellettuale (trattata in Gestione della proprietà intellettuale)
+  BC-4780.40.10:
+    name: Monitoraggio delle pubblicazioni
+    description: |
+      Monitoraggio delle pubblicazioni e dei risultati dei ricercatori.
+  BC-4780.40.20:
+    name: Gestione dell'accesso aperto e dei repository
+    description: |
+      Gestione della pubblicazione in accesso aperto e dei repository istituzionali.
+  BC-4780.40.30:
+    name: Gestione degli identificativi persistenti
+    description: |
+      Gestione degli identificativi persistenti dei ricercatori e dei risultati.
+  BC-4780.50:
+    name: Gestione della collaborazione e dei partenariati di ricerca
+    description: |
+      Costituzione e gestione dei partenariati di ricerca tra accademia,
+      industria e collaboratori internazionali.
+    in_scope:
+      - Accordi di ricerca inter-istituzionali
+      - Partnership di ricerca con l'industria
+      - Collaborazione internazionale nella ricerca
+    out_of_scope:
+      - Rapporti commerciali con i fornitori (trattati in Gestione dei fornitori)
+  BC-4780.50.10:
+    name: Gestione degli accordi di ricerca inter-istituzionali
+    description: |
+      Gestione degli accordi di ricerca con istituti partner.
+  BC-4780.50.20:
+    name: Gestione delle partnership di ricerca con l'industria
+    description: |
+      Gestione delle partnership di ricerca con l'industria e della ricerca sponsorizzata.
+  BC-4780.50.30:
+    name: Collaborazione internazionale nella ricerca
+    description: |
+      Costituzione e gestione delle collaborazioni internazionali nella ricerca.
+  BC-4780.60:
+    name: Impatto della ricerca e valutazione
+    description: |
+      Valutazione dell'impatto della ricerca attraverso casi studio, bibliometria e
+      partecipazione agli esercizi nazionali di valutazione della ricerca.
+    in_scope:
+      - Casi studio sull'impatto della ricerca
+      - Analisi bibliometrica e altmetrica
+      - Presentazione alle esercitazioni nazionali di valutazione della ricerca (es. REF)
+    out_of_scope:
+      - Revisioni di accreditamento accademico (trattate in Gestione della qualità accademica e dell'accreditamento)
+  BC-4780.60.10:
+    name: Casi studio sull'impatto della ricerca
+    description: |
+      Sviluppo di casi studio sull'impatto della ricerca.
+  BC-4780.60.20:
+    name: Analisi bibliometrica e altmetrica
+    description: |
+      Analisi bibliometrica e altmetrica della produzione e della diffusione della ricerca.
+  BC-4780.60.30:
+    name: Presentazione alle esercitazioni nazionali di valutazione della ricerca
+    description: |
+      Presentazione alle esercitazioni nazionali di valutazione della ricerca.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-reservation-booking-management.yaml
+++ b/catalogue/i18n/it/L1-reservation-booking-management.yaml
@@ -1,0 +1,213 @@
+# Gestione delle prenotazioni (it) — translations for L1-reservation-booking-management.yaml
+locale: it
+source: L1-reservation-booking-management.yaml
+entries:
+  BC-4020:
+    name: Gestione delle prenotazioni
+    description: |
+      Ciclo di vita della prenotazione, del PNR (Passenger Name Record) e del conto
+      alberghiero — acquisizione, modifica, cancellazione, blocchi di gruppo, conferme,
+      pagamenti e ri-prenotazione per disruption — indipendentemente dal canale
+      che ha originato la prenotazione.
+    in_scope:
+      - Acquisizione di prenotazioni per itinerari singoli, multi-passeggero e multi-componente
+      - Modifiche, cancellazioni e idoneità al rimborso delle prenotazioni
+      - Blocchi di gruppo, liste camere, cut-off e pickup
+      - Emissione di conferme, voucher e biglietti elettronici
+      - Pagamento a livello di prenotazione e regolamento BSP / ARC
+      - Risistemazione per cambio orario e IROPS
+    out_of_scope:
+      - Gestione dei canali e della parità (BC-4010)
+      - Motori di prezzo e decisioni di yield (BC-4030)
+      - Decisioni operative di disruption su aeromobili e equipaggi (BC-4080.60)
+  BC-4020.10:
+    name: Acquisizione della prenotazione
+    description: |
+      Acquisizione di prenotazioni per itinerari semplici e complessi
+      da qualsiasi canale o agente di origine.
+  BC-4020.10.10:
+    name: Acquisizione della prenotazione per itinerario singolo
+    description: |
+      Acquisizione di prenotazioni per itinerario singolo, come un soggiorno
+      in una struttura o un volo singolo.
+  BC-4020.10.20:
+    name: Acquisizione della prenotazione multi-passeggero
+    description: |
+      Acquisizione di prenotazioni multi-passeggero o multi-ospite che condividono
+      segmenti comuni dell'itinerario.
+  BC-4020.10.30:
+    name: Acquisizione della prenotazione multi-componente
+    description: |
+      Acquisizione di prenotazioni multi-componente che combinano voli,
+      hotel, ancillari e servizi a terra.
+  BC-4020.10.40:
+    name: Acquisizione della prenotazione tramite agente di viaggio
+    description: |
+      Acquisizione delle prenotazioni effettuate da agenti di viaggio retail
+      e corporate per conto dei viaggiatori.
+  BC-4020.20:
+    name: Modifica e cancellazione della prenotazione
+    description: |
+      Modifica volontaria e cancellazione delle prenotazioni, incluse
+      le penali di modifica, l'idoneità al rimborso e le operazioni di re-emissione.
+  BC-4020.20.10:
+    name: Gestione delle modifiche alla prenotazione
+    description: |
+      Gestione delle modifiche volontarie alla prenotazione relative a date,
+      prodotti e dati del viaggiatore.
+  BC-4020.20.20:
+    name: Gestione della cancellazione della prenotazione
+    description: |
+      Gestione delle cancellazioni volontarie e del rilascio dell'inventario
+      nel pool.
+  BC-4020.20.30:
+    name: Determinazione dell'idoneità al rimborso e calcolo del rimborso
+    description: |
+      Determinazione dell'idoneità al rimborso e calcolo degli importi rimborsabili,
+      incluse le penali.
+  BC-4020.20.40:
+    name: Operazioni di re-emissione volontaria
+    description: |
+      Operazioni di re-emissione volontaria, incluse la riscossione della differenza
+      tariffaria e la re-emissione del documento.
+  BC-4020.30:
+    name: Gestione del blocco di gruppo
+    description: |
+      Gestione dei blocchi di gruppo rispetto all'inventario contrattualizzato —
+      creazione del blocco, liste camere, cut-off e tracciamento del pickup.
+    in_scope:
+      - Ciclo di vita del blocco di gruppo dal contratto al wash e al pickup finale
+      - Acquisizione e aggiornamento della lista camere
+    out_of_scope:
+      - Contrattazione delle vendite di gruppo (BC-4110.10)
+      - Esecuzione del banquet event order (BC-4110.30)
+  BC-4020.30.10:
+    name: Creazione del blocco di gruppo
+    description: |
+      Creazione di blocchi di gruppo che riflettono l'inventario contrattualizzato
+      e gli impegni tariffari.
+  BC-4020.30.20:
+    name: Gestione della lista camere
+    description: |
+      Gestione delle liste camere che associano i singoli viaggiatori
+      all'inventario del blocco.
+  BC-4020.30.30:
+    name: Gestione del cut-off di gruppo
+    description: |
+      Gestione delle date di cut-off di gruppo e del rilascio dell'inventario
+      del blocco non utilizzato in vendita libera.
+  BC-4020.30.40:
+    name: Tracciamento del pickup di gruppo
+    description: |
+      Tracciamento del pickup di gruppo rispetto al contratto per il riconoscimento
+      dei ricavi e le previsioni.
+  BC-4020.40:
+    name: Conferma e documentazione della prenotazione
+    description: |
+      Emissione di conferme di prenotazione, voucher, biglietti elettronici
+      e documenti di itinerario per viaggiatori e agenti.
+  BC-4020.40.10:
+    name: Generazione della conferma di prenotazione
+    description: |
+      Generazione e invio delle conferme di prenotazione
+      attraverso i canali di notifica.
+  BC-4020.40.20:
+    name: Emissione di voucher e documenti di servizio
+    description: |
+      Emissione di voucher e documenti di servizio per componenti
+      di hotel, tour e attività.
+  BC-4020.40.30:
+    name: Emissione e re-emissione del biglietto elettronico
+    description: |
+      Emissione e re-emissione dei biglietti elettronici aerei,
+      inclusi gli aggiornamenti dello stato del coupon.
+  BC-4020.40.40:
+    name: Distribuzione dell'itinerario di prenotazione
+    description: |
+      Distribuzione dei documenti di itinerario a viaggiatori, agenti di viaggio
+      e sistemi integrati di gestione dei viaggiatori.
+  BC-4020.50:
+    name: Gestione dei blocchi provvisori e della lista d'attesa
+    description: |
+      Gestione dei blocchi provvisori, delle liste d'attesa e delle conversioni
+      quando la disponibilità è limitata o i termini richiedono un tempo di pagamento.
+  BC-4020.50.10:
+    name: Gestione del blocco provvisorio
+    description: |
+      Gestione dei blocchi provvisori con finestre di tempo di pagamento controllate.
+  BC-4020.50.20:
+    name: Acquisizione e prioritizzazione della lista d'attesa
+    description: |
+      Acquisizione delle richieste di lista d'attesa e definizione delle regole di priorità
+      per quando l'inventario si rende disponibile.
+  BC-4020.50.30:
+    name: Operazioni di conversione della lista d'attesa
+    description: |
+      Operazioni per convertire le richieste di lista d'attesa in prenotazioni confermate
+      al liberarsi dell'inventario.
+  BC-4020.50.40:
+    name: Gestione della scadenza del blocco provvisorio
+    description: |
+      Gestione delle scadenze dei blocchi provvisori e rilascio automatico
+      dell'inventario bloccato.
+  BC-4020.60:
+    name: Pagamento e regolamento della prenotazione
+    description: |
+      Pagamento a livello di prenotazione, caparra, acquisizione degli addebiti
+      e regolamento con i partner, inclusi BSP e ARC.
+  BC-4020.60.10:
+    name: Caparra e pre-autorizzazione della prenotazione
+    description: |
+      Acquisizione delle caparre di prenotazione e delle pre-autorizzazioni
+      della carta rispetto alle politiche di deposito e garanzia.
+  BC-4020.60.20:
+    name: Acquisizione degli addebiti della prenotazione
+    description: |
+      Acquisizione degli addebiti rispetto agli strumenti di pagamento
+      a livello di prenotazione nei momenti di eleggibilità.
+  BC-4020.60.30:
+    name: Operazioni di regolamento BSP e ARC
+    description: |
+      Operazioni per il regolamento delle prenotazioni emesse dagli agenti
+      tramite BSP, ARC e piani di regolamento equivalenti.
+  BC-4020.60.40:
+    name: Calcolo e pagamento delle commissioni
+    description: |
+      Calcolo e pagamento delle commissioni agli agenti di viaggio
+      e ai partner di distribuzione.
+  BC-4020.70:
+    name: Gestione della disruption e del re-booking della prenotazione
+    description: |
+      Risistemazione delle prenotazioni interessate da cambi di orario,
+      cancellazioni e disruption di massa, incluse le comunicazioni
+      e l'idoneità al risarcimento.
+    in_scope:
+      - Risistemazione per cambio orario
+      - Re-booking per disruption di massa (IROPS, maltempo, forza maggiore)
+      - Idoneità al risarcimento secondo le normative del vettore e del consumatore
+    out_of_scope:
+      - Decisioni operative su aeromobili, equipaggi e dispacciamento (BC-4080.60)
+      - Recupero dell'itinerario lato tour (BC-4100.60)
+  BC-4020.70.10:
+    name: Risistemazione per cambio orario
+    description: |
+      Risistemazione delle prenotazioni interessate da cambi di orario pubblicati,
+      incluse le opzioni offerte ai viaggiatori.
+  BC-4020.70.20:
+    name: Risistemazione per disruption di massa
+    description: |
+      Risistemazione di un gran numero di prenotazioni durante eventi
+      di maltempo, IROPS o forza maggiore.
+  BC-4020.70.30:
+    name: Determinazione dell'idoneità al risarcimento
+    description: |
+      Determinazione dell'idoneità al risarcimento secondo la politica del vettore
+      e le norme applicabili sui diritti dei passeggeri.
+  BC-4020.70.40:
+    name: Comunicazioni di risistemazione
+    description: |
+      Comunicazioni in uscita verso i viaggiatori e gli agenti interessati
+      durante gli eventi di risistemazione.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-retail-loss-prevention-management.yaml
+++ b/catalogue/i18n/it/L1-retail-loss-prevention-management.yaml
@@ -1,0 +1,116 @@
+# Gestione della prevenzione delle perdite nel retail (it) — translations for L1-retail-loss-prevention-management.yaml
+locale: it
+source: L1-retail-loss-prevention-management.yaml
+entries:
+  BC-2340:
+    name: Gestione della prevenzione delle perdite nel retail
+    description: |
+      Prevenzione, rilevamento, indagine e riduzione del calo delle scorte e delle frodi
+      in tutta la rete retail — dal taccheggio e dalla criminalità organizzata al furto
+      interno e agli abusi al POS.
+  BC-2340.10:
+    name: Gestione dell'analisi dello shrinkage
+    description: |
+      Misurazione, analisi delle cause profonde e reporting del calo delle scorte
+      attraverso punti vendita, canali e categorie.
+    in_scope:
+      - Misurazione delle perdite di scorte rispetto all'inventario contabile
+      - Reporting dello shrinkage per punto vendita, categoria e causa
+      - Analisi delle cause profonde delle perdite non identificate
+  BC-2340.10.10:
+    name: Misurazione dello shrinkage
+    description: |
+      Misurazione dello shrinkage rispetto all'inventario contabile e alle giacenze
+      fisiche.
+  BC-2340.10.20:
+    name: Analisi delle cause profonde dello shrinkage
+    description: |
+      Analisi delle cause profonde dello shrinkage tra perdite note e non identificate.
+  BC-2340.10.30:
+    name: Reporting e obiettivi di riduzione dello shrinkage
+    description: |
+      Reporting dello shrinkage e definizione degli obiettivi di riduzione per punto
+      vendita e categoria.
+  BC-2340.20:
+    name: Gestione delle indagini sul furto interno
+    description: |
+      Rilevamento, indagine e risoluzione dei casi di disonestà da parte dei dipendenti,
+      incluse le azioni disciplinari e di recupero.
+  BC-2340.20.10:
+    name: Rilevamento della disonestà dei dipendenti
+    description: |
+      Rilevamento della disonestà dei dipendenti tramite segnalazioni, analytics e
+      audit.
+  BC-2340.20.20:
+    name: Gestione dei casi di indagine interna
+    description: |
+      Gestione dei fascicoli per le indagini interne, inclusa la gestione delle prove.
+  BC-2340.20.30:
+    name: Coordinamento delle azioni di recupero e disciplinari
+    description: |
+      Coordinamento delle azioni di recupero, disciplinari e di follow-through con le
+      risorse umane.
+  BC-2340.30:
+    name: Gestione del furto esterno e della criminalità organizzata
+    description: |
+      Prevenzione e indagine del taccheggio e della criminalità organizzata nel retail,
+      inclusa la collaborazione con le forze dell'ordine e le associazioni di settore.
+  BC-2340.30.10:
+    name: Prevenzione del taccheggio
+    description: |
+      Prevenzione del taccheggio tramite deterrenza, layout del punto vendita e
+      intervento.
+  BC-2340.30.20:
+    name: Indagine sulla criminalità organizzata nel retail
+    description: |
+      Indagine su reti e schemi di criminalità organizzata nel retail.
+  BC-2340.30.30:
+    name: Collaborazione con le forze dell'ordine
+    description: |
+      Collaborazione con le forze dell'ordine e i forum di settore sui casi di criminalità
+      retail.
+  BC-2340.40:
+    name: Gestione della prevenzione delle frodi al POS
+    description: |
+      Rilevamento e prevenzione delle frodi al punto vendita, inclusi frodi sui resi,
+      sweethearting e reporting basato sulle eccezioni.
+    in_scope:
+      - Rilevamento delle frodi su resi e cambi
+      - Rilevamento di sweethearting e abuso degli sconti
+      - Reporting delle eccezioni POS
+  BC-2340.40.10:
+    name: Rilevamento delle frodi su resi e cambi
+    description: |
+      Rilevamento di schemi fraudolenti basati su resi e cambi.
+  BC-2340.40.20:
+    name: Rilevamento di sweethearting e abuso degli sconti
+    description: |
+      Rilevamento di sweethearting e applicazione non autorizzata di sconti.
+  BC-2340.40.30:
+    name: Reporting delle eccezioni POS
+    description: |
+      Reporting delle eccezioni sulle transazioni POS per evidenziare anomalie.
+  BC-2340.50:
+    name: Gestione della sicurezza fisica e della sorveglianza
+    description: |
+      Sicurezza fisica a livello di punto vendita, inclusi CCTV, EAS, controlli degli
+      accessi e servizi di guardiania.
+  BC-2340.50.10:
+    name: Operazioni CCTV in negozio
+    description: |
+      Operazione, monitoraggio e gestione delle prove del sistema CCTV in negozio.
+  BC-2340.50.20:
+    name: Operazioni di sorveglianza elettronica degli articoli (EAS)
+    description: |
+      Operazione dei varchi EAS e dell'etichettatura, inclusa la risposta agli allarmi.
+  BC-2340.50.30:
+    name: Controllo degli accessi al punto vendita
+    description: |
+      Controllo fisico degli accessi ai magazzini, agli uffici cassa e al retronegozio.
+  BC-2340.50.40:
+    name: Gestione dei servizi di guardiania
+    description: |
+      Impiego e gestione dei servizi di guardiania in negozio e in appalto.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-retail-site-network-planning-management.yaml
+++ b/catalogue/i18n/it/L1-retail-site-network-planning-management.yaml
@@ -1,0 +1,123 @@
+# Gestione della pianificazione della rete di punti vendita (it) — translations for L1-retail-site-network-planning-management.yaml
+locale: it
+source: L1-retail-site-network-planning-management.yaml
+entries:
+  BC-2350:
+    name: Gestione della pianificazione della rete di punti vendita
+    description: |
+      Selezione, dimensionamento e ciclo di vita della rete retail fisica — analisi del
+      bacino d'utenza, scelta del formato, identificazione delle opportunità di sviluppo
+      e decisioni sul ciclo di vita dei singoli punti vendita.
+  BC-2350.10:
+    name: Analisi dell'area di influenza e del bacino d'utenza
+    description: |
+      Definizione del bacino d'utenza, microanalisi del traffico pedonale e
+      demografica, e valutazione della densità competitiva per siti prospettici ed
+      esistenti.
+  BC-2350.10.10:
+    name: Definizione del bacino d'utenza
+    description: |
+      Definizione delle aree di bacino d'utenza mediante tempo di percorrenza, densità
+      e barriere geografiche.
+  BC-2350.10.20:
+    name: Microanalisi demografica
+    description: |
+      Analisi demografica e degli stili di vita a livello micro dei bacini d'utenza.
+  BC-2350.10.30:
+    name: Analisi del traffico pedonale e della mobilità
+    description: |
+      Analisi dei flussi pedonali, dei dati di mobilità e del traffico di passaggio.
+  BC-2350.10.40:
+    name: Analisi della densità competitiva
+    description: |
+      Analisi della densità dei concorrenti e della quota dell'area di influenza.
+  BC-2350.20:
+    name: Gestione della selezione del formato di punto vendita
+    description: |
+      Selezione del formato di punto vendita più appropriato — ipermercato, supermercato,
+      convenience, specializzato, dark store — per un dato bacino d'utenza e strategia.
+    in_scope:
+      - Scelta del formato per bacino d'utenza e missione d'acquisto
+      - Mix di formati nel portafoglio della rete
+      - Dimensionamento e superficie per formato
+    out_of_scope:
+      - Progettazione dettagliata degli interni del punto vendita (BC-2310.60)
+  BC-2350.20.10:
+    name: Scelta del formato per bacino d'utenza
+    description: |
+      Selezione del formato di punto vendita per bacino d'utenza in base alla missione
+      d'acquisto.
+  BC-2350.20.20:
+    name: Dimensionamento e superficie del formato
+    description: |
+      Dimensionamento della sala vendita, del retronegozio e della superficie complessiva
+      per formato.
+  BC-2350.20.30:
+    name: Pianificazione del mix di formati nel portafoglio
+    description: |
+      Pianificazione del mix di formati della rete e della migrazione tra formati.
+  BC-2350.30:
+    name: Ottimizzazione del perimetro della rete
+    description: |
+      Ottimizzazione del perimetro della rete tramite identificazione delle opportunità
+      di sviluppo, analisi della cannibalizzazione e copertura complessiva.
+  BC-2350.30.10:
+    name: Identificazione delle opportunità di sviluppo
+    description: |
+      Identificazione delle aree di influenza non servite e delle opportunità di
+      sviluppo.
+  BC-2350.30.20:
+    name: Modellazione della cannibalizzazione
+    description: |
+      Modellazione dell'impatto di cannibalizzazione di un nuovo punto vendita sugli
+      esistenti.
+  BC-2350.30.30:
+    name: Ottimizzazione della copertura e della reach
+    description: |
+      Ottimizzazione della copertura e della reach sul mercato target.
+  BC-2350.40:
+    name: Gestione del ciclo di vita delle performance del punto vendita
+    description: |
+      Decisioni sul ciclo di vita di ciascun punto vendita — trasferimento, ristrutturazione,
+      riduzione del formato o chiusura in base alle performance e ai cambiamenti del
+      bacino d'utenza.
+  BC-2350.40.10:
+    name: Diagnosi delle performance del punto vendita
+    description: |
+      Diagnosi dei punti vendita sottoperformanti, inclusi i cambiamenti del bacino
+      d'utenza.
+  BC-2350.40.20:
+    name: Decisioni di trasferimento e ristrutturazione del punto vendita
+    description: |
+      Decisioni su trasferimento o ristrutturazione del punto vendita rispetto alle
+      alternative.
+  BC-2350.40.30:
+    name: Decisioni di chiusura del punto vendita
+    description: |
+      Decisioni sulla chiusura del punto vendita, inclusi gli impatti sugli stakeholder
+      e sulle scorte.
+  BC-2350.50:
+    name: Gestione del brief immobiliare retail
+    description: |
+      Brief immobiliari specifici per il retail trasmessi ai team aziendali di real
+      estate per l'acquisizione dei siti, la negoziazione dei contratti di locazione e
+      le uscite.
+    in_scope:
+      - Brief di sito specifici per il retail
+      - Passaggio al team di acquisizione immobiliare aziendale (BC-710.20)
+      - Brief di uscita specifici per il retail (es. restrizioni commerciali)
+    out_of_scope:
+      - Negoziazione e gestione dei contratti di locazione (BC-710.20, BC-710.30)
+  BC-2350.50.10:
+    name: Redazione del brief di sito retail
+    description: |
+      Redazione di brief di sito specifici per il retail, inclusi requisiti di formato e
+      adiacenze.
+  BC-2350.50.20:
+    name: Redazione del brief di uscita retail
+    description: |
+      Redazione di brief di uscita specifici per il retail, inclusa la posizione sulle
+      restrizioni commerciali.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-retail-store-operations-management.yaml
+++ b/catalogue/i18n/it/L1-retail-store-operations-management.yaml
@@ -1,0 +1,145 @@
+# Gestione delle operazioni del punto vendita retail (it) — translations for L1-retail-store-operations-management.yaml
+locale: it
+source: L1-retail-store-operations-management.yaml
+entries:
+  BC-2310:
+    name: Gestione delle operazioni del punto vendita retail
+    description: |
+      Operazioni quotidiane dei punti vendita fisici — routine di apertura e chiusura,
+      esecuzione in negozio, gestione della forza lavoro a livello di punto vendita,
+      audit, cura degli arredi e fornitura coerente dell'esperienza del formato.
+  BC-2310.10:
+    name: Operazioni di apertura e chiusura del punto vendita
+    description: |
+      Routine quotidiane di apertura e chiusura del punto vendita, incluse la
+      preparazione del cassetto del denaro, la riconciliazione di fine giornata e il
+      passaggio di consegne tra turni.
+  BC-2310.10.10:
+    name: Esecuzione della routine di apertura
+    description: |
+      Esecuzione delle procedure di apertura del punto vendita inclusi i controlli di
+      prontezza operativa.
+  BC-2310.10.20:
+    name: Esecuzione della routine di chiusura
+    description: |
+      Routine di chiusura di fine giornata incluse riconciliazione e messa in sicurezza
+      del punto vendita.
+  BC-2310.10.30:
+    name: Gestione del passaggio di turno
+    description: |
+      Passaggio di consegne tra team con trasmissione di attività e segnalazione degli
+      incidenti.
+  BC-2310.20:
+    name: Gestione dell'esecuzione in negozio
+    description: |
+      Esecuzione di attività di merchandising, promozione, segnaletica e rifornimento
+      a livello di punto vendita affinché il negozio rispecchi il piano della sede centrale.
+    in_scope:
+      - Gestione delle attività per gli addetti al punto vendita
+      - Esecuzione di planogram e segnaletica
+      - Rifornimento in negozio dalle scorte di magazzino
+    out_of_scope:
+      - Progettazione del planogram (BC-2300.30.10)
+  BC-2310.20.10:
+    name: Gestione delle attività in negozio
+    description: |
+      Distribuzione e monitoraggio delle attività operative ai team del punto vendita.
+  BC-2310.20.20:
+    name: Esecuzione di planogram e segnaletica
+    description: |
+      Esecuzione in negozio dei planogram, della segnaletica e dell'allestimento
+      promozionale.
+  BC-2310.20.30:
+    name: Rifornimento in negozio
+    description: |
+      Rifornimento degli scaffali dal magazzino e dal retronegozio.
+  BC-2310.20.40:
+    name: Operazioni del magazzino e del retronegozio
+    description: |
+      Ricezione, organizzazione e gestione delle scorte nel magazzino e nel retronegozio.
+  BC-2310.30:
+    name: Gestione della forza lavoro nel punto vendita
+    description: |
+      Pianificazione del personale a livello di punto vendita, pianificazione della
+      forza lavoro oraria e gestione delle performance degli addetti.
+    in_scope:
+      - Previsioni orarie del fabbisogno di personale basate su traffico e vendite
+      - Pianificazione dei turni e gestione presenze
+      - Performance e coaching degli addetti a livello di punto vendita
+    out_of_scope:
+      - Gestione del capitale umano a livello aziendale (BC-300)
+  BC-2310.30.10:
+    name: Previsione del fabbisogno di personale
+    description: |
+      Previsione del fabbisogno orario di personale per punto vendita e reparto.
+  BC-2310.30.20:
+    name: Pianificazione dei turni in negozio
+    description: |
+      Pianificazione dei turni nel punto vendita nel rispetto dell'equità e delle norme
+      sul lavoro.
+  BC-2310.30.30:
+    name: Gestione delle presenze e dei timbrature
+    description: |
+      Registrazione delle timbrature di entrata e uscita e gestione delle eccezioni.
+  BC-2310.30.40:
+    name: Coaching delle performance degli addetti
+    description: |
+      Coaching, riconoscimento e gestione delle performance degli addetti al punto
+      vendita.
+  BC-2310.40:
+    name: Gestione degli audit e della conformità del punto vendita
+    description: |
+      Audit operativi, ispezioni di conformità, mystery shopping e rispetto degli
+      standard di marchio e operativi.
+  BC-2310.40.10:
+    name: Programma di audit operativo
+    description: |
+      Programma di audit operativi e ispezioni rispetto agli standard del punto vendita.
+  BC-2310.40.20:
+    name: Programma di mystery shopping
+    description: |
+      Programma di mystery shopping per la valutazione dell'esperienza del cliente in
+      negozio.
+  BC-2310.40.30:
+    name: Conformità agli standard del punto vendita
+    description: |
+      Conformità agli standard di marchio, sicurezza e operativi per punto vendita.
+  BC-2310.50:
+    name: Gestione della cura degli asset del punto vendita
+    description: |
+      Cura a livello di punto vendita di arredi, attrezzature, impianti di refrigerazione
+      e pulizia per mantenere il negozio pronto alla vendita.
+  BC-2310.50.10:
+    name: Manutenzione di arredi e attrezzature
+    description: |
+      Manutenzione degli arredi, dei rack e delle attrezzature in negozio.
+  BC-2310.50.20:
+    name: Gestione dell'uptime della refrigerazione
+    description: |
+      Monitoraggio e gestione dell'uptime degli impianti di refrigerazione nel retail
+      alimentare.
+  BC-2310.50.30:
+    name: Pulizia e igiene del punto vendita
+    description: |
+      Routine di pulizia, housekeeping e igiene per la sala vendita.
+  BC-2310.60:
+    name: Gestione del formato e dell'esperienza del punto vendita
+    description: |
+      Definizione e tutela degli standard dell'esperienza del formato di punto vendita,
+      inclusi modello di servizio, estetica e percorso del cliente.
+  BC-2310.60.10:
+    name: Standard del formato di punto vendita
+    description: |
+      Standard per ciascun formato di punto vendita relativi a layout, servizio e
+      atmosfera.
+  BC-2310.60.20:
+    name: Progettazione dell'esperienza del cliente in negozio
+    description: |
+      Progettazione del percorso del cliente in negozio e delle interazioni di servizio.
+  BC-2310.60.30:
+    name: Pianificazione del rinnovo del concept di punto vendita
+    description: |
+      Pianificazione dei rinnovi del concept di punto vendita e dei rollout pilota.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-route-charges-management.yaml
+++ b/catalogue/i18n/it/L1-route-charges-management.yaml
@@ -1,0 +1,91 @@
+# Gestione delle tariffe di rotta (it) — translations for L1-route-charges-management.yaml
+locale: it
+source: L1-route-charges-management.yaml
+entries:
+  BC-1270:
+    name: Gestione delle tariffe di rotta
+    description: |
+      Calcolo delle tariffe di navigazione aerea, fatturazione e riscossione dagli utenti dello spazio aereo.
+  BC-1270.10:
+    name: Gestione delle zone tariffarie
+    description: |
+      Definizione delle zone tariffarie, regole di fatturazione, definizione delle tariffe unitarie.
+  BC-1270.10.10:
+    name: Definizione delle zone tariffarie
+    description: |
+      Definizione delle zone tariffarie en route e terminali.
+  BC-1270.10.20:
+    name: Calcolo delle tariffe unitarie
+    description: |
+      Calcolo e approvazione delle tariffe unitarie per zona tariffaria.
+  BC-1270.10.30:
+    name: Gestione delle regole tariffarie
+    description: |
+      Manutenzione della formula tariffaria e delle regole di esenzione.
+  BC-1270.20:
+    name: Gestione del calcolo delle tariffe di rotta
+    description: |
+      Calcolo delle tariffe di rotta per singolo volo.
+  BC-1270.20.10:
+    name: Acquisizione dei dati di volo per la tariffazione
+    description: |
+      Acquisizione dei dati di volo in ingresso al sistema di calcolo tariffario.
+  BC-1270.20.20:
+    name: Calcolo della distanza e del peso
+    description: |
+      Calcolo della distanza addebitabile e dei fattori di peso.
+  BC-1270.20.30:
+    name: Calcolo delle tariffe
+    description: |
+      Applicazione della tariffa unitaria per derivare le tariffe di rotta per volo.
+  BC-1270.30:
+    name: Gestione della riscossione delle tariffe
+    description: |
+      Fatturazione, riscossione, elaborazione dei pagamenti, solleciti.
+  BC-1270.30.10:
+    name: Fatturazione delle tariffe
+    description: |
+      Generazione delle fatture mensili per le tariffe di rotta.
+  BC-1270.30.20:
+    name: Elaborazione dei pagamenti
+    description: |
+      Ricezione ed elaborazione dei pagamenti degli utenti dello spazio aereo.
+  BC-1270.30.30:
+    name: Solleciti e recupero crediti
+    description: |
+      Solleciti, recupero crediti e azioni coercitive per tariffe scadute.
+  BC-1270.40:
+    name: Gestione degli account delle compagnie aeree
+    description: |
+      Conti degli utenti dello spazio aereo, estratti conto, gestione delle contestazioni.
+  BC-1270.40.10:
+    name: Manutenzione degli account degli utenti dello spazio aereo
+    description: |
+      Manutenzione dei dati anagrafici degli account degli utenti dello spazio aereo.
+  BC-1270.40.20:
+    name: Fornitura di estratti conto e rendiconti
+    description: |
+      Fornitura di estratti conto e rendiconti agli utenti.
+  BC-1270.40.30:
+    name: Gestione delle contestazioni tariffarie
+    description: |
+      Gestione delle contestazioni e delle richieste di rettifica.
+  BC-1270.50:
+    name: Gestione della reportistica e della riconciliazione delle tariffe
+    description: |
+      Reportistica verso i regolatori, riconciliazioni in stile Eurocontrol.
+  BC-1270.50.10:
+    name: Reportistica verso i regolatori e il gestore della rete
+    description: |
+      Reportistica verso i regolatori e i gestori della rete equivalenti a Eurocontrol.
+  BC-1270.50.20:
+    name: Riconciliazione delle tariffe
+    description: |
+      Riconciliazione tra i dati di volo e i calcoli delle tariffe.
+  BC-1270.50.30:
+    name: Monitoraggio del recupero dei costi
+    description: |
+      Monitoraggio del recupero dei costi rispetto alla base di costo approvata.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-saas-platform-operations-management.yaml
+++ b/catalogue/i18n/it/L1-saas-platform-operations-management.yaml
@@ -1,0 +1,146 @@
+# Gestione operativa della piattaforma SaaS (it) — translations for L1-saas-platform-operations-management.yaml
+locale: it
+source: L1-saas-platform-operations-management.yaml
+entries:
+  BC-4220:
+    name: Gestione operativa della piattaforma SaaS
+    description: |
+      SRE (Site Reliability Engineering), observability, risposta on-call, gestione
+      della capacità, performance e operazioni di disaster recovery del servizio SaaS multi-tenant.
+  BC-4220.10:
+    name: Ingegneria dell'affidabilità del servizio
+    description: |
+      Definizione e gestione degli SLI, SLO e degli error budget
+      per il servizio SaaS.
+    in_scope:
+      - Disciplina SLI / SLO / error budget per il prodotto in esercizio
+    out_of_scope:
+      - Impegni SLA verso i clienti (coperti da Gestione della sicurezza e conformità del servizio SaaS)
+      - Livelli di servizio IT interni (coperti da Gestione dell'information technology)
+  BC-4220.10.10:
+    name: Definizione degli indicatori di livello di servizio
+    description: |
+      Definizione degli SLI che misurano l'esperienza del cliente
+      sui servizi in esercizio.
+  BC-4220.10.20:
+    name: Gestione degli obiettivi di livello di servizio
+    description: |
+      Definizione, revisione e aggiornamento degli SLO
+      sui diversi servizi.
+  BC-4220.10.30:
+    name: Gestione degli error budget
+    description: |
+      Gestione degli error budget e della policy che ne governa
+      il consumo.
+  BC-4220.20:
+    name: Gestione dell'observability
+    description: |
+      Log, metriche, trace e monitoraggio sintetico che rendono
+      il servizio in esercizio comprensibile in produzione.
+  BC-4220.20.10:
+    name: Gestione del logging applicativo
+    description: |
+      Gestione delle convenzioni di logging applicativo,
+      delle pipeline e della conservazione.
+  BC-4220.20.20:
+    name: Gestione della pipeline delle metriche
+    description: |
+      Gestione delle pipeline di ingestione, archiviazione
+      e interrogazione delle metriche.
+  BC-4220.20.30:
+    name: Distributed tracing
+    description: |
+      Distributed tracing end-to-end tra i servizi
+      per le analisi in produzione.
+  BC-4220.20.40:
+    name: Monitoraggio sintetico
+    description: |
+      Sonde sintetiche che esercitano i percorsi utente critici
+      dall'esterno del servizio.
+  BC-4220.30:
+    name: Gestione della risposta agli incidenti
+    description: |
+      Risposta on-call, rilevamento degli incidenti, coordinamento
+      e comunicazione ai clienti durante gli incidenti in produzione.
+  BC-4220.30.10:
+    name: Gestione dei turni on-call
+    description: |
+      Definizione e gestione dei turni on-call
+      nei team di prodotto.
+  BC-4220.30.20:
+    name: Rilevamento degli incidenti
+    description: |
+      Rilevamento degli incidenti in produzione da telemetria
+      e segnali esterni.
+  BC-4220.30.30:
+    name: Coordinamento degli incidenti
+    description: |
+      Coordinamento della risposta agli incidenti, inclusi ruoli, comunicazioni
+      e decisioni durante l'incidente.
+  BC-4220.30.40:
+    name: Comunicazione agli utenti durante gli incidenti
+    description: |
+      Comunicazione ai clienti coinvolti durante e dopo gli incidenti.
+  BC-4220.40:
+    name: Postmortem e miglioramento dell'affidabilità
+    description: |
+      Redazione dei postmortem e monitoraggio delle azioni di miglioramento
+      dell'affidabilità affinché le lezioni si accumulino nel tempo.
+  BC-4220.40.10:
+    name: Redazione dei postmortem
+    description: |
+      Redazione di postmortem blameless dopo incidenti
+      e near-miss significativi.
+  BC-4220.40.20:
+    name: Monitoraggio delle azioni di affidabilità
+    description: |
+      Monitoraggio delle azioni di miglioramento dell'affidabilità
+      fino alla chiusura nei team.
+  BC-4220.40.30:
+    name: Analisi dei trend di affidabilità
+    description: |
+      Analisi dei trend di affidabilità tra i servizi
+      e sulle diverse fasce temporali.
+  BC-4220.50:
+    name: Gestione della capacità e delle performance
+    description: |
+      Previsione della capacità, policy di auto-scaling e test di performance
+      del servizio SaaS.
+  BC-4220.50.10:
+    name: Previsione della capacità
+    description: |
+      Previsione della domanda di capacità tra i servizi
+      e le regioni.
+  BC-4220.50.20:
+    name: Gestione delle policy di auto-scaling
+    description: |
+      Definizione e ottimizzazione delle policy di auto-scaling
+      per i servizi di prodotto.
+  BC-4220.50.30:
+    name: Test di performance
+    description: |
+      Test di carico, stress e soak del servizio
+      in esercizio.
+  BC-4220.60:
+    name: Disaster recovery e resilienza
+    description: |
+      Backup e ripristino, orchestrazione del failover ed esercitazioni
+      di disaster recovery per il servizio SaaS.
+  BC-4220.60.10:
+    name: Gestione del backup e del ripristino
+    description: |
+      Policy di backup, esecuzione e validazione del ripristino
+      per i datastore del servizio.
+  BC-4220.60.20:
+    name: Orchestrazione del failover
+    description: |
+      Orchestrazione del failover tra zone di disponibilità
+      e regioni.
+  BC-4220.60.30:
+    name: Gestione delle esercitazioni di disaster recovery
+    description: |
+      Pianificazione ed esecuzione di esercitazioni di disaster recovery
+      e game-day.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-saas-tenant-management.yaml
+++ b/catalogue/i18n/it/L1-saas-tenant-management.yaml
@@ -1,0 +1,137 @@
+# Gestione dei tenant SaaS (it) — translations for L1-saas-tenant-management.yaml
+locale: it
+source: L1-saas-tenant-management.yaml
+entries:
+  BC-4230:
+    name: Gestione dei tenant SaaS
+    description: |
+      Provisioning, configurazione, isolamento, collocazione regionale, federazione delle identità
+      ed esportazione dei dati per tenant nel servizio multi-tenant.
+  BC-4230.10:
+    name: Provisioning e ciclo di vita del tenant
+    description: |
+      Creazione, sospensione, decommissioning e migrazione dei tenant
+      nel parco multi-tenant.
+  BC-4230.10.10:
+    name: Provisioning del tenant
+    description: |
+      Creazione di nuovi tenant e allocazione
+      delle risorse associate.
+  BC-4230.10.20:
+    name: Sospensione del tenant
+    description: |
+      Sospensione dei tenant per mancato pagamento,
+      abuso o motivi contrattuali.
+  BC-4230.10.30:
+    name: Decommissioning del tenant
+    description: |
+      Decommissioning dei tenant, incluse la cancellazione dei dati
+      o la restituzione secondo contratto.
+  BC-4230.10.40:
+    name: Migrazione del tenant
+    description: |
+      Migrazione dei tenant tra cluster, shard
+      o regioni.
+  BC-4230.20:
+    name: Gestione della configurazione del tenant
+    description: |
+      Configurazione delle funzionalità, branding e limiti per singolo tenant
+      al di sopra della baseline condivisa del prodotto.
+  BC-4230.20.10:
+    name: Configurazione delle funzionalità per tenant
+    description: |
+      Configurazione delle opzioni di funzionalità
+      a livello di tenant.
+  BC-4230.20.20:
+    name: Gestione del branding del tenant
+    description: |
+      Branding a livello di tenant, inclusi loghi,
+      colori e domini personalizzati.
+  BC-4230.20.30:
+    name: Gestione dei limiti del tenant
+    description: |
+      Configurazione dei limiti a livello di tenant
+      come quote e soglie di rate limiting.
+  BC-4230.30:
+    name: Gestione dell'isolamento del tenant
+    description: |
+      Meccanismi che mantengono l'isolamento logico e fisico tra i tenant
+      su dati, compute e percorsi di accesso.
+  BC-4230.30.10:
+    name: Isolamento dei dati del tenant
+    description: |
+      Isolamento dei dati del tenant tramite partizionamento,
+      cifratura e scoping degli accessi.
+  BC-4230.30.20:
+    name: Isolamento del compute del tenant
+    description: |
+      Isolamento dei carichi di lavoro del tenant tramite confini
+      di compute dedicati o vincolati.
+  BC-4230.30.30:
+    name: Prevenzione degli accessi cross-tenant
+    description: |
+      Controlli e monitoraggio che impediscono la contaminazione
+      di dati e identità tra tenant.
+  BC-4230.40:
+    name: Residenza dei dati e collocazione regionale
+    description: |
+      Assegnazione dei tenant alle regioni, applicazione degli impegni
+      di residenza dei dati e gestione della policy di replica cross-region.
+  BC-4230.40.10:
+    name: Assegnazione regionale del tenant
+    description: |
+      Assegnazione dei tenant alle regioni in conformità
+      al contratto e alla normativa.
+  BC-4230.40.20:
+    name: Applicazione della residenza dei dati
+    description: |
+      Applicazione dei confini di residenza dei dati
+      a runtime.
+  BC-4230.40.30:
+    name: Policy di replica cross-region
+    description: |
+      Policy che regola la replica cross-region
+      per resilienza e accesso.
+  BC-4230.50:
+    name: Federazione delle identità del tenant
+    description: |
+      Federazione degli identity provider dei tenant e ciclo di vita
+      degli account utente tramite single sign-on e SCIM.
+  BC-4230.50.10:
+    name: Configurazione SSO del tenant
+    description: |
+      Configurazione del single sign-on tra gli identity provider
+      dei tenant e il servizio.
+  BC-4230.50.20:
+    name: Provisioning utenti basato su SCIM
+    description: |
+      Ciclo di vita degli account utente del tenant gestito
+      tramite SCIM o protocolli di provisioning equivalenti.
+  BC-4230.50.30:
+    name: Onboarding degli identity provider del tenant
+    description: |
+      Onboarding e validazione degli identity provider
+      dei tenant.
+  BC-4230.60:
+    name: Gestione del backup e dell'esportazione del tenant
+    description: |
+      Capacità di esportazione, cancellazione e ripristino dei dati per tenant,
+      esposte a tenant e amministratori.
+  BC-4230.60.10:
+    name: Esportazione dei dati del tenant
+    description: |
+      Esportazione dei dati del tenant in formato leggibile dalla macchina
+      su richiesta o per contratto.
+  BC-4230.60.20:
+    name: Cancellazione dei dati del tenant
+    description: |
+      Cancellazione verificabile dei dati del tenant
+      alla cancellazione o su richiesta.
+  BC-4230.60.30:
+    name: Ripristino del backup del tenant
+    description: |
+      Ripristino dei dati del tenant da backup su richiesta
+      del tenant o dell'operatore.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-saas-trust-service-compliance-management.yaml
+++ b/catalogue/i18n/it/L1-saas-trust-service-compliance-management.yaml
@@ -1,0 +1,138 @@
+# Gestione della sicurezza e conformità del servizio SaaS (it) — translations for L1-saas-trust-service-compliance-management.yaml
+locale: it
+source: L1-saas-trust-service-compliance-management.yaml
+entries:
+  BC-4290:
+    name: Gestione della sicurezza e conformità del servizio SaaS
+    description: |
+      Attestazioni a livello di servizio, questionari di sicurezza dei clienti, divulgazioni
+      pubbliche di fiducia, gestione dei sub-responsabili del trattamento, impegni di privacy
+      del servizio e impegni di resilienza del servizio verso i clienti per l'offerta SaaS.
+  BC-4290.10:
+    name: Gestione delle attestazioni del servizio
+    description: |
+      Coordinamento delle attestazioni a livello di servizio quali SOC 2, ISO 27001
+      e FedRAMP per l'offerta SaaS.
+    in_scope:
+      - Prontezza all'audit per il servizio
+      - Coinvolgimento dei revisori e produzione dei report
+    out_of_scope:
+      - Programma di conformità a livello aziendale (coperto da Gestione della conformità)
+  BC-4290.10.10:
+    name: Coordinamento della prontezza all'audit
+    description: |
+      Coordinamento della prontezza all'audit tra i responsabili
+      dei controlli per il servizio.
+  BC-4290.10.20:
+    name: Coinvolgimento dei revisori
+    description: |
+      Coinvolgimento di revisori esterni e gestione
+      delle attività di audit sul campo.
+  BC-4290.10.30:
+    name: Gestione del rinnovo delle attestazioni
+    description: |
+      Gestione dei cicli di rinnovo delle attestazioni
+      e degli accordi di audit continuativo.
+  BC-4290.20:
+    name: Gestione dei questionari di sicurezza dei clienti
+    description: |
+      Gestione del repository dei questionari, redazione delle risposte e knowledge base
+      utilizzata per rispondere alle valutazioni del rischio fornitore dei clienti.
+  BC-4290.20.10:
+    name: Gestione del repository dei questionari
+    description: |
+      Manutenzione del repository dei questionari in ingresso
+      e instradamento.
+  BC-4290.20.20:
+    name: Redazione delle risposte ai questionari
+    description: |
+      Redazione delle risposte ai questionari
+      di sicurezza dei clienti.
+  BC-4290.20.30:
+    name: Manutenzione della knowledge base dei questionari
+    description: |
+      Manutenzione di una knowledge base curata di risposte approvate
+      ed evidenze.
+  BC-4290.30:
+    name: Trust portal e divulgazione pubblica
+    description: |
+      Gestione del trust centre dei clienti, delle divulgazioni pubbliche
+      sullo stato del servizio e dei workflow di distribuzione dei documenti.
+  BC-4290.30.10:
+    name: Gestione dei contenuti del trust portal
+    description: |
+      Cura dei contenuti pubblicati
+      sul trust centre dei clienti.
+  BC-4290.30.20:
+    name: Divulgazione pubblica dello stato del servizio
+    description: |
+      Divulgazione pubblica dello stato degli incidenti
+      e della cronologia del servizio.
+  BC-4290.30.30:
+    name: Workflow di distribuzione dei documenti
+    description: |
+      Distribuzione controllata di report di audit e documenti
+      di fiducia ai clienti.
+  BC-4290.40:
+    name: Gestione dei sub-responsabili del trattamento
+    description: |
+      Inventario, divulgazione e notifica delle modifiche ai sub-responsabili
+      del trattamento che gestiscono i dati dei clienti.
+  BC-4290.40.10:
+    name: Inventario dei sub-responsabili del trattamento
+    description: |
+      Inventario dei sub-responsabili e delle categorie
+      di dati dei clienti che trattano.
+  BC-4290.40.20:
+    name: Divulgazione dei sub-responsabili del trattamento
+    description: |
+      Divulgazione verso i clienti dell'elenco aggiornato
+      dei sub-responsabili del trattamento.
+  BC-4290.40.30:
+    name: Notifica delle modifiche ai sub-responsabili
+    description: |
+      Notifica preventiva delle aggiunte e delle rimozioni
+      di sub-responsabili del trattamento secondo contratto.
+  BC-4290.50:
+    name: Gestione degli impegni di privacy del servizio
+    description: |
+      Gestione degli accordi sul trattamento dei dati, delle divulgazioni
+      sui flussi di dati dei clienti e dell'instradamento delle richieste degli interessati.
+  BC-4290.50.10:
+    name: Gestione degli accordi sul trattamento dei dati
+    description: |
+      Manutenzione e sottoscrizione degli accordi
+      sul trattamento dei dati con i clienti.
+  BC-4290.50.20:
+    name: Mappatura dei flussi di dati dei clienti
+    description: |
+      Mappatura dei flussi di dati dei clienti
+      per divulgazione e valutazione.
+  BC-4290.50.30:
+    name: Instradamento delle richieste degli interessati
+    description: |
+      Instradamento delle richieste degli interessati ricevute tramite i clienti
+      ai gestori appropriati.
+  BC-4290.60:
+    name: Gestione degli impegni di resilienza del servizio
+    description: |
+      Impegni di livello di servizio verso i clienti, divulgazione dell'uptime
+      e amministrazione dei crediti di servizio.
+  BC-4290.60.10:
+    name: Gestione degli impegni di livello di servizio
+    description: |
+      Definizione e gestione degli impegni di livello di servizio
+      verso i clienti.
+  BC-4290.60.20:
+    name: Divulgazione dell'uptime
+    description: |
+      Divulgazione dell'uptime storico
+      rispetto ai livelli impegnati.
+  BC-4290.60.30:
+    name: Amministrazione dei crediti di servizio
+    description: |
+      Amministrazione dei crediti di servizio derivanti
+      dal mancato rispetto degli impegni.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-sales-management.yaml
+++ b/catalogue/i18n/it/L1-sales-management.yaml
@@ -1,0 +1,151 @@
+# Gestione delle vendite (it) — translations for L1-sales-management.yaml
+locale: it
+source: L1-sales-management.yaml
+entries:
+  BC-410:
+    name: Gestione delle vendite
+    description: |
+      Attività lead-to-order — account, pipeline, trattative, preventivi.
+  BC-410.10:
+    name: Gestione della strategia di vendita
+    description: |
+      Modello di copertura, segmentazione, pianificazione delle vendite.
+  BC-410.10.10:
+    name: Progettazione del modello di copertura delle vendite
+    description: |
+      Definizione dei segmenti di vendita, dei territori e dei modelli di copertura.
+  BC-410.10.20:
+    name: Assegnazione di territori e account
+    description: |
+      Progettazione dei territori, assegnazione degli account e ribilanciamento.
+  BC-410.10.30:
+    name: Definizione degli obiettivi di vendita
+    description: |
+      Definizione degli obiettivi di vendita e delle quote con approccio top-down e bottom-up.
+  BC-410.10.40:
+    name: Pianificazione della capacità di vendita
+    description: |
+      Pianificazione della capacità, del ramp-up e degli organici di vendita.
+  BC-410.20:
+    name: Gestione degli account
+    description: |
+      Gestione degli account strategici e chiave.
+  BC-410.20.10:
+    name: Pianificazione degli account
+    description: |
+      Piani di account strategici e analisi degli spazi bianchi.
+  BC-410.20.20:
+    name: Governance degli account chiave
+    description: |
+      Governance e sponsorizzazione esecutiva degli account chiave.
+  BC-410.20.30:
+    name: Sviluppo delle relazioni con gli account
+    description: |
+      Mappatura delle relazioni e coinvolgimento degli stakeholder negli account.
+  BC-410.20.40:
+    name: Monitoraggio della salute degli account
+    description: |
+      Metriche di salute degli account, scorecard e monitoraggio del rischio di rinnovo.
+  BC-410.30:
+    name: Gestione delle opportunità e della pipeline
+    description: |
+      Ciclo di vita di lead, opportunità e trattative.
+  BC-410.30.10:
+    name: Qualifica e trasferimento dei lead
+    description: |
+      Qualifica, scoring e trasferimento dei lead dal marketing.
+  BC-410.30.20:
+    name: Gestione delle opportunità
+    description: |
+      Creazione, qualifica e avanzamento delle fasi delle opportunità.
+  BC-410.30.30:
+    name: Strategia e sviluppo delle trattative
+    description: |
+      Sviluppo strategico delle trattative, win plan e revisioni delle offerte.
+  BC-410.30.40:
+    name: Previsione della pipeline
+    description: |
+      Copertura della pipeline, previsione ponderata e commit.
+  BC-410.40:
+    name: Gestione dei preventivi e della configurazione
+    description: |
+      CPQ — configurazione, prezzo, preventivo.
+  BC-410.40.10:
+    name: Configurazione del prodotto
+    description: |
+      Configurazione di prodotti e soluzioni con regole e vincoli.
+  BC-410.40.20:
+    name: Generazione di preventivi
+    description: |
+      Generazione di preventivi e proposte pronti per il cliente.
+  BC-410.40.30:
+    name: Flusso di approvazione dei preventivi
+    description: |
+      Flussi di approvazione di sconti e condizioni non standard.
+  BC-410.40.40:
+    name: Conversione di contratti e ordini
+    description: |
+      Conversione dei preventivi accettati in ordini e contratti.
+  BC-410.50:
+    name: Gestione delle operazioni di vendita
+    description: |
+      Processo di vendita, strumenti, enablement.
+  BC-410.50.10:
+    name: Governance del processo e della metodologia di vendita
+    description: |
+      Definizione e gestione del processo e della metodologia di vendita.
+  BC-410.50.20:
+    name: Tecnologia e strumenti di vendita
+    description: |
+      Amministrazione e integrazione del CRM e degli strumenti di vendita.
+  BC-410.50.30:
+    name: Sales enablement
+    description: |
+      Playbook di vendita, contenuti di enablement e certificazioni.
+  BC-410.50.40:
+    name: Dati e igiene delle vendite
+    description: |
+      Qualità dei dati CRM, governance e programmi di igiene dei dati.
+  BC-410.60:
+    name: Gestione delle vendite tramite canale
+    description: |
+      Canali indiretti, distributori, rivenditori.
+  BC-410.60.10:
+    name: Reclutamento di partner di canale
+    description: |
+      Reclutamento e onboarding di distributori, rivenditori e agenti.
+  BC-410.60.20:
+    name: Enablement dei partner di canale
+    description: |
+      Formazione, certificazione e enablement dei partner di canale.
+  BC-410.60.30:
+    name: Gestione del programma di canale
+    description: |
+      Livelli del programma di canale, incentivi e regole di ingaggio.
+  BC-410.60.40:
+    name: Gestione della performance dei partner
+    description: |
+      Monitoraggio delle vendite tramite partner, sell-out e metriche di performance.
+  BC-410.70:
+    name: Gestione della performance delle vendite
+    description: |
+      Piani di compensazione, gestione delle quote, analytics delle vendite.
+  BC-410.70.10:
+    name: Progettazione del piano di compensazione delle vendite
+    description: |
+      Progettazione di piani di retribuzione variabile, acceleratori e SPIF.
+  BC-410.70.20:
+    name: Gestione delle quote e del crediting
+    description: |
+      Allocazione delle quote, regole di crediting e riporto.
+  BC-410.70.30:
+    name: Calcolo delle provvigioni di vendita
+    description: |
+      Calcolo, validazione e pagamento delle provvigioni di vendita.
+  BC-410.70.40:
+    name: Analytics della performance di vendita
+    description: |
+      Analytics di win/loss, produttività e performance dei venditori.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-search-rescue-coordination-management.yaml
+++ b/catalogue/i18n/it/L1-search-rescue-coordination-management.yaml
@@ -1,0 +1,71 @@
+# Gestione del coordinamento della ricerca e del soccorso (it) — translations for L1-search-rescue-coordination-management.yaml
+locale: it
+source: L1-search-rescue-coordination-management.yaml
+entries:
+  BC-1260:
+    name: Gestione del coordinamento SAR
+    description: |
+      Allertamento SAR, coordinamento con i centri di soccorso, gestione dei segnalatori di emergenza.
+  BC-1260.10:
+    name: Gestione dell'allertamento SAR
+    description: |
+      Fasi di allarme — incertezza, allerta, segnale di soccorso.
+  BC-1260.10.10:
+    name: Gestione della fase di incertezza
+    description: |
+      Rilevamento e gestione della fase di incertezza INCERFA.
+  BC-1260.10.20:
+    name: Gestione della fase di allerta
+    description: |
+      Gestione della fase di allerta ALERFA ed escalation.
+  BC-1260.10.30:
+    name: Gestione della fase di segnale di soccorso
+    description: |
+      Gestione della fase di segnale di soccorso DETRESFA e avvio delle operazioni SAR.
+  BC-1260.20:
+    name: Gestione del coordinamento SAR
+    description: |
+      Coordinamento con i centri di coordinamento del soccorso (RCC).
+  BC-1260.20.10:
+    name: Collegamento con RCC
+    description: |
+      Collegamento con i centri nazionali e regionali di coordinamento del soccorso.
+  BC-1260.20.20:
+    name: Coordinamento della missione SAR
+    description: |
+      Coordinamento delle risorse e dei mezzi per la missione SAR.
+  BC-1260.20.30:
+    name: Coordinamento SAR transfrontaliero
+    description: |
+      Coordinamento transfrontaliero delle operazioni SAR.
+  BC-1260.30:
+    name: Gestione delle comunicazioni SAR
+    description: |
+      Reti di comunicazione SAR, canali di coordinamento.
+  BC-1260.30.10:
+    name: Operazioni di comunicazione vocale SAR
+    description: |
+      Operazione dei canali e delle frequenze vocali SAR.
+  BC-1260.30.20:
+    name: Operazioni di comunicazione dati SAR
+    description: |
+      Operazione delle reti dati e della messaggistica SAR.
+  BC-1260.40:
+    name: Gestione dei segnalatori di posizione di emergenza
+    description: |
+      Gestione delle attivazioni di ELT/EPIRB/PLB, interfaccia con COSPAS-SARSAT.
+  BC-1260.40.10:
+    name: Gestione delle attivazioni ELT
+    description: |
+      Rilevamento e gestione delle attivazioni degli ELT.
+  BC-1260.40.20:
+    name: Operazioni di interfaccia COSPAS-SARSAT
+    description: |
+      Interfaccia con i centri di controllo della missione COSPAS-SARSAT.
+  BC-1260.40.30:
+    name: Coordinamento della registrazione dei segnalatori
+    description: |
+      Coordinamento con i registri nazionali dei segnalatori di emergenza.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-shipment-visibility-tracking-management.yaml
+++ b/catalogue/i18n/it/L1-shipment-visibility-tracking-management.yaml
@@ -1,0 +1,102 @@
+# Gestione della visibilità e del tracciamento delle spedizioni (it) — translations for L1-shipment-visibility-tracking-management.yaml
+locale: it
+source: L1-shipment-visibility-tracking-management.yaml
+entries:
+  BC-2510:
+    name: Gestione della visibilità e del tracciamento delle spedizioni
+    description: |
+      Visibilità end-to-end delle spedizioni attraverso l'acquisizione di eventi,
+      la risoluzione degli stati, la previsione dell'ETA, gli avvisi di eccezione
+      e le operazioni della control tower logistica.
+  BC-2510.10:
+    name: Gestione dell'acquisizione degli eventi e degli stati
+    description: |
+      Acquisizione degli eventi di spedizione da vettori, IoT e sistemi operativi e
+      traduzione in stati canonici.
+    in_scope:
+      - Acquisizione di eventi EDI 214, IFTSTA ed EPCIS
+      - Acquisizione di eventi IoT e telematica
+    out_of_scope:
+      - Telematica per le condizioni degli asset (BC-2430.40)
+  BC-2510.10.10:
+    name: Acquisizione degli eventi dal vettore
+    description: |
+      Acquisizione degli eventi milestone lato vettore tramite EDI e API.
+  BC-2510.10.20:
+    name: Acquisizione di eventi IoT e telematica
+    description: |
+      Acquisizione degli eventi IoT e di telematica a livello di carico.
+  BC-2510.10.30:
+    name: Acquisizione degli aggiornamenti di stato manuali
+    description: |
+      Acquisizione degli aggiornamenti di stato manuali da autisti, agenti e partner.
+  BC-2510.20:
+    name: Gestione del tracciamento delle spedizioni
+    description: |
+      Risoluzione dello stato delle spedizioni tra tratte, modi e partner e distribuzione
+      alle superfici di tracciamento interne e rivolte ai clienti.
+  BC-2510.20.10:
+    name: Risoluzione dello stato della spedizione
+    description: |
+      Risoluzione dello stato canonico della spedizione dagli eventi grezzi.
+  BC-2510.20.20:
+    name: Ricucitura del tracciamento multi-tratta
+    description: |
+      Ricucitura di viaggi multi-tratta e multi-vettore in un'unica traccia.
+  BC-2510.20.30:
+    name: Operazioni del portale di tracciamento pubblico
+    description: |
+      Gestione dei portali di tracciamento pubblici e delle API per i clienti.
+  BC-2510.30:
+    name: Gestione della previsione dell'ETA
+    description: |
+      Calcolo e raffinamento continuo dell'orario stimato di arrivo (ETA).
+  BC-2510.30.10:
+    name: Calcolo dell'ETA
+    description: |
+      Calcolo deterministico dell'ETA da orari e milestone.
+  BC-2510.30.20:
+    name: Modellizzazione predittiva dell'ETA
+    description: |
+      Modellizzazione predittiva dell'ETA utilizzando dati storici e contestuali.
+  BC-2510.30.30:
+    name: Allerta per variazioni dell'ETA
+    description: |
+      Allerta per variazioni significative dell'ETA rispetto all'impegno concordato.
+  BC-2510.40:
+    name: Gestione delle eccezioni e degli avvisi
+    description: |
+      Rilevamento delle eccezioni operative, notifica agli stakeholder e monitoraggio
+      della risoluzione delle eccezioni.
+  BC-2510.40.10:
+    name: Rilevamento delle eccezioni
+    description: |
+      Rilevamento delle eccezioni operative basato su regole e modelli.
+  BC-2510.40.20:
+    name: Notifica agli stakeholder
+    description: |
+      Notifica a clienti, team operativi e partner.
+  BC-2510.40.30:
+    name: Monitoraggio della risoluzione delle eccezioni
+    description: |
+      Monitoraggio del triage, della responsabilità e della chiusura delle eccezioni.
+  BC-2510.50:
+    name: Gestione delle operazioni della control tower logistica
+    description: |
+      Visibilità end-to-end, monitoraggio della performance e coordinamento degli
+      interventi proattivi tra vettori e partner.
+  BC-2510.50.10:
+    name: Dashboard di visibilità end-to-end
+    description: |
+      Gestione dei dashboard di visibilità end-to-end sull'intera rete.
+  BC-2510.50.20:
+    name: Monitoraggio della performance cross-vettore
+    description: |
+      Monitoraggio della performance tra vettori e partner.
+  BC-2510.50.30:
+    name: Coordinamento degli interventi proattivi
+    description: |
+      Coordinamento degli interventi proattivi a tutela degli impegni verso i clienti.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-smelting-refining-operations-management.yaml
+++ b/catalogue/i18n/it/L1-smelting-refining-operations-management.yaml
@@ -1,0 +1,133 @@
+# Gestione delle operazioni di fusione e raffinazione (it) — translations for L1-smelting-refining-operations-management.yaml
+locale: it
+source: L1-smelting-refining-operations-management.yaml
+entries:
+  BC-4450:
+    name: Gestione delle operazioni di fusione e raffinazione
+    description: |
+      Raffinazione pirometallurgica ed elettrochimica di concentrati e intermedi in metallo consegnabile all'LME o a specifica, inclusi recupero dei sottoprodotti, trattamento dei gas di scarico e contabilità metallurgica.
+  BC-4450.10:
+    name: Ricevimento e miscelazione del concentrato
+    description: |
+      Campionamento al ricevimento, miscelazione dell'alimentazione e gestione dell'inventario dei concentrati in ingresso al complesso di fonderia.
+    in_scope:
+      - Campionamento al ricevimento e analisi del campione
+      - Miscelazione dell'alimentazione della fonderia
+      - Inventario del piazzale del concentrato
+    out_of_scope:
+      - Liquidazione delle vendite di concentrato (BC-4480.40)
+  BC-4450.10.10:
+    name: Campionamento del concentrato al ricevimento
+    description: |
+      Campionamento e analisi del campione dei concentrati ricevuti da miniere di terze parti e di proprietà.
+  BC-4450.10.20:
+    name: Miscelazione dell'alimentazione della fonderia
+    description: |
+      Miscelazione dei concentrati per rispettare i target di tenore e impurità dell'alimentazione della fonderia.
+  BC-4450.10.30:
+    name: Gestione dell'inventario del concentrato
+    description: |
+      Gestione dell'inventario del concentrato in piazzale, capannone e silo.
+  BC-4450.20:
+    name: Operazioni pirometallurgiche
+    description: |
+      Arrostimento, fusione, conversione e gestione delle scorie di concentrati solfuri e di ossido.
+  BC-4450.20.10:
+    name: Operazioni di arrostimento
+    description: |
+      Operazione di arrostitori a letto fluido e a più soli per l'ossidazione dei solfuri.
+  BC-4450.20.20:
+    name: Operazioni del forno di fusione
+    description: |
+      Operazione di forni di fusione a flash, elettrici e a bagno.
+  BC-4450.20.30:
+    name: Operazioni del convertitore
+    description: |
+      Operazione di convertitori Peirce-Smith, a rotazione top-blown e continui.
+  BC-4450.20.40:
+    name: Gestione delle scorie
+    description: |
+      Spillatura, granulazione, depurazione e destinazione delle scorie di forno e di convertitore.
+  BC-4450.30:
+    name: Operazioni di raffinazione elettrolitica
+    description: |
+      Operazioni di tankhouse per elettrodepositazione ed elettroraffinazione con produzione di catodo metallico.
+  BC-4450.30.10:
+    name: Operazioni di elettrodepositazione
+    description: |
+      Operazione di celle di elettrodepositazione per la produzione di catodo da elettrolito di lisciviazione.
+  BC-4450.30.20:
+    name: Operazioni di tankhouse di elettroraffinazione
+    description: |
+      Operazione di celle di elettroraffinazione per la produzione di catodo di alta purezza da anodi.
+  BC-4450.30.30:
+    name: Distacco e movimentazione del catodo
+    description: |
+      Distacco, lavaggio, pesatura e imballaggio del catodo per la vendita o la colata a valle.
+  BC-4450.40:
+    name: Recupero dei metalli sottoprodotti
+    description: |
+      Recupero di metalli preziosi e minori da fanghi anodici, polveri e flussi di sottoprodotti.
+  BC-4450.40.10:
+    name: Trattamento dei fanghi anodici
+    description: |
+      Trattamento dei fanghi anodici di elettroraffinazione per il recupero dei metalli preziosi.
+  BC-4450.40.20:
+    name: Raffinazione dei metalli preziosi
+    description: |
+      Raffinazione di oro, argento e metalli del gruppo del platino in lingotti o spugna.
+  BC-4450.40.30:
+    name: Recupero dei flussi di sottoprodotti
+    description: |
+      Recupero di selenio, tellurio, acido solforico e altri flussi di sottoprodotti.
+  BC-4450.50:
+    name: Casa di colata e finitura del prodotto
+    description: |
+      Colata, marcatura e ispezione della qualità dei prodotti metallici finiti secondo le specifiche commerciali.
+  BC-4450.50.10:
+    name: Operazioni di colata
+    description: |
+      Colata di barre, lingotti, billette, lastre e forme da metallo fuso.
+  BC-4450.50.20:
+    name: Marcatura e branding del prodotto
+    description: |
+      Marcatura, stampigliatura e applicazione del marchio sui prodotti colati per la tracciabilità e l'accettazione in borsa.
+  BC-4450.50.30:
+    name: Ispezione della qualità del metallo finito
+    description: |
+      Ispezione e certificazione del metallo finito rispetto alla specifica e ai requisiti di registrazione in borsa.
+  BC-4450.60:
+    name: Operazioni dell'impianto di gas di scarico e acido della fonderia
+    description: |
+      Pulizia dei gas di scarico della fonderia, operazioni dell'impianto di acido solforico e monitoraggio delle emissioni dal camino.
+  BC-4450.60.10:
+    name: Pulizia dei gas di scarico
+    description: |
+      Operazione di precipitatori elettrostatici, scrubber e sistemi di raffreddamento per i gas di scarico della fonderia.
+  BC-4450.60.20:
+    name: Operazioni dell'impianto di acido solforico
+    description: |
+      Operazione di impianti di acido solforico a doppio contatto e doppio assorbimento sui gas di scarico della fonderia.
+  BC-4450.60.30:
+    name: Monitoraggio delle emissioni dal camino
+    description: |
+      Monitoraggio continuo del camino per biossido di zolfo, particolato ed emissioni metalliche.
+  BC-4450.70:
+    name: Contabilità metallurgica della fonderia
+    description: |
+      Bilancio metallico, analisi per la liquidazione e contabilità del trattamento per conto terzi nell'intero complesso di fonderia.
+  BC-4450.70.10:
+    name: Bilancio metallico e analisi per la liquidazione
+    description: |
+      Riconciliazione periodica del bilancio metallico e analisi di tenore per la liquidazione dei prodotti spediti.
+  BC-4450.70.20:
+    name: Reporting del recupero e delle perdite
+    description: |
+      Reporting del recupero metallurgico e delle perdite di flusso in tutta la fonderia e la raffineria.
+  BC-4450.70.30:
+    name: Contabilità del trattamento per conto terzi
+    description: |
+      Contabilità dei concentrati di terze parti trattati per conto e del metallo di proprietà del cliente.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-software-product-engineering-management.yaml
+++ b/catalogue/i18n/it/L1-software-product-engineering-management.yaml
@@ -1,0 +1,182 @@
+# Gestione dell'ingegneria del prodotto software (it) — translations for L1-software-product-engineering-management.yaml
+locale: it
+source: L1-software-product-engineering-management.yaml
+entries:
+  BC-4200:
+    name: Gestione dell'ingegneria del prodotto software
+    description: |
+      Attività di discovery, specifica, progettazione, implementazione, code review e quality engineering
+      dei prodotti SaaS, dall'idea fino alla build pronta per il rilascio.
+  BC-4200.10:
+    name: Gestione del product discovery e del backlog
+    description: |
+      Ricerca sulle opportunità, ideazione, validazione e gestione del backlog che traducono
+      i segnali di mercato e dei clienti in un insieme di lavoro prioritizzato.
+    in_scope:
+      - Ricerca su utenti e mercato
+      - Grooming e prioritizzazione del backlog
+      - Definizione e aggiornamento della roadmap
+    out_of_scope:
+      - Analytics quantitativa di prodotto (coperta da Gestione della telemetria di prodotto e sperimentazione)
+      - Demand generation di marketing
+  BC-4200.10.10:
+    name: Ricerca utenti
+    description: |
+      Ricerca generativa e valutativa con gli utenti per individuare esigenze,
+      criticità e disponibilità a pagare.
+  BC-4200.10.20:
+    name: Raffinamento del backlog
+    description: |
+      Raffinamento continuo del backlog di prodotto, incluse la stima,
+      la scomposizione e la ri-prioritizzazione.
+  BC-4200.10.30:
+    name: Definizione della roadmap
+    description: |
+      Definizione e aggiornamento periodico della roadmap di prodotto
+      e delle aree di investimento tematiche.
+  BC-4200.10.40:
+    name: Sintesi del feedback dei clienti
+    description: |
+      Sintesi del feedback ricevuto da supporto, customer success, vendite e community
+      in segnali di prodotto azionabili.
+  BC-4200.20:
+    name: Gestione delle specifiche di prodotto
+    description: |
+      Raccolta del comportamento atteso, dei vincoli e dei criteri di accettazione
+      affinché il lavoro di sviluppo possa essere eseguito in modo prevedibile.
+    in_scope:
+      - Specifiche funzionali e non funzionali
+      - Criteri di accettazione
+    out_of_scope:
+      - Progettazione visiva e dell'interazione (coperta da Gestione del design del software)
+  BC-4200.20.10:
+    name: Specifica funzionale
+    description: |
+      Specifica del comportamento atteso e degli outcome visibili all'utente
+      per funzionalità e capacità.
+  BC-4200.20.20:
+    name: Specifica non funzionale
+    description: |
+      Specifica dei requisiti non funzionali quali disponibilità, latenza,
+      throughput e postura di sicurezza.
+  BC-4200.20.30:
+    name: Definizione dei criteri di accettazione
+    description: |
+      Definizione di criteri di accettazione verificabili che fissano il
+      significato di "completato" per funzionalità e user story.
+  BC-4200.30:
+    name: Gestione del design del software
+    description: |
+      Design della user experience, del sistema e dell'accessibilità per i prodotti software,
+      fondato su design system condivisi.
+  BC-4200.30.10:
+    name: Design dell'esperienza utente
+    description: |
+      Progettazione dell'interazione, dell'architettura informativa e del visual design
+      delle superfici di prodotto.
+  BC-4200.30.20:
+    name: Design del sistema
+    description: |
+      Progettazione architetturale di componenti software, servizi, flussi di dati
+      e interfacce esterne.
+  BC-4200.30.30:
+    name: Gestione del design system
+    description: |
+      Gestione del design system condiviso, inclusi componenti,
+      token e linee guida d'uso.
+  BC-4200.30.40:
+    name: Design per l'accessibilità
+    description: |
+      Conformità del design agli standard di accessibilità
+      su tutte le superfici di prodotto.
+  BC-4200.40:
+    name: Gestione della costruzione del software
+    description: |
+      Pratiche di implementazione, incluse la gestione del codice sorgente,
+      la code review e le discipline di programmazione collaborativa.
+  BC-4200.40.10:
+    name: Gestione del codice sorgente
+    description: |
+      Gestione dei repository sorgente, della policy di branching
+      e della proprietà del codice.
+  BC-4200.40.20:
+    name: Pratiche di code review
+    description: |
+      Revisione tra pari delle modifiche al codice rispetto agli standard
+      di ingegneria e sicurezza.
+  BC-4200.40.30:
+    name: Pratiche di pair e mob programming
+    description: |
+      Pratiche di programmazione collaborativa utilizzate per condividere
+      conoscenze e migliorare la qualità su lavori selezionati.
+  BC-4200.50:
+    name: Quality engineering del software
+    description: |
+      Strategia di test, gestione delle suite di test automatizzate e gestione
+      dei difetti per i prodotti software.
+    in_scope:
+      - Test automatizzati unitari, di integrazione ed end-to-end del prodotto
+      - Triage e risoluzione dei difetti
+    out_of_scope:
+      - Sistema di gestione della qualità a livello aziendale (coperto da Gestione della qualità)
+      - Test di performance e resilienza del servizio in esercizio (coperti da Gestione operativa della piattaforma SaaS)
+  BC-4200.50.10:
+    name: Definizione della strategia di test
+    description: |
+      Definizione della strategia di test su livelli unitari, di integrazione,
+      end-to-end ed esplorativi.
+  BC-4200.50.20:
+    name: Gestione della suite di test automatizzati
+    description: |
+      Gestione delle suite di test automatizzati, incluse copertura,
+      instabilità e tempi di esecuzione.
+  BC-4200.50.30:
+    name: Triage e risoluzione dei difetti
+    description: |
+      Triage e risoluzione dei difetti segnalati sul prodotto.
+  BC-4200.50.40:
+    name: Gestione della copertura di regressione
+    description: |
+      Gestione della copertura di regressione al crescere della superficie di prodotto.
+  BC-4200.60:
+    name: Gestione dell'open source
+    description: |
+      Utilizzo in ingresso, contribuzione in uscita e artefatti della supply chain
+      per il software open source integrato nel prodotto.
+  BC-4200.60.10:
+    name: Conformità alle licenze open source in ingresso
+    description: |
+      Conformità alle licenze open source in ingresso e agli obblighi di notifica.
+  BC-4200.60.20:
+    name: Contribuzione open source in uscita
+    description: |
+      Governance delle contribuzioni in uscita e della gestione
+      di progetti open source.
+  BC-4200.60.30:
+    name: Gestione della software bill of materials
+    description: |
+      Generazione, distribuzione e manutenzione delle software bill of materials
+      in formati standard.
+  BC-4200.70:
+    name: Gestione della produttività di sviluppo
+    description: |
+      Piattaforme interne per sviluppatori, strumenti e misurazione delle performance
+      di ingegneria che incrementano la produttività di consegna nel tempo.
+  BC-4200.70.10:
+    name: Gestione della toolchain degli sviluppatori
+    description: |
+      Selezione e gestione delle toolchain degli sviluppatori
+      nell'intera organizzazione di ingegneria.
+  BC-4200.70.20:
+    name: Gestione della piattaforma interna per sviluppatori
+    description: |
+      Gestione delle piattaforme interne che astraggono l'infrastruttura
+      e i workflow standard per gli sviluppatori.
+  BC-4200.70.30:
+    name: Metriche di performance dell'ingegneria
+    description: |
+      Misurazione delle performance di ingegneria tramite metriche di consegna
+      e di developer experience.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-software-release-deployment-management.yaml
+++ b/catalogue/i18n/it/L1-software-release-deployment-management.yaml
@@ -1,0 +1,155 @@
+# Gestione del rilascio e della distribuzione del software (it) — translations for L1-software-release-deployment-management.yaml
+locale: it
+source: L1-software-release-deployment-management.yaml
+entries:
+  BC-4210:
+    name: Gestione del rilascio e della distribuzione del software
+    description: |
+      Integrazione continua, gestione degli ambienti, release engineering,
+      feature flag e distribuzione progressiva dei prodotti SaaS in produzione.
+  BC-4210.10:
+    name: Gestione dell'integrazione continua
+    description: |
+      Pipeline di build, produzione degli artefatti e applicazione delle policy di pipeline
+      che mantengono il prodotto integrato sempre costruibile.
+  BC-4210.10.10:
+    name: Gestione della pipeline di build
+    description: |
+      Definizione e gestione delle pipeline di build automatizzate
+      per i componenti di prodotto.
+  BC-4210.10.20:
+    name: Gestione del repository degli artefatti
+    description: |
+      Archiviazione, conservazione e accesso agli artefatti di build
+      e ai pacchetti di dipendenza.
+  BC-4210.10.30:
+    name: Applicazione delle policy di pipeline
+    description: |
+      Applicazione dei gate obbligatori di qualità, sicurezza e provenienza
+      nelle pipeline.
+  BC-4210.20:
+    name: Gestione degli ambienti
+    description: |
+      Provisioning e gestione degli ambienti non di produzione utilizzati per
+      sviluppo, integrazione e validazione pre-produzione.
+  BC-4210.20.10:
+    name: Provisioning degli ambienti
+    description: |
+      Provisioning degli ambienti non di produzione in linea con
+      le esigenze di sviluppo e validazione.
+  BC-4210.20.20:
+    name: Configurazione degli ambienti
+    description: |
+      Configurazione degli ambienti non di produzione per mantenere la parità
+      con la produzione ove necessario.
+  BC-4210.20.30:
+    name: Gestione dei dati degli ambienti
+    description: |
+      Fornitura, mascheramento e aggiornamento dei dati
+      negli ambienti non di produzione.
+  BC-4210.30:
+    name: Gestione del release engineering
+    description: |
+      Cadenza, versioning, branching e disciplina delle note di rilascio
+      per i rilasci software.
+  BC-4210.30.10:
+    name: Gestione della cadenza di rilascio
+    description: |
+      Definizione e gestione della cadenza di rilascio
+      nelle diverse aree di prodotto.
+  BC-4210.30.20:
+    name: Versioning e branching
+    description: |
+      Schema di versioning e strategia di branching applicati
+      ai rilasci di prodotto.
+  BC-4210.30.30:
+    name: Redazione delle note di rilascio
+    description: |
+      Redazione delle note di rilascio rivolte a clienti e operatori
+      per ogni versione.
+  BC-4210.40:
+    name: Orchestrazione della distribuzione
+    description: |
+      Strategie per rilasciare le modifiche software in produzione in modo sicuro
+      e con un raggio d'impatto controllato.
+  BC-4210.40.10:
+    name: Rollout progressivo
+    description: |
+      Distribuzione graduale dei rilasci a coorti di tenant o utenti
+      sempre più ampie.
+  BC-4210.40.20:
+    name: Canary deployment
+    description: |
+      Distribuzione dei rilasci a una piccola popolazione canary
+      con valutazione automatica dello stato di salute.
+  BC-4210.40.30:
+    name: Blue-green deployment
+    description: |
+      Distribuzione su ambienti paralleli con deviazione del traffico
+      per modifiche con downtime quasi nullo.
+  BC-4210.40.40:
+    name: Coordinamento del rollback
+    description: |
+      Rollback coordinato dei rilasci in risposta a segnali avversi.
+  BC-4210.50:
+    name: Gestione dei feature flag
+    description: |
+      Ciclo di vita e controllo a runtime dei feature flag utilizzati per disaccoppiare
+      la distribuzione dal rilascio e indirizzare le funzionalità a coorti specifiche.
+    in_scope:
+      - Creazione, ritiro e audit dei feature flag
+      - Regole di targeting
+    out_of_scope:
+      - Metodologia di sperimentazione e aggiudicazione (coperta da Gestione della telemetria di prodotto e sperimentazione)
+  BC-4210.50.10:
+    name: Ciclo di vita dei feature flag
+    description: |
+      Ciclo di vita dei feature flag dalla creazione al ritiro.
+  BC-4210.50.20:
+    name: Gestione delle regole di targeting
+    description: |
+      Definizione delle regole di targeting che determinano quali soggetti
+      ricevono una variante del flag.
+  BC-4210.50.30:
+    name: Gestione dell'igiene dei feature flag
+    description: |
+      Pratiche di igiene che ritirano i flag obsoleti e prevengono
+      l'accumulo di codice condizionale inattivo.
+  BC-4210.60:
+    name: Gestione della configurazione e dei segreti
+    description: |
+      Gestione dei valori di configurazione a runtime e dei segreti
+      consumati dai servizi di prodotto.
+  BC-4210.60.10:
+    name: Gestione della configurazione a runtime
+    description: |
+      Archiviazione, distribuzione e audit dei valori di configurazione
+      a runtime.
+  BC-4210.60.20:
+    name: Gestione del ciclo di vita dei segreti
+    description: |
+      Emissione, rotazione e revoca dei segreti utilizzati
+      dai servizi di prodotto.
+  BC-4210.70:
+    name: Autorizzazione delle modifiche in produzione
+    description: |
+      Revisione pre-distribuzione, governance delle finestre di deployment
+      e autorizzazione degli accessi umani alla produzione.
+  BC-4210.70.10:
+    name: Revisione pre-distribuzione
+    description: |
+      Revisione e approvazione delle modifiche prima della distribuzione
+      in produzione.
+  BC-4210.70.20:
+    name: Governance delle finestre di deployment
+    description: |
+      Governance delle finestre di distribuzione consentite
+      e dei periodi di blocco.
+  BC-4210.70.30:
+    name: Autorizzazione degli accessi in produzione
+    description: |
+      Autorizzazione, concessione just-in-time e audit degli accessi
+      umani ai sistemi di produzione.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-spare-parts-aftermarket-management.yaml
+++ b/catalogue/i18n/it/L1-spare-parts-aftermarket-management.yaml
@@ -1,0 +1,127 @@
+# Gestione dei ricambi e del post-vendita (it) — translations for L1-spare-parts-aftermarket-management.yaml
+locale: it
+source: L1-spare-parts-aftermarket-management.yaml
+entries:
+  BC-1060:
+    name: Gestione dei ricambi e del post-vendita
+    description: |
+      Fornitura di ricambi, vendite post-vendita e servizi per la base installata.
+  BC-1060.10:
+    name: Gestione del catalogo ricambi
+    description: |
+      Catalogo, identificazione e sostituzione ricambio.
+  BC-1060.10.10:
+    name: Identificazione dei ricambi
+    description: |
+      Identificazione dei ricambi, inclusi i cataloghi illustrati delle parti.
+  BC-1060.10.20:
+    name: Gestione della sostituzione ricambio
+    description: |
+      Gestione delle sostituzioni e delle equivalenze di ricambi.
+  BC-1060.10.30:
+    name: Pubblicazione del catalogo
+    description: |
+      Pubblicazione e distribuzione dei cataloghi ricambi.
+  BC-1060.20:
+    name: Gestione della tariffazione ricambi
+    description: |
+      Strategia di tariffazione, listini prezzi e tariffazione specifica per cliente.
+  BC-1060.20.10:
+    name: Strategia di tariffazione ricambi
+    description: |
+      Strategia di tariffazione e segmentazione per i ricambi.
+  BC-1060.20.20:
+    name: Definizione dei prezzi dei ricambi
+    description: |
+      Definizione dei listini prezzi e tariffazione basata sul valore per i ricambi.
+  BC-1060.20.30:
+    name: Tariffazione ricambi specifica per cliente
+    description: |
+      Tariffazione personalizzata e a contratto per cliente per i ricambi.
+  BC-1060.30:
+    name: Previsione della domanda di ricambi
+    description: |
+      Previsione della domanda di ricambi (a bassa rotazione, domanda intermittente).
+  BC-1060.30.10:
+    name: Previsione della domanda intermittente
+    description: |
+      Previsione della domanda di ricambi a bassa rotazione e intermittenti.
+  BC-1060.30.20:
+    name: Previsione basata sulla base installata
+    description: |
+      Previsione della domanda guidata dai dati della base installata.
+  BC-1060.30.30:
+    name: Piano di stoccaggio ricambi
+    description: |
+      Piani di stoccaggio ricambi nei centri di distribuzione.
+  BC-1060.40:
+    name: Gestione delle vendite post-vendita
+    description: |
+      Vendite commerciali post-vendita, rinnovi e upselling.
+  BC-1060.40.10:
+    name: Generazione di contatti post-vendita
+    description: |
+      Generazione di contatti post-vendita dai dati della base installata.
+  BC-1060.40.20:
+    name: Gestione degli ordini post-vendita
+    description: |
+      Acquisizione ed elaborazione degli ordini post-vendita.
+  BC-1060.40.30:
+    name: Cross-selling e upselling post-vendita
+    description: |
+      Cross-selling e upselling di prodotti e servizi post-vendita.
+  BC-1060.50:
+    name: Gestione dell'assistenza e riparazione
+    description: |
+      Riparazioni, unità di scambio e ricondizionamento.
+  BC-1060.50.10:
+    name: Operazioni del laboratorio di riparazione
+    description: |
+      Gestione dei laboratori centrali di riparazione.
+  BC-1060.50.20:
+    name: Gestione del parco unità di scambio
+    description: |
+      Gestione del parco unità di scambio e dei componenti riparabili.
+  BC-1060.50.30:
+    name: Operazioni di ricondizionamento
+    description: |
+      Ricondizionamento, revisione e ricertificazione dei ricambi restituiti.
+  BC-1060.60:
+    name: Gestione della garanzia
+    description: |
+      Diritti di garanzia, reclami e recupero costi.
+  BC-1060.60.10:
+    name: Gestione delle politiche di garanzia
+    description: |
+      Definizione delle condizioni, dei periodi e delle esclusioni di garanzia.
+  BC-1060.60.20:
+    name: Elaborazione dei reclami in garanzia
+    description: |
+      Acquisizione e valutazione dei reclami in garanzia dei clienti.
+  BC-1060.60.30:
+    name: Recupero della garanzia dai fornitori
+    description: |
+      Recupero dei costi di garanzia dai fornitori.
+  BC-1060.60.40:
+    name: Gestione dei fondi di garanzia
+    description: |
+      Stima e contabilizzazione dei fondi di garanzia.
+  BC-1060.70:
+    name: Gestione della base installata
+    description: |
+      Dati della base installata, connettività degli asset e analisi del ciclo di vita.
+  BC-1060.70.10:
+    name: Gestione dei dati della base installata
+    description: |
+      Acquisizione e gestione dei dati della base installata.
+  BC-1060.70.20:
+    name: Operazioni degli asset connessi
+    description: |
+      Gestione degli asset connessi e telemetria IoT.
+  BC-1060.70.30:
+    name: Analisi della base installata
+    description: |
+      Analisi dell'utilizzo, delle condizioni e del ciclo di vita della base installata.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-specialty-formulation-blending-management.yaml
+++ b/catalogue/i18n/it/L1-specialty-formulation-blending-management.yaml
@@ -1,0 +1,136 @@
+# Gestione della formulazione specialistica e miscelazione (it) — translations for L1-specialty-formulation-blending-management.yaml
+locale: it
+source: L1-specialty-formulation-blending-management.yaml
+entries:
+  BC-4630:
+    name: Gestione della formulazione specialistica e miscelazione
+    description: |
+      Formulazione, miscelazione, compounding, riempimento e finitura di
+      prodotti chimici specialistici, inclusi rivestimenti, adesivi,
+      agroformulati, lubrificanti, tensioattivi e fini chimici.
+  BC-4630.10:
+    name: Progettazione e sviluppo della formulazione
+    description: |
+      Definizione delle specifiche, selezione delle materie prime, prove
+      a scala laboratorio e ottimizzazione dei costi delle formulazioni
+      specialistiche.
+  BC-4630.10.10:
+    name: Sviluppo delle specifiche di formulazione
+    description: |
+      Sviluppo delle specifiche di formulazione rispetto ai target applicativi.
+  BC-4630.10.20:
+    name: Selezione delle materie prime
+    description: |
+      Selezione delle materie prime in base a prestazioni, costo e requisiti HSE.
+  BC-4630.10.30:
+    name: Prove di formulazione a scala laboratorio
+    description: |
+      Preparazione e caratterizzazione a scala laboratorio delle formulazioni
+      candidate.
+  BC-4630.10.40:
+    name: Ottimizzazione dei costi di formulazione
+    description: |
+      Ottimizzazione dei costi di formulazione nel rispetto dei vincoli
+      di specifica.
+  BC-4630.20:
+    name: Operazioni di miscelazione
+    description: |
+      Conduzione di asset per la miscelazione di liquidi, solidi, emulsioni
+      e dispersioni.
+  BC-4630.20.10:
+    name: Operazioni di miscelazione di liquidi
+    description: |
+      Miscelazione in serbatoio e in linea di prodotti chimici liquidi.
+  BC-4630.20.20:
+    name: Operazioni di miscelazione di solidi
+    description: |
+      Miscelazione a nastro, a cono V e a tamburo di formulazioni solide.
+  BC-4630.20.30:
+    name: Operazioni di emulsificazione
+    description: |
+      Produzione di emulsioni mediante omogeneizzatori a rotore-statore
+      e ad alta pressione.
+  BC-4630.20.40:
+    name: Operazioni di dispersione e macinazione
+    description: |
+      Conduzione di mulini a sfere, mulini a tre cilindri e dispersori.
+  BC-4630.30:
+    name: Operazioni di compounding ed estrusione
+    description: |
+      Compounding di polimeri, produzione di masterbatch ed estrusione
+      di semilavorati specialistici.
+  BC-4630.30.10:
+    name: Compounding di polimeri
+    description: |
+      Compounding di polimeri con cariche, stabilizzanti e additivi.
+  BC-4630.30.20:
+    name: Produzione di masterbatch
+    description: |
+      Produzione di masterbatch coloranti, additivanti e funzionali.
+  BC-4630.30.30:
+    name: Operazioni di estrusione
+    description: |
+      Conduzione di linee di estrusione a vite singola e doppia.
+  BC-4630.40:
+    name: Operazioni di riempimento e confezionamento
+    description: |
+      Riempimento di prodotti specialistici in contenitori alla rinfusa,
+      fusti, IBC, confezioni di piccolo formato e contenitori pressurizzati.
+  BC-4630.40.10:
+    name: Riempimento di contenitori alla rinfusa
+    description: |
+      Riempimento di contenitori stradali, ferroviari e cisterne ISO alla rinfusa.
+  BC-4630.40.20:
+    name: Riempimento di fusti e IBC
+    description: |
+      Riempimento di fusti in acciaio e plastica e di contenitori intermedi
+      per liquidi sfusi.
+  BC-4630.40.30:
+    name: Riempimento di confezioni di piccolo formato
+    description: |
+      Riempimento ad alta velocità di flaconi, taniche e confezioni per
+      il consumatore.
+  BC-4630.40.40:
+    name: Riempimento di aerosol e contenitori pressurizzati
+    description: |
+      Riempimento e aggraffatura di bombolette aerosol e contenitori
+      pressurizzati.
+  BC-4630.50:
+    name: Test di prestazione della formulazione
+    description: |
+      Test di prestazione applicativa, stabilità e benchmarking delle
+      formulazioni specialistiche.
+  BC-4630.50.10:
+    name: Test di prestazione applicativa
+    description: |
+      Test delle formulazioni in condizioni simulate di utilizzo finale.
+  BC-4630.50.20:
+    name: Test di stabilità e durata
+    description: |
+      Test di stabilità e durata in tempo reale e accelerati.
+  BC-4630.50.30:
+    name: Benchmarking comparativo
+    description: |
+      Confronto diretto delle formulazioni rispetto ai prodotti della concorrenza.
+  BC-4630.60:
+    name: Gestione delle ricette specialistiche
+    description: |
+      Redazione della ricetta madre, controllo delle versioni e localizzazione
+      per la produzione di formulazioni in più siti.
+  BC-4630.60.10:
+    name: Manutenzione della ricetta madre
+    description: |
+      Redazione e manutenzione delle ricette madri secondo le convenzioni ISA-88.
+  BC-4630.60.20:
+    name: Controllo delle versioni delle ricette
+    description: |
+      Controllo delle versioni delle ricette attraverso i cicli di approvazione
+      e revisione.
+  BC-4630.60.30:
+    name: Localizzazione delle ricette
+    description: |
+      Localizzazione delle ricette madri per le apparecchiature specifiche
+      del sito.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-spectrum-frequency-management.yaml
+++ b/catalogue/i18n/it/L1-spectrum-frequency-management.yaml
@@ -1,0 +1,91 @@
+# Gestione dello spettro e delle frequenze (it) — translations for L1-spectrum-frequency-management.yaml
+locale: it
+source: L1-spectrum-frequency-management.yaml
+entries:
+  BC-2670:
+    name: Gestione dello spettro e delle frequenze
+    description: |
+      Gestione del portafoglio spettrale dell'operatore — acquisizione e rinnovo delle licenze, pianificazione e coordinamento delle frequenze, gestione delle interferenze e operazioni di spettro in accesso condiviso.
+  BC-2670.10:
+    name: Gestione del portafoglio spettrale
+    description: |
+      Manutenzione del registro delle disponibilità spettrali e supervisione delle decisioni strategiche sullo spettro.
+  BC-2670.10.10:
+    name: Registro delle disponibilità spettrali
+    description: |
+      Manutenzione del registro autorevole delle disponibilità spettrali dell'operatore per banda, area geografica e licenza spettrale.
+  BC-2670.10.20:
+    name: Valorizzazione dello spettro
+    description: |
+      Valorizzazione delle disponibilità spettrali per decisioni finanziarie, di M&A e d'asta.
+  BC-2670.10.30:
+    name: Negoziazione dello spettro
+    description: |
+      Acquisizione, cessione e locazione di diritti spettrali con altri operatori ove consentito dai regolatori.
+  BC-2670.20:
+    name: Gestione delle licenze spettrali
+    description: |
+      Gestione end-to-end delle licenze spettrali dalla partecipazione alle aste fino al rinnovo e alla reportistica di conformità.
+  BC-2670.20.10:
+    name: Acquisizione della licenza spettrale
+    description: |
+      Partecipazione ad aste, beauty contest e allocazioni bilaterali di spettro.
+  BC-2670.20.20:
+    name: Rinnovo della licenza spettrale
+    description: |
+      Gestione del rinnovo delle licenze spettrali rispetto ai calendari di scadenza.
+  BC-2670.20.30:
+    name: Reporting di conformità della licenza
+    description: |
+      Reporting rispetto alle condizioni della licenza spettrale, inclusi gli obblighi di copertura e dispiegamento.
+  BC-2670.30:
+    name: Pianificazione e coordinamento delle frequenze
+    description: |
+      Allocazione di canali e frequenze agli elementi di rete e coordinamento con gli utenti adiacenti.
+  BC-2670.30.10:
+    name: Assegnazione delle frequenze alle celle
+    description: |
+      Assegnazione di frequenze e PCI alle singole celle radio.
+  BC-2670.30.20:
+    name: Pianificazione dei canali
+    description: |
+      Pianificazione delle assegnazioni di canale per l'accesso radio e i collegamenti in microonde.
+  BC-2670.30.30:
+    name: Pianificazione delle celle adiacenti
+    description: |
+      Definizione delle relazioni di vicinanza per la gestione degli handover e delle interferenze.
+  BC-2670.40:
+    name: Gestione delle interferenze spettrali
+    description: |
+      Rilevamento, analisi e risoluzione delle interferenze spettrali dannose, in coordinamento con i regolatori.
+  BC-2670.40.10:
+    name: Rilevamento delle interferenze
+    description: |
+      Rilevamento delle interferenze dannose da sorgenti interne ed esterne.
+  BC-2670.40.20:
+    name: Risoluzione delle interferenze
+    description: |
+      Analisi e risoluzione dei casi di interferenza identificati.
+  BC-2670.40.30:
+    name: Coordinamento con i regolatori
+    description: |
+      Coordinamento con i regolatori nazionali sulle interferenze tra licenziatari e l'applicazione delle norme.
+  BC-2670.50:
+    name: Gestione della condivisione dello spettro
+    description: |
+      Operazione di regimi di condivisione dello spettro dinamica e di accesso condiviso quali CBRS.
+  BC-2670.50.10:
+    name: Condivisione dinamica dello spettro
+    description: |
+      Operazione della condivisione in stile DSS tra tecnologie radio sulla stessa banda.
+  BC-2670.50.20:
+    name: Coordinamento dell'accesso condiviso
+    description: |
+      Coordinamento con piattaforme di accesso condiviso quali SAS e AFC per l'ottenimento delle concessioni di canale.
+  BC-2670.50.30:
+    name: Coordinamento dell'uso secondario
+    description: |
+      Coordinamento con i licenziatari primari e i titolari di diritti preesistenti nei regimi di uso secondario.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-strategic-management.yaml
+++ b/catalogue/i18n/it/L1-strategic-management.yaml
@@ -1,0 +1,111 @@
+# Gestione strategica (it) — translations for L1-strategic-management.yaml
+locale: it
+source: L1-strategic-management.yaml
+entries:
+  BC-100:
+    name: Gestione strategica
+    description: |
+      Definizione della direzione d'impresa, visione, missione e obiettivi a lungo termine.
+  BC-100.10:
+    name: Pianificazione strategica
+    description: |
+      Formulazione di visione, missione, obiettivi strategici e piano a lungo termine.
+  BC-100.10.10:
+    name: Definizione di visione e missione
+    description: |
+      Articolazione della visione, missione e valori fondamentali dell'impresa.
+  BC-100.10.20:
+    name: Analisi dell'ambiente esterno e interno
+    description: |
+      Analisi esterna e interna tramite PESTLE, SWOT e intelligence competitiva.
+  BC-100.10.30:
+    name: Formulazione delle scelte strategiche
+    description: |
+      Valutazione delle opzioni strategiche e selezione della direzione strategica.
+  BC-100.10.40:
+    name: Sviluppo del piano a lungo termine
+    description: |
+      Piano pluriennale con obiettivi strategici, target e allocazione del capitale.
+  BC-100.10.50:
+    name: Pianificazione per scenario
+    description: |
+      Scenari futuri plausibili e strategie di contingenza.
+  BC-100.20:
+    name: Gestione dell'esecuzione della strategia
+    description: |
+      Traduzione della strategia in obiettivi, OKR e balanced scorecard.
+  BC-100.20.10:
+    name: Cascading degli obiettivi strategici
+    description: |
+      Traduzione della strategia d'impresa in obiettivi di business unit e funzionali.
+  BC-100.20.20:
+    name: Gestione della scorecard di performance
+    description: |
+      Balanced scorecard, OKR, definizione e monitoraggio dei KPI.
+  BC-100.20.30:
+    name: Revisione e riallineamento della strategia
+    description: |
+      Cicli periodici di revisione della strategia e correzione del percorso.
+  BC-100.20.40:
+    name: Governance delle iniziative strategiche
+    description: |
+      Governance a stage-gate sulle iniziative strategiche.
+  BC-100.30:
+    name: Gestione dello sviluppo aziendale
+    description: |
+      M&A, dismissioni, joint venture e partnership.
+  BC-100.30.10:
+    name: Esecuzione di fusioni e acquisizioni
+    description: |
+      Selezione dei target, due diligence, strutturazione e chiusura delle operazioni.
+  BC-100.30.20:
+    name: Gestione delle dismissioni
+    description: |
+      Carve-out, separazioni e cessioni di asset e entità.
+  BC-100.30.30:
+    name: Gestione di joint venture e alleanze
+    description: |
+      Costituzione e governo di joint venture, alleanze e partnership strategiche.
+  BC-100.30.40:
+    name: Integrazione post-acquisizione
+    description: |
+      Pianificazione dell'integrazione e realizzazione delle sinergie a seguito di M&A.
+  BC-100.40:
+    name: Gestione del portafoglio strategico
+    description: |
+      Portafoglio delle iniziative strategiche a livello d'impresa.
+  BC-100.40.10:
+    name: Definizione del portafoglio di iniziative
+    description: |
+      Inventario e categorizzazione delle iniziative strategiche.
+  BC-100.40.20:
+    name: Prioritizzazione del portafoglio
+    description: |
+      Scoring, selezione e prioritizzazione delle iniziative rispetto alla strategia.
+  BC-100.40.30:
+    name: Allocazione degli investimenti
+    description: |
+      Allocazione di capitale, persone e capacità nell'ambito del portafoglio.
+  BC-100.40.40:
+    name: Monitoraggio della performance del portafoglio
+    description: |
+      Monitoraggio della realizzazione dei benefici e dello stato del portafoglio.
+  BC-100.50:
+    name: Gestione del modello di business
+    description: |
+      Definizione, evoluzione e innovazione del modello di business.
+  BC-100.50.10:
+    name: Progettazione del modello di business
+    description: |
+      Articolazione della proposta di valore, dei segmenti di mercato e del modello di ricavo.
+  BC-100.50.20:
+    name: Innovazione del modello di business
+    description: |
+      Esplorazione e prototipazione di modelli di business nuovi o adiacenti.
+  BC-100.50.30:
+    name: Valutazione della performance del modello di business
+    description: |
+      Valutazione degli unit economics, della scalabilità e dell'adeguatezza del modello.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-student-enrolment-records-management.yaml
+++ b/catalogue/i18n/it/L1-student-enrolment-records-management.yaml
@@ -1,0 +1,151 @@
+# Gestione delle iscrizioni e dei registri degli studenti (it) — translations for L1-student-enrolment-records-management.yaml
+locale: it
+source: L1-student-enrolment-records-management.yaml
+entries:
+  BC-4720:
+    name: Gestione delle iscrizioni e dei registri degli studenti
+    description: |
+      Amministrazione del ciclo di vita attivo degli studenti dall'iscrizione e registrazione
+      attraverso i registri accademici, i trascritti accademici, il trasferimento dei crediti e la laurea,
+      nonché la gestione dei dati identificativi degli studenti.
+  BC-4720.10:
+    name: Iscrizione e registrazione
+    description: |
+      Iscrizione e registrazione ai corsi degli studenti ammessi per ogni periodo accademico,
+      incluse le modifiche al piano di studi e la continuazione tra i periodi.
+    in_scope:
+      - Registrazione ai corsi
+      - Aggiunta/abbandono di corsi e modifica del piano di studi
+      - Re-iscrizione e continuazione
+    out_of_scope:
+      - Decisioni iniziali di ammissione (trattate in Gestione del reclutamento e dell'ammissione degli studenti)
+  BC-4720.10.10:
+    name: Registrazione ai corsi
+    description: |
+      Registrazione degli studenti a corsi, sezioni e unità didattiche.
+  BC-4720.10.20:
+    name: Aggiunta e abbandono dei corsi e modifica del piano di studi
+    description: |
+      Elaborazione delle aggiunte e degli abbandoni dei corsi e delle modifiche al piano di studi entro le finestre stabilite.
+  BC-4720.10.30:
+    name: Re-iscrizione e continuazione
+    description: |
+      Re-iscrizione e continuazione tra periodi e anni accademici.
+  BC-4720.20:
+    name: Gestione del registro accademico
+    description: |
+      Manutenzione dei registri accademici degli studenti, inclusi voti,
+      trascritti accademici e determinazione della posizione accademica.
+    in_scope:
+      - Registrazione di voti e risultati
+      - Produzione del trascritto accademico
+      - Determinazione della posizione accademica
+    out_of_scope:
+      - Il processo di correzione stesso (trattato in Gestione della valutazione e degli esami)
+  BC-4720.20.10:
+    name: Registrazione di voti e risultati
+    description: |
+      Registrazione ufficiale di voti e risultati nel registro degli studenti.
+  BC-4720.20.20:
+    name: Produzione del trascritto accademico
+    description: |
+      Produzione ed emissione di trascritti accademici ufficiali e non ufficiali.
+  BC-4720.20.30:
+    name: Determinazione della posizione accademica
+    description: |
+      Determinazione della posizione accademica, dei riconoscimenti, del periodo di prova e dell'esclusione.
+  BC-4720.30:
+    name: Registri degli orari e della pianificazione dei corsi
+    description: |
+      Registri ufficiali degli orari delle sezioni dei corsi, dell'assegnazione delle aule
+      e delle decisioni di risoluzione dei conflitti utilizzati a valle dall'iscrizione.
+    in_scope:
+      - Registri degli orari per sezione e coorte
+      - Registri di assegnazione di aule e strutture
+      - Registri della risoluzione dei conflitti negli orari
+    out_of_scope:
+      - Erogazione quotidiana delle lezioni (trattata in Gestione delle operazioni didattiche e di apprendimento)
+  BC-4720.30.10:
+    name: Registri degli orari per sezione e coorte
+    description: |
+      Registri ufficiali degli orari per sezione e coorte.
+  BC-4720.30.20:
+    name: Registri di assegnazione di aule e strutture
+    description: |
+      Registri dell'assegnazione delle aule didattiche e delle strutture alle sessioni in orario.
+  BC-4720.30.30:
+    name: Registri della risoluzione dei conflitti negli orari
+    description: |
+      Registri dei conflitti negli orari identificati e risolti.
+  BC-4720.40:
+    name: Trasferimento dei crediti e riconoscimento
+    description: |
+      Valutazione e registrazione dei crediti trasferiti da altri istituti,
+      riconoscimento dell'apprendimento pregresso e applicazione degli accordi di articolazione.
+    in_scope:
+      - Valutazione dei crediti trasferiti
+      - Riconoscimento dell'apprendimento pregresso (RPL)
+      - Applicazione degli accordi di articolazione
+    out_of_scope:
+      - Valutazione delle credenziali internazionali in fase di ammissione (trattata in Gestione del reclutamento e dell'ammissione degli studenti)
+  BC-4720.40.10:
+    name: Valutazione dei crediti trasferiti
+    description: |
+      Valutazione dei crediti conseguiti presso altri istituti rispetto ai programmi dell'istituzione ospitante.
+  BC-4720.40.20:
+    name: Riconoscimento dell'apprendimento pregresso
+    description: |
+      Riconoscimento dell'apprendimento esperienziale e informale pregresso ai fini del credito.
+  BC-4720.40.30:
+    name: Applicazione degli accordi di articolazione
+    description: |
+      Applicazione degli accordi di articolazione inter-istituzionali ai registri degli studenti.
+  BC-4720.50:
+    name: Laurea e conferimento delle credenziali
+    description: |
+      Verifica dell'idoneità alla laurea, conferimento dei titoli ed emissione
+      di credenziali verificabili, diplomi e certificati.
+    in_scope:
+      - Verifica dell'idoneità alla laurea
+      - Conferimento del titolo
+      - Emissione delle credenziali e verifica a valle
+    out_of_scope:
+      - Elaborazione dei risultati degli esami (trattata in Gestione della valutazione e degli esami)
+  BC-4720.50.10:
+    name: Verifica dell'idoneità alla laurea
+    description: |
+      Verifica del registro degli studenti rispetto ai requisiti per la laurea.
+  BC-4720.50.20:
+    name: Conferimento del titolo
+    description: |
+      Conferimento formale di lauree e qualifiche.
+  BC-4720.50.30:
+    name: Emissione e verifica delle credenziali
+    description: |
+      Emissione e verifica di credenziali cartacee e digitali, incluse le credenziali verificabili.
+  BC-4720.60:
+    name: Identificativi degli studenti e registri del ciclo di vita
+    description: |
+      Manutenzione degli identificativi degli studenti, dei flag di stato dell'iscrizione
+      e dei registri di ritiro e congedo che supportano le azioni amministrative a valle.
+    in_scope:
+      - Gestione del ciclo di vita degli identificativi degli studenti
+      - Manutenzione dello stato di iscrizione
+      - Registri di ritiro e congedo
+    out_of_scope:
+      - Autenticazione dell'identità e accesso (trattati in Gestione della sicurezza informatica)
+  BC-4720.60.10:
+    name: Ciclo di vita dell'identità dello studente
+    description: |
+      Ciclo di vita degli identificativi univoci degli studenti dall'emissione alla chiusura.
+  BC-4720.60.20:
+    name: Manutenzione dello stato di iscrizione
+    description: |
+      Manutenzione dei flag ufficiali dello stato di iscrizione (attivo, in congedo, ritirato).
+  BC-4720.60.30:
+    name: Registri di ritiro e congedo
+    description: |
+      Registri di ritiri, congedi e re-ammissioni degli studenti.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-student-recruitment-admissions-management.yaml
+++ b/catalogue/i18n/it/L1-student-recruitment-admissions-management.yaml
@@ -1,0 +1,149 @@
+# Gestione del reclutamento e dell'ammissione degli studenti (it) — translations for L1-student-recruitment-admissions-management.yaml
+locale: it
+source: L1-student-recruitment-admissions-management.yaml
+entries:
+  BC-4710:
+    name: Gestione del reclutamento e dell'ammissione degli studenti
+    description: |
+      Attrazione, elaborazione delle domande, decisione e conversione end-to-end dei candidati
+      in studenti iscritti, inclusa la gestione delle offerte di aiuto finanziario e delle ammissioni internazionali.
+  BC-4710.10:
+    name: Contatto con i candidati e reclutamento
+    description: |
+      Reclutamento in uscita di potenziali studenti tramite campagne, eventi e attività di lead generation.
+    in_scope:
+      - Campagne di reclutamento e gestione delle richieste in entrata
+      - Open day, fiere e visite al campus
+      - Acquisizione e sviluppo dei lead di potenziali studenti
+    out_of_scope:
+      - Marketing istituzionale generale del brand (trattato in Gestione del marketing)
+  BC-4710.10.10:
+    name: Operazioni di campagna di reclutamento
+    description: |
+      Pianificazione ed esecuzione di campagne di reclutamento studentesco su più canali.
+  BC-4710.10.20:
+    name: Operazioni open day e visite al campus
+    description: |
+      Organizzazione di open day, sessioni di orientamento e visite di potenziali studenti.
+  BC-4710.10.30:
+    name: Gestione dei lead di potenziali studenti
+    description: |
+      Acquisizione, sviluppo e qualificazione dei lead di potenziali studenti.
+  BC-4710.20:
+    name: Gestione delle domande
+    description: |
+      Ricezione ed elaborazione delle domande di potenziali studenti,
+      inclusa la documentazione di supporto e le comunicazioni con i candidati.
+    in_scope:
+      - Ricezione e validazione delle domande
+      - Verifica dei documenti e delle referenze
+      - Comunicazione dello stato della domanda
+    out_of_scope:
+      - Decisione di ammissione (trattata in Decisione di ammissione)
+  BC-4710.20.10:
+    name: Ricezione e validazione delle domande
+    description: |
+      Ricezione e verifica della completezza delle domande su tutti i canali.
+  BC-4710.20.20:
+    name: Verifica dei documenti di supporto
+    description: |
+      Verifica di trascritti accademici, referenze e documenti di supporto.
+  BC-4710.20.30:
+    name: Comunicazione dello stato della domanda
+    description: |
+      Comunicazione ai candidati dell'avanzamento della loro domanda.
+  BC-4710.30:
+    name: Decisione di ammissione
+    description: |
+      Valutazione, scoring, revisione del comitato ed emissione delle decisioni di ammissione
+      rispetto ai criteri di accesso pubblicati.
+    in_scope:
+      - Valutazione e scoring delle ammissioni
+      - Revisione del comitato di ammissione
+      - Emissione delle decisioni di ammissione
+    out_of_scope:
+      - Assegnazione degli aiuti finanziari (trattata in Gestione degli aiuti finanziari e delle borse di studio)
+  BC-4710.30.10:
+    name: Valutazione e scoring delle ammissioni
+    description: |
+      Valutazione e scoring dei candidati rispetto ai criteri di accesso.
+  BC-4710.30.20:
+    name: Revisione del comitato di ammissione
+    description: |
+      Revisione da parte di comitati o panel delle domande borderline e competitive.
+  BC-4710.30.30:
+    name: Emissione della decisione
+    description: |
+      Emissione di offerte, offerte condizionate, liste d'attesa e rifiuti.
+  BC-4710.40:
+    name: Gestione degli aiuti finanziari e delle borse di studio
+    description: |
+      Determinazione, assegnazione ed erogazione di aiuti finanziari, borse di studio,
+      sussidi e sovvenzioni a supporto dell'accesso e dell'accessibilità economica.
+    in_scope:
+      - Valutazione dell'idoneità agli aiuti finanziari
+      - Amministrazione delle borse di studio
+      - Erogazione di sussidi e sovvenzioni
+    out_of_scope:
+      - Conformità al finanziamento pubblico (trattata in Gestione della conformità normativa nel settore dell'istruzione)
+  BC-4710.40.10:
+    name: Valutazione dell'idoneità agli aiuti finanziari
+    description: |
+      Valutazione dell'idoneità agli aiuti finanziari basati sul bisogno e sul merito.
+  BC-4710.40.20:
+    name: Amministrazione delle borse di studio
+    description: |
+      Amministrazione delle borse di studio da fonti interne ed esterne.
+  BC-4710.40.30:
+    name: Erogazione di sussidi e sovvenzioni
+    description: |
+      Erogazione di sussidi, sovvenzioni e pagamenti a supporto delle rette.
+  BC-4710.50:
+    name: Conversione delle offerte in iscrizioni
+    description: |
+      Conversione delle offerte di ammissione in iscrizioni confermate, inclusa
+      la gestione delle accettazioni, l'onboarding pre-iscrizione e le analisi di conversione.
+    in_scope:
+      - Monitoraggio dell'accettazione delle offerte
+      - Attività di onboarding pre-iscrizione
+      - Analisi del rendimento delle offerte e della conversione
+    out_of_scope:
+      - Iscrizione e registrazione attiva (trattate in Gestione delle iscrizioni e dei registri degli studenti)
+  BC-4710.50.10:
+    name: Emissione delle offerte e monitoraggio delle accettazioni
+    description: |
+      Emissione delle offerte e monitoraggio di accettazioni, rifiuti e rinvii.
+  BC-4710.50.20:
+    name: Onboarding pre-iscrizione
+    description: |
+      Attività di onboarding completate dagli studenti ammessi prima dell'iscrizione formale.
+  BC-4710.50.30:
+    name: Analisi del rendimento delle offerte e della conversione
+    description: |
+      Analisi del rendimento delle offerte, del tasso di abbandono e delle prestazioni di conversione.
+  BC-4710.60:
+    name: Gestione delle ammissioni internazionali
+    description: |
+      Gestione specializzata dei candidati internazionali, inclusa la valutazione delle credenziali,
+      la competenza linguistica e la documentazione per il visto di soggiorno.
+    in_scope:
+      - Valutazione delle credenziali internazionali
+      - Valutazione della competenza in lingua inglese
+      - Generazione della documentazione per il visto di soggiorno
+    out_of_scope:
+      - Conformità continua al visto per studenti iscritti (trattata in Gestione della conformità normativa nel settore dell'istruzione)
+  BC-4710.60.10:
+    name: Valutazione delle credenziali internazionali
+    description: |
+      Valutazione dei titoli accademici stranieri rispetto all'equivalenza nazionale.
+  BC-4710.60.20:
+    name: Valutazione della competenza in lingua inglese
+    description: |
+      Valutazione della competenza in lingua inglese per i candidati non madrelingua.
+  BC-4710.60.30:
+    name: Documentazione per il visto di soggiorno
+    description: |
+      Emissione della documentazione per il visto di soggiorno (es. I-20, CAS) agli studenti ammessi.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-student-support-wellbeing-management.yaml
+++ b/catalogue/i18n/it/L1-student-support-wellbeing-management.yaml
@@ -1,0 +1,153 @@
+# Gestione del supporto e del benessere degli studenti (it) — translations for L1-student-support-wellbeing-management.yaml
+locale: it
+source: L1-student-support-wellbeing-management.yaml
+entries:
+  BC-4770:
+    name: Gestione del supporto e del benessere degli studenti
+    description: |
+      Servizi non didattici a supporto del successo e del benessere degli studenti,
+      inclusi orientamento accademico, consulenza psicologica, accomodamenti per la disabilità,
+      servizi carriere e supporto tutoriale.
+  BC-4770.10:
+    name: Orientamento accademico
+    description: |
+      Orientamento degli studenti sulla pianificazione del programma, la scelta dei corsi
+      e la progressione accademica, incluso il supporto per i discenti a rischio.
+    in_scope:
+      - Orientamento sulla pianificazione del programma
+      - Orientamento per gli studenti a rischio
+      - Supporto in caso di periodo di prova accademica
+    out_of_scope:
+      - Orientamento professionale (trattato in Servizi carriere e placement)
+      - Consulenza psicologica per la salute mentale (trattata in Servizi di consulenza e salute mentale)
+  BC-4770.10.10:
+    name: Orientamento sulla pianificazione del programma
+    description: |
+      Orientamento sulla struttura del programma, la scelta dei corsi e i percorsi verso la laurea.
+  BC-4770.10.20:
+    name: Orientamento per gli studenti a rischio
+    description: |
+      Orientamento mirato per gli studenti segnalati come accademicamente a rischio.
+  BC-4770.10.30:
+    name: Supporto in caso di periodo di prova accademica
+    description: |
+      Supporto strutturato per gli studenti in periodo di prova accademica.
+  BC-4770.20:
+    name: Servizi di consulenza e salute mentale
+    description: |
+      Erogazione di servizi di valutazione della salute mentale, consulenza psicologica
+      e risposta alle crisi per gli studenti.
+    in_scope:
+      - Valutazione e triage della salute mentale
+      - Erogazione delle sessioni di consulenza psicologica
+      - Coordinamento della risposta alle crisi
+    out_of_scope:
+      - Cure mediche cliniche al di là della consulenza psicologica (trattate da servizi sanitari o riferimenti esterni)
+  BC-4770.20.10:
+    name: Valutazione e triage della salute mentale
+    description: |
+      Valutazione iniziale e triage dei bisogni di salute mentale degli studenti.
+  BC-4770.20.20:
+    name: Erogazione delle sessioni di consulenza psicologica
+    description: |
+      Erogazione di sessioni di consulenza psicologica individuali e di gruppo.
+  BC-4770.20.30:
+    name: Coordinamento della risposta alle crisi
+    description: |
+      Coordinamento della risposta alle crisi e dei rinvii a servizi esterni.
+  BC-4770.30:
+    name: Servizi per la disabilità e accomodamenti
+    description: |
+      Determinazione ed erogazione di accomodamenti ragionevoli per gli studenti
+      con disabilità e fornitura di tecnologie assistive.
+    in_scope:
+      - Revisione della documentazione sulla disabilità
+      - Fornitura di accomodamenti ragionevoli
+      - Supporto alle tecnologie assistive
+    out_of_scope:
+      - Programmi di istruzione speciale per il K-12 (trattati in Servizi di istruzione speciale)
+      - Rendicontazione della conformità ai diritti civili (trattata in Gestione della conformità normativa nel settore dell'istruzione)
+  BC-4770.30.10:
+    name: Revisione della documentazione sulla disabilità
+    description: |
+      Revisione della documentazione sulla disabilità a supporto delle richieste di accomodamento.
+  BC-4770.30.20:
+    name: Fornitura di accomodamenti ragionevoli
+    description: |
+      Fornitura di accomodamenti accademici e per la valutazione.
+  BC-4770.30.30:
+    name: Supporto alle tecnologie assistive
+    description: |
+      Fornitura e supporto di tecnologie assistive agli studenti.
+  BC-4770.40:
+    name: Servizi di istruzione speciale
+    description: |
+      Servizi di istruzione speciale di natura legale erogati principalmente nei contesti K-12,
+      inclusi piani educativi individualizzati e servizi correlati.
+    in_scope:
+      - Sviluppo del piano educativo individualizzato (IEP)
+      - Erogazione di istruzione specializzata
+      - Coordinamento dei servizi correlati (es. logopedia, terapia occupazionale, fisioterapia)
+    out_of_scope:
+      - Accomodamenti nell'istruzione superiore (trattati in Servizi per la disabilità e accomodamenti)
+  BC-4770.40.10:
+    name: Sviluppo del piano educativo individualizzato
+    description: |
+      Sviluppo degli IEP e dei piani individualizzati equivalenti.
+  BC-4770.40.20:
+    name: Erogazione di istruzione specializzata
+    description: |
+      Erogazione di istruzione specializzata agli studenti con bisogni identificati.
+  BC-4770.40.30:
+    name: Coordinamento dei servizi correlati
+    description: |
+      Coordinamento dei servizi correlati come logopedia, terapia occupazionale e fisioterapia.
+  BC-4770.50:
+    name: Servizi carriere e placement
+    description: |
+      Orientamento professionale, intermediazione di internship e placement,
+      e gestione dei rapporti con i datori di lavoro a supporto della transizione degli studenti al mondo del lavoro.
+    in_scope:
+      - Consulenza professionale
+      - Intermediazione di internship e placement
+      - Rapporti con i datori di lavoro e reclutamento in campus
+    out_of_scope:
+      - Supervisione del tirocinio a crediti accademici (trattata in Gestione delle operazioni didattiche e di apprendimento)
+  BC-4770.50.10:
+    name: Consulenza professionale
+    description: |
+      Consulenza professionale e pianificazione della carriera per studenti e laureati recenti.
+  BC-4770.50.20:
+    name: Intermediazione di internship e placement
+    description: |
+      Intermediazione di internship e opportunità di esperienza lavorativa.
+  BC-4770.50.30:
+    name: Gestione dei rapporti con i datori di lavoro e reclutamento in campus
+    description: |
+      Gestione dei rapporti con i datori di lavoro ed eventi di reclutamento in campus.
+  BC-4770.60:
+    name: Benessere degli studenti e supporto tutoriale
+    description: |
+      Supporto tutoriale, mentoring, supporto per la condotta e programmi di benessere
+      gestiti dall'istituzione.
+    in_scope:
+      - Supporto tutoriale e mentoring
+      - Supporto per la condotta e la disciplina degli studenti
+      - Operazioni dei programmi di benessere
+    out_of_scope:
+      - Azioni di enforcement per i diritti civili (trattate in Gestione della conformità normativa nel settore dell'istruzione)
+  BC-4770.60.10:
+    name: Supporto tutoriale e mentoring
+    description: |
+      Supporto tutoriale e mentoring degli studenti da parte di tutor e personale dedicato.
+  BC-4770.60.20:
+    name: Supporto per la condotta e la disciplina degli studenti
+    description: |
+      Supporto per i processi disciplinari e di condotta degli studenti.
+  BC-4770.60.30:
+    name: Operazioni dei programmi di benessere
+    description: |
+      Gestione dei programmi e delle campagne di benessere istituzionale.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-subscription-billing-revenue-management.yaml
+++ b/catalogue/i18n/it/L1-subscription-billing-revenue-management.yaml
@@ -1,0 +1,168 @@
+# Gestione della fatturazione e dei ricavi da abbonamento (it) — translations for L1-subscription-billing-revenue-management.yaml
+locale: it
+source: L1-subscription-billing-revenue-management.yaml
+entries:
+  BC-4250:
+    name: Gestione della fatturazione e dei ricavi da abbonamento
+    description: |
+      Misurazione dell'utilizzo, tariffazione, fatturazione, gestione dei mancati pagamenti,
+      riconoscimento dei ricavi da abbonamento, fiscalità e analytics dei ricavi ricorrenti
+      per il modello commerciale SaaS.
+  BC-4250.10:
+    name: Misurazione dell'utilizzo
+    description: |
+      Ingestione e aggregazione degli eventi di utilizzo che alimentano
+      la tariffazione downstream e le analytics.
+  BC-4250.10.10:
+    name: Ingestione degli eventi di utilizzo
+    description: |
+      Ingestione degli eventi di utilizzo dai servizi di prodotto
+      nella pipeline di misurazione.
+  BC-4250.10.20:
+    name: Aggregazione dell'utilizzo
+    description: |
+      Aggregazione degli eventi di utilizzo in quantità fatturabili
+      per tenant e contatore.
+  BC-4250.10.30:
+    name: Riconciliazione delle quantità misurate
+    description: |
+      Riconciliazione delle quantità misurate rispetto alla fonte di verità
+      e ai contatori visibili al cliente.
+  BC-4250.20:
+    name: Tariffazione e addebito
+    description: |
+      Applicazione di tariffe di abbonamento, tariffe di utilizzo, ripartizioni proporzionali
+      e sconti per il calcolo degli addebiti.
+  BC-4250.20.10:
+    name: Tariffazione degli abbonamenti
+    description: |
+      Calcolo degli addebiti ricorrenti dell'abbonamento
+      per ciclo.
+  BC-4250.20.20:
+    name: Tariffazione dell'utilizzo
+    description: |
+      Calcolo degli addebiti di utilizzo dalle quantità
+      tariffate e dalle tariffe.
+  BC-4250.20.30:
+    name: Calcolo della ripartizione proporzionale
+    description: |
+      Calcolo degli addebiti pro-rata derivanti
+      da modifiche a metà ciclo.
+  BC-4250.20.40:
+    name: Applicazione degli sconti
+    description: |
+      Applicazione di sconti e crediti negoziati
+      agli addebiti calcolati.
+  BC-4250.30:
+    name: Gestione delle fatture e dei rendiconti
+    description: |
+      Generazione, consegna e rettifica delle fatture e gestione
+      delle contestazioni di fatturazione dei clienti.
+  BC-4250.30.10:
+    name: Generazione delle fatture
+    description: |
+      Generazione delle fatture dagli addebiti tariffati
+      e dai termini contrattuali.
+  BC-4250.30.20:
+    name: Consegna delle fatture
+    description: |
+      Consegna delle fatture ai clienti tramite portale, email
+      e canali partner.
+  BC-4250.30.30:
+    name: Rettifica delle fatture
+    description: |
+      Rettifica delle fatture per crediti, errori
+      e scostamenti contrattuali.
+  BC-4250.30.40:
+    name: Gestione delle contestazioni di fatturazione
+    description: |
+      Triage e risoluzione delle contestazioni di fatturazione
+      dei clienti.
+  BC-4250.40:
+    name: Riscossione dei pagamenti e gestione dei mancati pagamenti
+    description: |
+      Gestione dei metodi di pagamento, autorizzazione, gestione dei mancati pagamenti
+      e recupero dell'abbandono involontario.
+  BC-4250.40.10:
+    name: Gestione dei metodi di pagamento
+    description: |
+      Acquisizione e gestione dei metodi di pagamento
+      e dei token dei clienti.
+  BC-4250.40.20:
+    name: Autorizzazione dei pagamenti
+    description: |
+      Autorizzazione e acquisizione dei pagamenti ricorrenti
+      tramite processori di pagamento.
+  BC-4250.40.30:
+    name: Workflow di gestione dei mancati pagamenti
+    description: |
+      Sequenze automatizzate di gestione dei mancati pagamenti
+      per pagamenti falliti e saldi in scadenza.
+  BC-4250.40.40:
+    name: Recupero dell'abbandono involontario
+    description: |
+      Recupero degli abbonamenti persi a causa di carte scadute,
+      rifiuti definitivi e analoghe problematiche di pagamento.
+  BC-4250.50:
+    name: Riconoscimento dei ricavi da abbonamento
+    description: |
+      Identificazione delle obbligazioni di performance e gestione
+      dei piani di ricavo in linea con ASC 606 / IFRS 15.
+  BC-4250.50.10:
+    name: Identificazione delle obbligazioni di performance
+    description: |
+      Identificazione delle obbligazioni di performance distinte
+      dai contratti di abbonamento.
+  BC-4250.50.20:
+    name: Gestione dei piani di ricavo
+    description: |
+      Generazione e manutenzione dei piani di riconoscimento dei ricavi
+      nel corso della vita del contratto.
+  BC-4250.50.30:
+    name: Riconciliazione dei ricavi differiti
+    description: |
+      Riconciliazione dei saldi dei ricavi differiti con gli importi
+      fatturati e riconosciuti.
+  BC-4250.60:
+    name: Gestione della fiscalità degli abbonamenti
+    description: |
+      Determinazione delle giurisdizioni fiscali, calcolo e gestione delle esenzioni
+      sulle tariffe ricorrenti e di utilizzo.
+  BC-4250.60.10:
+    name: Determinazione della giurisdizione fiscale
+    description: |
+      Determinazione delle giurisdizioni fiscali applicabili
+      per cliente e addebito.
+  BC-4250.60.20:
+    name: Calcolo delle imposte sugli abbonamenti
+    description: |
+      Calcolo dell'imposta indiretta sugli addebiti
+      di abbonamento e di utilizzo.
+  BC-4250.60.30:
+    name: Gestione delle esenzioni fiscali
+    description: |
+      Acquisizione e applicazione dei certificati di esenzione
+      fiscale dei clienti.
+  BC-4250.70:
+    name: Analytics dei ricavi da abbonamento
+    description: |
+      Calcolo e analisi delle metriche di salute dei ricavi ricorrenti,
+      inclusi ARR, MRR, NRR, GRR e viste per coorte.
+  BC-4250.70.10:
+    name: Calcolo di ARR e MRR
+    description: |
+      Calcolo dei ricavi ricorrenti annuali e mensili
+      dallo stato degli abbonamenti.
+  BC-4250.70.20:
+    name: Analisi della retention netta e lorda
+    description: |
+      Analisi della retention dei ricavi netta e lorda
+      tra le coorti di clienti.
+  BC-4250.70.30:
+    name: Analisi dei ricavi per coorte
+    description: |
+      Analisi per coorte dell'evoluzione dei ricavi
+      e delle dinamiche di retention.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-subscription-lifecycle-management.yaml
+++ b/catalogue/i18n/it/L1-subscription-lifecycle-management.yaml
@@ -1,0 +1,163 @@
+# Gestione del ciclo di vita degli abbonamenti (it) — translations for L1-subscription-lifecycle-management.yaml
+locale: it
+source: L1-subscription-lifecycle-management.yaml
+entries:
+  BC-4240:
+    name: Gestione del ciclo di vita degli abbonamenti
+    description: |
+      Progettazione di piani e diritti, contrattualizzazione degli abbonamenti, provisioning,
+      modifica, rinnovo, cancellazione e applicazione dei diritti a runtime
+      nel ciclo di vita commerciale SaaS.
+  BC-4240.10:
+    name: Progettazione di piani e diritti
+    description: |
+      Definizione di piani, diritti sulle funzionalità e regole che determinano
+      quali clienti sono idonei a ciascun piano.
+    in_scope:
+      - Catalogo dei piani e feature gating
+      - Regole di idoneità ai piani
+    out_of_scope:
+      - Strategia di pricing e governance del listino prezzi (coperta da Gestione del pricing)
+  BC-4240.10.10:
+    name: Definizione del catalogo dei piani
+    description: |
+      Definizione del catalogo dei piani, inclusi i livelli di piano
+      e i relativi contenuti.
+  BC-4240.10.20:
+    name: Definizione dei diritti sulle funzionalità
+    description: |
+      Definizione dei diritti sulle funzionalità associati a piani,
+      add-on e contratti personalizzati.
+  BC-4240.10.30:
+    name: Regole di idoneità ai piani
+    description: |
+      Regole che determinano quali clienti e casi d'uso
+      sono idonei a ciascun piano.
+  BC-4240.20:
+    name: Contrattualizzazione degli abbonamenti
+    description: |
+      Gestione delle offerte, generazione dei moduli d'ordine e acquisizione
+      degli artefatti contrattuali degli abbonamenti.
+  BC-4240.20.10:
+    name: Gestione delle offerte di abbonamento
+    description: |
+      Generazione e gestione delle offerte di abbonamento
+      nel processo di vendita.
+  BC-4240.20.20:
+    name: Generazione dei moduli d'ordine
+    description: |
+      Generazione dei moduli d'ordine che riflettono i termini concordati
+      per clienti nuovi ed esistenti.
+  BC-4240.20.30:
+    name: Acquisizione del contratto di abbonamento
+    description: |
+      Acquisizione e archiviazione degli artefatti del contratto di abbonamento
+      firmato e dei termini chiave.
+  BC-4240.30:
+    name: Provisioning degli abbonamenti
+    description: |
+      Attivazione del servizio per i nuovi abbonamenti, incluse la conversione
+      da prova gratuita a pagamento e il provisioning massivo dei posti.
+  BC-4240.30.10:
+    name: Provisioning iniziale
+    description: |
+      Provisioning iniziale dei diritti di servizio
+      all'inizio dell'abbonamento.
+  BC-4240.30.20:
+    name: Conversione della prova gratuita
+    description: |
+      Conversione degli account in prova gratuita
+      ad abbonamenti a pagamento.
+  BC-4240.30.30:
+    name: Provisioning massivo dei posti
+    description: |
+      Provisioning massivo dei posti per gli abbonamenti
+      enterprise.
+  BC-4240.40:
+    name: Modifica degli abbonamenti
+    description: |
+      Modifiche in corso di vita agli abbonamenti attivi, inclusi upgrade,
+      downgrade, rettifiche di posti e attivazione di add-on.
+  BC-4240.40.10:
+    name: Gestione degli upgrade di piano
+    description: |
+      Gestione degli upgrade di piano avviati dal cliente
+      o dal sistema.
+  BC-4240.40.20:
+    name: Gestione dei downgrade di piano
+    description: |
+      Gestione dei downgrade di piano, inclusi gli effetti
+      su diritti e dati.
+  BC-4240.40.30:
+    name: Rettifica dei posti
+    description: |
+      Rettifica del numero di posti
+      sugli abbonamenti attivi.
+  BC-4240.40.40:
+    name: Attivazione degli add-on
+    description: |
+      Attivazione di diritti add-on opzionali
+      sugli abbonamenti attivi.
+  BC-4240.50:
+    name: Gestione dei rinnovi
+    description: |
+      Previsione, elaborazione e negoziazione dei rinnovi degli abbonamenti,
+      sia automatici sia manuali.
+  BC-4240.50.10:
+    name: Previsione dei rinnovi
+    description: |
+      Previsione dei rinnovi imminenti
+      e degli esiti attesi.
+  BC-4240.50.20:
+    name: Elaborazione del rinnovo automatico
+    description: |
+      Elaborazione dei rinnovi automatici degli abbonamenti
+      secondo i termini contrattuali.
+  BC-4240.50.30:
+    name: Supporto alla negoziazione del rinnovo
+    description: |
+      Supporto alle trattative di rinnovo con dati, pricing
+      e pacchetti di modifica dei termini.
+  BC-4240.60:
+    name: Cancellazione e risoluzione
+    description: |
+      Cancellazione volontaria, risoluzione involontaria e conclusione
+      del servizio per i clienti che abbandonano.
+  BC-4240.60.10:
+    name: Elaborazione della cancellazione
+    description: |
+      Elaborazione delle cancellazioni
+      avviate dal cliente.
+  BC-4240.60.20:
+    name: Risoluzione involontaria
+    description: |
+      Risoluzione del servizio per mancato pagamento,
+      inadempimento o scadenza contrattuale.
+  BC-4240.60.30:
+    name: Coordinamento della conclusione del servizio
+    description: |
+      Conclusione coordinata del servizio, incluse l'esportazione dei dati
+      e la consegna per la cancellazione.
+  BC-4240.70:
+    name: Applicazione dei diritti
+    description: |
+      Risoluzione e applicazione a runtime dei diritti dell'abbonamento,
+      con audit trail delle decisioni di accesso.
+  BC-4240.70.10:
+    name: Risoluzione dei diritti
+    description: |
+      Risoluzione dei diritti effettivi per abbonamento,
+      account e utente.
+  BC-4240.70.20:
+    name: Applicazione dei gate sui diritti
+    description: |
+      Controllo a runtime delle funzionalità e delle quote
+      rispetto ai diritti risolti.
+  BC-4240.70.30:
+    name: Audit trail dei diritti
+    description: |
+      Registro di audit delle modifiche ai diritti
+      e delle decisioni di gate.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-subsurface-reservoir-management.yaml
+++ b/catalogue/i18n/it/L1-subsurface-reservoir-management.yaml
@@ -1,0 +1,141 @@
+# Gestione del sottosuolo e dei giacimenti (it) — translations for L1-subsurface-reservoir-management.yaml
+locale: it
+source: L1-subsurface-reservoir-management.yaml
+entries:
+  BC-3010:
+    name: Gestione del sottosuolo e dei giacimenti
+    description: |
+      Geoscienze e ingegneria di giacimento nel ciclo di vita degli asset produttivi:
+      caratterizzazione, simulazione, classificazione di riserve e risorse, strategia
+      di deplezione e progettazione del recupero migliorato.
+  BC-3010.10:
+    name: Gestione delle geoscienze del sottosuolo
+    description: |
+      Descrizione statica del sottosuolo attraverso modellazione geologica,
+      petrofisica e interpretazione strutturale sugli asset produttivi.
+  BC-3010.10.10:
+    name: Modellazione geologica
+    description: |
+      Costruzione e aggiornamento di modelli geologici statici e di facies.
+  BC-3010.10.20:
+    name: Analisi petrofisica
+    description: |
+      Analisi dei log, integrazione dei campioni carotati e valutazione petrofisica dei giacimenti.
+  BC-3010.10.30:
+    name: Interpretazione strutturale
+    description: |
+      Interpretazione strutturale e delle reti di faglie per gli asset produttivi.
+  BC-3010.10.40:
+    name: Aggiornamento del geomodello
+    description: |
+      Aggiornamento dei geomodelli con nuovi dati di pozzo, sismici e di produzione.
+  BC-3010.20:
+    name: Ingegneria di giacimento
+    description: |
+      Analisi del comportamento dinamico del giacimento attraverso simulazione, PVT,
+      bilancio di materia e metodi di analisi transiente di pressione.
+    in_scope:
+      - Simulazione di giacimento e history matching
+      - Analisi PVT e delle proprietà dei fluidi
+      - Analisi transiente di pressione e test di pozzi
+    out_of_scope:
+      - Analisi della curva di declino e previsione della produzione (BC-3010.50)
+  BC-3010.20.10:
+    name: Caratterizzazione del giacimento
+    description: |
+      Caratterizzazione statica e dinamica integrata dei giacimenti.
+  BC-3010.20.20:
+    name: Simulazione di giacimento
+    description: |
+      Simulazione numerica di giacimento, history matching e generazione di previsioni.
+  BC-3010.20.30:
+    name: Analisi PVT e dei fluidi
+    description: |
+      Campionamento PVT, analisi di laboratorio e modellazione delle proprietà dei fluidi.
+  BC-3010.20.40:
+    name: Analisi del bilancio di materia
+    description: |
+      Analisi del bilancio di materia per la stima dei volumi in posto e dei meccanismi di spinta.
+  BC-3010.20.50:
+    name: Analisi transiente di pressione
+    description: |
+      Analisi dei test di pozzi e interpretazione del transitorio di pressione.
+  BC-3010.30:
+    name: Gestione delle riserve e delle risorse
+    description: |
+      Stima, classificazione e registrazione ufficiale delle riserve di petrolio
+      e delle risorse contingenti in conformità con SPE-PRMS e i requisiti SEC.
+  BC-3010.30.10:
+    name: Stima delle riserve
+    description: |
+      Stima deterministica e probabilistica delle riserve di idrocarburi.
+  BC-3010.30.20:
+    name: Classificazione delle riserve
+    description: |
+      Classificazione delle riserve e delle risorse secondo le categorie SPE-PRMS.
+  BC-3010.30.30:
+    name: Registrazione delle riserve
+    description: |
+      Registrazione di fine anno delle riserve per le comunicazioni normative SEC ed equivalenti.
+  BC-3010.30.40:
+    name: Coordinamento dell'audit delle riserve
+    description: |
+      Coordinamento degli audit interni e di terze parti sulle riserve.
+  BC-3010.40:
+    name: Pianificazione dello sviluppo del campo
+    description: |
+      Selezione del concetto, strategia di deplezione e redazione del piano di sviluppo
+      del campo dalla scoperta fino alla sanzione allo sviluppo.
+  BC-3010.40.10:
+    name: Selezione del concetto
+    description: |
+      Selezione e selezione del concetto guidata dal sottosuolo per i nuovi sviluppi di campo.
+  BC-3010.40.20:
+    name: Redazione del piano di sviluppo del campo
+    description: |
+      Redazione dei piani di sviluppo del campo per l'approvazione normativa e dei partner.
+  BC-3010.40.30:
+    name: Definizione della strategia di deplezione
+    description: |
+      Definizione della strategia di deplezione del giacimento inclusi drenaggio e numero di pozzi.
+  BC-3010.40.40:
+    name: Valutazione del rischio del sottosuolo
+    description: |
+      Valutazione dell'incertezza del sottosuolo e del suo impatto commerciale sulle decisioni di sviluppo.
+  BC-3010.50:
+    name: Previsione della produzione
+    description: |
+      Generazione e riconciliazione delle previsioni di produzione per la pianificazione
+      degli asset, del business e delle riserve.
+  BC-3010.50.10:
+    name: Analisi della curva di declino
+    description: |
+      Analisi della curva di declino per la previsione della produzione di pozzi e campi.
+  BC-3010.50.20:
+    name: Generazione delle previsioni di produzione
+    description: |
+      Generazione di previsioni di produzione integrando i vincoli di pozzo, giacimento e impianto.
+  BC-3010.50.30:
+    name: Riconciliazione delle previsioni
+    description: |
+      Riconciliazione delle previsioni del sottosuolo con i dati consuntivi della contabilità della produzione.
+  BC-3010.60:
+    name: Gestione del recupero migliorato e potenziato
+    description: |
+      Progettazione e sorveglianza degli schemi di recupero secondario e terziario
+      inclusi iniezione d'acqua e gas e processi EOR.
+  BC-3010.60.10:
+    name: Progettazione del recupero secondario
+    description: |
+      Progettazione di schemi di recupero secondario a waterflooding e iniezione di gas.
+  BC-3010.60.20:
+    name: Progettazione del recupero terziario
+    description: |
+      Progettazione di schemi di EOR chimico, termico e miscibile.
+  BC-3010.60.30:
+    name: Sorveglianza della strategia di iniezione
+    description: |
+      Sorveglianza e ottimizzazione degli schemi di iniezione e del voidage replacement.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-supplier-management.yaml
+++ b/catalogue/i18n/it/L1-supplier-management.yaml
@@ -1,0 +1,107 @@
+# Gestione dei fornitori (it) — translations for L1-supplier-management.yaml
+locale: it
+source: L1-supplier-management.yaml
+entries:
+  BC-510:
+    name: Gestione dei fornitori
+    description: |
+      Qualifica dei fornitori, performance, rischio e gestione delle relazioni.
+  BC-510.10:
+    name: Gestione della qualifica dei fornitori
+    description: |
+      Qualifica, registrazione, due diligence.
+  BC-510.10.10:
+    name: Registrazione dei fornitori
+    description: |
+      Raccolta delle informazioni di identificazione, bancarie e fiscali dei fornitori.
+  BC-510.10.20:
+    name: Qualifica e pre-screening dei fornitori
+    description: |
+      Qualifica delle capacità, della situazione finanziaria e della conformità dei nuovi fornitori.
+  BC-510.10.30:
+    name: Due diligence sui fornitori
+    description: |
+      Due diligence su sanzioni, ABC, ESG e integrità dei fornitori.
+  BC-510.10.40:
+    name: Gestione del master data dei fornitori
+    description: |
+      Manutenzione del master data dei fornitori e modifiche del ciclo di vita.
+  BC-510.20:
+    name: Gestione della performance dei fornitori
+    description: |
+      Scorecard di performance, gestione degli SLA.
+  BC-510.20.10:
+    name: Scorecard e KPI dei fornitori
+    description: |
+      Definizione e monitoraggio delle scorecard di performance dei fornitori.
+  BC-510.20.20:
+    name: Gestione degli accordi sul livello di servizio
+    description: |
+      Definizione degli SLA, monitoraggio e applicazione dei rimedi.
+  BC-510.20.30:
+    name: Audit e ispezione dei fornitori
+    description: |
+      Audit e ispezioni in loco delle capacità e della qualità dei fornitori.
+  BC-510.20.40:
+    name: Gestione dei problemi e delle CAPA dei fornitori
+    description: |
+      Registrazione dei problemi, azioni correttive e preventive con i fornitori.
+  BC-510.30:
+    name: Gestione del rischio fornitore
+    description: |
+      Rischio finanziario, ESG, geopolitico e informatico dei fornitori.
+  BC-510.30.10:
+    name: Monitoraggio del rischio finanziario dei fornitori
+    description: |
+      Monitoraggio della salute finanziaria e del rischio di credito dei fornitori.
+  BC-510.30.20:
+    name: Rischio ESG e di sostenibilità dei fornitori
+    description: |
+      Rischio ESG, diritti umani e lavoro moderno nella base di fornitura.
+  BC-510.30.30:
+    name: Rischio informatico e IT dei fornitori
+    description: |
+      Valutazione e monitoraggio del rischio informatico e IT di terze parti.
+  BC-510.30.40:
+    name: Rischio geopolitico e di concentrazione dei fornitori
+    description: |
+      Rischio geopolitico, paese e di concentrazione nella base di fornitura.
+  BC-510.40:
+    name: Gestione dello sviluppo dei fornitori
+    description: |
+      Sviluppo delle capacità, programmi di miglioramento dei fornitori.
+  BC-510.40.10:
+    name: Sviluppo delle capacità dei fornitori
+    description: |
+      Sviluppo congiunto delle capacità, formazione e trasferimento tecnologico.
+  BC-510.40.20:
+    name: Programma di diversità dei fornitori
+    description: |
+      Identificazione e sviluppo di fornitori diversi e di piccole imprese.
+  BC-510.40.30:
+    name: Programma di innovazione dei fornitori
+    description: |
+      Programmi per favorire l'innovazione guidata dai fornitori e la co-progettazione.
+  BC-510.50:
+    name: Gestione delle relazioni con i fornitori
+    description: |
+      Relazioni strategiche con i fornitori, forum di governance.
+  BC-510.50.10:
+    name: Segmentazione strategica dei fornitori
+    description: |
+      Segmentazione dei fornitori per criticità e valore.
+  BC-510.50.20:
+    name: Coinvolgimento esecutivo dei fornitori
+    description: |
+      Sponsorizzazione esecutiva e steering con i fornitori strategici.
+  BC-510.50.30:
+    name: Pianificazione congiunta del business
+    description: |
+      Pianificazione congiunta del business e creazione di valore con i fornitori strategici.
+  BC-510.50.40:
+    name: Portale e collaborazione con i fornitori
+    description: |
+      Portale del fornitore, self-service e piattaforme di collaborazione.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-supply-chain-management.yaml
+++ b/catalogue/i18n/it/L1-supply-chain-management.yaml
@@ -1,0 +1,135 @@
+# Gestione della supply chain (it) — translations for L1-supply-chain-management.yaml
+locale: it
+source: L1-supply-chain-management.yaml
+entries:
+  BC-520:
+    name: Gestione della supply chain
+    description: |
+      Pianificazione, orchestrazione ed esecuzione della supply chain end-to-end.
+  BC-520.10:
+    name: Gestione della pianificazione della domanda
+    description: |
+      Previsione della domanda, pianificazione statistica e consensuale.
+  BC-520.10.10:
+    name: Previsione statistica della domanda
+    description: |
+      Previsioni della domanda basate su modelli statistici e machine learning.
+  BC-520.10.20:
+    name: Pianificazione consensuale della domanda
+    description: |
+      Consenso interfunzionale sulla domanda inclusa la sovrapposizione commerciale.
+  BC-520.10.30:
+    name: Pianificazione della domanda per nuovi prodotti
+    description: |
+      Pianificazione della domanda per lanci di nuovi prodotti e discontinuità.
+  BC-520.10.40:
+    name: Sensing e shaping della domanda
+    description: |
+      Sensing della domanda a breve termine e iniziative di demand shaping.
+  BC-520.20:
+    name: Gestione della pianificazione dell'offerta
+    description: |
+      Pianificazione della rete di fornitura, bilanciamento delle fonti.
+  BC-520.20.10:
+    name: Pianificazione della rete di fornitura
+    description: |
+      Pianificazione della rete di fornitura multi-livello tra stabilimenti e centri di distribuzione.
+  BC-520.20.20:
+    name: Generazione del piano di produzione
+    description: |
+      Generazione dei piani di produzione principali attraverso i siti di fornitura.
+  BC-520.20.30:
+    name: Allocazione dell'offerta
+    description: |
+      Allocazione dell'offerta vincolata tra regioni e clienti.
+  BC-520.20.40:
+    name: Bilanciamento delle fonti di fornitura
+    description: |
+      Bilanciamento tra più fonti di fornitura e dual sourcing.
+  BC-520.30:
+    name: Gestione della pianificazione vendite e operazioni
+    description: |
+      S&OP / IBP, allineamento interfunzionale.
+  BC-520.30.10:
+    name: Gestione del ciclo S&OP
+    description: |
+      Orchestrazione del ciclo mensile S&OP/IBP e cadenza delle riunioni.
+  BC-520.30.20:
+    name: Revisione della domanda
+    description: |
+      Revisione interfunzionale del piano di domanda non vincolata.
+  BC-520.30.30:
+    name: Revisione dell'offerta
+    description: |
+      Revisione della fattibilità dell'offerta e dei vincoli nel ciclo S&OP.
+  BC-520.30.40:
+    name: Riconciliazione integrata e S&OP esecutivo
+    description: |
+      Riconciliazione integrata e riunioni decisionali esecutive.
+  BC-520.40:
+    name: Gestione dell'evasione degli ordini
+    description: |
+      Promessa degli ordini, allocazione, orchestrazione dell'evasione.
+  BC-520.40.10:
+    name: Promessa degli ordini e disponibilità alla promessa
+    description: |
+      Promessa ATP/CTP degli ordini basata sull'offerta e sulla capacità.
+  BC-520.40.20:
+    name: Orchestrazione degli ordini
+    description: |
+      Orchestrazione dell'evasione degli ordini tra nodi e canali.
+  BC-520.40.30:
+    name: Tracciamento e visibilità degli ordini
+    description: |
+      Visibilità end-to-end dello stato degli ordini e delle spedizioni.
+  BC-520.40.40:
+    name: Resi e fulfillment inverso
+    description: |
+      Autorizzazione ai resi, logistica inversa e instradamento alla rimessa a nuovo.
+  BC-520.50:
+    name: Gestione delle operazioni logistiche
+    description: |
+      Trasporto, operazioni di magazzino nella supply chain.
+  BC-520.50.10:
+    name: Pianificazione del trasporto
+    description: |
+      Selezione del mezzo, instradamento e pianificazione dei carichi.
+  BC-520.50.20:
+    name: Gestione dei vettori
+    description: |
+      Selezione dei vettori, contratti e performance.
+  BC-520.50.30:
+    name: Operazioni di magazzino
+    description: |
+      Operazioni di ricevimento, stoccaggio, prelievo, confezionamento e spedizione.
+  BC-520.50.40:
+    name: Operazioni doganali e transfrontaliere
+    description: |
+      Movimenti transfrontalieri, sdoganamento e conformità commerciale.
+  BC-520.50.50:
+    name: Operazioni di consegna all'ultimo miglio
+    description: |
+      Instradamento della consegna all'ultimo miglio, gestione degli slot e prova di consegna.
+  BC-520.60:
+    name: Gestione del rischio della supply chain
+    description: |
+      Disruption della supply chain, visibilità, resilienza.
+  BC-520.60.10:
+    name: Visibilità end-to-end della supply chain
+    description: |
+      Visibilità multi-livello su fornitori, inventario e spedizioni.
+  BC-520.60.20:
+    name: Rilevamento e risposta alle disruption
+    description: |
+      Rilevamento delle disruption e azioni di risposta orchestrate.
+  BC-520.60.30:
+    name: Progettazione della resilienza della supply chain
+    description: |
+      Progettazione della rete per la resilienza, inclusi dual sourcing e scorte tampone.
+  BC-520.60.40:
+    name: Conformità della supply chain
+    description: |
+      Conformità alla due diligence della supply chain e alle normative commerciali.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-sustainability-management.yaml
+++ b/catalogue/i18n/it/L1-sustainability-management.yaml
@@ -1,0 +1,115 @@
+# Gestione della sostenibilità (it) — translations for L1-sustainability-management.yaml
+locale: it
+source: L1-sustainability-management.yaml
+entries:
+  BC-740:
+    name: Gestione della sostenibilità
+    description: |
+      Strategia ESG, clima, economia circolare e reporting di sostenibilità.
+  BC-740.10:
+    name: Gestione della strategia e del reporting ESG
+    description: |
+      Strategia ESG, analisi di materialità e rapporti di sostenibilità.
+  BC-740.10.10:
+    name: Sviluppo della strategia ESG
+    description: |
+      Strategia ESG, ambizioni e integrazione con la strategia aziendale.
+  BC-740.10.20:
+    name: Analisi di materialità
+    description: |
+      Analisi di materialità semplice e doppia ai sensi di ESRS / GRI.
+  BC-740.10.30:
+    name: Reporting e disclosure di sostenibilità
+    description: |
+      Redazione dei rapporti di sostenibilità e delle disclosure (CSRD, IFRS S1/S2, GRI).
+  BC-740.10.40:
+    name: Gestione e assurance dei dati ESG
+    description: |
+      Raccolta dei dati ESG, controlli interni e assurance esterna.
+  BC-740.20:
+    name: Gestione del clima e del carbonio
+    description: |
+      Impronta di carbonio, decarbonizzazione e disclosure climatiche.
+  BC-740.20.10:
+    name: Gestione dell'inventario dei gas a effetto serra
+    description: |
+      Inventario dei gas a effetto serra Scope 1, 2 e 3 secondo il GHG Protocol.
+  BC-740.20.20:
+    name: Gestione della roadmap di decarbonizzazione
+    description: |
+      Target science-based e pianificazione della roadmap di decarbonizzazione.
+  BC-740.20.30:
+    name: Analisi del rischio climatico e degli scenari
+    description: |
+      Rischio climatico fisico e di transizione e scenari allineati al TCFD.
+  BC-740.20.40:
+    name: Gestione dei crediti e degli offset di carbonio
+    description: |
+      Acquisto e utilizzo di crediti e offset di carbonio.
+  BC-740.20.50:
+    name: Approvvigionamento di energia rinnovabile
+    description: |
+      PPA, certificati di energia rinnovabile e acquisto di energia verde.
+  BC-740.30:
+    name: Gestione dell'economia circolare
+    description: |
+      Circolarità, riduzione dei rifiuti e programmi di ritiro dei prodotti.
+  BC-740.30.10:
+    name: Progettazione circolare del prodotto
+    description: |
+      Design orientato alla riparazione, al riutilizzo, al riciclo e alla riduzione dei materiali.
+  BC-740.30.20:
+    name: Programmi di ritiro e riutilizzo
+    description: |
+      Programmi di ritiro dai clienti, ricondizionamento e rivendita.
+  BC-740.30.30:
+    name: Riciclo e recupero dei materiali
+    description: |
+      Programmi di riciclo e riutilizzo dei materiali recuperati.
+  BC-740.30.40:
+    name: Sostenibilità degli imballaggi
+    description: |
+      Progettazione di imballaggi sostenibili e conformità alla Responsabilità Estesa del Produttore.
+  BC-740.40:
+    name: Gestione dell'approvvigionamento sostenibile
+    description: |
+      Catena di fornitura sostenibile e approvvigionamento etico.
+  BC-740.40.10:
+    name: Standard di sostenibilità per i fornitori
+    description: |
+      Codice di condotta dei fornitori e standard di sostenibilità.
+  BC-740.40.20:
+    name: Valutazione ESG dei fornitori
+    description: |
+      Rating ESG, audit e valutazioni dei fornitori.
+  BC-740.40.30:
+    name: Due diligence sui diritti umani
+    description: |
+      Due diligence sui diritti umani e sul lavoro forzato nelle catene di fornitura.
+  BC-740.40.40:
+    name: Approvvigionamento responsabile delle materie prime
+    description: |
+      Approvvigionamento responsabile di minerali di conflitto, legname e commodity.
+  BC-740.50:
+    name: Coinvolgimento degli stakeholder sulla sostenibilità
+    description: |
+      Engagement con ONG, comunità e agenzie di rating ESG.
+  BC-740.50.10:
+    name: Coinvolgimento di ONG e società civile
+    description: |
+      Engagement con ONG e società civile su tematiche di sostenibilità.
+  BC-740.50.20:
+    name: Investimento nella comunità
+    description: |
+      Investimento nella comunità, filantropia e programmi di impatto sociale.
+  BC-740.50.30:
+    name: Engagement con agenzie di rating e indici ESG
+    description: |
+      Engagement con agenzie di rating ESG e indici di sostenibilità.
+  BC-740.50.40:
+    name: Politiche pubbliche e advocacy
+    description: |
+      Advocacy di politiche pubbliche su temi di sostenibilità.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-tailings-mine-waste-management.yaml
+++ b/catalogue/i18n/it/L1-tailings-mine-waste-management.yaml
@@ -1,0 +1,126 @@
+# Gestione dei residui di lavorazione e dei rifiuti minerari (it) — translations for L1-tailings-mine-waste-management.yaml
+locale: it
+source: L1-tailings-mine-waste-management.yaml
+entries:
+  BC-4460:
+    name: Gestione dei residui di lavorazione e dei rifiuti minerari
+    description: |
+      Gestione del ciclo di vita delle TSF, dei discarichi di sterile, delle acque di miniera e dei rifiuti minerari pericolosi ai sensi del Global Industry Standard on Tailings Management e dei regimi normativi equivalenti.
+  BC-4460.10:
+    name: Ingegneria delle TSF
+    description: |
+      Progettazione ingegneristica e pianificazione del ciclo di vita delle TSF, incluse la selezione del sito, la costruzione della diga e la progettazione orientata alla chiusura.
+    in_scope:
+      - Selezione del sito e progettazione concettuale
+      - Ingegneria di rialzo e costruzione della diga
+      - Pianificazione della deposizione e modellizzazione della spiaggia
+    out_of_scope:
+      - Deposizione operativa dei residui di lavorazione (BC-4460.20)
+      - Monitoraggio strumentale dei residui di lavorazione (BC-4460.30)
+  BC-4460.10.10:
+    name: Selezione del sito della TSF
+    description: |
+      Selezione del sito con criteri multipli e analisi delle alternative per impianti di stoccaggio dei residui nuovi e ampliati.
+  BC-4460.10.20:
+    name: Ingegneria di costruzione della diga
+    description: |
+      Progettazione ingegneristica e garanzia della qualità della costruzione degli argini della diga dei residui di lavorazione.
+  BC-4460.10.30:
+    name: Pianificazione della deposizione dei residui di lavorazione
+    description: |
+      Pianificazione delle sequenze di deposizione, dello sviluppo della spiaggia e della posizione del laghetto.
+  BC-4460.10.40:
+    name: Progettazione dell'impianto orientata alla chiusura
+    description: |
+      Progettazione delle TSF allineata alla chiusura a lungo termine e alla morfologia finale sicura.
+  BC-4460.20:
+    name: Operazioni di deposizione dei residui di lavorazione
+    description: |
+      Deposizione operativa dei residui di lavorazione nelle strutture di stoccaggio, inclusa la movimentazione di slurry, pasta e residui filtrati e il recupero dell'acqua.
+  BC-4460.20.10:
+    name: Trasporto dello slurry di residui di lavorazione
+    description: |
+      Operazione di tubazioni, stazioni di pompaggio e sistemi di distribuzione dei residui di lavorazione.
+  BC-4460.20.20:
+    name: Operazioni di deposizione dei residui di lavorazione
+    description: |
+      Deposizione operativa dei residui di lavorazione nella struttura di stoccaggio secondo il piano di deposizione.
+  BC-4460.20.30:
+    name: Recupero dell'acqua dai residui di lavorazione
+    description: |
+      Recupero dell'acqua di sfioro e di infiltrazione dalle TSF per il riutilizzo.
+  BC-4460.20.40:
+    name: Operazioni di residui filtrati e dry-stack
+    description: |
+      Operazione di impianti di residui filtrati e posa in dry-stack.
+  BC-4460.30:
+    name: Sorveglianza delle TSF e sicurezza delle dighe
+    description: |
+      Sorveglianza, governance e preparazione alle emergenze delle TSF ai sensi del GISTM e dei regimi equivalenti di sicurezza delle dighe.
+  BC-4460.30.10:
+    name: Monitoraggio della strumentazione geotecnica
+    description: |
+      Monitoraggio di piezometri, inclinometri e prismi topografici sulle TSF.
+  BC-4460.30.20:
+    name: Coordinamento della revisione indipendente delle TSF
+    description: |
+      Coinvolgimento e coordinamento di comitati indipendenti di revisione e ingegneri di riferimento per le TSF.
+  BC-4460.30.30:
+    name: Preparazione alle emergenze delle TSF
+    description: |
+      Pianificazione della preparazione e della risposta alle emergenze per scenari di rottura della diga dei residui di lavorazione.
+  BC-4460.30.40:
+    name: Reporting di conformità agli standard per le TSF
+    description: |
+      Reporting di conformità al Global Industry Standard on Tailings Management e ai regolatori equivalenti.
+  BC-4460.40:
+    name: Gestione degli sterili
+    description: |
+      Caratterizzazione e gestione operativa delle discariche di sterili, inclusi i controlli del drenaggio acido e metallifero.
+  BC-4460.40.10:
+    name: Caratterizzazione degli sterili
+    description: |
+      Caratterizzazione geochimica degli sterili per il potenziale di drenaggio acido e metallifero.
+  BC-4460.40.20:
+    name: Operazioni di discarica degli sterili
+    description: |
+      Posa operativa degli sterili in discariche ingegnerizzate e aree di riempimento.
+  BC-4460.40.30:
+    name: Gestione del drenaggio acido e metallifero
+    description: |
+      Prevenzione, raccolta e trattamento del drenaggio acido e metallifero da sterili e stockpile di minerale.
+  BC-4460.50:
+    name: Gestione delle acque di miniera
+    description: |
+      Bilancio idrico del sito, trattamento e conformità agli scarichi idrici.
+  BC-4460.50.10:
+    name: Operazioni di bilancio idrico della miniera
+    description: |
+      Gestione operativa dei bilanci idrici del sito per cava, sotterraneo e sistemi di acqua di processo.
+  BC-4460.50.20:
+    name: Trattamento delle acque di miniera
+    description: |
+      Operazione di impianti di trattamento delle acque di miniera a calce, osmosi inversa e biologici.
+  BC-4460.50.30:
+    name: Monitoraggio della conformità agli scarichi idrici
+    description: |
+      Monitoraggio e reporting degli scarichi idrici rispetto alle condizioni della licenza ambientale.
+  BC-4460.60:
+    name: Gestione dei rifiuti minerari pericolosi
+    description: |
+      Gestione dei rifiuti di reagenti di processo, dei rifiuti contenenti cianuro e dei residui a elevato contenuto di metalli pesanti.
+  BC-4460.60.10:
+    name: Smaltimento dei rifiuti di reagenti
+    description: |
+      Smaltimento dei reagenti di processo esausti e dei contenitori contaminati.
+  BC-4460.60.20:
+    name: Gestione dei rifiuti contenenti cianuro
+    description: |
+      Destossificazione e gestione dei residui di lavorazione contenenti cianuro e dei residui di processo.
+  BC-4460.60.30:
+    name: Gestione dei rifiuti di mercurio e metalli pesanti
+    description: |
+      Gestione di residui contenenti mercurio, arsenico e altri metalli pesanti derivanti dalla lavorazione e dalla raffinazione.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-talent-creative-workforce-management.yaml
+++ b/catalogue/i18n/it/L1-talent-creative-workforce-management.yaml
@@ -1,0 +1,113 @@
+# Gestione dei talenti e delle risorse creative (it) — translations for L1-talent-creative-workforce-management.yaml
+locale: it
+source: L1-talent-creative-workforce-management.yaml
+entries:
+  BC-3790:
+    name: Gestione dei talenti e delle risorse creative
+    description: |
+      Selezione e casting di talenti sullo schermo e creativi, contrattualizzazione
+      e ingaggio dei talenti, distribuzione di residui e royalty, conformità con
+      guild e sindacati, e gestione delle relazioni creative a lungo termine.
+  BC-3790.10:
+    name: Ricerca e casting dei talenti
+    description: |
+      Redazione dei brief di casting e ricerca, selezione e scelta
+      dei talenti sullo schermo e vocali per le produzioni.
+  BC-3790.10.10:
+    name: Gestione del brief di casting
+    description: |
+      Redazione dei brief di casting e dei breakdown distribuiti ai
+      casting director e alle agenzie.
+  BC-3790.10.20:
+    name: Ricerca e provino dei talenti
+    description: |
+      Ricerca dei talenti, coordinamento dei self-tape e dei provini live
+      e workflow di selezione.
+  BC-3790.10.30:
+    name: Decisione di selezione del casting
+    description: |
+      Decisioni di selezione e approvazione del casting rispetto a
+      criteri creativi e commerciali.
+  BC-3790.20:
+    name: Contrattualizzazione e ingaggio dei talenti
+    description: |
+      Negoziazione e contrattualizzazione degli ingaggi dei talenti,
+      comprese strutture loan-out e società di servizi.
+  BC-3790.20.10:
+    name: Supporto alla negoziazione dei deal con i talenti
+    description: |
+      Supporto alla negoziazione dei deal con i talenti, compresa la
+      benchmarking su deal comparabili e la preparazione di term sheet.
+  BC-3790.20.20:
+    name: Contrattualizzazione loan-out e società di servizi
+    description: |
+      Contrattualizzazione tramite strutture loan-out e società di servizi
+      con considerazioni fiscali e di indennizzo.
+  BC-3790.20.30:
+    name: Gestione delle lettere di ingaggio
+    description: |
+      Redazione e ciclo di vita delle lettere di ingaggio e dei deal memo
+      in forma breve per talenti e cast tecnico.
+  BC-3790.30:
+    name: Distribuzione di residui e royalty
+    description: |
+      Calcolo e pagamento di residui, royalty e partecipazioni dovute
+      ai talenti e ai contributor creativi.
+  BC-3790.30.10:
+    name: Calcolo dei residui
+    description: |
+      Calcolo dei residui secondo le formule delle guild, i tipi di mercato
+      e le finestre di riutilizzo.
+  BC-3790.30.20:
+    name: Produzione dei rendiconti di distribuzione delle royalty
+    description: |
+      Produzione dei rendiconti di distribuzione delle royalty per i
+      talenti e i detentori dei diritti.
+  BC-3790.30.30:
+    name: Tracciamento delle partecipazioni sottostanti
+    description: |
+      Tracciamento delle partecipazioni sottostanti, compresi i
+      profit definition e i tier contabili.
+  BC-3790.40:
+    name: Conformità con guild e sindacati
+    description: |
+      Applicazione dei contratti collettivi, supporto ai report e alle
+      verifiche delle guild, e gestione dei contributi pensionistici e sanitari.
+  BC-3790.40.10:
+    name: Applicazione del contratto collettivo
+    description: |
+      Applicazione dei minimi CBA, delle norme di lavoro e delle strutture
+      per gli straordinari nelle produzioni.
+  BC-3790.40.20:
+    name: Reportistica alle guild e supporto alle verifiche
+    description: |
+      Produzione dei report per le guild e supporto alle verifiche delle
+      guild sulle produzioni.
+  BC-3790.40.30:
+    name: Gestione dei contributi pensionistici e sanitari
+    description: |
+      Calcolo e versamento dei contributi pensionistici e sanitari
+      ai fondi delle guild.
+  BC-3790.50:
+    name: Gestione delle relazioni con i talenti creativi
+    description: |
+      Gestione delle relazioni a lungo termine con i talenti creativi e
+      dei programmi che sostengono l'engagement e lo sviluppo dei talenti.
+  BC-3790.50.10:
+    name: Gestione delle relazioni a lungo termine con i talenti
+    description: |
+      Gestione di deal di first-look, overall e pod a lungo termine
+      con i talenti creativi.
+  BC-3790.50.20:
+    name: Tracciamento delle performance dei talenti
+    description: |
+      Tracciamento del contributo dei talenti e delle performance creative
+      su progetti e slate.
+  BC-3790.50.30:
+    name: Programmi di engagement dei talenti
+    description: |
+      Programmi di engagement comprensivi di writers' room, residenze
+      e fondi di sviluppo per i talenti creativi.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-tax-management.yaml
+++ b/catalogue/i18n/it/L1-tax-management.yaml
@@ -1,0 +1,111 @@
+# Gestione fiscale (it) — translations for L1-tax-management.yaml
+locale: it
+source: L1-tax-management.yaml
+entries:
+  BC-220:
+    name: Gestione fiscale
+    description: |
+      Pianificazione fiscale, conformità e reporting per imposte dirette e indirette.
+  BC-220.10:
+    name: Gestione delle imposte dirette
+    description: |
+      Pianificazione, conformità e adempimenti dell'imposta sul reddito delle società.
+  BC-220.10.10:
+    name: Stima delle imposte sul reddito societario
+    description: |
+      Calcolo delle imposte correnti e differite e stima del carico fiscale.
+  BC-220.10.20:
+    name: Dichiarazioni fiscali sul reddito societario
+    description: |
+      Predisposizione e presentazione delle dichiarazioni dei redditi societari.
+  BC-220.10.30:
+    name: Gestione delle ritenute fiscali
+    description: |
+      Determinazione, pagamento e certificazione delle ritenute alla fonte.
+  BC-220.10.40:
+    name: Gestione delle perdite e dei crediti fiscali
+    description: |
+      Utilizzo, monitoraggio e previsione delle perdite e dei crediti fiscali.
+  BC-220.20:
+    name: Gestione delle imposte indirette
+    description: |
+      IVA, GST, imposte sulle vendite e dazi doganali.
+  BC-220.20.10:
+    name: Determinazione dell'IVA e del GST
+    description: |
+      Mappatura dei codici fiscali, luogo di fornitura e determinazione dell'imposta indiretta.
+  BC-220.20.20:
+    name: Dichiarazioni e adempimenti IVA e GST
+    description: |
+      Predisposizione e presentazione delle dichiarazioni IVA, GST e delle imposte sulle vendite.
+  BC-220.20.30:
+    name: Fatturazione elettronica e reporting in tempo reale
+    description: |
+      Fatturazione elettronica e reporting in tempo reale alle autorità fiscali.
+  BC-220.20.40:
+    name: Gestione di dazi doganali e accise
+    description: |
+      Valutazione doganale, classificazione e amministrazione delle accise.
+  BC-220.30:
+    name: Gestione del transfer pricing
+    description: |
+      Politiche di transfer pricing, documentazione e difesa.
+  BC-220.30.10:
+    name: Definizione delle politiche di transfer pricing
+    description: |
+      Definizione delle politiche di transfer pricing in linea con le linee guida OCSE.
+  BC-220.30.20:
+    name: Documentazione del transfer pricing
+    description: |
+      Master file, local file e country-by-country reporting.
+  BC-220.30.30:
+    name: Operazioni di addebito intercompany
+    description: |
+      Calcolo, fatturazione e regolamento degli addebiti intercompany.
+  BC-220.30.40:
+    name: Difesa in materia di transfer pricing
+    description: |
+      Difesa in sede di audit, APA e procedure amichevoli.
+  BC-220.40:
+    name: Reporting e conformità fiscale
+    description: |
+      Dichiarazioni fiscali e informative fiscali di bilancio.
+  BC-220.40.10:
+    name: Contabilità e informativa fiscale
+    description: |
+      Informativa fiscale nei bilanci e analisi dell'aliquota fiscale effettiva.
+  BC-220.40.20:
+    name: Calendario degli adempimenti fiscali
+    description: |
+      Calendario globale degli adempimenti fiscali e monitoraggio degli obblighi.
+  BC-220.40.30:
+    name: Country-by-country reporting
+    description: |
+      Presentazioni di country-by-country reporting nell'ambito del BEPS OCSE.
+  BC-220.40.40:
+    name: Dati fiscali e riconciliazione
+    description: |
+      Estrazione dei dati fiscali, riconciliazione e quadratura con le dichiarazioni.
+  BC-220.50:
+    name: Pianificazione fiscale e consulenza
+    description: |
+      Strutturazione fiscale, consulenza e gestione del contenzioso.
+  BC-220.50.10:
+    name: Pianificazione fiscale strategica
+    description: |
+      Strutturazione fiscale efficiente di operazioni, finanziamenti e supply chain.
+  BC-220.50.20:
+    name: Consulenza fiscale sulle transazioni
+    description: |
+      Due diligence fiscale e strutturazione per M&A e riorganizzazioni.
+  BC-220.50.30:
+    name: Gestione del contenzioso fiscale
+    description: |
+      Audit fiscali, controversie e risoluzione delle dispute.
+  BC-220.50.40:
+    name: Rischio fiscale e governance
+    description: |
+      Framework del rischio fiscale, controlli e informativa sulla strategia fiscale.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-tax-revenue-administration-management.yaml
+++ b/catalogue/i18n/it/L1-tax-revenue-administration-management.yaml
@@ -1,0 +1,141 @@
+# Gestione dell'amministrazione fiscale e delle entrate (it) — translations for L1-tax-revenue-administration-management.yaml
+locale: it
+source: L1-tax-revenue-administration-management.yaml
+entries:
+  BC-3250:
+    name: Gestione dell'amministrazione fiscale e delle entrate
+    description: |
+      Amministrazione pubblica delle entrate fiscali e non fiscali, incluse la registrazione dei contribuenti, la gestione delle dichiarazioni, l'accertamento, la riscossione, la verifica fiscale, l'esecuzione e la gestione dei rimborsi.
+  BC-3250.10:
+    name: Registrazione e identità dei contribuenti
+    description: |
+      Registrazione dei contribuenti, gestione dell'identità fiscale e manutenzione dei dati anagrafici dei contribuenti.
+    in_scope:
+      - Registrazione dei contribuenti e rilascio del codice fiscale
+      - Manutenzione del profilo del contribuente
+      - Registri sulla titolarità effettiva
+    out_of_scope:
+      - Registrazione dell'identità civile (coperta dalla Gestione dell'anagrafe e della registrazione dell'identità)
+  BC-3250.10.10:
+    name: Registrazione del contribuente
+    description: |
+      Registrazione di contribuenti persone fisiche e giuridiche e rilascio dei codici fiscali.
+  BC-3250.10.20:
+    name: Manutenzione del profilo del contribuente
+    description: |
+      Manutenzione dei dati anagrafici del contribuente, dei recapiti e del registro degli obblighi fiscali.
+  BC-3250.10.30:
+    name: Registrazione della titolarità effettiva
+    description: |
+      Acquisizione della titolarità effettiva e delle strutture di gruppo delle entità.
+  BC-3250.20:
+    name: Gestione delle dichiarazioni e accertamento
+    description: |
+      Ricezione, validazione e accertamento delle dichiarazioni fiscali relative alle imposte dirette, indirette e a ritenuta.
+  BC-3250.20.10:
+    name: Presentazione della dichiarazione
+    description: |
+      Ricezione e acquisizione delle dichiarazioni fiscali e delle comunicazioni su tutti i canali.
+  BC-3250.20.20:
+    name: Validazione della dichiarazione
+    description: |
+      Validazione automatizzata e manuale delle dichiarazioni, inclusi calcoli, completezza e coerenza.
+  BC-3250.20.30:
+    name: Elaborazione dell'autoliquidazione
+    description: |
+      Elaborazione delle dichiarazioni in autoliquidazione e registrazione delle passività dichiarate.
+  BC-3250.20.40:
+    name: Emissione dell'accertamento d'ufficio
+    description: |
+      Emissione di accertamenti d'ufficio e di accertamenti induttivi per i non dichiaranti.
+  BC-3250.30:
+    name: Operazioni di riscossione delle entrate
+    description: |
+      Riscossione spontanea delle imposte tramite canali elettronici, a ritenuta, rateali e allo sportello.
+  BC-3250.30.10:
+    name: Operazioni dei canali di pagamento
+    description: |
+      Gestione dei canali di pagamento, inclusi bonifico bancario, carta, e-wallet e sportello.
+  BC-3250.30.20:
+    name: Ritenuta alla fonte e detraibilità alla fonte
+    description: |
+      Amministrazione delle ritenute fiscali e dei regimi di detraibilità alla fonte da parte degli agenti pagatori.
+  BC-3250.30.30:
+    name: Gestione dei piani rateali
+    description: |
+      Definizione e monitoraggio dei piani rateali e degli accordi di dilazione del pagamento.
+  BC-3250.30.40:
+    name: Riconciliazione degli incassi
+    description: |
+      Riconciliazione degli incassi fiscali con i conti dei contribuenti e la tesoreria.
+  BC-3250.40:
+    name: Verifica fiscale ed esame
+    description: |
+      Verifica fiscale, esame e riaccontamento basati sul rischio per la conformità dei contribuenti.
+  BC-3250.40.10:
+    name: Selezione dei casi di verifica
+    description: |
+      Selezione basata sul rischio dei casi di verifica mediante analisi e intelligence.
+  BC-3250.40.20:
+    name: Attività di verifica sul campo
+    description: |
+      Conduzione dell'attività di verifica in loco, esame dei documenti e colloqui con i contribuenti.
+  BC-3250.40.30:
+    name: Emissione del riaccontamento
+    description: |
+      Emissione di riaccontamenti, rettifiche e comunicazioni di decisione della verifica.
+  BC-3250.40.40:
+    name: Esame del transfer pricing
+    description: |
+      Esame dei prezzi delle operazioni tra parti correlate transfrontaliere ai sensi dei principi OCSE sul transfer pricing.
+  BC-3250.50:
+    name: Gestione del debito fiscale e dell'esecuzione
+    description: |
+      Recupero dei debiti fiscali tramite poteri esecutivi di legge, inclusi pignoramenti, privilegi, sequestri e segnalazione per procedimento penale.
+  BC-3250.50.10:
+    name: Gestione del portafoglio del debito fiscale
+    description: |
+      Segmentazione, invecchiamento e prioritizzazione del portafoglio del debito fiscale.
+  BC-3250.50.20:
+    name: Azione esecutiva di legge
+    description: |
+      Esercizio dei poteri esecutivi di legge, inclusi pignoramenti, privilegi e sequestri.
+  BC-3250.50.30:
+    name: Segnalazione dei reati fiscali
+    description: |
+      Indagine e segnalazione di presunte evasioni fiscali e reati fiscali all'autorità giudiziaria.
+  BC-3250.60:
+    name: Gestione di rimborsi e crediti
+    description: |
+      Elaborazione dei rimborsi fiscali, delle compensazioni con crediti e dei blocchi sugli importi contestati.
+  BC-3250.60.10:
+    name: Validazione dei rimborsi
+    description: |
+      Validazione delle richieste di rimborso rispetto alle dichiarazioni, ai pagamenti e ai profili di rischio.
+  BC-3250.60.20:
+    name: Emissione dei rimborsi
+    description: |
+      Emissione dei rimborsi e compensazione con le passività in sospeso.
+  BC-3250.60.30:
+    name: Screening delle frodi sui rimborsi
+    description: |
+      Screening delle richieste di rimborso per indicatori di furto di identità e frode sui rimborsi.
+  BC-3250.70:
+    name: Amministrazione delle entrate non fiscali
+    description: |
+      Amministrazione delle entrate pubbliche non fiscali, incluse tariffe, sanzioni, royalty e prelievi.
+  BC-3250.70.10:
+    name: Amministrazione di tariffe e canoni
+    description: |
+      Amministrazione delle tariffe, dei canoni e dei pagamenti degli utenti allo Stato.
+  BC-3250.70.20:
+    name: Riscossione di sanzioni e ammende
+    description: |
+      Riscossione di ammende e sanzioni giudiziarie e amministrative.
+  BC-3250.70.30:
+    name: Amministrazione di royalty e prelievi
+    description: |
+      Amministrazione delle royalty sulle risorse naturali, dei prelievi ambientali e degli oneri vincolati.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-teaching-learning-operations-management.yaml
+++ b/catalogue/i18n/it/L1-teaching-learning-operations-management.yaml
@@ -1,0 +1,151 @@
+# Gestione delle operazioni didattiche e di apprendimento (it) — translations for L1-teaching-learning-operations-management.yaml
+locale: it
+source: L1-teaching-learning-operations-management.yaml
+entries:
+  BC-4730:
+    name: Gestione delle operazioni didattiche e di apprendimento
+    description: |
+      Erogazione quotidiana dell'insegnamento e dell'apprendimento, che comprende la didattica
+      in aula e online, le piattaforme per l'ambiente di apprendimento, le operazioni di tirocinio
+      e placement, l'istruzione di supporto e il monitoraggio del coinvolgimento.
+  BC-4730.10:
+    name: Erogazione di lezioni e sessioni
+    description: |
+      Erogazione in presenza dell'insegnamento nei formati di lezione, seminario, laboratorio,
+      studio, workshop e tutoraggio.
+    in_scope:
+      - Erogazione di lezioni e seminari
+      - Erogazione di laboratori e studi
+      - Erogazione di workshop e tutoraggio
+    out_of_scope:
+      - Erogazione online e a distanza (trattata in Operazioni di apprendimento online e a distanza)
+  BC-4730.10.10:
+    name: Erogazione di lezioni e seminari
+    description: |
+      Erogazione di lezioni per grandi gruppi e didattica in formato seminario.
+  BC-4730.10.20:
+    name: Erogazione di laboratori e studi
+    description: |
+      Erogazione di didattica in laboratorio e studio con attività pratiche.
+  BC-4730.10.30:
+    name: Erogazione di workshop e tutoraggio
+    description: |
+      Erogazione di workshop e tutoraggio per piccoli gruppi.
+  BC-4730.20:
+    name: Operazioni di apprendimento online e a distanza
+    description: |
+      Erogazione sincrona, asincrona e in blended learning dell'insegnamento
+      tramite modalità online e a distanza.
+    in_scope:
+      - Erogazione sincrona di lezioni online
+      - Erogazione asincrona dei corsi
+      - Operazioni di blended learning
+    out_of_scope:
+      - Creazione di materiali didattici online (trattata in Gestione dei contenuti educativi e delle risorse didattiche)
+  BC-4730.20.10:
+    name: Erogazione sincrona di lezioni online
+    description: |
+      Lezioni online dal vivo condotte da un docente e sessioni di tutoraggio.
+  BC-4730.20.20:
+    name: Erogazione asincrona dei corsi
+    description: |
+      Erogazione di corsi asincroni in autoapprendimento con progressione strutturata.
+  BC-4730.20.30:
+    name: Operazioni di blended learning
+    description: |
+      Erogazione di corsi che combinano la didattica in presenza e quella online.
+  BC-4730.30:
+    name: Gestione dell'ambiente di apprendimento
+    description: |
+      Operazione dei sistemi di gestione dell'apprendimento, delle piattaforme per le classi virtuali
+      e integrazione con strumenti didattici e analitici a valle.
+    in_scope:
+      - Operazioni del LMS (Learning Management System)
+      - Operazioni della piattaforma per le classi virtuali
+      - Integrazione con LTI e strumenti didattici
+    out_of_scope:
+      - Infrastruttura IT generale (trattata in Gestione della tecnologia dell'informazione)
+  BC-4730.30.10:
+    name: Operazioni del LMS (Learning Management System)
+    description: |
+      Operazioni del LMS istituzionale.
+  BC-4730.30.20:
+    name: Operazioni della piattaforma per le classi virtuali
+    description: |
+      Operazioni delle piattaforme di classe virtuale e di videoconferenza utilizzate per la didattica.
+  BC-4730.30.30:
+    name: Integrazione degli strumenti didattici
+    description: |
+      Integrazione di strumenti didattici di terze parti tramite LTI e standard equivalenti.
+  BC-4730.40:
+    name: Operazioni di tirocinio clinico e sul campo
+    description: |
+      Gestione dell'apprendimento integrato nel lavoro, incluso il coordinamento dei tirocini,
+      la supervisione e il monitoraggio delle ore di tirocinio richieste.
+    in_scope:
+      - Coordinamento con le sedi di tirocinio
+      - Supervisione clinica e degli internship
+      - Monitoraggio delle ore di tirocinio e del diario
+    out_of_scope:
+      - Placement professionale post-laurea (trattato in Gestione del supporto e del benessere degli studenti)
+  BC-4730.40.10:
+    name: Coordinamento con le sedi di tirocinio
+    description: |
+      Coordinamento con le sedi di tirocinio esterne e le organizzazioni ospitanti.
+  BC-4730.40.20:
+    name: Supervisione clinica e degli internship
+    description: |
+      Supervisione degli studenti durante i tirocini clinici, professionali e gli internship.
+  BC-4730.40.30:
+    name: Monitoraggio delle ore di tirocinio e del diario
+    description: |
+      Monitoraggio delle ore di tirocinio, delle competenze e delle voci del diario.
+  BC-4730.50:
+    name: Tutoraggio e istruzione integrativa
+    description: |
+      Tutoraggio, apprendimento tra pari e istruzione integrativa di abilità accademiche
+      che integra la didattica principale.
+    in_scope:
+      - Operazioni di tutoraggio tra pari
+      - Erogazione di workshop di abilità accademiche
+      - Operazioni di tutoraggio specifico per materia
+    out_of_scope:
+      - Orientamento accademico sulla pianificazione del programma (trattato in Gestione del supporto e del benessere degli studenti)
+  BC-4730.50.10:
+    name: Operazioni di tutoraggio tra pari
+    description: |
+      Gestione di schemi di tutoraggio e supporto all'apprendimento condotti tra pari.
+  BC-4730.50.20:
+    name: Erogazione di workshop di abilità accademiche
+    description: |
+      Erogazione di workshop interdisciplinari di abilità accademiche.
+  BC-4730.50.30:
+    name: Operazioni di tutoraggio specifico per materia
+    description: |
+      Tutoraggio specifico per materia offerto da docenti, dipartimenti o servizi specializzati.
+  BC-4730.60:
+    name: Monitoraggio della frequenza e del coinvolgimento
+    description: |
+      Rilevazione e monitoraggio della frequenza degli studenti e del coinvolgimento dei discenti
+      con attivatori di intervento per gli studenti a rischio.
+    in_scope:
+      - Rilevazione della frequenza
+      - Monitoraggio del coinvolgimento dei discenti
+      - Attivazione di allerta precoce e intervento
+    out_of_scope:
+      - Intervento tutoriale e psicologico (trattato in Gestione del supporto e del benessere degli studenti)
+  BC-4730.60.10:
+    name: Rilevazione della frequenza
+    description: |
+      Rilevazione della frequenza degli studenti nelle attività didattiche.
+  BC-4730.60.20:
+    name: Monitoraggio del coinvolgimento dei discenti
+    description: |
+      Monitoraggio dei segnali di coinvolgimento digitale e comportamentale.
+  BC-4730.60.30:
+    name: Allerta precoce e intervento
+    description: |
+      Attivazione di flag di allerta precoce e instradamento verso i servizi di supporto.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-telecom-billing-revenue-management.yaml
+++ b/catalogue/i18n/it/L1-telecom-billing-revenue-management.yaml
@@ -1,0 +1,135 @@
+# Gestione della fatturazione e dei ricavi delle telecomunicazioni (it) — translations for L1-telecom-billing-revenue-management.yaml
+locale: it
+source: L1-telecom-billing-revenue-management.yaml
+entries:
+  BC-2660:
+    name: Gestione della fatturazione e dei ricavi delle telecomunicazioni
+    description: |
+      Mediazione, tariffazione, rating, fatturazione, presentazione, recupero crediti, assurance dei ricavi e trattamento delle imposte e dei supplementi specifici del settore telecom per servizi prepagati, postpagati e convergenti.
+  BC-2660.10:
+    name: Gestione della mediazione dell'utilizzo
+    description: |
+      Raccolta, normalizzazione e routing dei record di utilizzo dagli elementi di rete verso i sistemi di tariffazione e fatturazione.
+  BC-2660.10.10:
+    name: Raccolta dei CDR
+    description: |
+      Raccolta di CDR (Call Detail Record) di chiamate, sessioni ed eventi dagli elementi di rete e da fonti IPDR.
+  BC-2660.10.20:
+    name: Arricchimento dei CDR
+    description: |
+      Arricchimento dei CDR con dati di abbonato, tariffa e riferimento necessari a valle.
+  BC-2660.10.30:
+    name: Deduplicazione dei CDR
+    description: |
+      Rilevamento e rimozione dei record di utilizzo duplicati.
+  BC-2660.10.40:
+    name: Conversione del formato dei CDR
+    description: |
+      Conversione dei formati CDR tra le sorgenti di raccolta e i sistemi a valle.
+  BC-2660.20:
+    name: Gestione della tariffazione e del rating
+    description: |
+      Tariffazione online e offline, rating, gestione del saldo e ricarica per modelli prepagato e postpagato.
+  BC-2660.20.10:
+    name: Gestione della tariffazione online
+    description: |
+      Tariffazione in tempo reale di sessioni ed eventi rispetto al saldo e alla policy dell'abbonato.
+  BC-2660.20.20:
+    name: Gestione della tariffazione offline
+    description: |
+      Rating offline dei record di utilizzo ed eventi per la fatturazione postpagata.
+  BC-2660.20.30:
+    name: Gestione del saldo
+    description: |
+      Gestione dei saldi principali e dedicati, degli accumulatori e delle quote degli abbonati.
+  BC-2660.20.40:
+    name: Gestione di voucher e ricariche
+    description: |
+      Emissione, distribuzione e riscossione di voucher e ricariche elettroniche.
+  BC-2660.30:
+    name: Gestione delle operazioni di fatturazione
+    description: |
+      Esecuzione dei cicli di fatturazione, calcolo delle fatture e gestione delle rettifiche e correzioni.
+  BC-2660.30.10:
+    name: Esecuzione del ciclo di fatturazione
+    description: |
+      Esecuzione dei cicli di fatturazione pianificati e delle emissioni di fatture ad hoc.
+  BC-2660.30.20:
+    name: Calcolo della fattura
+    description: |
+      Calcolo degli addebiti, delle imposte e delle rettifiche su tutti i componenti dell'account.
+  BC-2660.30.30:
+    name: Rettifica della fattura
+    description: |
+      Applicazione di rettifiche approvate alle fatture, inclusi crediti e rinunce.
+  BC-2660.30.40:
+    name: Correzione della fattura
+    description: |
+      Correzione di fatture errate tramite rifatturazione o rettifiche compensative.
+  BC-2660.40:
+    name: Gestione della presentazione e delle richieste di chiarimento della fattura
+    description: |
+      Presentazione delle fatture in più formati e risoluzione delle richieste di chiarimento e dei contenziosi dei clienti.
+  BC-2660.40.10:
+    name: Presentazione della fattura
+    description: |
+      Produzione e distribuzione delle fatture in formato cartaceo, PDF e digitale.
+  BC-2660.40.20:
+    name: Richiesta di dettaglio della fattura
+    description: |
+      Gestione delle richieste di dettaglio e dell'avvio di contestazioni da parte dei clienti.
+  BC-2660.40.30:
+    name: Spiegazione della fattura
+    description: |
+      Spiegazione e visualizzazione delle voci della fattura per i clienti e gli agenti del servizio clienti.
+  BC-2660.50:
+    name: Gestione del recupero crediti nelle telecomunicazioni
+    description: |
+      Flussi di gestione del recupero crediti (dunning), sospensione, disconnessione e recupero del debito specifici del settore telecom.
+  BC-2660.50.10:
+    name: Flusso di gestione del recupero crediti
+    description: |
+      Flusso di gestione del recupero crediti (dunning) a più fasi per i conti postpagati in arretrato.
+  BC-2660.50.20:
+    name: Sospensione e disconnessione del servizio
+    description: |
+      Sospensione soft, disconnessione hard e riattivazione dei servizi per saldi non pagati.
+  BC-2660.50.30:
+    name: Coordinamento del recupero del debito
+    description: |
+      Coordinamento con agenzie interne e terze parti per il recupero del debito.
+  BC-2660.60:
+    name: Gestione dell'assurance dei ricavi
+    description: |
+      Rilevamento, quantificazione e rimedio delle perdite di ricavi (revenue leakage) lungo la catena del valore.
+  BC-2660.60.10:
+    name: Rilevamento delle perdite di ricavi
+    description: |
+      Rilevamento delle perdite tra utilizzo di rete, mediazione, tariffazione, fatturazione e contabilità.
+  BC-2660.60.20:
+    name: Verifica dell'accuratezza della fatturazione
+    description: |
+      Verifica campionaria ed esaustiva dell'accuratezza delle fatture rispetto agli eventi sorgente.
+  BC-2660.60.30:
+    name: Riconciliazione rete-fatturazione
+    description: |
+      Riconciliazione end-to-end degli eventi registrati dalla rete con i ricavi fatturati.
+  BC-2660.70:
+    name: Gestione delle imposte e dei supplementi nelle telecomunicazioni
+    description: |
+      Calcolo e versamento di imposte, supplementi e canoni regolamentari specifici del settore telecom.
+  BC-2660.70.10:
+    name: Supplemento del fondo per il servizio universale
+    description: |
+      Calcolo, fatturazione e versamento dei contributi al fondo per il servizio universale.
+  BC-2660.70.20:
+    name: Imposta di consumo sulle telecomunicazioni
+    description: |
+      Calcolo e versamento dell'imposta di consumo e delle imposte specifiche per le comunicazioni.
+  BC-2660.70.30:
+    name: Accantonamento dei canoni regolamentari
+    description: |
+      Accantonamento e versamento dei canoni regolamentari ricorrenti correlati al numero di abbonati e ai ricavi.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-telecom-fraud-management.yaml
+++ b/catalogue/i18n/it/L1-telecom-fraud-management.yaml
@@ -1,0 +1,103 @@
+# Gestione delle frodi nelle telecomunicazioni (it) — translations for L1-telecom-fraud-management.yaml
+locale: it
+source: L1-telecom-fraud-management.yaml
+entries:
+  BC-2690:
+    name: Gestione delle frodi nelle telecomunicazioni
+    description: |
+      Rilevamento, analisi, prevenzione, recupero e segnalazione inter-operatore delle frodi specifiche del settore telecom — frode sull'abbonamento, IRSF, wangiri, SIM-swap, bypass e schemi di revenue sharing — basata sulle linee guida GSMA in materia di frodi.
+  BC-2690.10:
+    name: Rilevamento delle frodi nelle telecomunicazioni
+    description: |
+      Rilevamento in tempo reale e quasi in tempo reale di pattern di frode specifici del settore telecom nel traffico voce, dati e di segnalazione.
+  BC-2690.10.10:
+    name: Rilevamento della frode sull'abbonamento
+    description: |
+      Rilevamento dell'acquisizione fraudolenta di servizi mediante identità rubate o falsificate.
+  BC-2690.10.20:
+    name: Rilevamento dell'IRSF
+    description: |
+      Rilevamento di pattern di traffico IRSF (International Revenue Share Fraud) che gonfiano la liquidazione verso destinazioni premium.
+  BC-2690.10.30:
+    name: Rilevamento del wangiri
+    description: |
+      Rilevamento dei pattern di frode da richiamata wangiri e degli intervalli di numerazione associati.
+  BC-2690.10.40:
+    name: Rilevamento del SIM-swap fraudolento
+    description: |
+      Rilevamento dei tentativi di SIM-swap e eSIM-swap fraudolenti e della successiva compromissione dell'account.
+  BC-2690.10.50:
+    name: Rilevamento della frode di bypass
+    description: |
+      Rilevamento di schemi SIM box e altri meccanismi di bypass che sottraggono ricavi di interconnessione.
+  BC-2690.20:
+    name: Analisi delle frodi nelle telecomunicazioni
+    description: |
+      Gestione dei casi di frode rilevati, conservazione delle prove e collegamento con le forze dell'ordine.
+  BC-2690.20.10:
+    name: Analisi dei casi di frode
+    description: |
+      Analisi strutturata dei casi di frode rilevati fino all'esito finale.
+  BC-2690.20.20:
+    name: Raccolta delle prove
+    description: |
+      Raccolta forense e conservazione delle prove a supporto delle analisi dei casi di frode.
+  BC-2690.20.30:
+    name: Collegamento con le forze dell'ordine
+    description: |
+      Collegamento con le forze dell'ordine sui casi di frode segnalati.
+  BC-2690.30:
+    name: Controlli preventivi antifrode nelle telecomunicazioni
+    description: |
+      Controlli preventivi — regole, limiti di velocità, innalzamento dell'autenticazione e blacklist — applicati al traffico in tempo reale.
+  BC-2690.30.10:
+    name: Gestione delle regole antifrode in tempo reale
+    description: |
+      Creazione e calibrazione dei set di regole in tempo reale utilizzati dalle piattaforme di gestione delle frodi.
+  BC-2690.30.20:
+    name: Gestione dei controlli di velocità
+    description: |
+      Controlli basati sulla velocità su utilizzo, ricariche e modifiche per limitare l'esposizione alle frodi.
+  BC-2690.30.30:
+    name: Innalzamento dell'autenticazione
+    description: |
+      Autenticazione step-up per transazioni ad alto rischio e azioni di self-care.
+  BC-2690.30.40:
+    name: Gestione della blacklist antifrode
+    description: |
+      Manutenzione delle blacklist antifrode per numeri, intervalli di numerazione, dispositivi e identità.
+  BC-2690.40:
+    name: Recupero delle perdite da frode nelle telecomunicazioni
+    description: |
+      Recupero degli addebiti fraudolenti, dei crediti inesigibili e degli asset nei casi di frode confermata.
+  BC-2690.40.10:
+    name: Recupero degli addebiti fraudolenti
+    description: |
+      Recupero degli addebiti generati da attività fraudolente confermate.
+  BC-2690.40.20:
+    name: Recupero dei crediti inesigibili
+    description: |
+      Recupero dei crediti inesigibili associati a frodi sull'abbonamento e alla compromissione degli account.
+  BC-2690.40.30:
+    name: Recupero degli asset
+    description: |
+      Recupero di dispositivi, SIM e altri asset connessi a ordini fraudolenti.
+  BC-2690.50:
+    name: Segnalazione inter-operatore delle frodi
+    description: |
+      Condivisione dell'intelligence sulle frodi nel settore e segnalazione ai regolatori ove richiesto.
+  BC-2690.50.10:
+    name: Condivisione dell'intelligence sulle frodi nel settore
+    description: |
+      Contributo e fruizione dei canali di intelligence sulle frodi del settore quali il GSMA fraud forum.
+  BC-2690.50.20:
+    name: Segnalazione delle frodi ai regolatori
+    description: |
+      Segnalazione degli incidenti di frode e dell'esposizione aggregata ai regolatori ove previsto.
+  BC-2690.50.30:
+    name: Segnalazione inter-operatore delle frodi
+    description: |
+      Segnalazione delle attività fraudolente sospette agli operatori di originazione o terminazione per un'azione congiunta.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-telecom-network-operations-management.yaml
+++ b/catalogue/i18n/it/L1-telecom-network-operations-management.yaml
@@ -1,0 +1,167 @@
+# Gestione operativa della rete di telecomunicazioni (it) — translations for L1-telecom-network-operations-management.yaml
+locale: it
+source: L1-telecom-network-operations-management.yaml
+entries:
+  BC-2600:
+    name: Gestione operativa della rete di telecomunicazioni
+    description: |
+      Operazione quotidiana di reti fisse, mobili e IP attraverso i domini di accesso radio, rete core, trasporto ed edge — comprendente la gestione dei guasti, la configurazione, le prestazioni, l'inventario, le modifiche, le operazioni di sicurezza e il coordinamento sul campo, basata sui principi TMN FCAPS e eTOM Resource Management & Operations.
+  BC-2600.10:
+    name: Gestione dei guasti di rete
+    description: |
+      Rilevamento, correlazione, ticketing, ripristino e analisi delle cause radice dei guasti di rete nei domini di accesso, rete core e trasporto.
+  BC-2600.10.10:
+    name: Correlazione degli allarmi
+    description: |
+      Correlazione in tempo reale e deduplicazione degli allarmi di rete in eventi su cui agire.
+  BC-2600.10.20:
+    name: Gestione dei trouble ticket
+    description: |
+      Gestione del ciclo di vita dei trouble ticket di rete dalla creazione alla chiusura.
+  BC-2600.10.30:
+    name: Gestione delle interruzioni di rete
+    description: |
+      Coordinamento della risposta alle principali interruzioni di rete, delle comunicazioni e delle azioni di ripristino.
+  BC-2600.10.40:
+    name: Analisi delle cause radice
+    description: |
+      Indagine strutturata su guasti ricorrenti o gravi per identificare ed eliminare le cause sottostanti.
+  BC-2600.20:
+    name: Gestione della configurazione di rete
+    description: |
+      Definizione e applicazione degli standard di configurazione degli elementi di rete e distribuzione controllata delle modifiche di configurazione.
+  BC-2600.20.10:
+    name: Gestione della configurazione di riferimento
+    description: |
+      Definizione e manutenzione delle configurazioni baseline approvate per tipo e ruolo di elemento di rete.
+  BC-2600.20.20:
+    name: Gestione dei parametri di rete
+    description: |
+      Gestione del ciclo di vita dei parametri di rete configurabili e dei loro intervalli autorizzati.
+  BC-2600.20.30:
+    name: Gestione delle immagini software
+    description: |
+      Custodia e controllo delle versioni approvate delle immagini software e del firmware degli elementi di rete.
+  BC-2600.20.40:
+    name: Distribuzione automatizzata della configurazione
+    description: |
+      Distribuzione guidata da strumenti di modifiche di configurazione approvate su larga scala con verifica e rollback.
+  BC-2600.30:
+    name: Gestione delle prestazioni di rete
+    description: |
+      Raccolta e analisi continua dei contatori di prestazione e dei KPI di rete per rilevare e prevenire il degrado.
+  BC-2600.30.10:
+    name: Raccolta dei KPI di rete
+    description: |
+      Raccolta e archiviazione dei contatori di prestazione e KPI a livello di elemento e di rete.
+  BC-2600.30.20:
+    name: Monitoraggio delle soglie
+    description: |
+      Monitoraggio dei KPI di prestazione rispetto alle soglie di ingegneria e degli SLA di rete.
+  BC-2600.30.30:
+    name: Monitoraggio dell'utilizzo della capacità
+    description: |
+      Tracciamento dell'utilizzo delle risorse rispetto alla capacità ingegneristica per segnalare condizioni di prossima saturazione.
+  BC-2600.30.40:
+    name: Correlazione dell'impatto sui clienti
+    description: |
+      Correlazione dei segnali di prestazione di rete con gli indicatori di esperienza del cliente per identificare condizioni di degrado del servizio.
+  BC-2600.40:
+    name: Gestione dell'inventario di rete
+    description: |
+      Registro autorevole delle risorse di rete logiche e fisiche e delle loro relazioni, mantenuto sincronizzato con la realtà attraverso la riconciliazione.
+  BC-2600.40.10:
+    name: Inventario logico di rete
+    description: |
+      Registro autorevole delle risorse logiche quali servizi, circuiti, assegnazioni IP/VLAN e percorsi bearer.
+  BC-2600.40.20:
+    name: Inventario fisico di rete
+    description: |
+      Registro autorevole degli asset fisici quali nodi, schede, porte, fibre, condotti e antenne.
+  BC-2600.40.30:
+    name: Riconciliazione dell'inventario
+    description: |
+      Riconciliazione dei record di inventario rispetto a discovery, progettazione e rilevamenti sul campo.
+  BC-2600.40.40:
+    name: Discovery delle risorse di rete
+    description: |
+      Discovery automatizzato degli elementi di rete dispiegati e del loro stato.
+  BC-2600.50:
+    name: Gestione delle modifiche e dei rilasci di rete
+    description: |
+      Pianificazione, approvazione, esecuzione, verifica e rollback delle modifiche agli elementi di rete e ai servizi in produzione.
+  BC-2600.50.10:
+    name: Pianificazione delle modifiche di rete
+    description: |
+      Pianificazione e valutazione dei rischi delle modifiche di rete, comprese le finestre di impatto.
+  BC-2600.50.20:
+    name: Implementazione delle modifiche di rete
+    description: |
+      Esecuzione controllata delle modifiche di rete approvate nelle finestre pianificate.
+  BC-2600.50.30:
+    name: Verifica delle modifiche
+    description: |
+      Verifica post-modifica che la rete si trovi nello stato atteso e operi entro le tolleranze previste.
+  BC-2600.50.40:
+    name: Rollback delle modifiche
+    description: |
+      Ripristino delle modifiche che non superano la verifica o che causano un impatto inaccettabile.
+  BC-2600.60:
+    name: Operazioni di sicurezza della rete
+    description: |
+      Monitoraggio e risposta alle minacce di sicurezza specifici per la rete di telecomunicazioni, nei domini di segnalazione, trasporto e rete core, a complemento della cybersecurity aziendale.
+  BC-2600.60.10:
+    name: Monitoraggio delle minacce di rete
+    description: |
+      Monitoraggio delle reti di segnalazione, trasporto e core alla ricerca di attività anomale e malevole.
+  BC-2600.60.20:
+    name: Protezione DDoS
+    description: |
+      Rilevamento e mitigazione degli attacchi di tipo denial-of-service volumetrici e basati su protocollo contro endpoint di rete e clienti.
+  BC-2600.60.30:
+    name: Controllo degli accessi di rete
+    description: |
+      Applicazione dei controlli di accesso amministrativo e macchina agli elementi di rete.
+  BC-2600.60.40:
+    name: Risposta agli incidenti di sicurezza di rete
+    description: |
+      Contenimento, eradicazione e ripristino a seguito di incidenti di sicurezza di rete confermati.
+  BC-2600.70:
+    name: Coordinamento delle operazioni sul campo
+    description: |
+      Dispatch, controllo dell'esecuzione e coordinamento dell'accesso ai siti per le attività sul campo della rete.
+  BC-2600.70.10:
+    name: Dispatch degli ordini di lavoro sul campo
+    description: |
+      Assegnazione degli ordini di lavoro di rete ai team interni e alle squadre esterne sul campo.
+  BC-2600.70.20:
+    name: Esecuzione delle procedure operative
+    description: |
+      Controllo dell'esecuzione delle procedure operative approvate sugli elementi di rete in produzione.
+  BC-2600.70.30:
+    name: Coordinamento dell'accesso ai siti
+    description: |
+      Coordinamento dell'accesso fisico ai siti di rete, compresi accompagnamento, permessi e controlli di sicurezza.
+  BC-2600.80:
+    name: Gestione dell'ottimizzazione della rete
+    description: |
+      Ottimizzazione continua degli elementi di rete e dei percorsi di traffico per massimizzare prestazioni, capacità ed esperienza del cliente.
+  BC-2600.80.10:
+    name: Ottimizzazione dell'accesso radio
+    description: |
+      Regolazione dei parametri di accesso radio, delle relazioni di vicinanza e della configurazione delle antenne.
+  BC-2600.80.20:
+    name: Ottimizzazione del trasporto
+    description: |
+      Regolazione dei percorsi della rete di trasporto, dell'allocazione della capacità e della qualità del servizio.
+  BC-2600.80.30:
+    name: Ingegneria del traffico
+    description: |
+      Instradamento del traffico IP e di trasporto attraverso la rete per obiettivi di prestazione, costo e resilienza.
+  BC-2600.80.40:
+    name: Automazione a ciclo chiuso
+    description: |
+      Cicli automatizzati di rilevamento-decisione-azione che ottimizzano continuamente la rete senza intervento manuale.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-telecom-network-planning-management.yaml
+++ b/catalogue/i18n/it/L1-telecom-network-planning-management.yaml
@@ -1,0 +1,115 @@
+# Gestione della pianificazione della rete di telecomunicazioni (it) — translations for L1-telecom-network-planning-management.yaml
+locale: it
+source: L1-telecom-network-planning-management.yaml
+entries:
+  BC-2610:
+    name: Gestione della pianificazione della rete di telecomunicazioni
+    description: |
+      Progettazione e dimensionamento a lungo termine di reti fisse, mobili e IP — previsione della domanda, pianificazione della copertura e della capacità, definizione dell'evoluzione tecnologica, programmazione del dispiegamento dei siti e coordinamento del ritiro delle reti legacy.
+  BC-2610.10:
+    name: Previsione della domanda di rete
+    description: |
+      Previsione della domanda a lungo termine di abbonati, traffico e servizi per orientare le decisioni di copertura e capacità.
+  BC-2610.10.10:
+    name: Previsione della crescita degli abbonati
+    description: |
+      Previsione della popolazione di abbonati per segmento, tecnologia e area geografica.
+  BC-2610.10.20:
+    name: Previsione della domanda di traffico
+    description: |
+      Previsione dei volumi di traffico voce, dati, video e segnalazione per dominio e cella.
+  BC-2610.10.30:
+    name: Modellazione della domanda di servizi
+    description: |
+      Modellazione della domanda di servizi nuovi ed in evoluzione per definire roadmap di capacità e funzionalità.
+  BC-2610.20:
+    name: Pianificazione della copertura di rete
+    description: |
+      Pianificazione degli obiettivi di copertura geografica e di resilienza per reti radio, in fibra e di trasporto.
+  BC-2610.20.10:
+    name: Pianificazione della copertura radio
+    description: |
+      Definizione degli obiettivi di copertura radio e modellazione della propagazione per banda e tecnologia.
+  BC-2610.20.20:
+    name: Pianificazione della copertura in fibra
+    description: |
+      Pianificazione dell'estensione della rete in fibra, delle abitazioni coperte e della collocazione dei nodi di accesso.
+  BC-2610.20.30:
+    name: Pianificazione di ridondanza e resilienza
+    description: |
+      Progettazione della diversità di percorso, della ridondanza geografica e degli obiettivi di resilienza.
+  BC-2610.30:
+    name: Pianificazione della capacità di rete
+    description: |
+      Dimensionamento della capacità nei domini di accesso radio, rete core e trasporto per soddisfare la domanda prevista entro i target di prestazione.
+  BC-2610.30.10:
+    name: Pianificazione della capacità dell'accesso radio
+    description: |
+      Dimensionamento della capacità di celle, settori e portanti nella rete di accesso radio.
+  BC-2610.30.20:
+    name: Pianificazione della capacità della rete core
+    description: |
+      Dimensionamento della capacità delle funzioni di rete core mobile e fissa e degli archivi dati degli abbonati.
+  BC-2610.30.30:
+    name: Pianificazione della capacità di trasporto
+    description: |
+      Dimensionamento della capacità di fronthaul, backhaul, metro e trasporto di aggregazione.
+  BC-2610.30.40:
+    name: Pianificazione della capacità del backbone IP
+    description: |
+      Dimensionamento della capacità del backbone IP, dei collegamenti di peering e di transito.
+  BC-2610.40:
+    name: Pianificazione dell'evoluzione tecnologica della rete
+    description: |
+      Definizione della roadmap tecnologica pluriennale della rete e dell'evoluzione dell'architettura.
+  BC-2610.40.10:
+    name: Definizione della roadmap tecnologica
+    description: |
+      Definizione della roadmap di evoluzione pluriennale nei domini radio, trasporto e core.
+  BC-2610.40.20:
+    name: Evoluzione dell'architettura di rete
+    description: |
+      Trasformazione architetturale verso architetture di riferimento target quali il core cloud-native e Open RAN.
+  BC-2610.40.30:
+    name: Selezione delle tecnologie dei fornitori
+    description: |
+      Valutazione e selezione delle tecnologie dei fornitori per nuovi domini di rete e cicli di rinnovo.
+  BC-2610.50:
+    name: Pianificazione dei siti di rete
+    description: |
+      Identificazione, rilevamento, approvazione e pianificazione del dispiegamento di nuovi siti di rete.
+  BC-2610.50.10:
+    name: Identificazione dei siti
+    description: |
+      Identificazione dei siti candidati in base ai criteri di copertura, capacità e backhaul.
+  BC-2610.50.20:
+    name: Rilevamento radio dei siti
+    description: |
+      Rilevamento dei siti candidati per le prestazioni RF, la fattibilità strutturale e le interferenze.
+  BC-2610.50.30:
+    name: Coordinamento delle approvazioni costruttive
+    description: |
+      Coordinamento delle approvazioni interne, dei permessi urbanistici e delle concessioni per i nuovi siti.
+  BC-2610.50.40:
+    name: Pianificazione del dispiegamento
+    description: |
+      Pianificazione e sequenziamento della costruzione dei siti rispetto agli impegni di capex, fornitori e copertura.
+  BC-2610.60:
+    name: Pianificazione del fine vita della rete
+    description: |
+      Pianificazione del ritiro delle reti legacy, della migrazione dei clienti e della dismissione degli asset.
+  BC-2610.60.10:
+    name: Pianificazione della dismissione delle reti legacy
+    description: |
+      Pianificazione della dismissione ordinata degli elementi di rete legacy e degli asset associati.
+  BC-2610.60.20:
+    name: Pianificazione della migrazione dei clienti
+    description: |
+      Pianificazione della migrazione dei clienti dalle tecnologie in dismissione alle piattaforme target.
+  BC-2610.60.30:
+    name: Pianificazione del tramonto tecnologico
+    description: |
+      Definizione delle tappe del tramonto tecnologico, delle notifiche regolamentari e degli eventi di spegnimento definitivo.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-telecom-product-catalogue-management.yaml
+++ b/catalogue/i18n/it/L1-telecom-product-catalogue-management.yaml
@@ -1,0 +1,91 @@
+# Gestione del catalogo prodotti telecomunicazioni (it) — translations for L1-telecom-product-catalogue-management.yaml
+locale: it
+source: L1-telecom-product-catalogue-management.yaml
+entries:
+  BC-2650:
+    name: Gestione del catalogo prodotti telecomunicazioni
+    description: |
+      Progettazione, configurazione, ciclo di vita e pubblicazione sui canali di prodotti, tariffe, piani, bundle e promozioni per clienti consumer, enterprise e wholesale.
+  BC-2650.10:
+    name: Progettazione delle offerte di prodotto
+    description: |
+      Progettazione di nuove offerte commerciali, incluse funzionalità, eleggibilità e strutture di pricing.
+  BC-2650.10.10:
+    name: Specifica dell'offerta
+    description: |
+      Specifica della composizione dell'offerta, delle funzionalità e delle condizioni rivolte al cliente.
+  BC-2650.10.20:
+    name: Fattibilità tecnica del prodotto
+    description: |
+      Validazione della realizzabilità tecnica dell'offerta proposta sulle reti e piattaforme target.
+  BC-2650.10.30:
+    name: Progettazione dei livelli di pricing
+    description: |
+      Progettazione dei livelli tariffari, delle regole di eleggibilità e delle strutture contrattuali per l'offerta.
+  BC-2650.20:
+    name: Gestione di tariffe e piani
+    description: |
+      Definizione e ciclo di vita di tariffe, addebiti ricorrenti e politiche di utilizzo equo alla base delle offerte.
+  BC-2650.20.10:
+    name: Definizione delle tariffe d'uso
+    description: |
+      Definizione delle tariffe per evento e per unità d'uso per tipo di servizio e giurisdizione.
+  BC-2650.20.20:
+    name: Definizione degli addebiti ricorrenti
+    description: |
+      Definizione degli addebiti ricorrenti, delle quote mensili e degli addebiti correlati al contratto.
+  BC-2650.20.30:
+    name: Gestione delle politiche di utilizzo equo
+    description: |
+      Definizione e ciclo di vita delle politiche di utilizzo equo e di utilizzo accettabile per piani illimitati e ad alto consumo.
+  BC-2650.30:
+    name: Gestione di bundle e promozioni
+    description: |
+      Composizione e regole dei bundle multi-prodotto e delle promozioni a tempo determinato.
+  BC-2650.30.10:
+    name: Composizione dei bundle
+    description: |
+      Composizione di bundle multi-servizio che includono mobile, fisso, contenuti e dispositivi.
+  BC-2650.30.20:
+    name: Regole di eleggibilità delle promozioni
+    description: |
+      Definizione delle regole di eleggibilità a livello di cliente e offerta per le promozioni.
+  BC-2650.30.30:
+    name: Regole di cumulo degli sconti
+    description: |
+      Regole che disciplinano la combinazione di più sconti e promozioni su un unico account.
+  BC-2650.40:
+    name: Pubblicazione del catalogo prodotti
+    description: |
+      Pubblicazione delle versioni del catalogo ai canali e ai partner con controllo delle versioni e varianti regionali.
+  BC-2650.40.10:
+    name: Pubblicazione multicanale del catalogo
+    description: |
+      Pubblicazione dei contenuti del catalogo sui canali retail, digitali, contact centre e partner.
+  BC-2650.40.20:
+    name: Controllo delle versioni del catalogo
+    description: |
+      Controllo delle versioni dei contenuti del catalogo, incluse le date di efficacia e il rollback.
+  BC-2650.40.30:
+    name: Gestione delle varianti regionali del catalogo
+    description: |
+      Gestione delle varianti di catalogo a livello regionale e di brand a partire da un master condiviso.
+  BC-2650.50:
+    name: Gestione del ciclo di vita del prodotto telecomunicazioni
+    description: |
+      Gestione del ciclo di vita delle offerte dal lancio attraverso la modifica, il ritiro e il grandfathering.
+  BC-2650.50.10:
+    name: Lancio dell'offerta
+    description: |
+      Coordinamento del lancio di nuove offerte attraverso sistemi, canali e aree geografiche.
+  BC-2650.50.20:
+    name: Modifica dell'offerta
+    description: |
+      Modifica controllata delle offerte in commercializzazione e migrazione degli abbonati esistenti ove applicabile.
+  BC-2650.50.30:
+    name: Ritiro e grandfathering dell'offerta
+    description: |
+      Ritiro delle offerte dalla vendita e mantenimento delle condizioni legacy per gli abbonati esistenti.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-telecom-regulatory-compliance-management.yaml
+++ b/catalogue/i18n/it/L1-telecom-regulatory-compliance-management.yaml
@@ -1,0 +1,123 @@
+# Gestione della conformità normativa nelle telecomunicazioni (it) — translations for L1-telecom-regulatory-compliance-management.yaml
+locale: it
+source: L1-telecom-regulatory-compliance-management.yaml
+entries:
+  BC-2700:
+    name: Gestione della conformità normativa nelle telecomunicazioni
+    description: |
+      Obblighi normativi specifici del settore telecom — servizio universale, intercettazione legale, conservazione dei dati, servizi di emergenza, accessibilità, neutralità della rete e reporting sulle condizioni di licenza — basata sui regolatori nazionali delle telecomunicazioni e sugli standard ETSI / 3GPP LI.
+  BC-2700.10:
+    name: Gestione degli obblighi di servizio universale
+    description: |
+      Erogazione e rendicontazione rispetto agli obblighi di servizio universale e ai relativi sussidi.
+  BC-2700.10.10:
+    name: Pianificazione delle aree di servizio universale
+    description: |
+      Pianificazione degli impegni di copertura e qualità del servizio universale per area geografica.
+  BC-2700.10.20:
+    name: Reporting dei sussidi di servizio universale
+    description: |
+      Reporting del numero di clienti sussidiati e dell'erogazione del servizio ai fondi per il servizio universale.
+  BC-2700.10.30:
+    name: Erogazione del servizio universale
+    description: |
+      Erogazione dei servizi USO obbligatori, incluse tariffe sussidiate e livelli minimi di servizio.
+  BC-2700.20:
+    name: Gestione dell'intercettazione legale
+    description: |
+      Predisposizione e consegna delle capacità di intercettazione legale nell'ambito di mandati autorizzati.
+  BC-2700.20.10:
+    name: Predisposizione dell'intercettazione legale
+    description: |
+      Predisposizione dei target di intercettazione legale negli elementi di rete nell'ambito di mandati autorizzati.
+  BC-2700.20.20:
+    name: Consegna dei dati di intercettazione legale
+    description: |
+      Consegna dei contenuti intercettati e dei metadati alle strutture di monitoraggio delle forze dell'ordine.
+  BC-2700.20.30:
+    name: Audit e controllo degli accessi all'intercettazione legale
+    description: |
+      Controllo degli accessi e audit dell'attività di intercettazione legale per prevenire usi non autorizzati.
+  BC-2700.30:
+    name: Gestione della conservazione dei dati nelle telecomunicazioni
+    description: |
+      Raccolta, archiviazione sicura e rilascio autorizzato dei dati di comunicazione conservati ai sensi dei quadri nazionali sulla conservazione dei dati.
+  BC-2700.30.10:
+    name: Raccolta dei dati conservati
+    description: |
+      Raccolta dei dati di comunicazione soggetti a obblighi di conservazione.
+  BC-2700.30.20:
+    name: Flusso di accesso ai dati conservati
+    description: |
+      Flusso di richiesta autorizzata per l'accesso ai dati conservati da parte delle autorità competenti.
+  BC-2700.30.30:
+    name: Cancellazione dei dati conservati
+    description: |
+      Cancellazione dei dati conservati alla scadenza dei periodi di conservazione.
+  BC-2700.40:
+    name: Gestione dei servizi di emergenza
+    description: |
+      Instradamento delle chiamate di emergenza, consegna della localizzazione e capacità di allarme pubblico previste dai regolatori.
+  BC-2700.40.10:
+    name: Instradamento delle chiamate di emergenza
+    description: |
+      Instradamento delle chiamate di emergenza ai centri di risposta alla sicurezza pubblica appropriati.
+  BC-2700.40.20:
+    name: Consegna della localizzazione del chiamante
+    description: |
+      Consegna delle informazioni di localizzazione del chiamante ai servizi di emergenza secondo gli standard E911, eCall e AML.
+  BC-2700.40.30:
+    name: Diffusione degli allarmi pubblici
+    description: |
+      Diffusione di messaggi di allarme pubblico tramite cell-broadcast e SMS su attivazione autorizzata.
+  BC-2700.50:
+    name: Gestione dell'accessibilità nelle telecomunicazioni
+    description: |
+      Erogazione di funzionalità di accessibilità e gestione dei reclami correlati nell'ambito degli obblighi specifici del settore telecom.
+  BC-2700.50.10:
+    name: Supporto per testo in tempo reale e TTY
+    description: |
+      Supporto dei servizi di testo in tempo reale e TTY per gli utenti non udenti e con difficoltà uditive.
+  BC-2700.50.20:
+    name: Erogazione delle funzionalità di accessibilità
+    description: |
+      Erogazione di funzionalità di accessibilità specifiche del settore telecom quali servizi di relay e fatture accessibili.
+  BC-2700.50.30:
+    name: Gestione dei reclami per accessibilità
+    description: |
+      Gestione dei reclami relativi all'accessibilità e del reporting richiesto dai regolatori.
+  BC-2700.60:
+    name: Neutralità della rete e trasparenza nella gestione del traffico
+    description: |
+      Informativa sulle pratiche di gestione del traffico e conformità ai regimi di neutralità della rete.
+  BC-2700.60.10:
+    name: Informativa sulla politica di gestione del traffico
+    description: |
+      Comunicazione delle pratiche di gestione del traffico ai clienti e ai regolatori.
+  BC-2700.60.20:
+    name: Trasparenza del throttling
+    description: |
+      Rendicontazione trasparente delle pratiche di throttling, prioritizzazione e zero-rating.
+  BC-2700.60.30:
+    name: Presentazione agli organi di regolamentazione sulla neutralità della rete
+    description: |
+      Presentazioni ai regolatori sulle pratiche e i reclami in materia di neutralità della rete.
+  BC-2700.70:
+    name: Reporting normativo nelle telecomunicazioni
+    description: |
+      Trasmissioni periodiche di KPI, dati di mercato e reporting sulla conformità alle condizioni di licenza ai regolatori delle telecomunicazioni.
+  BC-2700.70.10:
+    name: Trasmissione dei KPI regolamentari
+    description: |
+      Trasmissione dei KPI obbligatori su copertura, qualità e prestazioni del servizio.
+  BC-2700.70.20:
+    name: Trasmissione dei dati di mercato
+    description: |
+      Trasmissione dei dati di mercato relativi ad abbonati, ricavi e traffico.
+  BC-2700.70.30:
+    name: Reporting sulle condizioni di licenza
+    description: |
+      Reporting rispetto alle condizioni della licenza operativa, inclusi gli obblighi di copertura, dispiegamento e qualità.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-telecom-service-assurance-management.yaml
+++ b/catalogue/i18n/it/L1-telecom-service-assurance-management.yaml
@@ -1,0 +1,115 @@
+# Gestione dell'assurance dei servizi di telecomunicazioni (it) — translations for L1-telecom-service-assurance-management.yaml
+locale: it
+source: L1-telecom-service-assurance-management.yaml
+entries:
+  BC-2630:
+    name: Gestione dell'assurance dei servizi di telecomunicazioni
+    description: |
+      Gestione delle prestazioni a livello di servizio, della qualità, degli incidenti e dell'esperienza del cliente rispetto agli obiettivi concordati — basata su eTOM Service Assurance, qualità del servizio ITU-T E.800 e TM Forum SLA Open API.
+  BC-2630.10:
+    name: Gestione degli SLA di rete
+    description: |
+      Definizione, monitoraggio, reporting e gestione delle violazioni degli accordi sul livello di servizio con clienti e partner.
+  BC-2630.10.10:
+    name: Definizione dei livelli di servizio
+    description: |
+      Definizione degli obiettivi SLA, delle metriche e dei metodi di misurazione per ogni offerta di servizio.
+  BC-2630.10.20:
+    name: Monitoraggio dei livelli di servizio
+    description: |
+      Monitoraggio delle prestazioni di servizio misurate rispetto agli impegni SLA.
+  BC-2630.10.30:
+    name: Reporting dei livelli di servizio
+    description: |
+      Reporting degli esiti SLA a clienti, partner e stakeholder interni.
+  BC-2630.10.40:
+    name: Gestione delle violazioni degli SLA
+    description: |
+      Gestione delle violazioni degli SLA, incluso il calcolo dei crediti e la remediation per il cliente.
+  BC-2630.20:
+    name: Monitoraggio delle prestazioni del servizio
+    description: |
+      Monitoraggio continuo dei KPI di servizio end-to-end e degli indicatori di esperienza del cliente per rilevare il degrado.
+  BC-2630.20.10:
+    name: Monitoraggio dei KPI di servizio end-to-end
+    description: |
+      Monitoraggio dei KPI di servizio end-to-end aggregati attraverso i domini di rete sottostanti.
+  BC-2630.20.20:
+    name: Monitoraggio degli indicatori di esperienza del cliente
+    description: |
+      Monitoraggio degli indicatori di tipo QoE che riflettono la qualità del servizio percepita dal cliente.
+  BC-2630.20.30:
+    name: Rilevamento del degrado del servizio
+    description: |
+      Rilevamento precoce dei pattern di degrado del servizio prima dell'impatto sui clienti.
+  BC-2630.30:
+    name: Gestione degli incidenti con impatto sui clienti
+    description: |
+      Gestione end-to-end degli incidenti che interessano i clienti — rilevamento, notifica, escalation e revisione.
+  BC-2630.30.10:
+    name: Rilevamento degli incidenti sui clienti
+    description: |
+      Rilevamento degli incidenti che impattano uno o più clienti, attingendo a segnali di rete e da parte dei clienti.
+  BC-2630.30.20:
+    name: Notifica degli incidenti ai clienti
+    description: |
+      Notifica ai clienti e ai canali interessati con informazioni sullo stato, ETA e workaround disponibili.
+  BC-2630.30.30:
+    name: Escalation degli incidenti
+    description: |
+      Escalation degli incidenti con impatto sui clienti in base alle politiche di gravità e durata.
+  BC-2630.30.40:
+    name: Revisione post-incidente
+    description: |
+      Revisione strutturata degli incidenti significativi con impatto sui clienti per definire azioni correttive.
+  BC-2630.40:
+    name: Gestione della qualità del servizio
+    description: |
+      Misurazione, modellazione e reporting della qualità del servizio e dell'esperienza del cliente, incluso il reporting verso i regolatori.
+  BC-2630.40.10:
+    name: Misurazione della qualità del servizio (QoS)
+    description: |
+      Misurazione dei parametri QoS quali latenza, perdita, jitter e throughput per servizio.
+  BC-2630.40.20:
+    name: Modellazione della qualità dell'esperienza
+    description: |
+      Modellazione della qualità dell'esperienza percepita dal cliente a partire da segnali di rete e comportamentali.
+  BC-2630.40.30:
+    name: Reporting della qualità del servizio
+    description: |
+      Reporting delle metriche di qualità del servizio agli stakeholder interni e ai regolatori.
+  BC-2630.50:
+    name: Coordinamento del ripristino del servizio
+    description: |
+      Coordinamento delle attività di ripristino, dei workaround e della validazione del recupero per i servizi degradati.
+  BC-2630.50.10:
+    name: Flusso di lavoro per il ripristino del servizio
+    description: |
+      Orchestrazione dei task di ripristino tra i team di rete e sul campo.
+  BC-2630.50.20:
+    name: Coordinamento dei workaround
+    description: |
+      Coordinamento di workaround temporanei e percorsi alternativi durante interruzioni prolungate.
+  BC-2630.50.30:
+    name: Validazione del recupero del servizio
+    description: |
+      Validazione del ripristino del servizio ai valori di riferimento e della cessazione dell'impatto sui clienti.
+  BC-2630.60:
+    name: Gestione dell'esperienza del cliente
+    description: |
+      Misurazione dell'esperienza del cliente in relazione agli eventi di servizio e outreach proattivo per mitigare l'insoddisfazione.
+  BC-2630.60.10:
+    name: Misurazione del NPS post-evento di servizio
+    description: |
+      Misurazione della soddisfazione del cliente e del NPS nel contesto degli eventi con impatto sul servizio.
+  BC-2630.60.20:
+    name: Segnalazione del rischio di abbandono
+    description: |
+      Identificazione dei clienti a rischio elevato di abbandono (churn) in seguito a incidenti di servizio.
+  BC-2630.60.30:
+    name: Outreach proattivo verso i clienti
+    description: |
+      Outreach proattivo verso i clienti impattati con comunicazioni, crediti e offerte di fidelizzazione.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-telecom-service-fulfilment-management.yaml
+++ b/catalogue/i18n/it/L1-telecom-service-fulfilment-management.yaml
@@ -1,0 +1,115 @@
+# Gestione del provisioning dei servizi di telecomunicazioni (it) — translations for L1-telecom-service-fulfilment-management.yaml
+locale: it
+source: L1-telecom-service-fulfilment-management.yaml
+entries:
+  BC-2620:
+    name: Gestione del provisioning dei servizi di telecomunicazioni
+    description: |
+      Acquisizione, scomposizione, provisioning, attivazione, accettazione e installazione presso le sedi del cliente degli ordini di servizio per clienti consumer, enterprise e wholesale — basata su eTOM Service Fulfilment e TM Forum Open API.
+  BC-2620.10:
+    name: Acquisizione degli ordini di servizio
+    description: |
+      Acquisizione multicanale degli ordini di servizio con verifiche di fattibilità e merito creditizio prima della sottomissione.
+  BC-2620.10.10:
+    name: Acquisizione degli ordini omnicanale
+    description: |
+      Acquisizione degli ordini di servizio attraverso canali retail, digitali, contact centre e partner.
+  BC-2620.10.20:
+    name: Verifica di fattibilità del servizio
+    description: |
+      Verifiche di fattibilità a livello di indirizzo, copertura e risorse rispetto ai servizi richiesti.
+  BC-2620.10.30:
+    name: Valutazione del credito e del rischio
+    description: |
+      Valutazione del merito creditizio e screening del rischio frode prima dell'accettazione dell'ordine.
+  BC-2620.10.40:
+    name: Sottomissione dell'ordine
+    description: |
+      Validazione, persistenza e inoltro a valle degli ordini di servizio accettati.
+  BC-2620.20:
+    name: Scomposizione degli ordini di servizio
+    description: |
+      Scomposizione degli ordini rivolti al cliente in attività rivolte alle risorse e sequenziamento delle dipendenze.
+  BC-2620.20.10:
+    name: Scomposizione servizio-risorsa
+    description: |
+      Scomposizione dei servizi rivolti al cliente in servizi ed elementi rivolti alle risorse.
+  BC-2620.20.20:
+    name: Generazione degli ordini di lavoro
+    description: |
+      Generazione di ordini di lavoro di rete e sul campo a partire dagli ordini di servizio scomposti.
+  BC-2620.20.30:
+    name: Sequenziamento delle dipendenze
+    description: |
+      Sequenziamento del lavoro dipendente tra i domini di rete per erogare un servizio end-to-end.
+  BC-2620.30:
+    name: Provisioning dei servizi
+    description: |
+      Allocazione delle risorse di rete e orchestrazione delle modifiche di configurazione per istanziare i servizi.
+  BC-2620.30.10:
+    name: Allocazione delle risorse di rete
+    description: |
+      Allocazione di banda, porte, indirizzi IP e altre risorse a una specifica istanza di servizio.
+  BC-2620.30.20:
+    name: Orchestrazione dei servizi
+    description: |
+      Esecuzione orchestrata dei passi di provisioning attraverso funzioni di rete fisiche e virtualizzate.
+  BC-2620.30.30:
+    name: Distribuzione della configurazione
+    description: |
+      Applicazione della configurazione specifica del servizio agli elementi di rete target.
+  BC-2620.40:
+    name: Attivazione del servizio
+    description: |
+      Attivazione finale dei servizi predisposti e notifica al cliente e ai sistemi a valle.
+  BC-2620.40.10:
+    name: Messa in servizio
+    description: |
+      Commutazione dei servizi predisposti nello stato attivo.
+  BC-2620.40.20:
+    name: Registrazione degli abbonati
+    description: |
+      Registrazione degli abbonati nei sistemi di autenticazione, autorizzazione e policy per il nuovo servizio.
+  BC-2620.40.30:
+    name: Attivazione della fatturazione
+    description: |
+      Comunicazione degli eventi di attivazione alla fatturazione per l'avvio dell'addebito e l'inizializzazione del contratto.
+  BC-2620.40.40:
+    name: Notifica di attivazione al cliente
+    description: |
+      Notifica ai clienti e ai canali che il servizio è attivo e pronto per l'utilizzo.
+  BC-2620.50:
+    name: Test di accettazione del servizio
+    description: |
+      Test end-to-end e acquisizione dei valori di riferimento prima del formale passaggio in consegna dei nuovi servizi.
+  BC-2620.50.10:
+    name: Test del servizio end-to-end
+    description: |
+      Esecuzione di test funzionali e di prestazione end-to-end sui servizi di nuova predisposizione.
+  BC-2620.50.20:
+    name: Acquisizione del baseline del servizio
+    description: |
+      Acquisizione dei valori di prestazione di riferimento del servizio per il monitoraggio degli SLA a valle.
+  BC-2620.50.30:
+    name: Firma dell'accettazione
+    description: |
+      Accettazione formale e passaggio in consegna dei servizi alle operazioni e al cliente.
+  BC-2620.60:
+    name: Coordinamento dell'installazione presso le sedi del cliente
+    description: |
+      Coordinamento dell'installazione in loco del CPE (Customer Premises Equipment) e delle attività associate.
+  BC-2620.60.10:
+    name: Pianificazione degli appuntamenti di installazione
+    description: |
+      Pianificazione degli appuntamenti con i clienti per le installazioni in loco.
+  BC-2620.60.20:
+    name: Coordinamento dell'installazione in loco
+    description: |
+      Coordinamento delle attività degli installatori, dei materiali e degli accessi presso le sedi del cliente.
+  BC-2620.60.30:
+    name: Registrazione dell'apparato del cliente
+    description: |
+      Registrazione del CPE installato e associazione all'istanza di servizio.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-telecom-subscriber-management.yaml
+++ b/catalogue/i18n/it/L1-telecom-subscriber-management.yaml
@@ -1,0 +1,107 @@
+# Gestione degli abbonati di telecomunicazioni (it) — translations for L1-telecom-subscriber-management.yaml
+locale: it
+source: L1-telecom-subscriber-management.yaml
+entries:
+  BC-2640:
+    name: Gestione degli abbonati di telecomunicazioni
+    description: |
+      Gestione dell'identità dell'abbonato, ciclo di vita di SIM ed eSIM, numerazione, portabilità del numero, identità del dispositivo, autenticazione e autorizzazione nelle reti mobili e fisse.
+  BC-2640.10:
+    name: Gestione dell'identità dell'abbonato
+    description: |
+      Gestione del ciclo di vita degli identificatori e dei profili degli abbonati nello strato dati degli abbonati.
+  BC-2640.10.10:
+    name: Provisioning dell'IMSI
+    description: |
+      Allocazione e provisioning dell'IMSI e degli identificatori equivalenti negli archivi dati degli abbonati.
+  BC-2640.10.20:
+    name: Gestione del profilo dell'abbonato
+    description: |
+      Gestione dei record di profilo dell'abbonato in HLR, HSS, UDM e sistemi equivalenti.
+  BC-2640.10.30:
+    name: Revoca dell'identità dell'abbonato
+    description: |
+      Revoca delle identità degli abbonati in caso di disdetta, frode o su richiesta dell'NRA.
+  BC-2640.20:
+    name: Gestione del ciclo di vita di SIM ed eSIM
+    description: |
+      Gestione del ciclo di vita delle SIM fisiche e dei profili eSIM, incluse personalizzazione, distribuzione, sostituzione e cambio.
+  BC-2640.20.10:
+    name: Provisioning della SIM fisica
+    description: |
+      Personalizzazione e distribuzione delle SIM fisiche.
+  BC-2640.20.20:
+    name: Gestione del profilo eSIM
+    description: |
+      Gestione dei profili eSIM tramite SM-DP+, SM-SR e piattaforme equivalenti.
+  BC-2640.20.30:
+    name: Sostituzione e cambio del profilo
+    description: |
+      Sostituzione e cambio dei profili SIM ed eSIM dell'abbonato, inclusi i flussi di contrasto alle frodi.
+  BC-2640.30:
+    name: Gestione delle risorse di numerazione
+    description: |
+      Gestione delle risorse di numerazione telefonica assegnate dai regolatori e della loro attribuzione ai servizi.
+  BC-2640.30.10:
+    name: Allocazione dei blocchi di numerazione
+    description: |
+      Acquisizione e allocazione di blocchi di numerazione dall'NRA nell'inventario interno.
+  BC-2640.30.20:
+    name: Gestione dell'inventario di numerazione
+    description: |
+      Gestione dell'inventario di numerazione disponibile, riservato, assegnato e in quarantena.
+  BC-2640.30.30:
+    name: Prenotazione e restituzione dei numeri
+    description: |
+      Prenotazione dei numeri per gli ordini e restituzione dei numeri non utilizzati al pool o all'NRA.
+  BC-2640.40:
+    name: Gestione della portabilità del numero
+    description: |
+      Portabilità del numero in entrata e in uscita per reti mobili e fisse e manutenzione dei dati di riferimento per il routing.
+  BC-2640.40.10:
+    name: Gestione della portabilità in entrata
+    description: |
+      Gestione delle richieste di portabilità del numero in entrata da altri operatori.
+  BC-2640.40.20:
+    name: Gestione della portabilità in uscita
+    description: |
+      Gestione delle richieste di portabilità del numero in uscita verso altri operatori.
+  BC-2640.40.30:
+    name: Manutenzione dei dati di routing per la portabilità
+    description: |
+      Manutenzione dei dati di routing per la portabilità, inclusi ENUM e database di riferimento centrali.
+  BC-2640.50:
+    name: Gestione dell'identità del dispositivo
+    description: |
+      Registrazione e controllo degli identificatori di dispositivo per l'eleggibilità al servizio e la blacklist dei dispositivi rubati.
+  BC-2640.50.10:
+    name: Registrazione IMEI
+    description: |
+      Registrazione degli IMEI dei dispositivi in associazione agli abbonati e verifiche di eleggibilità al servizio.
+  BC-2640.50.20:
+    name: Manutenzione dell'Equipment Identity Register
+    description: |
+      Manutenzione dei dati EIR per dispositivi in whitelist, greylist e blacklist.
+  BC-2640.50.30:
+    name: Blacklist dei dispositivi rubati
+    description: |
+      Inserimento in blacklist dei dispositivi rubati e smarriti in collaborazione con registri del settore e delle forze dell'ordine.
+  BC-2640.60:
+    name: Autenticazione e autorizzazione degli abbonati
+    description: |
+      Autenticazione, autorizzazione e accounting di abbonati e dispositivi attraverso le tecnologie di accesso.
+  BC-2640.60.10:
+    name: Autenticazione degli abbonati
+    description: |
+      Autenticazione degli abbonati attraverso gli accessi mobile, fisso e Wi-Fi tramite protocolli AAA.
+  BC-2640.60.20:
+    name: Gestione delle policy di autorizzazione
+    description: |
+      Gestione delle regole di autorizzazione al servizio e delle policy per abbonato e dispositivo.
+  BC-2640.60.30:
+    name: Gestione dei record di accounting
+    description: |
+      Generazione e gestione dei record di accounting AAA per la tariffazione e l'analisi a valle.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-terminal-yard-operations-management.yaml
+++ b/catalogue/i18n/it/L1-terminal-yard-operations-management.yaml
@@ -1,0 +1,124 @@
+# Gestione delle operazioni di terminal e piazzale (it) — translations for L1-terminal-yard-operations-management.yaml
+locale: it
+source: L1-terminal-yard-operations-management.yaml
+entries:
+  BC-2470:
+    name: Gestione delle operazioni di terminal e piazzale
+    description: |
+      Gestione di terminal portuali, intermodali, ferroviari e aeroportuali cargo, incluse
+      operazioni di handling navale e aeronautico, gestione del piazzale, cancello e
+      attrezzature di terminal.
+  BC-2470.10:
+    name: Gestione del handling di navi e aeromobili
+    description: |
+      Ormeggio, handling in rampa e carico o scarico di merci da navi e aeromobili nei
+      terminal.
+    in_scope:
+      - Operazioni cargo lato banchina e lato rampa
+      - Pianificazione dello stivaggio all'interfaccia terminale
+    out_of_scope:
+      - Operazioni a bordo durante il trasporto principale (BC-2420.20)
+  BC-2470.10.10:
+    name: Ormeggio e stivaggio delle navi
+    description: |
+      Pianificazione dell'ormeggio, dell'attracco e dello stivaggio per le navi in porto.
+  BC-2470.10.20:
+    name: Handling in rampa degli aeromobili
+    description: |
+      Handling in rampa e carico o scarico delle merci dagli aeromobili.
+  BC-2470.10.30:
+    name: Operazioni di carico e scarico merci
+    description: |
+      Carico e scarico di container, ULD e carico rinfusa.
+  BC-2470.20:
+    name: Gestione del piazzale e delle aree di stoccaggio
+    description: |
+      Allocazione e movimentazione di container, semirimorchi e carri ferroviari all'interno
+      dei piazzali e delle aree di stoccaggio del terminal.
+  BC-2470.20.10:
+    name: Allocazione degli slot del piazzale
+    description: |
+      Allocazione degli slot del piazzale alle unità in entrata e in uscita.
+  BC-2470.20.20:
+    name: Pianificazione delle aree di stoccaggio container
+    description: |
+      Pianificazione delle aree di stoccaggio per ottimizzare la rimaneggiatura e la
+      preparazione del carico.
+  BC-2470.20.30:
+    name: Gestione delle aree reefer e per merci pericolose
+    description: |
+      Gestione specializzata delle aree per i reefer con presa di corrente e per le
+      unità con merci pericolose.
+  BC-2470.30:
+    name: Gestione delle operazioni di cancello
+    description: |
+      Operazioni di cancello per camion e treni, incluse pre-accettazione con appuntamento,
+      gate-in e gate-out.
+  BC-2470.30.10:
+    name: Operazioni di gate-in
+    description: |
+      Ricezione di camion e carri ferroviari in entrata al cancello del terminal.
+  BC-2470.30.20:
+    name: Operazioni di gate-out
+    description: |
+      Rilascio di camion e carri ferroviari in uscita dal cancello del terminal.
+  BC-2470.30.30:
+    name: Gestione della pre-accettazione e degli appuntamenti
+    description: |
+      Gestione dell'identità, dei documenti e delle finestre di appuntamento in
+      pre-accettazione.
+  BC-2470.40:
+    name: Gestione delle attrezzature di terminal
+    description: |
+      Gestione e manutenzione delle attrezzature di movimentazione del terminal quali
+      gru, RTG, reach stacker e attrezzature di servizio a terra.
+  BC-2470.40.10:
+    name: Operazioni di gru e RTG
+    description: |
+      Gestione delle gru ship-to-shore, RTG e gru a portale.
+  BC-2470.40.20:
+    name: Operazioni delle attrezzature di servizio a terra
+    description: |
+      Gestione delle attrezzature di servizio a terra (GSE) quali trattori, carrelli e
+      caricatori.
+  BC-2470.40.30:
+    name: Manutenzione delle attrezzature di terminal
+    description: |
+      Manutenzione e revisione delle attrezzature di movimentazione del terminal.
+  BC-2470.50:
+    name: Gestione del trasferimento intermodale
+    description: |
+      Trasferimento di merci e unità tra modi di trasporto in punti intermodali quali
+      piazzali ferrovia-strada e stazioni di interline cargo aereo.
+  BC-2470.50.10:
+    name: Interscambio nel piazzale ferroviario
+    description: |
+      Interscambio di carri ferroviari e unità intermodali tra operatori ferroviari.
+  BC-2470.50.20:
+    name: Operazioni di trasferimento camion-ferrovia
+    description: |
+      Trasferimento di container e semirimorchi tra camion e treno.
+  BC-2470.50.30:
+    name: Interline cargo aereo
+    description: |
+      Interline delle merci tra vettori aerei negli aeroporti hub.
+  BC-2470.60:
+    name: Gestione della capacità e della performance del terminal
+    description: |
+      Misurazione e miglioramento della produttività, del tempo di sosta e del throughput
+      del terminal.
+  BC-2470.60.10:
+    name: Produttività delle banchine e degli stalli
+    description: |
+      Misurazione della produttività alle banchine navali e agli stalli aeromobili.
+  BC-2470.60.20:
+    name: Gestione del tempo di sosta dei container
+    description: |
+      Gestione dei tempi di sosta dei container e dell'esposizione alla demurrage.
+  BC-2470.60.30:
+    name: Reportistica del throughput del terminal
+    description: |
+      Reportistica del throughput del terminal per modo di trasporto e tipo di unità.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-time-and-engagement-billing-management.yaml
+++ b/catalogue/i18n/it/L1-time-and-engagement-billing-management.yaml
@@ -1,0 +1,170 @@
+# Gestione della fatturazione per ore e commesse (it) — translations for L1-time-and-engagement-billing-management.yaml
+locale: it
+source: L1-time-and-engagement-billing-management.yaml
+entries:
+  BC-4330:
+    name: Gestione della fatturazione per ore e commesse
+    description: |
+      Rilevazione delle ore, WIP (work in progress), accordi economici, fatturazione,
+      tasso di realizzazione e controllo degli stralci per gli incarichi addebitabili,
+      nonché gestione dei fondi fiduciari e dei retainer tipica della pratica legale.
+  BC-4330.10:
+    name: Gestione della rilevazione delle ore
+    description: |
+      Acquisizione, validazione e invio delle registrazioni delle ore dei professionisti
+      con dettaglio narrativo a livello di incarico e attività.
+  BC-4330.10.10:
+    name: Acquisizione delle registrazioni orarie
+    description: |
+      Inserimento giornaliero delle ore addebitabili e non addebitabili
+      per incarico, attività e granularità dell'operazione.
+  BC-4330.10.20:
+    name: Gestione della qualità delle descrizioni orarie
+    description: |
+      Controllo della qualità delle descrizioni orarie per rispettare
+      le linee guida di fatturazione del cliente e i requisiti di e-billing.
+  BC-4330.10.30:
+    name: Invio e approvazione delle ore
+    description: |
+      Invio, approvazione del supervisore e blocco
+      delle registrazioni orarie.
+  BC-4330.20:
+    name: Gestione dei rimborsi spese dell'incarico
+    description: |
+      Acquisizione e allocazione dei rimborsi spese dell'incarico, quali spese processuali,
+      onorari di esperti, viaggi e stampa, da addebitare al cliente.
+  BC-4330.20.10:
+    name: Acquisizione dei rimborsi spese
+    description: |
+      Acquisizione dei rimborsi spese nel fascicolo dell'incarico
+      per il recupero.
+  BC-4330.20.20:
+    name: Revisione della recuperabilità dei rimborsi spese
+    description: |
+      Revisione della recuperabilità dei rimborsi spese rispetto alla lettera d'incarico
+      e alle linee guida di fatturazione del cliente.
+  BC-4330.20.30:
+    name: Addebito dei rimborsi spese all'incarico
+    description: |
+      Allocazione dei rimborsi spese approvati al WIP dell'incarico
+      per la fatturazione.
+  BC-4330.30:
+    name: Gestione del work in progress
+    description: |
+      Monitoraggio dei saldi di WIP non fatturato, dell'invecchiamento e delle decisioni
+      di write-up o write-down prima della fatturazione.
+  BC-4330.30.10:
+    name: Monitoraggio del WIP
+    description: |
+      Monitoraggio in tempo reale del WIP non fatturato
+      per incarico, partner e practice.
+  BC-4330.30.20:
+    name: Analisi dell'invecchiamento del WIP
+    description: |
+      Analisi dell'invecchiamento del WIP non fatturato
+      ed escalation dei saldi in stallo.
+  BC-4330.30.30:
+    name: Decisioni di write-up e write-down del WIP
+    description: |
+      Processo decisionale a livello di partner su write-up,
+      write-down e rinvii del WIP prima della fatturazione.
+  BC-4330.40:
+    name: Gestione degli accordi economici
+    description: |
+      Manutenzione delle strutture economiche a livello di incarico, incluse tariffe orarie,
+      accordi economici alternativi, tariffe fisse, success fee e retainer.
+  BC-4330.40.10:
+    name: Manutenzione della tariffa
+    description: |
+      Manutenzione delle tariffe orarie standard, specifiche per cliente
+      e specifiche per incarico.
+  BC-4330.40.20:
+    name: Configurazione degli accordi economici alternativi
+    description: |
+      Configurazione di accordi a tariffa fissa, con massimale, success fee,
+      contingency e retainer per incarico.
+  BC-4330.40.30:
+    name: Gestione degli sconti e dei prezzi a volume
+    description: |
+      Applicazione degli sconti concordati e dei prezzi a volume
+      sul portafoglio di incarichi del cliente.
+  BC-4330.50:
+    name: Gestione della generazione delle fatture
+    description: |
+      Produzione delle fatture dell'incarico, formattazione delle descrizioni
+      e conformità ai requisiti di formato e-billing del cliente.
+  BC-4330.50.10:
+    name: Preparazione della fattura pro forma
+    description: |
+      Preparazione e revisione da parte del partner delle fatture pro forma
+      prima dell'emissione definitiva.
+  BC-4330.50.20:
+    name: Emissione della fattura definitiva
+    description: |
+      Emissione delle fatture definitive dell'incarico, incluse descrizioni,
+      rimborsi spese e imposta.
+  BC-4330.50.30:
+    name: Conformità al formato e-billing del cliente
+    description: |
+      Conformità ai requisiti e-billing del cliente, inclusi formati LEDES,
+      codici attività UTBMS e invio tramite portale cliente.
+  BC-4330.50.40:
+    name: Rispetto delle linee guida di fatturazione del cliente
+    description: |
+      Applicazione delle linee guida di fatturazione del cliente per ore,
+      tariffe e rimborsi spese.
+  BC-4330.60:
+    name: Gestione del tasso di realizzazione
+    description: |
+      Monitoraggio dei rapporti di realizzazione fatturato/incassato e standard/fatturato,
+      degli stralci e della redditività degli incarichi.
+  BC-4330.60.10:
+    name: Monitoraggio della realizzazione standard/fatturato
+    description: |
+      Monitoraggio del WIP a tariffa standard rispetto all'importo fatturato
+      per evidenziare le perdite di ricavo.
+  BC-4330.60.20:
+    name: Monitoraggio della realizzazione fatturato/incassato
+    description: |
+      Monitoraggio dell'importo fatturato rispetto all'incassato,
+      inclusi accantonamenti per crediti inesigibili.
+  BC-4330.60.30:
+    name: Reporting sulla redditività degli incarichi
+    description: |
+      Reporting sulla redditività per incarico, partner e practice
+      utilizzando ricavi realizzati e costi diretti.
+  BC-4330.60.40:
+    name: Approvazione e analisi degli stralci
+    description: |
+      Workflow di approvazione e analisi delle cause radice
+      degli stralci di WIP e crediti.
+  BC-4330.70:
+    name: Gestione dei fondi fiduciari e dei retainer del cliente
+    description: |
+      Gestione dei fondi del cliente detenuti in trust, dei conti IOLTA e dei saldi
+      di retainer, con requisiti distintivi di segregazione e riconciliazione
+      applicabili alla pratica legale.
+    in_scope:
+      - Operazioni del conto fiduciario del cliente
+      - Monitoraggio dei saldi di retainer
+      - Riconciliazione e reporting del conto fiduciario
+    out_of_scope:
+      - Tesoreria generale dello studio (BC-180)
+  BC-4330.70.10:
+    name: Operazioni del conto fiduciario del cliente
+    description: |
+      Gestione dei conti fiduciari segregati del cliente, inclusi
+      incassi e pagamenti per conto del cliente.
+  BC-4330.70.20:
+    name: Gestione dei saldi di retainer
+    description: |
+      Monitoraggio dei saldi di retainer del cliente
+      e dei trigger di reintegro.
+  BC-4330.70.30:
+    name: Riconciliazione e reporting del fondo fiduciario
+    description: |
+      Riconciliazione a tre vie dei libri contabili fiduciari e reporting statutario
+      o dell'ordine professionale sui saldi fiduciari.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-tour-itinerary-operations-management.yaml
+++ b/catalogue/i18n/it/L1-tour-itinerary-operations-management.yaml
@@ -1,0 +1,203 @@
+# Gestione dei tour e degli itinerari (it) — translations for L1-tour-itinerary-operations-management.yaml
+locale: it
+source: L1-tour-itinerary-operations-management.yaml
+entries:
+  BC-4100:
+    name: Gestione dei tour e degli itinerari
+    description: |
+      Operazione delle attività di tour operator e destination management — assemblaggio
+      del prodotto e contrattazione con i fornitori, decisioni sulle partenze, erogazione
+      delle guide e degli accompagnatori, logistica in destinazione, coordinamento dei fornitori,
+      recupero dell'itinerario e documentazione dei clienti.
+    in_scope:
+      - Assemblaggio del prodotto tour e contrattazione con i fornitori
+      - Soglie di partenza e decisioni go/no-go
+      - Assegnazione, briefing e monitoraggio delle performance delle guide in tour
+      - Transfer in destinazione ed esecuzione dei day tour
+      - Modifica in tempo reale dell'itinerario e recupero in caso di forza maggiore
+      - Documentazione dei clienti e emissione di voucher
+    out_of_scope:
+      - Definizione del master prodotto tour e del pool di inventario (BC-4000.30)
+      - Ciclo di vita delle prenotazioni (BC-4020)
+      - Operazioni di crociera (BC-4090)
+  BC-4100.10:
+    name: Assemblaggio del prodotto tour e contrattazione
+    description: |
+      Assemblaggio dei prodotti tour, contrattazione con i fornitori, calcolo
+      dei costi, definizione dei percorsi e stato del ciclo di vita del prodotto
+      per i brand tour.
+  BC-4100.10.10:
+    name: Contrattazione con i fornitori e negoziazione degli allotment
+    description: |
+      Contrattazione con fornitori di alloggio, trasporto e attività,
+      inclusa la negoziazione degli allotment.
+  BC-4100.10.20:
+    name: Calcolo del costo del tour e costruzione del margine
+    description: |
+      Calcolo del costo dei prodotti tour e costruzione del margine
+      rispetto ai prezzi di vendita target.
+  BC-4100.10.30:
+    name: Composizione dell'itinerario e definizione del percorso
+    description: |
+      Composizione degli itinerari e definizione dei percorsi
+      tra destinazioni e componenti dei fornitori.
+  BC-4100.10.40:
+    name: Stato del ciclo di vita del prodotto tour
+    description: |
+      Stato del ciclo di vita dei prodotti tour dal concept
+      e dal pilota al ritiro.
+  BC-4100.20:
+    name: Gestione delle partenze dei tour
+    description: |
+      Decisioni sulle partenze dei tour, incluse soglie di numero minimo
+      di partecipanti, allocazione, consolidamento tra brand e cancellazione o sostituzione.
+  BC-4100.20.10:
+    name: Soglia di partenza e decisione go/no-go
+    description: |
+      Decisione sull'operatività delle partenze pianificate
+      rispetto alle soglie di numero minimo di partecipanti.
+  BC-4100.20.20:
+    name: Allocazione delle partenze e rilascio dell'inventario
+    description: |
+      Allocazione dei posti e decisioni di rilascio dell'inventario
+      tra le partenze.
+  BC-4100.20.30:
+    name: Consolidamento delle partenze tra brand
+    description: |
+      Consolidamento delle partenze marginali tra brand affiliati
+      o operatori partner.
+  BC-4100.20.40:
+    name: Cancellazione e sostituzione delle partenze
+    description: |
+      Cancellazione delle partenze non sostenibili e sostituzione
+      su date di partenza alternative.
+  BC-4100.30:
+    name: Operazioni di guida e accompagnatore del tour
+    description: |
+      Assegnazione, briefing, gestione delle performance e coordinamento
+      delle guide locali per l'erogazione del tour.
+  BC-4100.30.10:
+    name: Assegnazione di guide e tour director
+    description: |
+      Assegnazione di guide e tour director alle partenze
+      in base ai requisiti linguistici e di itinerario.
+  BC-4100.30.20:
+    name: Briefing pre-tour e gestione dei contenuti
+    description: |
+      Briefing pre-tour dei team di accompagnamento e gestione
+      degli script e dei contenuti dell'itinerario.
+  BC-4100.30.30:
+    name: Monitoraggio delle performance della guida in tour
+    description: |
+      Monitoraggio delle performance della guida durante l'erogazione
+      del tour tramite feedback degli ospiti e report degli accompagnatori.
+  BC-4100.30.40:
+    name: Coordinamento delle guide locali
+    description: |
+      Coordinamento delle guide locali nelle destinazioni rispetto
+      ai requisiti specifici per città e sito.
+  BC-4100.40:
+    name: Logistica in destinazione e transfer
+    description: |
+      Logistica in destinazione, inclusi servizi pullman e veicoli,
+      transfer aeroportuali e alberghieri, esecuzione di day tour
+      e biglietteria per le attività.
+  BC-4100.40.10:
+    name: Logistica pullman e veicoli
+    description: |
+      Logistica per i servizi pullman e veicoli
+      durante l'itinerario.
+  BC-4100.40.20:
+    name: Transfer aeroportuali e alberghieri
+    description: |
+      Operazione dei transfer aeroportuali e alberghieri
+      per i viaggiatori del tour.
+  BC-4100.40.30:
+    name: Operazioni di esecuzione dei day tour
+    description: |
+      Esecuzione dei day tour e delle escursioni all'interno
+      degli itinerari multi-giorno.
+  BC-4100.40.40:
+    name: Operazioni di biglietteria per attività e attrazioni
+    description: |
+      Operazioni di biglietteria per attività e attrazioni,
+      inclusa l'allocazione degli slot orari.
+  BC-4100.50:
+    name: Coordinamento dei fornitori del tour
+    description: |
+      Coordinamento con destination management company, strutture ricettive
+      e fornitori di attività nell'erogazione operativa.
+  BC-4100.50.10:
+    name: Coordinamento con DMC e operatori locali
+    description: |
+      Coordinamento con le destination management company e gli operatori
+      locali che erogano i servizi del tour.
+  BC-4100.50.20:
+    name: Coordinamento con i fornitori di alloggio
+    description: |
+      Coordinamento con i fornitori di alloggio su assegnazione camere,
+      orari di arrivo e richieste speciali.
+  BC-4100.50.30:
+    name: Coordinamento con i fornitori di attrazioni e attività
+    description: |
+      Coordinamento con i fornitori di attrazioni e attività, relativamente
+      ad accessi, capacità e disposizioni speciali.
+  BC-4100.50.40:
+    name: Operazioni di gestione delle performance dei fornitori
+    description: |
+      Gestione operativa delle performance dei fornitori del tour
+      sulla base del feedback degli accompagnatori e dell'esperienza dei viaggiatori.
+  BC-4100.60:
+    name: Modifica dell'itinerario e recupero
+    description: |
+      Modifica in tempo reale degli itinerari del tour e recupero
+      da eventi di disruption, inclusa la forza maggiore e le modifiche
+      richieste dal viaggiatore.
+  BC-4100.60.10:
+    name: Operazioni di modifica dell'itinerario in tempo reale
+    description: |
+      Modifica in tempo reale degli itinerari mentre il tour è in corso
+      a causa di eventi operativi.
+  BC-4100.60.20:
+    name: Recupero dell'itinerario in caso di forza maggiore
+    description: |
+      Recupero degli itinerari durante eventi di forza maggiore, come
+      maltempo, scioperi e instabilità politica.
+  BC-4100.60.30:
+    name: Modifica dell'itinerario su richiesta del viaggiatore
+    description: |
+      Gestione delle modifiche richieste dal viaggiatore che influenzano
+      le prenotazioni con i fornitori a valle.
+  BC-4100.60.40:
+    name: Determinazione del risarcimento per il recupero
+    description: |
+      Determinazione del risarcimento a seguito delle modifiche
+      all'itinerario, inclusi rimborso e gesto di buona volontà.
+  BC-4100.70:
+    name: Documentazione dei clienti del tour
+    description: |
+      Emissione e re-emissione dei documenti di viaggio finali, voucher,
+      informazioni pre-partenza e comunicazioni specifiche per i viaggiatori.
+  BC-4100.70.10:
+    name: Emissione dei documenti di viaggio finali
+    description: |
+      Emissione dei documenti di viaggio finali, inclusi l'itinerario
+      definitivo e i contatti di emergenza.
+  BC-4100.70.20:
+    name: Emissione di voucher e documenti di servizio
+    description: |
+      Emissione di voucher e documenti di servizio da presentare
+      presso i fornitori del tour.
+  BC-4100.70.30:
+    name: Pacchetto informativo pre-partenza
+    description: |
+      Compilazione dei pacchetti informativi pre-partenza, incluse
+      indicazioni su salute, visti e cosa portare.
+  BC-4100.70.40:
+    name: Operazioni di re-emissione dei documenti di viaggio
+    description: |
+      Re-emissione dei documenti dopo modifiche all'itinerario
+      e variazioni dei dati del viaggiatore.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-trade-finance-management.yaml
+++ b/catalogue/i18n/it/L1-trade-finance-management.yaml
@@ -1,0 +1,99 @@
+# Gestione del trade finance (it) — translations for L1-trade-finance-management.yaml
+locale: it
+source: L1-trade-finance-management.yaml
+entries:
+  BC-1350:
+    name: Gestione del trade finance
+    description: |
+      Crediti documentari, garanzie bancarie, supply chain finance e prestiti commerciali.
+  BC-1350.10:
+    name: Gestione dei crediti documentari
+    description: |
+      Lettere di credito, LC di importazione ed esportazione.
+  BC-1350.10.10:
+    name: Emissione di lettere di credito
+    description: |
+      Emissione di lettere di credito di importazione in conformità alle UCP 600.
+  BC-1350.10.20:
+    name: Avviso e conferma di lettere di credito
+    description: |
+      Avviso e conferma di lettere di credito di esportazione.
+  BC-1350.10.30:
+    name: Esame dei documenti e verifica della conformità
+    description: |
+      Esame dei documenti per la conformità alle UCP e alle ISBP.
+  BC-1350.10.40:
+    name: Regolamento e rimborso nell'ambito dei crediti documentari
+    description: |
+      Regolamento e rimborso nell'ambito dei crediti documentari.
+  BC-1350.20:
+    name: Gestione delle garanzie bancarie e delle lettere di credito stand-by
+    description: |
+      Garanzie bancarie, lettere di credito stand-by e fideiussioni.
+  BC-1350.20.10:
+    name: Emissione di garanzie bancarie
+    description: |
+      Emissione di garanzie bancarie e fideiussioni.
+  BC-1350.20.20:
+    name: Emissione di lettere di credito stand-by
+    description: |
+      Emissione di lettere di credito stand-by in conformità alle ISP98.
+  BC-1350.20.30:
+    name: Gestione delle escussioni di garanzia
+    description: |
+      Gestione delle richieste di escussione nell'ambito delle garanzie bancarie.
+  BC-1350.20.40:
+    name: Modifiche e cancellazione delle garanzie
+    description: |
+      Modifiche, proroghe e cancellazione delle garanzie bancarie.
+  BC-1350.30:
+    name: Gestione degli incassi documentari
+    description: |
+      Incassi documentari D/P e D/A.
+  BC-1350.30.10:
+    name: Operatività degli incassi contro pagamento
+    description: |
+      Operazioni di incasso documentario D/P in conformità alle URC 522.
+  BC-1350.30.20:
+    name: Operatività degli incassi contro accettazione
+    description: |
+      Operazioni di incasso documentario D/A, incluse le tratte.
+  BC-1350.30.30:
+    name: Regolamento degli incassi documentari
+    description: |
+      Regolamento e rimessa nell'ambito degli incassi documentari.
+  BC-1350.40:
+    name: Gestione della supply chain finance
+    description: |
+      Reverse factoring, finanziamento dei debiti commerciali e sconti dinamici.
+  BC-1350.40.10:
+    name: Finanziamento dei debiti commerciali su iniziativa del compratore
+    description: |
+      Programmi di reverse factoring e finanziamento dei debiti commerciali su iniziativa del compratore.
+  BC-1350.40.20:
+    name: Programmi di finanziamento dei crediti commerciali
+    description: |
+      Finanziamento dei crediti commerciali e factoring per i venditori.
+  BC-1350.40.30:
+    name: Operatività dello sconto dinamico
+    description: |
+      Piattaforme di sconto dinamico e calcolo dello sconto.
+  BC-1350.50:
+    name: Gestione dei prestiti commerciali
+    description: |
+      Finanziamento commerciale pre-export e post-export.
+  BC-1350.50.10:
+    name: Finanziamento commerciale pre-export
+    description: |
+      Finanziamento pre-export del capitale circolante e della produzione.
+  BC-1350.50.20:
+    name: Finanziamento commerciale post-export
+    description: |
+      Operazioni di sconto post-export e forfaiting.
+  BC-1350.50.30:
+    name: Finanziamento all'importazione
+    description: |
+      Finanziamento all'importazione, compresi i finanziamenti ponte e le ricevute fiduciarie.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-trade-promotion-management.yaml
+++ b/catalogue/i18n/it/L1-trade-promotion-management.yaml
@@ -1,0 +1,129 @@
+# Gestione delle promozioni commerciali (it) — translations for L1-trade-promotion-management.yaml
+locale: it
+source: L1-trade-promotion-management.yaml
+entries:
+  BC-2360:
+    name: Gestione delle promozioni commerciali
+    description: |
+      Disciplina dei beni di consumo relativa all'investimento commerciale con i clienti
+      retail — piani commerciali congiunti, budgeting dell'investimento promozionale,
+      esecuzione degli eventi in negozio, gestione delle detrazioni e misurazione del
+      sell-out post-evento.
+  BC-2360.10:
+    name: Strategia e pianificazione delle promozioni commerciali
+    description: |
+      Strategia annuale delle promozioni commerciali, pianificazione dell'investimento
+      per cliente e piani commerciali congiunti negoziati con i clienti retail.
+    in_scope:
+      - Calendario annuale delle promozioni commerciali
+      - Piani commerciali congiunti per cliente
+      - Strategia per slotting fee e listing fee
+  BC-2360.10.10:
+    name: Sviluppo del piano commerciale annuale
+    description: |
+      Sviluppo del piano annuale delle promozioni commerciali e del calendario degli
+      eventi.
+  BC-2360.10.20:
+    name: Pianificazione commerciale congiunta con i clienti
+    description: |
+      Pianificazione commerciale congiunta con i clienti retail strategici.
+  BC-2360.10.30:
+    name: Strategia per slotting fee e listing fee
+    description: |
+      Strategia e negoziazione delle slotting fee e delle listing fee per i nuovi
+      articoli.
+  BC-2360.20:
+    name: Gestione del budget dell'investimento promozionale
+    description: |
+      Budgeting dell'investimento promozionale, accantonamenti, allocazione per cliente
+      e controllo finanziario degli investimenti commerciali.
+  BC-2360.20.10:
+    name: Budgeting dell'investimento promozionale
+    description: |
+      Definizione del budget dell'investimento promozionale per cliente, marchio ed
+      evento.
+  BC-2360.20.20:
+    name: Gestione degli accantonamenti per investimento promozionale
+    description: |
+      Accantonamento delle passività relative all'investimento promozionale per cliente
+      ed evento.
+  BC-2360.20.30:
+    name: Allocazione dell'investimento promozionale
+    description: |
+      Allocazione delle risorse di investimento promozionale per clienti, aree
+      geografiche ed eventi.
+  BC-2360.20.40:
+    name: Controllo finanziario dell'investimento promozionale
+    description: |
+      Controllo finanziario dell'investimento promozionale, incluse le soglie di
+      approvazione.
+  BC-2360.30:
+    name: Gestione dell'esecuzione degli eventi promozionali
+    description: |
+      Esecuzione di eventi promozionali in negozio e online, inclusi audit del perfect
+      store e attivazione dei team sul campo.
+  BC-2360.30.10:
+    name: Impostazione dell'evento con il cliente
+    description: |
+      Impostazione degli eventi promozionali con il cliente retail, inclusi artwork e
+      previsioni.
+  BC-2360.30.20:
+    name: Attivazione e display in negozio
+    description: |
+      Attivazione di display in negozio, gondole e posizionamenti secondari.
+  BC-2360.30.30:
+    name: Esecuzione degli audit del perfect store
+    description: |
+      Esecuzione sul campo degli audit del perfect store e delle verifiche tramite image
+      recognition.
+  BC-2360.30.40:
+    name: Attivazione del team di vendita sul campo
+    description: |
+      Attivazione dei team di vendita sul campo per guidare l'esecuzione degli eventi.
+  BC-2360.40:
+    name: Gestione delle detrazioni e dei reclami
+    description: |
+      Validazione, contestazione e risoluzione delle detrazioni dei clienti e dei
+      reclami promozionali applicati sulle fatture.
+    in_scope:
+      - Acquisizione delle detrazioni e abbinamento agli eventi
+      - Validazione rispetto ai termini concordati
+      - Risoluzione delle controversie e recupero
+    out_of_scope:
+      - Riscossioni AR generiche (BC-200)
+  BC-2360.40.10:
+    name: Acquisizione e abbinamento delle detrazioni
+    description: |
+      Acquisizione delle detrazioni dei clienti e abbinamento agli eventi promozionali.
+  BC-2360.40.20:
+    name: Validazione delle detrazioni
+    description: |
+      Validazione delle detrazioni rispetto a termini, volumi e prezzi concordati.
+  BC-2360.40.30:
+    name: Risoluzione delle controversie e recupero
+    description: |
+      Risoluzione delle controversie con il cliente e recupero delle detrazioni non
+      valide.
+  BC-2360.50:
+    name: Misurazione dell'efficacia delle promozioni commerciali
+    description: |
+      Misurazione post-evento del sell-out incrementale, analisi baseline vs. incrementale
+      e ROI promozionale per evento, cliente e marchio.
+  BC-2360.50.10:
+    name: Misurazione della baseline e del sell-out incrementale
+    description: |
+      Misurazione delle vendite di baseline e del sell-out incrementale generato dagli
+      eventi promozionali.
+  BC-2360.50.20:
+    name: Analisi del ROI promozionale
+    description: |
+      Analisi del ROI promozionale delle promozioni commerciali per evento, cliente e
+      marchio.
+  BC-2360.50.30:
+    name: Analisi della cannibalizzazione e dell'anticipo della domanda
+    description: |
+      Analisi degli effetti di cannibalizzazione e di anticipo della domanda generati
+      dalle promozioni.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-transformation-management.yaml
+++ b/catalogue/i18n/it/L1-transformation-management.yaml
@@ -1,0 +1,87 @@
+# Gestione della trasformazione (it) — translations for L1-transformation-management.yaml
+locale: it
+source: L1-transformation-management.yaml
+entries:
+  BC-920:
+    name: Gestione della trasformazione
+    description: |
+      Programmi di trasformazione aziendale su larga scala.
+  BC-920.10:
+    name: Gestione del programma di trasformazione
+    description: |
+      Realizzazione end-to-end del programma di trasformazione.
+  BC-920.10.10:
+    name: Visione e design della trasformazione
+    description: |
+      Definizione della visione della trasformazione, dello stato target e del design.
+  BC-920.10.20:
+    name: Definizione della roadmap di trasformazione
+    description: |
+      Roadmap di trasformazione pluriennale e pianificazione delle wave.
+  BC-920.10.30:
+    name: Realizzazione dei workstream di trasformazione
+    description: |
+      Realizzazione dei workstream di trasformazione e gestione delle dipendenze.
+  BC-920.10.40:
+    name: Gestione del rischio di trasformazione
+    description: |
+      Identificazione e gestione dei rischi a livello di trasformazione.
+  BC-920.20:
+    name: Gestione della governance della trasformazione
+    description: |
+      Steering della trasformazione, diritti decisionali ed escalation.
+  BC-920.20.10:
+    name: Operatività dell'organo di steering della trasformazione
+    description: |
+      Operatività del comitato di steering e dell'authority di design.
+  BC-920.20.20:
+    name: Gestione delle decisioni di trasformazione
+    description: |
+      Framework decisionale, registro delle decisioni e percorsi di escalation.
+  BC-920.20.30:
+    name: Assurance della trasformazione
+    description: |
+      Assurance indipendente della salute e della qualità della trasformazione.
+  BC-920.30:
+    name: Gestione della realizzazione dei benefici
+    description: |
+      Identificazione, monitoraggio e realizzazione dei benefici.
+  BC-920.30.10:
+    name: Identificazione e mappatura dei benefici
+    description: |
+      Identificazione e mappa dei benefici collegati agli outcome attesi.
+  BC-920.30.20:
+    name: Definizione della baseline e dei target dei benefici
+    description: |
+      Misurazione della baseline e definizione dei target dei benefici.
+  BC-920.30.30:
+    name: Monitoraggio e reporting dei benefici
+    description: |
+      Monitoraggio dei benefici, reporting sulla realizzazione e validazione.
+  BC-920.30.40:
+    name: Ottimizzazione della cattura del valore
+    description: |
+      Identificazione di ulteriori opportunità di cattura del valore.
+  BC-920.40:
+    name: Operatività della transformation office
+    description: |
+      Servizi e operatività della transformation office.
+  BC-920.40.10:
+    name: Avvio della transformation office
+    description: |
+      Avvio della transformation office, definizione dei ruoli e del modello operativo.
+  BC-920.40.20:
+    name: Reporting della trasformazione
+    description: |
+      Reporting e dashboard sullo stato di avanzamento della trasformazione.
+  BC-920.40.30:
+    name: Gestione degli strumenti di trasformazione
+    description: |
+      Strumenti per il monitoraggio della trasformazione, delle dipendenze e dei benefici.
+  BC-920.40.40:
+    name: Sviluppo delle competenze di trasformazione
+    description: |
+      Sviluppo delle competenze e coaching per i leader della trasformazione.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-transport-network-planning-management.yaml
+++ b/catalogue/i18n/it/L1-transport-network-planning-management.yaml
@@ -1,0 +1,105 @@
+# Gestione della pianificazione della rete di trasporto (it) — translations for L1-transport-network-planning-management.yaml
+locale: it
+source: L1-transport-network-planning-management.yaml
+entries:
+  BC-2410:
+    name: Gestione della pianificazione della rete di trasporto
+    description: |
+      Progettazione di reti di trasporto, tratte, hub, orari e mix modale che definiscono
+      il portafoglio di servizi del vettore o del 3PL.
+  BC-2410.10:
+    name: Gestione della progettazione della rete
+    description: |
+      Progettazione a lungo orizzonte di hub, gateway, tratte e mix modale a supporto
+      del portafoglio di servizi.
+    in_scope:
+      - Decisioni strutturali hub-and-spoke e point-to-point
+      - Progettazione del mix modale su strada, ferrovia, mare e aria
+    out_of_scope:
+      - Progettazione della rete dal lato della domanda dei mittenti (BC-520)
+  BC-2410.10.10:
+    name: Progettazione di hub e gateway
+    description: |
+      Selezione e dimensionamento di hub, gateway e punti di consolidamento.
+  BC-2410.10.20:
+    name: Progettazione di tratte e servizi
+    description: |
+      Definizione delle tratte origine-destinazione e dei servizi operanti su di esse.
+  BC-2410.10.30:
+    name: Progettazione del mix modale
+    description: |
+      Scelta del modo di trasporto e del mix intermodale per ciascuna tratta e livello
+      di servizio.
+  BC-2410.20:
+    name: Gestione della pianificazione degli orari
+    description: |
+      Costruzione degli orari master, degli slot e delle finestre di servizio per
+      navigazioni, voli, tracce ferroviarie e partenze camion.
+  BC-2410.20.10:
+    name: Progettazione degli orari master
+    description: |
+      Progettazione degli orari ricorrenti per navigazioni, voli, treni e camion.
+  BC-2410.20.20:
+    name: Pianificazione degli slot e delle finestre
+    description: |
+      Allocazione delle finestre di ormeggio, pista e gate ai servizi programmati.
+  BC-2410.20.30:
+    name: Pubblicazione degli orari
+    description: |
+      Pubblicazione degli orari a clienti, partner e canali di prenotazione.
+  BC-2410.30:
+    name: Gestione dei pattern di servizio
+    description: |
+      Definizione dei prodotti di servizio, dei livelli di tempo di transito e del
+      catalogo dei servizi offerti ai clienti.
+  BC-2410.30.10:
+    name: Definizione dei livelli di servizio
+    description: |
+      Definizione dei livelli di servizio espresso, standard, differito e intermodale
+      con i relativi impegni.
+  BC-2410.30.20:
+    name: Ingegnerizzazione dei tempi di transito
+    description: |
+      Ingegnerizzazione dei tempi di transito end-to-end tra tratte e coincidenze.
+  BC-2410.30.30:
+    name: Gestione del catalogo dei servizi
+    description: |
+      Manutenzione del catalogo pubblicato dei servizi di trasporto.
+  BC-2410.40:
+    name: Gestione del bilanciamento capacità-domanda
+    description: |
+      Riconciliazione della capacità pianificata con la domanda prevista, incluso il
+      riposizionamento delle attrezzature vuote.
+  BC-2410.40.10:
+    name: Integrazione delle previsioni della domanda
+    description: |
+      Integrazione delle previsioni della domanda di clienti e mercato nei piani di rete.
+  BC-2410.40.20:
+    name: Riconciliazione del piano di capacità
+    description: |
+      Riconciliazione della capacità pianificata con la domanda e i vincoli operativi.
+  BC-2410.40.30:
+    name: Pianificazione del riposizionamento delle attrezzature vuote
+    description: |
+      Pianificazione del riposizionamento di container, semirimorchi e ULD vuoti.
+  BC-2410.50:
+    name: Ottimizzazione e simulazione della rete
+    description: |
+      Modellizzazione, simulazione e benchmarking di opzioni di rete e scenari di
+      perturbazione.
+  BC-2410.50.10:
+    name: Modellizzazione della rete
+    description: |
+      Costruzione di modelli analitici della rete di trasporto.
+  BC-2410.50.20:
+    name: Simulazione di scenari
+    description: |
+      Simulazione di domanda, perturbazioni e alternative progettuali.
+  BC-2410.50.30:
+    name: Benchmarking della performance della rete
+    description: |
+      Benchmarking del costo e del servizio della rete rispetto a concorrenti e
+      configurazioni precedenti.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-transport-operations-management.yaml
+++ b/catalogue/i18n/it/L1-transport-operations-management.yaml
@@ -1,0 +1,129 @@
+# Gestione delle operazioni di trasporto (it) — translations for L1-transport-operations-management.yaml
+locale: it
+source: L1-transport-operations-management.yaml
+entries:
+  BC-2420:
+    name: Gestione delle operazioni di trasporto
+    description: |
+      Esecuzione multimodale dei movimenti di trasporto dal ritiro al trasporto principale,
+      al drayage e alla consegna last mile, inclusa la risposta alle perturbazioni operative.
+  BC-2420.10:
+    name: Gestione del dispacciamento
+    description: |
+      Assegnazione di carichi, autisti, equipaggi e attrezzature a movimenti di trasporto
+      programmati e ad hoc.
+    in_scope:
+      - Assegnazione carico-autista e carico-veicolo
+      - Istruzioni per il posizionamento delle attrezzature
+    out_of_scope:
+      - Pianificazione turni autisti prima del dispacciamento (BC-2440)
+      - Allocazione della capacità per contratto (BC-2400.20)
+  BC-2420.10.10:
+    name: Assegnazione del carico
+    description: |
+      Assegnazione dei carichi a veicoli, navi, voli o tracce ferroviarie.
+  BC-2420.10.20:
+    name: Dispacciamento di autisti ed equipaggi
+    description: |
+      Dispacciamento di autisti ed equipaggi qualificati rispetto ai carichi assegnati.
+  BC-2420.10.30:
+    name: Dispacciamento delle attrezzature
+    description: |
+      Posizionamento di container, semirimorchi e ULD per i movimenti assegnati.
+  BC-2420.20:
+    name: Gestione delle operazioni di trasporto principale
+    description: |
+      Movimento a lunga distanza delle merci tra hub, terminal e gateway attraverso
+      i diversi modi di trasporto.
+  BC-2420.20.10:
+    name: Operazioni di trasporto principale su strada
+    description: |
+      Trasporto a lunga distanza su camion tra hub e terminal.
+  BC-2420.20.20:
+    name: Operazioni di trasporto principale su ferrovia
+    description: |
+      Gestione dei treni merci e dei servizi di treno blocco.
+  BC-2420.20.30:
+    name: Operazioni di trasporto principale via mare
+    description: |
+      Operazioni di navigazione tra porti, incluse le tratte di transhipment.
+  BC-2420.20.40:
+    name: Operazioni di trasporto principale via aerea
+    description: |
+      Gestione dei voli cargo e dei servizi freighter tra aeroporti.
+  BC-2420.30:
+    name: Gestione delle operazioni di ritiro e drayage
+    description: |
+      Ritiro first mile dai mittenti e drayage a corto raggio tra terminal, piazzali
+      e punti interni.
+  BC-2420.30.10:
+    name: Operazioni di ritiro
+    description: |
+      Raccolta delle merci da mittenti e consolidatori.
+  BC-2420.30.20:
+    name: Operazioni di drayage container
+    description: |
+      Drayage di container tra terminal portuali, raccordi ferroviari e depositi interni.
+  BC-2420.30.30:
+    name: Movimento delle attrezzature vuote
+    description: |
+      Movimento di container, semirimorchi e ULD vuoti tra depositi.
+  BC-2420.40:
+    name: Gestione delle operazioni di consegna last mile
+    description: |
+      Consegna dell'ultima tratta ai destinatari, inclusi routing, esecuzione e prova
+      di consegna (POD).
+  BC-2420.40.10:
+    name: Routing dell'ultima tratta
+    description: |
+      Routing e sequenziamento delle soste di consegna e delle finestre orarie.
+  BC-2420.40.20:
+    name: Esecuzione della consegna al cliente
+    description: |
+      Consegna in loco, acquisizione della firma e passaggio di consegna ai destinatari.
+  BC-2420.40.30:
+    name: Prova di consegna (POD)
+    description: |
+      Acquisizione e archiviazione delle prove di consegna (POD).
+  BC-2420.40.40:
+    name: Gestione delle eccezioni di consegna
+    description: |
+      Gestione di rifiuti, mancate consegne e nuovi tentativi.
+  BC-2420.50:
+    name: Gestione delle perturbazioni operative
+    description: |
+      Rilevamento delle perturbazioni operative in corso e coordinamento delle azioni
+      di recupero.
+  BC-2420.50.10:
+    name: Rilevamento degli incidenti operativi
+    description: |
+      Rilevamento di guasti, condizioni meteorologiche, ritardi portuali e altre
+      perturbazioni.
+  BC-2420.50.20:
+    name: Deviazione e recupero
+    description: |
+      Deviazione delle merci e recupero dei servizi perturbati.
+  BC-2420.50.30:
+    name: Ripristino del servizio
+    description: |
+      Ripristino degli orari normali e degli impegni verso i clienti.
+  BC-2420.60:
+    name: Gestione della performance operativa
+    description: |
+      Misurazione operativa della puntualità, dei tempi di transito e del rispetto
+      dei livelli di servizio.
+  BC-2420.60.10:
+    name: Monitoraggio della puntualità
+    description: |
+      Monitoraggio della puntualità di ritiro, partenza, arrivo e consegna.
+  BC-2420.60.20:
+    name: Monitoraggio dei tempi di transito
+    description: |
+      Monitoraggio dei tempi di transito effettivi rispetto a quelli concordati.
+  BC-2420.60.30:
+    name: Reportistica dei KPI operativi
+    description: |
+      Reportistica dei KPI operativi agli stakeholder interni ed esterni.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-travel-distribution-channel-management.yaml
+++ b/catalogue/i18n/it/L1-travel-distribution-channel-management.yaml
@@ -1,0 +1,194 @@
+# Gestione della distribuzione e dei canali di viaggio (it) — translations for L1-travel-distribution-channel-management.yaml
+locale: it
+source: L1-travel-distribution-channel-management.yaml
+entries:
+  BC-4010:
+    name: Gestione della distribuzione e dei canali di viaggio
+    description: |
+      Gestione della distribuzione e del merchandising dei prodotti di viaggio attraverso canali
+      diretti, GDS, OTA, wholesale e metasearch — incluse la connettività di canale,
+      la sindacazione dei contenuti e la parità di tariffa e disponibilità.
+    in_scope:
+      - Operazioni sui canali diretto, GDS, OTA, wholesale e metasearch
+      - Operazioni dell'hub channel manager e sindacazione dei contenuti
+      - Politica e applicazione della parità di tariffa e disponibilità
+    out_of_scope:
+      - Definizione del master prodotto e del pool di inventario (BC-4000)
+      - Ciclo di vita delle prenotazioni (BC-4020)
+      - Decisioni di prezzo e yield (BC-4030)
+  BC-4010.10:
+    name: Gestione della distribuzione sul canale diretto
+    description: |
+      Distribuzione dei prodotti di viaggio attraverso canali diretti di proprietà dell'impresa,
+      inclusi web, mobile, voce e chioschi self-service.
+  BC-4010.10.10:
+    name: Gestione della distribuzione sul sito del brand
+    description: |
+      Operazione del sito del brand come superficie di ricerca e prenotazione diretta
+      per i prodotti di viaggio.
+  BC-4010.10.20:
+    name: Gestione della distribuzione sull'app mobile
+    description: |
+      Operazione di applicazioni mobile native come superficie di distribuzione
+      e assistenza diretta.
+  BC-4010.10.30:
+    name: Distribuzione via voce e call centre
+    description: |
+      Distribuzione tramite voce e call centre, inclusa la ricerca e la prenotazione
+      assistita dagli agenti.
+  BC-4010.10.40:
+    name: Distribuzione tramite chiosco e self-service
+    description: |
+      Distribuzione self-service attraverso chioschi in aeroporti, hotel
+      e sedi partner.
+  BC-4010.20:
+    name: Gestione della distribuzione GDS
+    description: |
+      Distribuzione attraverso i global distribution system, inclusi sincronizzazione dei contenuti,
+      mappatura delle booking class e gestione dei costi.
+  BC-4010.20.10:
+    name: Operazioni di connettività GDS
+    description: |
+      Operazione della connettività con i provider GDS per i flussi di ricerca,
+      prenotazione e biglietteria.
+  BC-4010.20.20:
+    name: Push e sincronizzazione dei contenuti GDS
+    description: |
+      Push e sincronizzazione di contenuti, tariffe e disponibilità
+      verso i provider GDS.
+  BC-4010.20.30:
+    name: Mappatura delle booking class GDS
+    description: |
+      Mappatura delle classi di prodotto interne sulle booking class GDS
+      e sui codici tariffa.
+  BC-4010.20.40:
+    name: Gestione dei costi e dei supplementi GDS
+    description: |
+      Gestione delle commissioni di prenotazione GDS, dei supplementi
+      e dell'allocazione del costo di vendita.
+  BC-4010.30:
+    name: Gestione della distribuzione OTA e wholesale
+    description: |
+      Distribuzione attraverso agenzie di viaggio online, bedbank e distributori
+      B2B all'ingrosso, inclusi termini commerciali e override dei contenuti.
+  BC-4010.30.10:
+    name: Operazioni di connettività OTA
+    description: |
+      Operazione della connettività con le OTA per i flussi di ricerca,
+      prenotazione ed eventi post-prenotazione.
+  BC-4010.30.20:
+    name: Connettività con distributori wholesale e bedbank
+    description: |
+      Operazione della connettività con distributori wholesale e bedbank
+      per la redistribuzione B2B.
+  BC-4010.30.30:
+    name: Gestione dei termini commerciali OTA
+    description: |
+      Gestione dei termini commerciali con le OTA, inclusi modelli
+      a commissione, mark-up e tariffa netta.
+  BC-4010.30.40:
+    name: Gestione degli override dei contenuti OTA
+    description: |
+      Gestione degli override dei contenuti specifici per canale con le OTA,
+      nel rispetto della coerenza del brand.
+  BC-4010.40:
+    name: Gestione della distribuzione metasearch
+    description: |
+      Distribuzione e bidding sulle piattaforme metasearch, incluse
+      operazioni sui feed e tracciamento delle conversioni.
+  BC-4010.40.10:
+    name: Operazioni sul feed metasearch
+    description: |
+      Operazione dei feed di prezzo e disponibilità verso i provider metasearch.
+  BC-4010.40.20:
+    name: Operazioni di bidding sul metasearch
+    description: |
+      Operazione delle strategie di bidding sui posizionamenti metasearch
+      per mercati e dispositivi.
+  BC-4010.40.30:
+    name: Tracciamento delle conversioni metasearch
+    description: |
+      Tracciamento dell'attribuzione delle conversioni e dell'efficacia del bidding
+      sul traffico metasearch.
+  BC-4010.40.40:
+    name: Gestione dei conflitti di bidding sul brand
+    description: |
+      Gestione dei conflitti di bidding tra offerte del proprio brand e offerte OTA
+      su metasearch e paid search.
+  BC-4010.50:
+    name: Operazioni del channel manager
+    description: |
+      Operazione dell'hub channel manager che sincronizza inventario,
+      tariffe e restrizioni tra i canali di distribuzione.
+  BC-4010.50.10:
+    name: Configurazione della mappatura dei canali
+    description: |
+      Configurazione delle mappature tra prodotti interni
+      e cataloghi specifici per canale.
+  BC-4010.50.20:
+    name: Operazioni di push dell'inventario
+    description: |
+      Operazione degli aggiornamenti di inventario inviati dal pool centrale
+      a tutti i canali connessi.
+  BC-4010.50.30:
+    name: Operazioni di push delle tariffe
+    description: |
+      Operazione degli aggiornamenti tariffari inviati dai motori di prezzo
+      a tutti i canali connessi.
+  BC-4010.50.40:
+    name: Operazioni di push delle restrizioni
+    description: |
+      Operazione degli aggiornamenti delle restrizioni, come soggiorno minimo,
+      chiusura all'arrivo e stop-sell, su tutti i canali.
+  BC-4010.60:
+    name: Gestione della parità di tariffa e disponibilità
+    description: |
+      Definizione, monitoraggio e applicazione della parità di tariffa e disponibilità
+      tra canali diretti e indiretti.
+  BC-4010.60.10:
+    name: Definizione della politica di parità
+    description: |
+      Definizione della politica di parità di tariffa e disponibilità
+      tra tipologie di canale e segmenti partner.
+  BC-4010.60.20:
+    name: Monitoraggio e audit della parità
+    description: |
+      Monitoraggio dei canali per rilevare violazioni della parità e audit
+      periodico del mix di canali.
+  BC-4010.60.30:
+    name: Risoluzione delle violazioni di parità
+    description: |
+      Risoluzione delle violazioni di parità identificate con canali e partner.
+  BC-4010.60.40:
+    name: Gestione della disponibilità dell'ultima camera
+    description: |
+      Gestione degli impegni di disponibilità dell'ultima camera verso partner
+      corporate e di canale.
+  BC-4010.70:
+    name: Sindacazione dei contenuti di distribuzione
+    description: |
+      Sindacazione dei contenuti di prodotto ai partner di distribuzione,
+      con controlli su formato, freschezza e regole di fallback.
+  BC-4010.70.10:
+    name: Gestione del formato del feed di contenuti
+    description: |
+      Gestione dei formati e degli schemi dei feed di contenuti
+      specifici per canale.
+  BC-4010.70.20:
+    name: Monitoraggio della freschezza dei contenuti
+    description: |
+      Monitoraggio della freschezza dei contenuti sulle superfici dei partner di distribuzione
+      rispetto ai SLA di pubblicazione.
+  BC-4010.70.30:
+    name: Regole di fallback dei contenuti di canale
+    description: |
+      Regole di fallback utilizzate quando i contenuti specifici per partner
+      sono assenti o obsoleti.
+  BC-4010.70.40:
+    name: Riconciliazione degli override dei contenuti
+    description: |
+      Riconciliazione degli override dei contenuti dei partner rispetto
+      al record master dei contenuti.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-travel-loyalty-programme-management.yaml
+++ b/catalogue/i18n/it/L1-travel-loyalty-programme-management.yaml
@@ -1,0 +1,172 @@
+# Gestione del programma fedeltà nel settore dei viaggi (it) — translations for L1-travel-loyalty-programme-management.yaml
+locale: it
+source: L1-travel-loyalty-programme-management.yaml
+entries:
+  BC-4050:
+    name: Gestione del programma fedeltà nel settore dei viaggi
+    description: |
+      Progettazione e gestione dei programmi fedeltà per i viaggiatori — architettura
+      dei livelli di appartenenza, motori di accumulo e utilizzo, maturazione con i partner,
+      gestione dello status e comunicazioni ai membri — indipendentemente dal record
+      dell'ospite e dalle piattaforme di canale sottostanti.
+    in_scope:
+      - Architettura dei livelli del programma e catalogo dei benefit
+      - Motori di accumulo e utilizzo, inclusa la maturazione con i partner
+      - Qualificazione, mantenimento del livello e soft-landing
+      - Operazioni di comunicazione ai membri e di riconoscimento delle tappe
+    out_of_scope:
+      - Profilo e identità dell'ospite (BC-4040)
+      - Erogazione del riconoscimento in struttura (BC-4040.40)
+      - Esecuzione del canale marketing (BC-410)
+  BC-4050.10:
+    name: Progettazione del programma fedeltà
+    description: |
+      Progettazione dell'architettura del programma, inclusa la struttura dei livelli,
+      il catalogo dei benefit, i parametri dei tassi di accumulo e le regole del programma.
+  BC-4050.10.10:
+    name: Architettura dei livelli del programma fedeltà
+    description: |
+      Architettura dei livelli del programma fedeltà, incluse le soglie,
+      i benefit e le regole di progressione.
+  BC-4050.10.20:
+    name: Catalogo dei benefit per i membri
+    description: |
+      Catalogo dei benefit per i membri su superfici di prodotto e partner.
+  BC-4050.10.30:
+    name: Definizione dei tassi di accumulo e dei moltiplicatori
+    description: |
+      Definizione dei tassi di accumulo base e dei moltiplicatori
+      per livello e prodotto.
+  BC-4050.10.40:
+    name: Gestione dei termini e delle condizioni del programma
+    description: |
+      Gestione dei termini e delle condizioni del programma,
+      incluse le varianti giurisdizionali.
+  BC-4050.20:
+    name: Operazioni del motore di accumulo fedeltà
+    description: |
+      Operazione del motore di accumulo per soggiorni, voli, spesa con i partner,
+      bonus promozionali e gestione delle richieste di attività mancante.
+  BC-4050.20.10:
+    name: Elaborazione dell'accumulo per soggiorni e voli
+    description: |
+      Elaborazione degli eventi di accumulo da soggiorni, voli
+      e completamenti di tour.
+  BC-4050.20.20:
+    name: Elaborazione dell'accumulo da spesa con i partner
+    description: |
+      Elaborazione degli eventi di accumulo derivanti da spesa
+      con carta co-branded e presso partner retail.
+  BC-4050.20.30:
+    name: Accumulo di bonus promozionali
+    description: |
+      Accumulo di bonus promozionali legati alle regole delle campagne.
+  BC-4050.20.40:
+    name: Gestione delle richieste di attività mancante
+    description: |
+      Gestione delle richieste di attività mancante e degli aggiustamenti
+      retroattivi di accumulo.
+  BC-4050.30:
+    name: Operazioni di utilizzo e riscatto della fedeltà
+    description: |
+      Operazione dei flussi di riscatto, inclusi la disponibilità dei premi,
+      il pagamento misto contante e punti e il regolamento dell'inventario.
+  BC-4050.30.10:
+    name: Calcolo della disponibilità dei premi
+    description: |
+      Calcolo della disponibilità dei premi rispetto all'inventario
+      dei ricavi e alle regole di protezione.
+  BC-4050.30.20:
+    name: Prenotazione dei premi in riscatto
+    description: |
+      Prenotazione dei riscatti dei premi sull'inventario del proprio brand
+      e dei partner.
+  BC-4050.30.30:
+    name: Riscatto misto contante e punti
+    description: |
+      Flussi di riscatto che combinano il pagamento in contanti e in punti
+      per la stessa prenotazione.
+  BC-4050.30.40:
+    name: Regolamento dell'inventario di riscatto
+    description: |
+      Regolamento del consumo dell'inventario di riscatto tra il conto
+      del brand e quelli dei partner.
+  BC-4050.40:
+    name: Gestione dello status di livello
+    description: |
+      Operazione della qualificazione al livello, della promozione, della retrocessione,
+      dei programmi di status-match e delle regole di soft-landing.
+  BC-4050.40.10:
+    name: Tracciamento della qualificazione al livello
+    description: |
+      Tracciamento delle attività qualificanti rispetto alle soglie di livello
+      durante l'anno del programma.
+  BC-4050.40.20:
+    name: Operazioni di promozione e retrocessione di livello
+    description: |
+      Operazioni per promuovere, retrocedere e riqualificare i membri
+      al termine dei periodi.
+  BC-4050.40.30:
+    name: Programmi di status-match e sfida
+    description: |
+      Operazione dei programmi di status-match e di sfida al livello
+      per l'acquisizione mirata.
+  BC-4050.40.40:
+    name: Regole di soft-landing per la fidelizzazione
+    description: |
+      Regole di fidelizzazione che attenuano la perdita del livello
+      per i membri di alto valore nei periodi di qualificazione.
+  BC-4050.50:
+    name: Gestione del programma fedeltà con i partner
+    description: |
+      Gestione dei partner del programma fedeltà, incluse carte di credito,
+      partner retail e partner airline-hotel, per onboarding, configurazione
+      e regolamento.
+  BC-4050.50.10:
+    name: Onboarding e contrattazione dei partner
+    description: |
+      Onboarding e contrattazione di nuovi partner del programma fedeltà,
+      inclusa la due diligence e l'integrazione.
+  BC-4050.50.20:
+    name: Configurazione dei tassi di accumulo dei partner
+    description: |
+      Configurazione dei tassi di accumulo e delle strutture bonus
+      per ciascun partner del programma fedeltà.
+  BC-4050.50.30:
+    name: Regolamento e riconciliazione con i partner
+    description: |
+      Regolamento e riconciliazione dei punti emessi dai partner
+      e delle commissioni di accumulo.
+  BC-4050.50.40:
+    name: Gestione delle performance dei partner
+    description: |
+      Gestione delle performance dei partner del programma fedeltà
+      rispetto ai KPI contrattuali.
+  BC-4050.60:
+    name: Operazioni di comunicazione e riconoscimento del programma fedeltà
+    description: |
+      Operazione delle comunicazioni ai membri, del riconoscimento delle tappe
+      e dei gesti di surprise-and-delight nel ciclo di vita del programma fedeltà.
+  BC-4050.60.10:
+    name: Comunicazioni nel ciclo di vita dei membri
+    description: |
+      Comunicazioni ciclo di vita ai membri nelle fasi di onboarding,
+      attività e riattivazione.
+  BC-4050.60.20:
+    name: Riconoscimento delle tappe e degli anniversari
+    description: |
+      Riconoscimento delle tappe dei membri, degli anniversari di iscrizione
+      e delle promozioni di livello.
+  BC-4050.60.30:
+    name: Operazioni di surprise-and-delight
+    description: |
+      Operazione di gesti di surprise-and-delight attivati dal comportamento
+      dei membri o da eventi di servizio.
+  BC-4050.60.40:
+    name: Generazione degli estratti conto dei membri
+    description: |
+      Generazione degli estratti conto dei membri con saldo, attività
+      e progressione del livello.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-travel-product-inventory-management.yaml
+++ b/catalogue/i18n/it/L1-travel-product-inventory-management.yaml
@@ -1,0 +1,196 @@
+# Gestione del prodotto e dell'inventario di viaggio (it) — translations for L1-travel-product-inventory-management.yaml
+locale: it
+source: L1-travel-product-inventory-management.yaml
+entries:
+  BC-4000:
+    name: Gestione del prodotto e dell'inventario di viaggio
+    description: |
+      Definizione principale, struttura e controllo dell'inventario dei prodotti di viaggio prenotabili —
+      camere, tariffe, pacchetti, ancillari, attrazioni e la tassonomia e i contenuti che li descrivono —
+      indipendentemente dai canali attraverso cui vengono venduti.
+    in_scope:
+      - Tipi di camera per alloggio, piani tariffari e codici pacchetto
+      - Famiglie di tariffe aeree, tariffe branded e regole tariffarie
+      - Itinerari in pacchetto (statici e dinamici) e cataloghi di ancillari
+      - Pool di inventario, allotment e buffer di overbooking
+      - Dati master di prodotto, contenuti e immagini
+    out_of_scope:
+      - Configurazione della distribuzione per canale (BC-4010)
+      - Ciclo di vita delle prenotazioni (BC-4020)
+      - Strategia di prezzo e decisioni di yield (BC-4030)
+  BC-4000.10:
+    name: Gestione del prodotto ricettivo
+    description: |
+      Definizione dei prodotti di alloggio, inclusi tipi di camera, piani tariffari,
+      codici pacchetto e tassonomia ricettiva utilizzata in tutta l'impresa.
+  BC-4000.10.10:
+    name: Definizione del tipo di camera e della classe di inventario
+    description: |
+      Definizione dei tipi di camera, delle categorie suite e delle classi di inventario
+      che costituiscono la struttura portante del prodotto ricettivo.
+  BC-4000.10.20:
+    name: Definizione del piano tariffario e del codice tariffa
+    description: |
+      Definizione dei piani tariffari, dei codici tariffa e degli attributi del piano tariffario
+      relativi a rimborsabilità, prepagamento e regole di inclusione.
+  BC-4000.10.30:
+    name: Stato del ciclo di vita del prodotto ricettivo
+    description: |
+      Gestione dello stato del ciclo di vita dei prodotti ricettivi, dalla fase proposta
+      a quella attiva, sospesa e ritirata.
+  BC-4000.10.40:
+    name: Composizione del pacchetto ricettivo
+    description: |
+      Costruzione di pacchetti ricettivi che combinano l'alloggio con la colazione,
+      il parcheggio e altre inclusioni.
+  BC-4000.20:
+    name: Gestione del prodotto aereo
+    description: |
+      Definizione delle famiglie di tariffe aeree, degli attributi delle tariffe branded,
+      delle regole tariffarie e delle mappature dei prodotti in codeshare e interline.
+  BC-4000.20.10:
+    name: Definizione della famiglia di tariffe
+    description: |
+      Definizione delle famiglie di tariffe, delle classi di cabina e dei bucket tariffari
+      utilizzati per la ricerca e il controllo dell'inventario.
+  BC-4000.20.20:
+    name: Gestione degli attributi delle tariffe branded
+    description: |
+      Gestione degli attributi delle tariffe branded, come la franchigia bagaglio,
+      la scelta del posto e l'accesso alla lounge.
+  BC-4000.20.30:
+    name: Redazione delle regole tariffarie
+    description: |
+      Redazione delle regole tariffarie relative all'acquisto anticipato, al soggiorno minimo,
+      alla combinabilità e alle penali di modifica.
+  BC-4000.20.40:
+    name: Mappatura del prodotto in codeshare e interline
+    description: |
+      Mappatura dei prodotti dei vettori partner sulle proprie famiglie di tariffe
+      per la distribuzione in codeshare e interline.
+  BC-4000.30:
+    name: Gestione del prodotto tour e pacchetto
+    description: |
+      Definizione degli itinerari in pacchetto, dei prodotti di viaggio multi-tratta
+      e delle mappature dei componenti per il pacchetto dinamico.
+  BC-4000.30.10:
+    name: Definizione del pacchetto statico
+    description: |
+      Definizione di pacchetti fissi che combinano componenti predefiniti
+      in un unico prodotto vendibile.
+  BC-4000.30.20:
+    name: Mappatura dei componenti per il pacchetto dinamico
+    description: |
+      Mappatura dei componenti per il pacchetto dinamico, in cui il viaggiatore
+      assembla volo, hotel e ancillari al momento della ricerca.
+  BC-4000.30.30:
+    name: Versionamento del prodotto pacchetto
+    description: |
+      Versionamento dei prodotti pacchetto attraverso stagioni, cicli di brochure
+      e rilasci di nuove funzionalità.
+  BC-4000.30.40:
+    name: Calendario delle partenze del pacchetto
+    description: |
+      Definizione dei calendari di partenza dei pacchetti, delle date di blackout
+      e delle finestre stagionali.
+  BC-4000.40:
+    name: Gestione del prodotto ancillare e dei servizi aggiuntivi
+    description: |
+      Definizione dei prodotti ancillari e dei servizi aggiuntivi, come pasti, bagaglio,
+      transfer, attrazioni, spa e servizi a terra.
+  BC-4000.40.10:
+    name: Definizione del catalogo ancillari
+    description: |
+      Definizione del catalogo ancillari, comprese le categorie, le varianti
+      e le condizioni di applicabilità.
+  BC-4000.40.20:
+    name: Regole di composizione degli ancillari in bundle
+    description: |
+      Regole per la composizione in bundle degli ancillari con i prodotti di viaggio
+      principali e con altri ancillari.
+  BC-4000.40.30:
+    name: Regole di idoneità al cross-sell
+    description: |
+      Regole di idoneità che determinano quali ancillari possono essere oggetto di
+      cross-sell con quali prodotti principali e in quali canali.
+  BC-4000.40.40:
+    name: Gestione del ciclo di vita degli ancillari
+    description: |
+      Gestione del ciclo di vita degli ancillari dal lancio al ritiro,
+      comprese le offerte a tempo limitato.
+  BC-4000.50:
+    name: Allocazione dell'inventario di viaggio
+    description: |
+      Definizione e controllo dei pool di inventario, dei blocchi, degli allotment
+      e delle regole di riserva per i prodotti di viaggio.
+  BC-4000.50.10:
+    name: Definizione del pool di inventario
+    description: |
+      Definizione dei pool di inventario a livello di struttura, flotta o prodotto,
+      utilizzati come base per l'allocazione.
+  BC-4000.50.20:
+    name: Allocazione di allotment e blocchi
+    description: |
+      Allocazione di allotment e blocchi a canali, partner e tour operator.
+  BC-4000.50.30:
+    name: Regole di riserva e protezione della classe
+    description: |
+      Regole per proteggere l'inventario per segmenti specifici, canali
+      o membri del programma fedeltà.
+  BC-4000.50.40:
+    name: Configurazione del buffer di overbooking
+    description: |
+      Configurazione dei buffer di overbooking che riflettono i tassi attesi
+      di no-show e cancellazione.
+  BC-4000.60:
+    name: Governance dei dati master del prodotto di viaggio
+    description: |
+      Amministrazione della tassonomia del prodotto, delle classificazioni, degli standard
+      degli attributi e dell'integrità degli identificatori nel master del prodotto di viaggio.
+  BC-4000.60.10:
+    name: Standard degli attributi del prodotto
+    description: |
+      Standard per gli attributi del prodotto che garantiscono una semantica coerente
+      tra sistemi e canali.
+  BC-4000.60.20:
+    name: Classificazione e tagging del prodotto
+    description: |
+      Classificazione e tagging dei prodotti rispetto alle tassonomie utilizzate
+      per la ricerca, il merchandising e il reporting.
+  BC-4000.60.30:
+    name: Stato del ciclo di vita del master prodotto
+    description: |
+      Stato del ciclo di vita del master per i prodotti, esteso ai sotto-tipi di prodotto
+      e allineato alle variazioni di stato dei figli.
+  BC-4000.60.40:
+    name: Amministrazione degli identificatori di prodotto
+    description: |
+      Amministrazione degli identificatori canonici del prodotto e risoluzione
+      di collisioni e duplicati degli identificatori.
+  BC-4000.70:
+    name: Gestione dei contenuti e delle immagini del prodotto di viaggio
+    description: |
+      Redazione e gestione dei contenuti descrittivi, delle immagini, degli asset multimediali
+      e dei record di rating e certificazione che descrivono i prodotti di viaggio.
+  BC-4000.70.10:
+    name: Redazione dei contenuti descrittivi
+    description: |
+      Redazione di contenuti descrittivi in formato lungo e breve
+      per i prodotti di viaggio.
+  BC-4000.70.20:
+    name: Gestione delle immagini e degli asset multimediali
+    description: |
+      Gestione di asset fotografici, video e multimediali a 360 gradi
+      associati ai prodotti di viaggio.
+  BC-4000.70.30:
+    name: Record di classificazione a stelle e certificazione
+    description: |
+      Manutenzione delle classificazioni a stelle, delle certificazioni di terze parti
+      e dei marchi di qualità associati ai prodotti di viaggio.
+  BC-4000.70.40:
+    name: Localizzazione dei contenuti
+    description: |
+      Localizzazione dei contenuti del prodotto nei mercati e nelle lingue supportati.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-travel-revenue-yield-management.yaml
+++ b/catalogue/i18n/it/L1-travel-revenue-yield-management.yaml
@@ -1,0 +1,174 @@
+# Gestione dei ricavi e dello yield nel settore dei viaggi (it) — translations for L1-travel-revenue-yield-management.yaml
+locale: it
+source: L1-travel-revenue-yield-management.yaml
+entries:
+  BC-4030:
+    name: Gestione dei ricavi e dello yield nel settore dei viaggi
+    description: |
+      Previsione della domanda, determinazione dinamica dei prezzi, controlli sull'inventario
+      e decisioni di yield management che massimizzano i ricavi per i prodotti di viaggio —
+      distinta dalla definizione del master prodotto, dalla configurazione della distribuzione
+      e dal ciclo di vita delle prenotazioni.
+    in_scope:
+      - Previsione della domanda non vincolata e dell'andamento delle prenotazioni
+      - Gestione della strategia di prezzo e delle tariffe (BAR, classe tariffaria, stagione)
+      - Limiti di prenotazione, restrizioni sulla durata del soggiorno, overbooking e nesting
+      - Intelligence sulle tariffe competitive e posizionamento di mercato
+      - Meccanismi promozionali e di sconto
+      - Reporting delle performance dei ricavi (RevPAR, RevPAX, ADR, yield)
+    out_of_scope:
+      - Definizione del master prodotto (BC-4000)
+      - Bidding specifico per canale sul metasearch (BC-4010.40.20)
+      - Contrattazione delle vendite di gruppo (BC-4110.10)
+  BC-4030.10:
+    name: Previsione della domanda di viaggio
+    description: |
+      Previsione della domanda non vincolata, dell'andamento delle prenotazioni,
+      della domanda di gruppo e dei comportamenti di no-show e cancellazione
+      per i prodotti di viaggio.
+  BC-4030.10.10:
+    name: Previsione della domanda non vincolata
+    description: |
+      Previsione della domanda in assenza di vincoli di capacità e di prezzo.
+  BC-4030.10.20:
+    name: Previsione dell'andamento e del pickup delle prenotazioni
+    description: |
+      Previsione delle curve di andamento e di pickup rispetto ai pattern
+      storici e alle prenotazioni in essere.
+  BC-4030.10.30:
+    name: Previsione della domanda di gruppo
+    description: |
+      Previsione della domanda di gruppo, inclusi gli effetti di spiazzamento
+      sull'inventario transient.
+  BC-4030.10.40:
+    name: Previsione di no-show e cancellazioni
+    description: |
+      Previsione dei comportamenti di no-show e cancellazione come input
+      per l'overbooking e i controlli dell'inventario.
+  BC-4030.20:
+    name: Gestione della strategia di prezzo e delle tariffe
+    description: |
+      Definizione e adeguamento della strategia tariffaria per livelli BAR,
+      classi tariffarie, finestre stagionali e prezzi dei pacchetti.
+  BC-4030.20.10:
+    name: Impostazione della miglior tariffa disponibile
+    description: |
+      Impostazione delle scale della miglior tariffa disponibile per data e segmento.
+  BC-4030.20.20:
+    name: Strategia per classi tariffarie e bucket
+    description: |
+      Strategia per le classi tariffarie e i bucket di inventario,
+      incluse aperture, chiusure e ribilanciamenti.
+  BC-4030.20.30:
+    name: Prezzi stagionali e per tipo di giorno
+    description: |
+      Variazione dei prezzi per stagioni, pattern giornalieri della settimana
+      e finestre di evento.
+  BC-4030.20.40:
+    name: Prezzi di pacchetti e bundle
+    description: |
+      Determinazione del prezzo per prodotti in pacchetto e bundle,
+      inclusa l'allocazione dei componenti.
+  BC-4030.30:
+    name: Controlli sull'inventario e sulla capacità
+    description: |
+      Controlli sull'inventario, inclusi limiti di prenotazione, restrizioni
+      sulla durata del soggiorno, strategia di overbooking e nesting del bid price.
+  BC-4030.30.10:
+    name: Impostazione dei limiti di prenotazione e delle autorizzazioni
+    description: |
+      Impostazione dei limiti di prenotazione e dei livelli di autorizzazione
+      per classe, canale e segmento.
+  BC-4030.30.20:
+    name: Gestione delle restrizioni sulla durata del soggiorno
+    description: |
+      Gestione delle restrizioni sulla durata del soggiorno, incluse le regole
+      su minimi, massimi e giorno di arrivo.
+  BC-4030.30.30:
+    name: Gestione strategica dell'overbooking
+    description: |
+      Gestione strategica dei livelli di overbooking per data e segmento,
+      calibrata rispetto ai costi del servizio negato.
+  BC-4030.30.40:
+    name: Gestione del nesting e del bid price
+    description: |
+      Gestione del nesting dell'inventario e delle soglie di bid price
+      nei modelli di ottimizzazione dei ricavi.
+  BC-4030.40:
+    name: Intelligence sulle tariffe competitive
+    description: |
+      Rilevazione delle tariffe competitive, analisi della quota di mercato
+      e raccomandazioni di posizionamento tariffario.
+  BC-4030.40.10:
+    name: Rilevazione delle tariffe competitive
+    description: |
+      Rilevazione periodica delle tariffe dei concorrenti sui canali selezionati
+      e per date di arrivo.
+  BC-4030.40.20:
+    name: Analisi della quota di mercato e della penetrazione
+    description: |
+      Analisi della quota di mercato, dell'indice di occupazione e dell'indice
+      tariffario rispetto al competitive set.
+  BC-4030.40.30:
+    name: Raccomandazioni di posizionamento tariffario
+    description: |
+      Generazione di raccomandazioni di posizionamento tariffario rispetto
+      al competitive set e allo stato della domanda.
+  BC-4030.40.40:
+    name: Definizione e manutenzione del competitive set
+    description: |
+      Definizione e manutenzione continuativa dei competitive set
+      utilizzati per il benchmarking.
+  BC-4030.50:
+    name: Gestione di promozioni e sconti
+    description: |
+      Definizione e operatività di promozioni, codici sconto, prezzi opachi
+      e prezzi per gruppi chiusi di utenti per i prodotti di viaggio.
+  BC-4030.50.10:
+    name: Gestione del calendario promozionale
+    description: |
+      Gestione del calendario delle promozioni per stagioni
+      e finestre di prenotazione principali.
+  BC-4030.50.20:
+    name: Regole di idoneità alla promozione
+    description: |
+      Regole di idoneità che governano il riscatto della promozione
+      per segmento, canale e finestra di soggiorno.
+  BC-4030.50.30:
+    name: Gestione di codici sconto e voucher
+    description: |
+      Gestione di codici sconto, voucher e token in stile gift card
+      per uso promozionale.
+  BC-4030.50.40:
+    name: Prezzi opachi e per gruppi chiusi di utenti
+    description: |
+      Operazione di meccanismi di prezzo su canali opachi e per gruppi chiusi
+      di utenti che proteggono la visibilità delle tariffe pubbliche.
+  BC-4030.60:
+    name: Analisi delle performance dei ricavi
+    description: |
+      Reporting e analisi delle performance dei ricavi, inclusi RevPAR,
+      RevPAX, ADR, yield e scostamenti dalle previsioni.
+  BC-4030.60.10:
+    name: Reporting dei KPI dei ricavi
+    description: |
+      Reporting dei KPI principali dei ricavi rispetto al budget
+      e al periodo precedente.
+  BC-4030.60.20:
+    name: Analisi degli scostamenti di yield
+    description: |
+      Analisi degli scostamenti di yield che attribuisce la variazione
+      agli effetti di mix, tariffa e occupazione.
+  BC-4030.60.30:
+    name: Analisi del contributo dei ricavi per canale
+    description: |
+      Analisi del contributo dei ricavi per canale, segmento
+      e codice tariffa.
+  BC-4030.60.40:
+    name: Analisi delle previsioni rispetto ai ricavi effettivi
+    description: |
+      Analisi delle previsioni rispetto ai ricavi effettivi con attribuzione
+      alle fonti di errore di previsione.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-treasury-asset-liability-management.yaml
+++ b/catalogue/i18n/it/L1-treasury-asset-liability-management.yaml
@@ -1,0 +1,103 @@
+# Tesoreria e gestione dell'attivo e del passivo (it) — translations for L1-treasury-asset-liability-management.yaml
+locale: it
+source: L1-treasury-asset-liability-management.yaml
+entries:
+  BC-1360:
+    name: Tesoreria e gestione dell'attivo e del passivo
+    description: |
+      Tesoreria bancaria, ALM (gestione attivo-passivo), FTP, liquidità e rischio di tasso d'interesse bancario.
+  BC-1360.10:
+    name: Gestione della liquidità bancaria
+    description: |
+      Liquidità bancaria, liquidità infragiornaliera, LCR/NSFR.
+  BC-1360.10.10:
+    name: Gestione del LCR
+    description: |
+      Calcolo, monitoraggio e segnalazione del LCR in conformità a Basilea III.
+  BC-1360.10.20:
+    name: Gestione del NSFR
+    description: |
+      Calcolo del NSFR e gestione del funding strutturale.
+  BC-1360.10.30:
+    name: Gestione della liquidità infragiornaliera
+    description: |
+      Monitoraggio della liquidità infragiornaliera sui sistemi di pagamento.
+  BC-1360.10.40:
+    name: Gestione delle attività liquide di elevata qualità
+    description: |
+      Mantenimento e gestione del portafoglio di attività liquide di elevata qualità (HQLA).
+  BC-1360.20:
+    name: Gestione dell'attivo e del passivo
+    description: |
+      ALM (gestione attivo-passivo), gestione del bilancio e analisi dei gap.
+  BC-1360.20.10:
+    name: Gestione del bilancio
+    description: |
+      Gestione strategica e ottimizzazione del bilancio bancario.
+  BC-1360.20.20:
+    name: Analisi dei gap
+    description: |
+      Analisi dei gap di repricing e di liquidità sull'intero bilancio.
+  BC-1360.20.30:
+    name: Modellizzazione comportamentale
+    description: |
+      Modellizzazione comportamentale dei depositi a vista e dei rimborsi anticipati.
+  BC-1360.20.40:
+    name: Stress test ALM
+    description: |
+      Stress test dei disallineamenti di attivo e passivo.
+  BC-1360.30:
+    name: Gestione del transfer pricing bancario
+    description: |
+      Transfer pricing bancario e valorizzazione dei fondi interni.
+  BC-1360.30.10:
+    name: Gestione della metodologia di transfer pricing
+    description: |
+      Manutenzione della metodologia di transfer pricing bancario e costruzione delle curve.
+  BC-1360.30.20:
+    name: Applicazione dei tassi di transfer pricing
+    description: |
+      Applicazione dei tassi di transfer pricing bancario a prodotti e contratti.
+  BC-1360.30.30:
+    name: Reportistica e analisi del transfer pricing
+    description: |
+      Reportistica del transfer pricing bancario e analisi dell'impatto sulla redditività.
+  BC-1360.40:
+    name: Gestione del funding bancario
+    description: |
+      Funding wholesale, raccolta dei depositi e funding sui mercati dei capitali.
+  BC-1360.40.10:
+    name: Gestione del funding wholesale
+    description: |
+      Gestione del funding wholesale non garantito e garantito.
+  BC-1360.40.20:
+    name: Funding sui mercati dei capitali
+    description: |
+      Emissione obbligazionaria, MTN, covered bond e cartolarizzazione.
+  BC-1360.40.30:
+    name: Operatività delle facilities di banca centrale
+    description: |
+      Utilizzo delle facilities di banca centrale e gestione del collaterale.
+  BC-1360.40.40:
+    name: Gestione del piano di funding
+    description: |
+      Piano di funding annuale ed esecuzione rispetto al piano.
+  BC-1360.50:
+    name: Gestione del rischio di tasso d'interesse nel banking book
+    description: |
+      IRRBB, esposizione al tasso d'interesse nel banking book.
+  BC-1360.50.10:
+    name: Misurazione dell'IRRBB
+    description: |
+      Misurazione delle sensibilità EVE e NII per l'IRRBB.
+  BC-1360.50.20:
+    name: Hedging dell'IRRBB
+    description: |
+      Hedging del rischio di tasso d'interesse nel banking book.
+  BC-1360.50.30:
+    name: Reportistica dell'IRRBB
+    description: |
+      Reportistica regolamentare e gestionale dell'IRRBB.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-treasury-management.yaml
+++ b/catalogue/i18n/it/L1-treasury-management.yaml
@@ -1,0 +1,127 @@
+# Gestione della tesoreria (it) — translations for L1-treasury-management.yaml
+locale: it
+source: L1-treasury-management.yaml
+entries:
+  BC-210:
+    name: Gestione della tesoreria
+    description: |
+      Gestione della liquidità, del finanziamento e delle esposizioni sui mercati finanziari.
+  BC-210.10:
+    name: Gestione della liquidità operativa
+    description: |
+      Posizione di cassa, cash pooling e finanziamento intercompany.
+  BC-210.10.10:
+    name: Monitoraggio della posizione di cassa
+    description: |
+      Monitoraggio giornaliero delle posizioni di cassa per entità e valuta.
+  BC-210.10.20:
+    name: Operazioni di cash pooling
+    description: |
+      Cash pooling nozionale e fisico a livello di gruppo.
+  BC-210.10.30:
+    name: Finanziamento intercompany
+    description: |
+      Prestiti intercompany, banca interna e regolamento intercompany.
+  BC-210.10.40:
+    name: Gestione degli investimenti a breve termine
+    description: |
+      Attività di investimento sul mercato monetario e a breve termine.
+  BC-210.20:
+    name: Gestione della liquidità
+    description: |
+      Previsione della liquidità, stress test e piani di finanziamento.
+  BC-210.20.10:
+    name: Previsione del flusso di cassa
+    description: |
+      Previsioni di flusso di cassa a breve, medio e lungo termine.
+  BC-210.20.20:
+    name: Monitoraggio del rischio di liquidità
+    description: |
+      Ratios di liquidità, buffer e indicatori di allerta precoce.
+  BC-210.20.30:
+    name: Stress test di liquidità
+    description: |
+      Stress test sull'adeguatezza della liquidità in scenari avversi.
+  BC-210.20.40:
+    name: Pianificazione del finanziamento di contingenza
+    description: |
+      Piani di finanziamento di contingenza e linee di liquidità committed.
+  BC-210.30:
+    name: Gestione del finanziamento e del debito
+    description: |
+      Emissione di debito, gestione delle linee di credito e covenant.
+  BC-210.30.10:
+    name: Emissione di debito
+    description: |
+      Emissione di obbligazioni, commercial paper e collocamenti privati.
+  BC-210.30.20:
+    name: Gestione di prestiti bancari e linee di credito
+    description: |
+      Negoziazione e amministrazione di linee di credito e prestiti bilaterali.
+  BC-210.30.30:
+    name: Servizio del debito
+    description: |
+      Pianificazione ed esecuzione dei pagamenti di interessi, capitale e commissioni.
+  BC-210.30.40:
+    name: Gestione dei covenant e del rating
+    description: |
+      Monitoraggio dei covenant e rapporti con le agenzie di rating.
+  BC-210.40:
+    name: Gestione del rischio di cambio
+    description: |
+      Esposizione in valuta estera, hedging e regolamento.
+  BC-210.40.10:
+    name: Identificazione dell'esposizione in valuta estera
+    description: |
+      Identificazione e quantificazione delle esposizioni in valuta estera per entità.
+  BC-210.40.20:
+    name: Esecuzione del hedging valutario
+    description: |
+      Esecuzione di forward, swap e opzioni su cambi.
+  BC-210.40.30:
+    name: Regolamento e conferma delle operazioni in valuta
+    description: |
+      Regolamento, conferma e riconciliazione delle operazioni in valuta estera.
+  BC-210.40.40:
+    name: Gestione dell'esposizione da conversione
+    description: |
+      Hedging delle esposizioni da investimento netto e da conversione.
+  BC-210.50:
+    name: Gestione del rischio di tasso d'interesse
+    description: |
+      Esposizione al tasso d'interesse e strategie di hedging.
+  BC-210.50.10:
+    name: Misurazione dell'esposizione al tasso d'interesse
+    description: |
+      Misurazione della sensitività al tasso d'interesse sull'intero stato patrimoniale.
+  BC-210.50.20:
+    name: Hedging del tasso d'interesse
+    description: |
+      Esecuzione di interest rate swap, cap e altri derivati.
+  BC-210.50.30:
+    name: Hedge accounting
+    description: |
+      Designazione degli hedge, test di efficacia e contabilizzazione secondo IFRS 9.
+  BC-210.60:
+    name: Gestione delle relazioni bancarie
+    description: |
+      Struttura dei conti bancari e gestione dei partner bancari.
+  BC-210.60.10:
+    name: Gestione del ciclo di vita dei conti bancari
+    description: |
+      Apertura, modifica e chiusura dei conti bancari.
+  BC-210.60.20:
+    name: Gestione dei mandati bancari e dei firmatari
+    description: |
+      Elenchi dei firmatari bancari, mandati e variazioni di poteri.
+  BC-210.60.30:
+    name: Approvvigionamento dei servizi bancari
+    description: |
+      Selezione e contrattualizzazione dei partner e dei servizi bancari.
+  BC-210.60.40:
+    name: Gestione delle commissioni bancarie e della qualità del servizio
+    description: |
+      Monitoraggio delle commissioni bancarie, della qualità del servizio e analisi dei dati.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-utility-customer-metering-management.yaml
+++ b/catalogue/i18n/it/L1-utility-customer-metering-management.yaml
@@ -1,0 +1,142 @@
+# Gestione dei clienti e della misura nei servizi pubblici (it) — translations for L1-utility-customer-metering-management.yaml
+locale: it
+source: L1-utility-customer-metering-management.yaml
+entries:
+  BC-3910:
+    name: Gestione dei clienti e della misura nei servizi pubblici
+    description: |
+      Operazioni specifiche della utility per clienti e contatori dal punto di fornitura
+      agli input di fatturazione — gestione dei conti cliente, inventario dei contatori,
+      acquisizione dati AMI / contatore intelligente, lettura e validazione dei contatori,
+      input da contatore a incasso, attivazione e disattivazione del servizio
+      e tutela dei clienti vulnerabili.
+  BC-3910.10:
+    name: Gestione dei conti cliente della utility
+    description: |
+      Ciclo di vita del conto cliente specifico della utility, compresi gli
+      identificatori del punto di fornitura, i cambi di occupazione e l'assegnazione della tariffa.
+  BC-3910.10.10:
+    name: Registrazione del punto di fornitura
+    description: |
+      Registrazione e manutenzione degli identificatori del punto di fornitura (MPAN, MPRN, SPID).
+  BC-3910.10.20:
+    name: Operazioni di cambio di occupazione
+    description: |
+      Elaborazione dell'ingresso, dell'uscita e del cambio di conduttore per i punti di fornitura della utility.
+  BC-3910.10.30:
+    name: Assegnazione della tariffa al cliente
+    description: |
+      Assegnazione dei clienti alle tariffe applicabili e alle opzioni di prodotto.
+  BC-3910.20:
+    name: Gestione degli asset del contatore
+    description: |
+      Gestione del ciclo di vita degli asset fisici dei contatori e delle comunicazioni,
+      inclusi stock, installazione, sostituzione e recupero.
+  BC-3910.20.10:
+    name: Operazioni delle scorte di contatori
+    description: |
+      Gestione delle scorte, messa in servizio e fuori servizio degli asset dei contatori.
+  BC-3910.20.20:
+    name: Operazioni di installazione dei contatori
+    description: |
+      Installazione sul campo di contatori nuovi e in sostituzione.
+  BC-3910.20.30:
+    name: Recupero e smaltimento dei contatori
+    description: |
+      Recupero, ricondizionamento e smaltimento a fine vita degli asset dei contatori.
+  BC-3910.30:
+    name: Operazioni di acquisizione dati AMI
+    description: |
+      Acquisizione dei dati dell'infrastruttura di misura avanzata tramite sistemi
+      head-end, reti di comunicazione e MDM.
+    in_scope:
+      - Operazione del sistema head-end del contatore intelligente
+      - Monitoraggio della rete di comunicazione e dei concentratori
+      - Ingestione nel MDM
+    out_of_scope:
+      - Installazione fisica del contatore (BC-3910.20.20)
+      - Domanda aggregata lato trading (BC-3850.30.10)
+  BC-3910.30.10:
+    name: Operazioni del sistema head-end
+    description: |
+      Operazione dei sistemi head-end dei contatori intelligenti e emissione di comandi ai contatori.
+  BC-3910.30.20:
+    name: Operazioni della rete di comunicazione AMI
+    description: |
+      Operazione delle reti di comunicazione AMI RF, PLC e cellulari e dei concentratori.
+  BC-3910.30.30:
+    name: Ingestione nel sistema di MDM
+    description: |
+      Ingestione delle letture di intervallo e di registro nel sistema di gestione dei dati di misura.
+  BC-3910.40:
+    name: Lettura e validazione dei contatori
+    description: |
+      Lettura ciclica e basata su eventi dei contatori e validazione,
+      stima e modifica dei dati di consumo.
+  BC-3910.40.10:
+    name: Operazioni di lettura manuale e drive-by
+    description: |
+      Operazioni di lettura a piedi, drive-by e AMR per i contatori non-AMI.
+  BC-3910.40.20:
+    name: Validazione, stima e modifica
+    description: |
+      Elaborazione VEE delle letture di registro e di intervallo per produrre dati di qualità per la fatturazione.
+  BC-3910.40.30:
+    name: Aggregazione dei consumi
+    description: |
+      Aggregazione dei consumi per periodi di fatturazione e per profili di liquidazione.
+  BC-3910.50:
+    name: Operazioni da contatore a incasso
+    description: |
+      Operazioni specifiche della utility per la preparazione dei dati di utilizzo per la fatturazione
+      e la protezione dei ricavi, inclusa la gestione delle eccezioni di fatturazione
+      e il rilevamento delle perdite di ricavo.
+  BC-3910.50.10:
+    name: Preparazione dei determinanti di fatturazione
+    description: |
+      Preparazione dei determinanti di fatturazione — consumo, potenza impegnata e reattiva — per i sistemi di fatturazione.
+  BC-3910.50.20:
+    name: Gestione delle eccezioni di fatturazione
+    description: |
+      Indagine e risoluzione delle eccezioni di fatturazione e delle anomalie dei dati di misura.
+  BC-3910.50.30:
+    name: Operazioni di tutela dei ricavi
+    description: |
+      Rilevamento e indagine sul campo di manomissioni dei contatori e di furti di energia o acqua.
+  BC-3910.60:
+    name: Operazioni di attivazione e disattivazione del servizio
+    description: |
+      Attivazione, disattivazione e operazione in modalità prepagamento
+      delle forniture della utility all'interfaccia con il cliente.
+  BC-3910.60.10:
+    name: Operazioni di attivazione della fornitura
+    description: |
+      Attivazione di forniture nuove e riattivate, inclusa l'energizzazione da remoto.
+  BC-3910.60.20:
+    name: Disattivazione per mancato pagamento
+    description: |
+      Processi di disattivazione nel rispetto delle protezioni normative e regolamentari.
+  BC-3910.60.30:
+    name: Operazioni in modalità prepagamento
+    description: |
+      Operazione dei contatori a prepagamento e dei canali di ricarica.
+  BC-3910.70:
+    name: Gestione dei clienti vulnerabili
+    description: |
+      Identificazione e tutela dei clienti in condizioni di vulnerabilità, inclusi
+      i registri dei servizi prioritari e gli schemi di agevolazione.
+  BC-3910.70.10:
+    name: Operazioni del registro dei servizi prioritari
+    description: |
+      Manutenzione del registro dei servizi prioritari e dei flag di supporto personalizzato.
+  BC-3910.70.20:
+    name: Operazioni dei programmi di agevolazione economica
+    description: |
+      Amministrazione delle tariffe sociali e dei fondi di sostegno per i clienti della utility.
+  BC-3910.70.30:
+    name: Gestione dei clienti con apparecchiature mediche
+    description: |
+      Gestione dei clienti dipendenti da apparecchiature mediche o dialisi per la pianificazione delle interruzioni.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-utility-network-asset-management.yaml
+++ b/catalogue/i18n/it/L1-utility-network-asset-management.yaml
@@ -1,0 +1,141 @@
+# Gestione del patrimonio della rete di servizi pubblici (it) — translations for L1-utility-network-asset-management.yaml
+locale: it
+source: L1-utility-network-asset-management.yaml
+entries:
+  BC-3900:
+    name: Gestione del patrimonio della rete di servizi pubblici
+    description: |
+      Gestione del ciclo di vita completo delle infrastrutture di rete dei servizi pubblici —
+      asset elettrici, del gas, idrici e delle acque reflue — che comprende l'integrità del
+      registro degli asset, la sorveglianza delle condizioni e dello stato di salute, la valutazione
+      del rischio e della criticità, la pianificazione degli investimenti allineata alla RAB,
+      i programmi di sostituzione, la rendicontazione delle prestazioni e le registrazioni geospaziali della rete.
+  BC-3900.10:
+    name: Gestione del registro degli asset
+    description: |
+      Manutenzione del registro degli asset della utility come unica fonte di verità
+      per gli asset di rete e le loro relazioni gerarchiche.
+  BC-3900.10.10:
+    name: Gestione dei dati master degli asset
+    description: |
+      Gestione degli attributi e della classificazione dei dati master degli asset.
+  BC-3900.10.20:
+    name: Manutenzione della gerarchia degli asset
+    description: |
+      Manutenzione delle gerarchie funzionali e fisiche degli asset di rete.
+  BC-3900.10.30:
+    name: Riconciliazione del registro degli asset
+    description: |
+      Riconciliazione tra registro degli asset, GIS e sistemi operativi.
+  BC-3900.20:
+    name: Monitoraggio delle condizioni e dello stato degli asset
+    description: |
+      Ispezione, collaudo e sorveglianza online delle condizioni degli asset
+      a supporto della valutazione degli indici di salute e della prioritizzazione.
+  BC-3900.20.10:
+    name: Operazioni dei programmi di ispezione
+    description: |
+      Programmi di ispezione ciclica per gli impianti primari e gli asset di rete.
+  BC-3900.20.20:
+    name: Monitoraggio online delle condizioni
+    description: |
+      Monitoraggio online delle condizioni di trasformatori, cavi e macchine rotanti.
+  BC-3900.20.30:
+    name: Calcolo degli indici di salute degli asset
+    description: |
+      Calcolo degli indici di salute degli asset da dati di ispezione, collaudo e operativi.
+  BC-3900.30:
+    name: Valutazione del rischio e della criticità degli asset
+    description: |
+      Valutazione quantificata del rischio degli asset combinando probabilità,
+      conseguenze e criticità per prioritizzare gli interventi.
+  BC-3900.30.10:
+    name: Calcolo della criticità degli asset
+    description: |
+      Calcolo della criticità di rete e dell'impatto sociale degli asset della utility.
+  BC-3900.30.20:
+    name: Modellazione della probabilità di guasto
+    description: |
+      Modellazione statistica e basata sulle condizioni della probabilità di guasto.
+  BC-3900.30.30:
+    name: Calcolo del rischio monetizzato
+    description: |
+      Calcolo del rischio monetizzato allineato ai framework di analisi costi-benefici dei regolatori.
+  BC-3900.40:
+    name: Pianificazione degli investimenti negli asset
+    description: |
+      Pianificazione degli investimenti a lungo termine, allineata al controllo tariffario,
+      per categorie di rete in programmi regolati e non regolati.
+    in_scope:
+      - Sviluppo di piani pluriennali di capitale e TOTEX
+      - Analisi costi-benefici degli interventi sulla rete
+      - Prioritizzazione del portafoglio di investimenti
+    out_of_scope:
+      - Governance del portafoglio progetti cross-industry (BC-900)
+      - Pianificazione dei ricavi lato tariffa (BC-3920.30)
+  BC-3900.40.10:
+    name: Pianificazione degli investimenti in conto capitale
+    description: |
+      Pianificazione pluriennale del programma di capitale di rete per classe di asset.
+  BC-3900.40.20:
+    name: Analisi costi-benefici
+    description: |
+      Analisi costi-benefici delle opzioni di investimento rispetto alle regole del test del regolatore.
+  BC-3900.40.30:
+    name: Prioritizzazione del portafoglio di investimenti
+    description: |
+      Prioritizzazione del portafoglio tra categorie rispetto ai vincoli di capitale e di risorse.
+  BC-3900.50:
+    name: Pianificazione della sostituzione e del rinnovo degli asset
+    description: |
+      Pianificazione dei programmi di rinnovo, sostituzione e dismissione a fine vita
+      degli asset sulla rete.
+  BC-3900.50.10:
+    name: Previsione della fine vita
+    description: |
+      Previsione della fine vita degli asset per classe e coorte.
+  BC-3900.50.20:
+    name: Progettazione del programma di rinnovo
+    description: |
+      Progettazione di programmi pluriennali di rinnovo per categoria di asset e area geografica.
+  BC-3900.50.30:
+    name: Pianificazione della dismissione della rete
+    description: |
+      Pianificazione degli interventi di dismissione, abbandono e ripristino.
+  BC-3900.60:
+    name: Rendicontazione delle prestazioni degli asset
+    description: |
+      Rendicontazione delle prestazioni degli asset e dell'utilizzo del TOTEX rispetto
+      agli impegni di prestazione regolatori e interni.
+  BC-3900.60.10:
+    name: Rendicontazione dei KPI di prestazione della rete
+    description: |
+      Rendicontazione di SAIDI, SAIFI, perdite e KPI di rete equivalenti.
+  BC-3900.60.20:
+    name: Rendicontazione delle prestazioni TOTEX
+    description: |
+      Rendicontazione della spesa TOTEX rispetto all'ammontare consentito nell'ambito dei regimi di controllo tariffario.
+  BC-3900.60.30:
+    name: Analisi delle tendenze di guasto degli asset
+    description: |
+      Analisi delle tendenze dei guasti degli asset e dell'efficacia degli interventi.
+  BC-3900.70:
+    name: Gestione del GIS e delle registrazioni di rete
+    description: |
+      Registrazioni geospaziali degli asset di rete — circuiti, condotte, fognature
+      e punti di connessione — e loro integrazione con i sistemi operativi.
+  BC-3900.70.10:
+    name: Manutenzione delle registrazioni GIS della rete
+    description: |
+      Manutenzione delle registrazioni GIS della connettività di rete e delle ubicazioni degli asset.
+  BC-3900.70.20:
+    name: Acquisizione delle registrazioni as-built
+    description: |
+      Acquisizione delle modifiche as-built da progetti di costruzione e rinnovo nel GIS.
+  BC-3900.70.30:
+    name: Operazioni di ricerca degli asset sotterranei
+    description: |
+      Risposte alle richieste di ricerca dei dati degli asset sotterranei per gli scavatori terzi.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-utility-regulatory-price-control-management.yaml
+++ b/catalogue/i18n/it/L1-utility-regulatory-price-control-management.yaml
@@ -1,0 +1,140 @@
+# Gestione della regolazione e del controllo tariffario nei servizi pubblici (it) — translations for L1-utility-regulatory-price-control-management.yaml
+locale: it
+source: L1-utility-regulatory-price-control-management.yaml
+entries:
+  BC-3920:
+    name: Gestione della regolazione e del controllo tariffario nei servizi pubblici
+    description: |
+      Relazione con i regolatori del settore dei servizi pubblici e amministrazione dei regimi
+      di controllo tariffario — interazioni con il regolatore, presentazioni per il controllo tariffario,
+      progettazione della struttura tariffaria, rendicontazione normativa, impegni di prestazione
+      del servizio, allocazione dei costi regolatori e obblighi di servizio universale e di accessibilità.
+  BC-3920.10:
+    name: Relazione con il regolatore della utility
+    description: |
+      Gestione quotidiana delle relazioni e dei flussi informativi con i regolatori
+      di settore e gli organismi di tutela dei consumatori.
+  BC-3920.10.10:
+    name: Gestione della corrispondenza con il regolatore
+    description: |
+      Gestione della corrispondenza in entrata e in uscita e delle richieste di informazioni con i regolatori.
+  BC-3920.10.20:
+    name: Risposta alle consultazioni regolamentari
+    description: |
+      Preparazione e presentazione delle risposte alle consultazioni dei regolatori.
+  BC-3920.10.30:
+    name: Partecipazione alle audizioni regolamentari
+    description: |
+      Partecipazione alle audizioni regolamentari, alle conferenze tecniche e ai forum degli stakeholder.
+  BC-3920.20:
+    name: Gestione delle presentazioni per il controllo tariffario
+    description: |
+      Preparazione, presentazione e negoziazione end-to-end dei piani aziendali
+      per il controllo tariffario pluriennale o per i casi tariffari.
+    in_scope:
+      - Compilazione del piano aziendale (RIIO, PR, rate-case)
+      - Benchmarking dei costi e modellazione del TOTEX
+      - Negoziazione dei ricavi ammessi e degli output
+    out_of_scope:
+      - Pianificazione interna degli investimenti (BC-3900.40)
+      - Partecipazione al mercato all'ingrosso (BC-3850)
+  BC-3920.20.10:
+    name: Preparazione del piano aziendale
+    description: |
+      Preparazione dei piani aziendali per il controllo tariffario (RIIO, PR e equivalenti dei rate-case).
+  BC-3920.20.20:
+    name: Benchmarking dei costi e modellazione del TOTEX
+    description: |
+      Benchmarking dei costi e modellazione del TOTEX rispetto ai dataset del regolatore e dei pari.
+  BC-3920.20.30:
+    name: Negoziazione dei ricavi ammessi
+    description: |
+      Negoziazione con il regolatore dei ricavi ammessi, degli output e dei parametri degli incentivi.
+  BC-3920.30:
+    name: Progettazione della struttura tariffaria
+    description: |
+      Progettazione delle strutture tariffarie regolate — oneri energetici, oneri di rete
+      e oneri fissi — per clienti residenziali, commerciali e industriali.
+  BC-3920.30.10:
+    name: Progettazione della tariffa di utilizzo della rete
+    description: |
+      Progettazione delle tariffe di utilizzo della rete di distribuzione e di trasmissione.
+  BC-3920.30.20:
+    name: Progettazione dei listini tariffari retail
+    description: |
+      Progettazione dei listini tariffari retail, incluse le strutture time-of-use e stagionali.
+  BC-3920.30.30:
+    name: Metodologia di tariffazione delle connessioni
+    description: |
+      Metodologia di tariffazione delle connessioni e gestione del confine tra attività contestabili e non contestabili.
+  BC-3920.40:
+    name: Operazioni di rendicontazione normativa
+    description: |
+      Rendicontazione normativa periodica ai regolatori della utility, inclusi i rapporti
+      annuali di prestazione, i conti regolatori e le comunicazioni intermedie.
+  BC-3920.40.10:
+    name: Rendicontazione annuale delle prestazioni
+    description: |
+      Compilazione e presentazione dei rapporti annuali di prestazione ai regolatori.
+  BC-3920.40.20:
+    name: Preparazione dei conti regolatori
+    description: |
+      Preparazione dei conti regolatori secondo le linee guida contabili del regolatore.
+  BC-3920.40.30:
+    name: Comunicazioni normative ad hoc
+    description: |
+      Comunicazioni di dati ad hoc ai portali dei regolatori e risposte alle richieste di informazioni.
+  BC-3920.50:
+    name: Gestione degli impegni di prestazione del servizio
+    description: |
+      Monitoraggio e amministrazione degli incentivi agli output definiti dal regolatore
+      e degli impegni di livello di servizio.
+  BC-3920.50.10:
+    name: Monitoraggio degli incentivi alla consegna degli output
+    description: |
+      Monitoraggio degli ODI, degli impegni di prestazione e dei guadagni dagli incentivi.
+  BC-3920.50.20:
+    name: Amministrazione degli standard garantiti
+    description: |
+      Amministrazione dei pagamenti per gli standard garantiti di servizio ai clienti.
+  BC-3920.50.30:
+    name: Calcolo delle penali di prestazione
+    description: |
+      Calcolo delle penali e dei premi di prestazione regolatori.
+  BC-3920.60:
+    name: Allocazione dei costi regolatori
+    description: |
+      Allocazione dei costi tra unità di business regolate e non regolate
+      e tra categorie di controllo tariffario secondo la metodologia di allocazione dei costi.
+  BC-3920.60.10:
+    name: Manutenzione della metodologia di allocazione dei costi
+    description: |
+      Manutenzione delle metodologie di allocazione dei costi approvate dal regolatore.
+  BC-3920.60.20:
+    name: Ripartizione dei costi tra attività regolate e non regolate
+    description: |
+      Applicazione periodica della ripartizione dei costi tra attività regolate e non regolate.
+  BC-3920.60.30:
+    name: Classificazione capex/opex
+    description: |
+      Classificazione delle spese tra capex e opex secondo le definizioni del regolatore.
+  BC-3920.70:
+    name: Gestione del servizio universale e dell'accessibilità
+    description: |
+      Realizzazione dei programmi per gli obblighi di servizio universale e gli schemi
+      di accessibilità e di contrasto alla povertà energetica e idrica imposti dal regolatore.
+  BC-3920.70.10:
+    name: Adempimento dell'obbligo di servizio universale
+    description: |
+      Adempimento dei requisiti di obbligo di servizio universale ai clienti retail.
+  BC-3920.70.20:
+    name: Operazioni dei programmi di contrasto alla povertà energetica e idrica
+    description: |
+      Operazione dei programmi di contrasto alla povertà energetica e idrica.
+  BC-3920.70.30:
+    name: Rendicontazione dei programmi di accessibilità
+    description: |
+      Rendicontazione della realizzazione dei programmi di accessibilità al regolatore e al governo.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-vehicle-aftersales-warranty-management.yaml
+++ b/catalogue/i18n/it/L1-vehicle-aftersales-warranty-management.yaml
@@ -1,0 +1,177 @@
+# Gestione del post-vendita e della garanzia del veicolo (it) — translations for L1-vehicle-aftersales-warranty-management.yaml
+locale: it
+source: L1-vehicle-aftersales-warranty-management.yaml
+entries:
+  BC-3450:
+    name: Gestione del post-vendita e della garanzia del veicolo
+    description: |
+      Post-vendita lato OEM — operazioni e aggiudicazione della garanzia, gestione dei
+      richiami e delle campagne di assistenza, informazioni tecniche di servizio, assistenza
+      clienti e ciclo di feedback verso l'ingegneria, ancorata su Magnuson-Moss,
+      normative UE sulla vendita ai consumatori e regimi di richiamo NHTSA/UE.
+  BC-3450.10:
+    name: Gestione della politica di garanzia e dei reclami
+    description: |
+      Definizione delle politiche di garanzia e aggiudicazione dei reclami di garanzia
+      dei concessionari, incluso il recupero dai fornitori.
+  BC-3450.10.10:
+    name: Definizione della politica di garanzia
+    description: |
+      Definizione dei termini, delle durate, delle coperture e delle esclusioni della
+      garanzia nei mercati e nelle linee di prodotto.
+  BC-3450.10.20:
+    name: Aggiudicazione dei reclami di garanzia
+    description: |
+      Aggiudicazione dei reclami di garanzia dei concessionari, inclusi standard
+      di tempo di manodopera e validazione delle parti.
+  BC-3450.10.30:
+    name: Gestione della buona volontà e delle concessioni
+    description: |
+      Gestione delle riparazioni a buona volontà, delle concessioni e delle
+      estensioni di garanzia per la fidelizzazione del cliente.
+  BC-3450.10.40:
+    name: Gestione del recupero dai fornitori
+    description: |
+      Recupero del costo di garanzia dai fornitori responsabili nell'ambito
+      degli accordi di condivisione dei costi di garanzia.
+  BC-3450.20:
+    name: Gestione delle campagne di assistenza e dei richiami
+    description: |
+      Gestione end-to-end dei richiami per motivi di sicurezza e delle campagne
+      di assistenza non legate alla sicurezza, incluse notifica e monitoraggio del tasso
+      di completamento.
+  BC-3450.20.10:
+    name: Decisione di richiamo e notifica
+    description: |
+      Processo decisionale e notifica legale dei richiami per motivi di sicurezza
+      alle autorità e ai proprietari.
+  BC-3450.20.20:
+    name: Pianificazione delle campagne di assistenza
+    description: |
+      Pianificazione delle campagne di assistenza, incluse definizione del rimedio,
+      approvvigionamento delle parti e istruzioni ai concessionari.
+  BC-3450.20.30:
+    name: Gestione della notifica ai proprietari
+    description: |
+      Identificazione e notifica dei proprietari dei veicoli interessati tramite
+      posta, e-mail e canali nel veicolo.
+  BC-3450.20.40:
+    name: Monitoraggio del completamento delle campagne
+    description: |
+      Monitoraggio dei tassi di completamento dei richiami e delle campagne e
+      degli obblighi di reportistica alle autorità.
+  BC-3450.30:
+    name: Gestione delle informazioni tecniche di servizio
+    description: |
+      Redazione e distribuzione di procedure di riparazione, bollettini tecnici e
+      informazioni diagnostiche per la rete di assistenza dei concessionari.
+  BC-3450.30.10:
+    name: Redazione delle procedure di riparazione
+    description: |
+      Redazione delle procedure di riparazione del veicolo, delle viste esplose e
+      dei dati di coppia e serraggio.
+  BC-3450.30.20:
+    name: Gestione dei bollettini tecnici di servizio
+    description: |
+      Redazione, rilascio e gestione del ciclo di vita dei bollettini tecnici di
+      servizio.
+  BC-3450.30.30:
+    name: Gestione della libreria dei codici di guasto diagnostici
+    description: |
+      Manutenzione delle librerie DTC, degli alberi diagnostici e dei contenuti
+      di diagnostica guidata correlati.
+  BC-3450.30.40:
+    name: Specifica dell'attrezzatura di servizio
+    description: |
+      Specifica degli strumenti speciali e delle attrezzature di servizio del
+      concessionario per le operazioni di assistenza al veicolo.
+  BC-3450.40:
+    name: Operazioni di diagnostica del veicolo e assistenza telematica
+    description: |
+      Operazioni OEM a supporto della diagnostica connessa, dei dati diagnostici
+      remoti e degli ecosistemi di strumenti diagnostici dei concessionari.
+  BC-3450.40.10:
+    name: Operazioni di diagnostica remota del veicolo
+    description: |
+      Operatività dei servizi di diagnostica e salute remota del veicolo a
+      supporto dell'assistenza del concessionario.
+  BC-3450.40.20:
+    name: Gestione degli aggiornamenti degli strumenti diagnostici
+    description: |
+      Gestione del software degli strumenti diagnostici del concessionario, dei dati
+      di calibrazione e dell'accesso in sicurezza.
+  BC-3450.40.30:
+    name: Aggregazione dei dati di assistenza
+    description: |
+      Aggregazione e analisi dei dati sugli eventi di assistenza dai concessionari
+      e dai veicoli connessi.
+  BC-3450.50:
+    name: Operazioni di assistenza clienti e soccorso stradale
+    description: |
+      Servizi di assistenza clienti brandizzati OEM, inclusi soccorso stradale,
+      sostituzione della mobilità e rimpatrio del veicolo.
+  BC-3450.50.10:
+    name: Operazioni di soccorso stradale
+    description: |
+      Operatività del soccorso stradale brandizzato OEM per guasti e risposta
+      agli incidenti.
+  BC-3450.50.20:
+    name: Coordinamento della sostituzione della mobilità
+    description: |
+      Coordinamento del trasporto sostitutivo per i clienti durante la riparazione
+      o il guasto.
+  BC-3450.50.30:
+    name: Coordinamento del rimpatrio del veicolo
+    description: |
+      Coordinamento del rimpatrio del veicolo a seguito di incidenti all'estero o
+      guasti a lunga distanza.
+  BC-3450.60:
+    name: Coordinamento della logistica dei ricambi post-vendita
+    description: |
+      Coordinamento con la supply chain dei ricambi aftermarket per supportare la
+      domanda di assistenza dei concessionari e i rimedi dei richiami.
+    in_scope:
+      - Coordinamento della domanda e dell'offerta di parti con i concessionari
+      - Urgenza delle parti critiche per eventi vehicle-off-road
+      - Allocazione delle parti dei richiami nelle reti di concessionari
+    out_of_scope:
+      - Catalogo e pricing dei ricambi (BC-1060 Gestione dei ricambi e dell'aftermarket)
+      - Operazioni di magazzino e distribuzione fisica delle parti (BC-1060)
+  BC-3450.60.10:
+    name: Coordinamento della domanda di parti con i concessionari
+    description: |
+      Coordinamento della visibilità della domanda di parti dei concessionari e dei
+      segnali di rifornimento alla supply chain delle parti.
+  BC-3450.60.20:
+    name: Gestione delle urgenze per parti critiche
+    description: |
+      Urgenza delle parti critiche per casi vehicle-off-road e di alta gravità
+      per il cliente.
+  BC-3450.60.30:
+    name: Allocazione delle parti dei richiami
+    description: |
+      Allocazione delle parti di richiamo scarse ai concessionari e ai mercati in
+      base alle priorità della popolazione interessata.
+  BC-3450.70:
+    name: Performance post-vendita e feedback sulla qualità
+    description: |
+      Analisi delle tendenze di guasto sul campo e del feedback dei clienti e
+      instradamento delle criticità verso l'ingegneria e la produzione.
+  BC-3450.70.10:
+    name: Analisi delle tendenze di guasto sul campo
+    description: |
+      Analisi dei dati di garanzia e degli eventi di assistenza per identificare
+      tendenze di guasto sul campo e problemi emergenti.
+  BC-3450.70.20:
+    name: Gestione della voce del cliente post-vendita
+    description: |
+      Raccolta e analisi della voce del cliente post-vendita, incluse indagini
+      e feedback registrati dai concessionari.
+  BC-3450.70.30:
+    name: Gestione del ciclo di feedback verso l'ingegneria
+    description: |
+      Instradamento delle criticità di qualità sul campo verso l'ingegneria per
+      contenimento, risoluzione e lezioni apprese.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-vehicle-connected-services-management.yaml
+++ b/catalogue/i18n/it/L1-vehicle-connected-services-management.yaml
@@ -1,0 +1,162 @@
+# Gestione dei servizi connessi del veicolo (it) — translations for L1-vehicle-connected-services-management.yaml
+locale: it
+source: L1-vehicle-connected-services-management.yaml
+entries:
+  BC-3460:
+    name: Gestione dei servizi connessi del veicolo
+    description: |
+      Operatività dei servizi connessi del veicolo — piattaforma di connettività del
+      veicolo, aggiornamenti OTA del software, app e abbonamenti nel veicolo,
+      piattaforma dati del veicolo, servizi V2X, operazioni di sicurezza del veicolo
+      e assistenza clienti per i servizi connessi.
+  BC-3460.10:
+    name: Operazioni della piattaforma di connettività del veicolo
+    description: |
+      Operatività della connettività nel veicolo, del provisioning SIM e della
+      piattaforma di telemetria vehicle-to-cloud.
+  BC-3460.10.10:
+    name: Provisioning SIM e connettività del veicolo
+    description: |
+      Provisioning della connettività SIM embedded e del roaming dell'operatore per
+      i veicoli connessi.
+  BC-3460.10.20:
+    name: Operazioni della rete di connettività
+    description: |
+      Operatività del backbone di connettività a supporto dei servizi del veicolo,
+      inclusi failover e qualità del servizio.
+  BC-3460.10.30:
+    name: Operazioni di telemetria vehicle-to-cloud
+    description: |
+      Operatività delle pipeline di telemetria del veicolo dagli agenti nel veicolo
+      alle piattaforme cloud.
+  BC-3460.20:
+    name: Operazioni di aggiornamento OTA del software
+    description: |
+      Operatività delle campagne di aggiornamento OTA del software allineate a
+      UN R156 e al sistema di gestione degli aggiornamenti software.
+  BC-3460.20.10:
+    name: Pianificazione delle campagne OTA
+    description: |
+      Pianificazione delle campagne di aggiornamento OTA del software, inclusi
+      perimetro, idoneità e strategia di rollout.
+  BC-3460.20.20:
+    name: Distribuzione dei pacchetti OTA
+    description: |
+      Distribuzione di pacchetti OTA firmati ai veicoli e orchestrazione
+      dell'installazione sulle ECU.
+  BC-3460.20.30:
+    name: Gestione del rollback e del ripristino OTA
+    description: |
+      Gestione del rollback OTA, del ripristino e della risposta agli incidenti sul
+      campo quando gli aggiornamenti falliscono.
+  BC-3460.30:
+    name: Gestione delle app nel veicolo e degli abbonamenti
+    description: |
+      Operatività dell'app store nel veicolo, del ciclo di vita degli abbonamenti e
+      dei servizi di pagamento nel veicolo.
+  BC-3460.30.10:
+    name: Gestione del catalogo dei servizi connessi
+    description: |
+      Manutenzione del catalogo dei servizi connessi e delle app nel veicolo
+      offerte ai clienti.
+  BC-3460.30.20:
+    name: Gestione del ciclo di vita degli abbonamenti
+    description: |
+      Gestione del ciclo di vita degli abbonamenti dei clienti ai servizi connessi
+      e ai servizi feature-on-demand.
+  BC-3460.30.30:
+    name: Operazioni di pagamento nel veicolo
+    description: |
+      Operatività del pagamento nel veicolo, della tokenizzazione e del regolamento
+      delle transazioni.
+  BC-3460.40:
+    name: Operazioni della piattaforma dati del veicolo
+    description: |
+      Operatività della piattaforma dati del veicolo — ingestione, archiviazione,
+      condivisione e gestione del consenso — a supporto dei casi d'uso di prima e
+      terza parte.
+    in_scope:
+      - Ingestione e archiviazione dei dati del veicolo
+      - API di condivisione dei dati del veicolo per consumatori interni e partner
+      - Gestione della privacy e del consenso per i dati del veicolo
+    out_of_scope:
+      - Gestione generica dei dati aziendali (coperta da dati aziendali e IT)
+      - Redazione del safety case funzionale (BC-3400.80)
+  BC-3460.40.10:
+    name: Ingestione e archiviazione dei dati del veicolo
+    description: |
+      Ingestione, normalizzazione e archiviazione della telemetria del veicolo e
+      dei dati degli eventi su scala flotta.
+  BC-3460.40.20:
+    name: Condivisione dei dati del veicolo e gestione delle API
+    description: |
+      Fornitura di API per i dati del veicolo a team interni, concessionari e partner
+      esterni nell'ambito di accordi di condivisione dei dati.
+  BC-3460.40.30:
+    name: Gestione della privacy e del consenso sui dati del veicolo
+    description: |
+      Gestione del consenso dei clienti, delle preferenze e dei controlli sulla
+      privacy per i dati generati dal veicolo.
+  BC-3460.50:
+    name: Servizi V2X e di mobilità cooperativa
+    description: |
+      Operatività dei servizi di messaggistica V2X e dei servizi di mobilità
+      cooperativa con infrastrutture e altri veicoli.
+  BC-3460.50.10:
+    name: Operazioni del servizio V2I
+    description: |
+      Operatività dei servizi vehicle-to-infrastructure quali fase e timing del
+      semaforo, avvisi di cantiere e pedaggi.
+  BC-3460.50.20:
+    name: Operazioni dei messaggi V2V
+    description: |
+      Operatività dei servizi di messaggistica vehicle-to-vehicle e dei canali
+      broadcast secondo SAE J2735 ed equivalenti.
+  BC-3460.50.30:
+    name: Operazioni del servizio di consapevolezza cooperativa
+    description: |
+      Operatività dei servizi di consapevolezza cooperativa, avvisi di pericolo e
+      platooning su flotte miste.
+  BC-3460.60:
+    name: Operazioni di sicurezza del veicolo
+    description: |
+      Monitoraggio operativo della sicurezza della flotta di veicoli connessi e
+      risposta agli incidenti cyber del veicolo.
+  BC-3460.60.10:
+    name: Rilevamento delle minacce al veicolo
+    description: |
+      Rilevamento di minacce cyber e comportamenti anomali sulla flotta di
+      veicoli connessi.
+  BC-3460.60.20:
+    name: Risposta agli incidenti di cybersecurity del veicolo
+    description: |
+      Risposta agli incidenti di cybersecurity del veicolo, inclusi contenimento,
+      rimedio e notifica al cliente.
+  BC-3460.60.30:
+    name: Operazioni del SOC del veicolo
+    description: |
+      Operatività del security operations centre del veicolo e delle pipeline di
+      telemetria di supporto.
+  BC-3460.70:
+    name: Operazioni clienti per i servizi connessi
+    description: |
+      Operazioni rivolte al cliente per i servizi connessi, incluso il supporto
+      all'attivazione, la risoluzione dei problemi e la gestione dell'account.
+  BC-3460.70.10:
+    name: Supporto all'attivazione dei servizi connessi
+    description: |
+      Supporto all'attivazione, al trasferimento e alla disattivazione dei
+      servizi connessi da parte del cliente.
+  BC-3460.70.20:
+    name: Risoluzione dei problemi dei servizi connessi
+    description: |
+      Risoluzione dei problemi segnalati dai clienti sui servizi connessi attraverso
+      canali di contact centre, concessionario e self-service.
+  BC-3460.70.30:
+    name: Gestione dell'account dei servizi connessi
+    description: |
+      Gestione degli account cliente dei servizi connessi, dell'identità e
+      dell'abbinamento degli entitlement ai veicoli.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-vehicle-engineering-management.yaml
+++ b/catalogue/i18n/it/L1-vehicle-engineering-management.yaml
@@ -1,0 +1,264 @@
+# Gestione dell'ingegneria del veicolo (it) — translations for L1-vehicle-engineering-management.yaml
+locale: it
+source: L1-vehicle-engineering-management.yaml
+entries:
+  BC-3400:
+    name: Gestione dell'ingegneria del veicolo
+    description: |
+      Ingegneria del veicolo completo nelle aree carrozzeria, telaio, sistema di propulsione (ICE, elettrico,
+      cella a combustibile), architettura elettrica/elettronica, software embedded,
+      sicurezza funzionale, cybersecurity e SOTIF, ancorata su IATF 16949,
+      ISO 26262, ISO/SAE 21434, ISO 21448, ASPICE e AUTOSAR.
+  BC-3400.10:
+    name: Gestione dell'architettura del veicolo
+    description: |
+      Architettura del veicolo completo, packaging, definizione degli obiettivi degli attributi e
+      scomposizione della piattaforma/variante che inquadra tutta l'ingegneria a valle.
+    in_scope:
+      - Obiettivi degli attributi del veicolo e risoluzione dei compromessi
+      - Packaging, layout e definizione zonale del veicolo
+      - Scelte di architettura della piattaforma e dei moduli
+    out_of_scope:
+      - Governance dei gate di fase del programma (BC-3410)
+      - Ingegneria dettagliata a livello di componente (coperta dai livelli L2 specifici per disciplina)
+  BC-3400.10.10:
+    name: Definizione degli obiettivi degli attributi del veicolo
+    description: |
+      Definizione degli obiettivi di prestazione, comfort, sicurezza, efficienza e
+      attributi di marca a livello di veicolo e risoluzione dei compromessi.
+  BC-3400.10.20:
+    name: Packaging e layout del veicolo
+    description: |
+      Packaging del veicolo completo, layout degli occupanti e del bagagliaio, definizione
+      degli hard-point e allocazione zonale.
+  BC-3400.10.30:
+    name: Definizione dell'architettura della piattaforma
+    description: |
+      Definizione delle piattaforme di veicolo condivise, dei moduli comuni e
+      delle strategie di carry-over tra i programmi.
+  BC-3400.10.40:
+    name: Architettura di moduli e varianti
+    description: |
+      Strategia modulare e di variante per abilitare carrozzerie derivate, gruppi di trazione
+      e livelli di allestimento su un'architettura comune.
+  BC-3400.20:
+    name: Ingegneria del sistema di propulsione
+    description: |
+      Ingegneria dei sistemi di propulsione a combustione interna, elettrici e a cella a combustibile,
+      inclusi trasmissioni, linea di trasmissione e sistemi di accumulo dell'energia.
+  BC-3400.20.10:
+    name: Ingegneria del sistema di propulsione a combustione interna
+    description: |
+      Ingegneria di motori ICE, sistemi di alimentazione, post-trattamento dei gas di scarico
+      e relativa calibrazione.
+  BC-3400.20.20:
+    name: Ingegneria del sistema di propulsione elettrico
+    description: |
+      Ingegneria di unità di trazione elettrica, inverter, elettronica di ricarica
+      e integrazione con il sistema ad alta tensione.
+  BC-3400.20.30:
+    name: Ingegneria del sistema batteria
+    description: |
+      Ingegneria di celle, moduli, pacchi della batteria EV di trazione, BMS e
+      sottosistemi di gestione termica.
+  BC-3400.20.40:
+    name: Ingegneria del sistema a cella a combustibile
+    description: |
+      Ingegneria dello stoccaggio dell'idrogeno, dello stack della cella a combustibile, del balance-of-plant
+      e dell'integrazione nel veicolo.
+  BC-3400.20.50:
+    name: Ingegneria di trasmissione e linea di trasmissione
+    description: |
+      Ingegneria di trasmissioni, assali, semiassi e componenti del driveline con
+      vettorizzazione della coppia.
+  BC-3400.30:
+    name: Ingegneria del telaio e della dinamica del veicolo
+    description: |
+      Ingegneria delle sospensioni, dello sterzo, del sistema frenante, delle ruote e
+      degli pneumatici e del loro comportamento dinamico integrato.
+  BC-3400.30.10:
+    name: Ingegneria delle sospensioni e dello sterzo
+    description: |
+      Ingegneria della geometria delle sospensioni, degli ammortizzatori, delle molle e dei sistemi
+      di sterzo incluso lo steer-by-wire.
+  BC-3400.30.20:
+    name: Ingegneria del sistema frenante
+    description: |
+      Ingegneria dei freni di base, della miscelazione rigenerativa e dei sistemi
+      di controllo della frenata.
+  BC-3400.30.30:
+    name: Messa a punto della dinamica del veicolo
+    description: |
+      Messa a punto di comfort di marcia, maneggevolezza, stabilità e controllo della trazione
+      per conseguire gli attributi dinamici obiettivo.
+  BC-3400.30.40:
+    name: Ingegneria di ruote e pneumatici
+    description: |
+      Ingegneria e selezione di ruote e pneumatici, inclusi TPMS e
+      compromessi tra prestazione ed efficienza.
+  BC-3400.40:
+    name: Ingegneria della carrozzeria ed esterni
+    description: |
+      Ingegneria della scocca, delle chiusure, dei cristalli, delle finiture esterne, dell'illuminazione
+      e delle superfici aerodinamiche.
+  BC-3400.40.10:
+    name: Ingegneria della scocca
+    description: |
+      Ingegneria della struttura della carrozzeria, della strategia di giunzione e dei
+      percorsi di carico per la resistenza agli urti.
+  BC-3400.40.20:
+    name: Ingegneria di chiusure e cristalli
+    description: |
+      Ingegneria di portiere, cofani, portelloni, chiusure scorrevoli e
+      sistemi di cristalleria.
+  BC-3400.40.30:
+    name: Ingegneria delle finiture esterne e dell'illuminazione
+    description: |
+      Ingegneria delle finiture esterne, dei loghi e dei sistemi di illuminazione esterna,
+      incluse architetture di fari e indicatori.
+  BC-3400.40.40:
+    name: Ingegneria aerodinamica
+    description: |
+      Sviluppo della forma aerodinamica, bilanciamento di resistenza e portanza e
+      gestione del flusso nella parte inferiore del veicolo.
+  BC-3400.50:
+    name: Ingegneria degli interni e del comfort
+    description: |
+      Ingegneria dei sedili, dei sistemi di ritenuta, delle finiture interne, delle superfici HMI,
+      del climatizzatore e delle prestazioni acustiche/NVH.
+  BC-3400.50.10:
+    name: Ingegneria di sedili e sistemi di ritenuta
+    description: |
+      Ingegneria di sedili, cinture di sicurezza, airbag e altri sistemi di
+      ritenuta degli occupanti.
+  BC-3400.50.20:
+    name: Ingegneria delle finiture interne e HMI
+    description: |
+      Ingegneria del cruscotto, della console, del cielo dell'abitacolo e delle superfici
+      HMI fisiche e digitali.
+  BC-3400.50.30:
+    name: Ingegneria del climatizzatore
+    description: |
+      Ingegneria di HVAC, fluido refrigerante, pompa di calore e sistemi di
+      gestione termica della batteria e dell'abitacolo.
+  BC-3400.50.40:
+    name: Ingegneria acustica e NVH
+    description: |
+      Ingegneria e messa a punto di acustica, vibrazioni e asprezze (NVH)
+      sull'intero veicolo.
+  BC-3400.60:
+    name: Ingegneria dell'architettura elettrica ed elettronica
+    description: |
+      Ingegneria della topologia elettrica/elettronica del veicolo, delle reti di bordo,
+      della distribuzione dell'energia e dell'hardware ECU.
+  BC-3400.60.10:
+    name: Definizione della topologia E/E
+    description: |
+      Definizione della topologia E/E del veicolo, incluse architetture di calcolo
+      a dominio, zonale e centralizzata.
+  BC-3400.60.20:
+    name: Ingegneria della rete di bordo
+    description: |
+      Ingegneria di CAN, CAN-FD, LIN, FlexRay, Ethernet automotive e relative
+      reti di comunicazione di bordo.
+  BC-3400.60.30:
+    name: Ingegneria del cablaggio e della distribuzione dell'energia
+    description: |
+      Ingegneria di cablaggi, connettori e distribuzione dell'energia ad alta e
+      bassa tensione.
+  BC-3400.60.40:
+    name: Ingegneria hardware ECU
+    description: |
+      Ingegneria dell'hardware delle unità di controllo elettronico, dei semiconduttori e
+      dei progetti PCB secondo gli standard AEC-Q.
+  BC-3400.70:
+    name: Ingegneria del software del veicolo
+    description: |
+      Ingegneria del software embedded, delle piattaforme software automotive e dei
+      sistemi operativi del veicolo allineata ad AUTOSAR e ASPICE.
+  BC-3400.70.10:
+    name: Ingegneria del software embedded
+    description: |
+      Ingegneria del software embedded a livello ECU, inclusi driver di dispositivo
+      e componenti software di base.
+  BC-3400.70.20:
+    name: Ingegneria della piattaforma AUTOSAR
+    description: |
+      Ingegneria delle configurazioni e dell'integrazione della piattaforma AUTOSAR
+      Classic e Adaptive.
+  BC-3400.70.30:
+    name: Ingegneria del sistema operativo del veicolo
+    description: |
+      Ingegneria di sistemi operativi ad alte prestazioni, hypervisor e middleware
+      per veicoli software-defined.
+  BC-3400.70.40:
+    name: Integrazione del software e gestione della build
+    description: |
+      Integrazione, build e gestione del release-train del software del veicolo
+      attraverso ECU e domini.
+  BC-3400.80:
+    name: Ingegneria della sicurezza funzionale e della cybersecurity
+    description: |
+      Discipline ingegneristiche che garantiscono la sicurezza del veicolo safety-critical e
+      connesso, ancorate su ISO 26262, ISO/SAE 21434 e ISO 21448.
+    in_scope:
+      - Redazione del safety case funzionale (ISO 26262)
+      - Ingegneria della cybersecurity (ISO/SAE 21434)
+      - Analisi e validazione SOTIF (ISO 21448)
+      - HARA, FMEA-MSR e TARA
+    out_of_scope:
+      - SOC operativo del veicolo e risposta agli incidenti (BC-3460.60)
+      - Presentazioni per l'omologazione di tipo UN R155/R156 (BC-3420.50)
+  BC-3400.80.10:
+    name: Gestione del safety case funzionale
+    description: |
+      Redazione e manutenzione dei safety case ISO 26262, allocazione ASIL
+      e prove del safety argument.
+  BC-3400.80.20:
+    name: Ingegneria della cybersecurity automotive
+    description: |
+      Attività di ingegneria della cybersecurity allineate a ISO/SAE 21434,
+      incluse TARA, progettazione sicura e ciclo di vita dello sviluppo sicuro.
+  BC-3400.80.30:
+    name: Ingegneria SOTIF
+    description: |
+      Analisi e validazione della sicurezza della funzionalità prevista per
+      funzioni ADAS e di guida automatizzata secondo ISO 21448.
+  BC-3400.80.40:
+    name: Analisi dei pericoli e dei rischi
+    description: |
+      HARA, FMEA-MSR e altre analisi sistematiche dei pericoli alla base dei
+      requisiti di sicurezza funzionale e cybersecurity.
+  BC-3400.90:
+    name: Gestione della verifica e validazione del veicolo
+    description: |
+      Verifica e validazione di progettazioni di veicoli, sottosistemi e componenti
+      mediante campagne di test virtuali, su banco e fisici.
+  BC-3400.90.10:
+    name: Validazione virtuale
+    description: |
+      Verifica virtuale del comportamento del veicolo e dei sottosistemi mediante
+      CAE, MIL/SIL/HIL e digital twin.
+  BC-3400.90.20:
+    name: Test di componenti e sottosistemi
+    description: |
+      Test su banco e su rig di componenti e sottosistemi rispetto alle
+      specifiche ingegneristiche.
+  BC-3400.90.30:
+    name: Test di integrazione del veicolo
+    description: |
+      Test di integrazione del veicolo completo su piste di prova e su strade
+      pubbliche in condizioni controllate.
+  BC-3400.90.40:
+    name: Test di durabilità e affidabilità
+    description: |
+      Test di durabilità e affidabilità accelerati e correlati al cliente su
+      componenti e sull'intero veicolo.
+  BC-3400.90.50:
+    name: Test di crash e protezione degli occupanti
+    description: |
+      Test di crash e protezione degli occupanti a supporto dei requisiti
+      regolamentari e delle valutazioni consumer.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-vehicle-homologation-type-approval-management.yaml
+++ b/catalogue/i18n/it/L1-vehicle-homologation-type-approval-management.yaml
@@ -1,0 +1,183 @@
+# Gestione dell'omologazione del veicolo e dell'approvazione di tipo (it) — translations for L1-vehicle-homologation-type-approval-management.yaml
+locale: it
+source: L1-vehicle-homologation-type-approval-management.yaml
+entries:
+  BC-3420:
+    name: Gestione dell'omologazione del veicolo e dell'approvazione di tipo
+    description: |
+      Certificazione normativa di veicoli e componenti principali nei mercati —
+      omologazione di tipo UNECE WP.29, autocertificazione FMVSS, approvazioni regionali
+      (CCC, KS, MLIT), omologazione delle emissioni e dell'energia, programmi di crash
+      e valutazione consumer, e audit di conformità della produzione.
+  BC-3420.10:
+    name: Strategia e pianificazione dell'approvazione di tipo
+    description: |
+      Strategia di omologazione multi-mercato e pianificazione, incluso il coinvolgimento
+      delle autorità di approvazione e l'esecuzione del piano di omologazione.
+  BC-3420.10.10:
+    name: Strategia di approvazione sul mercato
+    description: |
+      Strategia per l'omologazione di tipo e la certificazione nei mercati target
+      e nei regimi normativi.
+  BC-3420.10.20:
+    name: Gestione del piano di omologazione
+    description: |
+      Gestione dei piani di omologazione a livello di programma, dei deliverable
+      e delle milestone.
+  BC-3420.10.30:
+    name: Coinvolgimento delle autorità di approvazione
+    description: |
+      Coinvolgimento delle autorità di approvazione e dei servizi tecnici nelle
+      varie giurisdizioni.
+  BC-3420.20:
+    name: Presentazioni per l'omologazione di tipo del veicolo
+    description: |
+      Preparazione e presentazione dei dossier di omologazione di tipo e di
+      autocertificazione nei regimi UNECE, FMVSS e regionali.
+  BC-3420.20.10:
+    name: Gestione del dossier di omologazione di tipo UNECE
+    description: |
+      Preparazione, presentazione e manutenzione dei dossier di omologazione di tipo
+      per l'intero veicolo secondo UNECE WP.29.
+  BC-3420.20.20:
+    name: Gestione dell'autocertificazione FMVSS
+    description: |
+      Gestione delle prove di autocertificazione per FMVSS/49 CFR 571 negli
+      Stati Uniti.
+  BC-3420.20.30:
+    name: Gestione delle presentazioni regionali
+    description: |
+      Gestione delle presentazioni per CCC, KS, MLIT, GCC e altri regimi
+      regionali di approvazione dei veicoli a motore.
+  BC-3420.20.40:
+    name: Gestione delle variazioni e delle estensioni dell'approvazione
+    description: |
+      Gestione delle variazioni, delle estensioni e delle revisioni dell'approvazione
+      lungo il ciclo di vita del veicolo.
+  BC-3420.30:
+    name: Omologazione delle emissioni e dell'energia
+    description: |
+      Omologazione delle emissioni del veicolo, del consumo energetico e dell'autonomia EV
+      secondo WLTP, RDE, EPA, CARB, regimi cinesi ed equivalenti.
+  BC-3420.30.10:
+    name: Esecuzione dei cicli di prova delle emissioni
+    description: |
+      Esecuzione dei cicli di prova delle emissioni e del consumo di carburante
+      secondo WLTP, FTP-75, normativa cinese e altri cicli normativi.
+  BC-3420.30.20:
+    name: Conformità alle emissioni da guida reale
+    description: |
+      Campagne di prova delle emissioni da guida reale e dimostrazione della
+      conformità per la verifica in servizio.
+  BC-3420.30.30:
+    name: Reportistica di CO2 e consumi
+    description: |
+      Reportistica normativa di CO2 e consumi nell'ambito delle regole EU CO2 fleet,
+      CAFE ed equivalenti.
+  BC-3420.30.40:
+    name: Omologazione dell'autonomia e dell'efficienza EV
+    description: |
+      Omologazione dell'autonomia del veicolo elettrico, del consumo energetico e delle
+      metriche di ricarica nei vari mercati.
+  BC-3420.40:
+    name: Omologazione del crash e della sicurezza degli occupanti
+    description: |
+      Omologazione normativa del crash, della protezione degli occupanti e della protezione
+      dei pedoni, insieme ai programmi di valutazione consumer.
+  BC-3420.40.10:
+    name: Gestione del programma di crash test
+    description: |
+      Pianificazione ed esecuzione delle campagne di crash test normativi e
+      di omologazione.
+  BC-3420.40.20:
+    name: Approvazione dei sistemi di ritenuta
+    description: |
+      Approvazione di cinture di sicurezza, airbag e ancoraggi per seggiolini
+      nei vari regimi normativi.
+  BC-3420.40.30:
+    name: Approvazione della protezione dei pedoni
+    description: |
+      Omologazione della protezione di pedoni e utenti vulnerabili della strada
+      secondo UNECE GTR 9 ed equivalenti.
+  BC-3420.40.40:
+    name: Gestione del programma NCAP
+    description: |
+      Gestione dei programmi di valutazione consumer del crash, inclusi Euro NCAP,
+      IIHS, NHTSA NCAP e NCAP regionali.
+  BC-3420.50:
+    name: Approvazione funzionale e cyber
+    description: |
+      Attività di omologazione di tipo specifiche per la cybersecurity UN R155,
+      gli aggiornamenti software UN R156 e ALKS/ADS UN R157, a complemento delle
+      attività ingegneristiche della gestione dell'ingegneria del veicolo.
+    in_scope:
+      - Audit CSMS e omologazione di tipo
+      - Audit SUMS e omologazione di tipo
+      - Presentazioni normative ALKS/ADS
+    out_of_scope:
+      - Attività di ingegneria della cybersecurity (BC-3400.80)
+      - Operazioni del SOC del veicolo (BC-3460.60)
+  BC-3420.50.10:
+    name: Gestione dell'omologazione di tipo CSMS
+    description: |
+      Omologazione di tipo del sistema di gestione della cybersecurity secondo
+      UN R155, inclusa la preparazione agli audit e la sorveglianza.
+  BC-3420.50.20:
+    name: Gestione dell'omologazione di tipo SUMS
+    description: |
+      Omologazione di tipo del sistema di gestione degli aggiornamenti software secondo
+      UN R156, inclusa la preparazione agli audit e la sorveglianza.
+  BC-3420.50.30:
+    name: Gestione dell'approvazione ALKS e ADS
+    description: |
+      Presentazioni per l'approvazione dei sistemi di mantenimento automatico
+      della corsia e dei sistemi di guida automatizzata più ampi secondo UN R157
+      e normative emergenti.
+  BC-3420.60:
+    name: Omologazione di tipo di componenti e sistemi
+    description: |
+      Approvazioni di tipo a livello di componente per sistemi quali illuminazione, EMC,
+      pneumatici e sistema frenante, necessarie a supportare l'approvazione dell'intero veicolo.
+  BC-3420.60.10:
+    name: Approvazione dell'illuminazione e della segnalazione
+    description: |
+      Approvazione di fari, dispositivi di segnalazione e sistemi di illuminazione
+      adattiva.
+  BC-3420.60.20:
+    name: Approvazione EMC
+    description: |
+      Approvazione della compatibilità elettromagnetica per il veicolo e i
+      sottoassiemi elettronici secondo UN R10.
+  BC-3420.60.30:
+    name: Approvazione di pneumatici e ruote
+    description: |
+      Approvazione e marcatura di pneumatici e ruote nei regimi UNECE e
+      regionali.
+  BC-3420.60.40:
+    name: Approvazione di componenti frenanti e dello sterzo
+    description: |
+      Approvazione dei componenti di frenata e sterzo secondo UN R13/R13H,
+      R79 ed equivalenti.
+  BC-3420.70:
+    name: Gestione della conformità della produzione
+    description: |
+      Audit di conformità della produzione e verifica periodica di campioni di
+      produzione rispetto alle specifiche approvate.
+  BC-3420.70.10:
+    name: Gestione degli audit CoP
+    description: |
+      Gestione degli audit di conformità della produzione da parte delle autorità
+      di approvazione e dei servizi tecnici.
+  BC-3420.70.20:
+    name: Verifica dei campioni di produzione
+    description: |
+      Verifica dei campioni di produzione rispetto alle specifiche e alle tolleranze
+      approvate in sede di omologazione di tipo.
+  BC-3420.70.30:
+    name: Sorveglianza della conformità in servizio
+    description: |
+      Test e sorveglianza della conformità in servizio per confermare il mantenimento
+      della conformità dopo il lancio.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-vehicle-programme-management.yaml
+++ b/catalogue/i18n/it/L1-vehicle-programme-management.yaml
@@ -1,0 +1,175 @@
+# Gestione del programma veicolo (it) — translations for L1-vehicle-programme-management.yaml
+locale: it
+source: L1-vehicle-programme-management.yaml
+entries:
+  BC-3410:
+    name: Gestione del programma veicolo
+    description: |
+      Governance pluriennale del programma veicolo nelle fasi di concept, milestone di gate,
+      strategia di piattaforma e variante, nonché costo, peso e timing del programma
+      dalla SOP all'end-of-production.
+  BC-3410.10:
+    name: Definizione e avvio del programma
+    description: |
+      Definizione del concept, business case, charter del programma e approvazione
+      per procedere per nuovi programmi veicolo e derivativi.
+    in_scope:
+      - Charter del programma e approvazione del business case
+      - Definizione del concept e del posizionamento del veicolo
+      - Allineamento della strategia di piattaforma e carry-over
+    out_of_scope:
+      - Ingegneria dettagliata dei sottosistemi del veicolo (BC-3400)
+      - Governance del portafoglio progetti d'impresa (BC-900)
+  BC-3410.10.10:
+    name: Charter del programma e business case
+    description: |
+      Charter del programma a livello di approvazione, business case finanziario e
+      autorizzazione all'investimento.
+  BC-3410.10.20:
+    name: Definizione del concept del veicolo
+    description: |
+      Concept del veicolo, posizionamento, definizione dei pacchetti cliente e
+      obiettivi degli attributi di alto livello.
+  BC-3410.10.30:
+    name: Allineamento della strategia di piattaforma
+    description: |
+      Allineamento dei programmi con le roadmap di piattaforma, le decisioni di carry-over
+      e le strategie di moduli condivisi.
+  BC-3410.10.40:
+    name: Gate di approvazione del programma
+    description: |
+      Gate iniziali di approvazione del programma, inclusi impegni di budget, timing
+      e risorse.
+  BC-3410.20:
+    name: Governance dei gate di fase del programma
+    description: |
+      Operatività del modello di gate di fase del programma veicolo con revisioni delle
+      milestone, assurance dei deliverable e controllo dei rischi e delle criticità.
+  BC-3410.20.10:
+    name: Pianificazione delle milestone
+    description: |
+      Pianificazione delle milestone del programma dalla PT e PVS fino alla SOP e
+      all'end-of-production.
+  BC-3410.20.20:
+    name: Esecuzione delle gate review
+    description: |
+      Esecuzione delle gate review inclusa la valutazione dei deliverable e le
+      decisioni di approvazione o sospensione.
+  BC-3410.20.30:
+    name: Gestione dei rischi e delle criticità del programma
+    description: |
+      Identificazione, escalation e mitigazione dei rischi di programma e delle
+      criticità.
+  BC-3410.20.40:
+    name: Valutazione della maturità del programma
+    description: |
+      Valutazione della maturità del programma rispetto ai criteri di prontezza
+      ingegneristica, produttiva e del fornitore.
+  BC-3410.30:
+    name: Gestione dei costi del programma
+    description: |
+      Definizione e monitoraggio degli obiettivi di costo del programma su distinta
+      base, attrezzature, investimenti e accantonamenti per garanzia.
+  BC-3410.30.10:
+    name: Definizione degli obiettivi di costo del programma
+    description: |
+      Definizione degli obiettivi di costo del programma, incluse le buste di
+      BoM, trasformazione e investimento.
+  BC-3410.30.20:
+    name: Monitoraggio del costo della distinta base
+    description: |
+      Monitoraggio del costo BoM del veicolo, dei preventivi dei fornitori e delle
+      decisioni di contenuto.
+  BC-3410.30.30:
+    name: Previsione dei costi variabili e fissi
+    description: |
+      Previsione dei costi variabili e fissi del programma nelle fasi di lancio e
+      di regime.
+  BC-3410.30.40:
+    name: Monitoraggio delle iniziative di riduzione dei costi
+    description: |
+      Monitoraggio delle iniziative di riduzione dei costi, del value engineering e
+      della loro realizzazione rispetto agli obiettivi.
+  BC-3410.40:
+    name: Monitoraggio del peso e degli attributi del programma
+    description: |
+      Monitoraggio del peso del veicolo, delle prestazioni e degli altri attributi
+      rispetto agli obiettivi del programma e risoluzione dei compromessi a livello di programma.
+  BC-3410.40.10:
+    name: Monitoraggio del peso del veicolo
+    description: |
+      Monitoraggio della costruzione di massa per sistema e delle riserve rispetto
+      agli obiettivi di peso del programma.
+  BC-3410.40.20:
+    name: Monitoraggio delle prestazioni degli attributi
+    description: |
+      Monitoraggio delle prestazioni degli attributi a livello di programma e delle
+      riserve rispetto agli obiettivi.
+  BC-3410.40.30:
+    name: Reportistica della conformità agli obiettivi
+    description: |
+      Reportistica dello stato di conformità agli obiettivi alla leadership del
+      programma e ai comitati direttivi.
+  BC-3410.50:
+    name: Pianificazione di varianti e derivativi
+    description: |
+      Pianificazione degli allestimenti, delle dotazioni, delle varianti regionali e
+      delle edizioni speciali lungo il ciclo di vita del programma.
+  BC-3410.50.10:
+    name: Pianificazione delle varianti di allestimento e dotazione
+    description: |
+      Pianificazione dei livelli di allestimento, delle opzioni e dei contenuti di
+      dotazione standard per mercato e segmento.
+  BC-3410.50.20:
+    name: Pianificazione dei derivativi regionali
+    description: |
+      Pianificazione dei derivativi regionali, inclusi carrozzerie, gruppi di trazione
+      e contenuto di funzionalità specifici per mercato.
+  BC-3410.50.30:
+    name: Pianificazione di edizioni speciali e serie limitate
+    description: |
+      Pianificazione di edizioni speciali, serie limitate e derivativi
+      provenienti dal motorsport.
+  BC-3410.60:
+    name: Coordinamento della SOP e dell'end-of-production
+    description: |
+      Coordinamento della prontezza alla SOP, della rampa produttiva e della fase
+      di dismissione dell'end-of-production tra stabilimenti e reti di fornitura.
+  BC-3410.60.10:
+    name: Coordinamento della prontezza alla SOP
+    description: |
+      Coordinamento dei criteri di prontezza alla SOP per ingegneria, fornitori,
+      stabilimento e post-vendita.
+  BC-3410.60.20:
+    name: Pianificazione della rampa produttiva
+    description: |
+      Pianificazione delle curve di rampa produttiva, della costruzione di pre-serie e
+      della cadenza dei volumi al lancio.
+  BC-3410.60.30:
+    name: Coordinamento della fase di dismissione EOP
+    description: |
+      Coordinamento del timing dell'end-of-production, degli ultimi acquisti e dei
+      piani di esaurimento scorte.
+  BC-3410.70:
+    name: Reportistica delle performance del programma
+    description: |
+      Reportistica dello stato del programma, delle decisioni e delle performance
+      post-lancio ai comitati direttivi e alla leadership esecutiva.
+  BC-3410.70.10:
+    name: Reportistica dello stato del programma
+    description: |
+      Reportistica periodica dello stato del programma su costo, timing, qualità e
+      rischio.
+  BC-3410.70.20:
+    name: Supporto al comitato direttivo del programma
+    description: |
+      Preparazione e supporto dei comitati direttivi del programma e delle
+      revisioni esecutive.
+  BC-3410.70.30:
+    name: Revisione post-lancio del programma
+    description: |
+      Revisioni post-lancio per raccogliere le lezioni apprese e alimentare la
+      successiva fase di avvio del programma.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-vehicle-sales-distribution-management.yaml
+++ b/catalogue/i18n/it/L1-vehicle-sales-distribution-management.yaml
@@ -1,0 +1,169 @@
+# Gestione della vendita e distribuzione di veicoli (it) — translations for L1-vehicle-sales-distribution-management.yaml
+locale: it
+source: L1-vehicle-sales-distribution-management.yaml
+entries:
+  BC-3440:
+    name: Gestione della vendita e distribuzione di veicoli
+    description: |
+      Vendita e distribuzione operativa di veicoli nuovi — pianificazione all'ingrosso,
+      allocazione degli slot di produzione in fabbrica, portafoglio ordini, inventario
+      di veicoli dimostrativi e usati certificati, vendite flotte e B2B, e interfaccia
+      di consegna e immatricolazione al cliente finale.
+  BC-3440.10:
+    name: Pianificazione delle vendite e allocazione dei veicoli
+    description: |
+      Pianificazione dei volumi di vendita all'ingrosso per mercato e concessionario e
+      allocazione degli slot di produzione in fabbrica di conseguenza.
+  BC-3440.10.10:
+    name: Pianificazione dei volumi all'ingrosso
+    description: |
+      Pianificazione periodica dei volumi di vendita di veicoli all'ingrosso per
+      mercato, modello e segmento.
+  BC-3440.10.20:
+    name: Allocazione dalla produzione al mercato
+    description: |
+      Allocazione della capacità limitata degli stabilimenti ai mercati e ai canali
+      in linea con la domanda e le priorità strategiche.
+  BC-3440.10.30:
+    name: Gestione degli slot di produzione
+    description: |
+      Allocazione, scambio e rilascio degli slot di produzione in fabbrica ai
+      concessionari e ai clienti flotta.
+  BC-3440.20:
+    name: Gestione del portafoglio ordini dei veicoli
+    description: |
+      Acquisizione, validazione della configurazione e gestione del ciclo di vita degli
+      ordini di veicoli a stock e cliente.
+  BC-3440.20.10:
+    name: Gestione degli ordini a stock
+    description: |
+      Gestione degli ordini a stock dei concessionari rispetto alle allocazioni e
+      agli obiettivi di scorta.
+  BC-3440.20.20:
+    name: Acquisizione degli ordini cliente
+    description: |
+      Acquisizione degli ordini di veicoli da clienti retail e flotta, incluse
+      configurazione e pricing.
+  BC-3440.20.30:
+    name: Validazione della configurazione degli ordini
+    description: |
+      Validazione delle configurazioni degli ordini rispetto alle regole di
+      fattibilità, normative e di pricing.
+  BC-3440.20.40:
+    name: Monitoraggio dello stato degli ordini
+    description: |
+      Monitoraggio end-to-end dello stato dell'ordine dalla ricezione alla
+      produzione, alla spedizione e all'arrivo dal concessionario.
+  BC-3440.30:
+    name: Operazioni di produzione su ordine e distribuzione
+    description: |
+      Coordinamento dell'esecuzione della produzione su ordine e della logistica
+      del veicolo in uscita dallo stabilimento al concessionario.
+  BC-3440.30.10:
+    name: Coordinamento della produzione su ordine
+    description: |
+      Coordinamento dell'esecuzione della produzione su ordine con le operazioni
+      produttive e i call-out ai fornitori.
+  BC-3440.30.20:
+    name: Coordinamento della logistica del veicolo
+    description: |
+      Coordinamento della logistica del veicolo in uscita su strada, ferrovia, nave
+      e movimenti di depositi interni.
+  BC-3440.30.30:
+    name: Coordinamento delle operazioni portuali e di deposito
+    description: |
+      Coordinamento delle operazioni portuali, dei centri di lavorazione e dei depositi,
+      inclusa l'accessorizzazione prima della consegna.
+  BC-3440.40:
+    name: Gestione delle scorte di veicoli e dei dimostrativi
+    description: |
+      Gestione delle scorte, dei veicoli dimostrativi, della stampa e dei parchi
+      auto sostitutivi dei concessionari.
+  BC-3440.40.10:
+    name: Gestione delle scorte di veicoli del concessionario
+    description: |
+      Visibilità e gestione delle scorte di veicoli presso i concessionari e in
+      transito.
+  BC-3440.40.20:
+    name: Gestione dei veicoli dimostrativi
+    description: |
+      Gestione dei parchi di veicoli dimostrativi utilizzati dai concessionari e
+      dalla forza vendita field dell'OEM.
+  BC-3440.40.30:
+    name: Gestione del parco auto stampa e sostitutivo
+    description: |
+      Gestione dei parchi auto per la stampa, il marketing e i sostitutivi, incluse
+      configurazioni e rotazione.
+  BC-3440.50:
+    name: Gestione del programma usato certificato
+    description: |
+      Gestione dei programmi OEM di veicoli usati certificati, che include ispezione,
+      idoneità, marchio e garanzia.
+    in_scope:
+      - Criteri di idoneità e ispezione dei veicoli usati certificati
+      - Inventario e pricing dei veicoli usati certificati
+      - Programmi di garanzia specifici per i veicoli usati certificati
+    out_of_scope:
+      - Rivendita di veicoli off-lease al di fuori del programma usato certificato
+  BC-3440.50.10:
+    name: Idoneità e ispezione del veicolo usato certificato
+    description: |
+      Definizione ed esecuzione dei criteri di idoneità e degli standard di
+      ispezione per i veicoli usati certificati.
+  BC-3440.50.20:
+    name: Gestione dell'inventario dei veicoli usati certificati
+    description: |
+      Gestione dell'inventario di veicoli usati certificati presso i concessionari
+      e nei depositi centrali.
+  BC-3440.50.30:
+    name: Garanzia e branding dei veicoli usati certificati
+    description: |
+      Progettazione e merchandising del programma di garanzia brandizzato per i
+      veicoli usati certificati.
+  BC-3440.60:
+    name: Gestione delle vendite flotte e B2B
+    description: |
+      Operazioni di vendita a flotte, leasing, noleggio e altri acquirenti B2B di
+      veicoli, inclusa la gestione di gare e offerte.
+  BC-3440.60.10:
+    name: Gestione degli account flotta
+    description: |
+      Gestione dei grandi account flotta e delle relazioni con i clienti aziendali.
+  BC-3440.60.20:
+    name: Gestione delle gare e delle offerte flotta
+    description: |
+      Risposta a gare flotta, RFP e processi di offerta strutturata per grandi
+      contratti di veicoli.
+  BC-3440.60.30:
+    name: Gestione delle specifiche dei veicoli flotta
+    description: |
+      Gestione delle specifiche, delle opzioni e delle conversioni di veicoli
+      specifiche per le flotte.
+  BC-3440.60.40:
+    name: Gestione del canale noleggio e leasing
+    description: |
+      Gestione delle relazioni OEM con le società di noleggio e leasing, inclusi
+      gli accordi di riacquisto.
+  BC-3440.70:
+    name: Supporto alla consegna e all'immatricolazione del veicolo
+    description: |
+      Supporto ai concessionari per la consegna del veicolo, l'immatricolazione e
+      l'ingresso nella fase di esperienza del cliente.
+  BC-3440.70.10:
+    name: Coordinamento dell'ispezione pre-consegna
+    description: |
+      Coordinamento degli standard PDI e delle approvazioni nei concessionari e
+      nei centri di lavorazione.
+  BC-3440.70.20:
+    name: Collegamento per l'immatricolazione del veicolo
+    description: |
+      Collegamento con le autorità di immatricolazione dei veicoli e fornitura
+      dei dati della prima immatricolazione.
+  BC-3440.70.30:
+    name: Esperienza di consegna al cliente
+    description: |
+      Definizione e garanzia dell'esperienza di consegna al cliente al momento
+      della consegna del veicolo.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-warehousing-operations-management.yaml
+++ b/catalogue/i18n/it/L1-warehousing-operations-management.yaml
@@ -1,0 +1,141 @@
+# Gestione delle operazioni di magazzino (it) — translations for L1-warehousing-operations-management.yaml
+locale: it
+source: L1-warehousing-operations-management.yaml
+entries:
+  BC-2460:
+    name: Gestione delle operazioni di magazzino
+    description: |
+      Gestione di magazzini e centri di distribuzione di terze parti, inclusi inbound,
+      stoccaggio, outbound, servizi a valore aggiunto e logistica inversa.
+  BC-2460.10:
+    name: Gestione delle operazioni inbound
+    description: |
+      Ricezione, controllo e stoccaggio delle merci in entrata nel magazzino.
+    in_scope:
+      - Gestione dell'avviso di spedizione anticipato (ASN) e della pre-ricezione
+      - Controllo in entrata e stoccaggio
+    out_of_scope:
+      - Dispacciamento outbound (BC-2460.30)
+      - Proprietà dell'inventario a livello del mittente (BC-530)
+  BC-2460.10.10:
+    name: Pianificazione della pre-ricezione
+    description: |
+      Acquisizione degli ASN, pianificazione delle banchine e pianificazione delle risorse
+      per le ricezioni.
+  BC-2460.10.20:
+    name: Ricezione e controllo delle merci
+    description: |
+      Ricezione fisica e controllo delle merci in entrata.
+  BC-2460.10.30:
+    name: Stoccaggio e allocazione delle ubicazioni
+    description: |
+      Stoccaggio delle merci ricevute e allocazione alle ubicazioni di stoccaggio.
+  BC-2460.20:
+    name: Gestione delle operazioni di stoccaggio e inventario
+    description: |
+      Operazioni di stoccaggio interne, inclusi slotting, inventari ciclici e stoccaggio
+      a temperatura controllata.
+  BC-2460.20.10:
+    name: Slotting e gestione delle ubicazioni
+    description: |
+      Decisioni di slotting e manutenzione delle ubicazioni di stoccaggio.
+  BC-2460.20.20:
+    name: Inventario ciclico e riconciliazione
+    description: |
+      Inventari ciclici, riconciliazione delle scorte e rettifiche di inventario.
+  BC-2460.20.30:
+    name: Tracciamento di lotti, seriali e batch
+    description: |
+      Tracciamento degli attributi di lotto, seriale e batch per le merci stoccate.
+  BC-2460.20.40:
+    name: Stoccaggio a freddo e condizionato
+    description: |
+      Gestione dello stoccaggio a temperatura controllata, per merci pericolose e in
+      deposito doganale.
+  BC-2460.30:
+    name: Gestione delle operazioni outbound
+    description: |
+      Prelievo, imballaggio, etichettatura e dispacciamento delle spedizioni in uscita.
+  BC-2460.30.10:
+    name: Operazioni di prelievo
+    description: |
+      Prelievo degli ordini con strategie batch, wave e zone.
+  BC-2460.30.20:
+    name: Imballaggio ed etichettatura
+    description: |
+      Imballaggio, etichettatura e preparazione dei documenti di spedizione.
+  BC-2460.30.30:
+    name: Dispacciamento e carico
+    description: |
+      Carico dei veicoli in uscita e conferma del dispacciamento.
+  BC-2460.40:
+    name: Gestione dei servizi a valore aggiunto
+    description: |
+      Servizi a valore aggiunto in magazzino quali kitting, co-packing, etichettatura
+      e configurazione.
+  BC-2460.40.10:
+    name: Servizi di kitting e assemblaggio
+    description: |
+      Kitting, sub-assemblaggio e assemblaggio di bundle all'interno del magazzino.
+  BC-2460.40.20:
+    name: Co-packing e ri-etichettatura
+    description: |
+      Servizi di co-packing, ri-imballaggio e ri-etichettatura.
+  BC-2460.40.30:
+    name: Postponement e configurazione
+    description: |
+      Configurazione del prodotto in fase tardiva e postponement.
+  BC-2460.50:
+    name: Gestione dei resi e delle operazioni inverse
+    description: |
+      Ricezione, triage e smaltimento delle merci restituite e dei flussi di logistica
+      inversa.
+  BC-2460.50.10:
+    name: Ricezione e triage dei resi
+    description: |
+      Ricezione e triage delle merci restituite.
+  BC-2460.50.20:
+    name: Ricondizionamento e smaltimento
+    description: |
+      Ricondizionamento, ri-imballaggio e decisioni di smaltimento.
+  BC-2460.50.30:
+    name: Smaltimento della logistica inversa
+    description: |
+      Smaltimento, riciclo e distruzione dei resi non recuperabili.
+  BC-2460.60:
+    name: Gestione delle risorse del magazzino
+    description: |
+      Gestione del lavoro, delle attrezzature di movimentazione e della capacità di
+      banchine e slot all'interno del magazzino.
+  BC-2460.60.10:
+    name: Pianificazione del lavoro e produttività
+    description: |
+      Pianificazione dei turni, assegnazione dei compiti e monitoraggio della produttività.
+  BC-2460.60.20:
+    name: Operazioni delle attrezzature di movimentazione
+    description: |
+      Gestione, allocazione e manutenzione di carrelli elevatori, nastri trasportatori
+      e AGV.
+  BC-2460.60.30:
+    name: Pianificazione delle banchine e degli slot
+    description: |
+      Pianificazione degli slot delle banchine inbound e outbound.
+  BC-2460.70:
+    name: Gestione della performance del magazzino
+    description: |
+      Misurazione dei KPI di servizio, accuratezza e throughput del magazzino.
+  BC-2460.70.10:
+    name: Monitoraggio dei KPI del ciclo d'ordine
+    description: |
+      Monitoraggio dei KPI di ciclo d'ordine, tasso di riempimento e accuratezza.
+  BC-2460.70.20:
+    name: Reportistica sull'accuratezza delle scorte
+    description: |
+      Reportistica sull'accuratezza delle scorte e sulle perdite di inventario.
+  BC-2460.70.30:
+    name: Reportistica su throughput e produttività
+    description: |
+      Reportistica su throughput, unità per ora e benchmark di produttività.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-wastewater-operations-management.yaml
+++ b/catalogue/i18n/it/L1-wastewater-operations-management.yaml
@@ -1,0 +1,145 @@
+# Gestione delle operazioni delle acque reflue (it) — translations for L1-wastewater-operations-management.yaml
+locale: it
+source: L1-wastewater-operations-management.yaml
+entries:
+  BC-3890:
+    name: Gestione delle operazioni delle acque reflue
+    description: |
+      Raccolta, trattamento e smaltimento delle acque reflue municipali e industriali —
+      operazione della rete fognaria, operazione degli impianti di depurazione,
+      risposta agli intasamenti e agli allagamenti, gestione del fango e dei biosolidi,
+      operazioni degli scarichi di emergenza e conformità della qualità dell'effluente finale.
+  BC-3890.10:
+    name: Operazioni della rete fognaria
+    description: |
+      Operazione delle reti fognarie nere, bianche e miste,
+      incluse le stazioni di pompaggio e le condotte in pressione.
+  BC-3890.10.10:
+    name: Operazioni delle stazioni di pompaggio fognarie
+    description: |
+      Operazione e sorveglianza delle stazioni di pompaggio fognarie e delle condotte in pressione.
+  BC-3890.10.20:
+    name: Sorveglianza della rete fognaria
+    description: |
+      Sorveglianza tramite telemetria dei livelli fognari e degli allarmi delle stazioni di pompaggio.
+  BC-3890.10.30:
+    name: Pulizia della rete fognaria
+    description: |
+      Pulizia programmata e reattiva, idrolavaggio e desabbiamento delle fognature.
+  BC-3890.20:
+    name: Operazioni degli impianti di depurazione
+    description: |
+      Operazione quotidiana degli impianti di trattamento delle acque reflue, inclusi
+      i processi di pretrattamento, primario, secondario e terziario.
+  BC-3890.20.10:
+    name: Operazioni di pretrattamento e trattamento primario
+    description: |
+      Operazione delle fasi di grigliatura, dissabbiatura e sedimentazione primaria.
+  BC-3890.20.20:
+    name: Operazioni di trattamento biologico secondario
+    description: |
+      Operazione dei processi secondari a fanghi attivi, filtri percolatori e MBR.
+  BC-3890.20.30:
+    name: Operazioni di trattamento terziario
+    description: |
+      Operazione delle fasi di rimozione dei nutrienti, filtrazione e disinfezione del trattamento terziario.
+  BC-3890.20.40:
+    name: Controllo e ottimizzazione del processo
+    description: |
+      Controllo di processo e ottimizzazione energetica delle fasi biologiche e di aerazione.
+  BC-3890.30:
+    name: Risposta agli intasamenti fognari e agli allagamenti
+    description: |
+      Risposta reattiva agli intasamenti fognari, agli allagamenti interni ed esterni
+      e agli incidenti di inquinamento.
+  BC-3890.30.10:
+    name: Operazioni di risposta agli intasamenti
+    description: |
+      Intervento sul campo per gli intasamenti fognari con idrolavaggio e rimozione.
+  BC-3890.30.20:
+    name: Risposta agli allagamenti interni da fognatura
+    description: |
+      Risposta rivolta ai clienti in caso di allagamento interno da fognatura.
+  BC-3890.30.30:
+    name: Risposta agli allagamenti esterni da fognatura
+    description: |
+      Risposta agli allagamenti esterni da fognatura e agli impatti sulla viabilità.
+  BC-3890.30.40:
+    name: Contenimento degli incidenti di inquinamento
+    description: |
+      Contenimento e rimedio degli incidenti di inquinamento da acque reflue nei corpi idrici.
+  BC-3890.40:
+    name: Gestione dei reflui industriali
+    description: |
+      Autorizzazione, monitoraggio e tariffazione degli scarichi di reflui industriali
+      alla fognatura pubblica.
+  BC-3890.40.10:
+    name: Amministrazione delle autorizzazioni agli scarichi industriali
+    description: |
+      Rilascio e modifica delle autorizzazioni agli scarichi industriali per i soggetti scaricatori.
+  BC-3890.40.20:
+    name: Operazioni di campionamento dei reflui industriali
+    description: |
+      Campionamento e analisi degli scarichi di reflui industriali rispetto alle condizioni dell'autorizzazione.
+  BC-3890.40.30:
+    name: Tariffazione dei reflui industriali
+    description: |
+      Calcolo delle tariffe per gli scarichi industriali secondo la formula Mogden o equivalenti.
+  BC-3890.50:
+    name: Gestione del fango e dei biosolidi
+    description: |
+      Trattamento, utilizzo benefico e smaltimento del fango da acque reflue,
+      inclusa la digestione anaerobica e il riciclo dei biosolidi in agricoltura.
+  BC-3890.50.10:
+    name: Operazioni di ispessimento e disidratazione del fango
+    description: |
+      Operazione dei sistemi di ispessimento, disidratazione e centrifugazione del fango.
+  BC-3890.50.20:
+    name: Operazioni di digestione anaerobica
+    description: |
+      Operazione dei digestori anaerobici mesofili e termofili e dei sistemi di biogas.
+  BC-3890.50.30:
+    name: Riciclo dei biosolidi in agricoltura
+    description: |
+      Applicazione dei biosolidi ai terreni agricoli nel rispetto dei regimi di utilizzo sicuro del fango.
+  BC-3890.50.40:
+    name: Operazioni di incenerimento e smaltimento del fango
+    description: |
+      Operazione degli impianti di incenerimento del fango e percorsi alternativi di smaltimento.
+  BC-3890.60:
+    name: Operazioni degli scarichi di emergenza
+    description: |
+      Operazione, monitoraggio e rendicontazione degli scarichi di emergenza delle fognature miste
+      e degli scarichi di emergenza, incluso il monitoraggio della durata degli eventi.
+  BC-3890.60.10:
+    name: Monitoraggio della durata degli eventi
+    description: |
+      Operazione della telemetria EDM sugli scarichi di emergenza delle fognature miste.
+  BC-3890.60.20:
+    name: Rendicontazione degli scarichi di emergenza
+    description: |
+      Rendicontazione dei volumi e delle durate degli scarichi ai regolatori e al pubblico.
+  BC-3890.60.30:
+    name: Operazioni delle vasche di accumulo
+    description: |
+      Operazione delle vasche di accumulo delle acque meteoriche e delle strutture di compenso agli ingressi degli impianti di depurazione.
+  BC-3890.70:
+    name: Operazioni di qualità dell'effluente finale
+    description: |
+      Campionamento, analisi e rendicontazione normativa della qualità dell'effluente
+      finale rispetto alle autorizzazioni allo scarico.
+  BC-3890.70.10:
+    name: Campionamento di conformità all'autorizzazione allo scarico
+    description: |
+      Campionamento di autocontrollo dell'operatore rispetto ai limiti numerici delle autorizzazioni allo scarico.
+  BC-3890.70.20:
+    name: Sorveglianza della qualità dell'effluente
+    description: |
+      Sorveglianza online e di laboratorio di BOD, ammoniaca e nutrienti dell'effluente finale.
+  BC-3890.70.30:
+    name: Rendicontazione dell'autorizzazione allo scarico
+    description: |
+      Rendicontazione normativa della conformità allo scarico agli enti regolatori ambientali.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-water-distribution-network-operations-management.yaml
+++ b/catalogue/i18n/it/L1-water-distribution-network-operations-management.yaml
@@ -1,0 +1,144 @@
+# Gestione delle operazioni della rete di distribuzione idrica (it) — translations for L1-water-distribution-network-operations-management.yaml
+locale: it
+source: L1-water-distribution-network-operations-management.yaml
+entries:
+  BC-3880:
+    name: Gestione delle operazioni della rete di distribuzione idrica
+    description: |
+      Operazione delle condotte principali e di distribuzione per la fornitura di acqua
+      trattata ai clienti — gestione idraulica e della pressione, controllo delle perdite,
+      qualità dell'acqua in rete, riparazione e sostituzione delle condotte
+      e realizzazione delle connessioni al cliente.
+  BC-3880.10:
+    name: Controllo della rete di distribuzione
+    description: |
+      Operazione 24/7 della sala controllo del sistema di distribuzione idrica
+      tramite telemetria, modelli idraulici e SCADA.
+  BC-3880.10.10:
+    name: Operazioni SCADA di distribuzione
+    description: |
+      Controllo supervisivo in tempo reale degli asset di pompaggio e pressione su tutta la rete.
+  BC-3880.10.20:
+    name: Operazioni del modello idraulico
+    description: |
+      Utilizzo di modelli idraulici online e offline per le decisioni di rete.
+  BC-3880.10.30:
+    name: Sorveglianza della telemetria di rete
+    description: |
+      Sorveglianza della telemetria sui distretti di misurazione, valvole e punti di pressione.
+  BC-3880.20:
+    name: Operazioni delle condotte principali e del pompaggio
+    description: |
+      Operazione delle condotte principali, delle stazioni di pompaggio e dei
+      trasferimenti interzonali, incluso il pompaggio di rilancio e la gestione dei colpi d'ariete.
+  BC-3880.20.10:
+    name: Operazioni delle stazioni di pompaggio
+    description: |
+      Operazione e ottimizzazione energetica delle stazioni di pompaggio della distribuzione.
+  BC-3880.20.20:
+    name: Operazioni delle condotte principali
+    description: |
+      Operazione, manovra delle valvole e gestione dei colpi d'ariete sulle condotte di trasmissione principali.
+  BC-3880.20.30:
+    name: Operazioni di trasferimento interzonale
+    description: |
+      Operazione dei trasferimenti interzonali e dei collegamenti di fornitura all'ingrosso tra zone di risorsa.
+  BC-3880.30:
+    name: Gestione delle perdite
+    description: |
+      Controllo attivo e passivo delle perdite nei distretti di misurazione
+      tramite analisi degli afflussi, rilevamento acustico e interventi di ricerca e riparazione.
+    in_scope:
+      - Analisi dell'afflusso nei DMA e del flusso minimo notturno
+      - Campagne di rilevamento acustico delle perdite
+      - Operazioni di ricerca e riparazione delle perdite
+    out_of_scope:
+      - Programmi di sostituzione delle condotte (BC-3900.50)
+      - Perdite sul lato del cliente (BC-3910.60)
+  BC-3880.30.10:
+    name: Analisi del distretto di misurazione
+    description: |
+      Analisi dei dati di afflusso e del flusso minimo notturno nei DMA per localizzare le perdite.
+  BC-3880.30.20:
+    name: Rilevamento acustico delle perdite
+    description: |
+      Sondaggi acustici, correlazione e campagne con data logger per la localizzazione delle perdite.
+  BC-3880.30.30:
+    name: Operazioni di ricerca e riparazione delle perdite
+    description: |
+      Operazioni sul campo di ricerca e riparazione delle perdite individuate rispetto agli obiettivi di tempo di riparazione.
+  BC-3880.30.40:
+    name: Rendicontazione delle prestazioni sulle perdite
+    description: |
+      Rendicontazione delle prestazioni sulle perdite rispetto ai parametri regolatori e IWA di bilancio idrico.
+  BC-3880.40:
+    name: Gestione della pressione
+    description: |
+      Ottimizzazione della pressione di distribuzione nelle zone a pressione gestita
+      per la riduzione delle perdite e il controllo del tasso di rotture.
+  BC-3880.40.10:
+    name: Configurazione delle zone di pressione
+    description: |
+      Configurazione delle zone a pressione gestita e dei setpoint dei riduttori di pressione.
+  BC-3880.40.20:
+    name: Controllo avanzato della pressione
+    description: |
+      Operazione di riduttori di pressione controllati da remoto e a modulazione temporale.
+  BC-3880.40.30:
+    name: Gestione della pressione transitoria
+    description: |
+      Analisi dei colpi d'ariete e mitigazione dei transitori sulle reti di distribuzione.
+  BC-3880.50:
+    name: Operazioni di qualità dell'acqua in rete
+    description: |
+      Sorveglianza della qualità dell'acqua in rete — cloro residuo, acqua
+      decolorata, gusto e odore — e operazioni di rimedio.
+  BC-3880.50.10:
+    name: Sorveglianza del cloro residuo in rete
+    description: |
+      Sorveglianza dei residui di cloro in tutta la rete e dosaggio di reclorazione.
+  BC-3880.50.20:
+    name: Controllo della decolorazione e dei sedimenti
+    description: |
+      Operazioni di spurgo e ice-pigging per gestire i reclami per acqua decolorata.
+  BC-3880.50.30:
+    name: Operazioni di campionamento in rete
+    description: |
+      Campionamento normativo presso i rubinetti dei clienti e i punti di fornitura.
+  BC-3880.60:
+    name: Operazioni di riparazione e sostituzione delle condotte
+    description: |
+      Riparazione reattiva di rotture e guasti ai giunti e realizzazione operativa
+      dei programmi di sostituzione delle condotte.
+  BC-3880.60.10:
+    name: Risposta alle rotture delle condotte
+    description: |
+      Risposta, isolamento e riparazione delle rotture delle condotte rispetto agli obiettivi di minuti cliente persi.
+  BC-3880.60.20:
+    name: Operazioni di riparazione degli allacciamenti
+    description: |
+      Riparazione delle tubazioni di raccordo e di allacciamento tra la condotta principale e il rubinetto di arresto.
+  BC-3880.60.30:
+    name: Operazioni di sostituzione delle condotte sul campo
+    description: |
+      Esecuzione sul campo dei programmi di sostituzione e riabilitazione delle condotte, inclusi i metodi senza scavo.
+  BC-3880.70:
+    name: Operazioni per le nuove connessioni idriche
+    description: |
+      Realizzazione di nuove connessioni idriche per clienti domestici, commerciali
+      e sviluppatori.
+  BC-3880.70.10:
+    name: Valutazione delle domande di nuova connessione
+    description: |
+      Valutazione tecnica delle domande di nuova connessione idrica e dei servizi per gli sviluppatori.
+  BC-3880.70.20:
+    name: Operazioni di installazione delle connessioni
+    description: |
+      Installazione di tubazioni di raccordo, ferule e contatori del cliente.
+  BC-3880.70.30:
+    name: Collaudo delle connessioni
+    description: |
+      Collaudo, spurgatura e disinfezione delle nuove connessioni prima dell'utilizzo.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-water-resource-management.yaml
+++ b/catalogue/i18n/it/L1-water-resource-management.yaml
@@ -1,0 +1,133 @@
+# Gestione delle risorse idriche (it) — translations for L1-water-resource-management.yaml
+locale: it
+source: L1-water-resource-management.yaml
+entries:
+  BC-3860:
+    name: Gestione delle risorse idriche
+    description: |
+      Governo sostenibile delle fonti di acqua grezza — protezione del bacino idrografico
+      e delle sorgenti, prelievo e stoccaggio dell'acqua grezza, pianificazione delle risorse
+      a lungo termine, gestione della siccità e delle restrizioni, conformità alle concessioni
+      idriche e reti di monitoraggio delle acque superficiali e sotterranee.
+  BC-3860.10:
+    name: Protezione del bacino idrografico e delle sorgenti
+    description: |
+      Protezione dei bacini idrografici delle sorgenti attraverso il coinvolgimento degli
+      stakeholder, misure di gestione del territorio e valutazione del rischio idrico.
+  BC-3860.10.10:
+    name: Valutazione del rischio del bacino idrografico
+    description: |
+      Valutazione del rischio del bacino idrografico per le fonti idropotabili secondo i principi del Water Safety Plan dell'OMS.
+  BC-3860.10.20:
+    name: Gestione delle zone di protezione delle sorgenti
+    description: |
+      Designazione e gestione delle zone di protezione delle sorgenti sotterranee e superficiali.
+  BC-3860.10.30:
+    name: Coinvolgimento degli stakeholder del bacino idrografico
+    description: |
+      Coinvolgimento di proprietari terrieri, regolatori e agricoltori sulle misure di gestione del bacino.
+  BC-3860.20:
+    name: Operazioni di prelievo dell'acqua grezza
+    description: |
+      Operazione quotidiana delle prese d'acqua, degli offtake fluviali e dei pozzi
+      d'acqua sotterranea che alimentano il parco impianti di trattamento.
+  BC-3860.20.10:
+    name: Operazioni delle prese d'acqua superficiale
+    description: |
+      Operazione delle prese da fiumi e serbatoi, inclusa la grigliatura e il pompaggio.
+  BC-3860.20.20:
+    name: Operazioni dei pozzi d'acqua sotterranea
+    description: |
+      Operazione e gestione della portata dei pozzi d'acqua sotterranea.
+  BC-3860.20.30:
+    name: Operazioni di pompaggio dell'acqua grezza
+    description: |
+      Pompaggio dell'acqua grezza verso gli impianti di trattamento e i sistemi di acquedotto.
+  BC-3860.30:
+    name: Operazioni di stoccaggio dell'acqua grezza
+    description: |
+      Operazione di serbatoi d'invaso e di compenso, dighe e stoccaggi di pretrattamento,
+      inclusa la sorveglianza della sicurezza delle dighe.
+  BC-3860.30.10:
+    name: Operazioni del livello dei serbatoi
+    description: |
+      Gestione secondo la curva operativa dei serbatoi d'invaso e di compenso.
+  BC-3860.30.20:
+    name: Sorveglianza della sicurezza delle dighe
+    description: |
+      Sorveglianza e ispezione delle dighe ai sensi dei regimi normativi di sicurezza delle dighe.
+  BC-3860.30.30:
+    name: Operazioni di qualità dell'acqua del serbatoio
+    description: |
+      Sorveglianza e gestione della qualità dell'acqua grezza, incluse le fioriture algali.
+  BC-3860.40:
+    name: Pianificazione delle risorse idriche
+    description: |
+      Pianificazione a lungo termine delle risorse idriche e della domanda, inclusi il bilancio
+      domanda-offerta, l'adattamento ai cambiamenti climatici e la valutazione delle opzioni.
+  BC-3860.40.10:
+    name: Previsione del bilancio domanda-offerta
+    description: |
+      Previsione a lungo termine di offerta e domanda per zona di risorsa.
+  BC-3860.40.20:
+    name: Valutazione delle opzioni di risorsa
+    description: |
+      Valutazione delle opzioni per nuove fonti, trasferimenti e misure di gestione della domanda.
+  BC-3860.40.30:
+    name: Adattamento delle risorse ai cambiamenti climatici
+    description: |
+      Adeguamento delle rese delle risorse e della domanda per gli scenari di cambiamento climatico.
+  BC-3860.50:
+    name: Gestione della siccità e delle restrizioni
+    description: |
+      Attivazione dei piani di siccità e delle restrizioni dell'approvvigionamento attraverso
+      i trigger di siccità, le restrizioni ai clienti e le domande di permesso di siccità emergenziale.
+  BC-3860.50.10:
+    name: Monitoraggio dei trigger di siccità
+    description: |
+      Monitoraggio dei trigger di siccità dei serbatoi, dei corsi d'acqua e delle acque sotterranee.
+  BC-3860.50.20:
+    name: Operazioni di restrizione idrica
+    description: |
+      Attuazione e revoca delle restrizioni all'uso dell'acqua per i clienti.
+  BC-3860.50.30:
+    name: Gestione dei permessi e degli ordini di siccità
+    description: |
+      Domanda e operazione di permessi e ordini di siccità autorizzati dai regolatori.
+  BC-3860.60:
+    name: Conformità alle concessioni idriche
+    description: |
+      Amministrazione delle concessioni idriche e rendicontazione della conformità
+      rispetto ai limiti di quantità, ai periodi di prelievo e alle condizioni ambientali.
+  BC-3860.60.10:
+    name: Amministrazione delle concessioni idriche
+    description: |
+      Manutenzione del portafoglio di concessioni idriche e del registro delle condizioni.
+  BC-3860.60.20:
+    name: Rendicontazione dei volumi di prelievo
+    description: |
+      Rendicontazione dei volumi prelevati e del rispetto delle condizioni di concessione.
+  BC-3860.60.30:
+    name: Conformità al deflusso minimo vitale
+    description: |
+      Monitoraggio del deflusso minimo vitale e delle condizioni di flusso ecologico sulle concessioni.
+  BC-3860.70:
+    name: Monitoraggio idrometrico
+    description: |
+      Operazione delle reti di monitoraggio delle acque superficiali e sotterranee,
+      a supporto della pianificazione delle risorse e delle decisioni operative.
+  BC-3860.70.10:
+    name: Monitoraggio delle acque superficiali
+    description: |
+      Operazione delle reti di monitoraggio del deflusso, dei livelli fluviali e delle precipitazioni.
+  BC-3860.70.20:
+    name: Monitoraggio del livello delle acque sotterranee
+    description: |
+      Operazione delle reti di pozzi di osservazione delle acque sotterranee.
+  BC-3860.70.30:
+    name: Gestione della qualità dei dati idrometrici
+    description: |
+      Controllo di qualità e gestione delle curve di deflusso per i dati idrometrici.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-water-treatment-operations-management.yaml
+++ b/catalogue/i18n/it/L1-water-treatment-operations-management.yaml
@@ -1,0 +1,132 @@
+# Gestione delle operazioni di trattamento delle acque (it) — translations for L1-water-treatment-operations-management.yaml
+locale: it
+source: L1-water-treatment-operations-management.yaml
+entries:
+  BC-3870:
+    name: Gestione delle operazioni di trattamento delle acque
+    description: |
+      Produzione di acqua potabile negli impianti di trattamento — operazione dei processi,
+      garanzia della qualità dell'acqua potabile, gestione dei reagenti chimici,
+      stoccaggio dell'acqua trattata e gestione dei residui di trattamento, nel rispetto
+      delle normative sull'acqua potabile e dei principi del Water Safety Plan dell'OMS.
+  BC-3870.10:
+    name: Operazioni degli impianti di trattamento
+    description: |
+      Operazione quotidiana degli impianti di potabilizzazione per la produzione
+      di acqua a specifica e in risposta alla domanda.
+  BC-3870.10.10:
+    name: Operazioni di turno degli impianti di trattamento
+    description: |
+      Operazione a turni di impianti di trattamento convenzionali e a membrana.
+  BC-3870.10.20:
+    name: Programmazione della produzione di trattamento
+    description: |
+      Programmazione della produzione degli impianti in funzione della domanda di distribuzione e dello stato degli stoccaggi.
+  BC-3870.10.30:
+    name: Rendicontazione delle prestazioni degli impianti di trattamento
+    description: |
+      Rendicontazione della produzione degli impianti, dei consumi energetici e degli indicatori di prestazione.
+  BC-3870.20:
+    name: Controllo del processo di trattamento
+    description: |
+      Controllo di processo delle operazioni unitarie di trattamento — coagulazione,
+      filtrazione, disinfezione e trattamento avanzato — rispetto al monitoraggio
+      online della qualità.
+  BC-3870.20.10:
+    name: Controllo della coagulazione e della chiarificazione
+    description: |
+      Controllo del dosaggio del coagulante, della flocculazione e delle prestazioni dei chiarificatori.
+  BC-3870.20.20:
+    name: Controllo del processo di filtrazione
+    description: |
+      Controllo della filtrazione a sabbia rapida, a sabbia lenta e a membrana.
+  BC-3870.20.30:
+    name: Controllo del processo di disinfezione
+    description: |
+      Controllo dei processi di clorazione, trattamento UV, ozonizzazione e disinfezione avanzata.
+  BC-3870.20.40:
+    name: Controllo del processo di trattamento avanzato
+    description: |
+      Controllo dei processi di carbone attivo granulare (GAC), scambio ionico e ossidazione avanzata.
+  BC-3870.30:
+    name: Operazioni di qualità dell'acqua potabile
+    description: |
+      Campionamento, analisi di laboratorio, sorveglianza online e rendicontazione
+      normativa della conformità della qualità dell'acqua potabile.
+    in_scope:
+      - Campionamento normativo dell'acqua potabile
+      - Analisi di laboratorio dei parametri microbiologici e chimici
+      - Risposta agli incidenti sulla qualità dell'acqua potabile
+    out_of_scope:
+      - Qualità dell'acqua nella rete di distribuzione (BC-3880.50)
+      - Qualità dell'effluente delle acque reflue (BC-3890.70)
+  BC-3870.30.10:
+    name: Programma di campionamento normativo
+    description: |
+      Gestione dei programmi di campionamento normativo dell'acqua potabile presso gli impianti di trattamento e i punti di fornitura.
+  BC-3870.30.20:
+    name: Monitoraggio online dell'acqua trattata
+    description: |
+      Monitoraggio online della torbidità, del cloro residuo e di altri parametri dell'acqua trattata.
+  BC-3870.30.30:
+    name: Risposta agli incidenti sulla qualità dell'acqua potabile
+    description: |
+      Indagine e rimedio degli incidenti di qualità e dei superamenti dei limiti dell'acqua potabile.
+  BC-3870.30.40:
+    name: Rendicontazione della qualità dell'acqua potabile
+    description: |
+      Rendicontazione normativa agli enti regolatori dell'acqua potabile (DWI, EPA e equivalenti).
+  BC-3870.40:
+    name: Gestione dei reagenti chimici di trattamento
+    description: |
+      Gestione operativa dei reagenti chimici di trattamento, incluse scorte,
+      dosaggio e sicurezza nella movimentazione dei prodotti chimici.
+  BC-3870.40.10:
+    name: Operazioni delle scorte di reagenti chimici
+    description: |
+      Gestione dei livelli di scorta dei reagenti chimici di trattamento presso gli impianti.
+  BC-3870.40.20:
+    name: Operazioni di dosaggio chimico
+    description: |
+      Operazione e calibrazione dei sistemi di dosaggio dei reagenti chimici di trattamento.
+  BC-3870.40.30:
+    name: Sicurezza nella movimentazione dei prodotti chimici
+    description: |
+      Movimentazione in sicurezza e controlli COSHH e DSEAR per i prodotti chimici di trattamento in loco.
+  BC-3870.50:
+    name: Operazioni di stoccaggio dell'acqua trattata
+    description: |
+      Operazione dei serbatoi di servizio, delle vasche di contatto e dei serbatoi pensili
+      per l'immissione dell'acqua trattata nella rete di distribuzione.
+  BC-3870.50.10:
+    name: Operazioni dei serbatoi di servizio
+    description: |
+      Operazione, controllo del livello e gestione del ricambio dei serbatoi di servizio.
+  BC-3870.50.20:
+    name: Operazioni delle vasche di contatto
+    description: |
+      Operazione delle vasche di contatto per la disinfezione con il rispetto dei valori CT richiesti.
+  BC-3870.50.30:
+    name: Ispezione dei serbatoi di servizio
+    description: |
+      Ispezione interna e pulizia degli asset di stoccaggio dell'acqua trattata.
+  BC-3870.60:
+    name: Gestione dei residui di trattamento
+    description: |
+      Operazione dei flussi di scarto derivanti dal trattamento — fanghi dei chiarificatori,
+      acque di lavaggio dei filtri e materiali esauriti — e loro percorsi di smaltimento.
+  BC-3870.60.10:
+    name: Operazioni dei fanghi dei chiarificatori
+    description: |
+      Operazione dell'ispessimento e della disidratazione dei fanghi negli impianti di potabilizzazione.
+  BC-3870.60.20:
+    name: Recupero delle acque di lavaggio dei filtri
+    description: |
+      Recupero e riciclo o smaltimento delle acque di controlavaggio dei filtri.
+  BC-3870.60.30:
+    name: Smaltimento dei materiali filtranti esauriti
+    description: |
+      Sostituzione e smaltimento dei materiali filtranti esauriti e delle resine a scambio ionico.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-wealth-management-operations-management.yaml
+++ b/catalogue/i18n/it/L1-wealth-management-operations-management.yaml
@@ -1,0 +1,99 @@
+# Gestione delle operazioni di gestione patrimoniale (it) — translations for L1-wealth-management-operations-management.yaml
+locale: it
+source: L1-wealth-management-operations-management.yaml
+entries:
+  BC-1390:
+    name: Gestione delle operazioni di gestione patrimoniale
+    description: |
+      Consulenza agli investimenti, gestione discrezionale di portafoglio, reporting per il cliente e adeguatezza.
+  BC-1390.10:
+    name: Gestione della consulenza agli investimenti
+    description: |
+      Mandati su consulenza e generazione delle raccomandazioni.
+  BC-1390.10.10:
+    name: Onboarding della clientela su mandato di consulenza
+    description: |
+      Onboarding della clientela per mandati di gestione su consulenza e accordi contrattuali.
+  BC-1390.10.20:
+    name: Generazione delle raccomandazioni di investimento
+    description: |
+      Generazione di raccomandazioni di investimento personalizzate.
+  BC-1390.10.30:
+    name: Gestione delle proposte di investimento
+    description: |
+      Produzione e approvazione delle proposte di investimento.
+  BC-1390.20:
+    name: Gestione discrezionale di portafoglio
+    description: |
+      Mandati di gestione discrezionale e costruzione del portafoglio.
+  BC-1390.20.10:
+    name: Configurazione del mandato discrezionale
+    description: |
+      Configurazione dei mandati di gestione discrezionale e documentazione IPS.
+  BC-1390.20.20:
+    name: Costruzione del portafoglio
+    description: |
+      Costruzione del portafoglio e asset allocation.
+  BC-1390.20.30:
+    name: Ribilanciamento del portafoglio
+    description: |
+      Ribilanciamento dei portafogli in gestione discrezionale rispetto al modello.
+  BC-1390.20.40:
+    name: Esecuzione delle operazioni per mandati
+    description: |
+      Esecuzione delle operazioni per conto dei mandati di gestione discrezionale.
+  BC-1390.30:
+    name: Gestione del reporting per il cliente
+    description: |
+      Rendiconti e report di performance per il cliente.
+  BC-1390.30.10:
+    name: Rendiconti periodici per il cliente
+    description: |
+      Produzione di rendiconti periodici e valorizzazioni per il cliente.
+  BC-1390.30.20:
+    name: Report di performance e di attività
+    description: |
+      Report di performance, di attività e fiscali per il cliente.
+  BC-1390.30.30:
+    name: Informativa regolamentare alla clientela
+    description: |
+      Informativa MiFID II su costi e oneri e altri obblighi di trasparenza regolamentare.
+  BC-1390.40:
+    name: Gestione della misurazione della performance
+    description: |
+      Attribuzione della performance e confronto con i benchmark.
+  BC-1390.40.10:
+    name: Calcolo della performance del portafoglio
+    description: |
+      Calcolo del rendimento TWR, MWR e di altri indicatori di performance.
+  BC-1390.40.20:
+    name: Analisi dell'attribuzione della performance
+    description: |
+      Analisi dell'attribuzione della performance con metodi Brinson e fattoriali.
+  BC-1390.40.30:
+    name: Confronto con benchmark e peer group
+    description: |
+      Confronto della performance di portafoglio con benchmark e peer group.
+  BC-1390.50:
+    name: Gestione dell'adeguatezza e dell'appropriatezza
+    description: |
+      Adeguatezza MiFID/equivalente e verifiche di appropriatezza.
+  BC-1390.50.10:
+    name: Profilazione del rischio del cliente
+    description: |
+      Profilazione della tolleranza al rischio e della capacità di rischio del cliente.
+  BC-1390.50.20:
+    name: Valutazione dell'adeguatezza
+    description: |
+      Valutazione dell'adeguatezza della consulenza e dei portafogli in gestione discrezionale.
+  BC-1390.50.30:
+    name: Valutazione dell'appropriatezza
+    description: |
+      Verifiche di appropriatezza per le transazioni in execution-only.
+  BC-1390.50.40:
+    name: Acquisizione delle preferenze di sostenibilità
+    description: |
+      Acquisizione e integrazione delle preferenze di sostenibilità del cliente.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-weapon-systems-management.yaml
+++ b/catalogue/i18n/it/L1-weapon-systems-management.yaml
@@ -1,0 +1,115 @@
+# Gestione dei sistemi d'arma (it) — translations for L1-weapon-systems-management.yaml
+locale: it
+source: L1-weapon-systems-management.yaml
+entries:
+  BC-1710:
+    name: Gestione dei sistemi d'arma
+    description: |
+      Gestione del ciclo di vita dei sistemi d'arma e delle piattaforme.
+  BC-1710.10:
+    name: Gestione dell'ingegneria dei sistemi d'arma
+    description: |
+      Ingegneria dei sistemi d'arma, requisiti e architettura del sistema.
+  BC-1710.10.10:
+    name: Ingegneria dei requisiti del sistema d'arma
+    description: |
+      Ingegneria dei requisiti per i sistemi d'arma.
+  BC-1710.10.20:
+    name: Progettazione dell'architettura del sistema d'arma
+    description: |
+      Progettazione dell'architettura e analisi dei trade-off.
+  BC-1710.10.30:
+    name: Modellazione e simulazione del sistema d'arma
+    description: |
+      Modellazione e simulazione delle prestazioni del sistema d'arma.
+  BC-1710.20:
+    name: Gestione della configurazione dei sistemi d'arma
+    description: |
+      Baseline di configurazione e controllo della configurazione.
+  BC-1710.20.10:
+    name: Gestione della baseline di configurazione
+    description: |
+      Definizione e mantenimento delle baseline di configurazione del sistema.
+  BC-1710.20.20:
+    name: Controllo delle modifiche alla configurazione
+    description: |
+      Controllo delle modifiche alla configurazione attraverso i CCB (Configuration Control Board).
+  BC-1710.20.30:
+    name: Contabilità dello stato della configurazione
+    description: |
+      Contabilità e audit dello stato della configurazione.
+  BC-1710.30:
+    name: Gestione dell'integrazione dei sistemi d'arma
+    description: |
+      Integrazione dei sottosistemi e sviluppo del sistema integrato.
+  BC-1710.30.10:
+    name: Integrazione dei sottosistemi
+    description: |
+      Integrazione dei sottosistemi nella piattaforma d'arma.
+  BC-1710.30.20:
+    name: Integrazione del sistema di missione
+    description: |
+      Integrazione dei sistemi di missione e dei sensori.
+  BC-1710.30.30:
+    name: Integrazione del sistema di sistemi
+    description: |
+      Integrazione con il più ampio sistema di sistemi e C5ISR.
+  BC-1710.40:
+    name: Gestione delle prove e qualificazione dei sistemi d'arma
+    description: |
+      Programmi di collaudo, qualificazione e certificazione.
+  BC-1710.40.10:
+    name: Pianificazione del programma di collaudo
+    description: |
+      Pianificazione del programma di collaudo e valutazione.
+  BC-1710.40.20:
+    name: Esecuzione del collaudo di sviluppo
+    description: |
+      Esecuzione dei collaudi di sviluppo sui prototipi.
+  BC-1710.40.30:
+    name: Esecuzione del collaudo operativo
+    description: |
+      Esecuzione del collaudo e valutazione operativa (OT&E).
+  BC-1710.40.40:
+    name: Certificazione di tipo
+    description: |
+      Certificazione di navigabilità militare e di tipo.
+  BC-1710.50:
+    name: Gestione del sostentamento dei sistemi d'arma
+    description: |
+      Sostentamento in servizio, manutenzione di deposito e gestione dell'obsolescenza.
+  BC-1710.50.10:
+    name: Supporto tecnico in servizio
+    description: |
+      Supporto tecnico in servizio ai sistemi dispiegati.
+  BC-1710.50.20:
+    name: Manutenzione di deposito
+    description: |
+      Manutenzione, revisione e ripristino a livello di deposito.
+  BC-1710.50.30:
+    name: Gestione dell'obsolescenza e DMSMS
+    description: |
+      Gestione DMSMS e dell'obsolescenza per i sistemi in servizio.
+  BC-1710.50.40:
+    name: Operazioni di logistica basata sulla performance
+    description: |
+      Gestione dei contratti di logistica basata sulla performance.
+  BC-1710.60:
+    name: Gestione delle modifiche e aggiornamenti dei sistemi d'arma
+    description: |
+      Aggiornamenti delle capacità, interventi a metà vita e retrofit.
+  BC-1710.60.10:
+    name: Pianificazione degli aggiornamenti delle capacità
+    description: |
+      Pianificazione degli aggiornamenti e dell'inserimento di nuove capacità.
+  BC-1710.60.20:
+    name: Gestione del programma di aggiornamento a metà vita
+    description: |
+      Gestione dei programmi di aggiornamento a metà vita del sistema.
+  BC-1710.60.30:
+    name: Esecuzione di retrofit e modifiche
+    description: |
+      Esecuzione di retrofit e modifiche sul campo.
+metadata:
+  status: draft
+  reviewer: pending

--- a/catalogue/i18n/it/L1-wholesale-interconnect-roaming-management.yaml
+++ b/catalogue/i18n/it/L1-wholesale-interconnect-roaming-management.yaml
@@ -1,0 +1,111 @@
+# Gestione di wholesale, interconnessione e roaming (it) — translations for L1-wholesale-interconnect-roaming-management.yaml
+locale: it
+source: L1-wholesale-interconnect-roaming-management.yaml
+entries:
+  BC-2680:
+    name: Gestione di wholesale, interconnessione e roaming
+    description: |
+      Servizi wholesale di telecomunicazioni ad altri operatori e partner — prodotti e pricing wholesale, partnership MVNO e MVNE, interconnessione e peering, relazioni con i partner di roaming, liquidazione wholesale tra operatori e accordi di capacità quali IRU e fibra spenta.
+  BC-2680.10:
+    name: Gestione del prodotto e del pricing wholesale
+    description: |
+      Definizione, pricing e negoziazione commerciale delle offerte wholesale verso operatori, MVNO e grandi partner.
+  BC-2680.10.10:
+    name: Progettazione delle tariffe wholesale
+    description: |
+      Progettazione delle tariffe wholesale per prodotti voce, dati, messaggistica e capacità.
+  BC-2680.10.20:
+    name: Pubblicazione dell'offerta wholesale
+    description: |
+      Pubblicazione delle offerte wholesale sui canali rivolti ai partner e sulle offerte di riferimento richieste dai regolatori.
+  BC-2680.10.30:
+    name: Negoziazione commerciale wholesale
+    description: |
+      Negoziazione commerciale bilaterale di accordi wholesale e condizioni personalizzate.
+  BC-2680.20:
+    name: Gestione delle partnership MVNO e MVNE
+    description: |
+      Onboarding e gestione continuativa dei partner MVNO e MVNE, inclusa l'integrazione BSS e la governance commerciale.
+  BC-2680.20.10:
+    name: Onboarding dei MVNO
+    description: |
+      Onboarding di nuovi partner MVNO e MVNE rispetto ai criteri di idoneità commerciale, regolamentare e tecnica.
+  BC-2680.20.20:
+    name: Integrazione BSS dei MVNO
+    description: |
+      Integrazione dei partner MVNO con il BSS del MNO ospitante per provisioning, rating e reporting.
+  BC-2680.20.30:
+    name: Gestione commerciale dei MVNO
+    description: |
+      Governance commerciale continuativa, revisioni delle prestazioni e gestione dell'uscita dei partner MVNO.
+  BC-2680.30:
+    name: Gestione degli accordi di interconnessione
+    description: |
+      Gestione degli accordi di interconnessione voce e IP, inclusi peering e transito.
+  BC-2680.30.10:
+    name: Gestione degli accordi di peering
+    description: |
+      Gestione degli accordi di peering IP e delle relative condizioni commerciali e operative.
+  BC-2680.30.20:
+    name: Gestione degli accordi di transito
+    description: |
+      Gestione degli accordi di transito voce e IP con i fornitori upstream.
+  BC-2680.30.30:
+    name: Misurazione dello scambio di traffico
+    description: |
+      Misurazione dei volumi di traffico scambiati con i partner di peering e di transito per la liquidazione wholesale e l'ingegneria.
+  BC-2680.40:
+    name: Gestione dei partner di roaming
+    description: |
+      Definizione e gestione delle relazioni di roaming con le reti partner internazionali.
+  BC-2680.40.10:
+    name: Gestione degli accordi di roaming
+    description: |
+      Negoziazione e gestione del ciclo di vita degli accordi di roaming bilaterali.
+  BC-2680.40.20:
+    name: Scambio di file TAP
+    description: |
+      Scambio di file TAP (Transferred Account Procedure) con i partner di roaming per la liquidazione dell'utilizzo.
+  BC-2680.40.30:
+    name: Onboarding dei partner di roaming
+    description: |
+      Onboarding tecnico e commerciale di nuovi partner di roaming, inclusi i test IREG e TADIG.
+  BC-2680.50:
+    name: Gestione della liquidazione wholesale tra operatori
+    description: |
+      Liquidazione dell'utilizzo inter-operatore e dei contenziosi per roaming e interconnessione.
+  BC-2680.50.10:
+    name: Liquidazione TAP e NRTRDE
+    description: |
+      Liquidazione dell'utilizzo di roaming sulla base di record TAP e NRTRDE in tempo quasi reale.
+  BC-2680.50.20:
+    name: Fatturazione di interconnessione
+    description: |
+      Fatturazione dei partner di interconnessione per il traffico in terminazione, originazione e transito.
+  BC-2680.50.30:
+    name: Risoluzione dei contenziosi di liquidazione
+    description: |
+      Risoluzione dei contenziosi sollevati sui rendiconti di liquidazione inter-operatore.
+  BC-2680.50.40:
+    name: Riconciliazione della liquidazione
+    description: |
+      Riconciliazione dei record di liquidazione inter-operatore con la contabilità interna e il tesoro.
+  BC-2680.60:
+    name: Gestione della capacità wholesale e degli IRU
+    description: |
+      Accordi wholesale di capacità a lungo termine, inclusi i diritti d'uso indefettibili e le locazioni di fibra spenta.
+  BC-2680.60.10:
+    name: Gestione dei diritti d'uso indefettibili
+    description: |
+      Vendita e acquisto di diritti d'uso indefettibili (IRU) su capacità a lungo raggio e sottomarina.
+  BC-2680.60.20:
+    name: Gestione della fibra spenta
+    description: |
+      Locazione e gestione di coppie di fibra spenta verso e da i partner.
+  BC-2680.60.30:
+    name: Gestione delle locazioni di capacità
+    description: |
+      Gestione delle locazioni di capacità ricorrenti su percorsi metro, a lungo raggio e sottomarini.
+metadata:
+  status: draft
+  reviewer: pending


### PR DESCRIPTION
## Summary
This pull request adds comprehensive Italian language translations for the Level 1 (L1) business capability catalogue. The translations cover 200+ capability management domains across various industries and business functions.

## Changes Made
- Added 200+ new Italian translation files in `catalogue/i18n/it/` directory
- Each translation file corresponds to an English source capability model file
- Translations include:
  - Localized capability names and descriptions
  - Italian metadata (locale: it, source references)
  - Complete entry mappings for business capability codes (e.g., BC-4300, BC-300, etc.)

## Coverage
The Italian translations span diverse business domains including:
- HVAC and building systems engineering and operations
- Client and human capital management
- Airline and cruise operations
- Chemical process and manufacturing
- Healthcare and clinical operations
- Financial and capital markets
- Real estate and property management
- Telecommunications and utilities
- Education and academic programs
- Retail and e-commerce
- And 150+ additional capability management areas

## Implementation Details
- All translation files follow the same YAML structure as their English source counterparts
- Each file maintains proper locale metadata and source file references
- Translations are complete for all visible entries in the source files

https://claude.ai/code/session_01K2U2AVhhJpE7E6L5c4ptHu