### PR TITLE
Add Portuguese (pt) translations for L1 business capability files

### DIFF
--- a/catalogue/i18n/pt/L1-academic-quality-accreditation-management.yaml
+++ b/catalogue/i18n/pt/L1-academic-quality-accreditation-management.yaml
@@ -1,0 +1,151 @@
+locale: pt
+source: L1-academic-quality-accreditation-management.yaml
+entries:
+  BC-4750:
+    name: Gestão de qualidade académica e acreditação
+    description: |
+      Garantia de qualidade interna e externa de programas académicos e da
+      instituição, incluindo revisão, acreditação, gestão de referenciais de
+      normas, feedback de estudantes e melhoria contínua.
+  BC-4750.10:
+    name: Revisão e validação de programas
+    description: |
+      Validação de novos programas e revalidação periódica face a normas
+      académicas institucionais e externas.
+    in_scope:
+      - Validação de novos programas
+      - Revisão periódica de programas
+      - Revalidação de programas
+    out_of_scope:
+      - Fases de aprovação de programas (abrangidas em Gestão do Currículo e Programa)
+  BC-4750.10.10:
+    name: Validação de novos programas
+    description: |
+      Validação de novos programas face a normas académicas e de qualidade.
+  BC-4750.10.20:
+    name: Revisão periódica de programas
+    description: |
+      Revisão de qualidade periódica de programas em funcionamento e dos seus resultados.
+  BC-4750.10.30:
+    name: Revalidação de programas
+    description: |
+      Revalidação de programas no final dos ciclos de validação.
+  BC-4750.20:
+    name: Autoavaliação institucional
+    description: |
+      Autoavaliação do desempenho institucional face a normas de qualidade e
+      comparação de referência com instituições pares.
+    in_scope:
+      - Produção de relatórios de autoavaliação
+      - Comparação de referência de indicadores de qualidade
+      - Planeamento estratégico de qualidade
+    out_of_scope:
+      - Visitas de acreditação externa (abrangidas em Coordenação de Acreditação e Auditoria Externa)
+  BC-4750.20.10:
+    name: Produção de relatórios de autoavaliação
+    description: |
+      Produção de relatórios de autoavaliação institucional.
+  BC-4750.20.20:
+    name: Comparação de referência de indicadores de qualidade
+    description: |
+      Comparação de referência de indicadores de qualidade com instituições pares.
+  BC-4750.20.30:
+    name: Planeamento estratégico de qualidade
+    description: |
+      Planeamento estratégico de prioridades e investimentos em qualidade académica.
+  BC-4750.30:
+    name: Coordenação de acreditação e auditoria externa
+    description: |
+      Coordenação com organismos de acreditação externos e reguladores de qualidade,
+      incluindo visitas ao local, inspeções e resposta a resultados.
+    in_scope:
+      - Envolvimento com organismos de acreditação
+      - Coordenação de visitas ao local e inspeções
+      - Resposta a resultados de acreditação e monitorização de condições
+    out_of_scope:
+      - Reporte regulatório estatutário (abrangido em Gestão de Conformidade e Reporte Regulatório em Educação)
+  BC-4750.30.10:
+    name: Envolvimento com organismos de acreditação
+    description: |
+      Gestão do envolvimento e submissões com organismos de acreditação.
+  BC-4750.30.20:
+    name: Coordenação de visitas ao local e inspeções
+    description: |
+      Coordenação de visitas ao local e logística de inspeções de acreditação.
+  BC-4750.30.30:
+    name: Resposta a resultados de acreditação
+    description: |
+      Resposta a resultados, condições e recomendações de acreditação.
+  BC-4750.40:
+    name: Gestão do referencial de normas de qualidade
+    description: |
+      Adoção, mapeamento e manutenção de normas de qualidade académica e
+      política de qualidade institucional.
+    in_scope:
+      - Adoção e manutenção de normas (p. ex. ESG, ABET, AACSB)
+      - Autoria de políticas de qualidade
+      - Mapeamento de normas de qualidade na prática operacional
+    out_of_scope:
+      - Operações de auditoria do dia a dia (abrangidas em Gestão de Auditoria Interna transversal)
+  BC-4750.40.10:
+    name: Adoção e manutenção de normas
+    description: |
+      Adoção e manutenção de normas de qualidade externas na instituição.
+  BC-4750.40.20:
+    name: Autoria de políticas de qualidade
+    description: |
+      Autoria e manutenção da política de qualidade institucional.
+  BC-4750.40.30:
+    name: Mapeamento de normas de qualidade
+    description: |
+      Mapeamento de normas de qualidade em processos e controlos operacionais.
+  BC-4750.50:
+    name: Feedback de estudantes e avaliação de módulos
+    description: |
+      Recolha, análise e ação sobre o feedback de estudantes ao nível do módulo,
+      programa e institucional.
+    in_scope:
+      - Operações de inquéritos de avaliação de módulos
+      - Inquéritos nacionais e inter-institucionais (p. ex. NSS, NSSE)
+      - Análise de feedback e ação consequente
+    out_of_scope:
+      - Análise de satisfação tipo cliente fora do contexto académico (abrangida em Gestão de Serviço ao Cliente transversal)
+  BC-4750.50.10:
+    name: Operações de inquéritos de avaliação de módulos
+    description: |
+      Operação de inquéritos de avaliação ao nível do módulo.
+  BC-4750.50.20:
+    name: Participação em inquéritos nacionais e inter-institucionais
+    description: |
+      Participação em inquéritos de estudantes nacionais e inter-institucionais.
+  BC-4750.50.30:
+    name: Análise de feedback e ação consequente
+    description: |
+      Análise do feedback e ação consequente visível com os estudantes.
+  BC-4750.60:
+    name: Melhoria contínua e monitorização de ações
+    description: |
+      Identificação, planeamento e monitorização de ações de melhoria da qualidade
+      resultantes de revisão, acreditação e feedback.
+    in_scope:
+      - Planeamento de ações de melhoria
+      - Monitorização da implementação de ações
+      - Repositório de lições aprendidas
+    out_of_scope:
+      - Métodos genéricos de melhoria de processos (abrangidos em Gestão de Qualidade transversal)
+  BC-4750.60.10:
+    name: Planeamento de ações de melhoria
+    description: |
+      Planeamento de ações de melhoria da qualidade académica.
+  BC-4750.60.20:
+    name: Monitorização da implementação de ações
+    description: |
+      Monitorização do estado de implementação e eficácia das ações de qualidade.
+  BC-4750.60.30:
+    name: Repositório de lições aprendidas
+    description: |
+      Curadoria de lições aprendidas em revisões de qualidade e ciclos de acreditação.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-actuarial-management.yaml
+++ b/catalogue/i18n/pt/L1-actuarial-management.yaml
@@ -1,0 +1,128 @@
+locale: pt
+source: L1-actuarial-management.yaml
+entries:
+  BC-2180:
+    name: Gestão atuarial
+    description: |
+      Modelos de tarifação, provisionamento, estudos de experiência, modelação de capital e solvência,
+      suporte ao relato atuarial IFRS 17 e modelação de catástrofes.
+  BC-2180.10:
+    name: Gestão atuarial de tarifação
+    description: |
+      Modelação de custo de sinistros, análise de adequação de tarifação, indicação de taxa e suporte à documentação de taxas registadas.
+  BC-2180.10.10:
+    name: Modelação de custo de sinistros
+    description: |
+      Modelação de custos de sinistros por segmento, peril e cobertura.
+  BC-2180.10.20:
+    name: Análise de adequação de tarifação
+    description: |
+      Análise da adequação de tarifação face às perdas esperadas e encargos de custos.
+  BC-2180.10.30:
+    name: Produção de indicação de taxa
+    description: |
+      Produção de indicações de taxa para comités de produto e tarifação.
+  BC-2180.10.40:
+    name: Suporte à documentação de taxas registadas
+    description: |
+      Produção de memorandos atuariais e anexos de suporte a registos de taxas.
+  BC-2180.20:
+    name: Gestão atuarial de provisionamento
+    description: |
+      Triangulação de sinistros, estimação de IBNR, provisionamento de ULAE e ALAE e documentação de aprovação de provisionamento.
+  BC-2180.20.10:
+    name: Triangulação e desenvolvimento de sinistros
+    description: |
+      Construção de triângulos de sinistros e seleção de fatores de desenvolvimento.
+  BC-2180.20.20:
+    name: Estimação de IBNR
+    description: |
+      Estimação de provisões de sinistros ocorridos mas não reportados em portefólios.
+  BC-2180.20.30:
+    name: Provisionamento de ULAE e ALAE
+    description: |
+      Provisionamento de despesas de regulação de sinistros não alocadas e alocadas.
+  BC-2180.20.40:
+    name: Documentação de aprovação de provisionamento
+    description: |
+      Produção de documentação do comité de provisionamento e declarações de opinião.
+  BC-2180.30:
+    name: Modelação de capital e solvência
+    description: |
+      Desenvolvimento de modelo de capital interno, cálculo de fórmula padrão, alocação de capital e suporte ao ORSA.
+  BC-2180.30.10:
+    name: Desenvolvimento de modelo de capital interno
+    description: |
+      Desenvolvimento e manutenção de modelos de capital interno para solvência e rating.
+  BC-2180.30.20:
+    name: Cálculo de fórmula padrão
+    description: |
+      Cálculo da fórmula padrão Solvência II e métricas de capital regulatório equivalentes.
+  BC-2180.30.30:
+    name: Alocação de capital
+    description: |
+      Alocação de capital requerido por linhas de negócio e segmentos.
+  BC-2180.30.40:
+    name: Suporte à modelação ORSA
+    description: |
+      Suporte de modelação para exercícios de Avaliação Própria do Risco e da Solvência.
+  BC-2180.40:
+    name: Estudos de experiência e gestão de pressupostos
+    description: |
+      Estudos de mortalidade, longevidade, caducidade, persistência e morbilidade, e governação de pressupostos.
+  BC-2180.40.10:
+    name: Estudos de mortalidade e longevidade
+    description: |
+      Estudos de experiência de mortalidade e longevidade em portefólios de vida e pensões.
+  BC-2180.40.20:
+    name: Estudos de caducidade e persistência
+    description: |
+      Estudos de experiência de caducidade e persistência em coortes de produto.
+  BC-2180.40.30:
+    name: Estudos de morbilidade e frequência de sinistros
+    description: |
+      Estudos de experiência de morbilidade e frequência de sinistros para ramos de saúde e proteção.
+  BC-2180.40.40:
+    name: Governação e aprovação de pressupostos
+    description: |
+      Governação e aprovação de pressupostos atuariais utilizados em tarifação, provisionamento e relato.
+  BC-2180.50:
+    name: Suporte ao relato atuarial IFRS 17
+    description: |
+      Margem de serviço contratual, ajustamento ao risco, construção de coortes e produção de divulgações IFRS 17.
+  BC-2180.50.10:
+    name: Cálculo de CSM e ajustamento ao risco
+    description: |
+      Cálculo da margem de serviço contratual e ajustamento ao risco para IFRS 17.
+  BC-2180.50.20:
+    name: Construção de coortes e grupos
+    description: |
+      Construção de grupos de contratos de seguro e coortes anuais.
+  BC-2180.50.30:
+    name: Produção de divulgações IFRS 17
+    description: |
+      Produção de inputs atuariais para divulgações e reconciliações IFRS 17.
+  BC-2180.60:
+    name: Modelação de catástrofes
+    description: |
+      Gestão de fornecedores de modelos CAT, preparação de dados de exposição, cálculo de PML e AAL e validação de modelos.
+  BC-2180.60.10:
+    name: Gestão de fornecedores de modelos CAT
+    description: |
+      Seleção e gestão de fornecedores de modelos CAT e portefólios de licenças.
+  BC-2180.60.20:
+    name: Preparação de dados de exposição
+    description: |
+      Preparação e condicionamento de dados de exposição para execuções de modelos CAT.
+  BC-2180.60.30:
+    name: Cálculo de PML e AAL
+    description: |
+      Cálculo de métricas de perda máxima provável e perda anual média.
+  BC-2180.60.40:
+    name: Validação e ajustamento de modelos CAT
+    description: |
+      Validação e ajustamento de visão de risco dos outputs de modelos CAT.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-advertising-sales-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-advertising-sales-operations-management.yaml
@@ -1,0 +1,132 @@
+locale: pt
+source: L1-advertising-sales-operations-management.yaml
+entries:
+  BC-3760:
+    name: Gestão de operações e comercialização publicitária
+    description: |
+      Inventário, vendas diretas e programáticas, tráfego e decisão de
+      anúncios, controlos de segurança de marca e qualidade de inventário,
+      e relatórios de receita para o negócio de publicidade em superfícies
+      lineares, digitais e de televisão ligada.
+  BC-3760.10:
+    name: Gestão de inventário publicitário
+    description: |
+      Previsão, alocação e reserva de inventário publicitário em superfícies
+      lineares e digitais.
+  BC-3760.10.10:
+    name: Previsão de disponibilidade
+    description: |
+      Previsão de impressões disponíveis, GRPs e disponibilidades segmentadas
+      por audiência ao longo do horizonte de inventário.
+  BC-3760.10.20:
+    name: Alocação de inventário
+    description: |
+      Alocação de inventário a reservas diretas, programáticas e internas
+      em superfícies.
+  BC-3760.10.30:
+    name: Reserva e retenção de inventário
+    description: |
+      Reserva e retenção de inventário para negócios comprometidos,
+      patrocínios e eventos de destaque.
+  BC-3760.20:
+    name: Gestão de vendas diretas de publicidade
+    description: |
+      Venda direta de inventário publicitário através de patrocínios,
+      upfront e canais de ordem de inserção.
+  BC-3760.20.10:
+    name: Vendas de patrocínio
+    description: |
+      Pipeline e contratação de patrocínios e negócios de integração.
+  BC-3760.20.20:
+    name: Vendas upfront e scatter
+    description: |
+      Vendas no mercado upfront e scatter de inventário linear e digital.
+  BC-3760.20.30:
+    name: Vendas de ordem de inserção e spot linear
+    description: |
+      Captura de ordens de inserção e reserva de spots lineares contra
+      o plano de disponibilidades.
+  BC-3760.30:
+    name: Gestão de vendas programáticas
+    description: |
+      Configuração e operação de leilões programáticos, marketplaces
+      privados e integrações de cadeia de fornecimento.
+  BC-3760.30.10:
+    name: Configuração de leilão
+    description: |
+      Configuração de pisos de leilão, IDs de negócio e elegibilidade de
+      licitadores no inventário.
+  BC-3760.30.20:
+    name: Gestão de negócios em marketplace privado
+    description: |
+      Criação e ciclo de vida de negócios programáticos garantidos e de
+      marketplace privado com compradores.
+  BC-3760.30.30:
+    name: Integração de header bidding e SSP
+    description: |
+      Integração de parceiros de header bidding e plataformas do lado da
+      oferta em superfícies.
+  BC-3760.40:
+    name: Tráfego e operações de anúncios
+    description: |
+      Integração de criativos, decisão e inserção de anúncios, e
+      calendarização de spots em estruturas de intervalo lineares e digitais.
+  BC-3760.40.10:
+    name: Integração e controlo de qualidade de criativos
+    description: |
+      Integração e controlo de qualidade de criativos publicitários contra
+      especificações técnicas e de política.
+  BC-3760.40.20:
+    name: Decisão e inserção de anúncios
+    description: |
+      Decisão sobre qual anúncio servir e inserção em intervalos lineares,
+      lado do servidor ou lado do cliente.
+  BC-3760.40.30:
+    name: Calendarização de spots
+    description: |
+      Construção de grelha para posicionamento de spots lineares e
+      otimização de padrão de intervalo.
+  BC-3760.50:
+    name: Gestão de segurança de marca e qualidade de inventário
+    description: |
+      Classificação de inventário para segurança de marca, deteção de
+      tráfego inválido e marcação de adequação para segmentação de compradores.
+  BC-3760.50.10:
+    name: Classificação de segurança de marca
+    description: |
+      Classificação de superfícies de conteúdo contra frameworks de segurança
+      e adequação de marca.
+  BC-3760.50.20:
+    name: Deteção de tráfego inválido
+    description: |
+      Deteção e exclusão de tráfego inválido no inventário próprio e de
+      parceiros.
+  BC-3760.50.30:
+    name: Marcação de adequação
+    description: |
+      Marcação de superfícies de conteúdo com atributos de adequação e
+      contextuais para segmentação de compradores.
+  BC-3760.60:
+    name: Relatórios de receita publicitária
+    description: |
+      Relatórios de entrega de campanha, reconciliação de compensação e
+      faturação e liquidação de anunciantes em vendas lineares e digitais.
+  BC-3760.60.10:
+    name: Relatórios de entrega de campanha
+    description: |
+      Relatórios de entrega e ritmo contra objetivos de campanha em
+      superfícies e moedas.
+  BC-3760.60.20:
+    name: Compensação e reconciliação
+    description: |
+      Reconciliação de impressões entregues com as encomendadas, com
+      tratamento de compensação e notas de crédito.
+  BC-3760.60.30:
+    name: Faturação e liquidação de anunciantes
+    description: |
+      Faturação de anunciantes e agências e liquidação contra descontos
+      e comissões de agências.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-aeronautical-information-management.yaml
+++ b/catalogue/i18n/pt/L1-aeronautical-information-management.yaml
@@ -1,0 +1,99 @@
+locale: pt
+source: L1-aeronautical-information-management.yaml
+entries:
+  BC-1230:
+    name: Gestão da informação aeronáutica
+    description: |
+      AIP, NOTAMs, bases de dados aeronáuticas, cartografia e AIM digital.
+  BC-1230.10:
+    name: Gestão da publicação de informação aeronáutica
+    description: |
+      AIP, ciclo AIRAC, alterações e suplementos.
+  BC-1230.10.10:
+    name: Produção da AIP
+    description: |
+      Produção da Publicação de Informação Aeronáutica.
+  BC-1230.10.20:
+    name: Gestão do ciclo AIRAC
+    description: |
+      Gestão do ciclo AIRAC e datas de entrada em vigor.
+  BC-1230.10.30:
+    name: Emissão de alterações e suplementos à AIP
+    description: |
+      Emissão de alterações e suplementos à AIP.
+  BC-1230.20:
+    name: Gestão de NOTAMs
+    description: |
+      Origem, publicação, disseminação e expiração de NOTAMs.
+  BC-1230.20.10:
+    name: Origem de NOTAMs
+    description: |
+      Origem e redação de NOTAMs.
+  BC-1230.20.20:
+    name: Publicação e disseminação de NOTAMs
+    description: |
+      Publicação e disseminação via AFTN/AMHS.
+  BC-1230.20.30:
+    name: Gestão do ciclo de vida de NOTAMs
+    description: |
+      Gestão do ciclo de vida incluindo substituição e cancelamento.
+  BC-1230.30:
+    name: Gestão de bases de dados aeronáuticas
+    description: |
+      Integridade de dados aeronáuticos, rastreabilidade, conformidade AIRAC e qualidade dos dados.
+  BC-1230.30.10:
+    name: Origem de dados aeronáuticos
+    description: |
+      Origem e captura de dados aeronáuticos segundo o Anexo 15 da OACI.
+  BC-1230.30.20:
+    name: Gestão da qualidade de dados aeronáuticos
+    description: |
+      Controlos de qualidade dos dados, exatidão, integridade e resolução.
+  BC-1230.30.30:
+    name: Distribuição de dados aeronáuticos
+    description: |
+      Distribuição de dados aeronáuticos a utilizadores e ferramentas.
+  BC-1230.30.40:
+    name: Rastreabilidade e auditoria de dados
+    description: |
+      Rastreabilidade da linhagem de dados aeronáuticos e auditoria.
+  BC-1230.40:
+    name: Gestão de cartografia e design de procedimentos
+    description: |
+      Cartas aeronáuticas, procedimentos de voo por instrumentos e design de procedimentos PBN.
+  BC-1230.40.10:
+    name: Produção de cartas aeronáuticas
+    description: |
+      Produção de cartas de rota, terminais e de aeródromo.
+  BC-1230.40.20:
+    name: Design de procedimentos de voo por instrumentos
+    description: |
+      Design de SIDs, STARs e procedimentos de aproximação por instrumentos.
+  BC-1230.40.30:
+    name: Design de procedimentos de navegação baseada em desempenho
+    description: |
+      Design de procedimentos PBN incluindo RNP e RNAV.
+  BC-1230.40.40:
+    name: Validação e aprovação de procedimentos
+    description: |
+      Validação de procedimentos, verificação de voo e aprovação regulatória.
+  BC-1230.50:
+    name: Gestão de serviços AIM digitais
+    description: |
+      Produtos de dados digitais, serviços SWIM e AIM legível por máquina.
+  BC-1230.50.10:
+    name: Gestão de produtos de dados digitais
+    description: |
+      Gestão de produtos de dados AIM digitais (baseados em AIXM).
+  BC-1230.50.20:
+    name: Prestação de serviços SWIM
+    description: |
+      Prestação de serviços de Gestão de Informação à Escala do Sistema (SWIM).
+  BC-1230.50.30:
+    name: Distribuição de AIM legível por máquina
+    description: |
+      Distribuição de AIM legível por máquina a subscritores.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-aeronautical-meteorology-management.yaml
+++ b/catalogue/i18n/pt/L1-aeronautical-meteorology-management.yaml
@@ -1,0 +1,75 @@
+locale: pt
+source: L1-aeronautical-meteorology-management.yaml
+entries:
+  BC-1250:
+    name: Gestão da meteorologia aeronáutica
+    description: |
+      Observação MET, previsão, briefing e serviços de tempo severo.
+  BC-1250.10:
+    name: Gestão das observações MET
+    description: |
+      METAR, observações automatizadas, redes de sensores e observações de superfície.
+  BC-1250.10.10:
+    name: Observação meteorológica de superfície
+    description: |
+      Observação meteorológica de superfície manual e automatizada em aeródromos.
+  BC-1250.10.20:
+    name: Produção de METAR e SPECI
+    description: |
+      Produção e disseminação de relatórios METAR e SPECI.
+  BC-1250.10.30:
+    name: Gestão da rede de sensores MET
+    description: |
+      Operação de sistemas automatizados de observação meteorológica e sensores.
+  BC-1250.20:
+    name: Gestão das previsões MET
+    description: |
+      TAFs, previsões de área, SIGMET, AIRMET e GAMET.
+  BC-1250.20.10:
+    name: Produção de previsões de aeródromo
+    description: |
+      Produção de TAFs e previsões de tendência para aeródromos.
+  BC-1250.20.20:
+    name: Produção de previsões de área
+    description: |
+      Produção de previsões de área, GAMET e de tempo significativo.
+  BC-1250.20.30:
+    name: Emissão de SIGMET e AIRMET
+    description: |
+      Emissão de avisos SIGMET e AIRMET.
+  BC-1250.30:
+    name: Gestão de briefing e assessoria MET
+    description: |
+      Briefings pré-voo, serviços de assessoria a unidades ATS e assessoria em voo.
+  BC-1250.30.10:
+    name: Serviço de briefing pré-voo
+    description: |
+      Prestação de serviços de auto-briefing e briefing assistido.
+  BC-1250.30.20:
+    name: Assessoria MET a unidades ATS
+    description: |
+      Prestação de assessorias MET a unidades ATS e supervisores.
+  BC-1250.30.30:
+    name: Assessoria MET em voo
+    description: |
+      Serviços de assessoria MET em voo a utilizadores do espaço aéreo.
+  BC-1250.40:
+    name: Gestão de tempo meteorológico perigoso
+    description: |
+      Avisos de cinzas vulcânicas, tempo severo e tempo espacial.
+  BC-1250.40.10:
+    name: Serviço de aviso de cinzas vulcânicas
+    description: |
+      Coordenação com VAACs e disseminação de avisos de cinzas vulcânicas.
+  BC-1250.40.20:
+    name: Serviço de aviso de tempo severo
+    description: |
+      Emissão de avisos de tempo severo (CB, turbulência, gelo).
+  BC-1250.40.30:
+    name: Serviço de aviso de tempo espacial
+    description: |
+      Avisos de tempo espacial alinhados com os requisitos da OACI.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-agri-environmental-stewardship-management.yaml
+++ b/catalogue/i18n/pt/L1-agri-environmental-stewardship-management.yaml
@@ -1,0 +1,149 @@
+locale: pt
+source: L1-agri-environmental-stewardship-management.yaml
+entries:
+  BC-3600:
+    name: Gestão da responsabilidade ambiental agrícola
+    description: |
+      Gestão responsável do ambiente na exploração — saúde do solo, gestão da
+      água, biodiversidade, gestão de gases com efeito de estufa na agricultura,
+      programas de carbono no solo, práticas regenerativas e participação em
+      esquemas agro-ambientais que complementam a sustentabilidade empresarial.
+  BC-3600.10:
+    name: Gestão responsável da saúde do solo
+    description: |
+      Gestão responsável da matéria orgânica do solo, culturas de cobertura e
+      controlo da erosão nas terras de cultivo.
+  BC-3600.10.10:
+    name: Monitorização do carbono orgânico do solo
+    description: |
+      Monitorização periódica do carbono orgânico do solo nas diferentes parcelas.
+  BC-3600.10.20:
+    name: Programas de culturas de cobertura
+    description: |
+      Programas de culturas de cobertura para manter a cobertura e biologia do
+      solo.
+  BC-3600.10.30:
+    name: Programas de controlo da erosão do solo
+    description: |
+      Programas de controlo da erosão, incluindo práticas de contorno, terraços
+      e tampões.
+  BC-3600.20:
+    name: Gestão da água na exploração
+    description: |
+      Eficiência do uso da água, proteção de zonas ripárias e gestão da qualidade
+      da água de drenagem ao nível da exploração.
+    in_scope:
+      - Monitorização da eficiência do uso da água
+      - Proteção de zonas ripárias e linhas de água
+      - Gestão da qualidade da drenagem
+    out_of_scope:
+      - Divulgação corporativa de água (BC-740)
+      - Calendarização da irrigação (BC-3500.60.10)
+  BC-3600.20.10:
+    name: Monitorização da eficiência do uso da água
+    description: |
+      Monitorização da eficiência do uso da água por cultura e parcela.
+  BC-3600.20.20:
+    name: Proteção de zonas ripárias e linhas de água
+    description: |
+      Proteção de zonas ripárias e linhas de água na exploração.
+  BC-3600.20.30:
+    name: Gestão da qualidade da drenagem
+    description: |
+      Gestão da qualidade da água de drenagem e perdas de nutrientes.
+  BC-3600.30:
+    name: Gestão da biodiversidade e habitats
+    description: |
+      Gestão da biodiversidade na exploração, incluindo registo de habitats,
+      gestão responsável de polinizadores e tampões de bordadura de campos.
+  BC-3600.30.10:
+    name: Registo de habitats na exploração
+    description: |
+      Registo de habitats e elementos de biodiversidade na exploração.
+  BC-3600.30.20:
+    name: Gestão responsável de polinizadores
+    description: |
+      Práticas favoráveis a polinizadores, incluindo faixas floridas e limiares
+      de GIP.
+  BC-3600.30.30:
+    name: Gestão de zonas tampão
+    description: |
+      Gestão de zonas tampão de bordadura de campos e linhas de água.
+  BC-3600.40:
+    name: Gestão de gases com efeito de estufa na agricultura
+    description: |
+      Quantificação e mitigação de gases com efeito de estufa na exploração,
+      incluindo metano entérico, óxido nitroso e CO2 na exploração.
+  BC-3600.40.10:
+    name: Programas de mitigação de metano entérico
+    description: |
+      Programas de mitigação do metano entérico em animais ruminantes.
+  BC-3600.40.20:
+    name: Programas de mitigação de óxido nitroso
+    description: |
+      Mitigação do óxido nitroso através da eficiência no uso de azoto e
+      calendarização.
+  BC-3600.40.30:
+    name: Inventário de emissões da exploração
+    description: |
+      Inventário de emissões de gases com efeito de estufa ao nível da exploração
+      que alimenta as divulgações.
+  BC-3600.50:
+    name: Programas de carbono no solo e créditos de carbono
+    description: |
+      Medição de linha de base de carbono no solo, conceção de projetos de créditos
+      de carbono e registos de emissão ao abrigo de metodologias reconhecidas.
+  BC-3600.50.10:
+    name: Medição de linha de base de carbono no solo
+    description: |
+      Campanhas de medição de linha de base de carbono no solo na inscrição no
+      projeto.
+  BC-3600.50.20:
+    name: Conceção de projetos de créditos de carbono
+    description: |
+      Conceção de projetos ao abrigo das metodologias Verra, Gold Standard e
+      equivalentes.
+  BC-3600.50.30:
+    name: Registos de emissão de créditos de carbono
+    description: |
+      Registos de emissão, retirada e alocação de créditos de carbono a
+      beneficiários.
+  BC-3600.60:
+    name: Gestão de práticas regenerativas
+    description: |
+      Adoção e registo de práticas regenerativas, incluindo mobilização reduzida,
+      integração e agrofloresta.
+  BC-3600.60.10:
+    name: Programas de sementeira direta e mobilização reduzida
+    description: |
+      Adoção e acompanhamento de programas de sementeira direta e mobilização
+      reduzida.
+  BC-3600.60.20:
+    name: Operações integradas de culturas e pecuária
+    description: |
+      Integração de operações de cultivo e pecuária para ciclagem de nutrientes.
+  BC-3600.60.30:
+    name: Registos de práticas de agrofloresta
+    description: |
+      Registos de plantações de agrofloresta e sistemas silvopastoris.
+  BC-3600.70:
+    name: Participação em esquemas agro-ambientais
+    description: |
+      Participação em eco-regimes PAC, programas de conservação NRCS e esquemas
+      de pagamento agro-ambiental equivalentes.
+  BC-3600.70.10:
+    name: Participação em eco-regimes PAC
+    description: |
+      Participação em eco-regimes PAC da UE e requisitos de condicionalidade.
+  BC-3600.70.20:
+    name: Participação em programas de conservação
+    description: |
+      Participação nos programas EQIP, CSP do NRCS da USDA e equivalentes.
+  BC-3600.70.30:
+    name: Reconciliação de pagamentos agro-ambientais
+    description: |
+      Reconciliação de pagamentos agro-ambientais face a compromissos do esquema.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-agri-food-compliance-certification-management.yaml
+++ b/catalogue/i18n/pt/L1-agri-food-compliance-certification-management.yaml
@@ -1,0 +1,153 @@
+locale: pt
+source: L1-agri-food-compliance-certification-management.yaml
+entries:
+  BC-3590:
+    name: Gestão de conformidade e certificação agroalimentar
+    description: |
+      Programas de conformidade e certificação específicos do setor — certificação
+      de boas práticas agrícolas, biológico, bem-estar animal, indicações
+      geográficas, conformidade com LMR, identificação de animais e registos de
+      rastreabilidade pré-portão da exploração, distintos da gestão genérica de
+      conformidade e qualidade.
+  BC-3590.10:
+    name: Gestão de certificação de boas práticas agrícolas
+    description: |
+      Gestão de programas de certificação de boas práticas agrícolas, incluindo
+      GLOBALG.A.P., LEAF Marque e esquemas nacionais equivalentes.
+    in_scope:
+      - GLOBALG.A.P. e boas práticas agrícolas equivalentes
+      - Participação no LEAF Marque
+      - Coordenação de auditorias e ações corretivas
+    out_of_scope:
+      - Gestão genérica de qualidade (BC-720)
+      - Programas de segurança alimentar do lado do retalho (BC-2380.10)
+  BC-3590.10.10:
+    name: Programas de certificação GLOBALG.A.P.
+    description: |
+      Gestão da certificação GLOBALG.A.P. IFA, Aquacultura e Pecuária.
+  BC-3590.10.20:
+    name: LEAF Marque e programas equivalentes
+    description: |
+      Participação no LEAF Marque e esquemas nacionais de certificação
+      equivalentes.
+  BC-3590.10.30:
+    name: Coordenação de auditorias de boas práticas agrícolas
+    description: |
+      Coordenação de auditorias de boas práticas agrícolas e acompanhamento de
+      ações corretivas.
+  BC-3590.20:
+    name: Gestão de certificação biológica
+    description: |
+      Gestão de certificação biológica ao abrigo do NOP da USDA, Regulamento
+      Biológico da UE, JAS Organic e regimes equivalentes.
+  BC-3590.20.10:
+    name: Registos de conformidade com a norma biológica
+    description: |
+      Registos de conformidade com a norma biológica aplicável.
+  BC-3590.20.20:
+    name: Coordenação de inspeções de certificação biológica
+    description: |
+      Coordenação de inspeções e auditorias de certificação biológica.
+  BC-3590.20.30:
+    name: Autorização de fatores de produção biológicos
+    description: |
+      Verificação de que os fatores de produção são autorizados ao abrigo da
+      norma biológica aplicável.
+  BC-3590.30:
+    name: Gestão de certificação de bem-estar animal
+    description: |
+      Programas de auditoria de bem-estar animal, registo de resultados de
+      bem-estar e conformidade com normas de bem-estar do setor e de certificação.
+  BC-3590.30.10:
+    name: Programas de auditoria de bem-estar animal
+    description: |
+      Programas internos e de terceiros de auditoria de bem-estar animal.
+  BC-3590.30.20:
+    name: Registo de resultados de bem-estar
+    description: |
+      Registo de medidas de resultados de bem-estar nos diferentes efetivos.
+  BC-3590.30.30:
+    name: Conformidade com normas de bem-estar
+    description: |
+      Evidências de conformidade face às normas de bem-estar do setor e de
+      certificação.
+  BC-3590.40:
+    name: Gestão de indicações geográficas e proveniência
+    description: |
+      Registos e verificação que suportam denominações de origem protegida,
+      indicações geográficas e declarações de proveniência.
+  BC-3590.40.10:
+    name: Registos de declarações de proveniência
+    description: |
+      Registos que comprovam declarações de origem, raça e proveniência.
+  BC-3590.40.20:
+    name: Conformidade com indicações geográficas
+    description: |
+      Conformidade com DOP, IGP e indicações geográficas equivalentes.
+  BC-3590.40.30:
+    name: Verificação de origem
+    description: |
+      Verificação de origem por métodos documentais, isotópicos e de ADN.
+  BC-3590.50:
+    name: Gestão de resíduos de pesticidas e LMR
+    description: |
+      Amostragem de resíduos, conformidade com LMR e cumprimento de intervalos
+      de segurança nos mercados de destino.
+  BC-3590.50.10:
+    name: Programas de amostragem de resíduos
+    description: |
+      Programas de amostragem de resíduos de pesticidas em culturas e lotes.
+  BC-3590.50.20:
+    name: Monitorização de conformidade com LMR
+    description: |
+      Monitorização de conformidade face às listas de LMR do mercado de destino.
+  BC-3590.50.30:
+    name: Cumprimento de intervalos de segurança
+    description: |
+      Cumprimento dos intervalos de segurança antes da colheita e de leite.
+  BC-3590.60:
+    name: Conformidade com identificação e movimento de animais
+    description: |
+      Marcação de identificação animal, licenças de movimento e certificação
+      sanitária transfronteiriça para animais e stocks de aquicultura.
+    in_scope:
+      - Identificação estatutária de animais
+      - Registo de licenças de movimento
+      - Certificação sanitária transfronteiriça
+    out_of_scope:
+      - Gestão genérica de conformidade (BC-130)
+  BC-3590.60.10:
+    name: Marcação de identificação animal
+    description: |
+      Marcação de identificação animal estatutária, incluindo EID e brincos.
+  BC-3590.60.20:
+    name: Registo de licenças de movimento
+    description: |
+      Registo de licenças de movimento estatutárias e registos de movimento na
+      exploração.
+  BC-3590.60.30:
+    name: Certificação sanitária transfronteiriça
+    description: |
+      Certificação sanitária transfronteiriça, incluindo registos TRACES NT.
+  BC-3590.70:
+    name: Registos de rastreabilidade pré-portão da exploração
+    description: |
+      Registos de rastreabilidade campo-a-lote, animal-a-carcaça e fator-a-produto
+      que ancoram os rastros EPCIS e de cadeia de custódia a jusante.
+  BC-3590.70.10:
+    name: Rastreabilidade campo para lote
+    description: |
+      Rastreabilidade que liga operações de campo a lotes colhidos.
+  BC-3590.70.20:
+    name: Rastreabilidade animal para carcaça
+    description: |
+      Rastreabilidade que liga animais individuais a carcaças e peças primárias.
+  BC-3590.70.30:
+    name: Registo de rastreio de fator para produto
+    description: |
+      Registo que liga fatores de produção aplicados aos lotes de produto
+      resultantes.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-agricultural-inputs-management.yaml
+++ b/catalogue/i18n/pt/L1-agricultural-inputs-management.yaml
@@ -1,0 +1,146 @@
+locale: pt
+source: L1-agricultural-inputs-management.yaml
+entries:
+  BC-3550:
+    name: Gestão de fatores de produção agrícola
+    description: |
+      Gestão do ciclo de vida dos fatores de produção agrícola — sementes e
+      material genético, fertilizantes, proteção das culturas, nutrição animal,
+      medicamentos veterinários e biológicos — incluindo rastreabilidade,
+      responsabilidade e requisitos de armazenamento específicos do setor,
+      distintos da contratação genérica.
+  BC-3550.10:
+    name: Gestão de sementes e material genético
+    description: |
+      Aprovisionamento de sementes certificadas, tratamento de sementes,
+      rastreabilidade de pedigree e características e inventário de sementes
+      ao longo do ciclo de plantação.
+    in_scope:
+      - Aprovisionamento de sementes certificadas
+      - Aplicação de tratamentos de sementes
+      - Rastreabilidade de pedigree e características
+      - Inventário de sementes na exploração e em depósito
+    out_of_scope:
+      - I&D em melhoramento de plantas (BC-810)
+      - Recomendação de variedades (BC-3530.40)
+  BC-3550.10.10:
+    name: Aprovisionamento e certificação de sementes
+    description: |
+      Aprovisionamento de sementes certificadas ao abrigo dos esquemas de sementes
+      OCDE e ensaios ISTA.
+  BC-3550.10.20:
+    name: Aplicação de tratamentos de sementes
+    description: |
+      Aplicação de tratamentos e revestimentos de sementes antes da sementeira.
+  BC-3550.10.30:
+    name: Rastreabilidade de pedigree e características das sementes
+    description: |
+      Rastreabilidade de pedigree, pilha de características e obrigações de
+      responsabilidade das sementes.
+  BC-3550.10.40:
+    name: Gestão do inventário de sementes
+    description: |
+      Gestão do inventário de sementes em depósitos e armazéns na exploração.
+  BC-3550.20:
+    name: Gestão de fertilizantes
+    description: |
+      Aprovisionamento, armazenamento, manuseamento e registos de aplicação de
+      fertilizantes sólidos e líquidos.
+  BC-3550.20.10:
+    name: Aprovisionamento de fertilizantes
+    description: |
+      Aprovisionamento de fertilizantes simples e compostos junto de fornecedores
+      e importadores.
+  BC-3550.20.20:
+    name: Armazenamento e manuseamento de fertilizantes
+    description: |
+      Armazenamento e manuseamento de fertilizantes na exploração e em depósito,
+      incluindo proteção secundária.
+  BC-3550.20.30:
+    name: Registos de aplicação de fertilizantes
+    description: |
+      Registos de aplicação de fertilizantes por parcela, produto e taxa.
+  BC-3550.30:
+    name: Gestão de fatores de proteção das culturas
+    description: |
+      Aprovisionamento, armazenamento, registos de aplicação e responsabilidade
+      de embalagens vazias de produtos fitossanitários.
+  BC-3550.30.10:
+    name: Aprovisionamento de produtos fitossanitários
+    description: |
+      Aprovisionamento de produtos fitossanitários autorizados através de canais
+      licenciados.
+  BC-3550.30.20:
+    name: Armazenamento e manuseamento de pesticidas
+    description: |
+      Armazenamento, segregação e controlos de manuseamento de pesticidas por
+      operadores.
+  BC-3550.30.30:
+    name: Registos de aplicação de pesticidas
+    description: |
+      Registos de aplicação de pesticidas que cumprem os requisitos regulatórios
+      e de certificação.
+  BC-3550.30.40:
+    name: Responsabilidade de embalagens vazias
+    description: |
+      Triple-enxaguamento, devolução e reciclagem de embalagens vazias de
+      pesticidas.
+  BC-3550.40:
+    name: Gestão de fatores de nutrição animal
+    description: |
+      Aprovisionamento, armazenamento e acompanhamento do uso de ingredientes
+      alimentares, pré-misturas e aditivos alimentares para operações pecuárias.
+  BC-3550.40.10:
+    name: Aprovisionamento de ingredientes alimentares
+    description: |
+      Aprovisionamento de cereais, farinhas proteicas e ingredientes forrageiros.
+  BC-3550.40.20:
+    name: Gestão de pré-misturas e aditivos
+    description: |
+      Aprovisionamento e inventário de pré-misturas, minerais e aditivos
+      alimentares.
+  BC-3550.40.30:
+    name: Inventário de alimentos e acompanhamento de rações
+    description: |
+      Inventário de alimentos na exploração e acompanhamento do uso de rações.
+  BC-3550.50:
+    name: Gestão de medicamentos veterinários
+    description: |
+      Aprovisionamento, armazenamento em cadeia de frio e registo do uso de
+      medicamentos veterinários e biológicos na exploração.
+  BC-3550.50.10:
+    name: Aprovisionamento de medicamentos veterinários
+    description: |
+      Aprovisionamento com receita de medicamentos veterinários e biológicos.
+  BC-3550.50.20:
+    name: Armazenamento em cadeia de frio de medicamentos veterinários
+    description: |
+      Armazenamento em cadeia de frio na exploração e gestão de desvios de
+      temperatura de medicamentos veterinários.
+  BC-3550.50.30:
+    name: Registo do uso de medicamentos veterinários
+    description: |
+      Registo do uso com detalhes de lote, dose, animal e operador.
+  BC-3550.60:
+    name: Fatores biológicos e corretivos do solo
+    description: |
+      Aprovisionamento de fatores biológicos, gestão de estrume e composto e
+      fornecimento de calcário e corretivos do solo.
+  BC-3550.60.10:
+    name: Aprovisionamento de fatores biológicos
+    description: |
+      Aprovisionamento de bioestimulantes, biofertilizantes e inoculantes
+      microbianos.
+  BC-3550.60.20:
+    name: Gestão de estrume e composto
+    description: |
+      Armazenamento de estrume na exploração, compostagem e operações de
+      recuperação de nutrientes.
+  BC-3550.60.30:
+    name: Aprovisionamento de calcário e corretivos do solo
+    description: |
+      Aprovisionamento de calcário, gesso e outros corretivos do solo.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-agronomy-farm-advisory-management.yaml
+++ b/catalogue/i18n/pt/L1-agronomy-farm-advisory-management.yaml
@@ -1,0 +1,132 @@
+locale: pt
+source: L1-agronomy-farm-advisory-management.yaml
+entries:
+  BC-3530:
+    name: Gestão de agronomia e consultoria agrícola
+    description: |
+      Análise do solo, planeamento da nutrição e proteção das culturas, gestão
+      integrada de pragas, recomendação de variedades, serviços de consultoria
+      e gestão de ensaios de campo que transformam a ciência agronómica em
+      decisões ao nível da parcela.
+  BC-3530.10:
+    name: Análise e teste do solo
+    description: |
+      Amostragem, análise laboratorial e interpretação de análises de solo que
+      orientam decisões de nutrição e correção.
+  BC-3530.10.10:
+    name: Operações de amostragem de solo
+    description: |
+      Amostragem de solo no campo por métodos de malha, zona e composta.
+  BC-3530.10.20:
+    name: Interpretação dos resultados das análises de solo
+    description: |
+      Interpretação dos resultados das análises de solo face às necessidades das
+      culturas.
+  BC-3530.10.30:
+    name: Acompanhamento de indicadores de saúde do solo
+    description: |
+      Acompanhamento de indicadores de saúde do solo ao longo do tempo nas
+      diferentes parcelas.
+  BC-3530.20:
+    name: Planeamento da gestão de nutrientes
+    description: |
+      Cálculo das necessidades nutritivas das culturas e geração de prescrições
+      de taxa variável alinhadas com a gestão de nutrientes 4R.
+    in_scope:
+      - Cálculo de necessidades nutritivas
+      - Geração de prescrições de taxa variável
+      - Registo de conformidade 4R
+    out_of_scope:
+      - Execução de aplicações de fertilizantes (BC-3500.40)
+      - Programas de carbono no solo (BC-3600.50)
+  BC-3530.20.10:
+    name: Cálculo de necessidades nutritivas
+    description: |
+      Cálculo de necessidades nutritivas por cultura, meta de rendimento e
+      parcela.
+  BC-3530.20.20:
+    name: Geração de mapas de prescrição de taxa variável
+    description: |
+      Geração de mapas de prescrição de taxa variável para fertilizantes e
+      corretivos.
+  BC-3530.20.30:
+    name: Registo de conformidade 4R
+    description: |
+      Registo de fonte, taxa, momento e local corretos face à gestão de nutrientes
+      4R.
+  BC-3530.30:
+    name: Planeamento da proteção das culturas
+    description: |
+      Avaliação de risco, planeamento de gestão integrada de pragas, desenho de
+      programas de pulverização e estratégia de gestão de resistências.
+  BC-3530.30.10:
+    name: Avaliação de risco de pragas e doenças
+    description: |
+      Avaliação de risco de pragas e doenças com base em previsões e informação
+      de campo.
+  BC-3530.30.20:
+    name: Planeamento de gestão integrada de pragas
+    description: |
+      Planeamento de GIP combinando medidas culturais, biológicas e químicas.
+  BC-3530.30.30:
+    name: Desenho de programas de pulverização
+    description: |
+      Desenho do programa de pulverização sazonal equilibrando eficácia, resíduos
+      e custo.
+  BC-3530.30.40:
+    name: Planeamento de gestão de resistências
+    description: |
+      Planeamento de gestão de resistências a pesticidas por modos de ação.
+  BC-3530.40:
+    name: Recomendação de variedades e híbridos
+    description: |
+      Análise de dados de ensaios de variedades e emissão de recomendações de
+      variedades e híbridos adaptadas localmente a agricultores.
+  BC-3530.40.10:
+    name: Análise de resultados de ensaios de variedades
+    description: |
+      Análise estatística de resultados de ensaios de variedades por local e
+      época.
+  BC-3530.40.20:
+    name: Recomendação local de variedades
+    description: |
+      Emissão de recomendações de variedades e híbridos por zona e uso final.
+  BC-3530.50:
+    name: Serviços de consultoria agronómica
+    description: |
+      Visitas de consultoria ao campo, recomendações de apoio à decisão e
+      formação de agricultores prestadas por profissionais de agronomia.
+  BC-3530.50.10:
+    name: Realização de visitas de consultoria ao campo
+    description: |
+      Visitas de consultoria à exploração e entrega de recomendações.
+  BC-3530.50.20:
+    name: Recomendação de apoio à decisão
+    description: |
+      Utilização de ferramentas de apoio à decisão para emitir recomendações
+      agronómicas.
+  BC-3530.50.30:
+    name: Realização de formação a agricultores
+    description: |
+      Realização de eventos de formação para agricultores e dias de campo.
+  BC-3530.60:
+    name: Gestão de ensaios de campo
+    description: |
+      Desenho, execução e análise de ensaios de campo replicados que suportam
+      avaliações de agronomia, variedades e produtos.
+  BC-3530.60.10:
+    name: Desenho de ensaios
+    description: |
+      Desenho estatístico de ensaios replicados e de demonstração.
+  BC-3530.60.20:
+    name: Execução e captura de dados dos ensaios
+    description: |
+      Execução de ensaios no local e captura de dados normalizada.
+  BC-3530.60.30:
+    name: Análise dos resultados dos ensaios
+    description: |
+      Análise estatística dos resultados dos ensaios e reporte a promotores.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-air-traffic-control-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-air-traffic-control-operations-management.yaml
@@ -1,0 +1,123 @@
+locale: pt
+source: L1-air-traffic-control-operations-management.yaml
+entries:
+  BC-1210:
+    name: Gestão das operações de controlo de tráfego aéreo
+    description: |
+      Serviços de tráfego aéreo em tempo real - rota, aproximação, torre aeródromo e oceânico.
+  BC-1210.10:
+    name: Gestão das operações de controlo em rota
+    description: |
+      Serviços de CTA em rota a alta altitude.
+  BC-1210.10.10:
+    name: Prestação de separação em rota
+    description: |
+      Prestação de separação horizontal e vertical no espaço aéreo de rota.
+  BC-1210.10.20:
+    name: Deteção e resolução de conflitos em rota
+    description: |
+      Deteção e resolução de conflitos entre voos em rota.
+  BC-1210.10.30:
+    name: Coordenação em rota
+    description: |
+      Coordenação inter-setor e inter-centro do tráfego em rota.
+  BC-1210.10.40:
+    name: Processamento de planos de voo
+    description: |
+      Processamento, ativação e atualizações de planos de voo.
+  BC-1210.20:
+    name: Gestão das operações de controlo de aproximação
+    description: |
+      Controlo de aproximação e partida na área terminal.
+  BC-1210.20.10:
+    name: Sequenciamento e metering de chegadas
+    description: |
+      Sequenciamento de chegadas, AMAN e operações de metering.
+  BC-1210.20.20:
+    name: Gestão de partidas
+    description: |
+      Gestão de partidas, DMAN e aderência a SID.
+  BC-1210.20.30:
+    name: Vectorização e espaçamento de aproximação
+    description: |
+      Vectorização e espaçamento para aproximação final.
+  BC-1210.20.40:
+    name: Coordenação na área terminal
+    description: |
+      Coordenação entre aproximação e unidades adjacentes.
+  BC-1210.30:
+    name: Gestão das operações da torre de aeródromo
+    description: |
+      Controlo de torre em aeródromos, incluindo movimentos no solo.
+  BC-1210.30.10:
+    name: Controlo de pista
+    description: |
+      Controlo de pista incluindo autorizações de descolagem e aterragem.
+  BC-1210.30.20:
+    name: Controlo de movimentos no solo
+    description: |
+      Controlo de movimentos de superfície de aeronaves e veículos.
+  BC-1210.30.30:
+    name: Emissão de autorizações
+    description: |
+      Emissão de autorizações de partida e informações pré-partida.
+  BC-1210.30.40:
+    name: Coordenação de aeródromo
+    description: |
+      Coordenação com operações aeroportuárias e serviços de emergência.
+  BC-1210.40:
+    name: Gestão das operações de controlo oceânico
+    description: |
+      Serviços de CTA procedimentais e oceânicos.
+  BC-1210.40.10:
+    name: Prestação de separação procedimentais
+    description: |
+      Separação procedimental no espaço aéreo oceânico sem radar.
+  BC-1210.40.20:
+    name: Gestão de autorizações oceânicas
+    description: |
+      Emissão de autorizações e reautorizações oceânicas.
+  BC-1210.40.30:
+    name: Operações CPDLC e ADS-C
+    description: |
+      Operações oceânicas por ligação de dados usando CPDLC e ADS-C.
+  BC-1210.50:
+    name: Gestão de turnos e vigilância CTA
+    description: |
+      Supervisão de turno, transferências de turno e planeamento de posições.
+  BC-1210.50.10:
+    name: Supervisão de turno
+    description: |
+      Supervisão operacional do turno e desempenho do período de serviço.
+  BC-1210.50.20:
+    name: Gestão da transferência de turno
+    description: |
+      Briefings e documentação estruturados de transferência de turno.
+  BC-1210.50.30:
+    name: Planeamento de posições
+    description: |
+      Planeamento de posições e gestão de fadiga dos controladores.
+  BC-1210.60:
+    name: Gestão de operações de contingência
+    description: |
+      Operações em modo degradado, resposta a falhas de sistema e procedimentos de emergência.
+  BC-1210.60.10:
+    name: Operações em modo degradado
+    description: |
+      Operações em modo degradado com suporte de sistema reduzido.
+  BC-1210.60.20:
+    name: Resposta a falhas de sistema
+    description: |
+      Procedimentos de resposta a falhas de sistemas CTA.
+  BC-1210.60.30:
+    name: Comutação para sistemas de reserva
+    description: |
+      Comutação para sistemas CTA de reserva e instalações de contingência.
+  BC-1210.60.40:
+    name: Manutenção dos planos de contingência
+    description: |
+      Manutenção e exercício dos planos de contingência operacional.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-air-traffic-controller-competency-management.yaml
+++ b/catalogue/i18n/pt/L1-air-traffic-controller-competency-management.yaml
@@ -1,0 +1,107 @@
+locale: pt
+source: L1-air-traffic-controller-competency-management.yaml
+entries:
+  BC-1290:
+    name: Gestão da competência do controlador de tráfego aéreo
+    description: |
+      Formação inicial, de unidade e de continuação; licenciamento e avaliação de competência de controladores.
+  BC-1290.10:
+    name: Gestão da formação inicial
+    description: |
+      Formação ab-initio, formação básica e de qualificação (normalmente em academia).
+  BC-1290.10.10:
+    name: Programa de formação ab-initio
+    description: |
+      Formação ATCO ab-initio incluindo fase básica.
+  BC-1290.10.20:
+    name: Formação de qualificação
+    description: |
+      Formação específica de qualificação (ACC, APP, ADC, OCN).
+  BC-1290.10.30:
+    name: Avaliação da formação inicial
+    description: |
+      Exames e avaliações durante a formação inicial.
+  BC-1290.20:
+    name: Gestão da formação de unidade
+    description: |
+      Formação em posto de trabalho na unidade operacional.
+  BC-1290.20.10:
+    name: Definição do plano de formação de unidade
+    description: |
+      Definição de planos de formação de unidade para a transição de ATCO.
+  BC-1290.20.20:
+    name: Entrega de formação em posto de trabalho
+    description: |
+      Entrega de OJT com instrutores OJT.
+  BC-1290.20.30:
+    name: Validação da formação de unidade
+    description: |
+      Validação da habilitação de unidade após conclusão da formação de unidade.
+  BC-1290.30:
+    name: Gestão da formação de continuação
+    description: |
+      Formação de atualização, conversão e situações de emergência e inusitadas.
+  BC-1290.30.10:
+    name: Formação de atualização
+    description: |
+      Formação periódica de atualização para controladores licenciados.
+  BC-1290.30.20:
+    name: Formação de conversão
+    description: |
+      Formação de conversão para novos procedimentos, sistemas ou setores.
+  BC-1290.30.30:
+    name: Formação em emergências e situações inusitadas
+    description: |
+      Formação em situações de emergência, anómalas e inusitadas.
+  BC-1290.40:
+    name: Gestão da avaliação de competências
+    description: |
+      Avaliações periódicas de competência, verificações de linha e validação.
+  BC-1290.40.10:
+    name: Manutenção do esquema de competências
+    description: |
+      Definição e manutenção do esquema de competências.
+  BC-1290.40.20:
+    name: Entrega de avaliações de competência
+    description: |
+      Realização de avaliações periódicas de competência e verificações de linha.
+  BC-1290.40.30:
+    name: Gestão de registos de competência
+    description: |
+      Gestão de registos de avaliação de competência e validade.
+  BC-1290.50:
+    name: Gestão de licenciamento e habilitações
+    description: |
+      Licenciamento ATCO, qualificações, habilitações e administração da aptidão médica.
+  BC-1290.50.10:
+    name: Emissão de licenças ATCO
+    description: |
+      Emissão e renovação de licenças e qualificações ATCO.
+  BC-1290.50.20:
+    name: Administração de habilitações
+    description: |
+      Administração de habilitações de unidade e de língua.
+  BC-1290.50.30:
+    name: Administração da aptidão médica
+    description: |
+      Administração da aptidão médica de Classe 3 para controladores.
+  BC-1290.60:
+    name: Gestão das operações de simulador
+    description: |
+      Simuladores CTA, design de cenários e operações de piloto de simulador.
+  BC-1290.60.10:
+    name: Design de cenários de simulador
+    description: |
+      Design de cenários e exercícios de formação em simulador.
+  BC-1290.60.20:
+    name: Operações de piloto de simulador
+    description: |
+      Operação de posições de piloto de simulador durante exercícios.
+  BC-1290.60.30:
+    name: Manutenção e configuração do simulador
+    description: |
+      Manutenção e configuração de simuladores CTA.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-air-traffic-flow-management.yaml
+++ b/catalogue/i18n/pt/L1-air-traffic-flow-management.yaml
@@ -1,0 +1,95 @@
+locale: pt
+source: L1-air-traffic-flow-management.yaml
+entries:
+  BC-1220:
+    name: Gestão do fluxo de tráfego aéreo
+    description: |
+      Planeamento de capacidade, regulação do fluxo, alocação de slots e equilíbrio procura-capacidade.
+  BC-1220.10:
+    name: Gestão do planeamento de capacidade
+    description: |
+      Avaliação da capacidade de setor e aeródromo e definição da capacidade declarada.
+  BC-1220.10.10:
+    name: Avaliação da capacidade de setor
+    description: |
+      Avaliação da capacidade de setor através da medição da carga de trabalho.
+  BC-1220.10.20:
+    name: Declaração de capacidade de aeródromo
+    description: |
+      Declaração da capacidade de pista e rampa do aeródromo.
+  BC-1220.10.30:
+    name: Planeamento estratégico de capacidade
+    description: |
+      Planeamento estratégico plurianual da capacidade CTA.
+  BC-1220.20:
+    name: Gestão da regulação do fluxo
+    description: |
+      Medidas de fluxo de tráfego, regulações e reencaminhamentos.
+  BC-1220.20.10:
+    name: Definição de medidas de fluxo
+    description: |
+      Definição de medidas ATFCM por setor e aeródromo.
+  BC-1220.20.20:
+    name: Gestão de propostas de reencaminhamento
+    description: |
+      Proposta e implementação de reencaminhamentos e cenários.
+  BC-1220.20.30:
+    name: Ajuste tático do fluxo
+    description: |
+      Ajuste tático de medidas de fluxo em tempo real.
+  BC-1220.30:
+    name: Gestão de alocação de slots
+    description: |
+      Horas de descolagem calculadas (CTOT), gestão de slots e permuta de slots.
+  BC-1220.30.10:
+    name: Emissão de horas de descolagem calculadas
+    description: |
+      Cálculo e emissão de CTOT aos utilizadores do espaço aéreo.
+  BC-1220.30.20:
+    name: Permuta e melhoria de slots
+    description: |
+      Permuta de slots, melhoria de slots e atualizações de horas alvo.
+  BC-1220.30.30:
+    name: Conformidade de slots de partida
+    description: |
+      Monitorização da aderência a slots e isenções.
+  BC-1220.40:
+    name: Gestão do desempenho da rede
+    description: |
+      Monitorização do desempenho da rede e relatório de KPIs.
+  BC-1220.40.10:
+    name: Monitorização dos KPIs da rede
+    description: |
+      Monitorização dos KPIs da rede (atraso, capacidade, previsibilidade).
+  BC-1220.40.20:
+    name: Relatório de desempenho
+    description: |
+      Relatório de desempenho para a rede e reguladores do CUE.
+  BC-1220.40.30:
+    name: Análise pós-operações
+    description: |
+      Análise pós-operações dos fluxos e estrangulamentos.
+  BC-1220.50:
+    name: Gestão do equilíbrio procura-capacidade
+    description: |
+      Equilíbrio procura-capacidade pré-tático e tático.
+  BC-1220.50.10:
+    name: Equilíbrio estratégico procura-capacidade
+    description: |
+      Equilíbrio procura-capacidade de longo prazo em toda a rede.
+  BC-1220.50.20:
+    name: Equilíbrio pré-tático procura-capacidade
+    description: |
+      Equilíbrio pré-tático (D-1) procura-capacidade.
+  BC-1220.50.30:
+    name: Equilíbrio tático procura-capacidade
+    description: |
+      Equilíbrio tático procura-capacidade em tempo real.
+  BC-1220.50.40:
+    name: Tomada de decisão colaborativa
+    description: |
+      Tomada de decisão colaborativa com utilizadores do espaço aéreo e aeroportos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-airline-flight-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-airline-flight-operations-management.yaml
@@ -1,0 +1,190 @@
+locale: pt
+source: L1-airline-flight-operations-management.yaml
+entries:
+  BC-4080:
+    name: Gestão de operações de voo de companhia aérea
+    description: |
+      Planeamento de horários, encaminhamento de aeronaves, planeamento
+      de tripulação, despacho, coordenação de porta e viragem, recuperação
+      IROPS e relatórios de desempenho e segurança de voo para transportadoras
+      aéreas.
+  BC-4080.10:
+    name: Planeamento do horário de voos
+    description: |
+      Construção e publicação do horário de voos da companhia aérea,
+      abrangendo rede, slots e bancos de ligação.
+  BC-4080.10.10:
+    name: Definição de plano de rede e rota
+    description: |
+      Definição da rede e do plano de rota contra planos de procura
+      e de frota.
+  BC-4080.10.20:
+    name: Coordenação de slots e aeroportos
+    description: |
+      Coordenação de slots aeroportuários e restrições, incluindo
+      calendarização alinhada com a IATA WSG.
+  BC-4080.10.30:
+    name: Construção e publicação do horário
+    description: |
+      Construção do horário publicado e publicação do ficheiro SSIM
+      a parceiros de distribuição.
+  BC-4080.10.40:
+    name: Otimização do banco de ligações
+    description: |
+      Otimização dos bancos de ligação em hub e tempos mínimos de
+      ligação.
+  BC-4080.20:
+    name: Encaminhamento de aeronaves e atribuição de matrícula
+    description: |
+      Construção de rotações de aeronaves, atribuições de matrícula,
+      operações de troca, coordenação de slots de manutenção e rastreio
+      de MEL.
+  BC-4080.20.10:
+    name: Planeamento de rotação de frota
+    description: |
+      Planeamento de rotações de frota na rede, abrangendo o equilíbrio
+      de horas de voo e ciclos.
+  BC-4080.20.20:
+    name: Atribuição de matrícula e operações de troca
+    description: |
+      Atribuição de matrículas específicas a voos e execução de trocas
+      táticas.
+  BC-4080.20.30:
+    name: Coordenação de slots de manutenção de aeronaves
+    description: |
+      Coordenação de slots de manutenção e voos de posicionamento
+      contra o horário.
+  BC-4080.20.40:
+    name: Rastreio da lista de equipamentos mínimos
+    description: |
+      Rastreio de diferimentos da lista de equipamentos mínimos contra
+      expiração e impacto operacional.
+  BC-4080.30:
+    name: Planeamento e escalonamento de tripulação
+    description: |
+      Planeamento de tripulação de cabine de pilotagem e de cabine,
+      incluindo construção de emparelhamentos, licitação, rastreio de
+      qualificações e conformidade com limitações de tempo de voo.
+  BC-4080.30.10:
+    name: Construção de emparelhamentos de tripulação
+    description: |
+      Construção de emparelhamentos de tripulação ao longo do horário,
+      respeitando as regras de legalidade.
+  BC-4080.30.20:
+    name: Licitação de tripulação e construção de escala
+    description: |
+      Operação de processos de licitação e construção de escala para
+      tripulação de cabine de pilotagem e de cabine.
+  BC-4080.30.30:
+    name: Rastreio de qualificação e atualização de tripulação
+    description: |
+      Rastreio de qualificação, recência e atualização para membros
+      de tripulação.
+  BC-4080.30.40:
+    name: Conformidade com limitações de tempo de voo e serviço
+    description: |
+      Conformidade com as regras de limitações de tempo de voo e serviço
+      no planeamento e na execução.
+  BC-4080.40:
+    name: Despacho de voo e controlo operacional
+    description: |
+      Geração de planos operacionais de voo, decisões sobre combustível,
+      briefings meteorológicos e NOTAM, e tomada de decisão do centro
+      de controlo de operações.
+  BC-4080.40.10:
+    name: Geração do plano de voo
+    description: |
+      Geração de planos operacionais de voo, incluindo rota, nível e
+      tempo de rota.
+  BC-4080.40.20:
+    name: Cálculo de combustível operacional
+    description: |
+      Cálculo de combustível operacional, incluindo reservas, contingência
+      e carregamento discricionário.
+  BC-4080.40.30:
+    name: Briefing meteorológico e de NOTAM
+    description: |
+      Compilação e entrega de briefings meteorológicos e de NOTAM à
+      tripulação e ao despacho.
+  BC-4080.40.40:
+    name: Tomada de decisão do centro de controlo de operações
+    description: |
+      Tomada de decisão do OCC em atrasos, desvios e opções de recuperação.
+  BC-4080.50:
+    name: Operações de porta e viragem
+    description: |
+      Planeamento de porta e coordenação de viragem em tempo real nos
+      aeroportos, incluindo manuseio de atraso em pista.
+  BC-4080.50.10:
+    name: Alocação de porta e sequenciamento
+    description: |
+      Alocação de portas e sequenciamento de posições ao longo do
+      dia operacional.
+  BC-4080.50.20:
+    name: Coordenação de viragem
+    description: |
+      Coordenação em tempo real das atividades de viragem, incluindo
+      catering, abastecimento e embarque.
+  BC-4080.50.30:
+    name: Operações de reboque e saída do bloco
+    description: |
+      Coordenação de reboque, saída do bloco e saída da posição.
+  BC-4080.50.40:
+    name: Gestão de atraso em pista
+    description: |
+      Gestão de atrasos em pista em conformidade com os limites de tempo
+      regulatórios e as obrigações de cuidado com passageiros.
+  BC-4080.60:
+    name: Gestão de perturbações de voo e IROPS
+    description: |
+      Decisões operacionais durante eventos de perturbação que abrangem
+      desvios, cancelamentos em massa e recuperação de tripulação, além
+      de coordenação com fluxos de nova reserva de passageiros.
+  BC-4080.60.10:
+    name: Operações de decisão de desvio
+    description: |
+      Operações para decidir e executar desvios em rota e antes da partida.
+  BC-4080.60.20:
+    name: Operações de recuperação de cancelamentos em massa
+    description: |
+      Operações de recuperação durante cancelamentos em massa, abrangendo
+      recuperação de aeronaves, tripulação e slots.
+  BC-4080.60.30:
+    name: Recuperação de perturbação de tripulação
+    description: |
+      Recuperação de escalas de tripulação durante perturbações, incluindo
+      atribuição de reserva e de recurso.
+  BC-4080.60.40:
+    name: Coordenação de nova reserva de passageiros
+    description: |
+      Coordenação com equipas de realocação de passageiros sobre opções
+      de recuperação e priorização.
+  BC-4080.70:
+    name: Relatórios de desempenho e segurança de voo
+    description: |
+      Relatórios de desempenho de voo, KPIs de pontualidade, relatórios
+      de segurança aérea e feeds de dados de segurança operacional.
+  BC-4080.70.10:
+    name: Relatórios de desempenho de pontualidade
+    description: |
+      Relatórios de desempenho de pontualidade e códigos de atraso na
+      rede.
+  BC-4080.70.20:
+    name: Captura de relatório de segurança aérea
+    description: |
+      Captura e triagem de relatórios de segurança aérea de tripulação
+      e pessoal operacional.
+  BC-4080.70.30:
+    name: Apoio a investigações de segurança operacional
+    description: |
+      Apoio a investigações de segurança operacional, incluindo recolha
+      de dados e ações de seguimento.
+  BC-4080.70.40:
+    name: Feeds de análise de dados de voo
+    description: |
+      Feeds de análise de dados de voo para programas de análise de
+      segurança e operações.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-airspace-management.yaml
+++ b/catalogue/i18n/pt/L1-airspace-management.yaml
@@ -1,0 +1,83 @@
+locale: pt
+source: L1-airspace-management.yaml
+entries:
+  BC-1200:
+    name: Gestão do espaço aéreo
+    description: |
+      Design do espaço aéreo, sectorização, áreas restritas e coordenação civil-militar.
+  BC-1200.10:
+    name: Gestão do design do espaço aéreo
+    description: |
+      Estrutura do espaço aéreo, classes, design da rede de rotas e limites de setor.
+  BC-1200.10.10:
+    name: Design da estrutura do espaço aéreo
+    description: |
+      Definição de FIR, UIR, áreas de controlo e classes de espaço aéreo segundo o Anexo 11 da OACI.
+  BC-1200.10.20:
+    name: Design da rede de rotas ATS
+    description: |
+      Design de redes de rotas ATS convencionais e PBN.
+  BC-1200.10.30:
+    name: Design dos limites de setor
+    description: |
+      Definição dos limites de setor e setores elementares.
+  BC-1200.10.40:
+    name: Design do espaço aéreo de rota livre
+    description: |
+      Design e implementação do espaço aéreo de rota livre.
+  BC-1200.20:
+    name: Gestão da sectorização do espaço aéreo
+    description: |
+      Definições de setor, esquemas de abertura e alinhamento com a carga de trabalho do controlador.
+  BC-1200.20.10:
+    name: Gestão da configuração de setores
+    description: |
+      Definição e manutenção de configurações de setor.
+  BC-1200.20.20:
+    name: Planeamento do esquema de abertura de setores
+    description: |
+      Planeamento de esquemas de abertura de setores por previsão de tráfego.
+  BC-1200.20.30:
+    name: Sectorização baseada na carga de trabalho
+    description: |
+      Sectorização alinhada com a avaliação da carga de trabalho do controlador.
+  BC-1200.30:
+    name: Gestão do espaço aéreo restrito
+    description: |
+      Áreas de perigo, áreas restritas, áreas proibidas e zonas militares.
+  BC-1200.30.10:
+    name: Definição de áreas restritas
+    description: |
+      Definição de áreas restritas, proibidas e de perigo.
+  BC-1200.30.20:
+    name: Gestão de áreas temporariamente reservadas
+    description: |
+      Gestão de áreas temporariamente reservadas e segregadas.
+  BC-1200.30.30:
+    name: Coordenação de ativação e liberação
+    description: |
+      Ativação, liberação e notificação do espaço aéreo restrito.
+  BC-1200.40:
+    name: Gestão da coordenação do espaço aéreo
+    description: |
+      Coordenação civil-militar, coordenação transfronteiriça e cooperação em blocos funcionais de espaço aéreo.
+  BC-1200.40.10:
+    name: Coordenação civil-militar do espaço aéreo
+    description: |
+      Coordenação civil-militar e utilização flexível do espaço aéreo.
+  BC-1200.40.20:
+    name: Coordenação transfronteiriça do espaço aéreo
+    description: |
+      Coordenação da utilização do espaço aéreo através das fronteiras FIR.
+  BC-1200.40.30:
+    name: Cooperação em blocos funcionais de espaço aéreo
+    description: |
+      Cooperação em blocos funcionais de espaço aéreo (FAB).
+  BC-1200.40.40:
+    name: Consulta a utilizadores do espaço aéreo
+    description: |
+      Consulta aos utilizadores do espaço aéreo sobre alterações de design.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-aquaculture-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-aquaculture-operations-management.yaml
@@ -1,0 +1,146 @@
+locale: pt
+source: L1-aquaculture-operations-management.yaml
+entries:
+  BC-3520:
+    name: Gestão de operações de aquicultura
+    description: |
+      Produção de espécies aquáticas em cativeiro — incubatório e repovoamento,
+      alimentação, qualidade da água, saúde animal, operações de jaulas e tanques,
+      colheita e conformidade ambiental para peixes, moluscos e plantas aquáticas.
+  BC-3520.10:
+    name: Operações de aprovisionamento e repovoamento de efectivos
+    description: |
+      Aprovisionamento de reprodutores, operações de incubatório e repovoamento
+      de juvenis em sistemas de engorda.
+  BC-3520.10.10:
+    name: Aprovisionamento de reprodutores
+    description: |
+      Aprovisionamento e quarentena de reprodutores para produção em incubatório.
+  BC-3520.10.20:
+    name: Operações de incubatório
+    description: |
+      Incubação de ovos, criação larvar e produção de juvenis em incubatórios.
+  BC-3520.10.30:
+    name: Operações de repovoamento com juvenis
+    description: |
+      Repovoamento de juvenis em jaulas, tanques e viveiros de engorda.
+  BC-3520.20:
+    name: Operações de alimentação em aquicultura
+    description: |
+      Planeamento de rações, distribuição e monitorização da conversão alimentar
+      para espécies aquáticas em cativeiro.
+  BC-3520.20.10:
+    name: Planeamento de rações alimentares
+    description: |
+      Planeamento de rações por espécie, estádio de vida e temperatura da água.
+  BC-3520.20.20:
+    name: Operações de distribuição de alimento
+    description: |
+      Distribuição manual, mecânica e automatizada de alimento a jaulas e tanques.
+  BC-3520.20.30:
+    name: Monitorização da conversão alimentar
+    description: |
+      Monitorização do índice de conversão alimentar face aos planos de alimentação.
+  BC-3520.30:
+    name: Gestão da qualidade da água
+    description: |
+      Monitorização contínua da qualidade da água, oxigenação e tratamento em
+      sistemas de aquicultura de fluxo contínuo e recirculação.
+    in_scope:
+      - Monitorização de oxigénio dissolvido e temperatura
+      - Operações de arejamento e oxigenação
+      - Tratamento e recirculação de água
+  BC-3520.30.10:
+    name: Monitorização da qualidade da água
+    description: |
+      Monitorização em tempo real de oxigénio dissolvido, temperatura, salinidade
+      e pH.
+  BC-3520.30.20:
+    name: Operações de arejamento e oxigenação
+    description: |
+      Operação de sistemas de arejamento e injeção de oxigénio.
+  BC-3520.30.30:
+    name: Tratamento e recirculação de água
+    description: |
+      Tratamento mecânico, biológico e UV da água em sistemas de recirculação.
+  BC-3520.40:
+    name: Gestão da saúde de animais aquáticos
+    description: |
+      Vigilância de doenças, tratamento, biossegurança e registo de mortalidade
+      de espécies aquáticas em cativeiro.
+  BC-3520.40.10:
+    name: Vigilância de doenças aquáticas
+    description: |
+      Vigilância de agentes patogénicos, parasitas e doenças aquáticas de
+      declaração obrigatória.
+  BC-3520.40.20:
+    name: Operações de tratamento em aquicultura
+    description: |
+      Operações de tratamento na água e por banho, incluindo controlo de piolhos
+      do mar.
+  BC-3520.40.30:
+    name: Operações de biossegurança em aquicultura
+    description: |
+      Biossegurança do local, desinfeção de equipamentos e controlos de
+      movimentos.
+  BC-3520.40.40:
+    name: Registo de mortalidade
+    description: |
+      Registo diário de mortalidade, classificação e gestão de eliminação.
+  BC-3520.50:
+    name: Operações de jaulas e tanques
+    description: |
+      Operação diária e integridade de jaulas, gaiolas e tanques de engorda,
+      incluindo controlo de predadores e antifouling.
+  BC-3520.50.10:
+    name: Inspeção de redes e gaiolas
+    description: |
+      Inspeção de rotina de redes, gaiolas e amarrações quanto à integridade.
+  BC-3520.50.20:
+    name: Prevenção de predação e fuga
+    description: |
+      Operações de dissuasão de predadores e prevenção de fugas.
+  BC-3520.50.30:
+    name: Operações de antifouling
+    description: |
+      Operações de limpeza de redes e antifouling em infraestrutura submersa.
+  BC-3520.60:
+    name: Operações de colheita em aquicultura
+    description: |
+      Amostragem pré-colheita, execução da colheita e manutenção em vivo para
+      processamento ou expedição para mercado em vivo.
+  BC-3520.60.10:
+    name: Amostragem pré-colheita
+    description: |
+      Amostragem de tamanho, qualidade e resíduos antes da colheita.
+  BC-3520.60.20:
+    name: Execução da colheita
+    description: |
+      Concentração, bombagem, atordoamento e execução da colheita.
+  BC-3520.60.30:
+    name: Manutenção em vivo e transferência
+    description: |
+      Manutenção em vivo e transferência por embarcação de transporte para
+      processador ou mercado.
+  BC-3520.70:
+    name: Conformidade ambiental em aquicultura
+    description: |
+      Monitorização ambiental ao nível do local e reporte exigidos por licenças
+      de aquicultura e esquemas de certificação.
+  BC-3520.70.10:
+    name: Monitorização ambiental do local
+    description: |
+      Monitorização ambiental ao nível do local face às condições da licença.
+  BC-3520.70.20:
+    name: Reporte de efluentes
+    description: |
+      Reporte de descargas de nutrientes e efluentes aos reguladores.
+  BC-3520.70.30:
+    name: Avaliação do impacto bentónico
+    description: |
+      Levantamentos de impacto bentónico e acompanhamento da remediação sob
+      locais de jaulas.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-assessment-examinations-management.yaml
+++ b/catalogue/i18n/pt/L1-assessment-examinations-management.yaml
@@ -1,0 +1,151 @@
+locale: pt
+source: L1-assessment-examinations-management.yaml
+entries:
+  BC-4740:
+    name: Gestão de avaliação e exames
+    description: |
+      Conceção, administração, correção, moderação e atribuição de avaliações e
+      exames que evidenciam a aprendizagem dos estudantes, incluindo supervisão
+      da integridade académica.
+  BC-4740.10:
+    name: Conceção de avaliações e banco de itens
+    description: |
+      Conceção de instrumentos de avaliação e manutenção de bancos de itens
+      calibrados que fundamentam uma avaliação consistente e fiável.
+    in_scope:
+      - Definição do plano de avaliação
+      - Autoria e calibração de itens
+      - Manutenção do banco de itens
+    out_of_scope:
+      - Conceção do programa de unidade curricular (abrangida em Gestão do Currículo e Programa)
+  BC-4740.10.10:
+    name: Definição do plano de avaliação
+    description: |
+      Definição de planos de avaliação e ponderação face aos resultados de aprendizagem.
+  BC-4740.10.20:
+    name: Autoria e calibração de itens
+    description: |
+      Autoria e calibração estatística de itens de avaliação.
+  BC-4740.10.30:
+    name: Manutenção do banco de itens
+    description: |
+      Manutenção de bancos de itens seguros ao longo de versões e ciclos de exposição.
+  BC-4740.20:
+    name: Operações de exames
+    description: |
+      Lecionação operacional de exames presenciais e online, incluindo planeamento,
+      vigilância e serviços de supervisão remota.
+    in_scope:
+      - Planeamento de exames
+      - Local de exame e vigilância
+      - Supervisão online e remota
+    out_of_scope:
+      - Avaliação diária em sala de aula (abrangida em Gestão de Operações de Ensino e Aprendizagem)
+  BC-4740.20.10:
+    name: Planeamento de exames
+    description: |
+      Planeamento de exames por coortes, locais e modalidades.
+  BC-4740.20.20:
+    name: Local de exame e vigilância
+    description: |
+      Organização do local e vigilância de exames presenciais.
+  BC-4740.20.30:
+    name: Supervisão online e remota
+    description: |
+      Operação de supervisão online e remota para exames online.
+  BC-4740.30:
+    name: Operações de correção e classificação
+    description: |
+      Correção de trabalhos de estudantes e cálculo de classificações, incluindo
+      dupla correção e correção anónima, e regras de agregação de notas.
+    in_scope:
+      - Aplicação de critérios de correção
+      - Dupla correção e correção anónima
+      - Agregação e cálculo de notas
+    out_of_scope:
+      - Manutenção dos registos autoritativos de notas (abrangida em Gestão de Matrículas e Registos de Estudantes)
+  BC-4740.30.10:
+    name: Aplicação de critérios de correção
+    description: |
+      Aplicação de critérios de correção e rubricas aos trabalhos de estudantes.
+  BC-4740.30.20:
+    name: Dupla correção e correção anónima
+    description: |
+      Operação de fluxos de trabalho de dupla correção e correção anónima.
+  BC-4740.30.30:
+    name: Agregação e cálculo de notas
+    description: |
+      Agregação e cálculo de componentes de notas em classificações finais.
+  BC-4740.40:
+    name: Moderação e júris de exames
+    description: |
+      Moderação interna, envolvimento de examinadores externos e tomada de decisão
+      por júris de exames sobre graus e progressão.
+    in_scope:
+      - Moderação interna
+      - Coordenação de examinadores externos
+      - Tomada de decisão pelos júris de exames
+    out_of_scope:
+      - Revisão ao nível do programa (abrangida em Gestão de Qualidade Académica e Acreditação)
+  BC-4740.40.10:
+    name: Moderação interna
+    description: |
+      Moderação interna das decisões de correção entre corretores e coortes.
+  BC-4740.40.20:
+    name: Coordenação de examinadores externos
+    description: |
+      Coordenação de examinadores externos e dos seus ciclos de reporte.
+  BC-4740.40.30:
+    name: Tomada de decisão pelos júris de exames
+    description: |
+      Tomada de decisão pelos júris de exames sobre resultados, progressão e graus.
+  BC-4740.50:
+    name: Emissão de graus e qualificações
+    description: |
+      Publicação de resultados e emissão de graus e qualificações, incluindo
+      tratamento de recursos de resultados.
+    in_scope:
+      - Publicação de resultados
+      - Emissão de certificados e diplomas
+      - Tratamento de recursos de resultados
+    out_of_scope:
+      - Credenciais digitais verificáveis (abrangidas em Gestão de Matrículas e Registos de Estudantes)
+  BC-4740.50.10:
+    name: Publicação de resultados
+    description: |
+      Publicação de resultados provisórios e ratificados aos estudantes.
+  BC-4740.50.20:
+    name: Emissão de certificados e diplomas
+    description: |
+      Emissão de certificados e diplomas que evidenciam os graus.
+  BC-4740.50.30:
+    name: Tratamento de recursos de resultados
+    description: |
+      Tratamento de recursos de estudantes face a resultados de avaliação.
+  BC-4740.60:
+    name: Gestão da integridade académica
+    description: |
+      Deteção, investigação e remediação de má conduta académica, incluindo
+      plágio e contratação de trabalhos.
+    in_scope:
+      - Deteção de plágio
+      - Investigação de má conduta
+      - Sanção e remediação
+    out_of_scope:
+      - Má conduta em investigação (abrangida em Gestão de Investigação e Bolsas de Estudo)
+  BC-4740.60.10:
+    name: Deteção de plágio
+    description: |
+      Deteção de plágio e contratação de trabalhos em trabalhos submetidos.
+  BC-4740.60.20:
+    name: Investigação de má conduta
+    description: |
+      Investigação de casos suspeitos de má conduta académica.
+  BC-4740.60.30:
+    name: Sanção e remediação
+    description: |
+      Aplicação de sanções e resultados de remediação por má conduta confirmada.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-audience-measurement-insights-management.yaml
+++ b/catalogue/i18n/pt/L1-audience-measurement-insights-management.yaml
@@ -1,0 +1,114 @@
+locale: pt
+source: L1-audience-measurement-insights-management.yaml
+entries:
+  BC-3770:
+    name: Gestão de medição de audiência e informações analíticas
+    description: |
+      Captura de telemetria de audiência, medição por painel e por censo,
+      análise de desempenho de conteúdo, modelação de recomendações e
+      investigação de audiência em serviços de conteúdo linear, a pedido
+      e ao vivo.
+  BC-3770.10:
+    name: Captura de dados de audiência
+    description: |
+      Captura de sintonização linear, telemetria de reprodução OTT e
+      sinais de censo de set-top box para a plataforma de análise.
+  BC-3770.10.10:
+    name: Captura de dados de sintonização linear
+    description: |
+      Captura de dados de sintonização linear a partir de caminhos de retorno
+      de operadores e fontes parceiras.
+  BC-3770.10.20:
+    name: Captura de telemetria de reprodução OTT
+    description: |
+      Captura de telemetria de reprodução OTT de clientes e serviços de
+      origem para análise.
+  BC-3770.10.30:
+    name: Captura de censo de set-top box
+    description: |
+      Captura ao nível de censo de eventos de visualização de set-top box
+      com controlos de privacidade aplicados.
+  BC-3770.20:
+    name: Medição de audiência por painel e censo
+    description: |
+      Calibração de painéis, produção de medição de referência e
+      deduplicação de audiência multiplataforma.
+  BC-3770.20.10:
+    name: Calibração de painel
+    description: |
+      Calibração de medição por painel contra sinais de censo e enquadramentos
+      demográficos.
+  BC-3770.20.20:
+    name: Produção de medição de referência
+    description: |
+      Produção de métricas de medição de audiência de grau de referência para
+      negociação e relatórios.
+  BC-3770.20.30:
+    name: Deduplicação de audiência multiplataforma
+    description: |
+      Deduplicação de audiências em superfícies lineares, OTT e digitais
+      para uma visão unificada multiplataforma.
+  BC-3770.30:
+    name: Análise de desempenho de conteúdo
+    description: |
+      Análise de como o conteúdo tem desempenho por título, coorte e ao
+      longo do tempo para informar encomenda e aquisição.
+  BC-3770.30.10:
+    name: Relatórios de desempenho por título
+    description: |
+      Relatórios de desempenho ao nível do título sobre alcance, conclusão
+      e contribuição.
+  BC-3770.30.20:
+    name: Análise do funil de envolvimento
+    description: |
+      Análise de funil em descoberta, início, conclusão e comportamentos
+      de visualização subsequentes.
+  BC-3770.30.30:
+    name: Análise de coorte e valor vitalício
+    description: |
+      Análise de retenção de coorte e valor vitalício para subscritores
+      diretos ao consumidor.
+  BC-3770.40:
+    name: Modelação de recomendações de conteúdo
+    description: |
+      Treino, teste e composição personalizada de recomendações de conteúdo
+      para superfícies de telespectadores.
+  BC-3770.40.10:
+    name: Treino de modelos de recomendação
+    description: |
+      Treino e ciclo de vida de modelos de recomendação contra sinais de
+      visualização e metadados.
+  BC-3770.40.20:
+    name: Gestão de testes A/B de recomendação
+    description: |
+      Testes A/B e multi-armed bandits para políticas de recomendação e
+      decisões de superfície.
+  BC-3770.40.30:
+    name: Composição de seleção personalizada
+    description: |
+      Composição de seleções personalizadas de início, linha e prateleira
+      para superfícies de telespectadores.
+  BC-3770.50:
+    name: Gestão de informações analíticas e investigação de audiência
+    description: |
+      Investigação de audiência quantitativa e qualitativa personalizada
+      e síntese e distribuição de informações analíticas para o negócio.
+  BC-3770.50.10:
+    name: Estudos de investigação de audiência personalizados
+    description: |
+      Conceção e realização de estudos de audiência personalizados, incluindo
+      trabalhos de segmentação e de acompanhamento.
+  BC-3770.50.20:
+    name: Gestão de investigação qualitativa
+    description: |
+      Investigação qualitativa com telespectadores, incluindo grupos de foco
+      e entrevistas em profundidade.
+  BC-3770.50.30:
+    name: Síntese e distribuição de informações analíticas
+    description: |
+      Síntese de resultados de medição e investigação em informações
+      analíticas e a sua distribuição para audiências de negócio.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-audience-viewer-management.yaml
+++ b/catalogue/i18n/pt/L1-audience-viewer-management.yaml
@@ -1,0 +1,115 @@
+locale: pt
+source: L1-audience-viewer-management.yaml
+entries:
+  BC-3750:
+    name: Gestão de audiência e telespectadores
+    description: |
+      Identidade do telespectador, subscrição e habilitação, autenticação
+      multi-dispositivo, envolvimento e retenção, e controlos parentais
+      para serviços de conteúdo direto ao consumidor em plataformas OTT,
+      IPTV e pay-TV.
+  BC-3750.10:
+    name: Gestão da identidade do telespectador
+    description: |
+      Provisionamento e gestão de contas de telespectadores, estruturas
+      de agregados familiares e identidade federada entre serviços.
+  BC-3750.10.10:
+    name: Provisionamento de conta de telespectador
+    description: |
+      Criação e ciclo de vida de contas de telespectadores, incluindo
+      operações de fusão e separação de contas.
+  BC-3750.10.20:
+    name: Gestão de agregado familiar e perfil
+    description: |
+      Gestão de estruturas de agregados familiares e perfis por telespectador
+      em contas partilhadas.
+  BC-3750.10.30:
+    name: Federação de identidade
+    description: |
+      Federação da identidade do telespectador com operadores, retalhistas
+      e fornecedores de identidade de terceiros.
+  BC-3750.20:
+    name: Gestão de subscrição e habilitação
+    description: |
+      Ciclo de vida das subscrições de telespectadores e dos registos de
+      habilitação que regem o acesso a serviços de conteúdo e níveis.
+  BC-3750.20.10:
+    name: Inscrição em plano de subscrição
+    description: |
+      Inscrição de telespectadores em planos de subscrição, transacionais
+      e suportados por publicidade.
+  BC-3750.20.20:
+    name: Concessão e revogação de habilitação
+    description: |
+      Concessão e revogação de habilitações de conteúdo impulsionadas por
+      subscrições, compras e pacotes de parceiros.
+  BC-3750.20.30:
+    name: Habilitação de fluxos simultâneos
+    description: |
+      Controlo impulsionado por habilitação de fluxos simultâneos e número
+      de dispositivos por conta.
+  BC-3750.30:
+    name: Autenticação multi-dispositivo
+    description: |
+      Autenticação de telespectadores no parque de dispositivos, incluindo
+      fluxos TV-Everywhere com fornecedores de identidade de operadores.
+  BC-3750.30.10:
+    name: Registo de dispositivos
+    description: |
+      Registo e cancelamento de registo de dispositivos em contas de
+      telespectadores.
+  BC-3750.30.20:
+    name: Gestão de sessões autenticadas
+    description: |
+      Gestão de sessões de reprodução autenticadas e ciclo de vida de tokens
+      em dispositivos.
+  BC-3750.30.30:
+    name: Autenticação TV-Everywhere
+    description: |
+      Autenticação de subscritores de pay-TV contra fornecedores de identidade
+      de operadores para habilitação over-the-top.
+  BC-3750.40:
+    name: Gestão do envolvimento e retenção de telespectadores
+    description: |
+      Modelação, conceção de jornadas e intervenção para aumentar o
+      envolvimento com conteúdos e reduzir a perda de subscritores em
+      serviços diretos ao consumidor.
+  BC-3750.40.10:
+    name: Modelação de hábitos de visualização
+    description: |
+      Modelação dos hábitos do telespectador, estados de visualização e
+      afinidade de conteúdo para orientar decisões de envolvimento.
+  BC-3750.40.20:
+    name: Gestão de programas de reconquista e retenção
+    description: |
+      Conceção e execução de programas de salvaguarda, reconquista e retenção
+      para telespectadores em risco e inativos.
+  BC-3750.40.30:
+    name: Gestão de jornadas de integração e ativação
+    description: |
+      Jornadas que integram novos telespectadores e impulsionam a ativação
+      na primeira visualização significativa.
+  BC-3750.50:
+    name: Gestão de controlos parentais e restrições de perfil
+    description: |
+      Configuração e aplicação de restrições de conteúdo ao nível do perfil,
+      bloqueios por PIN e limites de tempo de visualização.
+  BC-3750.50.10:
+    name: Restrição de conteúdo ao nível do perfil
+    description: |
+      Restrição por perfil de conteúdos por classificação etária, categoria
+      e listas de bloqueio personalizadas.
+  BC-3750.50.20:
+    name: Gestão de PIN e bloqueio
+    description: |
+      Gestão de PIN, bloqueio de perfil e bloqueio de compras em dispositivos
+      e superfícies.
+  BC-3750.50.30:
+    name: Configuração de limite de visualização
+    description: |
+      Configuração de limites de tempo de visualização, restrições por período
+      do dia e controlos de tempo de ecrã.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-autonomous-driving-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-autonomous-driving-operations-management.yaml
@@ -1,0 +1,163 @@
+locale: pt
+source: L1-autonomous-driving-operations-management.yaml
+entries:
+  BC-3470:
+    name: Gestão de operações de condução autónoma
+    description: |
+      Operação de frotas de condução automatizada — governação do domínio de
+      design operacional, bibliotecas de cenários, caso de segurança do ADS,
+      validação em simulação e em via pública, teleoperação e envolvimento com
+      reguladores em licenças e reporte de incidentes, ancorado na ISO 21448,
+      SAE J3016 e UN R157.
+  BC-3470.10:
+    name: Governação do domínio de design operacional
+    description: |
+      Definição, monitorização de conformidade e gestão do ciclo de vida do
+      domínio de design operacional para cada função de condução automatizada.
+  BC-3470.10.10:
+    name: Gestão da definição do ODD
+    description: |
+      Definição do domínio de design operacional, incluindo limites geográficos,
+      ambientais e comportamentais.
+  BC-3470.10.20:
+    name: Monitorização de conformidade do ODD
+    description: |
+      Monitorização da conformidade do ODD em serviço e deteção de operação
+      fora do domínio definido.
+  BC-3470.10.30:
+    name: Gestão de atualizações dos limites do ODD
+    description: |
+      Gestão de expansões e restrições do ODD ao longo do ciclo de vida,
+      incluindo aprovação e implementação.
+  BC-3470.20:
+    name: Gestão do catálogo de cenários e testes de condução
+    description: |
+      Curadoria da biblioteca de cenários de condução e catálogo de testes
+      utilizados para design, simulação e validação de sistemas de condução
+      automatizada.
+  BC-3470.20.10:
+    name: Curadoria da biblioteca de cenários
+    description: |
+      Curadoria de bibliotecas de cenários estruturados utilizados para design
+      e validação de ADS.
+  BC-3470.20.20:
+    name: Captura e triagem de casos extremos
+    description: |
+      Captura, triagem e priorização de casos extremos observados em simulação,
+      frotas de teste e em serviço.
+  BC-3470.20.30:
+    name: Reporte de cobertura de cenários
+    description: |
+      Reporte de cobertura de cenários e lacunas residuais face aos requisitos
+      do ODD.
+  BC-3470.30:
+    name: Operações de frota autónoma
+    description: |
+      Operações diárias de frotas de condução automatizada de teste, piloto e
+      comerciais, incluindo despacho, saúde e rotação.
+    in_scope:
+      - Despacho e encaminhamento de veículos autónomos
+      - Monitorização da saúde da frota e telemetria de referência
+      - Coordenação de carregamento, limpeza e rotação
+    out_of_scope:
+      - Reservas e preçário orientados para passageiros de serviços de mobilidade partilhada (BC-3490)
+      - Engenharia de veículos e desenvolvimento de software (BC-3400)
+  BC-3470.30.10:
+    name: Operações de despacho de veículos autónomos
+    description: |
+      Despacho e encaminhamento de veículos autónomos para missões de teste,
+      piloto e comerciais.
+  BC-3470.30.20:
+    name: Monitorização da saúde da frota autónoma
+    description: |
+      Monitorização em tempo real da saúde de frotas autónomas, incluindo
+      calibração de sensores e estado do software.
+  BC-3470.30.30:
+    name: Coordenação de carregamento e limpeza de veículos autónomos
+    description: |
+      Coordenação de atividades de carregamento, limpeza e rotação de frotas
+      autónomas em depósitos.
+  BC-3470.40:
+    name: Operações remotas e teleassistência
+    description: |
+      Operação de centros de teleassistência que prestam suporte remoto e
+      intervenção autorizada para frotas de condução automatizada.
+  BC-3470.40.10:
+    name: Operações do centro de teleassistência
+    description: |
+      Operação de centros de teleassistência remota, incluindo gestão de turnos
+      e vias de escalada.
+  BC-3470.40.20:
+    name: Gestão de decisões de intervenção remota
+    description: |
+      Quadros de decisão e autorização para intervenções remotas que variam de
+      aconselhamento a controlo direto do veículo.
+  BC-3470.40.30:
+    name: Gestão da força de trabalho de teleoperadores
+    description: |
+      Recrutamento, formação, certificação e gestão do desempenho da força de
+      trabalho de teleoperadores.
+  BC-3470.50:
+    name: Gestão do caso de segurança e garantia
+    description: |
+      Manutenção do caso de segurança operacional do ADS e dos indicadores que
+      monitorizam a sua validade contínua.
+  BC-3470.50.10:
+    name: Elaboração do caso de segurança
+    description: |
+      Elaboração do caso de segurança estruturado do ADS, incluindo afirmações,
+      argumentos e evidências.
+  BC-3470.50.20:
+    name: Manutenção dos argumentos de segurança
+    description: |
+      Manutenção dos argumentos de segurança à medida que o sistema, o ODD e o
+      contexto operacional evoluem.
+  BC-3470.50.30:
+    name: Acompanhamento de indicadores de desempenho de segurança
+    description: |
+      Definição e acompanhamento de indicadores de desempenho de segurança
+      antecipados e atrasados para a frota implementada.
+  BC-3470.60:
+    name: Operações de validação de condução autónoma
+    description: |
+      Operação das campanhas de validação — simulação, circuito fechado e via
+      pública — que fornecem evidências para o caso de segurança.
+  BC-3470.60.10:
+    name: Operações de validação baseada em simulação
+    description: |
+      Operação de plataformas de simulação de grande escala e regressão de
+      cenários para validação de ADS.
+  BC-3470.60.20:
+    name: Operações de validação em circuito fechado
+    description: |
+      Operação de programas de teste em circuito fechado e campanhas em pista de
+      ensaio para validação de ADS.
+  BC-3470.60.30:
+    name: Operações de ensaios em via pública
+    description: |
+      Operação de ensaios supervisionados em via pública, incluindo disciplina
+      de condutor de segurança e gestão de incidentes.
+  BC-3470.70:
+    name: Envolvimento regulatório do ADS
+    description: |
+      Envolvimento com reguladores e o público sobre autorizações de condução
+      automatizada, reporte de incidentes e criação de confiança.
+  BC-3470.70.10:
+    name: Gestão de licenças e autorizações do ADS
+    description: |
+      Gestão de licenças, isenções e autorizações para implementação de ADS em
+      cada jurisdição.
+  BC-3470.70.20:
+    name: Reporte de incidentes a reguladores
+    description: |
+      Reporte de incidentes e desativações do ADS a reguladores e coordenação
+      com investigações.
+  BC-3470.70.30:
+    name: Envolvimento público e de partes interessadas
+    description: |
+      Envolvimento com cidades, comunidades e partes interessadas sobre a
+      implementação, segurança e benefícios do ADS.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-aviation-safety-management.yaml
+++ b/catalogue/i18n/pt/L1-aviation-safety-management.yaml
@@ -1,0 +1,115 @@
+locale: pt
+source: L1-aviation-safety-management.yaml
+entries:
+  BC-1280:
+    name: Gestão da segurança da aviação
+    description: |
+      Sistema de gestão de segurança, avaliação de risco, cultura justa e investigação de ocorrências.
+  BC-1280.10:
+    name: Gestão do sistema de gestão de segurança
+    description: |
+      Quadro SMS, política de segurança, objetivos de segurança e governação de segurança.
+  BC-1280.10.10:
+    name: Política e objetivos de segurança
+    description: |
+      Definição da política de segurança e objetivos de segurança.
+  BC-1280.10.20:
+    name: Gestão do quadro SMS
+    description: |
+      Manutenção do quadro SMS segundo o Anexo 19 da OACI.
+  BC-1280.10.30:
+    name: Governação e responsabilização de segurança
+    description: |
+      Comités de revisão de segurança e disposições do gestor responsável.
+  BC-1280.10.40:
+    name: Gestão de recursos de segurança
+    description: |
+      Alocação de recursos à função de segurança.
+  BC-1280.20:
+    name: Gestão da avaliação do risco de segurança
+    description: |
+      Identificação de perigos, avaliação de risco e mitigação de risco.
+  BC-1280.20.10:
+    name: Identificação de perigos
+    description: |
+      Identificação proativa e reativa de perigos.
+  BC-1280.20.20:
+    name: Avaliação do risco de segurança
+    description: |
+      Avaliação da probabilidade e gravidade dos riscos de segurança.
+  BC-1280.20.30:
+    name: Mitigação do risco de segurança
+    description: |
+      Definição e acompanhamento de ações de mitigação do risco de segurança.
+  BC-1280.20.40:
+    name: Avaliação de segurança de alterações
+    description: |
+      Avaliação de segurança de alterações operacionais e técnicas.
+  BC-1280.30:
+    name: Gestão de cultura justa e reporte
+    description: |
+      Reporte confidencial, cultura justa e reporte voluntário de ocorrências.
+  BC-1280.30.10:
+    name: Programa de cultura justa
+    description: |
+      Programa de cultura justa e proteções para os reportantes.
+  BC-1280.30.20:
+    name: Reporte voluntário de ocorrências
+    description: |
+      Canais de reporte voluntário e confidencial de ocorrências.
+  BC-1280.30.30:
+    name: Reporte obrigatório de ocorrências
+    description: |
+      Reporte obrigatório de ocorrências aos reguladores.
+  BC-1280.40:
+    name: Gestão de investigação de ocorrências
+    description: |
+      Investigações internas, análise de causa raiz e lições aprendidas.
+  BC-1280.40.10:
+    name: Investigação interna de ocorrências
+    description: |
+      Investigação interna de ocorrências de segurança.
+  BC-1280.40.20:
+    name: Análise de causa raiz
+    description: |
+      Análise de causa raiz de ocorrências e fatores contribuintes.
+  BC-1280.40.30:
+    name: Lições aprendidas de investigação
+    description: |
+      Captura e disseminação de lições aprendidas de segurança.
+  BC-1280.50:
+    name: Gestão da monitorização do desempenho de segurança
+    description: |
+      SPIs, SPTs, dashboards de desempenho de segurança e relatório ao regulador.
+  BC-1280.50.10:
+    name: Gestão de indicadores de desempenho de segurança
+    description: |
+      Definição e acompanhamento de SPIs e SPTs.
+  BC-1280.50.20:
+    name: Análise de tendências de segurança
+    description: |
+      Análise de tendências de ocorrências e desempenho de SPI.
+  BC-1280.50.30:
+    name: Relatório de segurança ao regulador
+    description: |
+      Relatório periódico de desempenho de segurança à autoridade de aviação civil.
+  BC-1280.60:
+    name: Gestão da promoção da segurança
+    description: |
+      Programas de cultura de segurança, formação, sensibilização e comunicações.
+  BC-1280.60.10:
+    name: Programa de cultura de segurança
+    description: |
+      Inquéritos de cultura de segurança e programas de melhoria.
+  BC-1280.60.20:
+    name: Entrega de formação em segurança
+    description: |
+      Entrega de formação em segurança e formação SMS recorrente.
+  BC-1280.60.30:
+    name: Comunicação de segurança
+    description: |
+      Comunicações de segurança, boletins e campanhas de sensibilização.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-banking-customer-management.yaml
+++ b/catalogue/i18n/pt/L1-banking-customer-management.yaml
@@ -1,0 +1,119 @@
+locale: pt
+source: L1-banking-customer-management.yaml
+entries:
+  BC-1300:
+    name: Gestão de clientes bancários
+    description: |
+      Integração de clientes, KYC/CDD, atendimento e acesso a canais para clientes bancários.
+  BC-1300.10:
+    name: Gestão de integração de clientes
+    description: |
+      Abertura de contas, verificação de identidade, ativação de conta.
+  BC-1300.10.10:
+    name: Recolha de candidatura
+    description: |
+      Recolha de dados de candidatura de novos clientes e contas.
+  BC-1300.10.20:
+    name: Verificação de identidade
+    description: |
+      Verificação de identidade incluindo controlos documentais e biométricos.
+  BC-1300.10.30:
+    name: Configuração e ativação de conta
+    description: |
+      Configuração de contas, produtos e ativação do acesso a canais.
+  BC-1300.10.40:
+    name: Comunicação do estado de integração
+    description: |
+      Comunicação ao cliente sobre o estado de integração e próximos passos.
+  BC-1300.20:
+    name: Gestão de KYC e diligência devida de clientes
+    description: |
+      KYC, CDD, EDD, revisão periódica, rastreio de PEPs.
+  BC-1300.20.10:
+    name: Classificação de risco de cliente
+    description: |
+      Classificação de risco de clientes com base em fatores de risco AML.
+  BC-1300.20.20:
+    name: Recolha de documentação KYC
+    description: |
+      Recolha e validação de documentação KYC.
+  BC-1300.20.30:
+    name: Rastreio de sanções e PEPs
+    description: |
+      Rastreio de sanções, PEPs e média adversa.
+  BC-1300.20.40:
+    name: Diligência devida reforçada
+    description: |
+      EDD para clientes de alto risco e estruturas complexas.
+  BC-1300.20.50:
+    name: Revisão periódica de KYC
+    description: |
+      Revisão e atualização periódica da informação KYC dos clientes.
+  BC-1300.30:
+    name: Gestão do atendimento ao cliente
+    description: |
+      Pedidos de atendimento quotidianos, manutenção de contas.
+  BC-1300.30.10:
+    name: Manutenção de conta
+    description: |
+      Manutenção de contas incluindo limites, signatários e endereços.
+  BC-1300.30.20:
+    name: Tratamento de pedidos de serviço
+    description: |
+      Tratamento de pedidos de serviço e instruções de clientes.
+  BC-1300.30.30:
+    name: Fornecimento de extratos e documentos
+    description: |
+      Fornecimento de extratos, certificados e documentos de clientes.
+  BC-1300.30.40:
+    name: Gestão de encerramento de cliente
+    description: |
+      Desvinculação de clientes e encerramento de relações com clientes.
+  BC-1300.40:
+    name: Gestão de informação de clientes
+    description: |
+      Dados, consentimentos, preferências e registo mestre de clientes.
+  BC-1300.40.10:
+    name: Manutenção do perfil de cliente
+    description: |
+      Manutenção do perfil de cliente e dados demográficos.
+  BC-1300.40.20:
+    name: Gestão de beneficiário efetivo
+    description: |
+      Recolha e manutenção de informação sobre beneficiário efetivo.
+  BC-1300.40.30:
+    name: Gestão de consentimentos de cliente
+    description: |
+      Recolha e aplicação de consentimentos de marketing e partilha de dados.
+  BC-1300.40.40:
+    name: Gestão do registo mestre de cliente
+    description: |
+      Manutenção do registo mestre de cliente entre sistemas.
+  BC-1300.50:
+    name: Gestão de canais bancários
+    description: |
+      Operações de canais de balcão, ATM, online, móvel e telefónico.
+  BC-1300.50.10:
+    name: Operações do canal de balcão
+    description: |
+      Operação do canal de balcão físico e serviços de caixa.
+  BC-1300.50.20:
+    name: Operações de ATM e autoatendimento
+    description: |
+      Operação do parque de ATMs, quiosques e dispositivos de autoatendimento.
+  BC-1300.50.30:
+    name: Operações do canal digital
+    description: |
+      Operação dos canais de banca online e móvel.
+  BC-1300.50.40:
+    name: Operações do canal telefónico
+    description: |
+      Operação dos canais de banca telefónica e autenticação por voz.
+  BC-1300.50.50:
+    name: Operações de banca aberta e canal API
+    description: |
+      Operação de APIs de banca aberta e acesso de terceiros.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-banking-product-management.yaml
+++ b/catalogue/i18n/pt/L1-banking-product-management.yaml
@@ -1,0 +1,99 @@
+locale: pt
+source: L1-banking-product-management.yaml
+entries:
+  BC-1310:
+    name: Gestão de produtos bancários
+    description: |
+      Fábrica de produtos bancários — catálogo, parâmetros, preços e ciclo de vida.
+  BC-1310.10:
+    name: Gestão do catálogo de produtos
+    description: |
+      Catálogo de produtos bancários e dados mestre de produtos.
+  BC-1310.10.10:
+    name: Gestão de dados mestre de produtos
+    description: |
+      Manutenção de dados mestre de produtos e hierarquias de produtos.
+  BC-1310.10.20:
+    name: Publicação do catálogo de produtos
+    description: |
+      Publicação do catálogo de produtos em canais e parceiros.
+  BC-1310.10.30:
+    name: Gestão de divulgação de produtos
+    description: |
+      Produção e manutenção de documentos de divulgação de produtos.
+  BC-1310.20:
+    name: Gestão de parâmetros e configuração de produtos
+    description: |
+      Taxas, comissões, limites, regras de elegibilidade e parâmetros de produtos.
+  BC-1310.20.10:
+    name: Configuração de taxas de produto
+    description: |
+      Configuração de taxas de juro e tabelas de taxas.
+  BC-1310.20.20:
+    name: Configuração de comissões de produto
+    description: |
+      Configuração de comissões e isenções de produtos.
+  BC-1310.20.30:
+    name: Configuração de limites de produto
+    description: |
+      Configuração de limites de transação e de produto.
+  BC-1310.20.40:
+    name: Configuração de regras de elegibilidade de produto
+    description: |
+      Configuração de regras de elegibilidade e qualificação.
+  BC-1310.30:
+    name: Gestão de preços de produtos bancários
+    description: |
+      Preços de produtos, promoções, preços específicos por cliente.
+  BC-1310.30.10:
+    name: Preços padrão de produto
+    description: |
+      Preços padrão de produtos e serviços bancários.
+  BC-1310.30.20:
+    name: Preços promocionais
+    description: |
+      Campanhas de preços promocionais e ofertas por tempo limitado.
+  BC-1310.30.30:
+    name: Preços específicos por cliente e relacionamento
+    description: |
+      Preços específicos por cliente e baseados em relacionamento.
+  BC-1310.40:
+    name: Gestão de pacotes de produtos
+    description: |
+      Pacotes, conjuntos e preços por relacionamento.
+  BC-1310.40.10:
+    name: Definição de pacotes
+    description: |
+      Definição de pacotes de produtos, conjuntos e regras.
+  BC-1310.40.20:
+    name: Gestão de elegibilidade de pacotes
+    description: |
+      Regras de elegibilidade e critérios de qualificação para pacotes.
+  BC-1310.40.30:
+    name: Acompanhamento do desempenho de pacotes
+    description: |
+      Acompanhamento da adesão a pacotes e respetiva economia.
+  BC-1310.50:
+    name: Gestão do ciclo de vida de produtos bancários
+    description: |
+      Introdução de novos produtos, retirada e descontinuação.
+  BC-1310.50.10:
+    name: Aprovação de novos produtos
+    description: |
+      Processo de aprovação de novos produtos e governação do comité de produtos.
+  BC-1310.50.20:
+    name: Execução do lançamento de produto
+    description: |
+      Execução do lançamento de produto e prontidão de canais.
+  BC-1310.50.30:
+    name: Revisão do desempenho de produto
+    description: |
+      Revisões periódicas do desempenho e relação qualidade-preço dos produtos.
+  BC-1310.50.40:
+    name: Retirada e migração de produto
+    description: |
+      Retirada de produto e migração de clientes para produtos sucessores.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-banking-risk-management.yaml
+++ b/catalogue/i18n/pt/L1-banking-risk-management.yaml
@@ -1,0 +1,127 @@
+locale: pt
+source: L1-banking-risk-management.yaml
+entries:
+  BC-1410:
+    name: Gestão de risco bancário
+    description: |
+      Tipos de risco específicos da banca — crédito, mercado, liquidez, modelo e risco de crédito de contraparte.
+  BC-1410.10:
+    name: Gestão do risco de crédito bancário
+    description: |
+      Frameworks de risco de crédito, RWA e testes de esforço.
+  BC-1410.10.10:
+    name: Framework de risco de crédito
+    description: |
+      Definição do framework e políticas de risco de crédito.
+  BC-1410.10.20:
+    name: Cálculo e reporte de RWA
+    description: |
+      Cálculo e reporte de RWA pelo método standard e IRB.
+  BC-1410.10.30:
+    name: Testes de esforço de crédito
+    description: |
+      Testes de esforço de risco de crédito e análise de cenários.
+  BC-1410.10.40:
+    name: Gestão do risco de concentração
+    description: |
+      Gestão do risco de concentração por nome, setor e país.
+  BC-1410.20:
+    name: Gestão do risco de mercado
+    description: |
+      VaR, sensibilidades, limites de risco de mercado e FRTB.
+  BC-1410.20.10:
+    name: Medição do risco de mercado
+    description: |
+      Medição de VaR, ES e sensibilidades do livro de negociação.
+  BC-1410.20.20:
+    name: Gestão de limites de risco de mercado
+    description: |
+      Definição e monitorização de limites de risco de mercado.
+  BC-1410.20.30:
+    name: Testes de esforço de risco de mercado
+    description: |
+      Testes de esforço e de cenários de risco de mercado.
+  BC-1410.20.40:
+    name: Gestão da implementação do FRTB
+    description: |
+      Implementação e operação do FRTB SA e IMA.
+  BC-1410.30:
+    name: Gestão do risco operacional bancário
+    description: |
+      Frameworks de risco operacional, RCSA e dados de perdas.
+  BC-1410.30.10:
+    name: Framework de risco operacional
+    description: |
+      Framework, taxonomia e política de risco operacional.
+  BC-1410.30.20:
+    name: Autoavaliação de riscos e controlos
+    description: |
+      Execução de RCSA e atualização do perfil de risco.
+  BC-1410.30.30:
+    name: Registo de eventos de perda por risco operacional
+    description: |
+      Registo e classificação de eventos de perda por risco operacional.
+  BC-1410.30.40:
+    name: Gestão de indicadores-chave de risco operacional
+    description: |
+      Definição, limiares e monitorização de KRIs.
+  BC-1410.40:
+    name: Gestão do risco de liquidez
+    description: |
+      Frameworks de risco de liquidez, testes de esforço e plano de contingência de financiamento.
+  BC-1410.40.10:
+    name: Framework de risco de liquidez
+    description: |
+      Framework, apetite e política de risco de liquidez.
+  BC-1410.40.20:
+    name: Testes de esforço de liquidez
+    description: |
+      Testes de esforço e testes de esforço inverso específicos de liquidez.
+  BC-1410.40.30:
+    name: Gestão do plano de contingência de financiamento
+    description: |
+      Manutenção e teste do plano de contingência de financiamento.
+  BC-1410.50:
+    name: Gestão do risco de modelos
+    description: |
+      Validação de modelos, governação de modelos e inventário de modelos.
+  BC-1410.50.10:
+    name: Gestão do inventário de modelos
+    description: |
+      Manutenção do inventário de modelos da empresa.
+  BC-1410.50.20:
+    name: Classificação de risco de modelos
+    description: |
+      Classificação de modelos por risco para orientação da governação.
+  BC-1410.50.30:
+    name: Validação independente de modelos
+    description: |
+      Validação independente de modelos conforme SR 11-7 / TRIM.
+  BC-1410.50.40:
+    name: Monitorização do desempenho de modelos
+    description: |
+      Monitorização contínua do desempenho e recalibração de modelos.
+  BC-1410.60:
+    name: Gestão do risco de crédito de contraparte
+    description: |
+      CCR, CVA e exposição a contrapartes em derivados.
+  BC-1410.60.10:
+    name: Medição da exposição a contrapartes
+    description: |
+      Medição da exposição a contrapartes (PFE, EEPE).
+  BC-1410.60.20:
+    name: Gestão de CVA e XVA
+    description: |
+      Gestão de CVA, DVA, FVA e outros XVA.
+  BC-1410.60.30:
+    name: Gestão de limites de contraparte
+    description: |
+      Definição e monitorização de limites de contraparte.
+  BC-1410.60.40:
+    name: Gestão do risco de correlação adversa
+    description: |
+      Identificação e gestão do risco de correlação adversa específico e geral.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-border-immigration-management.yaml
+++ b/catalogue/i18n/pt/L1-border-immigration-management.yaml
@@ -1,0 +1,149 @@
+locale: pt
+source: L1-border-immigration-management.yaml
+entries:
+  BC-3300:
+    name: Gestão de fronteiras e imigração
+    description: |
+      Controlo de fronteiras de pessoas, autorização de vistos e viagem, determinação
+      do estatuto de refugiado e asilo, administração do estatuto e residência de
+      imigrantes, naturalização e operações de afastamento.
+  BC-3300.10:
+    name: Gestão de vistos e autorizações de viagem
+    description: |
+      Processamento de candidaturas, decisão e emissão de vistos e autorizações de
+      viagem, incluindo pré-autorização do tipo ATV.
+    in_scope:
+      - Processamento e decisão de pedidos de visto
+      - Autorização eletrónica de viagem
+      - Triagem de fraude de vistos
+    out_of_scope:
+      - Alfândega e conformidade de mercadorias (coberta pela Gestão de Conformidade Aduaneira e Comercial)
+  BC-3300.10.10:
+    name: Processamento de pedidos de visto
+    description: |
+      Receção, validação e processamento de pedidos de visto por categorias.
+  BC-3300.10.20:
+    name: Decisão sobre vistos
+    description: |
+      Decisão sobre pedidos de visto, incluindo recusa e condicionantes.
+  BC-3300.10.30:
+    name: Autorização eletrónica de viagem
+    description: |
+      Emissão e revogação de autorização eletrónica de viagem (tipo ATV)
+      antes da viagem.
+  BC-3300.10.40:
+    name: Triagem de fraude de vistos
+    description: |
+      Triagem de candidaturas quanto a fraude, adulteração de documentos e
+      anomalias em documentos de identidade.
+  BC-3300.20:
+    name: Inspeção e admissão na fronteira
+    description: |
+      Inspeção e admissão de viajantes nos postos de entrada, incluindo inspeção
+      primária e secundária.
+  BC-3300.20.10:
+    name: Processamento de informação antecipada sobre passageiros
+    description: |
+      Processamento de dados API e PNR antes da chegada do viajante.
+  BC-3300.20.20:
+    name: Inspeção primária
+    description: |
+      Inspeção primária nos postos de entrada, incluindo verificação biométrica.
+  BC-3300.20.30:
+    name: Inspeção secundária
+    description: |
+      Inspeção secundária de viajantes que requerem exame adicional.
+  BC-3300.20.40:
+    name: Decisão de admissão e recusa
+    description: |
+      Decisão sobre admissão, recusa e condições de entrada.
+  BC-3300.30:
+    name: Determinação do estatuto de asilo e refugiado
+    description: |
+      Receção, análise e determinação de pedidos de asilo ao abrigo da Convenção
+      de Refugiados de 1951 e regimes nacionais de proteção.
+  BC-3300.30.10:
+    name: Receção de pedidos de asilo
+    description: |
+      Receção e registo de pedidos de asilo na fronteira e em território nacional.
+  BC-3300.30.20:
+    name: Determinação do estatuto de refugiado
+    description: |
+      Apreciação do estatuto de refugiado ao abrigo da Convenção de 1951 e
+      proteção complementar.
+  BC-3300.30.30:
+    name: Coordenação de acolhimento e apoio a requerentes de asilo
+    description: |
+      Coordenação do acolhimento, alojamento e apoio básico a requerentes de asilo.
+  BC-3300.30.40:
+    name: Programas de reinstalação e vias humanitárias
+    description: |
+      Operação de programas de reinstalação e admissão humanitária.
+  BC-3300.40:
+    name: Gestão do estatuto e residência de imigrantes
+    description: |
+      Administração do estatuto de imigração em território nacional, incluindo
+      autorizações de residência, autorizações de trabalho e processos de
+      reagrupamento familiar.
+  BC-3300.40.10:
+    name: Administração de autorizações de residência
+    description: |
+      Emissão e renovação de autorizações de residência e cartões de residência
+      biométricos.
+  BC-3300.40.20:
+    name: Administração de autorizações de trabalho
+    description: |
+      Administração de autorizações de trabalho, licenças de patrocínio e testes
+      ao mercado de trabalho.
+  BC-3300.40.30:
+    name: Processamento de reagrupamento familiar
+    description: |
+      Processamento de pedidos de reagrupamento familiar e de dependentes.
+  BC-3300.40.40:
+    name: Monitorização da conformidade do estatuto
+    description: |
+      Monitorização do cumprimento das condições de imigração e alterações de
+      estatuto.
+  BC-3300.50:
+    name: Gestão de naturalização e cidadania
+    description: |
+      Apreciação de pedidos de naturalização, aquisição de cidadania por
+      descendência ou registo e processos de privação de cidadania.
+  BC-3300.50.10:
+    name: Processamento de pedidos de naturalização
+    description: |
+      Processamento de pedidos de naturalização e avaliações de idoneidade.
+  BC-3300.50.20:
+    name: Cidadania por descendência e registo
+    description: |
+      Determinação da cidadania por descendência, registo e adoção.
+  BC-3300.50.30:
+    name: Administração de cerimónias e juramentos de cidadania
+    description: |
+      Administração de cerimónias de cidadania e juramentos de fidelidade.
+  BC-3300.50.40:
+    name: Tratamento de privação de cidadania
+    description: |
+      Apreciação de processos de privação, renúncia e revogação de cidadania.
+  BC-3300.60:
+    name: Gestão de afastamento e detenção
+    description: |
+      Operações de detenção, afastamento e regresso voluntário de pessoas sem
+      estatuto de imigração regular.
+  BC-3300.60.10:
+    name: Operações de detenção de imigrantes
+    description: |
+      Operação de centros de detenção de imigrantes e normas de bem-estar.
+  BC-3300.60.20:
+    name: Execução de ordens de afastamento
+    description: |
+      Execução de ordens de afastamento e deportação, incluindo afastamentos
+      acompanhados.
+  BC-3300.60.30:
+    name: Operações de programa de regresso voluntário
+    description: |
+      Coordenação de programas de regresso voluntário assistido e reintegração.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-building-automation-system-engineering-management.yaml
+++ b/catalogue/i18n/pt/L1-building-automation-system-engineering-management.yaml
@@ -1,0 +1,195 @@
+locale: pt
+source: L1-building-automation-system-engineering-management.yaml
+entries:
+  BC-2010:
+    name: Gestão de engenharia de sistema de automação predial
+    description: |
+      Engenharia de produto de controladores BAS, dispositivos de campo, software de supervisão,
+      bibliotecas reutilizáveis de sequências de controlo, pilhas de protocolos de comunicação, modelos
+      semânticos de dados e cibersegurança BAS — ancorada em ISO 16484/ASHRAE 135 (BACnet)
+      e ASHRAE Guideline 36.
+  BC-2010.10:
+    name: Engenharia de produto de controlador BAS
+    description: |
+      Engenharia de produtos de controlador predial específicos para aplicação — controladores de zona, UTA, central,
+      programáveis e gateways edge.
+  BC-2010.10.10:
+    name: Engenharia de controlador de zona
+    description: |
+      Engenharia de controladores ao nível da zona para controlo VAV, ventiloconvetor e unitário.
+  BC-2010.10.20:
+    name: Engenharia de controlador de UTA
+    description: |
+      Engenharia de controladores de unidade de tratamento de ar com suporte de sequência integrado.
+  BC-2010.10.30:
+    name: Engenharia de controlador de central
+    description: |
+      Engenharia de controladores de central para plantas de chillers e caldeiras.
+  BC-2010.10.40:
+    name: Engenharia de controlador programável
+    description: |
+      Engenharia de controladores BAS livremente programáveis.
+  BC-2010.10.50:
+    name: Engenharia de gateway edge
+    description: |
+      Engenharia de gateways edge que traduzem entre BAS e plataformas IoT/cloud.
+  BC-2010.20:
+    name: Engenharia de dispositivos de campo BAS
+    description: |
+      Engenharia de sensores, válvulas, registos e dispositivos de campo sem fios que reportam para BAS.
+  BC-2010.20.10:
+    name: Engenharia de produto sensor
+    description: |
+      Engenharia de sensores de temperatura, humidade, pressão, CO2 e qualidade do ar interior como dispositivos BAS.
+  BC-2010.20.20:
+    name: Engenharia de válvulas e atuadores
+    description: |
+      Engenharia de válvulas de controlo e atuadores de válvula para sistemas hídricos.
+  BC-2010.20.30:
+    name: Engenharia de atuadores de registo
+    description: |
+      Engenharia de atuadores de registo para controlo do lado do ar no BAS.
+  BC-2010.20.40:
+    name: Engenharia de dispositivos de campo sem fios
+    description: |
+      Engenharia de sensores e atuadores sem fios para aplicações de retrofit e IoT.
+  BC-2010.30:
+    name: Engenharia de software de supervisão BAS
+    description: |
+      Engenharia de servidores de supervisão, interfaces do operador, motores de alarme e historiadores.
+  BC-2010.30.10:
+    name: Engenharia de servidor de supervisão
+    description: |
+      Engenharia de servidores de supervisão de topo de rede que gerem redes de controladores.
+  BC-2010.30.20:
+    name: Engenharia de interface do operador
+    description: |
+      Engenharia de interfaces gráficas do operador e painéis de controlo.
+  BC-2010.30.30:
+    name: Engenharia de motor de alarmes e eventos
+    description: |
+      Engenharia de motores de processamento, priorização e notificação de alarmes.
+  BC-2010.30.40:
+    name: Engenharia de tendências e historiador
+    description: |
+      Engenharia de subsistemas de registo de tendências e historiador de séries temporais.
+  BC-2010.40:
+    name: Engenharia de biblioteca de sequências de controlo
+    description: |
+      Engenharia de bibliotecas reutilizáveis e independentes de fornecedor de sequências de operação para subsistemas HVAC.
+  BC-2010.40.10:
+    name: Biblioteca de sequências VAV
+    description: |
+      Sequências reutilizáveis para controlo de zona de volume de ar variável.
+  BC-2010.40.20:
+    name: Biblioteca de sequências de UTA
+    description: |
+      Sequências reutilizáveis para controlo de unidade de tratamento de ar.
+  BC-2010.40.30:
+    name: Biblioteca de sequências de central
+    description: |
+      Sequências reutilizáveis para controlo de plantas de chillers e caldeiras.
+  BC-2010.40.40:
+    name: Biblioteca de sequências de controlo avançado
+    description: |
+      Sequências reutilizáveis para controlo baseado em modelo preditivo e em otimização.
+  BC-2010.50:
+    name: Engenharia de protocolo de comunicação BAS
+    description: |
+      Engenharia de pilhas de protocolos de comunicação de automação predial e drivers.
+  BC-2010.50.10:
+    name: Engenharia de pilha BACnet
+    description: |
+      Engenharia de pilhas de protocolo BACnet/IP e BACnet/MSTP.
+  BC-2010.50.20:
+    name: Engenharia de pilhas KNX e LonWorks
+    description: |
+      Engenharia de pilhas de protocolo KNX e LonWorks.
+  BC-2010.50.30:
+    name: Engenharia de drivers Modbus e DALI
+    description: |
+      Engenharia de drivers Modbus e DALI para integração HVAC e de iluminação.
+  BC-2010.50.40:
+    name: Engenharia de servidor OPC UA
+    description: |
+      Engenharia de servidores OPC UA para interoperabilidade BAS de grau industrial.
+  BC-2010.50.50:
+    name: Engenharia de mensagens MQTT e IoT
+    description: |
+      Engenharia de interfaces de mensagens MQTT e IoT para conectividade cloud.
+  BC-2010.60:
+    name: Engenharia do modelo semântico de dados predial
+    description: |
+      Engenharia de modelos semânticos, ontologias e convenções de nomenclatura utilizados para tornar os dados BAS interpretáveis por máquina.
+  BC-2010.60.10:
+    name: Modelação Brick Schema
+    description: |
+      Engenharia de modelos Brick Schema descrevendo a topologia predial e equipamentos.
+  BC-2010.60.20:
+    name: Engenharia de biblioteca de tags Haystack
+    description: |
+      Engenharia de bibliotecas de tags Haystack e convenções de etiquetagem.
+  BC-2010.60.30:
+    name: Biblioteca de pontos e convenção de nomenclatura
+    description: |
+      Manutenção de bibliotecas de convenções de nomenclatura de pontos e tags.
+  BC-2010.60.40:
+    name: Engenharia de ontologia de ativos
+    description: |
+      Engenharia de ontologias de ativos ligando dados BAS a equipamentos e localizações.
+  BC-2010.70:
+    name: Engenharia de cibersegurança BAS
+    description: |
+      Engenharia de segurança por conceção de produtos, redes e controlos de identidade BAS.
+  BC-2010.70.10:
+    name: Arquitetura de controlador seguro
+    description: |
+      Arranque seguro, atualização segura e arquitetura de controlador reforçada.
+  BC-2010.70.20:
+    name: Projeto de segmentação de rede BAS
+    description: |
+      Padrões de segmentação e zoneamento de redes BAS.
+  BC-2010.70.30:
+    name: Engenharia de autenticação e identidade
+    description: |
+      Engenharia de identidade de dispositivo, utilizador e serviço para BAS.
+  BC-2010.70.40:
+    name: Engenharia de gestão de vulnerabilidades BAS
+    description: |
+      Engenharia de triagem de vulnerabilidades de produto, aplicação de correções e divulgação para produtos BAS.
+  BC-2010.80:
+    name: Verificação e conformidade de produto BAS
+    description: |
+      Verificação de produtos BAS para conformidade de protocolo, interoperabilidade e prontidão para listagem.
+  BC-2010.80.10:
+    name: Teste de conformidade de protocolo
+    description: |
+      Teste de produtos face a suites de conformidade BACnet, LonMark, KNX e outros protocolos.
+  BC-2010.80.20:
+    name: Teste de interoperabilidade em laboratório
+    description: |
+      Teste de interoperabilidade multi-fornecedor em laboratórios dedicados.
+  BC-2010.80.30:
+    name: Teste de regressão de protocolo
+    description: |
+      Teste de regressão de pilhas de protocolo entre revisões de firmware.
+  BC-2010.80.40:
+    name: Documentação de conformidade
+    description: |
+      Elaboração de PICS, BIBB e documentação de conformidade equivalente.
+  in_scope:
+    - Engenharia de produto de controlador BAS e dispositivo de campo específico para aplicação
+    - Engenharia de software de servidor de supervisão, alarme e historiador de tendências
+    - Bibliotecas reutilizáveis de sequências de operação (Guideline 36 e controlo avançado)
+    - Pilhas de protocolo BACnet, KNX, LonWorks, Modbus, DALI, OPC UA, MQTT
+    - Modelação semântica de dados Brick/Haystack
+    - Controladores BAS seguros por conceção e cibersegurança de rede BAS
+  out_of_scope:
+    - Engenharia de produto eletrónico genérico coberta por BC-1900
+    - Listas de pontos e personalização de sequências ao nível do projeto (BC-2020)
+    - Engenharia de equipamento mecânico HVAC (BC-2000)
+    - Colocação em serviço no local e operações de serviço (BC-2050, BC-2060)
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-building-automation-system-engineering-management.yaml
+++ b/catalogue/i18n/pt/L1-building-automation-system-engineering-management.yaml
@@ -8,6 +8,18 @@ entries:
       bibliotecas reutilizáveis de sequências de controlo, pilhas de protocolos de comunicação, modelos
       semânticos de dados e cibersegurança BAS — ancorada em ISO 16484/ASHRAE 135 (BACnet)
       e ASHRAE Guideline 36.
+    in_scope:
+      - Engenharia de produto de controlador BAS e dispositivo de campo específico para aplicação
+      - Engenharia de software de servidor de supervisão, alarme e historiador de tendências
+      - Bibliotecas reutilizáveis de sequências de operação (Guideline 36 e controlo avançado)
+      - Pilhas de protocolo BACnet, KNX, LonWorks, Modbus, DALI, OPC UA, MQTT
+      - Modelação semântica de dados Brick/Haystack
+      - Controladores BAS seguros por conceção e cibersegurança de rede BAS
+    out_of_scope:
+      - Engenharia de produto eletrónico genérico coberta por BC-1900
+      - Listas de pontos e personalização de sequências ao nível do projeto (BC-2020)
+      - Engenharia de equipamento mecânico HVAC (BC-2000)
+      - Colocação em serviço no local e operações de serviço (BC-2050, BC-2060)
   BC-2010.10:
     name: Engenharia de produto de controlador BAS
     description: |
@@ -177,18 +189,6 @@ entries:
     name: Documentação de conformidade
     description: |
       Elaboração de PICS, BIBB e documentação de conformidade equivalente.
-  in_scope:
-    - Engenharia de produto de controlador BAS e dispositivo de campo específico para aplicação
-    - Engenharia de software de servidor de supervisão, alarme e historiador de tendências
-    - Bibliotecas reutilizáveis de sequências de operação (Guideline 36 e controlo avançado)
-    - Pilhas de protocolo BACnet, KNX, LonWorks, Modbus, DALI, OPC UA, MQTT
-    - Modelação semântica de dados Brick/Haystack
-    - Controladores BAS seguros por conceção e cibersegurança de rede BAS
-  out_of_scope:
-    - Engenharia de produto eletrónico genérico coberta por BC-1900
-    - Listas de pontos e personalização de sequências ao nível do projeto (BC-2020)
-    - Engenharia de equipamento mecânico HVAC (BC-2000)
-    - Colocação em serviço no local e operações de serviço (BC-2050, BC-2060)
 metadata:
   status: draft
   translator: claude-ai

--- a/catalogue/i18n/pt/L1-building-performance-management.yaml
+++ b/catalogue/i18n/pt/L1-building-performance-management.yaml
@@ -1,0 +1,187 @@
+locale: pt
+source: L1-building-performance-management.yaml
+entries:
+  BC-2070:
+    name: Gestão do desempenho de edifícios
+    description: |
+      Otimização contínua e orientada por dados do desempenho de edifícios — medição e verificação
+      de energia (IPMVP/ASHRAE Guideline 14), deteção e diagnóstico de avarias, análise de energia e
+      qualidade do ar interior, resposta à procura e interação com a rede, acompanhamento de carbono e
+      sustentabilidade e relatório periódico de desempenho a proprietários de edifícios.
+  BC-2070.10:
+    name: Medição e verificação de energia
+    description: |
+      Linha de base, cálculo de poupanças e ajuste do desempenho energético segundo IPMVP/ASHRAE Guideline 14.
+  BC-2070.10.10:
+    name: Modelação de linha de base
+    description: |
+      Modelação de linhas de base energéticas face às quais as poupanças são medidas.
+  BC-2070.10.20:
+    name: Elaboração do plano de M&V
+    description: |
+      Elaboração de planos de medição e verificação alinhados com protocolos reconhecidos.
+  BC-2070.10.30:
+    name: Cálculo de poupanças
+    description: |
+      Cálculo de poupanças de energia face à linha de base.
+  BC-2070.10.40:
+    name: Ajuste e normalização
+    description: |
+      Ajuste e normalização dos resultados de M&V para clima e ocupação.
+  BC-2070.20:
+    name: Operações de deteção e diagnóstico de avarias
+    description: |
+      Operação de bibliotecas de regras de FDD e triagem contínua de avarias detetadas.
+  BC-2070.20.10:
+    name: Gestão da biblioteca de regras FDD
+    description: |
+      Manutenção de bibliotecas de regras de deteção e diagnóstico de avarias.
+  BC-2070.20.20:
+    name: Triagem e priorização de avarias
+    description: |
+      Triagem e priorização de avarias detetadas por impacto.
+  BC-2070.20.30:
+    name: Análise de diagnóstico de causa raiz
+    description: |
+      Análise de diagnóstico para identificar causas raiz de avarias detetadas.
+  BC-2070.20.40:
+    name: Afinação de falsos positivos FDD
+    description: |
+      Afinação de regras FDD para reduzir taxas de alarme de falso positivo.
+  BC-2070.30:
+    name: Análise de desempenho energético
+    description: |
+      Análise do consumo de energia no portefólio de edifícios.
+  BC-2070.30.10:
+    name: Benchmarking e comparação com pares
+    description: |
+      Benchmarking do desempenho energético do edifício face a pares.
+  BC-2070.30.20:
+    name: Atribuição do consumo de energia
+    description: |
+      Atribuição do consumo de energia a sistemas, zonas e cargas.
+  BC-2070.30.30:
+    name: Deteção de anomalias energéticas
+    description: |
+      Deteção de anomalias nos padrões de consumo de energia.
+  BC-2070.30.40:
+    name: Previsão e definição de metas
+    description: |
+      Previsão do consumo futuro de energia e definição de metas face a objetivos de melhoria.
+  BC-2070.40:
+    name: Análise da qualidade do ambiente interior
+    description: |
+      Análise dos resultados de qualidade do ambiente interior, incluindo métricas de conforto, ar, acústica e iluminação.
+  BC-2070.40.10:
+    name: Análise de conforto térmico
+    description: |
+      Análise do conforto térmico face à ASHRAE 55 e critérios equivalentes.
+  BC-2070.40.20:
+    name: Análise da qualidade do ar
+    description: |
+      Análise da qualidade do ar interior face à ASHRAE 62.1 e critérios equivalentes.
+  BC-2070.40.30:
+    name: Análise acústica e de iluminação
+    description: |
+      Análise do desempenho acústico e de iluminação para resultados dos ocupantes.
+  BC-2070.40.40:
+    name: Correlação do feedback dos ocupantes
+    description: |
+      Correlação do feedback dos ocupantes com dados ambientais medidos.
+  BC-2070.50:
+    name: Gestão de resposta à procura e interação com a rede
+    description: |
+      Operação do comportamento interativo com a rede do edifício e participação em programas de resposta à procura.
+  BC-2070.50.10:
+    name: Inscrição em programa de resposta à procura
+    description: |
+      Inscrição de edifícios em programas de resposta à procura.
+  BC-2070.50.20:
+    name: Execução de corte de carga
+    description: |
+      Execução de eventos de corte de carga face a obrigações contratuais.
+  BC-2070.50.30:
+    name: Operações de edifício interativo com a rede
+    description: |
+      Operações de edifícios eficientes interativos com a rede.
+  BC-2070.50.40:
+    name: Resposta a tarifas e preços
+    description: |
+      Resposta das operações do edifício a tarifas de uso no tempo e dinâmicas.
+  BC-2070.60:
+    name: Acompanhamento de desempenho de carbono e sustentabilidade
+    description: |
+      Contabilidade de carbono operacional ao nível do edifício e acompanhamento de resultados de sustentabilidade.
+  BC-2070.60.10:
+    name: Contabilidade de carbono operacional
+    description: |
+      Contabilidade de emissões de carbono operacional ao nível do edifício.
+  BC-2070.60.20:
+    name: Alocação de energia renovável
+    description: |
+      Alocação de energia renovável no local e contratada a edifícios.
+  BC-2070.60.30:
+    name: Métricas ESG ao nível do edifício
+    description: |
+      Cálculo de métricas ESG ao nível do edifício para relatório de portefólio.
+  BC-2070.60.40:
+    name: Acompanhamento do desempenho de certificação de sustentabilidade
+    description: |
+      Acompanhamento do desempenho face a critérios de certificação de edifícios verdes.
+  BC-2070.70:
+    name: Gestão de recomendações de melhoria de desempenho
+    description: |
+      Identificação e gestão de oportunidades de melhoria de desempenho e casos de poupança.
+  BC-2070.70.10:
+    name: Identificação de oportunidades
+    description: |
+      Identificação de oportunidades de melhoria de desempenho a partir de análise.
+  BC-2070.70.20:
+    name: Caso de negócio de poupanças
+    description: |
+      Desenvolvimento de casos de negócio de suporte às melhorias recomendadas.
+  BC-2070.70.30:
+    name: Priorização de recomendações
+    description: |
+      Priorização de recomendações no portefólio.
+  BC-2070.70.40:
+    name: Acompanhamento da implementação
+    description: |
+      Acompanhamento da implementação das recomendações aceites.
+  BC-2070.80:
+    name: Relatório de desempenho e operações de painel de controlo
+    description: |
+      Painéis de controlo para proprietários, relatórios periódicos e relatório de desempenho regulatório.
+  BC-2070.80.10:
+    name: Operações de painel de controlo do proprietário
+    description: |
+      Operação de painéis de controlo de desempenho para proprietários.
+  BC-2070.80.20:
+    name: Relatório de desempenho periódico
+    description: |
+      Produção de relatórios de desempenho periódicos para clientes.
+  BC-2070.80.30:
+    name: Relatório de desempenho regulatório
+    description: |
+      Relatório do desempenho do edifício a programas regulatórios (ex.: benchmarking obrigatório).
+  BC-2070.80.40:
+    name: Briefings de desempenho a partes interessadas
+    description: |
+      Briefings a ocupantes, investidores e partes interessadas sobre o desempenho do edifício.
+  in_scope:
+    - Linha de base de M&V de energia, cálculo de poupanças e ajuste
+    - Bibliotecas de regras FDD e triagem contínua de avarias
+    - Benchmarking de energia predial, atribuição, deteção de anomalias e previsão
+    - Análise da qualidade do ambiente interior para resultados térmicos, de ar, acústicos e de iluminação
+    - Resposta à procura e operações interativas com a rede
+    - Carbono operacional, alocação de renováveis e métricas ESG ao nível do edifício
+    - Painéis de controlo para proprietários, relatórios periódicos e briefings a partes interessadas
+  out_of_scope:
+    - Cx e FPT durante a colocação em serviço do projeto (BC-2050)
+    - Execução de assistência em campo (BC-2060)
+    - Estratégia e relatório de sustentabilidade empresarial (BC-740)
+    - Projeto de equipamento HVAC (BC-2000) e engenharia de produto BAS (BC-2010)
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-building-performance-management.yaml
+++ b/catalogue/i18n/pt/L1-building-performance-management.yaml
@@ -8,6 +8,19 @@ entries:
       de energia (IPMVP/ASHRAE Guideline 14), deteção e diagnóstico de avarias, análise de energia e
       qualidade do ar interior, resposta à procura e interação com a rede, acompanhamento de carbono e
       sustentabilidade e relatório periódico de desempenho a proprietários de edifícios.
+    in_scope:
+      - Linha de base de M&V de energia, cálculo de poupanças e ajuste
+      - Bibliotecas de regras FDD e triagem contínua de avarias
+      - Benchmarking de energia predial, atribuição, deteção de anomalias e previsão
+      - Análise da qualidade do ambiente interior para resultados térmicos, de ar, acústicos e de iluminação
+      - Resposta à procura e operações interativas com a rede
+      - Carbono operacional, alocação de renováveis e métricas ESG ao nível do edifício
+      - Painéis de controlo para proprietários, relatórios periódicos e briefings a partes interessadas
+    out_of_scope:
+      - Cx e FPT durante a colocação em serviço do projeto (BC-2050)
+      - Execução de assistência em campo (BC-2060)
+      - Estratégia e relatório de sustentabilidade empresarial (BC-740)
+      - Projeto de equipamento HVAC (BC-2000) e engenharia de produto BAS (BC-2010)
   BC-2070.10:
     name: Medição e verificação de energia
     description: |
@@ -168,19 +181,6 @@ entries:
     name: Briefings de desempenho a partes interessadas
     description: |
       Briefings a ocupantes, investidores e partes interessadas sobre o desempenho do edifício.
-  in_scope:
-    - Linha de base de M&V de energia, cálculo de poupanças e ajuste
-    - Bibliotecas de regras FDD e triagem contínua de avarias
-    - Benchmarking de energia predial, atribuição, deteção de anomalias e previsão
-    - Análise da qualidade do ambiente interior para resultados térmicos, de ar, acústicos e de iluminação
-    - Resposta à procura e operações interativas com a rede
-    - Carbono operacional, alocação de renováveis e métricas ESG ao nível do edifício
-    - Painéis de controlo para proprietários, relatórios periódicos e briefings a partes interessadas
-  out_of_scope:
-    - Cx e FPT durante a colocação em serviço do projeto (BC-2050)
-    - Execução de assistência em campo (BC-2060)
-    - Estratégia e relatório de sustentabilidade empresarial (BC-740)
-    - Projeto de equipamento HVAC (BC-2000) e engenharia de produto BAS (BC-2010)
 metadata:
   status: draft
   translator: claude-ai

--- a/catalogue/i18n/pt/L1-building-systems-commissioning-management.yaml
+++ b/catalogue/i18n/pt/L1-building-systems-commissioning-management.yaml
@@ -1,0 +1,184 @@
+locale: pt
+source: L1-building-systems-commissioning-management.yaml
+entries:
+  BC-2050:
+    name: Gestão de colocação em serviço de sistemas prediais
+    description: |
+      Colocação em serviço de sistemas HVAC e BAS como serviço entregável — colocação em serviço inicial,
+      retrocommissioning, recommissioning e colocação em serviço baseada em monitorização. Ancorada no
+      processo de colocação em serviço total ASHRAE Guideline 0/Guideline 1.1.
+  BC-2050.10:
+    name: Planeamento e definição de âmbito da colocação em serviço
+    description: |
+      Estabelecimento do programa de colocação em serviço, âmbito e base de aceitação para o projeto.
+  BC-2050.10.10:
+    name: Revisão dos requisitos do projeto do dono de obra
+    description: |
+      Revisão dos Requisitos do Projeto do Dono de Obra como linha de base da colocação em serviço.
+  BC-2050.10.20:
+    name: Revisão da base de projeto
+    description: |
+      Revisão da Base de Projeto face aos Requisitos do Projeto do Dono de Obra.
+  BC-2050.10.30:
+    name: Elaboração do plano de colocação em serviço
+    description: |
+      Elaboração do plano de colocação em serviço definindo âmbito, funções e aceitação.
+  BC-2050.10.40:
+    name: Registo de riscos da colocação em serviço
+    description: |
+      Manutenção do registo de riscos da colocação em serviço durante a entrega.
+  BC-2050.20:
+    name: Gestão de inspeção pré-funcional
+    description: |
+      Verificação da conclusão da instalação e prontidão para arranque antes dos testes funcionais.
+  BC-2050.20.10:
+    name: Listas de verificação de instalação
+    description: |
+      Execução de listas de verificação de instalação.
+  BC-2050.20.20:
+    name: Inspeção de arranque
+    description: |
+      Inspeção do arranque do equipamento face aos requisitos do fabricante.
+  BC-2050.20.30:
+    name: Registo de problemas pré-funcionais
+    description: |
+      Registo de problemas pré-funcionais no registo de problemas de colocação em serviço.
+  BC-2050.20.40:
+    name: Aprovação pré-funcional
+    description: |
+      Aprovação de que a prontidão pré-funcional foi alcançada.
+  BC-2050.30:
+    name: Teste de desempenho funcional
+    description: |
+      Teste de desempenho funcional de subsistemas HVAC e BAS face a critérios documentados.
+  BC-2050.30.10:
+    name: Elaboração de scripts de teste
+    description: |
+      Elaboração de scripts de teste funcional face à intenção de projeto.
+  BC-2050.30.20:
+    name: Execução e testemunho de testes
+    description: |
+      Execução e testemunho de testes funcionais em sistemas HVAC e BAS.
+  BC-2050.30.30:
+    name: Resolução de problemas de teste
+    description: |
+      Resolução de problemas identificados durante os testes funcionais.
+  BC-2050.30.40:
+    name: Aprovação dos resultados de teste
+    description: |
+      Aprovação dos resultados de teste e encerramento dos casos de teste.
+  BC-2050.40:
+    name: Verificação de sequências de operação
+    description: |
+      Verificação das sequências de controlo programadas face às sequências de operação de projeto.
+  BC-2050.40.10:
+    name: Revisão da lógica de controlo
+    description: |
+      Revisão da lógica de controlo face às sequências elaboradas.
+  BC-2050.40.20:
+    name: Verificação de pontos de ajuste e modos
+    description: |
+      Verificação de pontos de ajuste e modos de operação nos programas.
+  BC-2050.40.30:
+    name: Teste de substituição e modo de falha
+    description: |
+      Teste de caminhos de substituição e comportamentos de modo de falha.
+  BC-2050.40.40:
+    name: Verificação baseada em tendências
+    description: |
+      Utilização de dados de tendências para verificar o desempenho das sequências ao longo do tempo.
+  BC-2050.50:
+    name: Teste de sistemas integrados
+    description: |
+      Teste de comportamentos integrados entre sistemas envolvendo HVAC, segurança de vida e sistemas elétricos.
+  BC-2050.50.10:
+    name: Teste de integração de incêndio e segurança de vida
+    description: |
+      Testes de integração abrangendo a interação do HVAC com sistemas de incêndio e segurança de vida.
+  BC-2050.50.20:
+    name: Teste de controlo de fumo e pressurização
+    description: |
+      Testes de sequências de controlo de fumo e pressurização.
+  BC-2050.50.30:
+    name: Teste de falha de energia e corte de carga
+    description: |
+      Testes do comportamento do HVAC durante falhas de energia e eventos de corte de carga.
+  BC-2050.50.40:
+    name: Teste de integração de rede predial
+    description: |
+      Testes de integração entre BAS e redes de IT predial adjacentes.
+  BC-2050.60:
+    name: Retrocommissioning e recommissioning
+    description: |
+      Serviço de colocação em serviço aplicado a edifícios existentes e como ciclos periódicos de recommissioning.
+  BC-2050.60.10:
+    name: Investigação de edifício existente
+    description: |
+      Investigação do desempenho do edifício existente face à intenção atual.
+  BC-2050.60.20:
+    name: Análise de lacunas de desempenho
+    description: |
+      Análise de lacunas de desempenho e causas raiz em edifícios existentes.
+  BC-2050.60.30:
+    name: Implementação de medidas de retrocommissioning
+    description: |
+      Implementação de medidas de retrocommissioning nos sistemas existentes.
+  BC-2050.60.40:
+    name: Execução do ciclo de recommissioning
+    description: |
+      Execução de ciclos periódicos de recommissioning para desempenho sustentado.
+  BC-2050.70:
+    name: Colocação em serviço baseada em monitorização
+    description: |
+      Colocação em serviço contínua orientada por dados, aproveitando instrumentação e telemetria.
+  BC-2050.70.10:
+    name: Plano de monitorização e instrumentação
+    description: |
+      Elaboração de planos de monitorização e seleção de instrumentação de suporte.
+  BC-2050.70.20:
+    name: Tendência de desempenho contínua
+    description: |
+      Tendência contínua do desempenho do edifício para perspetivas de colocação em serviço.
+  BC-2050.70.30:
+    name: Investigação de anomalias
+    description: |
+      Investigação de anomalias detetadas a partir de tendências contínuas.
+  BC-2050.70.40:
+    name: Verificação de persistência
+    description: |
+      Verificação de que o desempenho colocado em serviço persiste ao longo do tempo.
+  BC-2050.80:
+    name: Documentação e encerramento da colocação em serviço
+    description: |
+      Produção de entregáveis de colocação em serviço e encerramento formal do âmbito.
+  BC-2050.80.10:
+    name: Elaboração do relatório de colocação em serviço
+    description: |
+      Elaboração do relatório final de colocação em serviço.
+  BC-2050.80.20:
+    name: Compilação do manual do sistema
+    description: |
+      Compilação do manual do sistema para operação pelo dono de obra.
+  BC-2050.80.30:
+    name: Formação do dono de obra
+    description: |
+      Entrega de formação ao dono de obra sobre os sistemas colocados em serviço.
+  BC-2050.80.40:
+    name: Aprovação e entrega final
+    description: |
+      Aprovação final de colocação em serviço e entrega para as operações.
+  in_scope:
+    - Revisão dos requisitos do projeto do dono de obra e da base de projeto
+    - Verificação de instalação pré-funcional e inspeção de arranque
+    - Teste de desempenho funcional de sistemas HVAC e BAS
+    - Verificação de sequências de operação e testes de sistemas integrados
+    - Retrocommissioning, recommissioning e colocação em serviço baseada em monitorização
+    - Documentação de Cx, manuais de sistema e entrega de formação ao dono de obra
+  out_of_scope:
+    - Projeto de integração de engenharia ao nível do projeto (BC-2020)
+    - Operações de serviço contínuas após entrega (BC-2060)
+    - Colocação em serviço genérica de instalações de capital em projetos de engenharia (BC-1160)
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-building-systems-commissioning-management.yaml
+++ b/catalogue/i18n/pt/L1-building-systems-commissioning-management.yaml
@@ -7,6 +7,17 @@ entries:
       Colocação em serviço de sistemas HVAC e BAS como serviço entregável — colocação em serviço inicial,
       retrocommissioning, recommissioning e colocação em serviço baseada em monitorização. Ancorada no
       processo de colocação em serviço total ASHRAE Guideline 0/Guideline 1.1.
+    in_scope:
+      - Revisão dos requisitos do projeto do dono de obra e da base de projeto
+      - Verificação de instalação pré-funcional e inspeção de arranque
+      - Teste de desempenho funcional de sistemas HVAC e BAS
+      - Verificação de sequências de operação e testes de sistemas integrados
+      - Retrocommissioning, recommissioning e colocação em serviço baseada em monitorização
+      - Documentação de Cx, manuais de sistema e entrega de formação ao dono de obra
+    out_of_scope:
+      - Projeto de integração de engenharia ao nível do projeto (BC-2020)
+      - Operações de serviço contínuas após entrega (BC-2060)
+      - Colocação em serviço genérica de instalações de capital em projetos de engenharia (BC-1160)
   BC-2050.10:
     name: Planeamento e definição de âmbito da colocação em serviço
     description: |
@@ -167,17 +178,6 @@ entries:
     name: Aprovação e entrega final
     description: |
       Aprovação final de colocação em serviço e entrega para as operações.
-  in_scope:
-    - Revisão dos requisitos do projeto do dono de obra e da base de projeto
-    - Verificação de instalação pré-funcional e inspeção de arranque
-    - Teste de desempenho funcional de sistemas HVAC e BAS
-    - Verificação de sequências de operação e testes de sistemas integrados
-    - Retrocommissioning, recommissioning e colocação em serviço baseada em monitorização
-    - Documentação de Cx, manuais de sistema e entrega de formação ao dono de obra
-  out_of_scope:
-    - Projeto de integração de engenharia ao nível do projeto (BC-2020)
-    - Operações de serviço contínuas após entrega (BC-2060)
-    - Colocação em serviço genérica de instalações de capital em projetos de engenharia (BC-1160)
 metadata:
   status: draft
   translator: claude-ai

--- a/catalogue/i18n/pt/L1-business-continuity-management.yaml
+++ b/catalogue/i18n/pt/L1-business-continuity-management.yaml
@@ -1,0 +1,91 @@
+locale: pt
+source: L1-business-continuity-management.yaml
+entries:
+  BC-160:
+    name: Gestão da continuidade de negócio
+    description: |
+      Planeamento de resiliência, recuperação de desastres e resposta a crises.
+  BC-160.10:
+    name: Planeamento da continuidade de negócio
+    description: |
+      Análise de impacto no negócio, desenvolvimento de planos e estratégias de continuidade.
+  BC-160.10.10:
+    name: Análise de impacto no negócio
+    description: |
+      Identificação de processos críticos, RTO, RPO e dependências.
+  BC-160.10.20:
+    name: Definição da estratégia de continuidade
+    description: |
+      Seleção de estratégias de continuidade e opções de recuperação.
+  BC-160.10.30:
+    name: Desenvolvimento do plano de continuidade
+    description: |
+      Documentação de planos de continuidade de negócio alinhados com a ISO 22301.
+  BC-160.10.40:
+    name: Manutenção e atualização do plano
+    description: |
+      Revisão e atualização periódica dos planos de continuidade.
+  BC-160.20:
+    name: Gestão da recuperação de desastres
+    description: |
+      Recuperação de desastres de TI e operacional.
+  BC-160.20.10:
+    name: Planeamento de recuperação de serviços de TI
+    description: |
+      Planos de recuperação para serviços e infraestrutura de TI críticos.
+  BC-160.20.20:
+    name: Gestão de cópias de segurança e restauro
+    description: |
+      Estratégias de cópia de segurança, imutabilidade e validação do restauro.
+  BC-160.20.30:
+    name: Operações de failover e recuperação de local
+    description: |
+      Failover, ativação de local alternativo e recuperação operacional.
+  BC-160.20.40:
+    name: Coordenação da recuperação operacional
+    description: |
+      Coordenação das operações de negócio durante a ativação de recuperação.
+  BC-160.30:
+    name: Gestão de crises
+    description: |
+      Resposta a crises, estrutura de comando e escalada.
+  BC-160.30.10:
+    name: Estrutura de comando de crise
+    description: |
+      Equipa de gestão de crises, funções e estrutura de comando e controlo.
+  BC-160.30.20:
+    name: Comunicações de crise
+    description: |
+      Comunicações de crise internas e externas e gestão de partes interessadas.
+  BC-160.30.30:
+    name: Escalada e ativação de incidentes
+    description: |
+      Classificação de gravidade, vias de escalada e ativação do plano.
+  BC-160.30.40:
+    name: Revisão pós-crise
+    description: |
+      Lições aprendidas e ações de melhoria após crises.
+  BC-160.40:
+    name: Testes e exercícios de resiliência
+    description: |
+      Exercícios, simulações e validação do plano.
+  BC-160.40.10:
+    name: Exercícios de mesa e simulação
+    description: |
+      Exercícios de mesa, walkthrough e baseados em simulação.
+  BC-160.40.20:
+    name: Testes de failover em ambiente real
+    description: |
+      Testes de failover e recuperação em ambiente real face a metas de RTO e RPO.
+  BC-160.40.30:
+    name: Gestão do programa de exercícios
+    description: |
+      Calendário anual de exercícios, âmbito e cobertura de partes interessadas.
+  BC-160.40.40:
+    name: Resultados de testes e acompanhamento de melhorias
+    description: |
+      Registo dos resultados dos exercícios e acompanhamento das ações de melhoria.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-capital-markets-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-capital-markets-operations-management.yaml
@@ -1,0 +1,155 @@
+locale: pt
+source: L1-capital-markets-operations-management.yaml
+entries:
+  BC-1380:
+    name: Gestão de operações dos mercados de capitais
+    description: |
+      Confirmação de operações, compensação, liquidação, custódia, colateral, eventos corporativos e reconciliação.
+  BC-1380.10:
+    name: Gestão de confirmação de operações
+    description: |
+      Captura, registo, confirmação e alegação de operações.
+  BC-1380.10.10:
+    name: Captura e registo de operações
+    description: |
+      Captura e registo de operações em sistemas de front e middle office.
+  BC-1380.10.20:
+    name: Correspondência de confirmações de operações
+    description: |
+      Correspondência e afirmação de confirmações de operações.
+  BC-1380.10.30:
+    name: Tratamento de alegações de operações
+    description: |
+      Tratamento de alegações e operações sem correspondência.
+  BC-1380.20:
+    name: Gestão de compensação
+    description: |
+      Compensação central, CCP e adesão a câmaras de compensação.
+  BC-1380.20.10:
+    name: Submissão de operações à CCP
+    description: |
+      Submissão de operações compensadas a contrapartes centrais.
+  BC-1380.20.20:
+    name: Gestão de margens de compensação
+    description: |
+      Gestão de margens iniciais e de variação com CCPs.
+  BC-1380.20.30:
+    name: Operações de membro de compensação
+    description: |
+      Operação de serviços de membro de compensação direto e de cliente.
+  BC-1380.30:
+    name: Gestão de liquidação
+    description: |
+      Liquidação DvP, ciclos T+1/T+2 e gestão de falhas.
+  BC-1380.30.10:
+    name: Geração de instruções de liquidação
+    description: |
+      Geração de instruções de liquidação para operações.
+  BC-1380.30.20:
+    name: Operações de liquidação de valores mobiliários
+    description: |
+      Operações de liquidação DvP em CSDs e ICSDs.
+  BC-1380.30.30:
+    name: Gestão de falhas de liquidação
+    description: |
+      Identificação e resolução de falhas de liquidação (CSDR).
+  BC-1380.40:
+    name: Gestão de custódia
+    description: |
+      Guarda de valores mobiliários e redes de sub-custódia.
+  BC-1380.40.10:
+    name: Guarda de valores mobiliários
+    description: |
+      Guarda de valores mobiliários para clientes e contas proprietárias.
+  BC-1380.40.20:
+    name: Gestão da rede de sub-custódia
+    description: |
+      Gestão de rede de sub-custódia e bancos agentes.
+  BC-1380.40.30:
+    name: Serviços fiscais de custódia
+    description: |
+      Serviços de reclamação de reembolso fiscal e retenção na fonte em custódia.
+  BC-1380.50:
+    name: Gestão de colateral
+    description: |
+      Colateral, margens e otimização.
+  BC-1380.50.10:
+    name: Gestão de chamadas de margem
+    description: |
+      Emissão e resposta a chamadas de margem em regimes bilaterais e de CCP.
+  BC-1380.50.20:
+    name: Operações de movimentação de colateral
+    description: |
+      Movimentação operacional de colateral entre contrapartes.
+  BC-1380.50.30:
+    name: Otimização de colateral
+    description: |
+      Otimização da utilização e substituição de colateral.
+  BC-1380.50.40:
+    name: Gestão de elegibilidade de colateral
+    description: |
+      Regras de elegibilidade de colateral e aplicação de haircuts.
+  BC-1380.60:
+    name: Gestão de eventos corporativos
+    description: |
+      Processamento de eventos corporativos obrigatórios e voluntários.
+  BC-1380.60.10:
+    name: Notificação de eventos corporativos
+    description: |
+      Captura e notificação de eventos corporativos aos clientes.
+  BC-1380.60.20:
+    name: Processamento de eventos corporativos obrigatórios
+    description: |
+      Processamento de dividendos, juros e eventos obrigatórios.
+  BC-1380.60.30:
+    name: Processamento de eventos corporativos voluntários
+    description: |
+      Processamento de eventos voluntários incluindo eleições.
+  BC-1380.60.40:
+    name: Operações de voto por procuração
+    description: |
+      Recolha e submissão de votos por procuração.
+  BC-1380.70:
+    name: Gestão de reconciliação
+    description: |
+      Reconciliação de nostro/vostro, posições e tesouraria.
+  BC-1380.70.10:
+    name: Reconciliação de tesouraria
+    description: |
+      Reconciliação de contas de tesouraria incluindo nostro/vostro.
+  BC-1380.70.20:
+    name: Reconciliação de posições em valores mobiliários
+    description: |
+      Reconciliação de posições em valores mobiliários entre sistemas e depositários.
+  BC-1380.70.30:
+    name: Reconciliação de operações e front-back
+    description: |
+      Reconciliação de operações de front-to-back entre sistemas.
+  BC-1380.70.40:
+    name: Investigação de divergências de reconciliação
+    description: |
+      Investigação e resolução de divergências de reconciliação.
+  BC-1380.80:
+    name: Gestão de empréstimo de valores mobiliários
+    description: |
+      Empréstimo e tomada de empréstimo de valores mobiliários e gestão de colateral.
+  BC-1380.80.10:
+    name: Originação de empréstimo de valores mobiliários
+    description: |
+      Originação de operações de empréstimo e tomada de empréstimo de valores mobiliários.
+  BC-1380.80.20:
+    name: Operações de colateral em empréstimo de valores mobiliários
+    description: |
+      Operações de colateral de suporte ao empréstimo de valores mobiliários.
+  BC-1380.80.30:
+    name: Cálculo de comissões e rebates em empréstimo de valores mobiliários
+    description: |
+      Cálculo e liquidação de comissões e rebates.
+  BC-1380.80.40:
+    name: Gestão de recolha de valores mobiliários emprestados
+    description: |
+      Recolha de valores mobiliários emprestados e operações de substituição.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-capital-markets-trading-management.yaml
+++ b/catalogue/i18n/pt/L1-capital-markets-trading-management.yaml
@@ -1,0 +1,115 @@
+locale: pt
+source: L1-capital-markets-trading-management.yaml
+entries:
+  BC-1370:
+    name: Gestão de negociação nos mercados de capitais
+    description: |
+      Negociação de front-office, criação de mercado, gestão de posições e vendas e negociação.
+  BC-1370.10:
+    name: Gestão de criação de mercado
+    description: |
+      Criação de mercado em todas as classes de ativos.
+  BC-1370.10.10:
+    name: Geração de cotações
+    description: |
+      Geração de cotações de compra/venda em mercados.
+  BC-1370.10.20:
+    name: Gestão de inventário de criadores de mercado
+    description: |
+      Gestão do inventário e posição de risco de criadores de mercado.
+  BC-1370.10.30:
+    name: Motor de preços de criação de mercado
+    description: |
+      Operação do motor de preços e gestão de parâmetros.
+  BC-1370.20:
+    name: Gestão de posições de negociação
+    description: |
+      Posições de negociação e atribuição de P&L.
+  BC-1370.20.10:
+    name: Controlo de posições em tempo real
+    description: |
+      Acompanhamento em tempo real de posições do livro de negociação.
+  BC-1370.20.20:
+    name: Cálculo do P&L de negociação
+    description: |
+      Cálculo do P&L de negociação em todas as mesas.
+  BC-1370.20.30:
+    name: Análise de atribuição do P&L
+    description: |
+      Atribuição do P&L por fator de risco, tempo e operador.
+  BC-1370.30:
+    name: Gestão de ordens de negociação
+    description: |
+      Captura de ordens, execução, encaminhamento inteligente e melhor execução.
+  BC-1370.30.10:
+    name: Captura de ordens de negociação
+    description: |
+      Captura e validação de ordens de clientes e proprietárias.
+  BC-1370.30.20:
+    name: Encaminhamento inteligente de ordens
+    description: |
+      Encaminhamento inteligente de ordens em múltiplos mercados para melhor execução.
+  BC-1370.30.30:
+    name: Monitorização da qualidade de execução
+    description: |
+      Monitorização da qualidade de execução e análise de melhor execução.
+  BC-1370.30.40:
+    name: Gestão do ciclo de vida de ordens
+    description: |
+      Ciclo de vida de ordens incluindo alterações e cancelamentos.
+  BC-1370.40:
+    name: Gestão de negociação algorítmica
+    description: |
+      Estratégias algorítmicas, backtesting e conformidade.
+  BC-1370.40.10:
+    name: Desenvolvimento de estratégias algorítmicas
+    description: |
+      Desenvolvimento e certificação de estratégias algorítmicas.
+  BC-1370.40.20:
+    name: Backtesting algorítmico
+    description: |
+      Backtesting e simulação de algoritmos de negociação.
+  BC-1370.40.30:
+    name: Controlos de negociação algorítmica
+    description: |
+      Controlos pré-negociação e em tempo de execução sobre negociação algorítmica.
+  BC-1370.50:
+    name: Gestão de vendas e negociação
+    description: |
+      Mesas de vendas a clientes, negociação por voz e eletrónica.
+  BC-1370.50.10:
+    name: Operações da mesa de vendas a clientes
+    description: |
+      Operação de mesas de vendas por voz para clientes institucionais.
+  BC-1370.50.20:
+    name: Operações de negociação eletrónica
+    description: |
+      Operação de plataformas e conectividade de negociação eletrónica.
+  BC-1370.50.30:
+    name: Pesquisa e preços pré-negociação
+    description: |
+      Pesquisa pré-negociação, preços indicativos e suporte à estruturação.
+  BC-1370.60:
+    name: Gestão de conformidade e vigilância de negociação
+    description: |
+      Vigilância de negociação, deteção de abuso de mercado e MiFID II.
+  BC-1370.60.10:
+    name: Vigilância de negociação
+    description: |
+      Vigilância de negociação e deteção de padrões suspeitos.
+  BC-1370.60.20:
+    name: Deteção de abuso de mercado
+    description: |
+      Deteção de abuso de mercado incluindo utilização de informação privilegiada e manipulação.
+  BC-1370.60.30:
+    name: Vigilância de comunicações
+    description: |
+      Vigilância de comunicações e voz de operadores.
+  BC-1370.60.40:
+    name: Reporte regulatório de negociação
+    description: |
+      Reporte regulatório de negociação e transações (MiFIR, EMIR, SFTR).
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-care-coordination-management.yaml
+++ b/catalogue/i18n/pt/L1-care-coordination-management.yaml
@@ -1,0 +1,156 @@
+locale: pt
+source: L1-care-coordination-management.yaml
+entries:
+  BC-2820:
+    name: Gestão de coordenação de cuidados
+    description: |
+      Coordenação de cuidados entre prestadores, contextos e ao longo do tempo,
+      incluindo referenciações, gestão de casos, transições de cuidados, planeamento
+      de alta, gestão da utilização e ligação a determinantes sociais.
+  BC-2820.10:
+    name: Gestão de referenciações
+    description: |
+      Gestão end-to-end de referenciações de doentes, desde a captura da ordem
+      até à correspondência com o especialista, acompanhamento e encerramento.
+  BC-2820.10.10:
+    name: Captura de ordens de referenciação
+    description: |
+      Captura de ordens de referenciação dos prestadores referenciadores com o
+      contexto clínico necessário.
+  BC-2820.10.20:
+    name: Correspondência com especialista
+    description: |
+      Correspondência de referenciações a especialistas com base na necessidade
+      clínica, rede e acesso.
+  BC-2820.10.30:
+    name: Acompanhamento de referenciações
+    description: |
+      Acompanhamento do estado da referenciação, agendamento e conclusão em toda
+      a rede.
+  BC-2820.10.40:
+    name: Encerramento de referenciações
+    description: |
+      Encerramento de referenciações com retorno do relatório do consultor ao
+      prestador referenciador.
+  BC-2820.20:
+    name: Gestão de casos e cuidados
+    description: |
+      Identificação, planeamento e execução de intervenções de gestão de casos para
+      doentes de alto risco e complexos.
+  BC-2820.20.10:
+    name: Estratificação de casos
+    description: |
+      Estratificação de doentes em níveis de gestão de casos com base no risco
+      clínico e social.
+  BC-2820.20.20:
+    name: Desenvolvimento do plano de cuidados
+    description: |
+      Desenvolvimento de planos de cuidados individualizados com objectivos
+      centrados no doente.
+  BC-2820.20.30:
+    name: Execução do plano de cuidados
+    description: |
+      Execução e reavaliação contínua das intervenções do plano de cuidados.
+  BC-2820.20.40:
+    name: Atribuição de gestor de cuidados
+    description: |
+      Atribuição e gestão de carga de trabalho de gestores de cuidados e
+      navegadores.
+  BC-2820.30:
+    name: Planeamento de alta
+    description: |
+      Planeamento para alta segura do internamento, incluindo avaliação de
+      necessidades, colocação pós-aguda e educação do doente.
+  BC-2820.30.10:
+    name: Avaliação das necessidades de alta
+    description: |
+      Avaliação multidisciplinar das necessidades clínicas e sociais pós-alta.
+  BC-2820.30.20:
+    name: Desenvolvimento do plano de alta
+    description: |
+      Desenvolvimento de planos de alta, incluindo serviços, equipamentos e
+      seguimento.
+  BC-2820.30.30:
+    name: Colocação pós-aguda
+    description: |
+      Colocação de doentes em unidades de enfermagem especializada, reabilitação
+      e serviços de saúde domiciliária.
+  BC-2820.30.40:
+    name: Educação para a alta
+    description: |
+      Educação do doente e cuidador sobre instruções de alta, medicamentos e
+      sinais de alerta.
+  BC-2820.40:
+    name: Transições de cuidados
+    description: |
+      Coordenação das transições de doentes entre prestadores e contextos para
+      garantir continuidade, segurança e responsabilização pelos resultados.
+  BC-2820.40.10:
+    name: Comunicação de transferência de cuidados
+    description: |
+      Comunicação estruturada de transferência entre prestadores e equipas de
+      cuidados nas transições.
+  BC-2820.40.20:
+    name: Reconciliação de medicação nas transições
+    description: |
+      Reconciliação de medicamentos nas transições de cuidados.
+  BC-2820.40.30:
+    name: Agendamento de consulta de seguimento
+    description: |
+      Agendamento de consultas de seguimento pós-alta e pós-encontro.
+  BC-2820.40.40:
+    name: Acompanhamento de resultados na transição
+    description: |
+      Acompanhamento de métricas de readmissão, complicações e resultados nas
+      transições.
+  BC-2820.50:
+    name: Gestão da utilização
+    description: |
+      Revisão e supervisão de admissões, internamentos continuados e demora média,
+      face a critérios de necessidade médica e de utilização.
+  BC-2820.50.10:
+    name: Revisão de admissão
+    description: |
+      Revisão da necessidade médica de admissão e do estatuto de internamento
+      versus observação.
+  BC-2820.50.20:
+    name: Revisão de internamento continuado
+    description: |
+      Revisão periódica do internamento continuado face a critérios.
+  BC-2820.50.30:
+    name: Optimização da demora média
+    description: |
+      Optimização da demora média através da identificação e resolução de
+      obstáculos.
+  BC-2820.50.40:
+    name: Acompanhamento de dias evitáveis
+    description: |
+      Captura e análise de dias de internamento evitáveis e das suas causas.
+  BC-2820.60:
+    name: Determinantes sociais e ligação comunitária
+    description: |
+      Identificação dos determinantes sociais da saúde e ligação a recursos
+      comunitários para apoiar os resultados clínicos.
+  BC-2820.60.10:
+    name: Rastreio de necessidades sociais
+    description: |
+      Rastreio de necessidades de habitação, alimentação, transporte e outras
+      necessidades sociais.
+  BC-2820.60.20:
+    name: Referenciação para recursos comunitários
+    description: |
+      Referenciação para recursos comunitários que respondam às necessidades sociais
+      identificadas.
+  BC-2820.60.30:
+    name: Documentação de determinantes sociais
+    description: |
+      Documentação estruturada dos determinantes sociais no processo clínico.
+  BC-2820.60.40:
+    name: Acompanhamento de referenciação em circuito fechado
+    description: |
+      Acompanhamento em circuito fechado de referenciações comunitárias até ao
+      resultado e resolução.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-cargo-documentation-management.yaml
+++ b/catalogue/i18n/pt/L1-cargo-documentation-management.yaml
@@ -1,0 +1,105 @@
+locale: pt
+source: L1-cargo-documentation-management.yaml
+entries:
+  BC-2500:
+    name: Gestão de documentação de carga
+    description: |
+      Emissão, troca e gestão do ciclo de vida de documentos de carga, incluindo
+      conhecimentos de embarque, guias aéreas, notas de consignação rodoviárias
+      e ferroviárias, manifestos e os seus equivalentes eletrónicos.
+  BC-2500.10:
+    name: Gestão de conhecimento de embarque
+    description: |
+      Emissão, entrega e gestão de conhecimentos de embarque oceânicos e de vias
+      navegáveis interiores em formas negociáveis e não negociáveis.
+    in_scope:
+      - Conhecimentos de embarque master e de casa
+      - Variantes negociáveis, nominativas e seaway bill
+    out_of_scope:
+      - Gestão de carta de crédito em comércio internacional (BC-1360)
+  BC-2500.10.10:
+    name: Emissão de conhecimento de embarque
+    description: |
+      Emissão de conhecimentos de embarque master e de casa.
+  BC-2500.10.20:
+    name: Entrega e liberação de conhecimento de embarque
+    description: |
+      Telex release, entrega e liberação de carga contra conhecimentos de
+      embarque.
+  BC-2500.10.30:
+    name: Variantes de conhecimento negociável e nominativo
+    description: |
+      Emissão de variantes negociáveis, nominativas e seaway bill.
+  BC-2500.20:
+    name: Gestão de guia aérea
+    description: |
+      Emissão e gestão de guias aéreas master e de casa, incluindo e-AWB.
+  BC-2500.20.10:
+    name: Emissão de guia aérea master
+    description: |
+      Emissão de guias aéreas master por transportadoras aéreas.
+  BC-2500.20.20:
+    name: Emissão de guia aérea de casa
+    description: |
+      Emissão de guias aéreas de casa por transitários e consolidadores.
+  BC-2500.20.30:
+    name: Conversão e manutenção de e-AWB
+    description: |
+      Conversão de guias aéreas em papel para e-AWB e manutenção do ciclo de
+      vida.
+  BC-2500.30:
+    name: Gestão de nota de consignação rodoviária e ferroviária
+    description: |
+      Emissão e gestão de notas de consignação rodoviária e ferroviária ao abrigo
+      dos regimes CMR e CIM/SMGS.
+  BC-2500.30.10:
+    name: Emissão de nota de consignação CMR
+    description: |
+      Emissão de notas de consignação CMR para transporte rodoviário internacional.
+  BC-2500.30.20:
+    name: Emissão de nota de consignação CIM e SMGS
+    description: |
+      Emissão de notas de consignação CIM e SMGS para ferrovia internacional.
+  BC-2500.30.30:
+    name: Emissão de guia de transporte nacional
+    description: |
+      Emissão de guias de transporte nacionais e notas de entrega.
+  BC-2500.40:
+    name: Gestão de manifesto e declaração de carga
+    description: |
+      Submissão de manifestos de carga e declarações de carga pré-chegada junto
+      de alfândegas, terminais e transportadoras parceiras.
+  BC-2500.40.10:
+    name: Submissão de manifesto de entrada
+    description: |
+      Submissão de manifestos de entrada junto de terminais e alfândegas.
+  BC-2500.40.20:
+    name: Submissão de manifesto de saída
+    description: |
+      Submissão de manifestos de saída junto de terminais e alfândegas.
+  BC-2500.40.30:
+    name: Reporte de carga pré-chegada
+    description: |
+      Reporte pré-chegada ao abrigo de regimes como ICS2 e CBP ACE.
+  BC-2500.50:
+    name: Gestão de documentação eletrónica
+    description: |
+      Operação de plataformas de documentos de transporte eletrónicos, incluindo
+      trocas de eBL e ONE Record.
+  BC-2500.50.10:
+    name: Operações de conhecimento de embarque eletrónico
+    description: |
+      Operação de plataformas de conhecimento de embarque eletrónico.
+  BC-2500.50.20:
+    name: Operações de e-AWB e ONE Record
+    description: |
+      Operação de trocas de dados e-AWB e ONE Record.
+  BC-2500.50.30:
+    name: Troca e verificação de documentos
+    description: |
+      Troca inter-partes de documentos e verificação de assinaturas e selos
+      eletrónicos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-change-management.yaml
+++ b/catalogue/i18n/pt/L1-change-management.yaml
@@ -1,0 +1,91 @@
+locale: pt
+source: L1-change-management.yaml
+entries:
+  BC-910:
+    name: Gestão da mudança
+    description: |
+      Planeamento e execução da mudança organizacional.
+  BC-910.10:
+    name: Gestão da estratégia de mudança
+    description: |
+      Visão, narrativa e estratégia de mudança.
+  BC-910.10.10:
+    name: Visão e narrativa de mudança
+    description: |
+      Articulação da visão de mudança, caso para a mudança e narrativa.
+  BC-910.10.20:
+    name: Avaliação do impacto da mudança
+    description: |
+      Identificação e avaliação dos impactos da mudança nas pessoas e processos.
+  BC-910.10.30:
+    name: Avaliação da prontidão para a mudança
+    description: |
+      Avaliação da prontidão organizacional para a mudança.
+  BC-910.10.40:
+    name: Desenvolvimento do plano de mudança
+    description: |
+      Desenvolvimento de planos integrados de gestão da mudança.
+  BC-910.20:
+    name: Gestão do envolvimento das partes interessadas na mudança
+    description: |
+      Identificação, envolvimento e alinhamento das partes interessadas.
+  BC-910.20.10:
+    name: Identificação e mapeamento de partes interessadas
+    description: |
+      Identificação e mapeamento das partes interessadas afetadas.
+  BC-910.20.20:
+    name: Envolvimento de patrocinadores
+    description: |
+      Definição da coligação de patrocínio e envolvimento.
+  BC-910.20.30:
+    name: Gestão da rede de mudança
+    description: |
+      Redes de agentes e campeões da mudança.
+  BC-910.20.40:
+    name: Gestão da resistência
+    description: |
+      Identificação e gestão da resistência à mudança.
+  BC-910.30:
+    name: Gestão de comunicações e formação para a mudança
+    description: |
+      Comunicações e formação como parte da mudança.
+  BC-910.30.10:
+    name: Planeamento de comunicação da mudança
+    description: |
+      Planos de comunicação por público e canal para iniciativas de mudança.
+  BC-910.30.20:
+    name: Entrega de comunicação da mudança
+    description: |
+      Execução de campanhas e ativos de comunicação.
+  BC-910.30.30:
+    name: Design da formação em mudança
+    description: |
+      Design de formação em mudança e reforço de capacidades.
+  BC-910.30.40:
+    name: Entrega da formação em mudança
+    description: |
+      Entrega de formação durante a implementação da mudança.
+  BC-910.40:
+    name: Gestão da adoção e reforço da mudança
+    description: |
+      Acompanhamento da adoção, reforço e sustentação.
+  BC-910.40.10:
+    name: Medição da adoção
+    description: |
+      Medição da adoção, utilização e mudança de comportamento.
+  BC-910.40.20:
+    name: Reforço e sustentação
+    description: |
+      Mecanismos de reforço e sustentação de novos comportamentos.
+  BC-910.40.30:
+    name: Gestão do período de hiperatenção à mudança
+    description: |
+      Apoio no período de hiperatenção pós-implementação.
+  BC-910.40.40:
+    name: Lições aprendidas da mudança
+    description: |
+      Captura e disseminação de lições aprendidas da mudança.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-chemical-bulk-logistics-management.yaml
+++ b/catalogue/i18n/pt/L1-chemical-bulk-logistics-management.yaml
@@ -1,0 +1,157 @@
+locale: pt
+source: L1-chemical-bulk-logistics-management.yaml
+entries:
+  BC-4680:
+    name: Gestão de logística de granel químico
+    description: |
+      Manuseamento de químicos a granel em modos de parques de tanques, rodoviário,
+      ferroviário, marítimo, por pipeline e em armazém — incluindo operações em
+      conformidade com mercadorias perigosas, tolling e medição de transferência
+      de custódia a granel. Distinto dos L1 de Cadeia de Abastecimento (BC-520)
+      e Transporte transversais, que cobrem o frete genérico e multimodal ao nível da rede.
+  BC-4680.10:
+    name: Armazenamento a granel e operações de parque de tanques
+    description: |
+      Operação de tanques de armazenamento a granel e parques de tanques, incluindo
+      alocação, limpeza e reconciliação de perdas.
+  BC-4680.10.10:
+    name: Gestão do inventário do parque de tanques
+    description: |
+      Gestão do inventário em parques de tanques atmosféricos e pressurizados.
+  BC-4680.10.20:
+    name: Alocação e encaminhamento de tanques
+    description: |
+      Alocação de tanques a produtos e encaminhamento de fluxos de entrada e saída.
+  BC-4680.10.30:
+    name: Coordenação da limpeza de tanques
+    description: |
+      Coordenação da limpeza de tanques entre mudanças de produto.
+  BC-4680.10.40:
+    name: Reconciliação de perdas no parque de tanques
+    description: |
+      Reconciliação de perdas físicas nos inventários do parque de tanques.
+  BC-4680.20:
+    name: Logística de camiões-tanque e tanques ISO
+    description: |
+      Operação de frotas de camiões-tanque e tanques ISO, incluindo operações de
+      cais de carregamento e limpeza de contentores.
+  BC-4680.20.10:
+    name: Planeamento de camiões-tanque
+    description: |
+      Planeamento de movimentos de camiões-tanque e alocação de cais.
+  BC-4680.20.20:
+    name: Gestão da frota de tanques ISO
+    description: |
+      Gestão de frotas de tanques ISO, incluindo posicionamento e reutilização.
+  BC-4680.20.30:
+    name: Operações de cais de carregamento
+    description: |
+      Operação de cais de carregamento para expedição rodoviária e de tanques ISO.
+  BC-4680.20.40:
+    name: Coordenação da limpeza de contentores
+    description: |
+      Coordenação da limpeza aprovada de contentores entre cargas.
+  BC-4680.30:
+    name: Logística de vagões-tanque ferroviários
+    description: |
+      Alocação, carregamento, descarga e coordenação de manutenção de vagões-tanque ferroviários.
+  BC-4680.30.10:
+    name: Alocação de vagões-tanque ferroviários
+    description: |
+      Alocação de vagões-tanque ferroviários a produtos e rotas.
+  BC-4680.30.20:
+    name: Operações de carregamento e descarga ferroviários
+    description: |
+      Operação de plataformas de carregamento e descarga ferroviários.
+  BC-4680.30.30:
+    name: Coordenação da manutenção de vagões-tanque ferroviários
+    description: |
+      Coordenação da manutenção e qualificação de vagões-tanque ferroviários da frota.
+  BC-4680.40:
+    name: Logística marítima de químicos a granel
+    description: |
+      Logística marítima para navios parceleiros e químicos, incluindo fretamento,
+      carregamento e estiva.
+  BC-4680.40.10:
+    name: Coordenação do fretamento de navios químicos
+    description: |
+      Coordenação do fretamento de navios químicos e parceleiros.
+  BC-4680.40.20:
+    name: Operações de carregamento e descarga marítimos
+    description: |
+      Operação de instalações de carregamento e descarga marítimos.
+  BC-4680.40.30:
+    name: Planeamento de estiva de navios parceleiros
+    description: |
+      Planeamento da estiva de cargas parceleiras compatíveis em navios químicos.
+  BC-4680.50:
+    name: Coordenação de movimentos por pipeline
+    description: |
+      Nomeação, sequenciamento e coordenação de transferência de custódia para
+      movimentos de químicos a granel por pipeline.
+  BC-4680.50.10:
+    name: Gestão de nomeações de pipeline
+    description: |
+      Nomeação de movimentos de pipeline com operadores e contrapartes.
+  BC-4680.50.20:
+    name: Sequenciamento de lotes em pipelines
+    description: |
+      Sequenciamento de lotes com gestão de interfaces.
+  BC-4680.50.30:
+    name: Coordenação de transferência de custódia em pipeline
+    description: |
+      Coordenação da transferência de custódia nos pontos de injeção e entrega do pipeline.
+  BC-4680.60:
+    name: Operações de armazém de mercadorias perigosas
+    description: |
+      Receção, segregação e armazenamento de produtos químicos embalados perigosos
+      em armazéns conformes.
+  BC-4680.60.10:
+    name: Receção e arrumação em armazém de mercadorias perigosas
+    description: |
+      Receção e arrumação de produtos químicos embalados perigosos.
+  BC-4680.60.20:
+    name: Gestão da conformidade de segregação
+    description: |
+      Gestão da conformidade de segregação química no armazenamento.
+  BC-4680.60.30:
+    name: Operações de armazenamento de barris e GRG
+    description: |
+      Operações de armazenamento de barris e grandes recipientes para granéis.
+  BC-4680.70:
+    name: Coordenação de tolling e fabrico por terceiros
+    description: |
+      Coordenação de fabrico por tolling em ativos de terceiros, incluindo
+      reconciliação de materiais em tolling.
+  BC-4680.70.10:
+    name: Seleção e qualificação de tollers
+    description: |
+      Seleção e qualificação de parceiros de fabrico por tolling.
+  BC-4680.70.20:
+    name: Planeamento de campanhas de tolling
+    description: |
+      Planeamento de campanhas de tolling em ativos de terceiros.
+  BC-4680.70.30:
+    name: Reconciliação de materiais em tolling
+    description: |
+      Reconciliação de materiais que entram e saem do fabrico por tolling.
+  BC-4680.80:
+    name: Medição de transferência de custódia a granel
+    description: |
+      Medição de volume, massa e amostragem em interfaces de transferência de custódia.
+  BC-4680.80.10:
+    name: Medição de volume e massa
+    description: |
+      Medição calibrada de volume e massa nos pontos de custódia.
+  BC-4680.80.20:
+    name: Coordenação de amostragem
+    description: |
+      Coordenação de amostragem representativa na transferência de custódia.
+  BC-4680.80.30:
+    name: Documentação de transferência de custódia
+    description: |
+      Emissão e arquivo de documentação de transferência de custódia.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-chemical-commercial-trading-management.yaml
+++ b/catalogue/i18n/pt/L1-chemical-commercial-trading-management.yaml
@@ -1,0 +1,137 @@
+locale: pt
+source: L1-chemical-commercial-trading-management.yaml
+entries:
+  BC-4690:
+    name: Gestão comercial e de negociação química
+    description: |
+      Negociação de químicos a granel e de especialidade, gestão do equilíbrio
+      oferta-procura, abastecimento de matérias-primas, cobertura de risco,
+      contratos de offtake de longo prazo e referenciação de índices de preços.
+      Distinto de Vendas (BC-410) e Preços (BC-440) transversais, que cobrem
+      as disciplinas empresariais de vendas e preços.
+  BC-4690.10:
+    name: Negociação de químicos a granel
+    description: |
+      Negociação spot e a prazo de químicos de mercadoria a granel em mercados físicos.
+  BC-4690.10.10:
+    name: Negociação de cargas spot
+    description: |
+      Negociação de cargas spot aos preços de mercado vigentes.
+  BC-4690.10.20:
+    name: Negociação de contratos a prazo
+    description: |
+      Negociação e execução de negociações por contrato a prazo.
+  BC-4690.10.30:
+    name: Vendas de cargas em dificuldade
+    description: |
+      Alienação de cargas em dificuldade e excedentes através de canais de negociação.
+  BC-4690.20:
+    name: Gestão comercial de químicos de especialidade
+    description: |
+      Gestão de contas, distribuição e venda de soluções de químicos de especialidade diferenciados.
+  BC-4690.20.10:
+    name: Gestão de contas de especialidade
+    description: |
+      Gestão de contas estratégicas de químicos de especialidade.
+  BC-4690.20.20:
+    name: Gestão de canais de distribuição
+    description: |
+      Gestão de canais de distribuição indiretos.
+  BC-4690.20.30:
+    name: Venda por pull-through de aplicações
+    description: |
+      Venda por pull-through junto de contas de formuladores e transformadores a jusante.
+  BC-4690.20.40:
+    name: Coordenação de venda de soluções
+    description: |
+      Coordenação de venda multiproduto de soluções para aplicações complexas.
+  BC-4690.30:
+    name: Abastecimento de matérias-primas e petroquímicos
+    description: |
+      Abastecimento de matérias-primas de hidrocarbonetos, aromáticas, bio e inorgânicas
+      para operações químicas.
+  BC-4690.30.10:
+    name: Abastecimento de nafta e olefinas como matérias-primas
+    description: |
+      Abastecimento de nafta, etano e olefinas como matérias-primas para craqueadores.
+  BC-4690.30.20:
+    name: Abastecimento de aromáticas como matérias-primas
+    description: |
+      Abastecimento de benzeno, tolueno e xileno como matérias-primas.
+  BC-4690.30.30:
+    name: Abastecimento de bio-matérias-primas
+    description: |
+      Abastecimento de matérias-primas de base biológica em regimes de balanço de massa.
+  BC-4690.30.40:
+    name: Abastecimento de matérias-primas inorgânicas
+    description: |
+      Abastecimento de sais inorgânicos, minerais e minérios para processamento químico.
+  BC-4690.40:
+    name: Cobertura de risco e gestão do risco químico
+    description: |
+      Cobertura de risco de preço de matérias-primas, cambial e de margem
+      no livro de negociação química.
+  BC-4690.40.10:
+    name: Cobertura do risco de preço de matérias-primas
+    description: |
+      Cobertura do risco de preço de matérias-primas nos mercados de mercadorias.
+  BC-4690.40.20:
+    name: Cobertura da exposição cambial
+    description: |
+      Cobertura da exposição cambial em contratos de produtos químicos.
+  BC-4690.40.30:
+    name: Estratégia de cobertura de margens
+    description: |
+      Definição e execução de estratégias de cobertura de margens de craqueador e químicas.
+  BC-4690.50:
+    name: Gestão do equilíbrio oferta-procura
+    description: |
+      Compilação e reconciliação da oferta, procura e equilíbrio na gama de produtos químicos.
+  BC-4690.50.10:
+    name: Compilação de perspetivas de procura
+    description: |
+      Compilação de perspetivas de procura a curto e médio prazo.
+  BC-4690.50.20:
+    name: Compilação da capacidade de oferta
+    description: |
+      Compilação da capacidade de oferta em ativos próprios e em tolling.
+  BC-4690.50.30:
+    name: Reconciliação do equilíbrio
+    description: |
+      Reconciliação dos equilíbrios de oferta e procura e identificação de restrições.
+  BC-4690.60:
+    name: Gestão de contratos de offtake de longo prazo
+    description: |
+      Negociação, redação e gestão do desempenho de acordos de offtake e abastecimento de longo prazo.
+  BC-4690.60.10:
+    name: Negociação de term sheets de offtake
+    description: |
+      Negociação de term sheets de offtake de longo prazo.
+  BC-4690.60.20:
+    name: Redação de contratos de longo prazo
+    description: |
+      Redação de contratos definitivos de abastecimento e offtake de longo prazo.
+  BC-4690.60.30:
+    name: Monitorização do desempenho de offtake
+    description: |
+      Monitorização do desempenho de offtake face às obrigações contratuais.
+  BC-4690.70:
+    name: Gestão de índices de preços e referências
+    description: |
+      Gestão de subscrições e índices de preços de referência utilizados na fixação de preços químicos.
+  BC-4690.70.10:
+    name: Gestão de subscrições de índices de preços
+    description: |
+      Gestão de subscrições à ICIS, Argus, Platts e índices similares.
+  BC-4690.70.20:
+    name: Manutenção de curvas de preços de referência
+    description: |
+      Manutenção de curvas de preços de referência internas para produtos químicos.
+  BC-4690.70.30:
+    name: Cálculo de preços indexados
+    description: |
+      Cálculo de preços ao cliente indexados e liquidações de contratos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-chemical-manufacturing-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-chemical-manufacturing-operations-management.yaml
@@ -1,0 +1,176 @@
+locale: pt
+source: L1-chemical-manufacturing-operations-management.yaml
+entries:
+  BC-4620:
+    name: Gestão de operações de fabricação química
+    description: |
+      Operação diária de instalações de reação, separação, polimerização e
+      processos inorgânicos — incluindo vigilância de catalisadores, planeamento
+      da produção e coordenação de paragens programadas.
+  BC-4620.10:
+    name: Operações unitárias de reação
+    description: |
+      Operação de sistemas de reatores contínuos, descontínuos, catalíticos
+      e eletroquímicos.
+  BC-4620.10.10:
+    name: Operações de reatores contínuos
+    description: |
+      Operação de reatores de tanque agitado contínuo e de fluxo pistão.
+  BC-4620.10.20:
+    name: Operações de reatores descontínuos
+    description: |
+      Operação de reatores descontínuos e semi-descontínuos segundo receitas aprovadas.
+  BC-4620.10.30:
+    name: Operações de reatores catalíticos
+    description: |
+      Operação de reatores catalíticos de leito fixo e de leito fluidizado.
+  BC-4620.10.40:
+    name: Operações de reatores fotoquímicos e eletroquímicos
+    description: |
+      Operação de reatores fotoquímicos, eletroquímicos e de plasma.
+  BC-4620.20:
+    name: Operações unitárias de separação
+    description: |
+      Operação de unidades de destilação, cristalização, filtração, secagem
+      e separação por membranas.
+  BC-4620.20.10:
+    name: Operações de destilação
+    description: |
+      Operação de colunas de destilação com pratos e com recheio.
+  BC-4620.20.20:
+    name: Operações de cristalização
+    description: |
+      Operação de cristalizadores por arrefecimento, por evaporação e reativos.
+  BC-4620.20.30:
+    name: Filtração e separação sólido-líquido
+    description: |
+      Operação de centrífugas, filtros-prensa e filtros rotativos de vácuo.
+  BC-4620.20.40:
+    name: Operações de secagem
+    description: |
+      Operação de secadores de leito fluidizado, por atomização e de contacto.
+  BC-4620.20.50:
+    name: Operações de separação por membranas
+    description: |
+      Operação de membranas de osmose inversa, ultrafiltração e pervaporação.
+  BC-4620.30:
+    name: Operações de polimerização
+    description: |
+      Operação de polimerização em massa, em solução, em suspensão, em emulsão
+      e compoundagem a jusante de polímeros.
+  BC-4620.30.10:
+    name: Operações de polimerização em massa
+    description: |
+      Operação de reatores de polimerização em massa e em bloco.
+  BC-4620.30.20:
+    name: Operações de polimerização em solução
+    description: |
+      Operação de processos de polimerização em solução.
+  BC-4620.30.30:
+    name: Polimerização em suspensão e em emulsão
+    description: |
+      Operação de reatores de polimerização em suspensão e em emulsão.
+  BC-4620.30.40:
+    name: Operações de compoundagem de polímeros
+    description: |
+      Compoundagem de polímeros com aditivos por mistura em fusão.
+  BC-4620.40:
+    name: Operações inorgânicas e eletroquímicas
+    description: |
+      Operação de processos cloro-álcalis, eletrólise, calcinação e outros
+      processos de síntese inorgânica.
+  BC-4620.40.10:
+    name: Operações de células cloro-álcalis
+    description: |
+      Operação de células cloro-álcalis de membrana e de diafragma sem mercúrio.
+  BC-4620.40.20:
+    name: Operações de eletrólise
+    description: |
+      Operação de células de eletrólise de metais e de gases.
+  BC-4620.40.30:
+    name: Operações de calcinação e torrefação
+    description: |
+      Operação de fornos rotativos, torrefatores de leito fluidizado e calcinadores.
+  BC-4620.40.40:
+    name: Operações de síntese inorgânica
+    description: |
+      Operação de unidades de síntese inorgânica, incluindo precipitação e digestão.
+  BC-4620.50:
+    name: Gestão do ciclo de vida de catalisadores e produtos químicos de processo
+    description: |
+      Seleção, vigilância, regeneração e inventário de catalisadores e produtos
+      químicos de processo.
+  BC-4620.50.10:
+    name: Seleção e carga de catalisadores
+    description: |
+      Seleção e carga de catalisadores de leito fixo e de leito fluidizado.
+  BC-4620.50.20:
+    name: Vigilância do desempenho de catalisadores
+    description: |
+      Vigilância em serviço da atividade e seletividade de catalisadores.
+  BC-4620.50.30:
+    name: Coordenação da regeneração de catalisadores
+    description: |
+      Coordenação de campanhas de regeneração de catalisadores in situ e ex situ.
+  BC-4620.50.40:
+    name: Gestão do inventário de produtos químicos de processo
+    description: |
+      Gestão do inventário e consumo de solventes, aditivos e produtos químicos de processo.
+  BC-4620.60:
+    name: Controlo de processo e execução de operações
+    description: |
+      Execução diária de operações a partir do campo e da sala de controlo,
+      incluindo monitorização do envelope operacional.
+  BC-4620.60.10:
+    name: Execução de rondas de operadores
+    description: |
+      Execução de rondas estruturadas de operadores e verificações no campo.
+  BC-4620.60.20:
+    name: Operações de consola DCS
+    description: |
+      Operações de consola incluindo resposta a alarmes e controlo supervisório.
+  BC-4620.60.30:
+    name: Gestão da transferência de turno
+    description: |
+      Transferência estruturada de turno e revisão do registo operacional.
+  BC-4620.60.40:
+    name: Monitorização do envelope operacional
+    description: |
+      Monitorização em tempo real dos envelopes operacionais de segurança e qualidade.
+  BC-4620.70:
+    name: Coordenação de paragens programadas de instalação
+    description: |
+      Coordenação do âmbito, planeamento e execução de paragens programadas e
+      grandes encargamentos de instalações químicas.
+  BC-4620.70.10:
+    name: Gestão do âmbito da paragem programada
+    description: |
+      Definição e congelamento do âmbito da paragem programada, incluindo processo de contestação.
+  BC-4620.70.20:
+    name: Gestão do calendário da paragem programada
+    description: |
+      Planeamento detalhado da paragem programada e controlo do progresso.
+  BC-4620.70.30:
+    name: Coordenação de encerramento e arranque
+    description: |
+      Coordenação sequenciada do encerramento, descontaminação e arranque da unidade.
+  BC-4620.80:
+    name: Planeamento da produção química
+    description: |
+      Planeamento da produção em modo de campanha e contínuo e planeamento de mudanças.
+  BC-4620.80.10:
+    name: Planeamento de campanhas
+    description: |
+      Planeamento de campanhas multiproduto em ativos partilhados.
+  BC-4620.80.20:
+    name: Sequenciamento da produção
+    description: |
+      Sequenciamento de produtos para minimizar transições e perdas de rendimento.
+  BC-4620.80.30:
+    name: Planeamento de mudanças
+    description: |
+      Planeamento e coordenação de mudanças de qualidade e produto.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-chemical-process-engineering-management.yaml
+++ b/catalogue/i18n/pt/L1-chemical-process-engineering-management.yaml
@@ -1,0 +1,172 @@
+locale: pt
+source: L1-chemical-process-engineering-management.yaml
+entries:
+  BC-4610:
+    name: Gestão de engenharia de processos químicos
+    description: |
+      Design de processo, engenharia de balanços de massa e energia, simulação,
+      especificação de equipamentos e engenharia de fase inicial para instalações
+      e revamping de processos químicos. Distinto da Gestão de Disciplinas de
+      Engenharia transversal (BC-1100), que retém as disciplinas de engenharia
+      genéricas.
+  BC-4610.10:
+    name: Design de fluxograma de processo
+    description: |
+      Desenvolvimento de diagramas de blocos, de fluxo de processo e de tubagens
+      e instrumentação para processos químicos.
+  BC-4610.10.10:
+    name: Desenvolvimento de diagrama de blocos
+    description: |
+      Elaboração de diagramas de blocos para definição inicial do processo.
+  BC-4610.10.20:
+    name: Desenvolvimento de diagrama de fluxo de processo
+    description: |
+      Elaboração de diagramas de fluxo de processo com condições e propriedades
+      de correntes.
+  BC-4610.10.30:
+    name: Desenvolvimento de diagrama de tubagens e instrumentação
+    description: |
+      Elaboração e revisão de P&IDs para unidades de processo químico.
+  BC-4610.10.40:
+    name: Desenvolvimento de diagrama de fluxo de utilidades
+    description: |
+      Elaboração de diagramas de fluxo de utilidades abrangendo vapor, água
+      de arrefecimento e gás inerte.
+  BC-4610.20:
+    name: Dimensionamento de reatores e equipamentos de separação
+    description: |
+      Dimensionamento de reatores e equipamentos de separação com base em
+      cinética, termodinâmica e princípios de operações unitárias.
+  BC-4610.20.10:
+    name: Design de reatores
+    description: |
+      Dimensionamento e configuração de reatores CSTR, PFR e de leito fixo.
+  BC-4610.20.20:
+    name: Design de coluna de destilação
+    description: |
+      Design de colunas de destilação de pratos e de recheio, incluindo
+      internos.
+  BC-4610.20.30:
+    name: Design de rede de permutadores de calor
+    description: |
+      Design de redes de permutadores pelo método de Pinch para integração
+      energética.
+  BC-4610.20.40:
+    name: Dimensionamento de cristalizadores e filtros
+    description: |
+      Dimensionamento de cristalizadores, centrífugas e equipamentos de
+      filtração.
+  BC-4610.30:
+    name: Engenharia de balanços de massa e energia
+    description: |
+      Fecho de balanços de massa e energia globais e ao nível de unidade, e
+      estimativa da procura de utilidades.
+  BC-4610.30.10:
+    name: Cálculo de balanço de massa
+    description: |
+      Cálculo e reconciliação dos balanços de massa da instalação e de unidade.
+  BC-4610.30.20:
+    name: Cálculo de balanço de energia
+    description: |
+      Cálculo de balanços de energia em reatores, permutadores e utilidades.
+  BC-4610.30.30:
+    name: Estimativa da procura de utilidades
+    description: |
+      Estimativa da procura de vapor, energia, água de arrefecimento e gás
+      inerte.
+  BC-4610.40:
+    name: Gestão de simulação de processo
+    description: |
+      Construção e manutenção de simulações de processo em regime permanente
+      e dinâmico que suportam o design e as operações.
+  BC-4610.40.10:
+    name: Simulação de processo em regime permanente
+    description: |
+      Construção e execução de simuladores em regime permanente para design
+      e análise.
+  BC-4610.40.20:
+    name: Simulação de processo dinâmico
+    description: |
+      Construção e execução de simuladores dinâmicos para estudos de controlo
+      e segurança.
+  BC-4610.40.30:
+    name: Validação de modelos de simulação
+    description: |
+      Validação de modelos de simulação face a dados de instalação ou piloto.
+  BC-4610.50:
+    name: Gestão de especificação de equipamentos
+    description: |
+      Elaboração e gestão do ciclo de vida de fichas de dados de equipamentos
+      e desenhos de fornecedores.
+  BC-4610.50.10:
+    name: Elaboração de fichas de dados de equipamentos
+    description: |
+      Elaboração de fichas de dados mecânicos, elétricos e de instrumentação.
+  BC-4610.50.20:
+    name: Manutenção de especificações de equipamentos
+    description: |
+      Gestão de configuração das especificações de equipamentos aprovadas.
+  BC-4610.50.30:
+    name: Revisão de desenhos de fornecedores
+    description: |
+      Revisão dos desenhos de fornecedores face às fichas de dados e requisitos
+      de processo.
+  BC-4610.60:
+    name: Engenharia de layout e planta da instalação
+    description: |
+      Definição de plantas, espaçamentos de equipamentos e classificação de
+      zonas perigosas para instalações químicas.
+  BC-4610.60.10:
+    name: Desenvolvimento de planta
+    description: |
+      Desenvolvimento de plantas de unidade e gerais do sítio.
+  BC-4610.60.20:
+    name: Determinação do espaçamento de equipamentos
+    description: |
+      Determinação do espaçamento de equipamentos de acordo com a segurança
+      do processo e a construtibilidade.
+  BC-4610.60.30:
+    name: Classificação de zonas perigosas
+    description: |
+      Classificação de zonas perigosas para controlo de fontes de ignição.
+  BC-4610.70:
+    name: Desenvolvimento da filosofia de controlo de processo
+    description: |
+      Definição das estratégias de controlo de processo, controlo avançado e
+      base de procedimentos operacionais para instalações novas e modificadas.
+  BC-4610.70.10:
+    name: Definição de malhas de controlo
+    description: |
+      Definição de malhas de controlo regulatório e intenção de afinação.
+  BC-4610.70.20:
+    name: Estratégia de controlo avançado de processo
+    description: |
+      Definição de estratégias de controlo preditivo de modelo e controlo
+      avançado.
+  BC-4610.70.30:
+    name: Desenvolvimento da base de procedimentos operacionais
+    description: |
+      Desenvolvimento da base de procedimentos operacionais para instalações
+      novas e modificadas.
+  BC-4610.80:
+    name: Coordenação do design de engenharia de fase inicial
+    description: |
+      Coordenação de pacotes de engenharia conceptual, básica e de fase inicial
+      para projetos químicos.
+  BC-4610.80.10:
+    name: Coordenação de engenharia conceptual
+    description: |
+      Coordenação de estudos de engenharia conceptual e triagem de opções.
+  BC-4610.80.20:
+    name: Produção do pacote de engenharia básica
+    description: |
+      Produção de pacotes de engenharia básica entregues ao design de detalhe.
+  BC-4610.80.30:
+    name: Verificação de FEED
+    description: |
+      Verificação dos entregáveis de FEED face aos requisitos de processo e
+      de projeto.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-chemical-process-safety-management.yaml
+++ b/catalogue/i18n/pt/L1-chemical-process-safety-management.yaml
@@ -1,0 +1,185 @@
+locale: pt
+source: L1-chemical-process-safety-management.yaml
+entries:
+  BC-4640:
+    name: Gestão de segurança de processo químico
+    description: |
+      Prevenção de perigos de acidente grave em processos químicos reativos,
+      inflamáveis e tóxicos — análise de perigos de processo, integridade
+      mecânica, sistemas instrumentados de segurança, perigos reativos e de
+      poeiras combustíveis, reporte de desempenho e resposta a emergências.
+      Distinto da gestão transversal de HSE (BC-730), que retém o âmbito de
+      saúde ocupacional, ambiente e segurança pessoal.
+  BC-4640.10:
+    name: Análise de perigos de processo
+    description: |
+      Identificação e análise estruturada de perigos de acidente grave ao
+      longo do ciclo de vida do ativo.
+    in_scope:
+      - Análise HAZID, HAZOP, LOPA e bow-tie
+      - Avaliação quantitativa do risco
+    out_of_scope:
+      - Avaliação do risco de segurança pessoal (BC-730)
+  BC-4640.10.10:
+    name: Estudos HAZOP
+    description: |
+      Estudos de perigos e operabilidade em instalações novas e modificadas.
+  BC-4640.10.20:
+    name: Estudos HAZID
+    description: |
+      Estudos de identificação de perigos durante as fases iniciais de conceito e projeto.
+  BC-4640.10.30:
+    name: Estudos LOPA
+    description: |
+      Análise de camadas de proteção para definir níveis de integridade de segurança.
+  BC-4640.10.40:
+    name: Análise bow-tie
+    description: |
+      Análise bow-tie para mapear barreiras face a cenários de acidente grave.
+  BC-4640.10.50:
+    name: Avaliação quantitativa do risco
+    description: |
+      Avaliação quantitativa do risco de cenários de perigo de acidente grave.
+  BC-4640.20:
+    name: Gestão da integridade mecânica
+    description: |
+      Inspeção e gestão da integridade de equipamentos sob pressão e
+      dispositivos de segurança-alívio.
+  BC-4640.20.10:
+    name: Inspeção de vasos de pressão
+    description: |
+      Inspeção baseada no risco de vasos de pressão segundo a API 510.
+  BC-4640.20.20:
+    name: Inspeção da integridade de tubagens de processo
+    description: |
+      Inspeção de tubagens de processo segundo a API 570 e ASME B31.3.
+  BC-4640.20.30:
+    name: Inspeção de tanques de armazenamento
+    description: |
+      Inspeção de tanques de armazenamento atmosférico e pressurizado segundo a API 653.
+  BC-4640.20.40:
+    name: Gestão de dispositivos de alívio de pressão
+    description: |
+      Dimensionamento, teste e gestão do ciclo de vida de válvulas de segurança e discos de rutura.
+  BC-4640.20.50:
+    name: Integridade de ventilações atmosféricas e tochas
+    description: |
+      Garantia de integridade de ventilações atmosféricas, depuradores e tochas.
+  BC-4640.30:
+    name: Gestão de sistemas instrumentados de segurança
+    description: |
+      Gestão do ciclo de vida de segurança funcional de sistemas instrumentados
+      de segurança segundo a IEC 61511.
+  BC-4640.30.10:
+    name: Determinação do SIL
+    description: |
+      Determinação dos níveis de integridade de segurança para funções de proteção.
+  BC-4640.30.20:
+    name: Verificação de funções de segurança
+    description: |
+      Verificação de que as SIF concebidas cumprem o SIL exigido.
+  BC-4640.30.30:
+    name: Ensaios de prova de SIS
+    description: |
+      Ensaios de prova periódicos de sistemas instrumentados de segurança.
+  BC-4640.30.40:
+    name: Avaliação de segurança funcional
+    description: |
+      Avaliações de segurança funcional nas fases-chave do ciclo de vida.
+  BC-4640.40:
+    name: Gestão de perigos reativos e de poeiras combustíveis
+    description: |
+      Identificação e controlo de perigos de química reativa, reações
+      descontroladas, poeiras combustíveis e fontes de ignição.
+  BC-4640.40.10:
+    name: Avaliação do risco de química reativa
+    description: |
+      Avaliação dos riscos de química reativa, incluindo incompatibilidades.
+  BC-4640.40.20:
+    name: Prevenção de reações descontroladas
+    description: |
+      Prevenção e mitigação de reações exotérmicas descontroladas.
+  BC-4640.40.30:
+    name: Controlo de perigos de poeiras combustíveis
+    description: |
+      Controlo de perigos de poeiras combustíveis segundo a NFPA 654.
+  BC-4640.40.40:
+    name: Controlo de eletricidade estática e fontes de ignição
+    description: |
+      Controlo de fontes de ignição eletrostáticas e outras em áreas de processo.
+  BC-4640.50:
+    name: Gestão de alterações de segurança de processo
+    description: |
+      Governação de segurança de processo sobre alterações de instalações,
+      procedimentos e pessoal, incluindo revisão de segurança pré-arranque.
+  BC-4640.50.10:
+    name: Revisão de pedidos de alteração de PSM
+    description: |
+      Revisão de pedidos de alteração com impacto em PSM segundo normas de perigo.
+  BC-4640.50.20:
+    name: Revisão de segurança pré-arranque
+    description: |
+      Revisões de segurança pré-arranque para instalações novas e modificadas.
+  BC-4640.50.30:
+    name: Gestão de alterações temporárias
+    description: |
+      Gestão de alterações temporárias de processo dentro do prazo autorizado.
+  BC-4640.60:
+    name: Gestão do desempenho de segurança de processo
+    description: |
+      Monitorização e reporte de indicadores de segurança de processo avançados
+      e retrospetivos segundo o CCPS RBPS e referenciais equivalentes.
+  BC-4640.60.10:
+    name: Reporte de eventos de segurança de processo de nível 1 e 2
+    description: |
+      Registo e reporte de eventos de segurança de processo de nível 1 e 2.
+  BC-4640.60.20:
+    name: Monitorização de indicadores avançados
+    description: |
+      Monitorização de indicadores avançados de segurança de processo de nível 3 e 4.
+  BC-4640.60.30:
+    name: Reporte de KPI de segurança de processo
+    description: |
+      Reporte interno e externo do desempenho dos KPI de segurança de processo.
+  BC-4640.70:
+    name: Preparação e resposta a emergências
+    description: |
+      Planeamento da resposta a emergências, execução de simulacros e coordenação
+      da resposta a libertações tóxicas em cenários de acidente grave.
+  BC-4640.70.10:
+    name: Planeamento da resposta a emergências
+    description: |
+      Manutenção de planos de resposta a emergências de instalação e corporativos.
+  BC-4640.70.20:
+    name: Coordenação de simulacros e exercícios
+    description: |
+      Coordenação de simulacros de emergência e exercícios de grandes incidentes.
+  BC-4640.70.30:
+    name: Coordenação da resposta a libertações tóxicas
+    description: |
+      Coordenação das operações de resposta a libertações tóxicas e inflamáveis.
+  BC-4640.70.40:
+    name: Coordenação de auxílio mútuo
+    description: |
+      Coordenação do auxílio mútuo com cooperativas de resposta da indústria.
+  BC-4640.80:
+    name: Procedimentos operacionais de segurança de processo
+    description: |
+      Autoria, revisão e definição do envelope operacional para procedimentos
+      críticos de segurança de processo.
+  BC-4640.80.10:
+    name: Autoria de procedimentos críticos de segurança
+    description: |
+      Autoria de procedimentos operacionais críticos de segurança de processo.
+  BC-4640.80.20:
+    name: Definição do envelope operacional
+    description: |
+      Definição de envelopes operacionais seguros para unidades de processo.
+  BC-4640.80.30:
+    name: Revisão periódica de procedimentos
+    description: |
+      Revisão e atualização periódica de procedimentos de segurança de processo.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-chemical-product-stewardship-management.yaml
+++ b/catalogue/i18n/pt/L1-chemical-product-stewardship-management.yaml
@@ -1,0 +1,121 @@
+locale: pt
+source: L1-chemical-product-stewardship-management.yaml
+entries:
+  BC-4650:
+    name: Gestão de responsabilidade do produto químico
+    description: |
+      Classificação de perigos e rotulagem, autoria de fichas de dados de
+      segurança, cenários de exposição, programas de substâncias de preocupação
+      e comunicação de perigos ao cliente ao longo do ciclo de vida do produto químico.
+  BC-4650.10:
+    name: Classificação e rotulagem de perigos
+    description: |
+      Classificação GHS de substâncias e misturas e conceção de rótulos conformes.
+  BC-4650.10.10:
+    name: Classificação GHS
+    description: |
+      Classificação de substâncias segundo o esquema de perigos GHS da ONU.
+  BC-4650.10.20:
+    name: Classificação de misturas
+    description: |
+      Classificação de misturas utilizando princípios de extrapolação e dados de ensaios.
+  BC-4650.10.30:
+    name: Conceção de pictogramas de perigo e rótulos
+    description: |
+      Conceção de pictogramas conformes com o GHS, palavras-sinal e maquetes de rótulos.
+  BC-4650.10.40:
+    name: Localização multilingue de rótulos
+    description: |
+      Tradução e localização de rótulos para os mercados de destino.
+  BC-4650.20:
+    name: Gestão de fichas de dados de segurança
+    description: |
+      Autoria, revisão e distribuição de fichas de dados de segurança, incluindo
+      FDS alargadas para utilizadores a jusante.
+  BC-4650.20.10:
+    name: Autoria de FDS
+    description: |
+      Autoria de fichas de dados de segurança no formato de 16 secções.
+  BC-4650.20.20:
+    name: Revisão e atualização de FDS
+    description: |
+      Revisão e atualização de FDS face a novos dados e alterações regulatórias.
+  BC-4650.20.30:
+    name: Gestão da distribuição de FDS
+    description: |
+      Distribuição de FDS a clientes e parceiros da cadeia de abastecimento.
+  BC-4650.20.40:
+    name: Gestão de FDS alargadas
+    description: |
+      Gestão de anexos de FDS alargadas contendo cenários de exposição.
+  BC-4650.30:
+    name: Gestão de cenários de exposição
+    description: |
+      Desenvolvimento e manutenção de cenários de exposição de trabalhadores,
+      consumidores e ambiente para substâncias registadas.
+  BC-4650.30.10:
+    name: Desenvolvimento de cenários de exposição de trabalhadores
+    description: |
+      Desenvolvimento de cenários de exposição de trabalhadores em condições típicas de utilização.
+  BC-4650.30.20:
+    name: Desenvolvimento de cenários de exposição de consumidores
+    description: |
+      Desenvolvimento de cenários de exposição de consumidores para utilizações em produto final.
+  BC-4650.30.30:
+    name: Desenvolvimento de cenários de libertação ambiental
+    description: |
+      Desenvolvimento de cenários de libertação ambiental ao longo do ciclo de vida.
+  BC-4650.40:
+    name: Gestão de substâncias de preocupação
+    description: |
+      Identificação, substituição e monitorização de restrições de substâncias
+      muito preocupantes na carteira de produtos.
+  BC-4650.40.10:
+    name: Gestão do inventário de SVHC
+    description: |
+      Manutenção do inventário de presença de SVHC na carteira de produtos.
+  BC-4650.40.20:
+    name: Gestão do programa de substituição de substâncias
+    description: |
+      Gestão de programas de iniciativas de substituição por substâncias mais seguras.
+  BC-4650.40.30:
+    name: Manutenção da lista de substâncias restritas
+    description: |
+      Manutenção de listas internas de substâncias restritas e listas impostas por clientes.
+  BC-4650.50:
+    name: Comunicação de perigos ao cliente
+    description: |
+      Comunicação de informações de perigo a clientes e utilizadores a jusante.
+  BC-4650.50.10:
+    name: Notificação de responsabilidade ao cliente
+    description: |
+      Notificação de clientes sobre alterações relevantes em matéria de responsabilidade do produto.
+  BC-4650.50.20:
+    name: Produção de materiais de formação sobre perigos
+    description: |
+      Produção de materiais de formação sobre manuseamento e utilização seguros.
+  BC-4650.50.30:
+    name: Atendimento de consultas de utilizadores a jusante
+    description: |
+      Atendimento de consultas de responsabilidade do produto de utilizadores a jusante.
+  BC-4650.60:
+    name: Responsabilidade do produto ao longo do ciclo de vida
+    description: |
+      Responsabilidade do produto químico ao longo do ciclo de vida, incluindo
+      considerações de fim de vida, reciclabilidade e reutilização.
+  BC-4650.60.10:
+    name: Manutenção do perfil de perigos do produto
+    description: |
+      Manutenção de perfis de perigos consolidados por produto.
+  BC-4650.60.20:
+    name: Coordenação da responsabilidade no fim de vida
+    description: |
+      Coordenação de acordos de recolha e responsabilidade no fim de vida.
+  BC-4650.60.30:
+    name: Avaliação de reciclabilidade e reutilização
+    description: |
+      Avaliação do potencial de reciclabilidade e reutilização de produtos químicos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-chemical-quality-management.yaml
+++ b/catalogue/i18n/pt/L1-chemical-quality-management.yaml
@@ -1,0 +1,140 @@
+locale: pt
+source: L1-chemical-quality-management.yaml
+entries:
+  BC-4670:
+    name: Gestão da qualidade química
+    description: |
+      Definição de especificações específicas do setor químico, operações de
+      laboratório analítico, libertação de lotes, tratamento de reclamações e
+      disputas de certificados de análise, padrões de referência e conformidade
+      com BPF específica do setor. Distinto da Gestão de Qualidade transversal
+      (BC-720), que cobre o SGQ empresarial.
+  BC-4670.10:
+    name: Gestão de especificações químicas
+    description: |
+      Definição e gestão do ciclo de vida de especificações de matérias-primas,
+      intermédios e produtos acabados.
+  BC-4670.10.10:
+    name: Definição de especificações de matérias-primas
+    description: |
+      Definição e revisão de especificações de matérias-primas à entrada.
+  BC-4670.10.20:
+    name: Definição de especificações de intermédios
+    description: |
+      Definição de especificações de intermédios ao longo da cadeia de produção.
+  BC-4670.10.30:
+    name: Definição de especificações de produto acabado
+    description: |
+      Definição de especificações de produto acabado e critérios de libertação.
+  BC-4670.10.40:
+    name: Gestão do ciclo de vida de especificações
+    description: |
+      Gestão do ciclo de vida de especificações aprovadas e suas alterações.
+  BC-4670.20:
+    name: Operações de laboratório analítico
+    description: |
+      Operação de laboratórios de CQ que realizam química húmida, cromatografia,
+      espetroscopia e ensaios de propriedades físicas.
+  BC-4670.20.10:
+    name: Operações de laboratório de química húmida
+    description: |
+      Operação de fluxos de trabalho analíticos de química húmida.
+  BC-4670.20.20:
+    name: Operações de cromatografia
+    description: |
+      Operação de plataformas de HPLC, GC e cromatografia iónica.
+  BC-4670.20.30:
+    name: Operações de espetroscopia
+    description: |
+      Operação de plataformas de FTIR, RMN, ICP e espectrometria de massa.
+  BC-4670.20.40:
+    name: Ensaios de propriedades físicas
+    description: |
+      Ensaios de propriedades físicas como viscosidade, densidade e granulometria.
+  BC-4670.30:
+    name: Gestão da libertação de lotes
+    description: |
+      Decisões de disposição, emissão de certificados de análise e tratamento de
+      resultados fora de especificação para lotes químicos.
+  BC-4670.30.10:
+    name: Decisão de disposição de lotes
+    description: |
+      Decisão de disposição de lotes fabricados face à especificação.
+  BC-4670.30.20:
+    name: Emissão de certificados de análise
+    description: |
+      Emissão de certificados de análise a clientes.
+  BC-4670.30.30:
+    name: Investigação de resultados fora de especificação
+    description: |
+      Investigação de resultados analíticos fora de especificação.
+  BC-4670.40:
+    name: Gestão de reclamações de clientes e disputas de COA
+    description: |
+      Registo e resolução de reclamações de clientes e disputas de certificados de análise.
+  BC-4670.40.10:
+    name: Registo de reclamações de clientes
+    description: |
+      Registo e triagem de reclamações de clientes sobre produtos químicos.
+  BC-4670.40.20:
+    name: Investigação de disputas de COA
+    description: |
+      Investigação de disputas sobre valores de certificados de análise.
+  BC-4670.40.30:
+    name: Reanálise de amostras de clientes
+    description: |
+      Reanálise de amostras retidas e fornecidas pelo cliente.
+  BC-4670.50:
+    name: Gestão de materiais e padrões de referência
+    description: |
+      Obtenção, qualificação e monitorização da estabilidade de padrões e materiais de referência.
+  BC-4670.50.10:
+    name: Obtenção de padrões de referência
+    description: |
+      Obtenção de materiais de referência certificados junto de fornecedores acreditados.
+  BC-4670.50.20:
+    name: Qualificação de padrões de referência internos
+    description: |
+      Qualificação de padrões de referência de trabalho internos.
+  BC-4670.50.30:
+    name: Monitorização da estabilidade de padrões de referência
+    description: |
+      Monitorização da estabilidade de padrões de referência em uso.
+  BC-4670.60:
+    name: Desenvolvimento e validação de métodos
+    description: |
+      Desenvolvimento, validação e transferência de métodos analíticos entre laboratórios.
+  BC-4670.60.10:
+    name: Desenvolvimento de métodos analíticos
+    description: |
+      Desenvolvimento de novos métodos analíticos para suporte das especificações.
+  BC-4670.60.20:
+    name: Validação de métodos
+    description: |
+      Validação de métodos analíticos quanto à exatidão, precisão e robustez.
+  BC-4670.60.30:
+    name: Transferência de métodos
+    description: |
+      Transferência de métodos validados entre laboratórios.
+  BC-4670.70:
+    name: Conformidade com BPF específica do setor
+    description: |
+      Conformidade com regimes de BPF específicos do setor para produtos químicos
+      fornecidos a mercados a jusante regulamentados.
+  BC-4670.70.10:
+    name: Conformidade com BPF EFfCI
+    description: |
+      Conformidade com as BPF EFfCI para ingredientes cosméticos.
+  BC-4670.70.20:
+    name: Conformidade com BPF IPEC
+    description: |
+      Conformidade com as BPF IPEC para excipientes farmacêuticos.
+  BC-4670.70.30:
+    name: Conformidade com contacto com alimentos
+    description: |
+      Conformidade com regulamentação de contacto com alimentos para produtos químicos
+      fornecidos a embalagens alimentares.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-chemical-regulatory-compliance-management.yaml
+++ b/catalogue/i18n/pt/L1-chemical-regulatory-compliance-management.yaml
@@ -1,0 +1,141 @@
+locale: pt
+source: L1-chemical-regulatory-compliance-management.yaml
+entries:
+  BC-4660:
+    name: Gestão de conformidade regulatória química
+    description: |
+      Registo de substâncias, dossiês, autorizações, restrições, listagens de
+      inventários e controlos de importação/exportação sob o REACH, TSCA,
+      K-REACH, CWC e regimes equivalentes. Distinto da Gestão de Conformidade
+      transversal (BC-130), que cobre a conformidade com políticas empresariais.
+  BC-4660.10:
+    name: Gestão do registo de substâncias
+    description: |
+      Registo de substâncias nos principais regimes globais de inventário de
+      produtos químicos.
+  BC-4660.10.10:
+    name: Gestão do registo REACH
+    description: |
+      Gestão dos registos REACH, incluindo SIEF e submissão conjunta.
+  BC-4660.10.20:
+    name: PMN TSCA e notificação de inventário
+    description: |
+      Notificação pré-fabrico e notificação de inventário TSCA.
+  BC-4660.10.30:
+    name: Notificação K-REACH e Ásia-Pacífico
+    description: |
+      Notificação ao abrigo do K-REACH, China, Japão e outros regimes da Ásia-Pacífico.
+  BC-4660.10.40:
+    name: Gestão de notificação de polímeros
+    description: |
+      Gestão de notificações e isenções para substâncias poliméricas.
+  BC-4660.20:
+    name: Gestão de autorizações e restrições
+    description: |
+      Conformidade com autorizações, restrições e controlos de substâncias emergentes.
+  BC-4660.20.10:
+    name: Pedido de autorização REACH
+    description: |
+      Preparação e submissão de pedidos de autorização REACH ao abrigo do Anexo XIV.
+  BC-4660.20.20:
+    name: Conformidade com restrições REACH
+    description: |
+      Conformidade com as entradas de restrição do Anexo XVII do REACH.
+  BC-4660.20.30:
+    name: Monitorização da lista de candidatos SVHC
+    description: |
+      Monitorização de atualizações da lista de candidatos SVHC e análise de impacto.
+  BC-4660.20.40:
+    name: Gestão de PFAS e restrições emergentes
+    description: |
+      Gestão de PFAS, microplásticos e outras restrições emergentes.
+  BC-4660.30:
+    name: Gestão de dossiês regulatórios
+    description: |
+      Autoria e manutenção de dossiês regulatórios no IUCLID e formatos equivalentes.
+  BC-4660.30.10:
+    name: Gestão de dossiês IUCLID
+    description: |
+      Autoria e manutenção de dossiês IUCLID 6.
+  BC-4660.30.20:
+    name: Preparação de relatórios de segurança química
+    description: |
+      Preparação de relatórios de segurança química segundo o Anexo I do REACH.
+  BC-4660.30.30:
+    name: Manutenção do perfil de identidade da substância
+    description: |
+      Manutenção de perfis de identidade de substâncias e evidência analítica.
+  BC-4660.40:
+    name: Gestão de listagem em inventários
+    description: |
+      Gestão da presença de substâncias no EINECS, CE e inventários químicos nacionais.
+  BC-4660.40.10:
+    name: Gestão de números EINECS e CE
+    description: |
+      Gestão de atribuições e atualizações de números EINECS e CE.
+  BC-4660.40.20:
+    name: Notificação de novas substâncias em inventários
+    description: |
+      Notificação de novas substâncias a inventários nacionais.
+  BC-4660.40.30:
+    name: Reconciliação com inventários nacionais
+    description: |
+      Reconciliação da carteira de produtos com inventários químicos nacionais.
+  BC-4660.50:
+    name: Controlo de importação e exportação de produtos químicos
+    description: |
+      Conformidade com os controlos internacionais de comércio de produtos químicos,
+      incluindo CWC, precursores de drogas, dupla utilização e PIC.
+  BC-4660.50.10:
+    name: Conformidade com as listas CWC
+    description: |
+      Conformidade com a declaração e licenciamento das Listas 1, 2 e 3 da OPAQ.
+  BC-4660.50.20:
+    name: Controlo de precursores de drogas
+    description: |
+      Conformidade com o INCB e regimes nacionais de controlo de precursores de drogas.
+  BC-4660.50.30:
+    name: Licenciamento de exportação de dupla utilização
+    description: |
+      Licenciamento e conformidade de uso final para exportações de produtos químicos de dupla utilização.
+  BC-4660.50.40:
+    name: Conformidade com o consentimento prévio informado
+    description: |
+      Conformidade com o regime de consentimento prévio informado da Convenção de Roterdão.
+  BC-4660.60:
+    name: Vigilância e inteligência regulatória
+    description: |
+      Monitorização e avaliação de impacto das regulamentações químicas em evolução
+      nos diferentes mercados.
+  BC-4660.60.10:
+    name: Análise prospetiva regulatória
+    description: |
+      Análise prospetiva de regulamentações químicas pendentes e emergentes.
+  BC-4660.60.20:
+    name: Avaliação do impacto de alterações regulatórias
+    description: |
+      Avaliação do impacto de alterações regulatórias na carteira e nas operações.
+  BC-4660.60.30:
+    name: Liaison com associações da indústria
+    description: |
+      Liaison com a Cefic, ACC e associações sectoriais equivalentes.
+  BC-4660.70:
+    name: Interação com autoridades e submissões
+    description: |
+      Interação com autoridades regulatórias, incluindo submissões, consultas e inspeções.
+  BC-4660.70.10:
+    name: Preparação de submissões às autoridades
+    description: |
+      Preparação de submissões à ECHA, EPA e autoridades equivalentes.
+  BC-4660.70.20:
+    name: Resposta a consultas das autoridades
+    description: |
+      Resposta a consultas das autoridades sobre dossiês e registos.
+  BC-4660.70.30:
+    name: Prontidão para inspeções
+    description: |
+      Manutenção da prontidão para inspeções e auditorias regulatórias.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-chemical-research-process-development-management.yaml
+++ b/catalogue/i18n/pt/L1-chemical-research-process-development-management.yaml
@@ -1,0 +1,163 @@
+locale: pt
+source: L1-chemical-research-process-development-management.yaml
+entries:
+  BC-4600:
+    name: Gestão de investigação química e desenvolvimento de processos
+    description: |
+      Descoberta de novas moléculas e rotas de síntese, desenvolvimento de
+      processos à escala bancada, operação de instalação piloto e aumento de
+      escala para produção comercial de produtos químicos.
+  BC-4600.10:
+    name: Descoberta de moléculas e rotas de síntese
+    description: |
+      Identificação de moléculas alvo e seleção de rotas de síntese viáveis
+      para produtos químicos novos e existentes.
+  BC-4600.10.10:
+    name: Identificação de moléculas alvo
+    description: |
+      Identificação de moléculas candidatas face a alvos de aplicação.
+  BC-4600.10.20:
+    name: Análise retrossintética
+    description: |
+      Análise retrossintética assistida por computador e por especialistas
+      de rotas de síntese.
+  BC-4600.10.30:
+    name: Triagem de catalisadores e reagentes
+    description: |
+      Triagem de alto rendimento e direcionada de catalisadores e reagentes.
+  BC-4600.10.40:
+    name: Avaliação de seleção de rotas
+    description: |
+      Avaliação multicritério de rotas candidatas quanto a rendimento, custo,
+      segurança e sustentabilidade.
+  BC-4600.20:
+    name: Investigação de cinética de reações e termodinâmica
+    description: |
+      Geração de dados cinéticos e termodinâmicos necessários para modelar e
+      desenhar processos químicos.
+  BC-4600.20.10:
+    name: Medição de cinética de reações
+    description: |
+      Medição de velocidades de reação e constantes de velocidade em condições
+      controladas.
+  BC-4600.20.20:
+    name: Medição de propriedades termodinâmicas
+    description: |
+      Determinação de entalpia, entropia e capacidade calorífica de reagentes
+      e produtos.
+  BC-4600.20.30:
+    name: Estudos de equilíbrio de fases
+    description: |
+      Experimentação de equilíbrio vapor-líquido, líquido-líquido e sólido-líquido.
+  BC-4600.20.40:
+    name: Desenvolvimento de modelos cinéticos
+    description: |
+      Ajuste e validação de modelos cinéticos face a dados medidos.
+  BC-4600.30:
+    name: Desenvolvimento e otimização de processos
+    description: |
+      Desenvolvimento e otimização à escala bancada de janelas operativas do
+      processo químico antes dos ensaios piloto.
+  BC-4600.30.10:
+    name: Design de experiências à escala bancada
+    description: |
+      Design de experiências à escala bancada para caracterizar o comportamento
+      do processo.
+  BC-4600.30.20:
+    name: Otimização de parâmetros de processo
+    description: |
+      Otimização de temperatura, pressão, tempo de residência e estequiometria.
+  BC-4600.30.30:
+    name: Melhoria de rendimento e seletividade
+    description: |
+      Melhoria do rendimento e seletividade através de intervenções de
+      engenharia de reação.
+  BC-4600.30.40:
+    name: Seleção de sistema de solvente
+    description: |
+      Seleção e otimização de sistemas de solvente equilibrando desempenho e
+      HSE.
+  BC-4600.40:
+    name: Gestão de operações de instalação piloto
+    description: |
+      Planeamento, execução e análise de campanhas à escala piloto para
+      reduzir o risco do aumento de escala comercial.
+  BC-4600.40.10:
+    name: Planeamento de campanha piloto
+    description: |
+      Planeamento de campanhas de instalação piloto, incluindo objetivos e
+      balanços de material.
+  BC-4600.40.20:
+    name: Execução na instalação piloto
+    description: |
+      Execução de ensaios piloto em condições representativas do processo.
+  BC-4600.40.30:
+    name: Análise de dados piloto
+    description: |
+      Análise de dados piloto para refinar modelos cinéticos e de rendimento.
+  BC-4600.40.40:
+    name: Gestão de ativos da instalação piloto
+    description: |
+      Gestão do ciclo de vida de equipamentos e instrumentação da instalação
+      piloto.
+  BC-4600.50:
+    name: Gestão do aumento de escala do processo
+    description: |
+      Tradução de processos à escala piloto em definições de processo comercial
+      validadas.
+  BC-4600.50.10:
+    name: Modelação do aumento de escala
+    description: |
+      Utilização de análise dimensional e CFD para modelar os efeitos do
+      aumento de escala.
+  BC-4600.50.20:
+    name: Validação à escala demonstração
+    description: |
+      Operação de instalações à escala demonstração para validar os pressupostos
+      do aumento de escala.
+  BC-4600.50.30:
+    name: Definição do processo comercial
+    description: |
+      Finalização da base do processo comercial pronta para FEED.
+  BC-4600.60:
+    name: Triagem de perigos de segurança de processo
+    description: |
+      Triagem em fase inicial de perigos reactivos, térmicos e de pó durante
+      a investigação e desenvolvimento.
+  BC-4600.60.10:
+    name: Triagem de química reativa
+    description: |
+      Triagem de perigos de química reativa utilizando DSC, ARC e calorimetria
+      Calvet.
+  BC-4600.60.20:
+    name: Testes de estabilidade térmica
+    description: |
+      Determinação de limites de decomposição térmica e potencial de
+      descontrolo.
+  BC-4600.60.30:
+    name: Caracterização de perigos de pó
+    description: |
+      Caracterização de perigos de pó combustível, incluindo Kst e MIE.
+  BC-4600.70:
+    name: Gestão de conhecimento e dados de I&D
+    description: |
+      Captura e gestão do conhecimento de I&D, registos de experiências e
+      ativos de dados de processo.
+  BC-4600.70.10:
+    name: Gestão de cadernos de laboratório eletrónicos
+    description: |
+      Operação de cadernos de laboratório eletrónicos para I&D química.
+  BC-4600.70.20:
+    name: Gestão do repositório de conhecimento de processo
+    description: |
+      Curadoria do conhecimento de processo ao longo da descoberta, desenvolvimento
+      e aumento de escala.
+  BC-4600.70.30:
+    name: Curadoria de dados de I&D
+    description: |
+      Curadoria, retenção e reutilização de dados estruturados de experiências
+      de I&D.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-citizen-constituent-service-management.yaml
+++ b/catalogue/i18n/pt/L1-citizen-constituent-service-management.yaml
@@ -1,0 +1,141 @@
+locale: pt
+source: L1-citizen-constituent-service-management.yaml
+entries:
+  BC-3220:
+    name: Gestão do serviço ao cidadão e constituinte
+    description: |
+      Prestação multicanal de serviços governamentais a cidadãos, residentes e
+      constituintes, incluindo autenticação de identidade, gestão de casos,
+      pedidos de informação, recursos e participação.
+  BC-3220.10:
+    name: Operações de canais de serviço
+    description: |
+      Operação de canais presenciais, telefónicos, postais, digitais e móveis
+      através dos quais os cidadãos acedem a serviços governamentais.
+    in_scope:
+      - Centros de serviço e balcões únicos
+      - Centros de contacto e canais de telefonia
+      - Portais digitais e aplicações móveis
+      - Canais postais e baseados em formulários
+    out_of_scope:
+      - Verificação de identidade do cidadão (abrangida pela Identidade e Autenticação do Cidadão)
+  BC-3220.10.10:
+    name: Operações de balcão único
+    description: |
+      Operação de centros de serviço presenciais e balcões únicos entre agências.
+  BC-3220.10.20:
+    name: Operações de centro de contacto
+    description: |
+      Operação de centros de contacto telefónico e chat multiagência.
+  BC-3220.10.30:
+    name: Operações do portal de serviço digital
+    description: |
+      Operação de portais digitais e aplicações móveis de serviço orientadas ao
+      cidadão.
+  BC-3220.10.40:
+    name: Garantia de acessibilidade dos serviços
+    description: |
+      Garantia de acessibilidade WCAG e Section 508 em canais de serviço e suporte
+      a tecnologias de apoio.
+  BC-3220.20:
+    name: Identidade e autenticação do cidadão
+    description: |
+      Estabelecimento e verificação de identidades digitais, credenciais e níveis
+      de garantia de cidadãos para acesso a serviços governamentais.
+  BC-3220.20.10:
+    name: Confirmação de identidade
+    description: |
+      Confirmação de identidade alinhada com os níveis de garantia IAL do NIST
+      800-63 ou eIDAS.
+  BC-3220.20.20:
+    name: Emissão de credenciais
+    description: |
+      Emissão de autenticadores e credenciais para acesso governamental.
+  BC-3220.20.30:
+    name: Operações de autenticação
+    description: |
+      Autenticação do quotidiano de cidadãos face a serviços governamentais.
+  BC-3220.20.40:
+    name: Federação e confiança transfronteiriça
+    description: |
+      Federação de identidade entre agências e confiança transfronteiriça ao abrigo
+      do eIDAS ou equivalente.
+  BC-3220.30:
+    name: Gestão de casos do cidadão
+    description: |
+      Gestão end-to-end do ciclo de vida de casos de interacções de cidadãos entre
+      agências e programas.
+  BC-3220.30.10:
+    name: Recepção e triagem de casos
+    description: |
+      Recepção, classificação e triagem de casos de cidadãos.
+  BC-3220.30.20:
+    name: Encaminhamento e atribuição de casos
+    description: |
+      Encaminhamento de casos para assistentes sociais e agências com base na
+      jurisdição e regras.
+  BC-3220.30.30:
+    name: Progressão e resolução de casos
+    description: |
+      Progressão de casos pelos fluxos de trabalho de serviço até à resolução.
+  BC-3220.30.40:
+    name: Encerramento e revisão de qualidade de casos
+    description: |
+      Encerramento, revisão de qualidade e retrabalho de casos concluídos.
+  BC-3220.40:
+    name: Gestão de pedidos de serviço e pedidos de informação
+    description: |
+      Gestão de pedidos de informação, pedidos de serviço, reclamações e
+      submissões de acesso à informação através de canais.
+  BC-3220.40.10:
+    name: Gestão de pedidos de informação gerais
+    description: |
+      Gestão de pedidos de informação gerais e pedidos de informação.
+  BC-3220.40.20:
+    name: Gestão de reclamações
+    description: |
+      Recepção, investigação e resolução de reclamações de cidadãos.
+  BC-3220.40.30:
+    name: Gestão de pedidos de acesso à informação
+    description: |
+      Processamento de pedidos de acesso à informação e de acesso a registos.
+  BC-3220.50:
+    name: Gestão de recursos e Provedor de Justiça
+    description: |
+      Revisão administrativa independente de decisões de agências, incluindo
+      recursos, tribunais e investigações do Provedor de Justiça.
+  BC-3220.50.10:
+    name: Recepção de recursos administrativos
+    description: |
+      Recepção e validação de recursos administrativos contra decisões de agências.
+  BC-3220.50.20:
+    name: Audiência e decisão de recursos
+    description: |
+      Audiência de recursos e determinação de resultados por autoridades de revisão.
+  BC-3220.50.30:
+    name: Investigação do Provedor de Justiça
+    description: |
+      Investigação independente do Provedor de Justiça sobre reclamações de má
+      administração.
+  BC-3220.60:
+    name: Participação e envolvimento do cidadão
+    description: |
+      Envolvimento bidirecional com cidadãos através de plataformas de
+      participação, petições e canais de feedback.
+  BC-3220.60.10:
+    name: Gestão de petições e iniciativas dos cidadãos
+    description: |
+      Recepção, validação e resposta a petições e propostas iniciadas por cidadãos.
+  BC-3220.60.20:
+    name: Operações de plataformas participativas
+    description: |
+      Operação de plataformas de orçamentação participativa, deliberação e
+      co-criação.
+  BC-3220.60.30:
+    name: Medição da satisfação dos cidadãos
+    description: |
+      Medição da satisfação, confiança e experiência de serviço dos cidadãos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-civil-records-identity-registration-management.yaml
+++ b/catalogue/i18n/pt/L1-civil-records-identity-registration-management.yaml
@@ -1,0 +1,138 @@
+locale: pt
+source: L1-civil-records-identity-registration-management.yaml
+entries:
+  BC-3290:
+    name: Gestão de registos civis e de identidade
+    description: |
+      Registo e gestão de registos civis e estatutários, incluindo factos vitais,
+      identidade nacional, registos de empresas e entidades e cadastro predial,
+      juntamente com autenticação, divulgação e controlos de privacidade.
+  BC-3290.10:
+    name: Gestão de registos vitais
+    description: |
+      Registo de factos vitais, incluindo nascimentos, óbitos, casamentos,
+      uniões de facto e divórcios.
+    in_scope:
+      - Registo de nascimentos, óbitos, casamentos e divórcios
+      - Certificação de factos vitais
+      - Extração de estatísticas vitais
+    out_of_scope:
+      - Emissão de número de identidade nacional (coberta pelo Registo de Identidade Nacional)
+  BC-3290.10.10:
+    name: Registo de nascimentos
+    description: |
+      Registo de nascimentos e emissão de certidões de nascimento.
+  BC-3290.10.20:
+    name: Registo de óbitos
+    description: |
+      Registo de óbitos e emissão de certidões de óbito.
+  BC-3290.10.30:
+    name: Registo de casamentos e uniões de facto
+    description: |
+      Registo de casamentos e uniões de facto e emissão de certidões.
+  BC-3290.10.40:
+    name: Registo de divórcios e anulações
+    description: |
+      Registo de divórcios, anulações e sentenças de dissolução.
+  BC-3290.20:
+    name: Registo de identidade nacional
+    description: |
+      Criação, manutenção e autenticação de registos e credenciais de identidade
+      nacional de base.
+  BC-3290.20.10:
+    name: Inscrição de identidade
+    description: |
+      Inscrição de cidadãos e residentes no sistema de identidade nacional.
+  BC-3290.20.20:
+    name: Captura biométrica e deduplicação
+    description: |
+      Captura, deduplicação e correspondência de identificadores biométricos.
+  BC-3290.20.30:
+    name: Emissão de credenciais de identidade
+    description: |
+      Produção e emissão de cartões de identidade nacional e credenciais digitais.
+  BC-3290.20.40:
+    name: Atualização e ciclo de vida da identidade
+    description: |
+      Atualização de atributos de identidade, eventos do ciclo de vida e reemissão
+      de credenciais.
+  BC-3290.30:
+    name: Gestão do registo de empresas e entidades
+    description: |
+      Registo de sociedades, parcerias, associações e outras entidades jurídicas
+      e manutenção de registos de entidades.
+  BC-3290.30.10:
+    name: Registo de entidades
+    description: |
+      Registo de sociedades, parcerias, associações e outras entidades.
+  BC-3290.30.20:
+    name: Processamento de depósitos anuais
+    description: |
+      Receção e processamento de prestações anuais de contas, relatórios e atos
+      de gerência/administração.
+  BC-3290.30.30:
+    name: Gestão do registo de beneficiários efetivos
+    description: |
+      Manutenção das divulgações de beneficiários efetivos e controlo.
+  BC-3290.30.40:
+    name: Dissolução e extinção de entidades
+    description: |
+      Extinção, dissolução e restauração de entidades jurídicas.
+  BC-3290.40:
+    name: Gestão do registo predial e cadastro
+    description: |
+      Registo de títulos de propriedade, servidões, ónus e parcelas cadastrais e
+      manutenção de registos fundiários.
+  BC-3290.40.10:
+    name: Registo de propriedade
+    description: |
+      Registo de títulos de propriedade, transmissões e direitos reais.
+  BC-3290.40.20:
+    name: Registo de ónus e encargos
+    description: |
+      Registo de hipotecas, servidões e outros ónus.
+  BC-3290.40.30:
+    name: Manutenção do levantamento cadastral
+    description: |
+      Manutenção dos limites de parcelas cadastrais e registos de levantamento.
+  BC-3290.50:
+    name: Autenticação de documentos e apostilha
+    description: |
+      Autenticação de documentos públicos para uso interno e internacional,
+      incluindo serviços de apostilha ao abrigo da Convenção de Haia.
+  BC-3290.50.10:
+    name: Autenticação de documentos
+    description: |
+      Autenticação de documentos públicos para uso jurídico e administrativo.
+  BC-3290.50.20:
+    name: Emissão de apostilha
+    description: |
+      Emissão de certificações de apostilha ao abrigo da Convenção de Haia de 1961.
+  BC-3290.50.30:
+    name: Coordenação de serviços notariais
+    description: |
+      Coordenação de serviços notariais quando prestados pelo Estado.
+  BC-3290.60:
+    name: Divulgação de registos e privacidade
+    description: |
+      Divulgação controlada, redação e gestão da privacidade de registos civis e
+      estatutários.
+  BC-3290.60.10:
+    name: Serviços de pesquisa pública
+    description: |
+      Prestação de serviços de pesquisa e certidões ao público sobre registos
+      civis.
+  BC-3290.60.20:
+    name: Tratamento de divulgações restritas
+    description: |
+      Tratamento de divulgações restritas, incluindo adoção, proteção de
+      testemunhas e reservas de segurança.
+  BC-3290.60.30:
+    name: Privacidade e redação de registos
+    description: |
+      Aplicação de controlos de privacidade e redação a registos civis antes da
+      divulgação.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-classified-information-security-management.yaml
+++ b/catalogue/i18n/pt/L1-classified-information-security-management.yaml
@@ -1,0 +1,115 @@
+locale: pt
+source: L1-classified-information-security-management.yaml
+entries:
+  BC-1810:
+    name: Gestão de segurança da informação classificada
+    description: |
+      Habilitações de segurança do pessoal, classificação, segurança industrial, COMSEC e ameaças internas.
+  BC-1810.10:
+    name: Gestão de habilitações de segurança do pessoal
+    description: |
+      Candidaturas a habilitações, reinvestigações periódicas e desclassificação.
+  BC-1810.10.10:
+    name: Processamento de candidaturas a habilitações
+    description: |
+      Patrocínio e processamento de candidaturas a habilitações de segurança do pessoal.
+  BC-1810.10.20:
+    name: Reinvestigação periódica
+    description: |
+      Reinvestigação periódica e avaliação contínua do pessoal habilitado.
+  BC-1810.10.30:
+    name: Indoutrinação e desclassificação do pessoal habilitado
+    description: |
+      Indoutrinação de segurança, execução de NDA e desclassificação.
+  BC-1810.20:
+    name: Gestão da classificação da informação
+    description: |
+      Classificação, desclassificação e marcações de tratamento.
+  BC-1810.20.10:
+    name: Decisões de classificação original
+    description: |
+      Decisões da autoridade de classificação original.
+  BC-1810.20.20:
+    name: Classificação derivada
+    description: |
+      Classificação derivada de novos documentos a partir de material existente.
+  BC-1810.20.30:
+    name: Revisão de desclassificação
+    description: |
+      Revisão de desclassificação sistemática e obrigatória.
+  BC-1810.20.40:
+    name: Marcações de tratamento e rotulagem
+    description: |
+      Aplicação de marcações de tratamento, controlo de disseminação e rotulagem.
+  BC-1810.30:
+    name: Gestão da segurança física de defesa
+    description: |
+      Instalações habilitadas, SCIF e áreas de segurança.
+  BC-1810.30.10:
+    name: Acreditação de instalações habilitadas
+    description: |
+      Acreditação e manutenção de instalações habilitadas.
+  BC-1810.30.20:
+    name: Operações SCIF
+    description: |
+      Operação de instalações de informação compartimentada sensível (SCIF).
+  BC-1810.30.30:
+    name: Controlo de acesso a áreas de segurança
+    description: |
+      Controlo de acesso e gestão de visitantes em áreas de segurança.
+  BC-1810.40:
+    name: Gestão da segurança industrial
+    description: |
+      NISPOM/equivalente, FOCI e segurança da cadeia de abastecimento.
+  BC-1810.40.10:
+    name: Gestão da conformidade com o NISPOM
+    description: |
+      Conformidade com NISPOM/32 CFR 117 ou regulamentos nacionais equivalentes.
+  BC-1810.40.20:
+    name: Gestão de propriedade, controlo e influência estrangeiros
+    description: |
+      Avaliação e medidas de mitigação de FOCI.
+  BC-1810.40.30:
+    name: Verificação da segurança da cadeia de abastecimento
+    description: |
+      Verificação de parceiros habilitados na cadeia de abastecimento e alinhamento com CMMC.
+  BC-1810.40.40:
+    name: Administração de contratos classificados
+    description: |
+      Administração dos requisitos de contratos classificados do Formulário DD 254.
+  BC-1810.50:
+    name: Gestão de COMSEC
+    description: |
+      Segurança das comunicações e gestão de chaves criptográficas.
+  BC-1810.50.10:
+    name: Gestão de contas COMSEC
+    description: |
+      Operação de contas COMSEC e responsabilidades do responsável de custódia.
+  BC-1810.50.20:
+    name: Gestão de chaves criptográficas
+    description: |
+      Gestão de chaves criptográficas incluindo EKMS/KMI.
+  BC-1810.50.30:
+    name: Custódia de equipamento COMSEC
+    description: |
+      Custódia e responsabilização do equipamento COMSEC.
+  BC-1810.60:
+    name: Gestão de ameaças internas
+    description: |
+      Programas de ameaças internas, monitorização e resposta.
+  BC-1810.60.10:
+    name: Operação do programa de ameaças internas
+    description: |
+      Operação do programa de ameaças internas ao abrigo da E.O. 13587.
+  BC-1810.60.20:
+    name: Monitorização da atividade dos utilizadores
+    description: |
+      Monitorização da atividade dos utilizadores em sistemas de informação classificada.
+  BC-1810.60.30:
+    name: Investigação de ameaças internas
+    description: |
+      Investigação de indicadores e incidentes de ameaças internas.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-client-engagement-management.yaml
+++ b/catalogue/i18n/pt/L1-client-engagement-management.yaml
@@ -1,0 +1,214 @@
+locale: pt
+source: L1-client-engagement-management.yaml
+entries:
+  BC-4300:
+    name: Gestão de relacionamento com clientes
+    description: |
+      Ciclo de vida de entrada de clientes e projetos, definição de âmbito,
+      mobilização, controlo de alterações, encerramento e gestão contínua
+      de clientes em matéria jurídica, projetos de assessoria e projetos
+      de auditoria e garantia.
+  BC-4300.10:
+    name: Gestão de aceitação de clientes
+    description: |
+      Integração de novas relações com clientes, incluindo KYC, triagem AML,
+      verificações de sanções e PEP e verificação de beneficiário efetivo
+      antes de aceitar qualquer projeto.
+    in_scope:
+      - Aprovação KYC e AML de novos clientes
+      - Triagem de sanções e PEP em clientes prospetivos
+      - Verificações de beneficiário efetivo e fonte de fundos
+      - Atualização periódica dos ficheiros KYC de clientes
+    out_of_scope:
+      - Avaliação de independência e conflitos de interesses (BC-4350)
+      - Aceitação de risco específica do projeto (BC-4300.20)
+  BC-4300.10.10:
+    name: Captura de KYC do cliente
+    description: |
+      Captura de informações de identificação, beneficiário efetivo e
+      fonte de fundos para clientes prospetivos e existentes.
+  BC-4300.10.20:
+    name: Triagem de sanções e PEP do cliente
+    description: |
+      Triagem de clientes e beneficiários efetivos em listas de sanções,
+      PEP e media adversa.
+  BC-4300.10.30:
+    name: Classificação de risco do cliente
+    description: |
+      Classificação de risco da relação com o cliente para orientar a
+      profundidade da diligência devida e a cadência de revisão.
+  BC-4300.10.40:
+    name: Atualização periódica de diligência devida do cliente
+    description: |
+      Atualização do KYC, propriedade e classificações de risco do cliente
+      num ciclo definido.
+  BC-4300.20:
+    name: Gestão de aceitação de projetos
+    description: |
+      Fluxo de trabalho de decisão para aceitar ou recusar um projeto específico,
+      tendo em conta a aprovação de independência e conflitos, avaliação de
+      capacidade, viabilidade de honorários e avaliação de risco específica
+      do projeto.
+    in_scope:
+      - Avaliação de risco do projeto
+      - Verificação de capacidade e competência
+      - Decisão de prosseguir ou não o projeto
+    out_of_scope:
+      - Verificações substantivas de independência e conflitos (BC-4350)
+      - Atividade de prospeção e proposta (BC-4360)
+  BC-4300.20.10:
+    name: Avaliação de risco do projeto
+    description: |
+      Avaliação do risco específico do projeto, incluindo complexidade da
+      matéria, integridade do cliente e recuperabilidade de honorários.
+  BC-4300.20.20:
+    name: Verificação de capacidade e competência
+    description: |
+      Confirmação de que a firma tem a competência técnica e a capacidade de
+      recursos para executar o projeto.
+  BC-4300.20.30:
+    name: Decisão de prosseguir ou não o projeto
+    description: |
+      Decisão de prosseguir ou não o projeto ao nível do sócio, integrando
+      risco, conflitos, independência, capacidade e contribuições comerciais.
+  BC-4300.30:
+    name: Gestão de âmbito e termos do projeto
+    description: |
+      Definição do âmbito do projeto, entregáveis, pressupostos, termos de
+      honorários e carta de missão ou acordo de retenção.
+    in_scope:
+      - Definição do âmbito dos serviços
+      - Estrutura de honorários e elaboração de termos
+      - Emissão da carta de missão ou acordo de retenção
+    out_of_scope:
+      - Estratégia de preços ao nível da firma (BC-4360.50)
+      - Proposta em fase de prospeção (BC-4360.30)
+  BC-4300.30.10:
+    name: Definição do âmbito do projeto
+    description: |
+      Definição dos serviços, entregáveis, pressupostos, exclusões e
+      dependências do projeto.
+  BC-4300.30.20:
+    name: Elaboração da carta de missão
+    description: |
+      Elaboração de cartas de missão e acordos de retenção alinhados com os
+      modelos da firma e as normas profissionais aplicáveis.
+  BC-4300.30.30:
+    name: Negociação dos termos do projeto
+    description: |
+      Negociação dos termos do projeto com o cliente, incluindo tetos de
+      responsabilidade, lei aplicável e cláusulas de resolução de litígios.
+  BC-4300.30.40:
+    name: Execução da carta de missão
+    description: |
+      Assinatura, contra-assinatura e arquivo das cartas de missão executadas
+      como condição prévia para a mobilização do projeto.
+  BC-4300.40:
+    name: Gestão de mobilização de projetos
+    description: |
+      Arranque operacional de um projeto aceite, incluindo formação da equipa,
+      reunião de arranque, acesso seguro a dados e configuração de infraestrutura
+      do projeto.
+  BC-4300.40.10:
+    name: Formação da equipa do projeto
+    description: |
+      Identificação e confirmação dos papéis de sócio, gestor e colaborador
+      na equipa do projeto.
+  BC-4300.40.20:
+    name: Gestão da reunião de arranque do projeto
+    description: |
+      Reuniões de arranque internas e com o cliente, materiais de briefing e
+      confirmação de objetivos e formas de trabalho.
+  BC-4300.40.30:
+    name: Configuração de acesso a dados do projeto
+    description: |
+      Provisionamento de salas de dados seguras, portais de cliente e
+      credenciais de acesso específicas do projeto.
+  BC-4300.40.40:
+    name: Configuração de infraestrutura do projeto
+    description: |
+      Configuração de códigos de projeto, estruturas de faturação e numeração
+      de processos nos sistemas da firma.
+  BC-4300.50:
+    name: Gestão de alterações do projeto
+    description: |
+      Controlo de alterações ao âmbito do projeto, honorários, prazos ou
+      composição da equipa após a execução da carta de missão.
+  BC-4300.50.10:
+    name: Gestão de pedidos de alteração de âmbito
+    description: |
+      Captura, avaliação e disposição de pedidos de alteração de âmbito do
+      cliente ou da equipa do projeto.
+  BC-4300.50.20:
+    name: Aprovação de variação de honorários
+    description: |
+      Fluxo de trabalho de aprovação para ajustes de honorários, retenções
+      adicionais e autorizações de trabalho fora do âmbito.
+  BC-4300.50.30:
+    name: Aditamento à carta de missão
+    description: |
+      Emissão e execução de aditamentos e cartas laterais que refletem as
+      alterações aprovadas do projeto.
+  BC-4300.60:
+    name: Gestão de encerramento do projeto
+    description: |
+      Conclusão dos projetos concluídos, incluindo entrega de entregáveis,
+      retenção de papéis de trabalho, acionamento da faturação final e
+      debriefing pós-projeto.
+  BC-4300.60.10:
+    name: Gestão da entrega de entregáveis
+    description: |
+      Entrega final de relatórios, pareceres e produtos de trabalho ao
+      cliente com transmissão associada.
+  BC-4300.60.20:
+    name: Configuração de retenção do ficheiro do projeto
+    description: |
+      Encerramento do ficheiro do projeto e configuração de políticas de
+      retenção, recuperação e destruição.
+  BC-4300.60.30:
+    name: Debriefing e lições aprendidas do projeto
+    description: |
+      Revisão pós-projeto com a equipa para capturar lições aprendidas e
+      ações de melhoria.
+  BC-4300.60.40:
+    name: Comunicação de encerramento ao cliente
+    description: |
+      Comunicação de encerramento ao cliente, incluindo relatório final,
+      inquérito de satisfação e agendamento de acompanhamento.
+  BC-4300.70:
+    name: Gestão da relação com clientes estratégicos
+    description: |
+      Gestão contínua de relações com clientes estratégicos, incluindo
+      responsabilidade do sócio responsável, planeamento de conta de cliente
+      e coordenação entre práticas.
+    in_scope:
+      - Atribuição do sócio responsável
+      - Planeamento de conta de cliente em múltiplos projetos
+      - Acompanhamento da satisfação do cliente
+    out_of_scope:
+      - Atividade de prospeção e proposta (BC-4360)
+      - CRM genérico (BC-3060)
+  BC-4300.70.10:
+    name: Atribuição do sócio responsável
+    description: |
+      Atribuição e rotação do sócio responsável principal para cada cliente
+      estratégico.
+  BC-4300.70.20:
+    name: Planeamento de conta de cliente
+    description: |
+      Planeamento ao nível da conta no portefólio de projetos com um único
+      cliente, incluindo objetivos de quota de carteira e de relação.
+  BC-4300.70.30:
+    name: Acompanhamento da satisfação do cliente
+    description: |
+      Captura do feedback do cliente, NPS ou medidas equivalentes, e
+      escalamento de sinais de insatisfação.
+  BC-4300.70.40:
+    name: Coordenação entre práticas do cliente
+    description: |
+      Coordenação entre grupos de prática e geografias que servem um cliente
+      partilhado.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-clinical-care-delivery-management.yaml
+++ b/catalogue/i18n/pt/L1-clinical-care-delivery-management.yaml
@@ -1,0 +1,202 @@
+locale: pt
+source: L1-clinical-care-delivery-management.yaml
+entries:
+  BC-2810:
+    name: Gestão de prestação de cuidados clínicos
+    description: |
+      Prestação de cuidados clínicos directos em contextos de internamento,
+      ambulatório, urgência, cirurgia, maternidade, saúde mental, reabilitação
+      e cuidados domiciliários.
+  BC-2810.10:
+    name: Prestação de cuidados em internamento
+    description: |
+      Prestação de cuidados agudos, intermédios e intensivos de internamento,
+      incluindo avaliação, visitas clínicas, cuidados à cabeceira e operações de
+      cuidados intensivos.
+  BC-2810.10.10:
+    name: Avaliação de admissão
+    description: |
+      História clínica e exame físico, avaliação de enfermagem e rastreio de risco
+      na admissão.
+  BC-2810.10.20:
+    name: Visitas clínicas
+    description: |
+      Visitas clínicas multidisciplinares e planeamento de cuidados à cabeceira do
+      doente.
+  BC-2810.10.30:
+    name: Cuidados à cabeceira
+    description: |
+      Cuidados directos de enfermagem e clínicos à cabeceira, incluindo apoio nas
+      actividades de vida diária.
+  BC-2810.10.40:
+    name: Operações de cuidados intensivos
+    description: |
+      Operações de cuidados intensivos, incluindo cuidados de ventilação,
+      hemodinâmica e monitorização contínua.
+  BC-2810.20:
+    name: Prestação de cuidados em ambulatório
+    description: |
+      Prestação de serviços ambulatórios, de telesaúde e de procedimentos e
+      tratamentos em consulta externa e hospital de dia.
+  BC-2810.20.10:
+    name: Realização de consulta ambulatória
+    description: |
+      Realização de consultas em consultório e clínica, incluindo consultas de
+      medicina geral e especialidade.
+  BC-2810.20.20:
+    name: Prestação de procedimentos em ambulatório
+    description: |
+      Prestação de procedimentos de ambulatório e em regime de dia, incluindo
+      cirurgia minor e infusões.
+  BC-2810.20.30:
+    name: Prestação de consultas de telesaúde
+    description: |
+      Prestação de consultas de telesaúde síncronas e assíncronas.
+  BC-2810.20.40:
+    name: Administração de tratamentos em ambulatório
+    description: |
+      Administração de tratamentos em ambulatório, como quimioterapia, diálise e
+      infusões.
+  BC-2810.30:
+    name: Prestação de cuidados de urgência
+    description: |
+      Prestação de triagem, estabilização, resposta a trauma e decisões de destino
+      no serviço de urgência para cuidados não programados.
+  BC-2810.30.10:
+    name: Triagem no serviço de urgência
+    description: |
+      Triagem e atribuição de acuidade a doentes que se apresentam no serviço de
+      urgência.
+  BC-2810.30.20:
+    name: Estabilização de emergência
+    description: |
+      Avaliação inicial, reanimação e estabilização de doentes agudamente doentes
+      ou feridos.
+  BC-2810.30.30:
+    name: Resposta a trauma
+    description: |
+      Activação de trauma, resposta de equipa e cuidados de controlo de danos para
+      casos de trauma major.
+  BC-2810.30.40:
+    name: Destino no serviço de urgência
+    description: |
+      Decisões de destino, incluindo internamento, transferência, observação e alta
+      do serviço de urgência.
+  BC-2810.40:
+    name: Prestação de cuidados cirúrgicos e de procedimentos
+    description: |
+      Cuidados pré-, intra- e pós-operatórios para procedimentos cirúrgicos e
+      intervencionistas em blocos operatórios e salas de procedimentos.
+  BC-2810.40.10:
+    name: Cuidados pré-operatórios
+    description: |
+      Avaliação pré-operatória, optimização e cuidados em sala de espera.
+  BC-2810.40.20:
+    name: Gestão intra-operatória
+    description: |
+      Cuidados cirúrgicos, anestésicos e da equipa circulante durante a operação.
+  BC-2810.40.30:
+    name: Cuidados pós-anestesia
+    description: |
+      Recuperação na unidade de cuidados pós-anestesia e avaliação de prontidão
+      para alta.
+  BC-2810.40.40:
+    name: Endoscopia e procedimentos intervencionistas
+    description: |
+      Prestação de procedimentos endoscópicos, de radiologia intervencionista e
+      cardiologia intervencionista.
+  BC-2810.50:
+    name: Prestação de cuidados maternos e neonatais
+    description: |
+      Prestação de cuidados pré-parto, intraparto, pós-parto e neonatais em
+      serviços de maternidade e neonatologia.
+  BC-2810.50.10:
+    name: Cuidados pré-parto
+    description: |
+      Avaliação pré-natal, rastreio e internamentos pré-parto.
+  BC-2810.50.20:
+    name: Cuidados intraparto
+    description: |
+      Gestão do trabalho de parto e parto, incluindo cesariana e parto operatório.
+  BC-2810.50.30:
+    name: Cuidados pós-parto
+    description: |
+      Recuperação materna pós-parto, apoio à amamentação e educação pós-parto.
+  BC-2810.50.40:
+    name: Cuidados neonatais
+    description: |
+      Cuidados em berçário de recém-nascidos saudáveis, rastreio e prestação de
+      cuidados intensivos neonatais.
+  BC-2810.60:
+    name: Prestação de cuidados de saúde mental
+    description: |
+      Cuidados de saúde mental em avaliação psiquiátrica, unidades de internamento
+      psiquiátrico, terapia em ambulatório e tratamento de dependências.
+  BC-2810.60.10:
+    name: Avaliação psiquiátrica
+    description: |
+      Avaliação psiquiátrica e psicológica e intervenção em crise.
+  BC-2810.60.20:
+    name: Cuidados em internamento psiquiátrico
+    description: |
+      Cuidados psiquiátricos em internamento, incluindo terapia de meio e
+      tratamento farmacológico.
+  BC-2810.60.30:
+    name: Terapia comportamental em ambulatório
+    description: |
+      Psicoterapia, terapia de grupo e programas de hospitalização parcial em
+      ambulatório.
+  BC-2810.60.40:
+    name: Cuidados de dependências
+    description: |
+      Serviços de desintoxicação, tratamento assistido por medicação e reabilitação
+      de dependências.
+  BC-2810.70:
+    name: Serviços de reabilitação e terapia
+    description: |
+      Serviços de fisioterapia, terapia ocupacional, terapia da fala e linguagem, e
+      reabilitação cardiopulmonar em contextos de internamento e ambulatório.
+  BC-2810.70.10:
+    name: Fisioterapia
+    description: |
+      Avaliação e tratamento de fisioterapia em contextos de internamento e
+      ambulatório.
+  BC-2810.70.20:
+    name: Terapia ocupacional
+    description: |
+      Avaliação e tratamento de terapia ocupacional orientados para a independência
+      funcional.
+  BC-2810.70.30:
+    name: Terapia da fala e linguagem
+    description: |
+      Serviços de terapia da fala, linguagem e deglutição.
+  BC-2810.70.40:
+    name: Reabilitação cardíaca e pulmonar
+    description: |
+      Prestação de programas de reabilitação cardíaca e pulmonar.
+  BC-2810.80:
+    name: Prestação de cuidados domiciliários e comunitários
+    description: |
+      Cuidados prestados no domicílio ou na comunidade do doente, incluindo visitas
+      domiciliárias de saúde, cuidados paliativos e monitorização remota.
+  BC-2810.80.10:
+    name: Visitas domiciliárias de saúde
+    description: |
+      Visitas domiciliárias qualificadas de enfermagem e terapia no domicílio.
+  BC-2810.80.20:
+    name: Cuidados paliativos domiciliários
+    description: |
+      Cuidados de fim de vida e paliativos prestados no domicílio.
+  BC-2810.80.30:
+    name: Visitas de saúde comunitária
+    description: |
+      Visitas de agentes de saúde comunitária e programas de extensão comunitária.
+  BC-2810.80.40:
+    name: Cuidados de monitorização remota
+    description: |
+      Serviços de monitorização remota de doentes para populações crónicas e
+      pós-agudas.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-clinical-documentation-management.yaml
+++ b/catalogue/i18n/pt/L1-clinical-documentation-management.yaml
@@ -1,0 +1,149 @@
+locale: pt
+source: L1-clinical-documentation-management.yaml
+entries:
+  BC-2830:
+    name: Gestão de documentação clínica
+    description: |
+      Documentação do clínico, entrada informatizada de ordens, revisão de
+      resultados, suporte de decisão, melhoria da documentação e fluxo de trabalho
+      mediado pelo RES que sustenta o registo activo dos cuidados ao doente.
+  BC-2830.10:
+    name: Documentação de notas clínicas
+    description: |
+      Redacção de notas clínicas em múltiplos tipos de encontro utilizando
+      modalidades narrativas, estruturadas, de voz e de captura ambiental.
+  BC-2830.10.10:
+    name: Redacção de notas de evolução
+    description: |
+      Redacção de notas de evolução de internamento e ambulatório.
+  BC-2830.10.20:
+    name: Redacção de notas de procedimentos
+    description: |
+      Redacção de notas operatórias e de procedimentos.
+  BC-2830.10.30:
+    name: Redacção de cartas de alta
+    description: |
+      Redacção de resumos de alta e de transferência.
+  BC-2830.10.40:
+    name: Documentação por voz e ambiental
+    description: |
+      Fluxos de trabalho de ditado por voz e de documentação por captura ambiental.
+  BC-2830.20:
+    name: Entrada informatizada de ordens do prestador
+    description: |
+      Entrada de ordens do prestador para medicamentos, diagnósticos e procedimentos,
+      incluindo conjuntos de ordens e protocolos clínicos.
+  BC-2830.20.10:
+    name: Entrada de ordens de medicação
+    description: |
+      Entrada de ordens de medicação pelo prestador com dose, via e frequência.
+  BC-2830.20.20:
+    name: Entrada de ordens de diagnóstico
+    description: |
+      Entrada de ordens laboratoriais, de imagiologia e de outros diagnósticos pelo
+      prestador.
+  BC-2830.20.30:
+    name: Entrada de ordens de procedimentos
+    description: |
+      Entrada de ordens de procedimentos e de consulta pelo prestador.
+  BC-2830.20.40:
+    name: Utilização de conjuntos de ordens e protocolos
+    description: |
+      Utilização de conjuntos de ordens normalizados, planos de poder e protocolos
+      clínicos.
+  BC-2830.30:
+    name: Revisão e validação de resultados
+    description: |
+      Encaminhamento, revisão e validação de resultados de diagnóstico e gestão da
+      notificação de valores críticos.
+  BC-2830.30.10:
+    name: Notificação e encaminhamento de resultados
+    description: |
+      Encaminhamento de resultados para os prestadores solicitantes e de cobertura.
+  BC-2830.30.20:
+    name: Confirmação de resultados
+    description: |
+      Confirmação e validação de resultados recebidos pelo prestador.
+  BC-2830.30.30:
+    name: Comunicação de resultados críticos
+    description: |
+      Comunicação com prazo definido de resultados críticos e valores de pânico.
+  BC-2830.30.40:
+    name: Revisão de tendências de resultados
+    description: |
+      Revisão de tendências de resultados e dados longitudinais no processo clínico.
+  BC-2830.40:
+    name: Suporte de decisão clínica
+    description: |
+      Suporte de decisão clínica em tempo real, incluindo alertas, percursos,
+      apresentação de pontuações de risco e avisos de boas práticas.
+  BC-2830.40.10:
+    name: Alertas de interacção medicamentosa
+    description: |
+      Alertas de interacção fármaco-fármaco, fármaco-alergia e fármaco-doença.
+  BC-2830.40.20:
+    name: Orientação por percursos clínicos
+    description: |
+      Suporte de decisão baseado em percursos e directrizes no ponto de cuidados.
+  BC-2830.40.30:
+    name: Apresentação de pontuações de risco
+    description: |
+      Apresentação de pontuações de risco clínico, como preditores de deterioração
+      e sépsis.
+  BC-2830.40.40:
+    name: Gestão de avisos de boas práticas
+    description: |
+      Redacção, ajuste e governação de avisos de boas práticas.
+  BC-2830.50:
+    name: Melhoria da documentação clínica
+    description: |
+      Revisão concorrente e retrospectiva, consulta e programas de educação para
+      melhorar a completude e especificidade da documentação.
+  BC-2830.50.10:
+    name: Revisão concorrente da documentação
+    description: |
+      Revisão concorrente da documentação de internamento quanto à exactidão e
+      especificidade clínica.
+  BC-2830.50.20:
+    name: Gestão de consultas ao prestador
+    description: |
+      Geração e acompanhamento de consultas de documentação clínica conformes.
+  BC-2830.50.30:
+    name: Auditoria de qualidade da documentação
+    description: |
+      Auditoria da qualidade da documentação clínica e do impacto no índice de
+      case-mix.
+  BC-2830.50.40:
+    name: Educação do prestador em documentação
+    description: |
+      Educação do prestador sobre normas de documentação e oportunidades de
+      melhoria.
+  BC-2830.60:
+    name: Gestão do fluxo de trabalho do RES
+    description: |
+      Fluxo de trabalho do registo electrónico de saúde para o clínico, incluindo
+      caixa de entrada, tarefas, encerramento de encontros e gestão de
+      transferências.
+  BC-2830.60.10:
+    name: Gestão de caixa de entrada e tarefas
+    description: |
+      Gestão de mensagens na caixa de entrada, tarefas e listas de afazeres do
+      clínico.
+  BC-2830.60.20:
+    name: Encerramento de encontro
+    description: |
+      Encerramento de encontro incluindo codificação, faturação e conclusão da
+      documentação.
+  BC-2830.60.30:
+    name: Documentação de cobertura cruzada
+    description: |
+      Fluxos de trabalho de documentação em cobertura cruzada e de chamada.
+  BC-2830.60.40:
+    name: Gestão de lista de doentes e transferências
+    description: |
+      Gestão de listas de doentes e documentação estruturada de transferência entre
+      turnos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-clinical-quality-safety-management.yaml
+++ b/catalogue/i18n/pt/L1-clinical-quality-safety-management.yaml
@@ -1,0 +1,148 @@
+locale: pt
+source: L1-clinical-quality-safety-management.yaml
+entries:
+  BC-2840:
+    name: Gestão de qualidade clínica e segurança
+    description: |
+      Gestão de eventos de segurança do doente, prevenção e controlo de infecção,
+      medição de resultados clínicos, prontidão para acreditação, risco clínico e
+      responsabilidade, e programas de melhoria da qualidade específicos dos
+      cuidados clínicos.
+  BC-2840.10:
+    name: Gestão de eventos de segurança do doente
+    description: |
+      Captura, investigação e gestão de eventos de segurança do doente, incluindo
+      eventos sentinela e quasi-acidentes.
+  BC-2840.10.10:
+    name: Reporte e captura de eventos
+    description: |
+      Reporte e captura multicanal de eventos de segurança do doente e
+      quasi-acidentes.
+  BC-2840.10.20:
+    name: Análise de causa raiz
+    description: |
+      Análise de causa raiz e de causa aparente de eventos de segurança do doente.
+  BC-2840.10.30:
+    name: Gestão de eventos sentinela
+    description: |
+      Identificação, resposta e reporte de eventos sentinela e eventos nunca
+      admissíveis.
+  BC-2840.10.40:
+    name: Investigação de cultura justa
+    description: |
+      Revisão de cultura justa de factores humanos e responsabilização em eventos
+      de segurança.
+  BC-2840.20:
+    name: Prevenção e controlo de infecção
+    description: |
+      Vigilância, prevenção e controlo de infecções associadas aos cuidados de
+      saúde, incluindo resposta a surtos e gestão de antimicrobianos.
+  BC-2840.20.10:
+    name: Vigilância de infecções associadas aos cuidados de saúde
+    description: |
+      Vigilância e reporte de infecções associadas aos cuidados de saúde.
+  BC-2840.20.20:
+    name: Investigação de surtos
+    description: |
+      Investigação e contenção de agrupamentos de infecções e surtos.
+  BC-2840.20.30:
+    name: Supervisão do processamento de esterilização
+    description: |
+      Supervisão das operações e conformidade do serviço de esterilização.
+  BC-2840.20.40:
+    name: Gestão de antimicrobianos
+    description: |
+      Operações do programa de gestão de antimicrobianos e supervisão da prescrição.
+  BC-2840.30:
+    name: Medição de resultados clínicos
+    description: |
+      Medição e reporte de resultados clínicos face a medidas nucleares, submissões
+      a registos e resultados reportados pelos doentes.
+  BC-2840.30.10:
+    name: Reporte de medidas nucleares
+    description: |
+      Captura e submissão de medidas de qualidade nucleares regulatórias.
+  BC-2840.30.20:
+    name: Acompanhamento de mortalidade e readmissões
+    description: |
+      Acompanhamento de mortalidade, readmissão e resultados ajustados pelo risco.
+  BC-2840.30.30:
+    name: Submissão a registos de resultados de especialidade
+    description: |
+      Submissão a registos de resultados de especialidade, como registos de
+      cardiologia, cirurgia e AVC.
+  BC-2840.30.40:
+    name: Captura de resultados reportados pelos doentes
+    description: |
+      Captura e análise de resultados e medidas de experiência reportados pelos
+      doentes.
+  BC-2840.40:
+    name: Acreditação e prontidão para inspecção
+    description: |
+      Prontidão para acreditação em programas clínicos, regulatórios e de
+      inspecção de especialidade.
+  BC-2840.40.10:
+    name: Programas de simulacro de inspecção
+    description: |
+      Operações de simulacros de inspecção e de programas de prontidão contínua.
+  BC-2840.40.20:
+    name: Metodologia de rastreador
+    description: |
+      Metodologia de rastreador de doente e de sistema para prontidão de
+      acreditação.
+  BC-2840.40.30:
+    name: Acompanhamento da conformidade com normas
+    description: |
+      Acompanhamento da conformidade com normas de acreditação e regulatórias.
+  BC-2840.40.40:
+    name: Coordenação da resposta a inspecções
+    description: |
+      Coordenação de inspecções de acreditação, conclusões e planos de acção
+      correctiva.
+  BC-2840.50:
+    name: Gestão de risco clínico e responsabilidade
+    description: |
+      Identificação e mitigação de risco clínico e defesa de reclamações de
+      responsabilidade específicas dos cuidados médicos.
+  BC-2840.50.10:
+    name: Avaliação de risco clínico
+    description: |
+      Identificação e avaliação de riscos clínicos em serviços e processos.
+  BC-2840.50.20:
+    name: Apoio na defesa de reclamações
+    description: |
+      Apoio na investigação e defesa de reclamações de negligência médica.
+  BC-2840.50.30:
+    name: Processo de divulgação e pedido de desculpas
+    description: |
+      Operações do programa de divulgação e pedido de desculpas para eventos
+      adversos.
+  BC-2840.50.40:
+    name: Planeamento de mitigação de risco clínico
+    description: |
+      Planeamento e execução de acções de mitigação de risco clínico.
+  BC-2840.60:
+    name: Programas de melhoria da qualidade
+    description: |
+      Metodologia de melhoria do desempenho, implementação de pacotes e iniciativas
+      de alta fiabilidade.
+  BC-2840.60.10:
+    name: Gestão do ciclo PDSA
+    description: |
+      Gestão do ciclo Planear-Fazer-Estudar-Agir para a melhoria clínica.
+  BC-2840.60.20:
+    name: Implementação de pacotes e protocolos
+    description: |
+      Implementação de pacotes baseados em evidências e protocolos clínicos.
+  BC-2840.60.30:
+    name: Acompanhamento de projectos de melhoria do desempenho
+    description: |
+      Acompanhamento de projectos de melhoria do desempenho e resultados.
+  BC-2840.60.40:
+    name: Iniciativas de alta fiabilidade
+    description: |
+      Princípios de organização de alta fiabilidade e gestão de iniciativas.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-clinical-trials-management.yaml
+++ b/catalogue/i18n/pt/L1-clinical-trials-management.yaml
@@ -1,0 +1,143 @@
+locale: pt
+source: L1-clinical-trials-management.yaml
+entries:
+  BC-1520:
+    name: Gestão de ensaios clínicos
+    description: |
+      Planeamento, execução e monitorização de estudos clínicos.
+  BC-1520.10:
+    name: Gestão da conceção de ensaios clínicos
+    description: |
+      Conceção do protocolo, metodologia estatística e endpoints.
+  BC-1520.10.10:
+    name: Redação do protocolo clínico
+    description: |
+      Redação de protocolos de estudos clínicos.
+  BC-1520.10.20:
+    name: Definição do plano de análise estatística
+    description: |
+      Metodologia estatística e definição do plano de análise.
+  BC-1520.10.30:
+    name: Definição de endpoints e outcomes
+    description: |
+      Definição de endpoints primários, secundários e exploratórios.
+  BC-1520.10.40:
+    name: Gestão de desenho adaptativo
+    description: |
+      Conceção de ensaios adaptativos e plataforma.
+  BC-1520.20:
+    name: Gestão de centros de ensaios clínicos
+    description: |
+      Seleção, ativação e supervisão de centros.
+  BC-1520.20.10:
+    name: Identificação e viabilidade de centros
+    description: |
+      Identificação e avaliação da viabilidade de centros de investigação.
+  BC-1520.20.20:
+    name: Ativação de centros
+    description: |
+      Ativação de centros incluindo ética, regulamentação e contratação.
+  BC-1520.20.30:
+    name: Formação de investigadores e centros
+    description: |
+      Realização de formação de investigadores e centros.
+  BC-1520.20.40:
+    name: Gestão do desempenho dos centros
+    description: |
+      Acompanhamento e remediação do desempenho dos centros.
+  BC-1520.30:
+    name: Gestão de participantes em ensaios clínicos
+    description: |
+      Recrutamento, rastreio, retenção e consentimento informado.
+  BC-1520.30.10:
+    name: Recrutamento de participantes
+    description: |
+      Recrutamento de participantes incluindo canais de recrutamento digital.
+  BC-1520.30.20:
+    name: Gestão do consentimento informado
+    description: |
+      Recolha do consentimento informado e consentimento eletrónico.
+  BC-1520.30.30:
+    name: Rastreio e inscrição de participantes
+    description: |
+      Rastreio e inscrição segundo critérios de inclusão/exclusão.
+  BC-1520.30.40:
+    name: Retenção de participantes
+    description: |
+      Estratégias de retenção e envolvimento de doentes.
+  BC-1520.40:
+    name: Gestão de dados clínicos
+    description: |
+      EDC, recolha de dados, gestão de queries e bloqueio da base de dados.
+  BC-1520.40.10:
+    name: Gestão de EDC e CRF
+    description: |
+      Sistema de recolha eletrónica de dados e conceção de CRF.
+  BC-1520.40.20:
+    name: Gestão de queries de dados clínicos
+    description: |
+      Geração, resolução e limpeza de dados e queries.
+  BC-1520.40.30:
+    name: Padronização de dados clínicos
+    description: |
+      Padronização de dados CDISC SDTM/ADaM.
+  BC-1520.40.40:
+    name: Bloqueio e arquivo da base de dados
+    description: |
+      Bloqueio, arquivo e preparação do pacote de submissão da base de dados.
+  BC-1520.50:
+    name: Gestão da monitorização de ensaios clínicos
+    description: |
+      Monitorização em centro, monitorização baseada em risco e auditorias.
+  BC-1520.50.10:
+    name: Monitorização em centro
+    description: |
+      Verificação de dados de origem e visitas de monitorização em centro.
+  BC-1520.50.20:
+    name: Monitorização centralizada e baseada em risco
+    description: |
+      Programas de monitorização centralizada e baseada em risco.
+  BC-1520.50.30:
+    name: Auditorias de qualidade clínica
+    description: |
+      Auditorias GCP a ensaios, centros e fornecedores.
+  BC-1520.60:
+    name: Gestão de aprovisionamento de ensaios clínicos
+    description: |
+      Aprovisionamento de IMP, distribuição, aleatorização e responsabilização de medicamentos.
+  BC-1520.60.10:
+    name: Produção e embalagem de IMP
+    description: |
+      Produção e embalagem de medicamentos experimentais.
+  BC-1520.60.20:
+    name: Distribuição e operações de depósito de IMP
+    description: |
+      Operações de depósito e distribuição global de IMP.
+  BC-1520.60.30:
+    name: Aleatorização e operações de IRT
+    description: |
+      Aleatorização IRT/IWRS e gestão do aprovisionamento do ensaio.
+  BC-1520.60.40:
+    name: Responsabilização e reconciliação de IMP
+    description: |
+      Responsabilização, devoluções e destruição de IMP.
+  BC-1520.70:
+    name: Gestão de externalização clínica e CRO
+    description: |
+      Seleção, contratação e supervisão de CROs.
+  BC-1520.70.10:
+    name: Seleção e contratação de CRO
+    description: |
+      Seleção, âmbito e contratação de CROs.
+  BC-1520.70.20:
+    name: Supervisão do desempenho de CRO
+    description: |
+      Supervisão do patrocinador sobre o desempenho e KPIs do CRO.
+  BC-1520.70.30:
+    name: Supervisão da qualidade de fornecedores
+    description: |
+      Supervisão da qualidade de fornecedores clínicos e laboratórios.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-commissioning-handover-management.yaml
+++ b/catalogue/i18n/pt/L1-commissioning-handover-management.yaml
@@ -1,0 +1,103 @@
+locale: pt
+source: L1-commissioning-handover-management.yaml
+entries:
+  BC-1160:
+    name: Gestão da colocação em serviço e transferência
+    description: |
+      Pré-colocação em serviço, colocação em serviço, ensaios de desempenho e transferência.
+  BC-1160.10:
+    name: Gestão da pré-colocação em serviço
+    description: |
+      Conclusão mecânica, lavagem, ensaios de estanquidade e energização.
+  BC-1160.10.10:
+    name: Verificação da conclusão mecânica
+    description: |
+      Verificação da conclusão mecânica face às listas de pendências.
+  BC-1160.10.20:
+    name: Operações de lavagem e limpeza
+    description: |
+      Lavagem, limpeza e condicionamento químico de tubagem.
+  BC-1160.10.30:
+    name: Ensaios de pressão e estanquidade
+    description: |
+      Ensaios hidrostáticos, ensaios pneumáticos e verificação de estanquidade.
+  BC-1160.10.40:
+    name: Energização de equipamentos
+    description: |
+      Primeira energização e verificações funcionais de equipamentos.
+  BC-1160.20:
+    name: Gestão da execução da colocação em serviço
+    description: |
+      Colocação em serviço de sistemas, ensaios funcionais e ensaios integrados.
+  BC-1160.20.10:
+    name: Planeamento da colocação em serviço do sistema
+    description: |
+      Planos de colocação em serviço por sistema e subsistema.
+  BC-1160.20.20:
+    name: Ensaios funcionais do sistema
+    description: |
+      Ensaios funcionais de sistemas individuais.
+  BC-1160.20.30:
+    name: Ensaios integrados do sistema
+    description: |
+      Ensaios integrados entre múltiplos sistemas.
+  BC-1160.20.40:
+    name: Documentação da colocação em serviço
+    description: |
+      Registos, dossiês e certificados de colocação em serviço.
+  BC-1160.30:
+    name: Gestão dos ensaios de desempenho
+    description: |
+      Execuções de ensaios de desempenho e validação de critérios de aceitação.
+  BC-1160.30.10:
+    name: Planeamento dos ensaios de desempenho
+    description: |
+      Protocolos de ensaios de desempenho e critérios de aceitação.
+  BC-1160.30.20:
+    name: Execução dos ensaios de desempenho
+    description: |
+      Execução de ensaios de desempenho e recolha de dados.
+  BC-1160.30.30:
+    name: Avaliação dos ensaios de desempenho
+    description: |
+      Avaliação dos resultados dos ensaios e validação face às garantias.
+  BC-1160.40:
+    name: Gestão da transferência e aceitação
+    description: |
+      Aceitação final, certificados, encerramento da lista de pendências e transferência para o operador.
+  BC-1160.40.10:
+    name: Encerramento da lista de pendências
+    description: |
+      Acompanhamento e encerramento dos itens da lista de pendências antes da aceitação.
+  BC-1160.40.20:
+    name: Certificação de aceitação
+    description: |
+      Emissão de certificados de aceitação provisórios e definitivos.
+  BC-1160.40.30:
+    name: Formação do operador e transferência
+    description: |
+      Formação da equipa de operações e transferência da instalação.
+  BC-1160.40.40:
+    name: Transferência de custódia
+    description: |
+      Transferência formal da custódia da instalação e ativos para o cliente.
+  BC-1160.50:
+    name: Gestão do apoio pós-transferência
+    description: |
+      Período de responsabilidade por defeitos, período de garantia e apoio técnico residual.
+  BC-1160.50.10:
+    name: Gestão da responsabilidade por defeitos
+    description: |
+      Gestão do período de responsabilidade por defeitos e retificação de pendências.
+  BC-1160.50.20:
+    name: Apoio em garantia
+    description: |
+      Coordenação do apoio em garantia e reclamações de garantia de fornecedores.
+  BC-1160.50.30:
+    name: Apoio técnico residual
+    description: |
+      Apoio técnico às operações durante o período operativo inicial.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-commodity-origination-merchandising-management.yaml
+++ b/catalogue/i18n/pt/L1-commodity-origination-merchandising-management.yaml
@@ -1,0 +1,142 @@
+locale: pt
+source: L1-commodity-origination-merchandising-management.yaml
+entries:
+  BC-3570:
+    name: Gestão de captação e comercialização de produtos de base
+    description: |
+      Programas de captação junto de agricultores, contratação de produtos de
+      base, pesagem e amostragem, posições de inventário físico, negociação
+      em dinheiro e base, cobertura e liquidação de grãos, oleaginosas, produtos
+      moles, animais e produtos lácteos.
+  BC-3570.10:
+    name: Gestão de programas de captação
+    description: |
+      Contratação de agricultores, gestão de relações com produtores e previsão
+      de captação que alimenta o livro de fornecimento.
+  BC-3570.10.10:
+    name: Programas de contratação de agricultores
+    description: |
+      Conceção e execução de programas de contratação de agricultores por região.
+  BC-3570.10.20:
+    name: Gestão de relações com produtores
+    description: |
+      Gestão de relações com produtores distinta do CRM genérico.
+  BC-3570.10.30:
+    name: Previsão de captação
+    description: |
+      Previsão de volumes esperados de captação por região e cultura.
+  BC-3570.20:
+    name: Gestão de contratos de produtos de base
+    description: |
+      Emissão e acompanhamento do desempenho de contratos a prazo, de produção
+      e de preços diferidos de produtos de base.
+    in_scope:
+      - Contratos a prazo com agricultores e contrapartes
+      - Contratos de produção com especificações de qualidade
+      - Acompanhamento do desempenho de contratos
+    out_of_scope:
+      - Gestão genérica de contratos jurídicos (BC-150)
+  BC-3570.20.10:
+    name: Emissão de contratos a prazo
+    description: |
+      Emissão de contratos a prazo a preço fixo e base.
+  BC-3570.20.20:
+    name: Gestão de contratos de produção
+    description: |
+      Gestão de contratos de produção com especificações de qualidade e entrega.
+  BC-3570.20.30:
+    name: Acompanhamento do desempenho de contratos
+    description: |
+      Acompanhamento de toneladas entregues face ao desempenho do contrato.
+  BC-3570.30:
+    name: Pesagem e amostragem inbound
+    description: |
+      Operações de pesagem, amostragem e classificação de qualidade e cálculo
+      do ajuste de receção no ponto de receção.
+  BC-3570.30.10:
+    name: Operações de pesagem
+    description: |
+      Operações de pesagem inbound e outbound e emissão de talão de pesagem.
+  BC-3570.30.20:
+    name: Amostragem e classificação de qualidade
+    description: |
+      Amostragem de receção e classificação face às especificações comerciais.
+  BC-3570.30.30:
+    name: Cálculo do ajuste de receção
+    description: |
+      Cálculo de descontos e prémios baseados em qualidade na receção.
+  BC-3570.40:
+    name: Gestão de posição de inventário de produtos de base
+    description: |
+      Acompanhamento de posições físicas de produtos de base, decisões de mistura
+      e posições em trânsito na rede.
+  BC-3570.40.10:
+    name: Acompanhamento de posições físicas
+    description: |
+      Acompanhamento de posições físicas longas e curtas por local e qualidade.
+  BC-3570.40.20:
+    name: Decisões de mistura de qualidade
+    description: |
+      Decisões de mistura para cumprir as especificações de qualidade do contrato.
+  BC-3570.40.30:
+    name: Acompanhamento de posições em trânsito
+    description: |
+      Acompanhamento de posições em trânsito por navio, comboio e camião.
+  BC-3570.50:
+    name: Operações de negociação de produtos de base
+    description: |
+      Negociação em dinheiro e base, execução de vendas a prazo e gestão de
+      spread entre produtos nos livros físicos de produtos de base.
+  BC-3570.50.10:
+    name: Negociação em dinheiro e base
+    description: |
+      Negociação de posições em dinheiro e base em produtos físicos.
+  BC-3570.50.20:
+    name: Execução de vendas a prazo
+    description: |
+      Execução de vendas a prazo a processadores e exportadores.
+  BC-3570.50.30:
+    name: Gestão de spread entre produtos
+    description: |
+      Gestão de spreads entre produtos como margens de esmagamento e crack.
+  BC-3570.60:
+    name: Gestão de cobertura e posição de risco
+    description: |
+      Execução e reconciliação de coberturas de futuros e opções face a posições
+      físicas de produtos de base.
+  BC-3570.60.10:
+    name: Execução de cobertura com futuros
+    description: |
+      Execução de coberturas com futuros em mercados regulados.
+  BC-3570.60.20:
+    name: Execução de cobertura com opções
+    description: |
+      Execução de coberturas com opções para gerir o risco de cauda de preço.
+  BC-3570.60.30:
+    name: Reconciliação de posição de cobertura
+    description: |
+      Reconciliação de posições de cobertura face às exposições físicas
+      subjacentes.
+  BC-3570.70:
+    name: Liquidação e preçário de produtos de base
+    description: |
+      Preçário final, emissão de extratos de liquidação e resolução de
+      reclamações de qualidade com contrapartes.
+  BC-3570.70.10:
+    name: Preçário final e cálculo de desconto
+    description: |
+      Preçário final incluindo aplicação de desconto e prémio baseados em
+      qualidade.
+  BC-3570.70.20:
+    name: Emissão de extratos de liquidação
+    description: |
+      Emissão de extratos de liquidação a agricultores e contrapartes.
+  BC-3570.70.30:
+    name: Resolução de reclamações de qualidade
+    description: |
+      Resolução de reclamações de qualidade com agricultores, compradores e
+      organismos de arbitragem.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-communication-navigation-surveillance-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-communication-navigation-surveillance-operations-management.yaml
@@ -1,0 +1,123 @@
+locale: pt
+source: L1-communication-navigation-surveillance-operations-management.yaml
+entries:
+  BC-1240:
+    name: Gestão das operações de CNS (Comunicações Navegação Vigilância)
+    description: |
+      Infraestrutura CNS - comunicações de voz e dados, auxílios de navegação, radar/ADS-B/multilateração.
+  BC-1240.10:
+    name: Gestão de sistemas de comunicação de voz
+    description: |
+      Comunicações de voz ar-solo, sistemas de voz controlador-piloto e voz solo-solo.
+  BC-1240.10.10:
+    name: Operações de voz ar-solo
+    description: |
+      Operação de comunicações de rádio de voz ar-solo.
+  BC-1240.10.20:
+    name: Operações de voz solo-solo
+    description: |
+      Operação de circuitos de voz inter-centro e inter-setor.
+  BC-1240.10.30:
+    name: Gravação e reprodução de voz
+    description: |
+      Gravação e reprodução de voz operacional para segurança e auditoria.
+  BC-1240.20:
+    name: Gestão de comunicações por ligação de dados
+    description: |
+      CPDLC, ADS-C, FANS e ligações de dados ATN.
+  BC-1240.20.10:
+    name: Operações CPDLC
+    description: |
+      Operação das comunicações por ligação de dados controlador-piloto.
+  BC-1240.20.20:
+    name: Operações ADS-C
+    description: |
+      Operação da vigilância dependente automática por contrato.
+  BC-1240.20.30:
+    name: Operações de rede ATN e FANS
+    description: |
+      Operações de rede de ligação de dados ATN e FANS.
+  BC-1240.30:
+    name: Gestão de auxílios de navegação
+    description: |
+      Serviços de navegação baseados em VOR, DME, ILS e GNSS.
+  BC-1240.30.10:
+    name: Operações VOR e DME
+    description: |
+      Operação e manutenção de balizas VOR e DME.
+  BC-1240.30.20:
+    name: Operações ILS
+    description: |
+      Operação e manutenção de sistemas de aproximação ILS.
+  BC-1240.30.30:
+    name: Serviço de navegação baseado em GNSS
+    description: |
+      Prestação de serviços de navegação GNSS, SBAS e GBAS.
+  BC-1240.30.40:
+    name: Inspeção de voo
+    description: |
+      Inspeção periódica de voo dos auxílios de navegação.
+  BC-1240.40:
+    name: Gestão de sistemas de vigilância
+    description: |
+      Radar primário, radar secundário, ADS-B e multilateração.
+  BC-1240.40.10:
+    name: Operações de radar de vigilância primário
+    description: |
+      Operação de sistemas de radar de vigilância primário.
+  BC-1240.40.20:
+    name: Operações de radar de vigilância secundário
+    description: |
+      Operação de sistemas SSR Modo S e Modo A/C convencional.
+  BC-1240.40.30:
+    name: Operações de vigilância ADS-B
+    description: |
+      Operação de estações terrestres ADS-B e processamento.
+  BC-1240.40.40:
+    name: Operações de multilateração
+    description: |
+      Operação de vigilância WAM/MLAT.
+  BC-1240.40.50:
+    name: Fusão de dados de vigilância
+    description: |
+      Fusão de fontes de vigilância para apresentação CTA.
+  BC-1240.50:
+    name: Gestão da manutenção da infraestrutura CNS
+    description: |
+      Manutenção de campo de equipamentos CNS, calibração e inspeção de voo.
+  BC-1240.50.10:
+    name: Manutenção preventiva CNS
+    description: |
+      Manutenção preventiva programada de equipamentos CNS.
+  BC-1240.50.20:
+    name: Manutenção corretiva CNS
+    description: |
+      Manutenção corretiva e resposta a avarias de equipamentos CNS.
+  BC-1240.50.30:
+    name: Calibração de equipamentos CNS
+    description: |
+      Calibração e alinhamento de equipamentos CNS.
+  BC-1240.50.40:
+    name: Gestão de peças sobresselentes CNS
+    description: |
+      Stock e fornecimento de peças sobresselentes e consumíveis CNS.
+  BC-1240.60:
+    name: Gestão de espectro e frequências
+    description: |
+      Alocação de frequências aeronáuticas, coordenação e gestão de interferências.
+  BC-1240.60.10:
+    name: Alocação de frequências
+    description: |
+      Alocação de frequências aeronáuticas a serviços.
+  BC-1240.60.20:
+    name: Coordenação de frequências
+    description: |
+      Coordenação de frequências transfronteiriça e inter-serviços.
+  BC-1240.60.30:
+    name: Deteção e resolução de interferências
+    description: |
+      Deteção e resolução de incidentes de interferência de frequências.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-compliance-management.yaml
+++ b/catalogue/i18n/pt/L1-compliance-management.yaml
@@ -1,0 +1,119 @@
+locale: pt
+source: L1-compliance-management.yaml
+entries:
+  BC-130:
+    name: Gestão da conformidade
+    description: |
+      Garantia de cumprimento de leis, regulamentos e políticas internas.
+  BC-130.10:
+    name: Gestão da conformidade regulatória
+    description: |
+      Conformidade com regulamentos específicos do setor.
+  BC-130.10.10:
+    name: Gestão do inventário regulatório
+    description: |
+      Inventário de regulamentos e obrigações aplicáveis em todas as jurisdições.
+  BC-130.10.20:
+    name: Monitorização de alterações regulatórias
+    description: |
+      Análise de horizonte de desenvolvimentos regulatórios e avaliação de impacto.
+  BC-130.10.30:
+    name: Avaliação do risco de conformidade
+    description: |
+      Avaliação do risco de conformidade por linha de negócio, geografia e produto.
+  BC-130.10.40:
+    name: Monitorização e teste de conformidade
+    description: |
+      Plano de monitorização de conformidade, teste de controlos e reporte.
+  BC-130.10.50:
+    name: Gestão do relacionamento com reguladores
+    description: |
+      Notificações a reguladores, inspeções e acompanhamento de medidas corretivas.
+  BC-130.20:
+    name: Gestão de políticas
+    description: |
+      Ciclo de vida das políticas — elaboração, aprovação, atestação e extinção.
+  BC-130.20.10:
+    name: Elaboração de políticas
+    description: |
+      Redação e revisão de políticas e normas corporativas.
+  BC-130.20.20:
+    name: Aprovação e publicação de políticas
+    description: |
+      Aprovação por parte da governação e publicação controlada de políticas.
+  BC-130.20.30:
+    name: Atestação de políticas
+    description: |
+      Reconhecimento e atestação por colaboradores e terceiros.
+  BC-130.20.40:
+    name: Gestão de exceções às políticas
+    description: |
+      Registo e aprovação de exceções e dispensas às políticas.
+  BC-130.30:
+    name: Gestão de ética e conduta
+    description: |
+      Código de conduta, ética e programas de denúncia de irregularidades.
+  BC-130.30.10:
+    name: Administração do código de conduta
+    description: |
+      Manutenção e divulgação do código de conduta empresarial.
+  BC-130.30.20:
+    name: Gestão de conflitos de interesses
+    description: |
+      Divulgação e gestão de conflitos pessoais e organizacionais.
+  BC-130.30.30:
+    name: Gestão de denúncias e canal de comunicação
+    description: |
+      Canais de denúncia, receção, triagem e proteção de denunciantes.
+  BC-130.30.40:
+    name: Investigações de conduta
+    description: |
+      Investigação de alegados incumprimentos e gestão de processos disciplinares.
+  BC-130.40:
+    name: Gestão antissuborno e anticorrupção
+    description: |
+      Programas ABC, due diligence de terceiros, ofertas e hospitalidade.
+  BC-130.40.10:
+    name: Governação do programa ABC
+    description: |
+      Design do programa antissuborno e anticorrupção alinhado com FCPA e UKBA.
+  BC-130.40.20:
+    name: Due diligence de integridade de terceiros
+    description: |
+      Due diligence de integridade e monitorização contínua de intermediários.
+  BC-130.40.30:
+    name: Gestão de ofertas, hospitalidade e patrocínios
+    description: |
+      Pré-aprovação e registos de ofertas, hospitalidade e patrocínios.
+  BC-130.40.40:
+    name: Formação e sensibilização ABC
+    description: |
+      Formação direcionada e comunicações sobre requisitos antissuborno.
+  BC-130.50:
+    name: Gestão de privacidade e proteção de dados
+    description: |
+      Conformidade com o RGPD/equivalente, direitos dos titulares de dados e privacidade por design.
+  BC-130.50.10:
+    name: Governação do programa de privacidade
+    description: |
+      Quadro de privacidade, função de DPO e disposições de responsabilização.
+  BC-130.50.20:
+    name: Gestão de registos de tratamento
+    description: |
+      Manutenção de registos de atividades de tratamento e fluxos de dados.
+  BC-130.50.30:
+    name: Avaliação de impacto sobre a proteção de dados
+    description: |
+      DPIAs e revisões de privacidade por design de novas atividades de tratamento.
+  BC-130.50.40:
+    name: Tratamento de direitos dos titulares de dados
+    description: |
+      Receção e cumprimento de pedidos de acesso, retificação e apagamento.
+  BC-130.50.50:
+    name: Gestão de violações de dados pessoais
+    description: |
+      Deteção, notificação e remediação de violações de dados pessoais.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-connected-product-firmware-management.yaml
+++ b/catalogue/i18n/pt/L1-connected-product-firmware-management.yaml
@@ -1,0 +1,148 @@
+locale: pt
+source: L1-connected-product-firmware-management.yaml
+entries:
+  BC-1950:
+    name: Gestão de produto conectado e firmware
+    description: |
+      Ciclo de vida operacional de produtos elétricos conectados em campo — identidade de dispositivo,
+      compilação e lançamento de firmware, atualizações OTA, telemetria, cibersegurança do produto e operações de plataforma IIoT.
+  BC-1950.10:
+    name: Gestão de identidade e aprovisionamento de dispositivos
+    description: |
+      Emissão e ciclo de vida de identidades de dispositivos e credenciais criptográficas.
+  BC-1950.10.10:
+    name: Emissão de identidade de dispositivo
+    description: |
+      Emissão de identidades únicas de dispositivo no momento do fabrico.
+  BC-1950.10.20:
+    name: Aprovisionamento de chaves criptográficas
+    description: |
+      Aprovisionamento de chaves criptográficas para dispositivos.
+  BC-1950.10.30:
+    name: Integração de dispositivos na plataforma
+    description: |
+      Integração de dispositivos na plataforma de produto conectado.
+  BC-1950.10.40:
+    name: Desativação de dispositivos
+    description: |
+      Desativação e revogação de credenciais de dispositivos retirados.
+  BC-1950.20:
+    name: Gestão de compilação e lançamento de firmware
+    description: |
+      Pipelines de compilação, aprovação de lançamento, assinatura e inventário de versões para firmware em produção.
+  BC-1950.20.10:
+    name: Gestão do pipeline de compilação de firmware
+    description: |
+      Operação de pipelines de compilação de firmware e integração contínua.
+  BC-1950.20.20:
+    name: Aprovação de lançamento de firmware
+    description: |
+      Aprovação por fases de lançamentos de firmware para implementação.
+  BC-1950.20.30:
+    name: Assinatura e gestão de integridade do firmware
+    description: |
+      Assinatura de código e proteção de integridade de artefactos de firmware.
+  BC-1950.20.40:
+    name: Inventário de versões de firmware
+    description: |
+      Inventário de versões de firmware implementadas na base instalada.
+  BC-1950.30:
+    name: Gestão de atualizações over-the-air
+    description: |
+      Planeamento, execução e reversão de atualizações de firmware over-the-air.
+  BC-1950.30.10:
+    name: Planeamento de campanhas OTA
+    description: |
+      Planeamento de campanhas OTA e coortes de implementação.
+  BC-1950.30.20:
+    name: Execução de implementação OTA
+    description: |
+      Execução de implementações OTA e acompanhamento do progresso.
+  BC-1950.30.30:
+    name: Gestão de reversão OTA
+    description: |
+      Reversão de atualizações OTA falhadas para versões conhecidas como boas.
+  BC-1950.30.40:
+    name: Verificação de compatibilidade OTA
+    description: |
+      Verificação de compatibilidade de firmware antes do lançamento OTA.
+  BC-1950.40:
+    name: Gestão de telemetria e conectividade de dispositivos
+    description: |
+      Ingestão de telemetria, estado de conectividade, encaminhamento e gestão de operador ou SIM.
+  BC-1950.40.10:
+    name: Operações de ingestão de telemetria
+    description: |
+      Ingestão de telemetria de dispositivos em repositórios da plataforma.
+  BC-1950.40.20:
+    name: Monitorização do estado de conectividade
+    description: |
+      Monitorização do estado de conectividade e acessibilidade dos dispositivos.
+  BC-1950.40.30:
+    name: Encaminhamento de dados de telemetria
+    description: |
+      Encaminhamento de telemetria para consumidores a jusante e análise.
+  BC-1950.40.40:
+    name: Gestão de operador de rede e SIM
+    description: |
+      Gestão das relações com operadores de rede celular e inventário de SIM.
+  BC-1950.50:
+    name: Gestão de cibersegurança de produto conectado
+    description: |
+      Cibersegurança do lado do produto abrangendo ameaças, vulnerabilidades, arranque seguro e conformidade.
+  BC-1950.50.10:
+    name: Modelação de ameaças ao produto
+    description: |
+      Modelação de ameaças para projetos de produto conectado.
+  BC-1950.50.20:
+    name: Divulgação e resposta a vulnerabilidades
+    description: |
+      Divulgação coordenada e resposta a vulnerabilidades de produto.
+  BC-1950.50.30:
+    name: Arranque seguro e atestação
+    description: |
+      Mecanismos de arranque seguro e atestação nos dispositivos.
+  BC-1950.50.40:
+    name: Conformidade de cibersegurança do produto
+    description: |
+      Conformidade de produtos conectados com IEC 62443 e regimes equivalentes.
+  BC-1950.60:
+    name: Operações da plataforma de produto conectado
+    description: |
+      Operação da plataforma IIoT subjacente a produtos conectados.
+  BC-1950.60.10:
+    name: Gestão de inquilinos da plataforma IIoT
+    description: |
+      Integração de inquilinos e isolamento na plataforma IIoT.
+  BC-1950.60.20:
+    name: Capacidade e desempenho da plataforma
+    description: |
+      Planeamento de capacidade e gestão do desempenho da plataforma.
+  BC-1950.60.30:
+    name: Serviços de integração da plataforma
+    description: |
+      Integração da plataforma com sistemas empresariais e de clientes.
+  BC-1950.60.40:
+    name: Ciclo de vida da API da plataforma
+    description: |
+      Ciclo de vida das API e SDK expostos pela plataforma.
+  BC-1950.70:
+    name: Gestão de operações de edge e gateway
+    description: |
+      Operação de aplicações edge e dispositivos gateway em campo.
+  BC-1950.70.10:
+    name: Implementação de aplicações edge
+    description: |
+      Implementação de aplicações edge em gateways e controladores.
+  BC-1950.70.20:
+    name: Gestão de configuração de gateway
+    description: |
+      Gestão de configuração de dispositivos gateway em campo.
+  BC-1950.70.30:
+    name: Monitorização de saúde de edge
+    description: |
+      Monitorização da saúde de dispositivos e aplicações edge.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-construction-management.yaml
+++ b/catalogue/i18n/pt/L1-construction-management.yaml
@@ -1,0 +1,135 @@
+locale: pt
+source: L1-construction-management.yaml
+entries:
+  BC-1150:
+    name: Gestão da construção
+    description: |
+      Supervisão e execução de construção (para empresas EPC).
+  BC-1150.10:
+    name: Gestão do planeamento da construção
+    description: |
+      Sequenciamento da construção, métodos e programas gerais.
+  BC-1150.10.10:
+    name: Declaração do método de construção
+    description: |
+      Definição dos métodos de construção e sequenciamento.
+  BC-1150.10.20:
+    name: Programa geral de construção
+    description: |
+      Programa geral de construção e planos de antecipação.
+  BC-1150.10.30:
+    name: Planeamento de recursos de construção
+    description: |
+      Planeamento de mão de obra, equipamentos e materiais para a construção.
+  BC-1150.10.40:
+    name: Plano de execução da construção
+    description: |
+      Plano de execução do projeto cobrindo a estratégia de construção.
+  BC-1150.20:
+    name: Gestão da mobilização e instalação do estaleiro
+    description: |
+      Instalação do estaleiro, instalações temporárias e logística do estaleiro.
+  BC-1150.20.10:
+    name: Instalação do estaleiro
+    description: |
+      Montagem de instalações temporárias, escritórios e comodidades.
+  BC-1150.20.20:
+    name: Planeamento da logística do estaleiro
+    description: |
+      Planeamento de acessos, áreas de armazenamento e manuseamento de materiais no estaleiro.
+  BC-1150.20.30:
+    name: Mobilização de equipamentos de construção
+    description: |
+      Mobilização de gruas, equipamentos industriais e de construção.
+  BC-1150.30:
+    name: Gestão da supervisão da construção
+    description: |
+      Supervisão do estaleiro, gestão de frentes de trabalho e operações diárias do estaleiro.
+  BC-1150.30.10:
+    name: Operações diárias do estaleiro
+    description: |
+      Coordenação diária do estaleiro, briefings e execução.
+  BC-1150.30.20:
+    name: Gestão de frentes de trabalho
+    description: |
+      Definição e progressão das frentes de trabalho de construção.
+  BC-1150.30.30:
+    name: Conformidade com licenças e métodos
+    description: |
+      Conformidade com licenças e declarações de método aprovadas.
+  BC-1150.40:
+    name: Gestão de subcontratados
+    description: |
+      Seleção, supervisão, desempenho e certificação de pagamentos de subcontratados.
+  BC-1150.40.10:
+    name: Seleção de subcontratados
+    description: |
+      Pré-qualificação e seleção de subcontratados de construção.
+  BC-1150.40.20:
+    name: Supervisão de subcontratados
+    description: |
+      Supervisão no estaleiro do desempenho e conformidade dos subcontratados.
+  BC-1150.40.30:
+    name: Certificação de pagamentos
+    description: |
+      Medição e certificação de pagamentos de subcontratados.
+  BC-1150.40.40:
+    name: Gestão de variações de subcontratados
+    description: |
+      Gestão de variações e reclamações de subcontratados.
+  BC-1150.50:
+    name: Gestão da qualidade da construção
+    description: |
+      GA/CQ no estaleiro, inspeções, pontos de retenção e testemunho.
+  BC-1150.50.10:
+    name: Planos de inspeção e ensaios do estaleiro
+    description: |
+      Definição de ITP, pontos de retenção e testemunho e programas de inspeção.
+  BC-1150.50.20:
+    name: Inspeção de qualidade do estaleiro
+    description: |
+      Execução de inspeções e ensaios de qualidade no estaleiro.
+  BC-1150.50.30:
+    name: Gestão de não conformidades e lista de pendências
+    description: |
+      Relatórios de não conformidade do estaleiro e encerramento da lista de pendências.
+  BC-1150.60:
+    name: Gestão do progresso da construção
+    description: |
+      Medição do progresso, valor ganho e análise de desvios.
+  BC-1150.60.10:
+    name: Medição do progresso da construção
+    description: |
+      Medição do progresso com base em quantidades no estaleiro.
+  BC-1150.60.20:
+    name: Relatório de valor ganho
+    description: |
+      Análise de valor ganho e relatório de desempenho do projeto.
+  BC-1150.60.30:
+    name: Análise de desvios de cronograma e custo
+    description: |
+      Análise de desvios e ação corretiva.
+  BC-1150.70:
+    name: Gestão de HSE do estaleiro
+    description: |
+      Segurança do estaleiro, licença de trabalho, gestão de perigos e resposta de emergência.
+  BC-1150.70.10:
+    name: Planeamento de HSE do estaleiro
+    description: |
+      Planos de HSE do estaleiro e avaliações de risco.
+  BC-1150.70.20:
+    name: Licença de trabalho do estaleiro
+    description: |
+      Licença de trabalho do estaleiro e autorização de trabalhos a quente.
+  BC-1150.70.30:
+    name: Inspeções e auditorias de segurança do estaleiro
+    description: |
+      Inspeções de segurança, auditorias e observações comportamentais.
+  BC-1150.70.40:
+    name: Resposta de emergência do estaleiro
+    description: |
+      Planos de resposta de emergência do estaleiro, simulacros e gestão de incidentes.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-content-compliance-standards-management.yaml
+++ b/catalogue/i18n/pt/L1-content-compliance-standards-management.yaml
@@ -1,0 +1,134 @@
+locale: pt
+source: L1-content-compliance-standards-management.yaml
+entries:
+  BC-3780:
+    name: Gestão de conformidade de conteúdos e normas
+    description: |
+      Classificação e avaliação de conteúdos, normas editoriais, conformidade
+      regulatória de difusão e conteúdos em linha, moderação de conteúdos
+      gerados por utilizadores, conformidade de acessibilidade e tratamento
+      de notificações e remoções no portfólio de conteúdos.
+  BC-3780.10:
+    name: Gestão de classificação e avaliação de conteúdos
+    description: |
+      Submissão, aplicação e autoclassificação de classificações etárias e
+      de conteúdo em territórios e plataformas.
+  BC-3780.10.10:
+    name: Submissão de classificação pré-lançamento
+    description: |
+      Submissão de títulos a organismos de classificação para classificações
+      etárias territoriais antes do lançamento.
+  BC-3780.10.20:
+    name: Conformidade na apresentação de classificações
+    description: |
+      Apresentação de classificações etárias, descritores de conteúdo e
+      avisos em superfícies de consumo.
+  BC-3780.10.30:
+    name: Gestão de autoclassificação
+    description: |
+      Operação de regimes de autoclassificação e adesão a ferramentas de
+      classificação etária de plataformas.
+  BC-3780.20:
+    name: Gestão de normas editoriais
+    description: |
+      Criação de política editorial, revisão de conformidade pré-transmissão
+      e tratamento de reclamações editoriais.
+  BC-3780.20.10:
+    name: Gestão de política editorial
+    description: |
+      Criação e ciclo de vida de políticas editoriais e normas de
+      imparcialidade e rigor.
+  BC-3780.20.20:
+    name: Revisão de conformidade pré-transmissão
+    description: |
+      Revisão pré-transmissão de programas e intervalos contra normas
+      editoriais e regulatórias.
+  BC-3780.20.30:
+    name: Tratamento de reclamações editoriais
+    description: |
+      Triagem, investigação e resposta a reclamações editoriais de
+      telespectadores e reguladores.
+  BC-3780.30:
+    name: Conformidade regulatória de difusão
+    description: |
+      Conformidade com regulamentação audiovisual e de difusão, incluindo
+      regras de calendarização, quotas de conteúdo e códigos de publicidade.
+  BC-3780.30.10:
+    name: Conformidade de horário de proteção e calendarização
+    description: |
+      Conformidade com regras de horário de proteção e faixas horárias para
+      calendarização de conteúdo para adultos.
+  BC-3780.30.20:
+    name: Conformidade de quotas e conteúdo local
+    description: |
+      Conformidade com quotas de conteúdo, incluindo obras europeias,
+      produção independente e obrigações de conteúdo em língua local.
+  BC-3780.30.30:
+    name: Conformidade do código de publicidade
+    description: |
+      Conformidade da publicidade e dos patrocínios com os códigos aplicáveis
+      e restrições por categoria.
+  BC-3780.40:
+    name: Moderação de conteúdos gerados por utilizadores
+    description: |
+      Moderação de conteúdos gerados por utilizadores através de triagem
+      automatizada, revisão humana e fluxos de trabalho de sinalizadores
+      de confiança.
+  BC-3780.40.10:
+    name: Triagem automatizada de conteúdos
+    description: |
+      Triagem e classificação automatizadas de conteúdos gerados por
+      utilizadores para questões de segurança e política.
+  BC-3780.40.20:
+    name: Gestão da fila de revisão humana
+    description: |
+      Operação de filas de revisão humana, incluindo garantia de qualidade
+      e controlos de bem-estar dos revisores.
+  BC-3780.40.30:
+    name: Gestão de sinalizadores de confiança
+    description: |
+      Gestão de relações com sinalizadores de confiança e canais de revisão
+      prioritária ao abrigo da regulamentação de conteúdos em linha.
+  BC-3780.50:
+    name: Gestão de conformidade de acessibilidade
+    description: |
+      Conformidade com obrigações de acessibilidade em legendas, audiodescrição
+      e disponibilização de língua gestual.
+  BC-3780.50.10:
+    name: Conformidade de legendagem
+    description: |
+      Conformidade com obrigações de legendagem, incluindo cobertura, qualidade
+      e normas de apresentação.
+  BC-3780.50.20:
+    name: Conformidade de audiodescrição
+    description: |
+      Conformidade com obrigações de cobertura e qualidade da audiodescrição.
+  BC-3780.50.30:
+    name: Conformidade da disponibilização de língua gestual
+    description: |
+      Conformidade com obrigações de interpretação em língua gestual e
+      assinatura em imagem.
+  BC-3780.60:
+    name: Gestão de notificações e remoções
+    description: |
+      Tratamento de notificações de direitos de autor e conteúdos em linha,
+      incluindo contranotificações e processos de recurso.
+  BC-3780.60.10:
+    name: Tratamento de notificações de direitos de autor
+    description: |
+      Tratamento de notificações de remoção de direitos de autor e aplicação
+      da política de infratores reincidentes.
+  BC-3780.60.20:
+    name: Tratamento de notificações de conteúdos em linha
+    description: |
+      Tratamento de notificações de conteúdos ilegais e ordens ao abrigo
+      da regulamentação de conteúdos em linha.
+  BC-3780.60.30:
+    name: Gestão de contranotificações e recursos
+    description: |
+      Gestão de contranotificações e mecanismos de recurso extrajudicial
+      para decisões de remoção de conteúdos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-content-distribution-delivery-management.yaml
+++ b/catalogue/i18n/pt/L1-content-distribution-delivery-management.yaml
@@ -1,0 +1,134 @@
+locale: pt
+source: L1-content-distribution-delivery-management.yaml
+entries:
+  BC-3740:
+    name: Gestão de distribuição e entrega de conteúdos
+    description: |
+      Difusão linear, entrega por OTT e streaming, operações de redes de
+      distribuição de conteúdos, IPTV e multicast, proteção de conteúdos,
+      e distribuição sindicalizada e a afiliadas de conteúdos para superfícies
+      de consumo e parceiros.
+  BC-3740.10:
+    name: Distribuição de difusão linear
+    description: |
+      Operação da distribuição de difusão linear por vias de transporte
+      terrestre digital, satélite e cabo.
+  BC-3740.10.10:
+    name: Operações de difusão terrestre
+    description: |
+      Operação de cadeias de transmissão terrestre digital e transporte
+      de multiplex.
+  BC-3740.10.20:
+    name: Operações de uplink via satélite
+    description: |
+      Operação de cadeias de uplink via satélite para distribuição direta
+      ao lar e de contribuição.
+  BC-3740.10.30:
+    name: Operações de headend de cabo
+    description: |
+      Operação do transporte por cabo e integração do headend com plataformas
+      de operadores.
+  BC-3740.20:
+    name: Entrega por OTT e streaming
+    description: |
+      Operação de origem de streaming, empacotamento e streaming ao vivo
+      para serviços OTT diretos ao consumidor e de parceiros.
+  BC-3740.20.10:
+    name: Operações do serviço de origem
+    description: |
+      Operação de serviços de origem de streaming a fornecer conteúdos a
+      pedido e ao vivo para superfícies de entrega.
+  BC-3740.20.20:
+    name: Empacotamento de streaming adaptativo
+    description: |
+      Streaming adaptativo just-in-time e pré-empacotado para HLS,
+      MPEG-DASH e CMAF.
+  BC-3740.20.30:
+    name: Operações de streaming ao vivo
+    description: |
+      Operação de pipelines de streaming ao vivo para eventos, canais e
+      serviços fast.
+  BC-3740.30:
+    name: Operações da rede de distribuição de conteúdos
+    description: |
+      Gestão de capacidade, cache e desempenho de custos das redes de
+      distribuição de conteúdos para distribuição de conteúdos.
+  BC-3740.30.10:
+    name: Planeamento de capacidade da rede de distribuição de conteúdos
+    description: |
+      Previsão e provisionamento de capacidade da rede de distribuição de
+      conteúdos por regiões, peering e eventos de pico.
+  BC-3740.30.20:
+    name: Gestão da cache de extremidade
+    description: |
+      Gestão da área de cache de extremidade, comportamento de preenchimento
+      e descarga para caches parceiras.
+  BC-3740.30.30:
+    name: Otimização de custo e desempenho da rede de distribuição de conteúdos
+    description: |
+      Direcionamento multi-CDN e otimização de custo-desempenho entre
+      parceiros de entrega.
+  BC-3740.40:
+    name: Gestão de entrega por IPTV e multicast
+    description: |
+      Operação de headends IPTV de grau de telecomunicação, fluxos multicast
+      e ativação do serviço de set-top box.
+  BC-3740.40.10:
+    name: Operações de headend IPTV
+    description: |
+      Operação de headends IPTV, incluindo aquisição de sinal, codificação
+      e integração de acesso condicional.
+  BC-3740.40.20:
+    name: Gestão de fluxo multicast
+    description: |
+      Gestão do provisionamento de fluxos multicast em portadores IP e de
+      difusão 3GPP.
+  BC-3740.40.30:
+    name: Ativação do serviço de set-top box
+    description: |
+      Ativação de set-top boxes e dispositivos geridos no serviço IPTV,
+      incluindo provisionamento da linha de canais.
+  BC-3740.50:
+    name: Gestão de proteção de conteúdos e DRM
+    description: |
+      Operação de sistemas de proteção de conteúdos, incluindo gestão de
+      chaves e licenças, marcação de água e controlo de fluxos simultâneos.
+  BC-3740.50.10:
+    name: Gestão de licenças e chaves
+    description: |
+      Emissão e gestão de licenças DRM e chaves de conteúdo em dispositivos
+      e plataformas.
+  BC-3740.50.20:
+    name: Marcação de água e rastreio forense
+    description: |
+      Aplicação de marcas de água de sessão e forenses para deteção de
+      pirataria e rastreio de origem.
+  BC-3740.50.30:
+    name: Controlo de fluxos simultâneos
+    description: |
+      Aplicação de limites de fluxos simultâneos e política de partilha de
+      conta entre telespectadores e dispositivos.
+  BC-3740.60:
+    name: Distribuição sindicalizada e a afiliadas
+    description: |
+      Distribuição de programação e feeds a afiliadas sindicalizadas e
+      plataformas de terceiros com contabilização de entrega.
+  BC-3740.60.10:
+    name: Gestão de encomendas de sindicação
+    description: |
+      Captura e cumprimento de encomendas de sindicação contra direitos
+      detidos e espaços de entrega.
+  BC-3740.60.20:
+    name: Distribuição de feeds a afiliadas
+    description: |
+      Distribuição de feeds de rede e canal a afiliadas de difusão com
+      transferências de localização.
+  BC-3740.60.30:
+    name: Rastreio de entrega de programas
+    description: |
+      Rastreio de entregas de programas a plataformas e parceiros, incluindo
+      prova de entrega e tratamento de exceções.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-content-origination-production-management.yaml
+++ b/catalogue/i18n/pt/L1-content-origination-production-management.yaml
@@ -1,0 +1,155 @@
+locale: pt
+source: L1-content-origination-production-management.yaml
+entries:
+  BC-3700:
+    name: Gestão de criação e produção de conteúdo
+    description: |
+      Aprovação, pré-produção, rodagem principal ou produção em estúdio,
+      produção ao vivo e de notícias, pós-produção e localização de conteúdo
+      audiovisual, áudio e editorial, desde o conceito até ao master pronto
+      para entrega.
+  BC-3700.10:
+    name: Encomenda e aprovação de conteúdo
+    description: |
+      Avaliação de conceitos e pitches, composição da grelha de produção e
+      autoridade para encomendar novas produções ou aquisições.
+  BC-3700.10.10:
+    name: Avaliação de conceitos e pitches
+    description: |
+      Avaliação estruturada de pitches, tratamentos e bíblias recebidos face
+      a critérios editoriais e comerciais.
+  BC-3700.10.20:
+    name: Planeamento de grelha e portefólio
+    description: |
+      Composição da grelha de produção por géneros, orçamentos, audiências e
+      janelas de lançamento.
+  BC-3700.10.30:
+    name: Decisão de aprovação
+    description: |
+      Autoridade e registo da decisão de aprovação, incluindo orçamento,
+      calendário e envelope criativo.
+  BC-3700.10.40:
+    name: Gestão de briefings de encomenda
+    description: |
+      Criação e ciclo de vida dos briefings de encomenda emitidos a unidades
+      de produção internas e produtores externos.
+  BC-3700.20:
+    name: Gestão de pré-produção
+    description: |
+      Desenvolvimento de guião, orçamentação, calendarização e planeamento
+      de locais e cenários que levam um projeto aprovado ao estado pronto
+      para rodagem.
+  BC-3700.20.10:
+    name: Desenvolvimento de guião e storyboard
+    description: |
+      Desenvolvimento iterativo de guiões, storyboards e listas de planos
+      para produções escritas e não escritas.
+  BC-3700.20.20:
+    name: Planeamento do orçamento de produção
+    description: |
+      Orçamento de produção detalhado de baixo para cima por departamento e
+      fase, com considerações de contingência e caução de conclusão.
+  BC-3700.20.30:
+    name: Calendarização da produção
+    description: |
+      Construção de planos de filmagem e calendários de rodagem, janelas de
+      disponibilidade de talentos e equipa, e divisões de unidade.
+  BC-3700.20.40:
+    name: Planeamento de locais e cenários
+    description: |
+      Reconhecimento de locais, licenças e planeamento de design e construção
+      de cenários em estúdio e locais práticos.
+  BC-3700.30:
+    name: Gestão de operações de produção
+    description: |
+      Execução da rodagem principal ou produção em estúdio, incluindo a
+      logística de equipa, equipamento e fluxo de trabalho em set.
+  BC-3700.30.10:
+    name: Operações de produção em estúdio
+    description: |
+      Produção em estúdio para formatos de entretenimento, ficção e não-ficção,
+      incluindo configurações de estúdio multicâmara.
+  BC-3700.30.20:
+    name: Operações de produção em exterior
+    description: |
+      Execução de produção em locais práticos e remotos, incluindo gestão de
+      unidade e segurança em set.
+  BC-3700.30.30:
+    name: Logística de produção e operações de equipa
+    description: |
+      Logística de folhas de chamada de equipa, transporte, catering e
+      movimentação de equipamento ao longo da produção.
+  BC-3700.40:
+    name: Gestão de produção de eventos ao vivo e notícias
+    description: |
+      Produção em tempo real de eventos ao vivo, desporto e boletins
+      informativos, incluindo direção multicâmara e grafismo ao vivo.
+  BC-3700.40.10:
+    name: Produção de eventos ao vivo
+    description: |
+      Produção de entretenimento ao vivo e eventos especiais com mistura de
+      imagem e áudio em tempo real.
+  BC-3700.40.20:
+    name: Produção de boletins informativos
+    description: |
+      Produção de boletins e transmissão de notícias contínuas em redação,
+      incluindo gestão de alinhamento e coordenação de inserções ao vivo.
+  BC-3700.40.30:
+    name: Produção de cobertura desportiva
+    description: |
+      Produção multicâmara de desporto ao vivo, incluindo operações de
+      transmissão exterior e de difusão principal.
+  BC-3700.40.40:
+    name: Grafismo em tempo real e repetição imediata
+    description: |
+      Grafismo em antena, marcadores e operações de repetição imediata para
+      produções ao vivo e quase ao vivo.
+  BC-3700.50:
+    name: Gestão de pós-produção
+    description: |
+      Fluxos de trabalho de imagem, áudio, cor e finalização que levam o
+      material captado a um master de qualidade de entrega.
+  BC-3700.50.10:
+    name: Montagem de imagem e efeitos visuais
+    description: |
+      Montagem de imagem offline e online, integração de efeitos visuais e
+      conformação de decisões de edição.
+  BC-3700.50.20:
+    name: Pós-produção de áudio
+    description: |
+      Edição de diálogo, ADR, foley, design de som e mistura final para
+      especificações de loudness de entrega.
+  BC-3700.50.30:
+    name: Gradação de cor e finalização
+    description: |
+      Gradação de cor criativa e técnica e finalização para entregas em HDR
+      e SDR.
+  BC-3700.50.40:
+    name: Masterização e conformação
+    description: |
+      Produção de masters de entrega, pacotes IMF e mezzanine de difusão, e
+      conformação face às especificações de entrega.
+  BC-3700.60:
+    name: Gestão de localização e versões
+    description: |
+      Legendagem, legendagem para surdos, dobragem e versões regionais ou
+      específicas de plataforma e masters de versão para distribuição.
+  BC-3700.60.10:
+    name: Produção de legendas e legendagem para surdos
+    description: |
+      Criação de legendas e legendas fechadas em múltiplos idiomas e
+      formatos.
+  BC-3700.60.20:
+    name: Produção de dobragem
+    description: |
+      Tradução, casting e gravação de faixas de áudio dobradas para
+      lançamento territorial.
+  BC-3700.60.30:
+    name: Gestão de versões linguísticas e cortes regionais
+    description: |
+      Produção de masters de versões linguísticas e regionais, incluindo
+      cortes de edição por território.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-content-rights-licensing-management.yaml
+++ b/catalogue/i18n/pt/L1-content-rights-licensing-management.yaml
@@ -1,0 +1,153 @@
+locale: pt
+source: L1-content-rights-licensing-management.yaml
+entries:
+  BC-3720:
+    name: Gestão de direitos e licenciamento de conteúdo
+    description: |
+      Aquisição, inventário, licenciamento de saída, direitos desportivos e
+      musicais, receitas de royalties, e autorização e cadeia de título de
+      conteúdo audiovisual, áudio e editorial.
+  BC-3720.10:
+    name: Gestão de aquisição de direitos
+    description: |
+      Negociação e contratação de direitos de entrada para conteúdo que a
+      empresa adquire a detentores de direitos ou produtores.
+  BC-3720.10.10:
+    name: Apoio à negociação de direitos
+    description: |
+      Preparação de term sheets, análise de acordos comparáveis e apoio à
+      negociação de acordos de conteúdo de entrada.
+  BC-3720.10.20:
+    name: Gestão de contratos de aquisição
+    description: |
+      Criação, execução e gestão do ciclo de vida de contratos de direitos de
+      entrada e respetivos aditamentos.
+  BC-3720.10.30:
+    name: Acompanhamento de aquisição de janelas de direitos
+    description: |
+      Acompanhamento de janelas, territórios, plataformas e termos de
+      exclusividade adquiridos face ao contrato.
+  BC-3720.20:
+    name: Gestão de inventário de direitos
+    description: |
+      Gestão responsável do inventário consolidado de direitos detidos e
+      consulta de disponibilidade para programação e licenciamento a jusante.
+  BC-3720.20.10:
+    name: Acompanhamento de janelas de direitos e territórios
+    description: |
+      Acompanhamento de janelas de direitos disponíveis por título, território,
+      plataforma e idioma.
+  BC-3720.20.20:
+    name: Acompanhamento de períodos de bloqueio e exclusividade
+    description: |
+      Acompanhamento de períodos de bloqueio e restrições de exclusividade
+      que condicionam a utilização a jusante.
+  BC-3720.20.30:
+    name: Consulta de disponibilidade de direitos
+    description: |
+      Serviços de consulta que respondem se um título está disponível para
+      licenciamento para uma determinada utilização, janela e território.
+  BC-3720.30:
+    name: Gestão de licenciamento de saída
+    description: |
+      Venda e gestão do ciclo de vida de direitos licenciados a
+      radiodifusores, plataformas e outros terceiros.
+  BC-3720.30.10:
+    name: Gestão de vendas de licenciamento
+    description: |
+      Pipeline, estruturação de acordos e fecho de acordos de licenciamento
+      de saída por territórios e plataformas.
+  BC-3720.30.20:
+    name: Gestão de acordos de saída
+    description: |
+      Gestão de acordos de saída e volume de múltiplos títulos com
+      licenciados a jusante.
+  BC-3720.30.30:
+    name: Gestão de licenciamento de formatos
+    description: |
+      Licenciamento de formatos e bíblias de ficção e não-ficção a produtores
+      e radiodifusores locais.
+  BC-3720.40:
+    name: Gestão de direitos desportivos e de eventos ao vivo
+    description: |
+      Concurso, acompanhamento e exploração de direitos desportivos e de
+      eventos ao vivo, incluindo destaques derivados.
+  BC-3720.40.10:
+    name: Concurso de direitos desportivos
+    description: |
+      Preparação de propostas, valorização e resposta a concursos de direitos
+      desportivos e de eventos ao vivo.
+  BC-3720.40.20:
+    name: Acompanhamento de direitos de calendário de eventos
+    description: |
+      Acompanhamento de direitos ao nível de jogo face aos direitos de
+      competição e torneio detidos.
+  BC-3720.40.30:
+    name: Gestão de direitos de destaques e clipes
+    description: |
+      Gestão de direitos derivados para destaques, clipes e exploração em
+      formato curto para redes sociais e digital.
+  BC-3720.50:
+    name: Gestão de direitos musicais e de execução
+    description: |
+      Licenciamento e reporte de direitos musicais e de execução, incluindo
+      sincronização, mecânicos e execução pública.
+  BC-3720.50.10:
+    name: Licenciamento mecânico e de sincronização
+    description: |
+      Autorização e licenciamento de direitos mecânicos e de sincronização
+      para música utilizada em produções e plataformas.
+  BC-3720.50.20:
+    name: Reporte de direitos de execução
+    description: |
+      Reporte de execução pública e utilização em difusão a organizações de
+      gestão coletiva.
+  BC-3720.50.30:
+    name: Gestão de folhas de alinhamento musical
+    description: |
+      Produção e distribuição de folhas de alinhamento musical a sociedades
+      e detentores de direitos.
+  BC-3720.60:
+    name: Gestão de receitas de royalties
+    description: |
+      Receção, reconciliação e distribuição de receitas de royalties devidas
+      à empresa enquanto detentora de direitos.
+  BC-3720.60.10:
+    name: Reconciliação de extratos de royalties
+    description: |
+      Reconciliação de extratos de royalties de entrada de licenciados e
+      sociedades face aos direitos detidos.
+  BC-3720.60.20:
+    name: Registo de recebimentos de royalties
+    description: |
+      Registo de recebimentos de royalties no livro de direitos e
+      reconhecimento contabilístico subsequente.
+  BC-3720.60.30:
+    name: Distribuição a detentores de direitos subjacentes
+    description: |
+      Distribuição de royalties recebidos a detentores de direitos subjacentes
+      nos termos de participação e subpublicação.
+  BC-3720.70:
+    name: Gestão de autorização de direitos e cadeia de título
+    description: |
+      Verificação e documentação de direitos subjacentes e cadeia de título
+      para suportar a exploração e a cobertura de erros e omissões.
+  BC-3720.70.10:
+    name: Verificação de direitos subjacentes
+    description: |
+      Verificação de direitos literários, musicais e de imagem subjacentes
+      incorporados na obra.
+  BC-3720.70.20:
+    name: Acompanhamento do estado de autorização
+    description: |
+      Acompanhamento do estado de autorização por elemento com gestão de
+      ações pendentes.
+  BC-3720.70.30:
+    name: Documentação de cadeia de título
+    description: |
+      Manutenção de registos de cadeia de título suficientes para cobertura
+      de E&O e devida diligência de licenciados a jusante.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-corporate-communications-management.yaml
+++ b/catalogue/i18n/pt/L1-corporate-communications-management.yaml
@@ -1,0 +1,119 @@
+locale: pt
+source: L1-corporate-communications-management.yaml
+entries:
+  BC-850:
+    name: Gestão das comunicações corporativas
+    description: |
+      Comunicações corporativas internas e externas.
+  BC-850.10:
+    name: Gestão das comunicações internas
+    description: |
+      Comunicações com colaboradores e comunicações de liderança.
+  BC-850.10.10:
+    name: Comunicações com colaboradores
+    description: |
+      Boletins informativos, intranet e assembleias gerais com colaboradores.
+  BC-850.10.20:
+    name: Comunicações de liderança
+    description: |
+      Comunicações e mensagens do CEO e da equipa executiva.
+  BC-850.10.30:
+    name: Comunicações de mudança e transformação
+    description: |
+      Comunicações internas de apoio à mudança e transformação.
+  BC-850.10.40:
+    name: Gestão de canais internos
+    description: |
+      Gestão de canais internos (intranet, Slack, Teams).
+  BC-850.20:
+    name: Gestão das comunicações externas
+    description: |
+      Mensagens corporativas externas e declarações.
+  BC-850.20.10:
+    name: Arquitetura de mensagens externas
+    description: |
+      Arquitetura de mensagens e narrativa para públicos externos.
+  BC-850.20.20:
+    name: Declarações corporativas e documentos de posição
+    description: |
+      Elaboração de declarações corporativas e documentos de posição.
+  BC-850.20.30:
+    name: Website corporativo e canais próprios
+    description: |
+      Conteúdo do website corporativo e canais externos próprios.
+  BC-850.30:
+    name: Gestão de relações públicas
+    description: |
+      Gestão de reputação, relações públicas com partes interessadas.
+  BC-850.30.10:
+    name: Gestão de reputação
+    description: |
+      Monitorização de reputação, análise de sentimento e estratégia de reputação.
+  BC-850.30.20:
+    name: Gestão de liderança de pensamento
+    description: |
+      Conteúdo de liderança de pensamento e posicionamento de executivos.
+  BC-850.30.30:
+    name: Assuntos públicos e relações governamentais
+    description: |
+      Relações governamentais e envolvimento com decisores políticos.
+  BC-850.40:
+    name: Gestão de relações com os meios de comunicação
+    description: |
+      Envolvimento com meios de comunicação, comunicados de imprensa e briefings.
+  BC-850.40.10:
+    name: Gestão de comunicados de imprensa
+    description: |
+      Elaboração, aprovação e distribuição de comunicados de imprensa.
+  BC-850.40.20:
+    name: Envolvimento com jornalistas
+    description: |
+      Relações com jornalistas, entrevistas e briefings.
+  BC-850.40.30:
+    name: Monitorização dos meios de comunicação
+    description: |
+      Monitorização da cobertura mediática e da quota de voz.
+  BC-850.40.40:
+    name: Preparação de porta-vozes dos meios de comunicação
+    description: |
+      Identificação, formação e preparação de mensagens dos porta-vozes.
+  BC-850.50:
+    name: Gestão de comunicações de crise
+    description: |
+      Comunicações durante crises e incidentes.
+  BC-850.50.10:
+    name: Planeamento de comunicação de crise
+    description: |
+      Planos de comunicação de crise pré-preparados por cenário.
+  BC-850.50.20:
+    name: Preparação de declarações de crise
+    description: |
+      Preparação rápida de declarações e perguntas e respostas durante incidentes.
+  BC-850.50.30:
+    name: Gestão de porta-vozes em crise
+    description: |
+      Gestão de porta-vozes e tratamento dos meios de comunicação durante crises.
+  BC-850.50.40:
+    name: Recuperação de reputação pós-crise
+    description: |
+      Comunicações pós-crise e recuperação de reputação.
+  BC-850.60:
+    name: Gestão de comunicações com partes interessadas
+    description: |
+      Comunicações direcionadas a grupos específicos de partes interessadas.
+  BC-850.60.10:
+    name: Mapeamento de partes interessadas
+    description: |
+      Mapeamento e segmentação de partes interessadas externas.
+  BC-850.60.20:
+    name: Planeamento do envolvimento com partes interessadas
+    description: |
+      Planos de envolvimento adaptados a grupos de partes interessadas.
+  BC-850.60.30:
+    name: Envolvimento com comunidades e partes interessadas locais
+    description: |
+      Envolvimento com comunidades locais e partes interessadas comunitárias.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-corporate-governance.yaml
+++ b/catalogue/i18n/pt/L1-corporate-governance.yaml
@@ -1,0 +1,103 @@
+locale: pt
+source: L1-corporate-governance.yaml
+entries:
+  BC-110:
+    name: Governação corporativa
+    description: |
+      Processos de governação do conselho de administração, comités e acionistas.
+  BC-110.10:
+    name: Gestão do conselho e comités
+    description: |
+      Composição do conselho, reuniões, comités e documentação.
+  BC-110.10.10:
+    name: Gestão da composição do conselho
+    description: |
+      Nomeação, sucessão, independência e matriz de competências dos administradores.
+  BC-110.10.20:
+    name: Administração das reuniões do conselho
+    description: |
+      Agendas, documentos, atas e deliberações das reuniões do conselho.
+  BC-110.10.30:
+    name: Operações dos comités
+    description: |
+      Operações dos comités de auditoria, risco, remuneração e nomeações.
+  BC-110.10.40:
+    name: Integração e formação de administradores
+    description: |
+      Indução, formação contínua e avaliações da eficácia do conselho.
+  BC-110.20:
+    name: Gestão de acionistas e capital próprio
+    description: |
+      Estrutura de capital próprio, registo de ações e direitos dos acionistas.
+  BC-110.20.10:
+    name: Manutenção do registo de ações
+    description: |
+      Manutenção do registo de membros e registos de titularidade efetiva.
+  BC-110.20.20:
+    name: Gestão de assembleias de acionistas
+    description: |
+      Convocação de assembleias gerais anuais/extraordinárias, avisos, votação e deliberações.
+  BC-110.20.30:
+    name: Administração de dividendos e distribuições
+    description: |
+      Declarações de dividendos, pagamentos e distribuições de capital.
+  BC-110.20.40:
+    name: Gestão da estrutura de capital próprio
+    description: |
+      Classes de ações, aumentos de capital, recompras e desdobramentos de ações.
+  BC-110.30:
+    name: Gestão de secretariado corporativo
+    description: |
+      Depósitos estatutários, registos societários e formalidades.
+  BC-110.30.10:
+    name: Administração de depósitos estatutários
+    description: |
+      Depósitos junto de conservatórias e autoridades societárias.
+  BC-110.30.20:
+    name: Gestão de registos societários
+    description: |
+      Manutenção de livros estatutários, registos e arquivos corporativos.
+  BC-110.30.30:
+    name: Administração de deliberações societárias
+    description: |
+      Elaboração, execução e registo de deliberações do conselho e dos acionistas.
+  BC-110.40:
+    name: Gestão de subsidiárias e entidades
+    description: |
+      Estrutura de entidades jurídicas e governação em todo o grupo.
+  BC-110.40.10:
+    name: Gestão do ciclo de vida de entidades jurídicas
+    description: |
+      Constituição, reestruturação, inatividade e liquidação de entidades.
+  BC-110.40.20:
+    name: Governação da estrutura do grupo
+    description: |
+      Manutenção e supervisão do organigrama de entidades jurídicas e cadeias de participação.
+  BC-110.40.30:
+    name: Normas de governação de subsidiárias
+    description: |
+      Normas de governação do grupo aplicadas em todas as subsidiárias.
+  BC-110.40.40:
+    name: Conformidade de entidades transfronteiriças
+    description: |
+      Conformidade estatutária e de governação societária local para subsidiárias estrangeiras.
+  BC-110.50:
+    name: Gestão de delegações e autoridades
+    description: |
+      Matrizes de autoridade, delegações e direitos de assinatura.
+  BC-110.50.10:
+    name: Quadro de delegação de autoridade
+    description: |
+      Níveis de autoridade, limiares de aprovação e hierarquias de delegação.
+  BC-110.50.20:
+    name: Administração de autoridade de assinatura
+    description: |
+      Listas de signatários autorizados, procurações e mandatos bancários.
+  BC-110.50.30:
+    name: Monitorização da conformidade com delegações
+    description: |
+      Monitorização das decisões tomadas face aos limites de autoridade delegada.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-corporate-real-estate-management.yaml
+++ b/catalogue/i18n/pt/L1-corporate-real-estate-management.yaml
@@ -1,0 +1,87 @@
+locale: pt
+source: L1-corporate-real-estate-management.yaml
+entries:
+  BC-710:
+    name: Gestão de imobiliário corporativo
+    description: |
+      Portefólio de propriedades, arrendamentos, transações e planeamento de espaços.
+  BC-710.10:
+    name: Gestão da estratégia e portefólio imobiliário
+    description: |
+      Estratégia imobiliária, forma do portefólio e planeamento de implantação.
+  BC-710.10.10:
+    name: Desenvolvimento da estratégia imobiliária
+    description: |
+      Estratégia imobiliária plurianual alinhada com as necessidades do negócio.
+  BC-710.10.20:
+    name: Planeamento da implantação do portefólio
+    description: |
+      Planeamento de implantação, estratégia de localização e análise de consolidação.
+  BC-710.10.30:
+    name: Gestão do desempenho de propriedades
+    description: |
+      Acompanhamento de custo, utilização e desempenho por propriedade.
+  BC-710.10.40:
+    name: Gestão do risco imobiliário
+    description: |
+      Risco de mercado imobiliário, de país e de contraparte.
+  BC-710.20:
+    name: Gestão de aquisição e alienação imobiliária
+    description: |
+      Aquisições, alienações e saídas.
+  BC-710.20.10:
+    name: Aquisição de propriedades
+    description: |
+      Aquisição de propriedades próprias e arrendadas incluindo due diligence.
+  BC-710.20.20:
+    name: Alienação e saída de propriedades
+    description: |
+      Venda, subarrendamento e saída de ativos e arrendamentos de propriedades.
+  BC-710.20.30:
+    name: Seleção de local e negociação
+    description: |
+      Análise de localização, seleção de local e negociação de arrendamento.
+  BC-710.30:
+    name: Gestão de administração de arrendamentos
+    description: |
+      Ciclo de vida do arrendamento, contabilidade e opções.
+  BC-710.30.10:
+    name: Gestão de documentação de arrendamentos
+    description: |
+      Manutenção de documentos de arrendamento, abstracts e termos-chave.
+  BC-710.30.20:
+    name: Contabilidade de arrendamentos
+    description: |
+      Contabilidade de arrendamentos segundo IFRS 16 / ASC 842.
+  BC-710.30.30:
+    name: Pagamento e reconciliação de arrendamentos
+    description: |
+      Pagamentos de renda, encargos de serviço e CAM e reconciliação.
+  BC-710.30.40:
+    name: Gestão de opções e renovações de arrendamento
+    description: |
+      Acompanhamento e exercício de opções, cláusulas de saída e renovações.
+  BC-710.40:
+    name: Gestão da estratégia de local de trabalho
+    description: |
+      Conceitos de local de trabalho, trabalho híbrido e normas de design.
+  BC-710.40.10:
+    name: Design do conceito de local de trabalho
+    description: |
+      Definição de conceitos de local de trabalho incluindo trabalho baseado em atividades.
+  BC-710.40.20:
+    name: Normas de design do local de trabalho
+    description: |
+      Guias de design, normas de acabamento e normas de marca para locais de trabalho.
+  BC-710.40.30:
+    name: Implementação da política de trabalho híbrido
+    description: |
+      Implementação de modelos de trabalho híbrido e espaço de suporte.
+  BC-710.40.40:
+    name: Medição da experiência no local de trabalho
+    description: |
+      Medição da experiência e satisfação no local de trabalho.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-credit-lending-management.yaml
+++ b/catalogue/i18n/pt/L1-credit-lending-management.yaml
@@ -1,0 +1,139 @@
+locale: pt
+source: L1-credit-lending-management.yaml
+entries:
+  BC-1320:
+    name: Gestão de crédito e financiamento
+    description: |
+      Originação de crédito, subscrição, manutenção de empréstimos, cobranças e gestão de portefólio.
+  BC-1320.10:
+    name: Gestão de originação de crédito
+    description: |
+      Receção de candidaturas a crédito, pré-seleção e fluxos de originação.
+  BC-1320.10.10:
+    name: Recolha de candidaturas a crédito
+    description: |
+      Recolha de candidaturas a crédito em todos os canais.
+  BC-1320.10.20:
+    name: Pré-seleção e avaliação de acessibilidade
+    description: |
+      Pré-seleção, verificações de acessibilidade e capacidade de reembolso.
+  BC-1320.10.30:
+    name: Orquestração do fluxo de originação
+    description: |
+      Orquestração dos fluxos de originação de crédito e SLAs.
+  BC-1320.10.40:
+    name: Recolha de documentação de originação
+    description: |
+      Recolha e verificação de documentação de suporte à originação.
+  BC-1320.20:
+    name: Gestão de subscrição e decisão de crédito
+    description: |
+      Subscrição, análise financeira, decisão e autoridade delegada.
+  BC-1320.20.10:
+    name: Avaliação do risco de crédito
+    description: |
+      Avaliação do risco de crédito de candidatos e exposições.
+  BC-1320.20.20:
+    name: Análise e decomposição financeira
+    description: |
+      Decomposição de demonstrações financeiras e análise de rácios.
+  BC-1320.20.30:
+    name: Decisão de crédito
+    description: |
+      Motores de decisão e decisão discricionária de processos de crédito.
+  BC-1320.20.40:
+    name: Aprovação de crédito e autoridade delegada
+    description: |
+      Governação da aprovação de crédito e aplicação de autoridade delegada.
+  BC-1320.20.50:
+    name: Avaliação e gestão de garantias
+    description: |
+      Identificação, avaliação e registo de garantias reais.
+  BC-1320.30:
+    name: Gestão de manutenção de empréstimos
+    description: |
+      Manutenção de empréstimos, pagamentos, alterações de plano e modificações.
+  BC-1320.30.10:
+    name: Desembolso de empréstimo
+    description: |
+      Gestão de desembolso e levantamento de empréstimos.
+  BC-1320.30.20:
+    name: Processamento de reembolsos
+    description: |
+      Planeamento, processamento e reconciliação de reembolsos.
+  BC-1320.30.30:
+    name: Modificação de empréstimo
+    description: |
+      Modificações de condições de empréstimo, reestruturações e refinanciamentos.
+  BC-1320.30.40:
+    name: Liquidação e encerramento de empréstimo
+    description: |
+      Liquidação, emissão de declaração e operações de encerramento de empréstimos.
+  BC-1320.40:
+    name: Gestão de cobranças e recuperações
+    description: |
+      Cobranças, reestruturação, operações de recuperação e resolução de NPL.
+  BC-1320.40.10:
+    name: Cobranças em fase inicial
+    description: |
+      Gestão de atrasos iniciais e lembretes.
+  BC-1320.40.20:
+    name: Cobranças em fase tardia
+    description: |
+      Cobranças em fase tardia e encaminhamento para litígio.
+  BC-1320.40.30:
+    name: Reestruturação e moratória
+    description: |
+      Propostas de reestruturação, moratória e apoio a clientes em dificuldades.
+  BC-1320.40.40:
+    name: Recuperação e abate
+    description: |
+      Operações de recuperação, abate e atividades pós-abate.
+  BC-1320.40.50:
+    name: Resolução de NPL
+    description: |
+      Resolução, venda e titularização de créditos malparados.
+  BC-1320.50:
+    name: Gestão de portefólio de empréstimos
+    description: |
+      Análise, otimização e gestão de capital do portefólio.
+  BC-1320.50.10:
+    name: Análise de risco do portefólio
+    description: |
+      Análise do portefólio incluindo vintage, concentração e testes de esforço.
+  BC-1320.50.20:
+    name: Otimização do portefólio
+    description: |
+      Otimização da composição, preços e relação risco-retorno do portefólio.
+  BC-1320.50.30:
+    name: Gestão de capital do portefólio
+    description: |
+      Gestão de capital para portefólios de crédito ao abrigo das regras de Basileia.
+  BC-1320.50.40:
+    name: Relatório do portefólio
+    description: |
+      Relatórios do portefólio para comités de risco e reguladores.
+  BC-1320.60:
+    name: Gestão de modelação de risco de crédito
+    description: |
+      Modelos PD/LGD/EAD, IRB e ECL conforme IFRS 9.
+  BC-1320.60.10:
+    name: Desenvolvimento de modelos PD/LGD/EAD
+    description: |
+      Desenvolvimento de modelos de PD, LGD e EAD.
+  BC-1320.60.20:
+    name: Modelação de ECL conforme IFRS 9
+    description: |
+      Desenvolvimento e operação do modelo de perda de crédito esperada conforme IFRS 9.
+  BC-1320.60.30:
+    name: Validação de modelos
+    description: |
+      Validação independente de modelos de risco de crédito.
+  BC-1320.60.40:
+    name: Monitorização de modelos
+    description: |
+      Monitorização contínua do desempenho e recalibração de modelos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-crop-production-management.yaml
+++ b/catalogue/i18n/pt/L1-crop-production-management.yaml
@@ -1,0 +1,195 @@
+locale: pt
+source: L1-crop-production-management.yaml
+entries:
+  BC-3500:
+    name: Gestão da produção de culturas
+    description: |
+      Operações de cultivo na exploração agrícola — planeamento do sistema de
+      culturas, preparação do solo, plantação, nutrição, proteção das culturas,
+      irrigação, monitorização e previsão de rendimento para culturas arvenses,
+      hortícolas e especiais.
+  BC-3500.10:
+    name: Planeamento do sistema de culturas
+    description: |
+      Planeamento plurianual de rotações de culturas, afetação de parcelas,
+      janelas de plantação e seleção de variedades no conjunto da exploração
+      agrícola.
+    in_scope:
+      - Desenho de rotações de culturas
+      - Afetação de culturas por parcela
+      - Planeamento de janelas de plantação
+      - Seleção de variedades e híbridos
+    out_of_scope:
+      - Execução de ensaios de variedades (BC-3530.60)
+      - Prescrições agronómicas (BC-3530.20)
+  BC-3500.10.10:
+    name: Planeamento de rotação de culturas
+    description: |
+      Desenho de rotações de culturas plurianuais que equilibram a saúde do solo,
+      a procura do mercado e os ciclos de pragas.
+  BC-3500.10.20:
+    name: Planeamento de afetação de parcelas
+    description: |
+      Afetação de culturas a parcelas e lotes específicos para a época de
+      plantação.
+  BC-3500.10.30:
+    name: Planeamento de janelas de plantação
+    description: |
+      Planeamento de janelas de plantação ótimas por cultura, variedade e zona
+      agroclimática.
+  BC-3500.10.40:
+    name: Decisões de seleção de variedades
+    description: |
+      Seleção de variedades e híbridos para a época de plantação com base em
+      critérios agronómicos e de mercado.
+  BC-3500.20:
+    name: Operações de preparação do solo
+    description: |
+      Operações de mobilização, preparação de camas e correção do solo antes da
+      plantação para estabelecer uma cama de sementeira viável.
+  BC-3500.20.10:
+    name: Operações de mobilização do solo
+    description: |
+      Operações de preparação do terreno convencional, em mobilização reduzida
+      e sem mobilização.
+  BC-3500.20.20:
+    name: Operações de preparação de camas
+    description: |
+      Formação de camas, levantamento de cavalões e mulching para produção
+      hortícola e em linha.
+  BC-3500.20.30:
+    name: Aplicação de corretivos antes da plantação
+    description: |
+      Aplicação de corretivos antes da plantação, como calcário, gesso e matéria
+      orgânica.
+  BC-3500.30:
+    name: Operações de plantação e sementeira
+    description: |
+      Colocação de semente e transplante, incluindo decisões de replantação e
+      estabelecimento da população de plantas.
+  BC-3500.30.10:
+    name: Finalização da cama de sementeira
+    description: |
+      Preparação final da cama de sementeira imediatamente antes da plantação.
+  BC-3500.30.20:
+    name: Colocação de semente e transplante
+    description: |
+      Colocação mecânica e manual de semente e transplantes no campo.
+  BC-3500.30.30:
+    name: Operações de replantação e colmatagem de falhas
+    description: |
+      Replantação e colmatagem de falhas onde o estabelecimento inicial da
+      população falhou.
+  BC-3500.40:
+    name: Operações de nutrição das culturas
+    description: |
+      Entrega de nutrientes na época de cultivo através de métodos de aplicação
+      sólida, líquida, foliar e fertirrigação.
+  BC-3500.40.10:
+    name: Aplicação de fertilizantes sólidos
+    description: |
+      Aplicação de fertilizantes sólidos a lanço, em banda e a taxa variável.
+  BC-3500.40.20:
+    name: Aplicação de nutrição foliar
+    description: |
+      Aplicação foliar de macro e micronutrientes durante a época de crescimento.
+  BC-3500.40.30:
+    name: Operações de fertirrigação
+    description: |
+      Entrega de nutrientes através de sistemas de irrigação, incluindo injeção
+      e controlo de dosagem.
+  BC-3500.50:
+    name: Operações de proteção das culturas
+    description: |
+      Aplicação de intervenções químicas, biológicas e mecânicas de proteção de
+      culturas e registos de suporte.
+    in_scope:
+      - Aplicação de pesticidas e herbicidas
+      - Aplicação de produtos de controlo biológico
+      - Controlo mecânico e térmico de infestantes
+      - Registos de pulverização e aplicação
+    out_of_scope:
+      - Planeamento de proteção integrada (BC-3530.30)
+      - Monitorização de conformidade com LMR (BC-3590.50)
+  BC-3500.50.10:
+    name: Operações de aplicação de pesticidas
+    description: |
+      Aplicação de pesticidas por via terrestre e aérea, incluindo gestão de
+      deriva de pulverização.
+  BC-3500.50.20:
+    name: Aplicação de controlo biológico
+    description: |
+      Libertação de agentes de controlo biológico e produtos biopesticidas.
+  BC-3500.50.30:
+    name: Controlo mecânico e térmico de infestantes
+    description: |
+      Controlo mecânico e térmico de infestantes, incluindo sacha e monda
+      por chama.
+  BC-3500.50.40:
+    name: Registo de aplicações de pulverização
+    description: |
+      Registos de pulverização ao nível do campo, incluindo produto, taxa,
+      condições meteorológicas e operador.
+  BC-3500.60:
+    name: Operações de irrigação
+    description: |
+      Decisões diárias de calendarização, aplicação e drenagem de irrigação que
+      governam o estado hídrico das culturas.
+  BC-3500.60.10:
+    name: Calendarização da irrigação
+    description: |
+      Calendarização da irrigação com base na humidade do solo e na procura das
+      culturas.
+  BC-3500.60.20:
+    name: Operações de aplicação de irrigação
+    description: |
+      Aplicação de água de irrigação através de sistemas de aspersão, micro e
+      superficial.
+  BC-3500.60.30:
+    name: Operações de drenagem do campo
+    description: |
+      Operações de drenagem superficial e subsuperficial e controlo do nível
+      freático.
+  BC-3500.70:
+    name: Monitorização e prospeção das culturas
+    description: |
+      Monitorização ao nível do campo da saúde das culturas, pressão de pragas
+      e fenologia, utilizando métodos de prospeção, sensores e teledetecção.
+  BC-3500.70.10:
+    name: Operações de prospeção no campo
+    description: |
+      Percursos manuais de prospeção para avaliação de pragas, doenças e estado
+      das culturas.
+  BC-3500.70.20:
+    name: Vigilância de pragas e doenças
+    description: |
+      Vigilância de pressão de pragas e doenças por armadilhas e sensores.
+  BC-3500.70.30:
+    name: Acompanhamento da fenologia das culturas
+    description: |
+      Acompanhamento dos estádios de crescimento, unidades de calor e marcos
+      fenológicos.
+  BC-3500.70.40:
+    name: Monitorização das culturas por teledetecção
+    description: |
+      Monitorização do estado das culturas por satélite, drone e sensores de
+      proximidade.
+  BC-3500.80:
+    name: Previsão de rendimento das culturas
+    description: |
+      Estimativa de rendimento na época de cultivo e pré-colheita, alimentando
+      a captação/origem, logística e planeamento comercial.
+  BC-3500.80.10:
+    name: Estimativa de rendimento em época de cultivo
+    description: |
+      Estimativas de rendimento a meio da época a partir de índices de cultura e
+      medições no campo.
+  BC-3500.80.20:
+    name: Previsão de rendimento pré-colheita
+    description: |
+      Previsões de rendimento pré-colheita que alimentam planos de colheita,
+      armazenamento e captação/origem.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-cruise-voyage-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-cruise-voyage-operations-management.yaml
@@ -1,0 +1,187 @@
+locale: pt
+source: L1-cruise-voyage-operations-management.yaml
+entries:
+  BC-4090:
+    name: Gestão de operações de viagem de cruzeiro
+    description: |
+      Operação de viagens de cruzeiro — planeamento de itinerário, operações
+      em porto e de excursões em terra, programas de cabine e de hóspedes a
+      bordo, operações marítimas e de ponte, embarque, e saúde e saneamento
+      a bordo — prestados ao abrigo da regulamentação internacional de
+      segurança marítima.
+  BC-4090.10:
+    name: Planeamento de itinerário de viagem
+    description: |
+      Planeamento de itinerários de viagem, implantação, reposicionamento
+      e decisões de substituição de itinerário.
+  BC-4090.10.10:
+    name: Conceção e implantação de itinerário
+    description: |
+      Conceção de itinerários de cruzeiro e atribuição de navios a
+      épocas de implantação.
+  BC-4090.10.20:
+    name: Planeamento de viagem de reposicionamento e fretamento
+    description: |
+      Planeamento de viagens de reposicionamento e implantações de
+      fretamento entre épocas.
+  BC-4090.10.30:
+    name: Sequenciamento de escalas portuárias
+    description: |
+      Sequenciamento de escalas portuárias num itinerário contra maré,
+      tempo de viragem e acordos com parceiros.
+  BC-4090.10.40:
+    name: Alteração e substituição de itinerário
+    description: |
+      Alteração e substituição em tempo real de itinerários devido a
+      eventos meteorológicos, médicos ou geopolíticos.
+  BC-4090.20:
+    name: Operações em porto e de excursões em terra
+    description: |
+      Operações em escalas portuárias, incluindo viragem, serviço de
+      tender, e catálogo, vendas e entrega de excursões em terra.
+  BC-4090.20.10:
+    name: Operações de viragem no porto
+    description: |
+      Coordenação das operações de viragem no porto, incluindo aprovisionamento,
+      resíduos e troca de tripulação.
+  BC-4090.20.20:
+    name: Operações de serviço de tender
+    description: |
+      Operação de serviços de tender de e para portos de ancoragem.
+  BC-4090.20.30:
+    name: Catálogo e vendas de excursões em terra
+    description: |
+      Catálogo e vendas de excursões em terra a hóspedes nos canais
+      pré-cruzeiro e a bordo.
+  BC-4090.20.40:
+    name: Coordenação da entrega de excursões em terra
+    description: |
+      Coordenação da entrega de excursões em terra, incluindo transferência
+      para operadores locais e reconciliação de hóspedes.
+  BC-4090.30:
+    name: Operações de cabine e camarote a bordo
+    description: |
+      Operações de cabine e camarote a bordo, incluindo viragem, atribuição,
+      upsell a meio-cruzeiro e serviço em suites de especialidade.
+  BC-4090.30.10:
+    name: Operações de viragem de camarote
+    description: |
+      Operação de viragem de camarotes durante o embarque e os dias
+      de mudança de hóspedes.
+  BC-4090.30.20:
+    name: Atribuição de cabine e upsell
+    description: |
+      Atribuição de cabines e execução de decisões de upsell antes e
+      durante a viagem.
+  BC-4090.30.30:
+    name: Operações de manutenção de cabine
+    description: |
+      Manutenção dos sistemas e acabamentos de cabine durante a viagem.
+  BC-4090.30.40:
+    name: Operações de serviço em suites de especialidade
+    description: |
+      Operações de serviço para cabines de suite de especialidade e com
+      serviço de mordomo.
+  BC-4090.40:
+    name: Operações do programa de hóspedes a bordo
+    description: |
+      Entretenimento, atividades, clubes de crianças e operações de
+      espaços de especialidade a bordo ao longo da viagem.
+  BC-4090.40.10:
+    name: Operações do programa de entretenimento
+    description: |
+      Operação de programas de entretenimento em teatro, salão e artista
+      convidado a bordo.
+  BC-4090.40.20:
+    name: Operações de atividades e enriquecimento
+    description: |
+      Operação de programas de atividades e enriquecimento, incluindo
+      conferências, aulas e desportos.
+  BC-4090.40.30:
+    name: Operações de programa infantil e juvenil
+    description: |
+      Operação de programas infantis e juvenis, incluindo atividades
+      adequadas à idade e supervisão.
+  BC-4090.40.40:
+    name: Reservas de espaços de especialidade
+    description: |
+      Reservas a bordo para restaurantes de especialidade, spa e eventos
+      com bilhete.
+  BC-4090.50:
+    name: Operações marítimas e de ponte
+    description: |
+      Operações marítimas e de ponte que abrangem navegação, propulsão,
+      documentação portuária e coordenação de aprovisionamento.
+  BC-4090.50.10:
+    name: Operações de ponte e navegação
+    description: |
+      Quarto de vigília de ponte e operações de navegação ao longo da
+      viagem.
+  BC-4090.50.20:
+    name: Operações de sala de máquinas e propulsão
+    description: |
+      Quarto de vigília de sala de máquinas e operações de propulsão.
+  BC-4090.50.30:
+    name: Documentação portuária e desalfandegamento
+    description: |
+      Preparação de documentação portuária e gestão do estado do porto
+      e desalfandegamento aduaneiro.
+  BC-4090.50.40:
+    name: Coordenação de abastecimento e aprovisionamento
+    description: |
+      Coordenação de abastecimento de combustível e aprovisionamento
+      nas escalas portuárias.
+  BC-4090.60:
+    name: Embarque e desembarque a bordo
+    description: |
+      Operações de embarque e desembarque, incluindo verificação
+      pré-embarque, desalfandegamento e fluxo de bagagem a bordo.
+  BC-4090.60.10:
+    name: Verificação de documentos pré-embarque
+    description: |
+      Verificação de documentos de viagem e atestações de saúde dos
+      hóspedes antes do embarque.
+  BC-4090.60.20:
+    name: Operações de fluxo de embarque
+    description: |
+      Operação de fluxos de embarque do terminal ao navio em janelas
+      de chegada em lotes.
+  BC-4090.60.30:
+    name: Desembarque e desalfandegamento
+    description: |
+      Operação de fluxos de desembarque, incluindo desalfandegamento
+      e controlo de imigração no porto.
+  BC-4090.60.40:
+    name: Operações de bagagem a bordo
+    description: |
+      Operação do fluxo de bagagem no embarque, entrega em cabine e
+      desembarque.
+  BC-4090.70:
+    name: Operações de saúde e saneamento de cruzeiro
+    description: |
+      Operações de saúde e saneamento a bordo, incluindo prontidão para
+      inspeção, deteção e resposta a surtos, e saneamento de água e piscina.
+  BC-4090.70.10:
+    name: Prontidão para inspeção de saneamento
+    description: |
+      Manutenção da prontidão para inspeção ao abrigo dos regimes VSP,
+      USPH e equivalentes.
+  BC-4090.70.20:
+    name: Deteção de surtos a bordo
+    description: |
+      Deteção de surtos gastrointestinais e respiratórios através de
+      vigilância a bordo.
+  BC-4090.70.30:
+    name: Operações de resposta a surtos
+    description: |
+      Operações de resposta durante surtos, incluindo contenção e
+      comunicação.
+  BC-4090.70.40:
+    name: Saneamento de água potável e piscina
+    description: |
+      Operações de saneamento para sistemas de água potável e de água
+      recreativa a bordo.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-curriculum-programme-management.yaml
+++ b/catalogue/i18n/pt/L1-curriculum-programme-management.yaml
@@ -1,0 +1,153 @@
+locale: pt
+source: L1-curriculum-programme-management.yaml
+entries:
+  BC-4700:
+    name: Gestão do currículo e programa
+    description: |
+      Definição, estruturação, governação e melhoria contínua de programas
+      académicos, cursos, módulos, qualificações e os resultados de aprendizagem
+      que os fundamentam.
+  BC-4700.10:
+    name: Arquitetura de programa
+    description: |
+      Definição da estrutura do programa, nível de qualificação, ponderação de
+      créditos e os resultados de aprendizagem pretendidos de graus académicos.
+    in_scope:
+      - Definição da estrutura e percurso do programa
+      - Estrutura de credenciação de graus e qualificações
+      - Resultados de aprendizagem pretendidos ao nível do programa
+    out_of_scope:
+      - Autoria do programa de unidade curricular (abrangido em Conceção de Cursos e Módulos)
+      - Resultados de acreditação externa (abrangidos em Gestão de Qualidade Académica e Acreditação)
+  BC-4700.10.10:
+    name: Definição do programa
+    description: |
+      Definição do propósito do programa, coorte-alvo, requisitos de entrada e forma estrutural.
+  BC-4700.10.20:
+    name: Estruturação de qualificações e credenciais
+    description: |
+      Estruturação de graus, valores de crédito e percursos de credenciais empilháveis.
+  BC-4700.10.30:
+    name: Definição de resultados de aprendizagem
+    description: |
+      Articulação dos resultados de aprendizagem pretendidos ao nível do programa e do curso.
+  BC-4700.20:
+    name: Conceção de cursos e módulos
+    description: |
+      Especificação e autoria de cursos individuais, módulos e unidades de
+      aprendizagem que compõem os programas académicos.
+    in_scope:
+      - Especificações de cursos e descritores de módulos
+      - Autoria e aprovação de programas de unidade curricular
+      - Objetivos de aprendizagem ao nível da unidade e planos de avaliação
+    out_of_scope:
+      - Produção de materiais de ensino (abrangida em Gestão de Conteúdo Educativo e Recursos de Aprendizagem)
+  BC-4700.20.10:
+    name: Especificação de cursos
+    description: |
+      Autoria e aprovação de especificações e descritores formais de cursos.
+  BC-4700.20.20:
+    name: Conceção de módulos e unidades
+    description: |
+      Conceção de módulos e unidades de aprendizagem dentro dos cursos.
+  BC-4700.20.30:
+    name: Autoria de programas de unidade curricular
+    description: |
+      Autoria de programas de unidade curricular que estabelecem conteúdos, métodos e avaliações por oferta.
+  BC-4700.30:
+    name: Mapeamento e alinhamento curricular
+    description: |
+      Mapeamento do conteúdo curricular com referenciais de competências, referenciais
+      de qualificações e percursos profissionais ou de carreira a jusante.
+    in_scope:
+      - Mapeamento de competências para currículo
+      - Alinhamento com ISCED, EQF, NQF e referenciais equivalentes
+      - Mapeamento de percursos de competências e carreira
+    out_of_scope:
+      - Aquisição individual de competências pelo estudante (abrangida em Gestão de Avaliação e Exames)
+  BC-4700.30.10:
+    name: Alinhamento com o referencial de competências
+    description: |
+      Alinhamento do currículo com referenciais de competências definidos (p. ex. CASE).
+  BC-4700.30.20:
+    name: Mapeamento com o referencial de qualificações
+    description: |
+      Mapeamento de qualificações com o ISCED, EQF, NQF e referenciais similares.
+  BC-4700.30.30:
+    name: Mapeamento de percursos de competências e carreira
+    description: |
+      Mapeamento do currículo com percursos ocupacionais, profissionais e de carreira.
+  BC-4700.40:
+    name: Gestão do catálogo de programas
+    description: |
+      Autoria, versionamento e publicação do catálogo institucional de programas e
+      cursos disponíveis para estudantes potenciais e atuais.
+    in_scope:
+      - Autoria e fluxo editorial do catálogo
+      - Versionamento e datação efetiva do catálogo
+      - Publicação interna e pública do catálogo
+    out_of_scope:
+      - Materiais de marketing de recrutamento (abrangidos em Gestão de Recrutamento e Admissões de Estudantes)
+  BC-4700.40.10:
+    name: Autoria do catálogo
+    description: |
+      Autoria de entradas do catálogo para programas, cursos e módulos.
+  BC-4700.40.20:
+    name: Versionamento e datação efetiva do catálogo
+    description: |
+      Controlo de versões e gestão da data efetiva das entradas do catálogo.
+  BC-4700.40.30:
+    name: Publicação do catálogo
+    description: |
+      Publicação interna e pública do catálogo de programas e cursos.
+  BC-4700.50:
+    name: Aprovação e governação de programas
+    description: |
+      Percursos de aprovação internos e externos para programas novos, modificados e
+      extintos, incluindo decisões de suspensão e encerramento.
+    in_scope:
+      - Aprovação e governação académica interna
+      - Aprovação por regulador externo e organismo profissional
+      - Suspensão e encerramento ordenado do programa
+    out_of_scope:
+      - Revisão curricular do dia a dia (abrangida em Revisão Curricular e Melhoria Contínua)
+      - Acreditação cíclica (abrangida em Gestão de Qualidade Académica e Acreditação)
+  BC-4700.50.10:
+    name: Aprovação interna de programas
+    description: |
+      Aprovação académica interna de programas novos e modificados.
+  BC-4700.50.20:
+    name: Aprovação externa de programas
+    description: |
+      Aprovação de programas por regulador externo, ministério ou organismo profissional.
+  BC-4700.50.30:
+    name: Suspensão e encerramento de programas
+    description: |
+      Suspensão ordenada, teach-out e encerramento de programas.
+  BC-4700.60:
+    name: Revisão curricular e melhoria contínua
+    description: |
+      Revisão e melhoria periódica do conteúdo curricular com base em resultados,
+      contributos das partes interessadas e requisitos externos.
+    in_scope:
+      - Ciclos periódicos de revisão curricular
+      - Contributos de partes interessadas, empregadores e estudantes
+      - Monitorização da implementação de alterações curriculares
+    out_of_scope:
+      - Revisões de garantia de qualidade de programas (abrangidas em Gestão de Qualidade Académica e Acreditação)
+  BC-4700.60.10:
+    name: Revisão curricular periódica
+    description: |
+      Revisão cíclica da eficácia e relevância curricular.
+  BC-4700.60.20:
+    name: Contributo das partes interessadas para o currículo
+    description: |
+      Recolha de contributos de estudantes, empregadores e conselhos consultivos para a conceção curricular.
+  BC-4700.60.30:
+    name: Implementação de alterações curriculares
+    description: |
+      Monitorização e implementação de alterações curriculares aprovadas.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-customer-relationship-management.yaml
+++ b/catalogue/i18n/pt/L1-customer-relationship-management.yaml
@@ -1,0 +1,91 @@
+locale: pt
+source: L1-customer-relationship-management.yaml
+entries:
+  BC-420:
+    name: Gestão do relacionamento com clientes
+    description: |
+      Dados de clientes, segmentação, ciclo de vida e fidelização.
+  BC-420.10:
+    name: Gestão de dados de clientes
+    description: |
+      Dados mestre de clientes, resolução de identidade e registo dourado.
+  BC-420.10.10:
+    name: Gestão de dados mestre de clientes
+    description: |
+      Criação, manutenção e governação de registos mestre de clientes.
+  BC-420.10.20:
+    name: Resolução de identidade de clientes
+    description: |
+      Correspondência, fusão e deduplicação de registos de clientes.
+  BC-420.10.30:
+    name: Gestão de consentimento e preferências
+    description: |
+      Captura e aplicação de consentimentos e preferências de marketing.
+  BC-420.10.40:
+    name: Visão 360 do cliente
+    description: |
+      Vista agregada do cliente em produtos, canais e interações.
+  BC-420.20:
+    name: Gestão da segmentação de clientes
+    description: |
+      Segmentos, personas e estratégias de tratamento.
+  BC-420.20.10:
+    name: Segmentação comportamental
+    description: |
+      Segmentação baseada em comportamento, RFM e sinais de envolvimento.
+  BC-420.20.20:
+    name: Segmentação baseada em valor
+    description: |
+      Segmentação por valor de vida do cliente e rentabilidade.
+  BC-420.20.30:
+    name: Desenvolvimento de personas de clientes
+    description: |
+      Definição de personas e arquétipos de clientes-alvo.
+  BC-420.20.40:
+    name: Definição de estratégias de tratamento
+    description: |
+      Estratégias de tratamento diferenciadas por segmento.
+  BC-420.30:
+    name: Gestão do ciclo de vida do cliente
+    description: |
+      Aquisição, crescimento, retenção e reconquista.
+  BC-420.30.10:
+    name: Gestão da aquisição de clientes
+    description: |
+      Campanhas de aquisição, conversão e orquestração de integração.
+  BC-420.30.20:
+    name: Crescimento e cross-sell de clientes
+    description: |
+      Programas de cross-sell, up-sell e expansão de clientes.
+  BC-420.30.30:
+    name: Gestão da retenção de clientes
+    description: |
+      Previsão de churn, ofertas de retenção e desks de salvaguarda.
+  BC-420.30.40:
+    name: Gestão de reconquista de clientes
+    description: |
+      Campanhas de reconquista e reativação de clientes inativos.
+  BC-420.40:
+    name: Gestão de fidelização e retenção
+    description: |
+      Programas de fidelização e iniciativas de retenção.
+  BC-420.40.10:
+    name: Design do programa de fidelização
+    description: |
+      Design de estruturas, níveis e benefícios do programa de fidelização.
+  BC-420.40.20:
+    name: Operações do programa de fidelização
+    description: |
+      Acumulação, utilização e assistência a membros de programas de fidelização.
+  BC-420.40.30:
+    name: Gestão do passivo de fidelização
+    description: |
+      Contabilidade e gestão do passivo e breakage de fidelização.
+  BC-420.40.40:
+    name: Gestão do ecossistema de parceiros de fidelização
+    description: |
+      Integração de parceiros, resgates e arranjos de coligação.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-customer-service-management.yaml
+++ b/catalogue/i18n/pt/L1-customer-service-management.yaml
@@ -1,0 +1,111 @@
+locale: pt
+source: L1-customer-service-management.yaml
+entries:
+  BC-430:
+    name: Gestão do serviço ao cliente
+    description: |
+      Consultas, reclamações, suporte e operações do centro de contacto.
+  BC-430.10:
+    name: Gestão de consultas de clientes
+    description: |
+      Contactos de entrada, encaminhamento e resolução.
+  BC-430.10.10:
+    name: Receção e encaminhamento de consultas
+    description: |
+      Receção multicanal, classificação e encaminhamento de consultas.
+  BC-430.10.20:
+    name: Gestão de casos
+    description: |
+      Criação, responsabilidade e acompanhamento da resolução de casos.
+  BC-430.10.30:
+    name: Cumprimento de pedidos de serviço
+    description: |
+      Cumprimento de pedidos de serviço standard e alterações de conta.
+  BC-430.10.40:
+    name: Gestão de escaladas
+    description: |
+      Vias de escalada, regras de gravidade e gestão de casos escalados.
+  BC-430.20:
+    name: Gestão de reclamações e problemas
+    description: |
+      Captura, causa raiz e resolução de reclamações.
+  BC-430.20.10:
+    name: Captura e reconhecimento de reclamações
+    description: |
+      Captura, reconhecimento e triagem de reclamações de clientes.
+  BC-430.20.20:
+    name: Investigação e resolução de reclamações
+    description: |
+      Investigação, reparação e resolução de reclamações.
+  BC-430.20.30:
+    name: Análise de causa raiz
+    description: |
+      Análise de causa raiz e identificação de tendências nas reclamações.
+  BC-430.20.40:
+    name: Reporte regulatório de reclamações
+    description: |
+      Reporte regulatório de reclamações e tratamento de processos no provedor.
+  BC-430.30:
+    name: Gestão de operações do centro de contacto
+    description: |
+      Funcionamento do centro de contacto, gestão de força de trabalho e telefonia.
+  BC-430.30.10:
+    name: Gestão da força de trabalho do centro de contacto
+    description: |
+      Previsão, agendamento e cumprimento nas operações do centro de contacto.
+  BC-430.30.20:
+    name: Encaminhamento de contactos e IVR
+    description: |
+      Design de IVR, encaminhamento baseado em competências e orquestração de canais.
+  BC-430.30.30:
+    name: Monitorização de qualidade e coaching
+    description: |
+      Monitorização de qualidade de chamadas, pontuação e coaching de agentes.
+  BC-430.30.40:
+    name: Reporte de desempenho do centro de contacto
+    description: |
+      Reporte de nível de serviço, AHT, FCR e desempenho operacional.
+  BC-430.40:
+    name: Gestão de self-service
+    description: |
+      FAQ, base de conhecimento, chatbots e portais self-service.
+  BC-430.40.10:
+    name: Gestão da base de conhecimento
+    description: |
+      Autoria e manutenção de conteúdo de conhecimento orientado ao cliente.
+  BC-430.40.20:
+    name: Gestão do portal self-service
+    description: |
+      Portais self-service e funcionalidades de gestão de conta para clientes.
+  BC-430.40.30:
+    name: Gestão de IA conversacional
+    description: |
+      Design, formação e operações de chatbots e voicebots.
+  BC-430.40.40:
+    name: Gestão de suporte comunitário
+    description: |
+      Moderação de comunidade de utilizadores e suporte peer-to-peer.
+  BC-430.50:
+    name: Gestão de feedback de clientes
+    description: |
+      Inquéritos, NPS e programas de voz do cliente.
+  BC-430.50.10:
+    name: Programa de voz do cliente
+    description: |
+      Programa estruturado de voz do cliente em todos os pontos de contacto.
+  BC-430.50.20:
+    name: Gestão de inquéritos a clientes
+    description: |
+      Design, distribuição e análise de inquéritos NPS, CSAT e CES.
+  BC-430.50.30:
+    name: Feedback em loop fechado
+    description: |
+      Follow-up em loop fechado sobre feedback de detratores e ações de recuperação.
+  BC-430.50.40:
+    name: Reporte de insights de clientes
+    description: |
+      Reporte de insights de clientes ao produto, operações e liderança.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-customer-success-management.yaml
+++ b/catalogue/i18n/pt/L1-customer-success-management.yaml
@@ -1,0 +1,151 @@
+locale: pt
+source: L1-customer-success-management.yaml
+entries:
+  BC-4260:
+    name: Gestão de sucesso do cliente
+    description: |
+      Integração de clientes, adoção, monitorização de saúde, retenção, defesa
+      de expansão e cultivo de clientes de referência, distinto do serviço
+      reativo ao cliente.
+  BC-4260.10:
+    name: Integração e ativação de clientes
+    description: |
+      Integração estruturada de novos clientes em direção ao primeiro valor
+      e marcos de ativação.
+    in_scope:
+      - Planos de integração, arranque e acompanhamento do tempo até ao valor
+    out_of_scope:
+      - Provisionamento técnico do tenant (abrangido pela Gestão de Tenants SaaS)
+      - Provisionamento de subscrições (abrangido pela Gestão do Ciclo de Vida da Subscrição)
+  BC-4260.10.10:
+    name: Definição do plano de integração
+    description: |
+      Definição de planos de integração adaptados ao segmento e caso de uso.
+  BC-4260.10.20:
+    name: Acompanhamento de marcos de ativação
+    description: |
+      Acompanhamento dos marcos de ativação face aos objetivos de tempo
+      até ao valor.
+  BC-4260.10.30:
+    name: Coordenação de implementação
+    description: |
+      Coordenação das atividades de implementação do lado do cliente e
+      envolvimento de parceiros.
+  BC-4260.20:
+    name: Gestão de adoção
+    description: |
+      Programas que aumentam a adoção de funcionalidades e a amplitude de
+      utilização em toda a base de clientes.
+  BC-4260.20.10:
+    name: Design de programas de adoção
+    description: |
+      Design de programas de adoção estruturados para segmentos, produtos
+      e personas.
+  BC-4260.20.20:
+    name: Execução de campanhas de adoção
+    description: |
+      Execução de campanhas de adoção com pontos de contacto no produto e
+      externos.
+  BC-4260.20.30:
+    name: Capacitação de utilizadores avançados
+    description: |
+      Capacitação de utilizadores avançados do cliente e campeões internos.
+  BC-4260.30:
+    name: Gestão de saúde do cliente
+    description: |
+      Modelação e monitorização da saúde do cliente para antecipar riscos e
+      orientar intervenções.
+  BC-4260.30.10:
+    name: Modelação da pontuação de saúde do cliente
+    description: |
+      Modelação de pontuações de saúde do cliente a partir de sinais de produto,
+      suporte e comerciais.
+  BC-4260.30.20:
+    name: Monitorização de sinais de risco
+    description: |
+      Monitorização de sinais de risco em toda a base de clientes.
+  BC-4260.30.30:
+    name: Intervenção em contas em risco
+    description: |
+      Intervenção coordenada em contas identificadas como estando em risco.
+  BC-4260.40:
+    name: Envolvimento no ciclo de vida do cliente
+    description: |
+      Pontos de contacto recorrentes no ciclo de vida, incluindo revisões
+      de negócio, patrocínio executivo e planeamento de sucesso conjunto.
+  BC-4260.40.10:
+    name: Gestão de revisões de negócio trimestrais
+    description: |
+      Planeamento e realização de revisões de negócio recorrentes com
+      clientes.
+  BC-4260.40.20:
+    name: Programa de patrocinadores executivos
+    description: |
+      Operação de emparelhamentos de patrocinadores executivos entre o
+      fornecedor e o cliente.
+  BC-4260.40.30:
+    name: Manutenção do plano de sucesso
+    description: |
+      Manutenção de planos de sucesso conjuntos que capturam resultados
+      e marcos do cliente.
+  BC-4260.50:
+    name: Defesa de retenção e renovação
+    description: |
+      Defesa e intervenção focadas no processo de renovação, incluindo
+      estratégias de salvaguarda e contribuição para previsão de renovações.
+  BC-4260.50.10:
+    name: Mitigação de riscos de renovação
+    description: |
+      Mitigação dos riscos de renovação identificados antes da data de renovação.
+  BC-4260.50.20:
+    name: Execução de estratégias de salvaguarda
+    description: |
+      Execução de estratégias de salvaguarda em contas com intenção de cancelar.
+  BC-4260.50.30:
+    name: Submissão de previsões de renovação
+    description: |
+      Submissão de previsões de renovação informadas por sinais de saúde e
+      envolvimento.
+  BC-4260.60:
+    name: Defesa de expansão e venda cruzada
+    description: |
+      Identificação e qualificação de oportunidades de expansão e coordenação
+      com vendas para venda cruzada.
+  BC-4260.60.10:
+    name: Identificação de oportunidades de expansão
+    description: |
+      Identificação de oportunidades de expansão a partir de sinais de
+      utilização e envolvimento.
+  BC-4260.60.20:
+    name: Qualificação de upsell
+    description: |
+      Qualificação de oportunidades de upsell antes do envolvimento das vendas.
+  BC-4260.60.30:
+    name: Coordenação de venda cruzada
+    description: |
+      Coordenação com as vendas em processos de venda cruzada em toda a
+      base de clientes.
+  BC-4260.70:
+    name: Defesa e referência de clientes
+    description: |
+      Cultivo de referências, estudos de caso e medição estruturada do
+      sentimento do cliente.
+  BC-4260.70.10:
+    name: Gestão do programa de referências
+    description: |
+      Gestão do programa de referências de clientes, incluindo adesão,
+      governação e utilização.
+  BC-4260.70.20:
+    name: Desenvolvimento de estudos de caso
+    description: |
+      Desenvolvimento de estudos de caso de clientes em colaboração com
+      o marketing.
+  BC-4260.70.30:
+    name: Programa de inquéritos de Net Promoter
+    description: |
+      Operação de programas de inquéritos de NPS e de sentimento do cliente
+      equivalentes.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-customs-trade-compliance-management.yaml
+++ b/catalogue/i18n/pt/L1-customs-trade-compliance-management.yaml
@@ -1,0 +1,124 @@
+locale: pt
+source: L1-customs-trade-compliance-management.yaml
+entries:
+  BC-2480:
+    name: Gestão de conformidade aduaneira e comércio
+    description: |
+      Conformidade com regimes aduaneiros, sanções, origem e operador de confiança
+      para movimentos transfronteiriços, incluindo determinação de direitos e
+      impostos indiretos.
+  BC-2480.10:
+    name: Gestão de classificação pautal
+    description: |
+      Determinação e manutenção de classificações pautais para mercadorias
+      transacionadas.
+    in_scope:
+      - Determinação do código pautal por artigo e envio
+      - Informações pautais vinculativas
+    out_of_scope:
+      - Rastreio de sanções e partes (BC-2480.40)
+  BC-2480.10.10:
+    name: Determinação do código pautal
+    description: |
+      Determinação de códigos pautais por artigo e envio.
+  BC-2480.10.20:
+    name: Gestão de decisões de classificação
+    description: |
+      Pedido e gestão de decisões pautais vinculativas.
+  BC-2480.10.30:
+    name: Manutenção da base de dados de classificação
+    description: |
+      Manutenção de bases de dados de classificação mestre para artigos
+      transacionados.
+  BC-2480.20:
+    name: Gestão de declarações aduaneiras
+    description: |
+      Submissão de declarações de importação, exportação e trânsito junto das
+      autoridades aduaneiras.
+  BC-2480.20.10:
+    name: Submissão de declaração de importação
+    description: |
+      Preparação e submissão de declarações de importação.
+  BC-2480.20.20:
+    name: Submissão de declaração de exportação
+    description: |
+      Preparação e submissão de declarações de exportação.
+  BC-2480.20.30:
+    name: Gestão de declarações de trânsito
+    description: |
+      Submissão e descarga de declarações de trânsito, incluindo TIR e NCTS.
+  BC-2480.30:
+    name: Gestão de origem e acordos de livre comércio
+    description: |
+      Determinação e certificação de origem preferencial ao abrigo de acordos de
+      livre comércio.
+  BC-2480.30.10:
+    name: Determinação de origem
+    description: |
+      Determinação da origem preferencial e não preferencial.
+  BC-2480.30.20:
+    name: Documentação de qualificação ALC
+    description: |
+      Emissão e gestão de certificados de origem ALC.
+  BC-2480.30.30:
+    name: Trilha de auditoria de origem
+    description: |
+      Manutenção de evidências de suporte para auditorias de origem.
+  BC-2480.40:
+    name: Gestão de rastreio de sanções e partes proibidas
+    description: |
+      Rastreio de partes, navios e mercadorias face a listas de sanções e de
+      partes proibidas.
+  BC-2480.40.10:
+    name: Rastreio de partes e navios
+    description: |
+      Rastreio de clientes, destinatários e meios de transporte face a listas de
+      sanções.
+  BC-2480.40.20:
+    name: Gestão de listas de sanções
+    description: |
+      Manutenção de listas consolidadas de sanções e de partes proibidas.
+  BC-2480.40.30:
+    name: Processamento de bloqueios e liberações
+    description: |
+      Processamento de ocorrências no rastreio, bloqueios e liberações autorizadas.
+  BC-2480.50:
+    name: Gestão do programa de operador de confiança
+    description: |
+      Candidatura, manutenção e auditoria de programas de operador de confiança
+      como AEO e C-TPAT.
+  BC-2480.50.10:
+    name: Candidatura e manutenção AEO
+    description: |
+      Candidatura ao AEO e manutenção contínua do programa.
+  BC-2480.50.20:
+    name: Gestão do programa C-TPAT
+    description: |
+      Adesão ao C-TPAT e conformidade com os critérios mínimos de segurança.
+  BC-2480.50.30:
+    name: Coordenação de auditorias aduaneiras
+    description: |
+      Coordenação de auditorias aduaneiras e de operador de confiança.
+  BC-2480.60:
+    name: Gestão de direitos e impostos indiretos
+    description: |
+      Determinação, pagamento e recuperação de direitos, impostos indiretos e
+      restituições em movimentos transfronteiriços.
+  BC-2480.60.10:
+    name: Cálculo de direitos
+    description: |
+      Cálculo dos direitos devidos sobre importações e exportações.
+  BC-2480.60.20:
+    name: Determinação de impostos indiretos
+    description: |
+      Determinação de IVA, GST e impostos especiais de consumo em fluxos
+      transfronteiriços.
+  BC-2480.60.30:
+    name: Restituição e reembolso de direitos
+    description: |
+      Recuperação de direitos através de regimes de restituição, suspensão e
+      reembolso.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-cyber-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-cyber-operations-management.yaml
@@ -1,0 +1,95 @@
+locale: pt
+source: L1-cyber-operations-management.yaml
+entries:
+  BC-1740:
+    name: Gestão de operações cibernéticas
+    description: |
+      Operações cibernéticas defensivas e ofensivas e informações cibernéticas.
+  BC-1740.10:
+    name: Gestão de operações cibernéticas defensivas
+    description: |
+      Defesa de rede, caça a ameaças e resposta a incidentes.
+  BC-1740.10.10:
+    name: Operações de defesa de rede
+    description: |
+      Operação de sensores e ferramentas de defesa cibernética.
+  BC-1740.10.20:
+    name: Caça a ameaças cibernéticas
+    description: |
+      Caça a ameaças em redes militares.
+  BC-1740.10.30:
+    name: Resposta a incidentes cibernéticos
+    description: |
+      Deteção, resposta e recuperação de incidentes em redes de missão.
+  BC-1740.10.40:
+    name: Manobra cibernética defensiva
+    description: |
+      Manobra cibernética defensiva e defesa ativa.
+  BC-1740.20:
+    name: Gestão de operações cibernéticas ofensivas
+    description: |
+      Capacidades cibernéticas ofensivas e entrega de efeitos cibernéticos.
+  BC-1740.20.10:
+    name: Desenvolvimento de capacidades cibernéticas
+    description: |
+      Desenvolvimento autorizado de capacidades cibernéticas ofensivas.
+  BC-1740.20.20:
+    name: Entrega de efeitos cibernéticos
+    description: |
+      Entrega autorizada de efeitos cibernéticos contra adversários.
+  BC-1740.20.30:
+    name: Autorização de operações cibernéticas
+    description: |
+      Framework de autorização para operações cibernéticas ofensivas.
+  BC-1740.30:
+    name: Gestão de informações cibernéticas
+    description: |
+      Informações sobre ameaças cibernéticas e rastreio de adversários.
+  BC-1740.30.10:
+    name: Produção de informações sobre ameaças cibernéticas
+    description: |
+      Produção de avaliações de informações sobre ameaças cibernéticas.
+  BC-1740.30.20:
+    name: Rastreio de adversários
+    description: |
+      Rastreio das técnicas de trabalho e infraestrutura de adversários.
+  BC-1740.30.30:
+    name: Gestão de indicadores cibernéticos
+    description: |
+      Gestão de indicadores de comprometimento cibernéticos.
+  BC-1740.40:
+    name: Gestão de efeitos cibernéticos
+    description: |
+      Targeting, coordenação de efeitos e desconflitualização.
+  BC-1740.40.10:
+    name: Targeting cibernético
+    description: |
+      Targeting específico de ciberespaço e desenvolvimento de alvos.
+  BC-1740.40.20:
+    name: Coordenação de efeitos cibernéticos
+    description: |
+      Coordenação de efeitos cibernéticos com operações cinéticas.
+  BC-1740.40.30:
+    name: Desconflitualização cibernética
+    description: |
+      Desconflitualização de operações cibernéticas entre formações.
+  BC-1740.50:
+    name: Gestão da garantia da missão cibernética
+    description: |
+      Resiliência cibernética dos sistemas de missão e garantia.
+  BC-1740.50.10:
+    name: Avaliação do risco cibernético de sistemas de missão
+    description: |
+      Avaliação do risco cibernético de sistemas de missão.
+  BC-1740.50.20:
+    name: Engenharia de resiliência da missão
+    description: |
+      Engenharia de resiliência cibernética para sistemas de missão.
+  BC-1740.50.30:
+    name: Reporte da garantia da missão cibernética
+    description: |
+      Reporte da postura de garantia da missão cibernética.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-cybersecurity-management.yaml
+++ b/catalogue/i18n/pt/L1-cybersecurity-management.yaml
@@ -1,0 +1,147 @@
+locale: pt
+source: L1-cybersecurity-management.yaml
+entries:
+  BC-620:
+    name: Gestão de cibersegurança
+    description: |
+      Estratégia de segurança, controlos, identidade e resposta a ameaças.
+  BC-620.10:
+    name: Gestão da estratégia e governação de segurança
+    description: |
+      Estratégia de segurança, políticas, quadros e GRC.
+  BC-620.10.10:
+    name: Desenvolvimento da estratégia de segurança
+    description: |
+      Estratégia plurianual de cibersegurança alinhada com o risco de negócio.
+  BC-620.10.20:
+    name: Política e normas de segurança
+    description: |
+      Políticas e normas de segurança alinhadas com NIST CSF e ISO 27001.
+  BC-620.10.30:
+    name: Gestão do risco de segurança
+    description: |
+      Identificação, avaliação e tratamento do risco cibernético.
+  BC-620.10.40:
+    name: Gestão da conformidade de segurança
+    description: |
+      Conformidade com regulamentos de cibersegurança (DORA, NIS2, setoriais).
+  BC-620.10.50:
+    name: Métricas e reporte de segurança
+    description: |
+      KPIs de segurança, dashboards e reporte ao conselho.
+  BC-620.20:
+    name: Gestão de identidade e acesso
+    description: |
+      IAM, PAM, federação e processos de joiners-movers-leavers.
+  BC-620.20.10:
+    name: Gestão do ciclo de vida da identidade
+    description: |
+      Processos de joiner, mover e leaver e aprovisionamento de identidade.
+  BC-620.20.20:
+    name: Gestão de acesso e autenticação
+    description: |
+      Autenticação, MFA, single sign-on e federação.
+  BC-620.20.30:
+    name: Gestão de acesso privilegiado
+    description: |
+      PAM, acesso just-in-time e monitorização de sessões privilegiadas.
+  BC-620.20.40:
+    name: Governação e recertificação de acessos
+    description: |
+      Revisões de acessos, segregação de funções e recertificação.
+  BC-620.20.50:
+    name: Gestão de identidade de clientes
+    description: |
+      CIAM para clientes externos, parceiros e consumidores.
+  BC-620.30:
+    name: Gestão da deteção e resposta a ameaças
+    description: |
+      SOC, SIEM e resposta a incidentes.
+  BC-620.30.10:
+    name: Monitorização de segurança e operações SIEM
+    description: |
+      Monitorização de SIEM, SOAR e telemetria de segurança.
+  BC-620.30.20:
+    name: Caça a ameaças
+    description: |
+      Caça proativa a ameaças orientada por hipóteses.
+  BC-620.30.30:
+    name: Inteligência de ameaças cibernéticas
+    description: |
+      Recolha, análise e disseminação de inteligência de ameaças cibernéticas.
+  BC-620.30.40:
+    name: Resposta a incidentes cibernéticos
+    description: |
+      Deteção, contenção, erradicação e recuperação de incidentes cibernéticos.
+  BC-620.30.50:
+    name: Forense digital
+    description: |
+      Aquisição e análise forense em apoio a incidentes e litígios.
+  BC-620.40:
+    name: Gestão de vulnerabilidades
+    description: |
+      Varrimento de vulnerabilidades, patching e remediação.
+  BC-620.40.10:
+    name: Varrimento de vulnerabilidades
+    description: |
+      Varrimento autenticado e não autenticado em todo o parque.
+  BC-620.40.20:
+    name: Triagem e priorização de vulnerabilidades
+    description: |
+      Priorização baseada no risco de vulnerabilidades para remediação.
+  BC-620.40.30:
+    name: Gestão de patching e remediação
+    description: |
+      Coordenação de patching e remediação entre responsáveis.
+  BC-620.40.40:
+    name: Testes de penetração e red teaming
+    description: |
+      Testes de penetração, exercícios de red team e simulação de adversário.
+  BC-620.50:
+    name: Gestão da arquitetura de segurança
+    description: |
+      Design seguro, padrões de segurança e zero trust.
+  BC-620.50.10:
+    name: Padrões de arquitetura de segurança
+    description: |
+      Padrões de segurança de referência e controlos reutilizáveis.
+  BC-620.50.20:
+    name: Arquitetura zero trust
+    description: |
+      Princípios zero trust, micro-segmentação e aplicação de políticas.
+  BC-620.50.30:
+    name: Engenharia de segurança de aplicações
+    description: |
+      Práticas de security-by-design, SAST, DAST e threat modelling.
+  BC-620.50.40:
+    name: Arquitetura de segurança cloud
+    description: |
+      Baselines de segurança cloud, CSPM e design de controlos cloud-native.
+  BC-620.50.50:
+    name: Criptografia e gestão de chaves
+    description: |
+      Normas criptográficas, gestão de chaves e operações de PKI.
+  BC-620.60:
+    name: Gestão da sensibilização para a segurança
+    description: |
+      Formação de sensibilização, simulações de phishing e cultura.
+  BC-620.60.10:
+    name: Formação de sensibilização para a segurança
+    description: |
+      Formação de sensibilização para a segurança anual e por função.
+  BC-620.60.20:
+    name: Simulação de phishing
+    description: |
+      Simulações de phishing e coaching de seguimento.
+  BC-620.60.30:
+    name: Programa de cultura de segurança
+    description: |
+      Programas de mudança cultural e redes de campeões de segurança.
+  BC-620.60.40:
+    name: Comunicações de segurança
+    description: |
+      Alertas, avisos e comunicações de segurança a partes interessadas.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-dangerous-goods-management.yaml
+++ b/catalogue/i18n/pt/L1-dangerous-goods-management.yaml
@@ -1,0 +1,114 @@
+locale: pt
+source: L1-dangerous-goods-management.yaml
+entries:
+  BC-2490:
+    name: Gestão de mercadorias perigosas
+    description: |
+      Aceitação, documentação, manuseamento, formação e resposta a incidentes
+      em movimentos de mercadorias perigosas em modos rodoviário, ferroviário,
+      marítimo e aéreo, ao abrigo dos regimes IMDG, IATA DGR, ADR e RID.
+  BC-2490.10:
+    name: Gestão de aceitação de mercadorias perigosas
+    description: |
+      Revisão prévia de envios de mercadorias perigosas face às regras modais e
+      decisão de aceitação.
+    in_scope:
+      - Revisão da declaração do expedidor
+      - Verificações de compatibilidade, segregação e quantidade
+    out_of_scope:
+      - Restrições aduaneiras a substâncias perigosas (BC-2480)
+      - Reclamações de carga por danos em mercadorias perigosas (BC-2530.40)
+  BC-2490.10.10:
+    name: Revisão da declaração do expedidor
+    description: |
+      Revisão das declarações de mercadorias perigosas do expedidor e documentação
+      de suporte.
+  BC-2490.10.20:
+    name: Verificação de compatibilidade e segregação
+    description: |
+      Verificações de compatibilidade, segregação e quantidade de acordo com as
+      regulamentações modais.
+  BC-2490.10.30:
+    name: Decisão de aceitação e endosso
+    description: |
+      Decisão de aceitação, endosso ou recusa de consignações de mercadorias
+      perigosas.
+  BC-2490.20:
+    name: Gestão de documentação de mercadorias perigosas
+    description: |
+      Emissão e manutenção de declarações de mercadorias perigosas, NOTOC e
+      documentação multimodal de mercadorias perigosas.
+  BC-2490.20.10:
+    name: Emissão de declaração de mercadorias perigosas
+    description: |
+      Emissão de declarações de mercadorias perigosas de acordo com IMDG, DGR,
+      ADR e RID.
+  BC-2490.20.20:
+    name: Preparação de NOTOC e manifesto
+    description: |
+      Preparação de notificação ao comandante e manifesto de carga perigosa.
+  BC-2490.20.30:
+    name: Reconciliação de documentação multimodal
+    description: |
+      Reconciliação de documentos de mercadorias perigosas em transferências
+      modais.
+  BC-2490.30:
+    name: Gestão de manuseamento e estiva de mercadorias perigosas
+    description: |
+      Conformidade do manuseamento físico e estiva com os requisitos de
+      mercadorias perigosas.
+  BC-2490.30.10:
+    name: Conformidade de segregação e estiva
+    description: |
+      Conformidade de segregação e estiva a bordo, no convés e em armazém.
+  BC-2490.30.20:
+    name: Armazenamento em área restrita
+    description: |
+      Armazenamento de mercadorias perigosas em áreas restritas, ventiladas e
+      com bacia de contenção.
+  BC-2490.30.30:
+    name: Utilização de equipamento especializado de manuseamento
+    description: |
+      Utilização de equipamento especializado de manuseamento de mercadorias
+      perigosas e equipamento de proteção individual.
+  BC-2490.40:
+    name: Gestão de formação e competência em mercadorias perigosas
+    description: |
+      Formação inicial e recorrente, avaliação de competência e registos para
+      pessoal que manuseia mercadorias perigosas.
+  BC-2490.40.10:
+    name: Formação inicial em mercadorias perigosas
+    description: |
+      Formação inicial em mercadorias perigosas de acordo com a autoridade modal.
+  BC-2490.40.20:
+    name: Formação recorrente em mercadorias perigosas
+    description: |
+      Formação recorrente e de atualização em mercadorias perigosas.
+  BC-2490.40.30:
+    name: Gestão de registos de competência
+    description: |
+      Manutenção de registos de competência em mercadorias perigosas e evidências
+      de auditoria.
+  BC-2490.50:
+    name: Gestão de incidentes com mercadorias perigosas
+    description: |
+      Deteção, resposta, notificação e reporte de incidentes e derrames com
+      mercadorias perigosas.
+  BC-2490.50.10:
+    name: Deteção de incidentes com mercadorias perigosas
+    description: |
+      Deteção de incidentes com mercadorias perigosas durante o manuseamento e
+      transporte.
+  BC-2490.50.20:
+    name: Resposta a derrames e libertações de mercadorias perigosas
+    description: |
+      Contenção de derrames, resposta a libertações e descontaminação.
+  BC-2490.50.30:
+    name: Notificação e reporte a autoridades
+    description: |
+      Notificação e reporte de incidentes com mercadorias perigosas às autoridades
+      competentes.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-dealer-network-management.yaml
+++ b/catalogue/i18n/pt/L1-dealer-network-management.yaml
@@ -1,0 +1,165 @@
+locale: pt
+source: L1-dealer-network-management.yaml
+entries:
+  BC-3430:
+    name: Gestão da rede de concessionários
+    description: |
+      Governação da rede de concessionários franquiados ou autorizados —
+      nomeações, contratos, normas de marca e instalações, desempenho, formação
+      e desenvolvimento da rede ao abrigo do Regulamento de Isenção por Categoria
+      da UE e regras equivalentes de retalho.
+  BC-3430.10:
+    name: Estratégia e planeamento da rede de concessionários
+    description: |
+      Planeamento estratégico da presença, formato, cobertura e normas de marca
+      dos concessionários nos vários mercados.
+  BC-3430.10.10:
+    name: Planeamento de cobertura de mercado e rede
+    description: |
+      Análise de lacunas de cobertura de mercado e definição da presença de
+      concessionários alvo por área.
+  BC-3430.10.20:
+    name: Otimização da presença de concessionários
+    description: |
+      Otimização da presença de concessionários existente, incluindo consolidação,
+      relocalização e expansão de capacidade.
+  BC-3430.10.30:
+    name: Definição de formato de rede e normas de marca
+    description: |
+      Definição de formatos de concessionários, conceitos de retalho e normas
+      de experiência de marca.
+  BC-3430.20:
+    name: Gestão de nomeação e contratos de concessionários
+    description: |
+      Integração, contratação e rescisão de concessionários, incluindo gestão de
+      território e direitos de marca.
+  BC-3430.20.10:
+    name: Candidatura e seleção de concessionários
+    description: |
+      Receção e avaliação de candidaturas de concessionários, incluindo due
+      diligence financeira, jurídica e operacional.
+  BC-3430.20.20:
+    name: Redação e celebração de contratos de concessionário
+    description: |
+      Redação, negociação e celebração de contratos de concessão alinhados com
+      a legislação da concorrência aplicável.
+  BC-3430.20.30:
+    name: Gestão de território e direitos de marca
+    description: |
+      Alocação e gestão de território e direitos de marca, incluindo definições
+      de área de responsabilidade.
+  BC-3430.20.40:
+    name: Gestão de rescisão de concessionários
+    description: |
+      Gestão da rescisão, encerramento e reatribuição de território de
+      concessionários.
+  BC-3430.30:
+    name: Normas e conformidade de concessionários
+    description: |
+      Manutenção e auditoria de normas de marca, instalações e operacionais na
+      rede de concessionários.
+  BC-3430.30.10:
+    name: Gestão de normas de marca e instalações
+    description: |
+      Manutenção de normas de marca, instalações e experiência do cliente para
+      conformidade dos concessionários.
+  BC-3430.30.20:
+    name: Auditoria de conformidade de concessionários
+    description: |
+      Auditoria periódica de concessionários face a normas de marca, vendas e
+      pós-venda.
+  BC-3430.30.30:
+    name: Gestão de ações corretivas
+    description: |
+      Gestão de planos de ações corretivas para concessionários não conformes
+      até ao encerramento.
+  BC-3430.40:
+    name: Gestão do desempenho de concessionários
+    description: |
+      Medição e melhoria do desempenho comercial e operacional dos concessionários
+      através de scorecards e programas de incentivos.
+  BC-3430.40.10:
+    name: Gestão do scorecard de concessionários
+    description: |
+      Definição e operação de scorecards de concessionários em métricas de
+      vendas, pós-venda e experiência do cliente.
+  BC-3430.40.20:
+    name: Revisões de desempenho de vendas e pós-venda
+    description: |
+      Revisões periódicas de desempenho de concessionários e planeamento
+      conjunto de negócio com gestores de área.
+  BC-3430.40.30:
+    name: Gestão de programas de incentivos a concessionários
+    description: |
+      Conceção e operação de programas de bónus, margem e incentivos a
+      concessionários.
+  BC-3430.50:
+    name: Gestão de financiamento e plano de piso de concessionários
+    description: |
+      Financiamento do inventário grossista de concessionários e gestão de
+      créditos e programas de apoio ao fundo de maneio.
+    in_scope:
+      - Administração do plano de piso grossista
+      - Limites de crédito e monitorização de exposição de concessionários
+      - Apoio ao fundo de maneio de concessionários apoiado pelo OEM
+    out_of_scope:
+      - Crédito ao consumo de financiamento automóvel cativo (coberto pelo crédito e financiamento empresarial)
+  BC-3430.50.10:
+    name: Administração do plano de piso grossista
+    description: |
+      Administração do financiamento do plano de piso grossista para inventário
+      de veículos dos concessionários.
+  BC-3430.50.20:
+    name: Gestão de crédito e contas a receber de concessionários
+    description: |
+      Gestão de limites de crédito, antiguidade de contas a receber e cobranças
+      de concessionários.
+  BC-3430.50.30:
+    name: Apoio ao fundo de maneio de concessionários
+    description: |
+      Apoio ao fundo de maneio dos concessionários apoiado pelo OEM, financiamento
+      de peças e programas de assistência sazonal.
+  BC-3430.60:
+    name: Formação e certificação de concessionários
+    description: |
+      Formação e certificação do pessoal de vendas, pós-venda e gestão dos
+      concessionários.
+  BC-3430.60.10:
+    name: Certificação de vendas de concessionários
+    description: |
+      Certificação de consultores de vendas de concessionários em normas de
+      produto, marca e experiência do cliente.
+  BC-3430.60.20:
+    name: Certificação de técnicos de serviço de concessionários
+    description: |
+      Certificação de técnicos de serviço de concessionários em procedimentos
+      de diagnóstico, reparação e VE/HV.
+  BC-3430.60.30:
+    name: Desenvolvimento de gestão de concessionários
+    description: |
+      Programas de desenvolvimento de liderança e gestão para responsáveis e
+      diretores de departamento de concessionários.
+  BC-3430.70:
+    name: Operações de sistemas e dados de concessionários
+    description: |
+      Operação de sistemas orientados para concessionários e fluxos de dados que
+      ligam concessionários a plataformas comerciais, técnicas e de reporte do OEM.
+  BC-3430.70.10:
+    name: Integração de sistemas de gestão de concessionários
+    description: |
+      Integração de sistemas de gestão de concessionários com backbones de
+      encomendas, peças, garantia e reporte do OEM.
+  BC-3430.70.20:
+    name: Gestão de dados mestre de concessionários
+    description: |
+      Manutenção de dados mestre de concessionários, incluindo pontos de venda,
+      contactos e autorizações.
+  BC-3430.70.30:
+    name: Reporte e análise de concessionários
+    description: |
+      Reporte, benchmarking e análise ao nível dos concessionários nas dimensões
+      comercial e operacional.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-decommissioning-abandonment-management.yaml
+++ b/catalogue/i18n/pt/L1-decommissioning-abandonment-management.yaml
@@ -1,0 +1,123 @@
+locale: pt
+source: L1-decommissioning-abandonment-management.yaml
+entries:
+  BC-3120:
+    name: Gestão de desativação e abandono
+    description: |
+      Gestão de fim de vida de activos de petróleo — tamponamento e abandono de
+      poços, desativação de instalações, desativação de gasodutos, restauração de
+      locais, provisionamento de responsabilidades de desativação e monitorização
+      pós-encerramento.
+  BC-3120.10:
+    name: Operações de tamponamento e abandono de poços
+    description: |
+      Concepção e execução de campanhas de tamponamento e abandono permanente de
+      poços.
+    in_scope:
+      - Concepção P&A e verificação de barreiras
+      - Operações de execução de tamponamento e abandono
+      - Corte e recuperação de cabeças de poço e tubos de revestimento conductores
+    out_of_scope:
+      - Vigilância de integridade de poços em produção (BC-3020.50)
+  BC-3120.10.10:
+    name: Concepção de tamponamento e abandono
+    description: |
+      Concepção de configurações de barreiras permanentes para abandono de poços.
+  BC-3120.10.20:
+    name: Execução de tamponamento e abandono
+    description: |
+      Execução de operações de cimentação, colocação de tampões e verificação de
+      barreiras.
+  BC-3120.10.30:
+    name: Corte e recuperação de cabeças de poço
+    description: |
+      Corte e recuperação de cabeças de poço, tubos condutores e colunas de
+      revestimento.
+  BC-3120.20:
+    name: Desativação de instalações de superfície
+    description: |
+      Desativação, remoção e recuperação de instalações de superfície e subsea a
+      montante e midstream.
+  BC-3120.20.10:
+    name: Planeamento da remoção de topsides
+    description: |
+      Engenharia da remoção de topsides e metodologia de instalação inversa.
+  BC-3120.20.20:
+    name: Execução da remoção de topsides
+    description: |
+      Execução de remoção de topsides em levantamento único, modular ou em partes
+      pequenas.
+  BC-3120.20.30:
+    name: Recuperação de equipamento subsea
+    description: |
+      Recuperação de árvores subsea, manifolds, jumpers e umbilicais.
+  BC-3120.30:
+    name: Desativação de gasodutos
+    description: |
+      Desativação, remoção ou decisões de deixar in-situ para gasodutos
+      redundantes.
+  BC-3120.30.10:
+    name: Lavagem e limpeza de gasodutos
+    description: |
+      Lavagem, limpeza e inertização de gasodutos antes da desativação.
+  BC-3120.30.20:
+    name: Decisão de desativação de gasodutos
+    description: |
+      Avaliação comparativa da remoção versus desativação in-situ de gasodutos.
+  BC-3120.30.30:
+    name: Execução da desativação de gasodutos
+    description: |
+      Execução de remoção, corte e levantamento, ou deixar in-situ de gasodutos.
+  BC-3120.40:
+    name: Restauração e remediação de locais
+    description: |
+      Restauração de locais onshore e subsea, remediação de solos e sedimentos e
+      verificação de limpeza do fundo do mar.
+  BC-3120.40.10:
+    name: Remediação de solos e sedimentos
+    description: |
+      Remediação de solos e sedimentos contaminados em locais desativados.
+  BC-3120.40.20:
+    name: Restauração vegetal
+    description: |
+      Re-vegetação e modelação de locais onshore desativados.
+  BC-3120.40.30:
+    name: Limpeza do local subsea
+    description: |
+      Verificação de limpeza do fundo do mar subsea e recuperação de objectos
+      largados.
+  BC-3120.50:
+    name: Gestão de responsabilidades de desativação
+    description: |
+      Estimativa de custos, provisionamento e prestação de garantia para obrigações
+      de desativação.
+  BC-3120.50.10:
+    name: Estimativa de custos de abandono
+    description: |
+      Estimativa probabilística de custos de desativação e abandono.
+  BC-3120.50.20:
+    name: Provisionamento de desativação
+    description: |
+      Manutenção de provisões de desativação em linha com as normas contabilísticas.
+  BC-3120.50.30:
+    name: Prestação de garantia de desativação
+    description: |
+      Prestação e renovação de garantia de desativação a governos anfitriões.
+  BC-3120.60:
+    name: Monitorização pós-encerramento
+    description: |
+      Monitorização ambiental a longo prazo e acompanhamento de responsabilidades
+      residuais após encerramento.
+  BC-3120.60.10:
+    name: Monitorização ambiental a longo prazo
+    description: |
+      Monitorização ambiental a longo prazo de águas subterrâneas, solos e
+      ambiente marinho.
+  BC-3120.60.20:
+    name: Acompanhamento de responsabilidades residuais
+    description: |
+      Acompanhamento de responsabilidades e indemnizações residuais pós-encerramento.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-defense-capture-bid-management.yaml
+++ b/catalogue/i18n/pt/L1-defense-capture-bid-management.yaml
@@ -1,0 +1,99 @@
+locale: pt
+source: L1-defense-capture-bid-management.yaml
+entries:
+  BC-1750:
+    name: Gestão de captação e concurso de defesa
+    description: |
+      Gestão de captação, inteligência de cliente e desenvolvimento de propostas/concursos para contratos de defesa.
+  BC-1750.10:
+    name: Gestão de captação
+    description: |
+      Atividades de captação pré-RFP, modelação do cliente e estratégia de ganho.
+  BC-1750.10.10:
+    name: Identificação de oportunidades
+    description: |
+      Identificação de oportunidades e candidaturas de defesa.
+  BC-1750.10.20:
+    name: Atividades de modelação do cliente
+    description: |
+      Modelação pré-RFP do cliente e influência sobre requisitos.
+  BC-1750.10.30:
+    name: Desenvolvimento da estratégia de ganho
+    description: |
+      Desenvolvimento da estratégia de ganho, temas e diferenciadores.
+  BC-1750.10.40:
+    name: Análise black hat e competitiva
+    description: |
+      Revisões black hat e análise competitiva.
+  BC-1750.20:
+    name: Gestão de inteligência de cliente de defesa
+    description: |
+      Relações com clientes e inteligência sobre requisitos e orçamentos.
+  BC-1750.20.10:
+    name: Mapeamento de relações com o cliente
+    description: |
+      Mapeamento de organizações cliente e partes interessadas-chave.
+  BC-1750.20.20:
+    name: Inteligência sobre orçamentos e aquisição
+    description: |
+      Inteligência sobre orçamentos, ciclos de aquisição e prioridades.
+  BC-1750.20.30:
+    name: Recolha de inteligência sobre requisitos
+    description: |
+      Recolha de requisitos emergentes do cliente.
+  BC-1750.30:
+    name: Gestão de concursos de defesa
+    description: |
+      Decisões concurso/não concurso, governação e recursos de concurso.
+  BC-1750.30.10:
+    name: Decisão de concurso/não concurso
+    description: |
+      Governação e aprovações da decisão de concurso/não concurso.
+  BC-1750.30.20:
+    name: Recursos e financiamento do concurso
+    description: |
+      Alocação de recursos e financiamento de concurso e proposta.
+  BC-1750.30.30:
+    name: Gestão do risco de concurso
+    description: |
+      Identificação e gestão de riscos de concurso.
+  BC-1750.40:
+    name: Gestão de propostas de defesa
+    description: |
+      Redação de proposta, revisões por cores e produção de proposta.
+  BC-1750.40.10:
+    name: Redação de proposta
+    description: |
+      Redação dos volumes da proposta de defesa.
+  BC-1750.40.20:
+    name: Execução de revisões por cores
+    description: |
+      Revisões por cores rosa, vermelho, ouro e revisão final da proposta.
+  BC-1750.40.30:
+    name: Produção e submissão de proposta
+    description: |
+      Produção e submissão atempada de propostas.
+  BC-1750.40.40:
+    name: Verificação de conformidade da proposta
+    description: |
+      Verificação de conformidade com as instruções do RFP e L/M.
+  BC-1750.50:
+    name: Gestão de estratégia de equipa e subcontratados
+    description: |
+      Acordos de equipa e seleção de subcontratados para concursos.
+  BC-1750.50.10:
+    name: Definição da estratégia de equipa
+    description: |
+      Definição da estratégia de equipa e de prime/sub para concursos.
+  BC-1750.50.20:
+    name: Negociação de acordos de equipa
+    description: |
+      Negociação e celebração de acordos de equipa e NDA.
+  BC-1750.50.30:
+    name: Seleção de subcontratados para o concurso
+    description: |
+      Seleção de subcontratados e parceiros de pequenas empresas para concursos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-defense-logistics-management.yaml
+++ b/catalogue/i18n/pt/L1-defense-logistics-management.yaml
@@ -1,0 +1,107 @@
+locale: pt
+source: L1-defense-logistics-management.yaml
+entries:
+  BC-1720:
+    name: Gestão de logística de defesa
+    description: |
+      Prontidão de material, sustentação, logística de projeção e logística em teatro.
+  BC-1720.10:
+    name: Gestão da prontidão de material
+    description: |
+      Reporte de prontidão e disponibilidade de frota/equipamento.
+  BC-1720.10.10:
+    name: Acompanhamento da disponibilidade de equipamento
+    description: |
+      Acompanhamento da disponibilidade e operacionalidade do equipamento.
+  BC-1720.10.20:
+    name: Reporte de prontidão
+    description: |
+      Reporte periódico de prontidão ao comando.
+  BC-1720.10.30:
+    name: Melhoria da taxa de capacidade operacional
+    description: |
+      Iniciativas para melhorar as taxas de capacidade operacional.
+  BC-1720.20:
+    name: Gestão de inventário de defesa
+    description: |
+      Classes de abastecimento militar I-IX e reservas de guerra.
+  BC-1720.20.10:
+    name: Gestão de inventário de classes I-V
+    description: |
+      Inventário de subsistências, combustível, munições e consumíveis.
+  BC-1720.20.20:
+    name: Gestão de inventário de classes VII-IX
+    description: |
+      Gestão de inventário de itens de alta mobilidade e peças sobressalentes.
+  BC-1720.20.30:
+    name: Gestão de material de reserva de guerra
+    description: |
+      Gestão de stocks de reserva de guerra e pré-posicionados.
+  BC-1720.20.40:
+    name: Gestão de inventário de munições
+    description: |
+      Gestão de inventário de munições e explosivos.
+  BC-1720.30:
+    name: Gestão de projeção e distribuição
+    description: |
+      Logística de projeção estratégica e tática.
+  BC-1720.30.10:
+    name: Planeamento estratégico de projeção
+    description: |
+      Planeamento estratégico de projeção e TPFDD.
+  BC-1720.30.20:
+    name: Operações de transporte estratégico
+    description: |
+      Operações de transporte estratégico aéreo, marítimo e terrestre.
+  BC-1720.30.30:
+    name: Distribuição em teatro
+    description: |
+      Logística de distribuição e sustentação em teatro.
+  BC-1720.30.40:
+    name: Receção conjunta e movimento para o interior
+    description: |
+      Receção, estacionamento e movimento para o interior conjuntos.
+  BC-1720.40:
+    name: Gestão de manutenção de defesa
+    description: |
+      Manutenção orgânica e contratada, ao nível de depósito/intermédio/organizacional.
+  BC-1720.40.10:
+    name: Manutenção ao nível organizacional
+    description: |
+      Manutenção ao nível da unidade (nível O).
+  BC-1720.40.20:
+    name: Manutenção ao nível intermédio
+    description: |
+      Manutenção e reparação ao nível intermédio (nível I).
+  BC-1720.40.30:
+    name: Manutenção ao nível de depósito
+    description: |
+      Manutenção e revisão geral ao nível de depósito (nível D).
+  BC-1720.40.40:
+    name: Suporte logístico contratado
+    description: |
+      Acordos de suporte logístico contratado.
+  BC-1720.50:
+    name: Gestão de sobressalentes e aprovisionamento
+    description: |
+      Aprovisionamento inicial, reabastecimento e satisfação da procura.
+  BC-1720.50.10:
+    name: Aprovisionamento inicial
+    description: |
+      Aprovisionamento inicial de sobressalentes para novas plataformas.
+  BC-1720.50.20:
+    name: Reabastecimento de sobressalentes
+    description: |
+      Reabastecimento de sobressalentes com base na procura e previsões.
+  BC-1720.50.30:
+    name: Acompanhamento da satisfação da procura
+    description: |
+      Acompanhamento da satisfação da procura e taxa de preenchimento.
+  BC-1720.50.40:
+    name: Catalogação e gestão de NSN
+    description: |
+      Catalogação de Número de Stock NATO e identificação de itens.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-defense-programme-management.yaml
+++ b/catalogue/i18n/pt/L1-defense-programme-management.yaml
@@ -1,0 +1,119 @@
+locale: pt
+source: L1-defense-programme-management.yaml
+entries:
+  BC-1760:
+    name: Gestão de programas de defesa
+    description: |
+      Entrega de programas de grande escala, EVM, governação de programas e gestão de subcontratos.
+  BC-1760.10:
+    name: Gestão de aquisição de programas
+    description: |
+      Estratégia de aquisição, planeamento de programa e revisões de marcos.
+  BC-1760.10.10:
+    name: Definição da estratégia de aquisição
+    description: |
+      Definição da estratégia de aquisição alinhada com DoD 5000 ou equivalente.
+  BC-1760.10.20:
+    name: Planeamento e linha de base do programa
+    description: |
+      Planeamento do programa e estabelecimento da linha de base do plano mestre integrado.
+  BC-1760.10.30:
+    name: Revisões de decisão de marcos
+    description: |
+      Preparação e condução de revisões de decisão de marcos.
+  BC-1760.20:
+    name: Gestão de valor ganho do programa
+    description: |
+      EVM, desempenho de custo, desempenho de prazo e IBR.
+  BC-1760.20.10:
+    name: Operação do sistema EVM
+    description: |
+      Operação de um sistema EVM em conformidade com EIA-748.
+  BC-1760.20.20:
+    name: Revisão integrada da linha de base
+    description: |
+      Condução de revisões integradas da linha de base com o cliente.
+  BC-1760.20.30:
+    name: Análise do desempenho de custo e prazo
+    description: |
+      Análise de métricas e tendências de CV, SV, CPI e SPI.
+  BC-1760.20.40:
+    name: Previsão da estimativa no término
+    description: |
+      Previsão do EAC e análise do índice de desempenho para completar.
+  BC-1760.30:
+    name: Gestão de custo e preços do programa
+    description: |
+      Normas de contabilidade de custos e preços para contratos governamentais.
+  BC-1760.30.10:
+    name: Conformidade com normas de contabilidade de custos
+    description: |
+      Conformidade com as Normas de Contabilidade de Custos (CAS).
+  BC-1760.30.20:
+    name: Preços de contratos governamentais
+    description: |
+      Preços de contratos governamentais incluindo FAR/DFARS.
+  BC-1760.30.30:
+    name: Estimativa de custo do programa
+    description: |
+      Estimativa de custo do programa e documentação da base de estimativa.
+  BC-1760.30.40:
+    name: Gestão de taxas indiretas
+    description: |
+      Cálculo de taxas de custo indireto e negociação de taxas com o governo.
+  BC-1760.40:
+    name: Gestão do cliente governamental
+    description: |
+      Relação com o cliente governamental e interface com o responsável de contrato.
+  BC-1760.40.10:
+    name: Interface com o responsável de contrato
+    description: |
+      Interface com responsáveis de contrato e representantes do responsável de contrato.
+  BC-1760.40.20:
+    name: Envolvimento com o gabinete do programa
+    description: |
+      Envolvimento com gabinetes de programa governamentais e PMOs.
+  BC-1760.40.30:
+    name: Reporte e revisões ao cliente
+    description: |
+      Reporte periódico ao cliente e revisões de gestão do programa.
+  BC-1760.50:
+    name: Gestão de subcontratados de defesa
+    description: |
+      Cadeia de abastecimento de defesa, flow-down e planos de pequenas empresas.
+  BC-1760.50.10:
+    name: Seleção e adjudicação de subcontratados
+    description: |
+      Seleção e adjudicação de subcontratados de defesa.
+  BC-1760.50.20:
+    name: Administração de cláusulas de flow-down
+    description: |
+      Administração de cláusulas FAR/DFARS de flow-down para subcontratados.
+  BC-1760.50.30:
+    name: Gestão do desempenho de subcontratados
+    description: |
+      Desempenho e vigilância de subcontratados de defesa.
+  BC-1760.50.40:
+    name: Gestão do plano de pequenas empresas
+    description: |
+      Execução e reporte do plano de subcontratação de pequenas empresas.
+  BC-1760.60:
+    name: Gestão do ciclo de vida do programa
+    description: |
+      Gestão do ciclo de vida conforme DoD 5000 ou equivalente e marcos.
+  BC-1760.60.10:
+    name: Gestão das fases do ciclo de vida
+    description: |
+      Gestão das fases do ciclo de vida do programa conforme DoD 5000 ou equivalente.
+  BC-1760.60.20:
+    name: Gestão de risco do programa
+    description: |
+      Gestão de risco e oportunidade ao nível do programa.
+  BC-1760.60.30:
+    name: Encerramento e transição do programa
+    description: |
+      Encerramento do programa, transição e encerramento do contrato.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-defense-sustainment-support-management.yaml
+++ b/catalogue/i18n/pt/L1-defense-sustainment-support-management.yaml
@@ -1,0 +1,115 @@
+locale: pt
+source: L1-defense-sustainment-support-management.yaml
+entries:
+  BC-1780:
+    name: Gestão de sustentação e suporte de defesa
+    description: |
+      Suporte em serviço, manutenção em depósito, engenharia RAM, sobressalentes e reparação, obsolescência.
+  BC-1780.10:
+    name: Gestão do suporte em serviço
+    description: |
+      Contratos de suporte ao longo da vida, engenharia de suporte.
+  BC-1780.10.10:
+    name: Operações de contratos de suporte ao longo da vida
+    description: |
+      Operação de contratos de suporte ao longo da vida.
+  BC-1780.10.20:
+    name: Engenharia de suporte
+    description: |
+      Suporte de engenharia a sistemas de armas em operação.
+  BC-1780.10.30:
+    name: Suporte à gestão de frota
+    description: |
+      Suporte à gestão de frota incluindo acompanhamento de configuração.
+  BC-1780.20:
+    name: Gestão de manutenção em depósito
+    description: |
+      Reparação, revisão geral e recondicionamento ao nível de depósito.
+  BC-1780.20.10:
+    name: Operações de reparação em depósito
+    description: |
+      Operação de oficinas de reparação ao nível de depósito.
+  BC-1780.20.20:
+    name: Programas de revisão geral em depósito
+    description: |
+      Programas periódicos de revisão geral e reset em depósito.
+  BC-1780.20.30:
+    name: Gestão da capacidade do depósito
+    description: |
+      Gestão da capacidade do depósito e tempo de reposição.
+  BC-1780.30:
+    name: Gestão de engenharia RAM
+    description: |
+      Engenharia de fiabilidade, disponibilidade e manutenibilidade.
+  BC-1780.30.10:
+    name: Engenharia de fiabilidade
+    description: |
+      Previsão, alocação e crescimento de fiabilidade.
+  BC-1780.30.20:
+    name: Modelação de disponibilidade
+    description: |
+      Modelação e análise da disponibilidade operacional.
+  BC-1780.30.30:
+    name: Engenharia de manutenibilidade
+    description: |
+      Análises de manutenibilidade e influência no design.
+  BC-1780.30.40:
+    name: Análise de suporte logístico
+    description: |
+      Análise de suporte logístico conforme MIL-HDBK-502.
+  BC-1780.40:
+    name: Gestão de sobressalentes e reparação de defesa
+    description: |
+      Sobressalentes, circuitos de reparação e unidades de troca.
+  BC-1780.40.10:
+    name: Aprovisionamento de sobressalentes de defesa
+    description: |
+      Aprovisionamento de sobressalentes para sistemas de defesa.
+  BC-1780.40.20:
+    name: Gestão do circuito de reparação
+    description: |
+      Gestão de circuitos de reparação e devolução.
+  BC-1780.40.30:
+    name: Operações de reserva de unidades de troca
+    description: |
+      Operação de reservas de unidades rotáveis e de troca.
+  BC-1780.50:
+    name: Gestão de publicações técnicas
+    description: |
+      Ordens técnicas, IETMs, manuais e documentação S1000D.
+  BC-1780.50.10:
+    name: Documentação técnica S1000D
+    description: |
+      Redação e manutenção de publicações técnicas S1000D.
+  BC-1780.50.20:
+    name: Operações de manuais técnicos eletrónicos interativos
+    description: |
+      Operação e atualização de IETMs no terreno.
+  BC-1780.50.30:
+    name: Gestão de alterações a ordens técnicas
+    description: |
+      Gestão de alterações a OT e atualizações no terreno.
+  BC-1780.60:
+    name: Gestão de obsolescência de defesa
+    description: |
+      DMSMS, previsão de obsolescência e mitigação.
+  BC-1780.60.10:
+    name: Monitorização de DMSMS
+    description: |
+      Monitorização de DMSMS de componentes e fornecedores.
+  BC-1780.60.20:
+    name: Previsão de obsolescência
+    description: |
+      Previsão da obsolescência de peças e materiais.
+  BC-1780.60.30:
+    name: Mitigação de obsolescência
+    description: |
+      Estratégias de mitigação incluindo LTB, redesign e substituição.
+  BC-1780.60.40:
+    name: Manutenção do plano de gestão de obsolescência
+    description: |
+      Manutenção de planos de gestão de obsolescência ao nível do programa.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-defense-systems-engineering-management.yaml
+++ b/catalogue/i18n/pt/L1-defense-systems-engineering-management.yaml
@@ -1,0 +1,115 @@
+locale: pt
+source: L1-defense-systems-engineering-management.yaml
+entries:
+  BC-1770:
+    name: Gestão de engenharia de sistemas de defesa
+    description: |
+      Engenharia de sistemas conforme MIL-STD — requisitos, arquitetura, V&V, configuração e integração.
+  BC-1770.10:
+    name: Gestão de engenharia de requisitos de defesa
+    description: |
+      Elicitação, decomposição e rastreabilidade de requisitos.
+  BC-1770.10.10:
+    name: Elicitação de requisitos das partes interessadas
+    description: |
+      Elicitação de necessidades das partes interessadas e requisitos operacionais.
+  BC-1770.10.20:
+    name: Decomposição de requisitos do sistema
+    description: |
+      Decomposição de requisitos do sistema em subsistemas.
+  BC-1770.10.30:
+    name: Rastreabilidade de requisitos
+    description: |
+      Rastreabilidade bidirecional de requisitos para design e testes.
+  BC-1770.10.40:
+    name: Planeamento de verificação de requisitos
+    description: |
+      Definição de métodos de verificação e critérios de aceitação.
+  BC-1770.20:
+    name: Gestão de arquitetura de sistemas de defesa
+    description: |
+      Arquitetura do sistema, modelos e linhas de base.
+  BC-1770.20.10:
+    name: Modelação de arquitetura operacional e do sistema
+    description: |
+      Modelação de arquiteturas operacionais e do sistema (DoDAF/MoDAF).
+  BC-1770.20.20:
+    name: Análise de trade-off de arquitetura
+    description: |
+      Análise de trade-off entre opções de arquitetura.
+  BC-1770.20.30:
+    name: Gestão da linha de base de arquitetura
+    description: |
+      Definição e controlo de linhas de base de arquitetura.
+  BC-1770.30:
+    name: Gestão de definição de interfaces de defesa
+    description: |
+      Controlo de interfaces, ICDs e planos de gestão de interfaces.
+  BC-1770.30.10:
+    name: Identificação de interfaces
+    description: |
+      Identificação de interfaces internas e externas do sistema.
+  BC-1770.30.20:
+    name: Gestão de documentos de controlo de interfaces
+    description: |
+      Redação e controlo de ICDs e IRSs.
+  BC-1770.30.30:
+    name: Verificação de interfaces
+    description: |
+      Verificação da conformidade de interfaces durante a integração.
+  BC-1770.40:
+    name: Gestão de verificação e validação de defesa
+    description: |
+      Planeamento, execução e certificação de V&V.
+  BC-1770.40.10:
+    name: Planeamento de V&V
+    description: |
+      Estratégia e planeamento de verificação e validação.
+  BC-1770.40.20:
+    name: Execução de V&V
+    description: |
+      Execução de V&V em análises, demonstrações, inspeções e testes.
+  BC-1770.40.30:
+    name: Reporte de resultados de V&V
+    description: |
+      Reporte de resultados e discrepâncias de V&V.
+  BC-1770.50:
+    name: Gestão da configuração de defesa
+    description: |
+      Identificação, controlo, registo do estado e auditorias de configuração.
+  BC-1770.50.10:
+    name: Identificação da configuração de defesa
+    description: |
+      Identificação de configuração conforme MIL-HDBK-61.
+  BC-1770.50.20:
+    name: Controlo de alterações de configuração de defesa
+    description: |
+      Controlo de alterações ECP, RFD e DD-1694.
+  BC-1770.50.30:
+    name: Registo do estado de configuração de defesa
+    description: |
+      Registo e reporte do estado de configuração.
+  BC-1770.50.40:
+    name: Auditorias de configuração
+    description: |
+      Auditorias de configuração funcional e física.
+  BC-1770.60:
+    name: Gestão da integração de sistemas de defesa
+    description: |
+      Integração de subsistemas, ensaio integrado e integração de sistema-de-sistemas.
+  BC-1770.60.10:
+    name: Execução da integração de subsistemas
+    description: |
+      Execução de sequências de integração de subsistemas.
+  BC-1770.60.20:
+    name: Execução de ensaios integrados
+    description: |
+      Execução de ensaios integrados em ambientes de laboratório e campo.
+  BC-1770.60.30:
+    name: Integração de sistema-de-sistemas
+    description: |
+      Integração com o sistema-de-sistemas alargado e arquiteturas conjuntas.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-defense-test-evaluation-management.yaml
+++ b/catalogue/i18n/pt/L1-defense-test-evaluation-management.yaml
@@ -1,0 +1,99 @@
+locale: pt
+source: L1-defense-test-evaluation-management.yaml
+entries:
+  BC-1800:
+    name: Gestão de teste e avaliação de defesa
+    description: |
+      DT&E, OT&E, operações de campo de tiro, planos de teste e dados de teste.
+  BC-1800.10:
+    name: Gestão de teste e avaliação de desenvolvimento
+    description: |
+      DT&E, testes do contratante e testes de qualificação.
+  BC-1800.10.10:
+    name: Programa de teste do contratante
+    description: |
+      Gestão do programa de teste de desenvolvimento liderado pelo contratante.
+  BC-1800.10.20:
+    name: Coordenação governamental de DT&E
+    description: |
+      Coordenação das atividades governamentais de DT&E.
+  BC-1800.10.30:
+    name: Execução de testes de qualificação
+    description: |
+      Execução de testes de qualificação face a especificações.
+  BC-1800.20:
+    name: Gestão de teste e avaliação operacional
+    description: |
+      OT&E, testes de utilizadores e adequação operacional.
+  BC-1800.20.10:
+    name: Teste e avaliação operacional inicial
+    description: |
+      Execução e relatório de IOT&E.
+  BC-1800.20.20:
+    name: Teste operacional de seguimento
+    description: |
+      Teste e avaliação operacional de seguimento.
+  BC-1800.20.30:
+    name: Avaliação de adequação operacional
+    description: |
+      Avaliação da adequação e eficácia operacional.
+  BC-1800.30:
+    name: Gestão de operações de campo de tiro
+    description: |
+      Agendamento do campo de tiro, segurança e dados de campo de tiro.
+  BC-1800.30.10:
+    name: Agendamento do campo de tiro
+    description: |
+      Agendamento da utilização do campo de tiro e dos seus ativos.
+  BC-1800.30.20:
+    name: Operações de segurança do campo de tiro
+    description: |
+      Operações de segurança e autorização do campo de tiro.
+  BC-1800.30.30:
+    name: Aquisição de dados do campo de tiro
+    description: |
+      Aquisição de dados de telemetria, ótica e instrumentação do campo de tiro.
+  BC-1800.30.40:
+    name: Manutenção de ativos do campo de tiro
+    description: |
+      Manutenção da instrumentação e infraestrutura do campo de tiro.
+  BC-1800.40:
+    name: Gestão de planos e procedimentos de teste
+    description: |
+      Planos de teste, procedimentos e revisões de prontidão para teste.
+  BC-1800.40.10:
+    name: Plano mestre de teste e avaliação
+    description: |
+      Manutenção do TEMP de acordo com os requisitos do programa.
+  BC-1800.40.20:
+    name: Elaboração de procedimentos detalhados de teste
+    description: |
+      Elaboração de procedimentos detalhados de teste e fichas de pré-teste.
+  BC-1800.40.30:
+    name: Revisão de prontidão para teste
+    description: |
+      Revisões de prontidão para teste antes da execução dos testes.
+  BC-1800.50:
+    name: Gestão de dados de teste
+    description: |
+      Aquisição, análise e arquivo de dados de teste.
+  BC-1800.50.10:
+    name: Aquisição de dados de teste
+    description: |
+      Aquisição de dados de telemetria e instrumentação de teste.
+  BC-1800.50.20:
+    name: Análise de dados de teste
+    description: |
+      Redução e análise de dados de teste.
+  BC-1800.50.30:
+    name: Arquivo e reutilização de dados de teste
+    description: |
+      Arquivo e reutilização de conjuntos históricos de dados de teste.
+  BC-1800.50.40:
+    name: Relatório de anomalias de teste
+    description: |
+      Relatório e acompanhamento de anomalias e deficiências de teste.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-deposits-savings-management.yaml
+++ b/catalogue/i18n/pt/L1-deposits-savings-management.yaml
@@ -1,0 +1,103 @@
+locale: pt
+source: L1-deposits-savings-management.yaml
+entries:
+  BC-1330:
+    name: Gestão de depósitos e poupança
+    description: |
+      Ciclo de vida de contas à ordem, poupança e depósitos a prazo.
+  BC-1330.10:
+    name: Gestão de contas de depósito
+    description: |
+      Contas de depósito à ordem, contas correntes.
+  BC-1330.10.10:
+    name: Operações de conta corrente
+    description: |
+      Operação de contas correntes incluindo gestão de descoberto.
+  BC-1330.10.20:
+    name: Gestão de contas conjuntas e com mandato
+    description: |
+      Administração de contas conjuntas, de fidúcia e com mandato.
+  BC-1330.10.30:
+    name: Extratismo de conta de depósito
+    description: |
+      Geração e entrega de extratos de contas de depósito.
+  BC-1330.20:
+    name: Gestão de produtos de poupança
+    description: |
+      Poupança, poupança regular, ISAs e produtos com benefícios fiscais.
+  BC-1330.20.10:
+    name: Operações de poupança de acesso imediato
+    description: |
+      Operação de contas de poupança de acesso imediato e com aviso prévio.
+  BC-1330.20.20:
+    name: Operações de planos de poupança regular
+    description: |
+      Operação de planos de poupança regular e ordens de transferência periódica.
+  BC-1330.20.30:
+    name: Operações de poupança com benefícios fiscais
+    description: |
+      Operações de ISA, IRA e equivalentes com benefícios fiscais.
+  BC-1330.30:
+    name: Gestão de depósitos a prazo
+    description: |
+      Depósitos a prazo, CDs e depósitos estruturados.
+  BC-1330.30.10:
+    name: Contratação de depósito a prazo
+    description: |
+      Contratação e confirmação de depósitos a prazo.
+  BC-1330.30.20:
+    name: Gestão do vencimento de depósito a prazo
+    description: |
+      Gestão do vencimento, renovação automática e opções de renovação.
+  BC-1330.30.30:
+    name: Operações de depósitos estruturados
+    description: |
+      Operação de depósitos estruturados e em dupla divisa.
+  BC-1330.30.40:
+    name: Levantamento antecipado e cálculo de penalizações
+    description: |
+      Gestão de levantamentos antecipados e cálculo de penalizações por quebra.
+  BC-1330.40:
+    name: Gestão do ciclo de vida de contas
+    description: |
+      Abertura, dormência e encerramento de contas.
+  BC-1330.40.10:
+    name: Operações de abertura de conta
+    description: |
+      Abertura operacional de novas contas de depósito.
+  BC-1330.40.20:
+    name: Gestão de dormência
+    description: |
+      Identificação e tratamento de contas dormentes.
+  BC-1330.40.30:
+    name: Operações de encerramento de conta
+    description: |
+      Operações de encerramento de conta e liquidação final.
+  BC-1330.40.40:
+    name: Comunicação de saldos não reclamados
+    description: |
+      Reporte e remessa de saldos não reclamados.
+  BC-1330.50:
+    name: Gestão de preços e juros de depósitos
+    description: |
+      Taxas de juro, extratos e acréscimos.
+  BC-1330.50.10:
+    name: Definição de taxas de juro de depósito
+    description: |
+      Definição de taxas de juro de depósito e tabelas de taxas.
+  BC-1330.50.20:
+    name: Acréscimo e cálculo de juros
+    description: |
+      Acréscimo diário de juros e creditação periódica de juros.
+  BC-1330.50.30:
+    name: Retenção fiscal sobre juros
+    description: |
+      Retenção fiscal sobre juros de depósito e respetivo reporte.
+  BC-1330.50.40:
+    name: Reporte ao fundo de garantia de depósitos
+    description: |
+      Reporte ao regime de garantia de depósitos e contribuições.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-design-management.yaml
+++ b/catalogue/i18n/pt/L1-design-management.yaml
@@ -1,0 +1,119 @@
+locale: pt
+source: L1-design-management.yaml
+entries:
+  BC-1120:
+    name: Gestão do design
+    description: |
+      Ciclo de vida do design de engenharia desde o conceito até ao design detalhado e verificação.
+  BC-1120.10:
+    name: Gestão do design conceptual
+    description: |
+      Estudos de conceito, viabilidade, análise de opções e pré-FEED.
+  BC-1120.10.10:
+    name: Definição do estudo de conceito
+    description: |
+      Âmbito do estudo de conceito, base de design e premissas.
+  BC-1120.10.20:
+    name: Análise de viabilidade
+    description: |
+      Análise de viabilidade técnica, de cronograma e económica.
+  BC-1120.10.30:
+    name: Análise e seleção de opções
+    description: |
+      Análise multicriterial de opções e seleção do conceito.
+  BC-1120.20:
+    name: Gestão do design de engenharia de fase inicial
+    description: |
+      FEED, engenharia básica, definição do âmbito e custo.
+  BC-1120.20.10:
+    name: Design de engenharia básica
+    description: |
+      Engenharia básica das disciplinas de processo, mecânica e elétrica.
+  BC-1120.20.20:
+    name: Estimativa de custo e cronograma do FEED
+    description: |
+      Estimativas de custo e cronograma de Classe 3/Classe 2 a partir do FEED.
+  BC-1120.20.30:
+    name: Produção de entregáveis do FEED
+    description: |
+      Produção de entregáveis do FEED e base de design.
+  BC-1120.30:
+    name: Gestão do design detalhado
+    description: |
+      Engenharia detalhada, desenhos de execução, especificações e mapa de quantidades.
+  BC-1120.30.10:
+    name: Cálculos detalhados de engenharia
+    description: |
+      Cálculos e análises detalhadas de disciplina.
+  BC-1120.30.20:
+    name: Produção de desenhos de execução
+    description: |
+      Produção de desenhos emitidos para construção.
+  BC-1120.30.30:
+    name: Elaboração de especificações detalhadas
+    description: |
+      Elaboração de especificações detalhadas de equipamentos e materiais.
+  BC-1120.30.40:
+    name: Produção do mapa de quantidades
+    description: |
+      Produção e gestão do mapa de quantidades para aprovisionamento e construção.
+  BC-1120.40:
+    name: Gestão de revisão e verificação do design
+    description: |
+      HAZOP, revisões de design, verificação e validação.
+  BC-1120.40.10:
+    name: Workshops HAZOP e HAZID
+    description: |
+      Identificação de perigos e facilitação de workshops HAZOP.
+  BC-1120.40.20:
+    name: Portais de revisão de design
+    description: |
+      Revisões de design por portal de fase (30%, 60%, 90%).
+  BC-1120.40.30:
+    name: Verificação do design
+    description: |
+      Verificação do design face aos requisitos e normas.
+  BC-1120.40.40:
+    name: Validação do design
+    description: |
+      Validação do design face ao uso pretendido e necessidades do cliente.
+  BC-1120.50:
+    name: Gestão de software de design e CAD
+    description: |
+      Ferramentas CAD/CAE, modelação 3D, BIM e ambiente de design digital.
+  BC-1120.50.10:
+    name: Gestão de normas CAD
+    description: |
+      Normas CAD, esquemas de camadas e bibliotecas de modelos.
+  BC-1120.50.20:
+    name: Gestão de modelos 3D
+    description: |
+      Gestão de modelos 3D integrados entre disciplinas.
+  BC-1120.50.30:
+    name: Gestão do ambiente BIM
+    description: |
+      Ambiente de dados comuns BIM e alinhamento com ISO 19650.
+  BC-1120.50.40:
+    name: Administração de software de engenharia
+    description: |
+      Administração e licenciamento de ferramentas de software de engenharia.
+  BC-1120.60:
+    name: Gestão de coordenação multidisciplinar de design
+    description: |
+      Coordenação interdisciplinar, deteção de interferências e gestão de modelos integrados.
+  BC-1120.60.10:
+    name: Deteção de interferências
+    description: |
+      Deteção de interferências entre modelos 3D de disciplinas.
+  BC-1120.60.20:
+    name: Coordenação do modelo integrado
+    description: |
+      Coordenação de modelos integrados multidisciplinares.
+  BC-1120.60.30:
+    name: Resolução de problemas de design
+    description: |
+      Resolução de problemas de coordenação de design.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-developer-platform-api-ecosystem-management.yaml
+++ b/catalogue/i18n/pt/L1-developer-platform-api-ecosystem-management.yaml
@@ -1,0 +1,161 @@
+locale: pt
+source: L1-developer-platform-api-ecosystem-management.yaml
+entries:
+  BC-4270:
+    name: Gestão da plataforma de desenvolvedor e ecossistema de API
+    description: |
+      APIs públicas, SDKs, portal de desenvolvedor, identidade de desenvolvedor,
+      governação do consumo de API, aplicações de parceiros, listagens em
+      mercados de software e subscrições de webhooks de saída para o ecossistema
+      SaaS.
+  BC-4270.10:
+    name: Gestão do ciclo de vida de APIs públicas
+    description: |
+      Especificação, versionamento e descontinuação de APIs públicas expostas
+      a desenvolvedores externos.
+  BC-4270.10.10:
+    name: Elaboração de especificações de API
+    description: |
+      Elaboração e revisão de especificações de API públicas em formato
+      legível por máquina.
+  BC-4270.10.20:
+    name: Versionamento de API
+    description: |
+      Versionamento de APIs públicas com garantias de compatibilidade
+      documentadas.
+  BC-4270.10.30:
+    name: Gestão de descontinuação de API
+    description: |
+      Comunicação e execução de descontinuações de API com aviso adequado.
+  BC-4270.20:
+    name: Gestão de SDK e bibliotecas cliente
+    description: |
+      Geração, cobertura de linguagens e manutenção de amostras de SDKs e
+      bibliotecas cliente que encapsulam APIs públicas.
+  BC-4270.20.10:
+    name: Geração e lançamento de SDK
+    description: |
+      Geração e lançamento de SDKs alinhados com as versões de API.
+  BC-4270.20.20:
+    name: Gestão de cobertura de linguagens de SDK
+    description: |
+      Seleção e gestão de linguagens e runtimes de SDK suportados.
+  BC-4270.20.30:
+    name: Manutenção de amostras de SDK
+    description: |
+      Manutenção de amostras de código de SDK e projetos de arranque.
+  BC-4270.30:
+    name: Gestão do portal de desenvolvedor
+    description: |
+      Documentação, referências interativas e fluxos de integração que
+      ajudam os desenvolvedores a integrar com a plataforma.
+  BC-4270.30.10:
+    name: Elaboração de documentação para desenvolvedores
+    description: |
+      Elaboração de documentação conceptual, de tarefas e de referência
+      para desenvolvedores.
+  BC-4270.30.20:
+    name: Referência interativa de API
+    description: |
+      Operação de referências interativas de API e experiências de
+      experimentação imediata.
+  BC-4270.30.30:
+    name: Integração de desenvolvedores
+    description: |
+      Fluxos de integração que levam os desenvolvedores do registo à
+      primeira chamada de API bem-sucedida.
+  BC-4270.40:
+    name: Gestão de identidade e credenciais de desenvolvedor
+    description: |
+      Emissão e gestão de credenciais de desenvolvedor, clientes OAuth e
+      identidade federada de desenvolvedor.
+  BC-4270.40.10:
+    name: Emissão de chaves de API
+    description: |
+      Emissão, rotação e revogação de chaves de API de desenvolvedor.
+  BC-4270.40.20:
+    name: Registo de clientes OAuth
+    description: |
+      Registo e gestão de aplicações cliente OAuth.
+  BC-4270.40.30:
+    name: Federação de identidade de desenvolvedor
+    description: |
+      Federação de identidade de desenvolvedor a partir de fornecedores de
+      identidade externos.
+  BC-4270.50:
+    name: Governação do consumo de API
+    description: |
+      Quotas, limites de taxa, análise de utilização e mapeamento do consumo
+      de API para níveis de plano comercial.
+  BC-4270.50.10:
+    name: Gestão de quotas e limites de taxa de API
+    description: |
+      Definição e aplicação de quotas e limites de taxa de API por consumidor.
+  BC-4270.50.20:
+    name: Análise de utilização de API
+    description: |
+      Análise dos padrões de consumo de API por endpoint, consumidor e plano.
+  BC-4270.50.30:
+    name: Mapeamento de níveis de plano de API
+    description: |
+      Mapeamento de níveis de acesso à API para planos de subscrição e direitos.
+  BC-4270.60:
+    name: Gestão do programa de aplicações de parceiros
+    description: |
+      Gestão de aplicações de parceiros terceiros, incluindo listagem,
+      certificação e partilha de receita.
+  BC-4270.60.10:
+    name: Gestão de listagem de aplicações de parceiros
+    description: |
+      Listagem de aplicações de parceiros no diretório de aplicações da plataforma.
+  BC-4270.60.20:
+    name: Certificação de aplicações de parceiros
+    description: |
+      Certificação de aplicações de parceiros face a padrões de segurança
+      e qualidade.
+  BC-4270.60.30:
+    name: Partilha de receita de aplicações de parceiros
+    description: |
+      Acordos de partilha de receita com desenvolvedores de aplicações de parceiros.
+  BC-4270.70:
+    name: Gestão de listagem em mercados de software
+    description: |
+      Listagem e gestão da oferta SaaS em mercados de software de terceiros
+      e em mercados de cloud.
+  BC-4270.70.10:
+    name: Elaboração de listagens em mercados
+    description: |
+      Elaboração de listagens em mercados, incluindo metadados, preços e
+      recursos.
+  BC-4270.70.20:
+    name: Manutenção de listagens em mercados
+    description: |
+      Manutenção contínua das listagens em mercados à medida que a oferta evolui.
+  BC-4270.70.30:
+    name: Coordenação de co-venda em mercados
+    description: |
+      Coordenação de processos de co-venda com operadores de mercados.
+  BC-4270.80:
+    name: Gestão de webhooks e subscrições de eventos
+    description: |
+      Ciclo de vida das subscrições de webhooks de saída, esquemas de eventos
+      e fiabilidade de entrega.
+  BC-4270.80.10:
+    name: Ciclo de vida das subscrições de webhooks
+    description: |
+      Ciclo de vida das subscrições de webhooks de saída desde o registo
+      até à retirada.
+  BC-4270.80.20:
+    name: Catálogo de esquemas de eventos
+    description: |
+      Catálogo de esquemas de eventos de saída e as respetivas garantias
+      de compatibilidade.
+  BC-4270.80.30:
+    name: Gestão de fiabilidade de entrega de webhooks
+    description: |
+      Gestão de novas tentativas, recuo e tratamento de mensagens mortas para
+      entrega de webhooks de saída.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-diagnostic-services-management.yaml
+++ b/catalogue/i18n/pt/L1-diagnostic-services-management.yaml
@@ -1,0 +1,148 @@
+locale: pt
+source: L1-diagnostic-services-management.yaml
+entries:
+  BC-2860:
+    name: Gestão de serviços de diagnóstico
+    description: |
+      Laboratório, anatomia patológica, imagiologia de diagnóstico, diagnósticos
+      cardiopulmonares, testes point-of-care e gestão end-to-end de resultados de
+      diagnóstico.
+  BC-2860.10:
+    name: Gestão de serviços laboratoriais
+    description: |
+      Colheita de amostras, bioquímica clínica, hematologia, microbiologia, testes
+      moleculares e operações do sistema de informação laboratorial.
+  BC-2860.10.10:
+    name: Colheita e transporte de amostras
+    description: |
+      Flebotomia, colheita de amostras e logística de transporte.
+  BC-2860.10.20:
+    name: Bioquímica clínica e hematologia
+    description: |
+      Operações de bioquímica clínica, hematologia e testes de coagulação.
+  BC-2860.10.30:
+    name: Microbiologia e testes moleculares
+    description: |
+      Testes de diagnóstico de microbiologia, virologia e molecular.
+  BC-2860.10.40:
+    name: Operações do sistema de informação laboratorial
+    description: |
+      Operação do sistema de informação laboratorial e interfaces com equipamentos.
+  BC-2860.20:
+    name: Serviços de anatomia patológica
+    description: |
+      Operações de histologia, citologia, anatomia patológica cirúrgica e patologia
+      digital.
+  BC-2860.20.10:
+    name: Processamento histológico
+    description: |
+      Processamento, inclusão, corte e coloração de tecidos para histologia.
+  BC-2860.20.20:
+    name: Serviços de citologia
+    description: |
+      Preparação, rastreio e reporte de amostras citológicas.
+  BC-2860.20.30:
+    name: Reporte de anatomia patológica cirúrgica
+    description: |
+      Interpretação e reporte pelo patologista de casos de anatomia patológica
+      cirúrgica.
+  BC-2860.20.40:
+    name: Operações de patologia digital
+    description: |
+      Aquisição, armazenamento e fluxo de trabalho de imagem de lâmina completa
+      em patologia digital.
+  BC-2860.30:
+    name: Serviços de imagiologia de diagnóstico
+    description: |
+      Aquisição, leitura, arquivo e gestão de dose para modalidades de imagiologia
+      de diagnóstico.
+  BC-2860.30.10:
+    name: Aquisição de imagens
+    description: |
+      Aquisição de exames de imagiologia em radiografia, TC, RMN, ecografia e
+      medicina nuclear.
+  BC-2860.30.20:
+    name: Leitura e reporte de imagens
+    description: |
+      Leitura e reporte estruturado de estudos de imagiologia pelo radiologista.
+  BC-2860.30.30:
+    name: Operações de arquivo de imagens
+    description: |
+      Operação de arquivos de imagiologia e troca de imagens entre unidades.
+  BC-2860.30.40:
+    name: Gestão da dose de radiação
+    description: |
+      Acompanhamento, optimização e reporte da dose de radiação ao doente.
+  BC-2860.40:
+    name: Diagnósticos de cardiologia e cardiopulmonar
+    description: |
+      Serviços de electrocardiografia, ecocardiografia, cateterismo cardíaco e
+      testes de função pulmonar.
+  BC-2860.40.10:
+    name: Electrocardiografia e telemetria
+    description: |
+      Aquisição de electrocardiograma, monitorização de telemetria e interpretação
+      de arritmias.
+  BC-2860.40.20:
+    name: Ecocardiografia
+    description: |
+      Serviços de ecocardiografia transtorácica, transesofágica e de esforço.
+  BC-2860.40.30:
+    name: Cateterismo cardíaco
+    description: |
+      Serviços de cateterismo cardíaco de diagnóstico e estudos electrofisiológicos.
+  BC-2860.40.40:
+    name: Testes de função pulmonar
+    description: |
+      Espirometria, volumes pulmonares, difusão e testes de função pulmonar de
+      esforço.
+  BC-2860.50:
+    name: Testes point-of-care
+    description: |
+      Governação, controlo de qualidade, competência do operador e integração de
+      resultados para testes point-of-care em toda a organização.
+  BC-2860.50.10:
+    name: Gestão de dispositivos point-of-care
+    description: |
+      Gestão do inventário e ciclo de vida de dispositivos de teste point-of-care.
+  BC-2860.50.20:
+    name: Controlo de qualidade point-of-care
+    description: |
+      Controlo de qualidade e testes de proficiência para dispositivos point-of-care.
+  BC-2860.50.30:
+    name: Gestão de competência do operador
+    description: |
+      Certificação e avaliação de competência dos operadores em testes
+      point-of-care.
+  BC-2860.50.40:
+    name: Integração de resultados point-of-care
+    description: |
+      Integração de resultados point-of-care no registo laboratorial e no processo
+      clínico.
+  BC-2860.60:
+    name: Gestão de resultados de diagnóstico
+    description: |
+      Validação, distribuição e gestão de regras de reflexo para resultados de
+      diagnóstico em todas as modalidades.
+  BC-2860.60.10:
+    name: Validação de resultados
+    description: |
+      Validação técnica e clínica de resultados de diagnóstico.
+  BC-2860.60.20:
+    name: Notificação de valores críticos
+    description: |
+      Notificação com prazo definido de valores críticos aos prestadores
+      solicitantes.
+  BC-2860.60.30:
+    name: Distribuição de resultados
+    description: |
+      Distribuição de resultados aos prestadores solicitantes, doentes e sistemas
+      externos.
+  BC-2860.60.40:
+    name: Regras de testes de reflexo
+    description: |
+      Redacção e operação de regras de testes de reflexo e lógica de adição.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-distributed-energy-resource-management.yaml
+++ b/catalogue/i18n/pt/L1-distributed-energy-resource-management.yaml
@@ -1,0 +1,154 @@
+locale: pt
+source: L1-distributed-energy-resource-management.yaml
+entries:
+  BC-3840:
+    name: Gestão de recursos de energia distribuída
+    description: |
+      Integração, agregação e coordenação operacional de recursos de
+      energia distribuída ligados à rede de distribuição — solar em
+      cobertura, armazenamento atrás do contador, resposta à procura,
+      carregamento de veículos elétricos e microrredes — e a sua
+      participação em mercados grossistas e de flexibilidade.
+  BC-3840.10:
+    name: Registo e integração de recursos de energia distribuída
+    description: |
+      Registo de recursos de energia distribuída, qualificação técnica
+      e aceitação de ligação ao abrigo das regras IEEE 1547 / Requisitos
+      da UE para Geradores.
+  BC-3840.10.10:
+    name: Avaliação de candidaturas de recursos de energia distribuída
+    description: |
+      Avaliação de candidaturas de ligação de recursos de energia
+      distribuída contra a capacidade de acolhimento.
+  BC-3840.10.20:
+    name: Qualificação técnica de recursos de energia distribuída
+    description: |
+      Ensaio de tipo e verificação no local da capacidade e proteções
+      de recursos de energia distribuída.
+  BC-3840.10.30:
+    name: Manutenção do registo de recursos de energia distribuída
+    description: |
+      Manutenção do registo de ativos de energia distribuída ligados
+      e respetivas capacidades.
+  BC-3840.20:
+    name: Operações de central elétrica virtual
+    description: |
+      Agregação e despacho de recursos distribuídos como entidade operacional
+      única em mercados grossistas e de balanceamento.
+  BC-3840.20.10:
+    name: Gestão do portfólio de central elétrica virtual
+    description: |
+      Composição e reequilíbrio do portfólio de central elétrica virtual
+      por classes de ativos.
+  BC-3840.20.20:
+    name: Operações de despacho de central elétrica virtual
+    description: |
+      Instruções de despacho em tempo real para ativos de energia distribuída
+      agregados.
+  BC-3840.20.30:
+    name: Liquidação do desempenho de central elétrica virtual
+    description: |
+      Liquidação do desempenho de central elétrica virtual contra
+      compromissos de mercado e bilaterais.
+  BC-3840.30:
+    name: Operações de resposta à procura
+    description: |
+      Recrutamento, despacho e liquidação de programas de resposta do lado
+      da procura para clientes residenciais, comerciais e industriais.
+  BC-3840.30.10:
+    name: Inscrição no programa de resposta à procura
+    description: |
+      Inscrição de clientes e gestão do consentimento para programas de
+      resposta à procura.
+  BC-3840.30.20:
+    name: Despacho de eventos de resposta à procura
+    description: |
+      Despacho de eventos de resposta à procura e instruções de
+      curtailment a clientes participantes.
+  BC-3840.30.30:
+    name: Verificação do desempenho da resposta à procura
+    description: |
+      Verificação da entrega de resposta à procura contra as linhas de
+      base dos clientes.
+  BC-3840.40:
+    name: Gestão da integração de veículos elétricos na rede
+    description: |
+      Gestão da interação do carregamento de veículos elétricos com a
+      rede elétrica, incluindo carregamento gerido, V2G e tarifas
+      específicas para veículos elétricos.
+  BC-3840.40.10:
+    name: Operações de carregamento gerido
+    description: |
+      Operação de esquemas de carregamento gerido e inteligente para
+      frotas e residências de veículos elétricos.
+  BC-3840.40.20:
+    name: Coordenação de veículo para rede
+    description: |
+      Coordenação da descarga bidirecional V2G para a rede ou atrás
+      do contador.
+  BC-3840.40.30:
+    name: Análise de capacidade de acolhimento de veículos elétricos
+    description: |
+      Análise de capacidade de acolhimento ao nível do alimentador
+      para penetração do carregamento de veículos elétricos.
+  BC-3840.50:
+    name: Coordenação de armazenamento atrás do contador
+    description: |
+      Coordenação da participação de armazenamento em bateria atrás do
+      contador em programas de serviço público e serviços de rede elétrica.
+  BC-3840.50.10:
+    name: Inscrição de bateria atrás do contador
+    description: |
+      Inscrição e consentimento para participação de bateria atrás
+      do contador.
+  BC-3840.50.20:
+    name: Despacho de armazenamento atrás do contador
+    description: |
+      Instruções de despacho para ativos de armazenamento atrás do contador.
+  BC-3840.50.30:
+    name: Rastreio do desempenho do armazenamento atrás do contador
+    description: |
+      Rastreio da entrega de bateria atrás do contador contra compromissos
+      do serviço público.
+  BC-3840.60:
+    name: Previsão de recursos de energia distribuída
+    description: |
+      Previsão de curto prazo de geração distribuída e carga flexível que
+      contribui para calendários do operador de sistema e de mercado.
+  BC-3840.60.10:
+    name: Previsão solar atrás do contador
+    description: |
+      Previsão de geração fotovoltaica atrás do contador ao nível do
+      alimentador e zonal.
+  BC-3840.60.20:
+    name: Previsão de carga flexível
+    description: |
+      Previsão de perfis de carregamento de veículos elétricos e de
+      carga flexível.
+  BC-3840.60.30:
+    name: Monitorização do desempenho de previsão de recursos de energia distribuída
+    description: |
+      Monitorização do viés e capacidade de previsão contra valores reais.
+  BC-3840.70:
+    name: Operações de microrredes
+    description: |
+      Operação de microrredes de serviço público e de clientes, incluindo
+      modos ligado à rede e em ilha e controlo de transição sem descontinuidade.
+  BC-3840.70.10:
+    name: Operações de controlador de microrrede
+    description: |
+      Operação de controladores de microrredes e despacho de recursos internos.
+  BC-3840.70.20:
+    name: Operações de transição para modo de ilha
+    description: |
+      Transições planeadas e de emergência entre operação ligada à rede
+      e em ilha.
+  BC-3840.70.30:
+    name: Exercícios de resiliência de microrredes
+    description: |
+      Exercícios de resiliência e simulações de transição sem descontinuidade
+      para microrredes de carga crítica.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-drilling-wells-management.yaml
+++ b/catalogue/i18n/pt/L1-drilling-wells-management.yaml
@@ -1,0 +1,174 @@
+locale: pt
+source: L1-drilling-wells-management.yaml
+entries:
+  BC-3020:
+    name: Gestão de perfuração e poços
+    description: |
+      Engenharia, execução e integridade ao longo da vida dos poços — desde a
+      concepção e operações de perfuração até às completações, intervenções,
+      workover e controlo de poços.
+  BC-3020.10:
+    name: Engenharia e concepção de poços
+    description: |
+      Concepção da arquitectura do poço, revestimentos, tubagem, fluidos de
+      perfuração e estimativas de custos para programas de perfuração.
+  BC-3020.10.10:
+    name: Concepção da arquitectura do poço
+    description: |
+      Concepção da trajectória, secções do furo e arquitectura geral do poço.
+  BC-3020.10.20:
+    name: Concepção de revestimentos e tubagem
+    description: |
+      Concepção de colunas de revestimento, liner e tubagem, incluindo verificações
+      de tensão e rebentamento-colapso.
+  BC-3020.10.30:
+    name: Concepção de fluidos de perfuração
+    description: |
+      Selecção do sistema de lama e concepção reológica para secções de perfuração.
+  BC-3020.10.40:
+    name: Estimativa de custos do poço
+    description: |
+      Estimativa de custos para autorização de despesas de programas de perfuração
+      e completação.
+  BC-3020.20:
+    name: Gestão de operações de perfuração
+    description: |
+      Execução de operações de perfuração, incluindo coordenação de sondas,
+      monitorização em tempo real, perfuração direccional e cimentação.
+    in_scope:
+      - Supervisão de perfuração na sonda
+      - Monitorização de dados de perfuração em tempo real
+      - Perfuração direccional e com pressão gerida
+      - Operações de cimentação e passagem de revestimentos
+    out_of_scope:
+      - Instalação de completações (BC-3020.30)
+      - Segurança de processo em instalações de perfuração (BC-3050)
+  BC-3020.20.10:
+    name: Coordenação de operações da sonda
+    description: |
+      Coordenação do quotidiano das operações da sonda e actividades dos
+      empreiteiros.
+  BC-3020.20.20:
+    name: Monitorização de perfuração em tempo real
+    description: |
+      Monitorização de dados de perfuração em tempo real a partir de centros de
+      suporte operacional.
+  BC-3020.20.30:
+    name: Execução de perfuração direccional
+    description: |
+      Execução de perfuração direccional, horizontal e de alcance alargado.
+  BC-3020.20.40:
+    name: Operações de fluidos de perfuração
+    description: |
+      Engenharia de lamas, tratamento e controlo de sólidos durante a perfuração.
+  BC-3020.20.50:
+    name: Operações de cimentação
+    description: |
+      Operações de cimentação primária e remediadora.
+  BC-3020.30:
+    name: Gestão de completações de poços
+    description: |
+      Concepção e instalação de completações, incluindo operações de perforação e
+      estimulação.
+  BC-3020.30.10:
+    name: Concepção de completação
+    description: |
+      Concepção de completações superiores e inferiores, incluindo controlo de
+      areia quando aplicável.
+  BC-3020.30.20:
+    name: Instalação de completação
+    description: |
+      Passagem e instalação de colunas de completação e acessórios.
+  BC-3020.30.30:
+    name: Operações de perforação
+    description: |
+      Selecção de canhão de perforação e execução para estabelecer vias de fluxo.
+  BC-3020.30.40:
+    name: Operações de estimulação
+    description: |
+      Fracturação hidráulica, acidificação e outros tratamentos de estimulação.
+  BC-3020.40:
+    name: Gestão de intervenções e workovers em poços
+    description: |
+      Intervenções ao longo da vida do poço, desde operações de wireline até
+      workovers completos.
+  BC-3020.40.10:
+    name: Operações de coiled tubing
+    description: |
+      Operações de intervenção com coiled tubing.
+  BC-3020.40.20:
+    name: Operações de wireline e slickline
+    description: |
+      Aquisição de dados e operações de intervenção por wireline e slickline.
+  BC-3020.40.30:
+    name: Operações de workover
+    description: |
+      Operações de workover major em poços produtores e injectores.
+  BC-3020.40.40:
+    name: Intervenções através da tubagem
+    description: |
+      Intervenções remediatórias e de estimulação através da tubagem de produção.
+  BC-3020.50:
+    name: Gestão da integridade dos poços
+    description: |
+      Verificação e vigilância das barreiras dos poços ao longo da vida, incluindo
+      gestão de pressão de espaço anular e pressão sustentada no revestimento.
+  BC-3020.50.10:
+    name: Verificação de barreiras do poço
+    description: |
+      Verificação das barreiras primárias e secundárias do poço segundo as normas
+      de integridade.
+  BC-3020.50.20:
+    name: Monitorização de pressão de espaço anular
+    description: |
+      Monitorização contínua e periódica das pressões do espaço anular dos poços.
+  BC-3020.50.30:
+    name: Avaliação de risco de integridade dos poços
+    description: |
+      Avaliação de risco do estado de integridade dos poços no portefólio.
+  BC-3020.50.40:
+    name: Gestão de pressão sustentada no revestimento
+    description: |
+      Diagnóstico e gestão de eventos de pressão sustentada no revestimento.
+  BC-3020.60:
+    name: Gestão do controlo de poços
+    description: |
+      Prevenção e resposta a eventos de controlo de poços, incluindo detecção de
+      influxos, operações de preventor de erupções e competência em controlo de
+      poços.
+  BC-3020.60.10:
+    name: Detecção e resposta a influxos
+    description: |
+      Metodologias de detecção de influxos e procedimentos de resposta ao controlo
+      de poços.
+  BC-3020.60.20:
+    name: Operações de preventor de erupções
+    description: |
+      Operação, teste funcional e manutenção de preventores de erupções.
+  BC-3020.60.30:
+    name: Garantia de competência em controlo de poços
+    description: |
+      Coordenação de programas de competência IWCF e IADC WellCAP.
+  BC-3020.70:
+    name: Gestão de empreiteiros de perfuração
+    description: |
+      Garantia, gestão do desempenho e supervisão contratual de empreiteiros de
+      sondas e serviços de perfuração.
+  BC-3020.70.10:
+    name: Garantia e auditoria de sondas
+    description: |
+      Auditoria de pré-aceitação e em serviço de sondas de perfuração e
+      empreiteiros.
+  BC-3020.70.20:
+    name: Gestão do desempenho do empreiteiro de perfuração
+    description: |
+      Gestão do desempenho face a contratos de sonda e KPIs de serviço.
+  BC-3020.70.30:
+    name: Gestão de contratos de serviços de perfuração
+    description: |
+      Gestão de contratos de linhas de serviço de perfuração (lamas, cimentação,
+      direcional, etc.).
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-driver-crew-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-driver-crew-operations-management.yaml
@@ -1,0 +1,109 @@
+locale: pt
+source: L1-driver-crew-operations-management.yaml
+entries:
+  BC-2440:
+    name: Gestão de operações de condutor e tripulação
+    description: |
+      Qualificação, escalonamento, conformidade com horas de serviço, gestão da
+      fadiga e desempenho de condutores e tripulações de operação em modos
+      rodoviário, ferroviário, marítimo e aéreo.
+  BC-2440.10:
+    name: Gestão de qualificação de condutor e tripulação
+    description: |
+      Manutenção de licenças, habilitações, ratings e registos de aptidão médica
+      de condutores e tripulações.
+    in_scope:
+      - Qualificações profissionais CDL, STCW, ATPL e equivalentes
+      - Registos de aptidão médica e psicológica
+    out_of_scope:
+      - Registos genéricos de RH e processamento salarial (BC-300)
+      - Competência de controlador de tráfego aéreo (BC-1290)
+  BC-2440.10.10:
+    name: Acompanhamento de licenças e habilitações
+    description: |
+      Acompanhamento de licenças profissionais, habilitações e datas de expiração.
+  BC-2440.10.20:
+    name: Gestão de ratings específicos por modo
+    description: |
+      Gestão de ratings específicos por modo, como habilitações STCW e ratings de
+      tipo de aeronave.
+  BC-2440.10.30:
+    name: Certificação médica e de aptidão física
+    description: |
+      Certificações médicas e de aptidão física periódicas para pessoal de
+      operação.
+  BC-2440.20:
+    name: Gestão de escalonamento e horários
+    description: |
+      Construção de escalas de serviço, sistemas de quartos e emparelhamentos de
+      tripulação face a restrições de serviço e regulamentares.
+  BC-2440.20.10:
+    name: Planeamento de escalas de serviço
+    description: |
+      Planeamento de escalas de serviço por base, depósito e serviço.
+  BC-2440.20.20:
+    name: Emparelhamento e rotação de tripulação
+    description: |
+      Emparelhamento e rotação de tripulações em viagens de vários dias ou múltiplas
+      etapas.
+  BC-2440.20.30:
+    name: Gestão de stand-by e reserva
+    description: |
+      Disposições de stand-by, reserva e cobertura de chamada.
+  BC-2440.30:
+    name: Gestão de horas de serviço e fadiga
+    description: |
+      Conformidade com as regras de horas de serviço e operação de sistemas de
+      gestão de risco de fadiga.
+  BC-2440.30.10:
+    name: Conformidade com horas de serviço
+    description: |
+      Registo e aplicação de limites de horas de serviço via tacógrafo, ELD e
+      equivalentes.
+  BC-2440.30.20:
+    name: Gestão do risco de fadiga
+    description: |
+      Operação de sistemas de gestão de risco de fadiga e modelação bio-matemática.
+  BC-2440.30.30:
+    name: Aplicação de períodos de descanso
+    description: |
+      Aplicação de períodos de descanso obrigatórios, layovers e limites semanais.
+  BC-2440.40:
+    name: Gestão do desempenho de condutor e tripulação
+    description: |
+      Pontuação de desempenho, formação e gestão de infrações de condutores e
+      tripulações.
+  BC-2440.40.10:
+    name: Pontuação de desempenho de condutor e tripulação
+    description: |
+      Pontuação do pessoal de operação face a KPIs de segurança, combustível e
+      serviço.
+  BC-2440.40.20:
+    name: Formação e treino recorrente
+    description: |
+      Formação, cursos de atualização e treino corretivo.
+  BC-2440.40.30:
+    name: Gestão de incidentes e infrações
+    description: |
+      Acompanhamento e resolução de incidentes operacionais e infrações a regras.
+  BC-2440.50:
+    name: Gestão de viagem e alojamento de tripulação
+    description: |
+      Viagem, alojamento e logística de mudança de tripulação para rotações
+      marítimas, aéreas e ferroviárias.
+  BC-2440.50.10:
+    name: Reserva de viagem de tripulação
+    description: |
+      Reserva de viagem de posicionamento para rotações de tripulação.
+  BC-2440.50.20:
+    name: Gestão de alojamento de tripulação
+    description: |
+      Gestão de hotel e alojamento para layover e rotação.
+  BC-2440.50.30:
+    name: Coordenação de mudança de tripulação
+    description: |
+      Coordenação de mudanças de tripulação em portos, aeroportos e depósitos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-drug-development-management.yaml
+++ b/catalogue/i18n/pt/L1-drug-development-management.yaml
@@ -1,0 +1,119 @@
+locale: pt
+source: L1-drug-development-management.yaml
+entries:
+  BC-1510:
+    name: Gestão de desenvolvimento de fármacos
+    description: |
+      Desenvolvimento pré-clínico e clínico em todas as fases.
+  BC-1510.10:
+    name: Gestão do desenvolvimento pré-clínico
+    description: |
+      Farmacologia, toxicologia e ADME pré-clínicos.
+  BC-1510.10.10:
+    name: Farmacologia pré-clínica
+    description: |
+      Estudos e modelação de farmacologia pré-clínica.
+  BC-1510.10.20:
+    name: Toxicologia pré-clínica
+    description: |
+      Estudos de toxicologia GLP para avaliação de segurança.
+  BC-1510.10.30:
+    name: Estudos ADME e PK
+    description: |
+      Estudos ADME e farmacocinéticos.
+  BC-1510.10.40:
+    name: Bioanálise pré-clínica
+    description: |
+      Desenvolvimento e análise de métodos bioanalíticos.
+  BC-1510.20:
+    name: Gestão do desenvolvimento clínico de fase I
+    description: |
+      Primeira administração em humanos, segurança e PK/PD.
+  BC-1510.20.10:
+    name: Realização do estudo de primeira administração em humanos
+    description: |
+      Planeamento e realização do estudo de primeira administração em humanos.
+  BC-1510.20.20:
+    name: Monitorização de segurança na fase I
+    description: |
+      Monitorização de segurança e escalada de dose na fase I.
+  BC-1510.20.30:
+    name: Modelação clínica PK/PD
+    description: |
+      Modelação clínica PK/PD e seleção de dose.
+  BC-1510.30:
+    name: Gestão do desenvolvimento clínico de fase II
+    description: |
+      Prova de conceito e determinação de dose.
+  BC-1510.30.10:
+    name: Estudos de prova de conceito de fase II
+    description: |
+      Realização de estudos de prova de conceito.
+  BC-1510.30.20:
+    name: Estudos de determinação de dose de fase II
+    description: |
+      Estudos de determinação e resposta à dose.
+  BC-1510.30.30:
+    name: Operações de ensaios adaptativos de fase II
+    description: |
+      Operação de desenhos adaptativos de fase II.
+  BC-1510.40:
+    name: Gestão do desenvolvimento clínico de fase III
+    description: |
+      Ensaios pivô e estudos de registo.
+  BC-1510.40.10:
+    name: Realização de ensaios de fase III
+    description: |
+      Realização de ensaios pivô de fase III.
+  BC-1510.40.20:
+    name: Análise estatística de ensaios pivô
+    description: |
+      Análise estatística de ensaios pivô conforme ICH E9.
+  BC-1510.40.30:
+    name: Reporte de ensaios pivô
+    description: |
+      Reporte e divulgação de resultados de ensaios pivô.
+  BC-1510.50:
+    name: Gestão do desenvolvimento de fase IV e pós-comercialização
+    description: |
+      Estudos pós-comercialização e evidência do mundo real.
+  BC-1510.50.10:
+    name: Estudos de compromisso pós-comercialização
+    description: |
+      Realização de estudos de compromisso e requisito pós-comercialização.
+  BC-1510.50.20:
+    name: Geração de evidência do mundo real
+    description: |
+      Geração de evidência do mundo real e estudos observacionais.
+  BC-1510.50.30:
+    name: Expansão de indicação ao longo do ciclo de vida
+    description: |
+      Desenvolvimento ao longo do ciclo de vida e expansão de indicações.
+  BC-1510.60:
+    name: Gestão do desenvolvimento CMC
+    description: |
+      Desenvolvimento de química, fabrico e controlos.
+  BC-1510.60.10:
+    name: Desenvolvimento da substância ativa
+    description: |
+      Desenvolvimento do processo de síntese da substância ativa.
+  BC-1510.60.20:
+    name: Desenvolvimento do medicamento
+    description: |
+      Desenvolvimento da forma farmacêutica e formulação do medicamento.
+  BC-1510.60.30:
+    name: Desenvolvimento de métodos analíticos
+    description: |
+      Desenvolvimento e validação de métodos analíticos.
+  BC-1510.60.40:
+    name: Gestão do programa de estabilidade
+    description: |
+      Programa de estabilidade alinhado com ICH Q1.
+  BC-1510.60.50:
+    name: Validação de processos
+    description: |
+      Validação de processos alinhada com ICH Q7-Q12.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-drug-discovery-management.yaml
+++ b/catalogue/i18n/pt/L1-drug-discovery-management.yaml
@@ -1,0 +1,119 @@
+locale: pt
+source: L1-drug-discovery-management.yaml
+entries:
+  BC-1500:
+    name: Gestão de descoberta de fármacos
+    description: |
+      Identificação de alvos, hit-to-lead e otimização de lead.
+  BC-1500.10:
+    name: Gestão de identificação e validação de alvos
+    description: |
+      Biologia da doença, identificação e validação de alvos.
+  BC-1500.10.10:
+    name: Investigação da biologia da doença
+    description: |
+      Investigação de mecanismos e vias de doenças.
+  BC-1500.10.20:
+    name: Identificação de alvos
+    description: |
+      Identificação de alvos biológicos através de ómica e genética.
+  BC-1500.10.30:
+    name: Validação de alvos
+    description: |
+      Validação de alvos em modelos in vitro e in vivo.
+  BC-1500.10.40:
+    name: Avaliação da druggabilidade do alvo
+    description: |
+      Avaliação da druggabilidade e tratabilidade do alvo.
+  BC-1500.20:
+    name: Gestão da descoberta de hits
+    description: |
+      Rastreio de alto rendimento, rastreio virtual e identificação de hits.
+  BC-1500.20.10:
+    name: Desenvolvimento de ensaios
+    description: |
+      Desenvolvimento de ensaios bioquímicos e celulares.
+  BC-1500.20.20:
+    name: Rastreio de alto rendimento
+    description: |
+      Execução de campanhas de rastreio de alto rendimento.
+  BC-1500.20.30:
+    name: Rastreio virtual e baseado em IA
+    description: |
+      Rastreio virtual e identificação de hits por IA.
+  BC-1500.20.40:
+    name: Triagem e confirmação de hits
+    description: |
+      Triagem, confirmação e priorização de hits de rastreio.
+  BC-1500.30:
+    name: Gestão de otimização de lead
+    description: |
+      Química medicinal, SAR e otimização de lead.
+  BC-1500.30.10:
+    name: Síntese de química medicinal
+    description: |
+      Síntese e conceção em química medicinal.
+  BC-1500.30.20:
+    name: Análise de relação estrutura-atividade
+    description: |
+      Análise SAR para orientar a otimização estrutural.
+  BC-1500.30.30:
+    name: Perfilagem ADMET
+    description: |
+      Perfilagem ADMET in vitro de séries de otimização.
+  BC-1500.30.40:
+    name: Seleção de séries lead
+    description: |
+      Seleção de séries lead em campanhas de otimização.
+  BC-1500.40:
+    name: Gestão da seleção de candidatos pré-clínicos
+    description: |
+      Seleção de candidatos e estudos de capacitação para IND.
+  BC-1500.40.10:
+    name: Perfilagem de candidatos pré-clínicos
+    description: |
+      Perfilagem de candidatos pré-clínicos face ao perfil do produto-alvo.
+  BC-1500.40.20:
+    name: Governação de nomeação de candidatos
+    description: |
+      Governação e nomeação de candidatos pré-clínicos.
+  BC-1500.40.30:
+    name: Coordenação de estudos de capacitação para IND
+    description: |
+      Coordenação de estudos de toxicologia e segurança de capacitação para IND.
+  BC-1500.50:
+    name: Gestão de investigação translacional
+    description: |
+      Ciência translacional e desenvolvimento de biomarcadores.
+  BC-1500.50.10:
+    name: Ciência translacional
+    description: |
+      Ciência translacional que une a descoberta ao desenvolvimento clínico.
+  BC-1500.50.20:
+    name: Descoberta e desenvolvimento de biomarcadores
+    description: |
+      Descoberta e desenvolvimento de biomarcadores.
+  BC-1500.50.30:
+    name: Estratégia de estratificação de doentes
+    description: |
+      Estratégias de estratificação de doentes para a conceção de ensaios.
+  BC-1500.60:
+    name: Gestão de compostos e bibliotecas
+    description: |
+      Bibliotecas de compostos, amostras e gestão de repositórios.
+  BC-1500.60.10:
+    name: Curadoria de bibliotecas de compostos
+    description: |
+      Curadoria e registo de bibliotecas de compostos.
+  BC-1500.60.20:
+    name: Gestão de amostras e repositórios
+    description: |
+      Armazenamento, recuperação e cadeia de custódia de amostras.
+  BC-1500.60.30:
+    name: Gestão de reagentes e materiais biológicos
+    description: |
+      Gestão de reagentes e materiais biológicos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-education-compliance-regulatory-reporting-management.yaml
+++ b/catalogue/i18n/pt/L1-education-compliance-regulatory-reporting-management.yaml
@@ -1,0 +1,153 @@
+locale: pt
+source: L1-education-compliance-regulatory-reporting-management.yaml
+entries:
+  BC-4810:
+    name: Gestão de conformidade e reporte regulatório em educação
+    description: |
+      Conformidade regulatória específica do setor educativo e reporte estatutário,
+      incluindo privacidade de dados de estudantes, regimes de direitos civis,
+      obrigações estatutárias de educação especial, conformidade de vistos de
+      estudantes internacionais e conformidade com financiamento público. Complementa
+      a Gestão de Conformidade transversal para obrigações regulatórias gerais.
+  BC-4810.10:
+    name: Conformidade com a privacidade de dados de estudantes
+    description: |
+      Conformidade com regimes de privacidade de dados de estudantes específicos
+      do setor, incluindo FERPA, COPPA e regimes equivalentes.
+    in_scope:
+      - Operações de conformidade FERPA
+      - Operações de conformidade COPPA
+      - Gestão de acordos de partilha de dados de estudantes
+    out_of_scope:
+      - Proteção de dados genérica (abrangida em Gestão de Informação e Dados transversal)
+  BC-4810.10.10:
+    name: Operações de conformidade FERPA
+    description: |
+      Conformidade FERPA do dia a dia, consentimentos e divulgações.
+  BC-4810.10.20:
+    name: Operações de conformidade COPPA
+    description: |
+      Conformidade COPPA para serviços destinados a crianças com menos de 13 anos.
+  BC-4810.10.30:
+    name: Gestão de acordos de partilha de dados de estudantes
+    description: |
+      Negociação e gestão de acordos de partilha de dados de estudantes com fornecedores.
+  BC-4810.20:
+    name: Reporte estatutário em educação
+    description: |
+      Submissão de estatísticas educativas estatutárias e relatórios de desempenho
+      a autoridades nacionais, estaduais e locais.
+    in_scope:
+      - Submissão de estatísticas nacionais (p. ex. IPEDS, HESA)
+      - Relatórios para autoridades educativas estaduais e locais
+      - Divulgação de financiamento e desempenho
+    out_of_scope:
+      - Reporte interno de desempenho (abrangido em Gestão de Qualidade Académica e Acreditação)
+  BC-4810.20.10:
+    name: Submissão de estatísticas nacionais
+    description: |
+      Submissão de relatórios a agências nacionais de estatísticas educativas.
+  BC-4810.20.20:
+    name: Relatórios para autoridades educativas estaduais e locais
+    description: |
+      Relatórios para autoridades educativas estaduais, provinciais e locais.
+  BC-4810.20.30:
+    name: Divulgação de financiamento e desempenho
+    description: |
+      Divulgação pública do uso de financiamento e métricas de desempenho educativo.
+  BC-4810.30:
+    name: Conformidade com direitos civis
+    description: |
+      Conformidade com regimes de direitos civis específicos da educação, incluindo
+      Title IX, Secção 504 e ADA no contexto académico.
+    in_scope:
+      - Investigação e reporte ao abrigo do Title IX
+      - Conformidade com a Secção 504 / ADA
+      - Aplicação de políticas de não discriminação
+    out_of_scope:
+      - Acomodações do dia a dia (abrangidas em Gestão de Apoio ao Estudante e Bem-Estar)
+  BC-4810.30.10:
+    name: Investigação e reporte ao abrigo do Title IX
+    description: |
+      Receção, investigação, audiência e reporte estatutário ao abrigo do Title IX.
+  BC-4810.30.20:
+    name: Conformidade com a Secção 504 / ADA
+    description: |
+      Conformidade com a Secção 504 e ADA no contexto académico e de admissões.
+  BC-4810.30.30:
+    name: Aplicação de políticas de não discriminação
+    description: |
+      Aplicação de políticas de não discriminação em educação e tratamento de reclamações.
+  BC-4810.40:
+    name: Conformidade com educação especial
+    description: |
+      Conformidade com regimes estatutários de educação especial para populações
+      em idade escolar e de intervenção precoce.
+    in_scope:
+      - Conformidade com a Parte B da IDEA
+      - Conformidade com a Parte C da IDEA / intervenção precoce
+      - Conformidade estatutária equivalente de NEE/ALN
+    out_of_scope:
+      - Prestação de serviços de educação especial (abrangida em Gestão de Apoio ao Estudante e Bem-Estar)
+  BC-4810.40.10:
+    name: Conformidade com a Parte B da IDEA
+    description: |
+      Conformidade estatutária com a Parte B da IDEA para educação especial em idade escolar.
+  BC-4810.40.20:
+    name: Conformidade com a Parte C da IDEA / intervenção precoce
+    description: |
+      Conformidade com a Parte C da IDEA para serviços de intervenção precoce.
+  BC-4810.40.30:
+    name: Conformidade estatutária equivalente de NEE e ALN
+    description: |
+      Conformidade estatutária equivalente de NEE, ALN e educação inclusiva fora dos EUA.
+  BC-4810.50:
+    name: Conformidade de estudantes internacionais
+    description: |
+      Conformidade de vistos e monitorização estatutária de estudantes internacionais
+      ao abrigo de regimes como o SEVIS e a Rota de Estudante do Reino Unido.
+    in_scope:
+      - Operações de conformidade SEVIS / I-20
+      - Reporte de vistos de estudante (Rota de Estudante do Reino Unido, equivalentes)
+      - Monitorização e reporte de estudantes internacionais
+    out_of_scope:
+      - Emissão inicial de documentação de apoio ao visto (abrangida em Gestão de Recrutamento e Admissões de Estudantes)
+  BC-4810.50.10:
+    name: Operações de conformidade SEVIS / I-20
+    description: |
+      Conformidade SEVIS e I-20 do dia a dia para estudantes patrocinados nos EUA.
+  BC-4810.50.20:
+    name: Reporte de vistos de estudante
+    description: |
+      Reporte estatutário sobre estudantes patrocinados ao abrigo de regimes de visto fora dos EUA.
+  BC-4810.50.30:
+    name: Monitorização de estudantes internacionais
+    description: |
+      Monitorização do estado, presença e morada de estudantes internacionais, conforme exigido pelos deveres de patrocínio.
+  BC-4810.60:
+    name: Conformidade com financiamento público / Title IV
+    description: |
+      Conformidade com regimes de apoio financeiro a estudantes e financiamento
+      educativo público, incluindo o Title IV nos EUA e regimes equivalentes noutros países.
+    in_scope:
+      - Conformidade de elegibilidade e desembolso ao abrigo do Title IV
+      - Devolução de fundos e reconciliação de apoio financeiro
+      - Resposta a auditorias de financiamento público
+    out_of_scope:
+      - Atribuição de ofertas de apoio financeiro (abrangida em Gestão de Recrutamento e Admissões de Estudantes)
+  BC-4810.60.10:
+    name: Conformidade de elegibilidade e desembolso ao abrigo do Title IV
+    description: |
+      Conformidade de elegibilidade institucional ao abrigo do Title IV e desembolso de apoio financeiro a estudantes.
+  BC-4810.60.20:
+    name: Devolução de fundos e reconciliação de apoio financeiro
+    description: |
+      Reconciliação e devolução de apoio financeiro não ganho, conforme exigido pelos regimes de financiamento.
+  BC-4810.60.30:
+    name: Resposta a auditorias de financiamento público
+    description: |
+      Resposta a auditorias e revisões de apoio financeiro público a estudantes e financiamento educativo.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-educational-content-learning-resource-management.yaml
+++ b/catalogue/i18n/pt/L1-educational-content-learning-resource-management.yaml
@@ -1,0 +1,151 @@
+locale: pt
+source: L1-educational-content-learning-resource-management.yaml
+entries:
+  BC-4790:
+    name: Gestão de conteúdo educativo e recursos de aprendizagem
+    description: |
+      Autoria, catalogação, licenciamento e distribuição de conteúdo educativo e
+      recursos de aprendizagem utilizados no ensino, incluindo courseware, objetos
+      digitais de aprendizagem, recursos educativos abertos, coleções de biblioteca e manuais.
+  BC-4790.10:
+    name: Autoria e produção de courseware
+    description: |
+      Conceção instrucional e produção de courseware, incluindo conteúdo multimédia
+      e compilação de packs de cursos.
+    in_scope:
+      - Conceção instrucional
+      - Produção de conteúdo multimédia
+      - Compilação de packs de cursos
+    out_of_scope:
+      - Lecionação (abrangida em Gestão de Operações de Ensino e Aprendizagem)
+  BC-4790.10.10:
+    name: Conceção instrucional
+    description: |
+      Conceção instrucional de cursos, módulos e experiências de aprendizagem.
+  BC-4790.10.20:
+    name: Produção de conteúdo multimédia
+    description: |
+      Produção de conteúdo de aprendizagem em vídeo, áudio e multimédia interativo.
+  BC-4790.10.30:
+    name: Compilação de packs de cursos
+    description: |
+      Compilação de packs de cursos e conjuntos de aprendizagem para distribuição.
+  BC-4790.20:
+    name: Catálogo de objetos digitais de aprendizagem
+    description: |
+      Catalogação, versionamento e reutilização de objetos digitais de aprendizagem
+      em programas e modalidades.
+    in_scope:
+      - Catalogação e metadados de objetos de aprendizagem
+      - Versionamento de objetos de aprendizagem
+      - Descoberta e reutilização de objetos reutilizáveis
+    out_of_scope:
+      - Lecionação operacional no LMS (abrangida em Gestão de Operações de Ensino e Aprendizagem)
+  BC-4790.20.10:
+    name: Catalogação e metadados de objetos de aprendizagem
+    description: |
+      Catalogação de objetos de aprendizagem e metadados face a normas de interoperabilidade.
+  BC-4790.20.20:
+    name: Versionamento de objetos de aprendizagem
+    description: |
+      Versionamento e gestão do ciclo de vida de objetos de aprendizagem.
+  BC-4790.20.30:
+    name: Descoberta e reutilização de objetos reutilizáveis
+    description: |
+      Descoberta e reutilização de objetos de aprendizagem em cursos e disciplinas.
+  BC-4790.30:
+    name: Gestão de recursos educativos abertos
+    description: |
+      Obtenção, licenciamento e contribuição de recursos educativos abertos (REA)
+      utilizados no ensino.
+    in_scope:
+      - Obtenção e curadoria de REA
+      - Conformidade com licenciamento de REA
+      - Contribuição e partilha de REA
+    out_of_scope:
+      - Aquisição de manuais comerciais (abrangida em Aquisição de Manuais e Materiais de Curso)
+  BC-4790.30.10:
+    name: Obtenção e curadoria de REA
+    description: |
+      Obtenção e curadoria de recursos educativos abertos para uso institucional.
+  BC-4790.30.20:
+    name: Conformidade com licenciamento de REA
+    description: |
+      Conformidade com licenças de REA (p. ex. Creative Commons) na utilização e reutilização.
+  BC-4790.30.30:
+    name: Contribuição e partilha de REA
+    description: |
+      Contribuição de conteúdo de autoria institucional para o ecossistema REA.
+  BC-4790.40:
+    name: Operações de biblioteca e recursos de informação
+    description: |
+      Desenvolvimento de coleções de biblioteca, gestão de listas de leitura e
+      apoio à literacia da informação no ensino e na investigação.
+    in_scope:
+      - Desenvolvimento de coleções
+      - Gestão de listas de leitura e reserva
+      - Apoio à literacia da informação
+    out_of_scope:
+      - Operações de biblioteca pública não integradas na distribuição educativa
+  BC-4790.40.10:
+    name: Desenvolvimento de coleções
+    description: |
+      Desenvolvimento de coleções de biblioteca impressas e eletrónicas.
+  BC-4790.40.20:
+    name: Gestão de listas de leitura e reserva
+    description: |
+      Gestão de listas de leitura de cursos e coleções de reserva.
+  BC-4790.40.30:
+    name: Apoio à literacia da informação
+    description: |
+      Apoio e instrução em literacia da informação e competências de investigação.
+  BC-4790.50:
+    name: Licenciamento de conteúdo e gestão de direitos
+    description: |
+      Licenciamento, autorização de direitos de autor e gestão de exceções
+      educativas para uso de conteúdo de terceiros no ensino.
+    in_scope:
+      - Licenciamento de conteúdo educativo
+      - Autorização de direitos de autor
+      - Gestão de uso justo e exceções educativas
+    out_of_scope:
+      - Propriedade intelectual institucional (abrangida em Gestão de Propriedade Intelectual transversal)
+  BC-4790.50.10:
+    name: Licenciamento de conteúdo educativo
+    description: |
+      Licenciamento de conteúdo de terceiros para uso educativo.
+  BC-4790.50.20:
+    name: Autorização de direitos de autor
+    description: |
+      Autorização de direitos de autor para conteúdo utilizado no ensino e avaliação.
+  BC-4790.50.30:
+    name: Gestão de uso justo e exceções educativas
+    description: |
+      Gestão de uso justo, fair dealing e exceções de direitos de autor educativos.
+  BC-4790.60:
+    name: Aquisição de manuais e materiais de curso
+    description: |
+      Especificação e aquisição de manuais e materiais de curso, incluindo programas
+      de materiais acessíveis.
+    in_scope:
+      - Especificação de leituras obrigatórias
+      - Aquisição de manuais
+      - Programas de materiais acessíveis (p. ex. acesso inclusivo)
+    out_of_scope:
+      - Aquisição genérica (abrangida em Gestão de Compras transversal)
+  BC-4790.60.10:
+    name: Especificação de leituras obrigatórias
+    description: |
+      Especificação de leituras obrigatórias e recomendadas para cursos.
+  BC-4790.60.20:
+    name: Aquisição de manuais
+    description: |
+      Aquisição de manuais e materiais de curso.
+  BC-4790.60.30:
+    name: Programa de materiais acessíveis
+    description: |
+      Operação de programas de materiais acessíveis e de acesso inclusivo.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-educator-workforce-management.yaml
+++ b/catalogue/i18n/pt/L1-educator-workforce-management.yaml
@@ -1,0 +1,175 @@
+locale: pt
+source: L1-educator-workforce-management.yaml
+entries:
+  BC-4760:
+    name: Gestão do corpo docente
+    description: |
+      Gestão do ciclo de vida de docentes e pessoal de ensino específica da educação,
+      cobrindo recrutamento, credenciação, permanência e promoção, alocação de carga
+      de ensino, desenvolvimento profissional e gestão de docentes adjuntos/por sessão.
+      Complementa a Gestão de Capital Humano transversal para RH genérico.
+  BC-4760.10:
+    name: Recrutamento e nomeação de docentes
+    description: |
+      Definição, pesquisa, seleção e nomeação de docentes académicos, incluindo
+      práticas de pesquisa académica especializadas.
+    in_scope:
+      - Definição de posições de docentes
+      - Pesquisa e seleção de docentes
+      - Nomeação e integração de docentes
+    out_of_scope:
+      - Recrutamento genérico de pessoal (abrangido em Gestão de Capital Humano transversal)
+  BC-4760.10.10:
+    name: Definição de posições de docentes
+    description: |
+      Definição de posições de docentes, categorias e foco disciplinar.
+  BC-4760.10.20:
+    name: Pesquisa e seleção de docentes
+    description: |
+      Operações do comité de pesquisa académica e seleção de candidatos a docentes.
+  BC-4760.10.30:
+    name: Nomeação e integração de docentes
+    description: |
+      Nomeação, contratação e integração académica de novos docentes.
+  BC-4760.20:
+    name: Credenciação académica e verificação de qualificações
+    description: |
+      Verificação e manutenção contínua das credenciais académicas e profissionais
+      de docentes e competências por área de especialização.
+    in_scope:
+      - Verificação de qualificações de docentes
+      - Credenciação por área de especialização
+      - Manutenção contínua de credenciais
+    out_of_scope:
+      - Certificações de funcionários transversais (abrangidas em Gestão de Capital Humano transversal)
+  BC-4760.20.10:
+    name: Verificação de qualificações de docentes
+    description: |
+      Verificação de graus, certificações e licenças detidas por docentes.
+  BC-4760.20.20:
+    name: Credenciação por área de especialização
+    description: |
+      Credenciação de docentes face a competências por área de especialização e pedagógicas.
+  BC-4760.20.30:
+    name: Manutenção de credenciais contínuas
+    description: |
+      Monitorização de credenciais profissionais contínuas e renovações.
+  BC-4760.30:
+    name: Gestão de permanência e promoção
+    description: |
+      Administração da progressão na carreira de permanência, decisões de permanência
+      e processos de promoção académica.
+    in_scope:
+      - Gestão da carreira de permanência e período probatório
+      - Revisão e decisão de permanência
+      - Revisão e decisão de promoção
+    out_of_scope:
+      - Gestão de desempenho genérica (abrangida em Gestão de Capital Humano transversal)
+  BC-4760.30.10:
+    name: Gestão da carreira de permanência e período probatório
+    description: |
+      Gestão da progressão na carreira de permanência e períodos probatórios.
+  BC-4760.30.20:
+    name: Revisão e decisão de permanência
+    description: |
+      Processos do comité de revisão de permanência e decisões finais de permanência.
+  BC-4760.30.30:
+    name: Revisão e decisão de promoção
+    description: |
+      Revisão e tomada de decisão sobre promoção académica nas diferentes categorias docentes.
+  BC-4760.40:
+    name: Gestão da carga de ensino e de trabalho
+    description: |
+      Alocação e equilíbrio de cargas de ensino, investigação e serviço, e
+      planeamento de licenças académicas, incluindo sabáticas.
+    in_scope:
+      - Alocação de atribuições de ensino
+      - Equilíbrio de carga de trabalho entre ensino, investigação e serviço
+      - Planeamento de sabáticas e licenças académicas
+    out_of_scope:
+      - Administração de licenças genéricas de RH (abrangida em Gestão de Capital Humano transversal)
+  BC-4760.40.10:
+    name: Alocação de atribuições de ensino
+    description: |
+      Alocação de atribuições de ensino a docentes e instrutores.
+  BC-4760.40.20:
+    name: Equilíbrio de carga de trabalho
+    description: |
+      Equilíbrio das obrigações de ensino, investigação e serviço entre docentes.
+  BC-4760.40.30:
+    name: Planeamento de sabáticas e licenças
+    description: |
+      Planeamento de sabáticas e cobertura de licenças académicas.
+  BC-4760.50:
+    name: Desenvolvimento profissional académico
+    description: |
+      Desenvolvimento profissional pedagógico, disciplinar e de indução para
+      docentes e pessoal de ensino.
+    in_scope:
+      - Desenvolvimento de pedagogia e prática de ensino
+      - Desenvolvimento de disciplina/especialidade
+      - Mentoria e indução de docentes
+    out_of_scope:
+      - Aprendizagem e desenvolvimento genérico (abrangidos em Gestão de Capital Humano transversal)
+  BC-4760.50.10:
+    name: Desenvolvimento de pedagogia e prática de ensino
+    description: |
+      Desenvolvimento das capacidades de pedagogia e prática de ensino de docentes.
+  BC-4760.50.20:
+    name: Desenvolvimento de especialidade disciplinar
+    description: |
+      Desenvolvimento de especialidade em área disciplinar.
+  BC-4760.50.30:
+    name: Mentoria e indução de docentes
+    description: |
+      Programas de mentoria e indução para novos docentes.
+  BC-4760.60:
+    name: Desempenho de docentes e revisão de pares
+    description: |
+      Revisão de desempenho específica de docentes, incluindo observação de ensino,
+      revisão de pares e reconhecimento académico.
+    in_scope:
+      - Observação de ensino e revisão de pares
+      - Revisão de desempenho anual de docentes
+      - Reconhecimento e prémios de docentes
+    out_of_scope:
+      - Gestão de desempenho genérica de pessoal (abrangida em Gestão de Capital Humano transversal)
+  BC-4760.60.10:
+    name: Observação de ensino e revisão de pares
+    description: |
+      Observação de ensino e revisão de pares da prática de docentes.
+  BC-4760.60.20:
+    name: Revisão de desempenho anual
+    description: |
+      Revisão de desempenho anual de docentes e pessoal de ensino.
+  BC-4760.60.30:
+    name: Reconhecimento e prémios de docentes
+    description: |
+      Esquemas de reconhecimento e prémios para docentes.
+  BC-4760.70:
+    name: Gestão de docentes adjuntos e por sessão
+    description: |
+      Gestão de pessoal de ensino a tempo parcial, por sessão e adjunto, incluindo
+      recrutamento, contratação e garantia de qualidade.
+    in_scope:
+      - Recrutamento de pool de adjuntos
+      - Administração de contratos por sessão
+      - Integração de adjuntos e garantia de qualidade
+    out_of_scope:
+      - Gestão genérica de prestadores de serviços (abrangida em Gestão de Fornecedores transversal)
+  BC-4760.70.10:
+    name: Recrutamento de pool de adjuntos
+    description: |
+      Recrutamento e manutenção de um pool ativo de docentes adjuntos.
+  BC-4760.70.20:
+    name: Administração de contratos por sessão
+    description: |
+      Administração de contratos de ensino por sessão e adjunto.
+  BC-4760.70.30:
+    name: Integração de adjuntos e garantia de qualidade
+    description: |
+      Integração de adjuntos com as normas académicas e garantia de qualidade contínua.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-electoral-administration-management.yaml
+++ b/catalogue/i18n/pt/L1-electoral-administration-management.yaml
@@ -1,0 +1,166 @@
+locale: pt
+source: L1-electoral-administration-management.yaml
+entries:
+  BC-3330:
+    name: Gestão da administração eleitoral
+    description: |
+      Administração de eleições, incluindo recenseamento eleitoral, gestão de
+      círculos eleitorais, registo de candidatos e partidos, conceção e produção
+      de boletins de voto, operações de votação, apuramento e tabulação de
+      resultados e divulgação do financiamento de campanhas.
+  BC-3330.10:
+    name: Gestão do recenseamento eleitoral
+    description: |
+      Manutenção dos cadernos eleitorais, incluindo inscrição, alteração de
+      morada e atividades de atualização das listas.
+    in_scope:
+      - Inscrição e reinscrição de eleitores
+      - Manutenção das listas eleitorais
+      - Verificação de elegibilidade
+    out_of_scope:
+      - Registo de identidade civil (coberto pela Gestão de Registos Civis e de Identidade)
+  BC-3330.10.10:
+    name: Inscrição de eleitores
+    description: |
+      Inscrição de eleitores elegíveis nos cadernos eleitorais em vários canais.
+  BC-3330.10.20:
+    name: Manutenção das listas eleitorais
+    description: |
+      Atualização das listas, incluindo alterações de morada, remoção de falecidos
+      e tratamento de duplicados.
+  BC-3330.10.30:
+    name: Verificação de elegibilidade eleitoral
+    description: |
+      Verificação da elegibilidade dos eleitores face a critérios de cidadania,
+      idade e residência.
+  BC-3330.10.40:
+    name: Prestação de informação ao eleitor
+    description: |
+      Prestação de cartões de eleitor, consulta de local de voto e informação de
+      educação cívica.
+  BC-3330.20:
+    name: Gestão de círculos e distritos eleitorais
+    description: |
+      Manutenção de círculos eleitorais, geografias de mesas de voto e ciclos
+      de redesenho de círculos.
+  BC-3330.20.10:
+    name: Manutenção de círculos eleitorais
+    description: |
+      Manutenção dos limites dos círculos e constituências eleitorais.
+  BC-3330.20.20:
+    name: Designação de locais de voto
+    description: |
+      Designação, avaliação de acessibilidade e publicação de locais de voto.
+  BC-3330.20.30:
+    name: Coordenação de redesenho de círculos
+    description: |
+      Coordenação de ciclos estatutários de redesenho de círculos e comissões
+      de delimitação.
+  BC-3330.30:
+    name: Registo de candidatos e partidos
+    description: |
+      Registo de partidos políticos, candidatos, apresentação de candidaturas e
+      acesso ao boletim de voto.
+  BC-3330.30.10:
+    name: Registo de partidos políticos
+    description: |
+      Registo e reconhecimento de partidos políticos e identificadores partidários.
+  BC-3330.30.20:
+    name: Apresentação de candidaturas
+    description: |
+      Receção e verificação de candidaturas e declarações estatutárias.
+  BC-3330.30.30:
+    name: Determinação de acesso ao boletim de voto
+    description: |
+      Determinação do acesso ao boletim de voto, incluindo requisitos de assinaturas
+      e limiares de qualificação.
+  BC-3330.40:
+    name: Conceção e produção de boletins de voto
+    description: |
+      Conceção, disposição, acessibilidade, tradução e produção de boletins de
+      voto em formato papel e eletrónico.
+  BC-3330.40.10:
+    name: Conceção e disposição do boletim de voto
+    description: |
+      Conceção e disposição de boletins de voto para clareza, acessibilidade e
+      cobertura linguística.
+  BC-3330.40.20:
+    name: Tradução e acessibilidade do boletim de voto
+    description: |
+      Prestação de boletins traduzidos e formatos acessíveis a eleitores com
+      deficiência.
+  BC-3330.40.30:
+    name: Produção e distribuição de boletins de voto
+    description: |
+      Impressão, programação e distribuição segura de boletins de voto em papel
+      e eletrónicos.
+  BC-3330.50:
+    name: Operações de votação
+    description: |
+      Operação de locais de voto no dia das eleições, incluindo gestão de
+      escrutinadores, registo de eleitores e exercício do voto sob controlos
+      alinhados com o VVSG.
+  BC-3330.50.10:
+    name: Gestão de escrutinadores
+    description: |
+      Recrutamento, formação e mobilização de escrutinadores e membros de mesa.
+  BC-3330.50.20:
+    name: Registo do eleitor na mesa de voto
+    description: |
+      Registo do eleitor, verificação de identidade e entrega do boletim de voto
+      no local de voto.
+  BC-3330.50.30:
+    name: Votação presencial
+    description: |
+      Votação presencial em papel ou em equipamento de votação certificado pelo
+      VVSG.
+  BC-3330.50.40:
+    name: Operações de voto por correio e ausência
+    description: |
+      Operações de apoio ao voto por ausência, postal e no estrangeiro.
+  BC-3330.60:
+    name: Contagem de votos e tabulação de resultados
+    description: |
+      Contagem de boletins de voto, tabulação de resultados, auditorias e
+      certificação dos resultados eleitorais.
+  BC-3330.60.10:
+    name: Contagem de votos
+    description: |
+      Contagem de boletins em papel e eletrónicos em conformidade com o
+      procedimento legal.
+  BC-3330.60.20:
+    name: Tabulação e reporte de resultados
+    description: |
+      Agregação de resultados por secção e divulgação pública.
+  BC-3330.60.30:
+    name: Auditoria pós-eleitoral
+    description: |
+      Auditorias de limitação de risco e pós-eleitorais às contagens e
+      equipamentos.
+  BC-3330.60.40:
+    name: Certificação eleitoral
+    description: |
+      Certificação estatutária dos resultados eleitorais e proclamação dos
+      eleitos.
+  BC-3330.70:
+    name: Divulgação do financiamento de campanhas
+    description: |
+      Registo de comissões políticas, divulgação de donativos e despesas e
+      aplicação dos limites do financiamento de campanhas.
+  BC-3330.70.10:
+    name: Registo de comissões políticas
+    description: |
+      Registo de comissões políticas, partidos e entidades equivalentes a PAC.
+  BC-3330.70.20:
+    name: Reporte de donativos e despesas
+    description: |
+      Receção, validação e publicação de divulgações de donativos e despesas.
+  BC-3330.70.30:
+    name: Aplicação das regras de financiamento de campanhas
+    description: |
+      Investigação e aplicação de violações de limites e divulgação do
+      financiamento de campanhas.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-electrical-equipment-service-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-electrical-equipment-service-operations-management.yaml
@@ -1,0 +1,144 @@
+locale: pt
+source: L1-electrical-equipment-service-operations-management.yaml
+entries:
+  BC-1960:
+    name: Gestão de operações de assistência a equipamentos elétricos
+    description: |
+      Serviços liderados pelo OEM em equipamentos expedidos — levantamento do local, FAT e SAT, energização,
+      definições de proteção, configuração da base instalada, retrofits, contratos de desempenho e monitorização de condição.
+  BC-1960.10:
+    name: Levantamento do local e engenharia de pré-colocação em serviço
+    description: |
+      Avaliação do local e preparação de engenharia antes da colocação em serviço do equipamento.
+  BC-1960.10.10:
+    name: Execução do levantamento do local
+    description: |
+      Execução de levantamentos do local para capturar as condições existentes.
+  BC-1960.10.20:
+    name: Avaliação de prontidão do local
+    description: |
+      Avaliação da prontidão do local para entrega e energização do equipamento.
+  BC-1960.10.30:
+    name: Estudos de engenharia de pré-colocação em serviço
+    description: |
+      Estudos de engenharia antes da colocação em serviço, incluindo coordenação e ligação à terra.
+  BC-1960.20:
+    name: Coordenação do teste de aceitação em fábrica
+    description: |
+      Planeamento e execução de testes de aceitação em fábrica com testemunho do cliente.
+  BC-1960.20.10:
+    name: Elaboração do plano FAT
+    description: |
+      Elaboração de planos FAT alinhados com os requisitos do contrato.
+  BC-1960.20.20:
+    name: Coordenação de testemunhas no FAT
+    description: |
+      Coordenação de testemunhas do cliente e do organismo de certificação no FAT.
+  BC-1960.20.30:
+    name: Gestão da lista de pendências do FAT
+    description: |
+      Acompanhamento e encerramento dos itens da lista de pendências do FAT.
+  BC-1960.30:
+    name: Gestão do teste de aceitação no local e energização
+    description: |
+      Testes de aceitação no local, energização e supervisão da operação inicial.
+  BC-1960.30.10:
+    name: Execução do teste de aceitação no local
+    description: |
+      Execução de testes de aceitação no local no equipamento instalado.
+  BC-1960.30.20:
+    name: Execução do procedimento de energização
+    description: |
+      Energização controlada do equipamento de acordo com os procedimentos de manobra.
+  BC-1960.30.30:
+    name: Supervisão da operação inicial
+    description: |
+      Supervisão da operação inicial e da corrida de fiabilidade.
+  BC-1960.30.40:
+    name: Documentação de entrega
+    description: |
+      Compilação de dossiers de entrega e registos tal como colocado em serviço.
+  BC-1960.40:
+    name: Gestão de definições de proteção e controlo
+    description: |
+      Engenharia e implementação de definições de proteção e controlo no equipamento instalado.
+  BC-1960.40.10:
+    name: Estudo de coordenação de proteção
+    description: |
+      Estudos de coordenação para dispositivos de proteção na rede instalada.
+  BC-1960.40.20:
+    name: Cálculo de definições de relé
+    description: |
+      Cálculo de definições dos relés de proteção.
+  BC-1960.40.30:
+    name: Implementação e verificação de ficheiros de definições
+    description: |
+      Implementação de ficheiros de definições nos relés e verificação no local.
+  BC-1960.50:
+    name: Gestão da configuração da base instalada
+    description: |
+      Manutenção dos dados de configuração tal como instalada na base instalada global.
+  BC-1960.50.10:
+    name: Registo da base instalada
+    description: |
+      Registo do equipamento instalado por número de série, local e cliente.
+  BC-1960.50.20:
+    name: Captura da configuração tal como construída
+    description: |
+      Captura da configuração tal como construída na colocação em serviço.
+  BC-1960.50.30:
+    name: Registos de modificação da base instalada
+    description: |
+      Registos de modificações pós-colocação em serviço no equipamento instalado.
+  BC-1960.60:
+    name: Serviços de retrofit e atualização de equipamentos
+    description: |
+      Engenharia e execução de retrofits e atualizações de capacidade no equipamento instalado.
+  BC-1960.60.10:
+    name: Engenharia de retrofit
+    description: |
+      Projeto de engenharia de pacotes de retrofit e atualização.
+  BC-1960.60.20:
+    name: Execução de retrofit
+    description: |
+      Execução no local de retrofits e instalações de atualização.
+  BC-1960.60.30:
+    name: Validação de atualização
+    description: |
+      Testes de validação após retrofit ou atualização.
+  BC-1960.70:
+    name: Operações de contratos de serviço baseados em desempenho
+    description: |
+      Operação de contratos de serviço baseados em desempenho e resultados.
+  BC-1960.70.10:
+    name: Execução de contrato de desempenho
+    description: |
+      Execução de obrigações de serviço baseadas em desempenho.
+  BC-1960.70.20:
+    name: Relatório de resultados do nível de serviço
+    description: |
+      Relatório de resultados contratados e métricas de nível de serviço.
+  BC-1960.70.30:
+    name: Operações do mecanismo de partilha de risco
+    description: |
+      Operação de mecanismos de bónus e penalização por partilha de risco.
+  BC-1960.80:
+    name: Prestação de serviço de monitorização de condição
+    description: |
+      Prestação de serviços de monitorização remota de condição e perspetivas preditivas.
+  BC-1960.80.10:
+    name: Operações de monitorização remota de condição
+    description: |
+      Centro de operações para monitorização remota de condição de ativos instalados.
+  BC-1960.80.20:
+    name: Prestação de perspetivas de diagnóstico
+    description: |
+      Prestação de perspetivas de diagnóstico aos clientes.
+  BC-1960.80.30:
+    name: Recomendações de manutenção preditiva
+    description: |
+      Recomendações de manutenção preditiva para o equipamento instalado.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-electrical-product-catalogue-management.yaml
+++ b/catalogue/i18n/pt/L1-electrical-product-catalogue-management.yaml
@@ -1,0 +1,116 @@
+locale: pt
+source: L1-electrical-product-catalogue-management.yaml
+entries:
+  BC-1940:
+    name: Gestão do catálogo de produto elétrico
+    description: |
+      Estrutura de produtos vendáveis para produtos elétricos — variantes, regras do configurador,
+      SKU jurisdicionais, introdução e retirada gradual, fichas de dados e material de marketing.
+  BC-1940.10:
+    name: Gestão do registo mestre de produto vendável
+    description: |
+      Manutenção de registos mestres de produtos vendáveis e hierarquias de famílias.
+  BC-1940.10.10:
+    name: Gestão do registo de produto vendável
+    description: |
+      Criação e manutenção de registos mestres de produtos vendáveis.
+  BC-1940.10.20:
+    name: Gestão da hierarquia e família de produto
+    description: |
+      Definição de estruturas de família e hierarquia de produto.
+  BC-1940.10.30:
+    name: Normalização de atributos de produto
+    description: |
+      Normalização de atributos entre famílias de produto.
+  BC-1940.20:
+    name: Gestão de variantes e opções de produto
+    description: |
+      Gestão de variantes de tensão, frequência, proteção, protocolo e acessórios.
+  BC-1940.20.10:
+    name: Gestão de variantes de tensão e frequência
+    description: |
+      Gestão de variantes de classificação de tensão e frequência.
+  BC-1940.20.20:
+    name: Gestão de variantes de proteção e invólucro
+    description: |
+      Gestão de variantes de proteção contra penetração e invólucro.
+  BC-1940.20.30:
+    name: Gestão de variantes de protocolo de comunicação
+    description: |
+      Gestão de opções de protocolo de comunicação em produtos conectados.
+  BC-1940.20.40:
+    name: Gestão de acessórios e opções
+    description: |
+      Gestão de definições de acessórios e funcionalidades opcionais.
+  BC-1940.30:
+    name: Gestão de regras do configurador de produto
+    description: |
+      Elaboração e validação de regras de configuração por encomenda.
+  BC-1940.30.10:
+    name: Elaboração de regras de configuração
+    description: |
+      Elaboração de regras de combinações válidas para produtos configuráveis.
+  BC-1940.30.20:
+    name: Gestão de restrições de compatibilidade
+    description: |
+      Gestão de restrições de compatibilidade entre opções.
+  BC-1940.30.30:
+    name: Teste de validação do configurador
+    description: |
+      Teste de validação de conjuntos de regras do configurador.
+  BC-1940.40:
+    name: Gestão de SKU jurisdicionais
+    description: |
+      Gestão de SKU específicos por jurisdição, normas de ficha elétrica e variantes de idioma.
+  BC-1940.40.10:
+    name: Definição de variante jurisdicional
+    description: |
+      Definição de variantes vendáveis exigidas pela jurisdição-alvo.
+  BC-1940.40.20:
+    name: Gestão de normas de ficha e conector
+    description: |
+      Gestão de variantes de normas de ficha e conector por região.
+  BC-1940.40.30:
+    name: Variante de documentação em idioma local
+    description: |
+      Manuais e variantes de rotulagem em idioma local por jurisdição.
+  BC-1940.50:
+    name: Gestão de introdução e retirada gradual de produto
+    description: |
+      Ativação no catálogo, mapeamento de substituição, fim de venda e janelas de última compra.
+  BC-1940.50.10:
+    name: Ativação no catálogo no lançamento do produto
+    description: |
+      Ativação de novos produtos no catálogo vendável no lançamento.
+  BC-1940.50.20:
+    name: Mapeamento de produto de substituição
+    description: |
+      Mapeamento de produtos descontinuados para SKU de substituição.
+  BC-1940.50.30:
+    name: Notificação de fim de venda
+    description: |
+      Notificação de datas de fim de venda a canais e clientes.
+  BC-1940.50.40:
+    name: Gestão da última compra e janela de assistência
+    description: |
+      Gestão das janelas de última compra e disponibilidade apenas para assistência.
+  BC-1940.60:
+    name: Gestão de documentação e ficha de dados do produto
+    description: |
+      Elaboração e manutenção de fichas de dados, manuais e material de marketing associado a SKU.
+  BC-1940.60.10:
+    name: Elaboração de fichas de dados
+    description: |
+      Elaboração de fichas de dados de produto e especificações técnicas.
+  BC-1940.60.20:
+    name: Elaboração de manuais técnicos
+    description: |
+      Elaboração de manuais de instalação e operação.
+  BC-1940.60.30:
+    name: Material de marketing do catálogo
+    description: |
+      Material de marketing associado a SKU do catálogo.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-electrical-product-certification-management.yaml
+++ b/catalogue/i18n/pt/L1-electrical-product-certification-management.yaml
@@ -1,0 +1,120 @@
+locale: pt
+source: L1-electrical-product-certification-management.yaml
+entries:
+  BC-1910:
+    name: Gestão de certificação de produto elétrico
+    description: |
+      Certificação de segurança de produto, CEM e energia em múltiplas jurisdições — estratégia, dossiers técnicos,
+      relacionamento com organismos de certificação, licenciamento de marcas, vigilância e gestão de não conformidades em campo.
+  BC-1910.10:
+    name: Estratégia e roteiro de certificação
+    description: |
+      Definição das marcas e aprovações necessárias e respetiva sequência.
+  BC-1910.10.10:
+    name: Análise de requisitos de acesso ao mercado
+    description: |
+      Identificação dos requisitos de certificação por mercado-alvo.
+  BC-1910.10.20:
+    name: Seleção de esquemas de certificação
+    description: |
+      Seleção de esquemas de certificação e vias de reconhecimento.
+  BC-1910.10.30:
+    name: Planeamento do roteiro de certificação
+    description: |
+      Sequenciamento de aprovações face a marcos de lançamento do produto.
+  BC-1910.20:
+    name: Gestão do dossier técnico e evidências
+    description: |
+      Elaboração e gestão de dossiers de construção técnica e evidências de suporte.
+  BC-1910.20.10:
+    name: Elaboração do dossier de construção técnica
+    description: |
+      Elaboração de dossiers de construção técnica de suporte à aprovação de tipo.
+  BC-1910.20.20:
+    name: Agregação de relatórios de teste
+    description: |
+      Agregação e indexação de relatórios de teste acreditados.
+  BC-1910.20.30:
+    name: Elaboração da declaração de conformidade
+    description: |
+      Elaboração e assinatura de declarações de conformidade.
+  BC-1910.20.40:
+    name: Arquivo de evidências de conformidade
+    description: |
+      Arquivo a longo prazo das evidências de conformidade de acordo com os requisitos regulatórios de retenção.
+  BC-1910.30:
+    name: Gestão do organismo de certificação e aprovações
+    description: |
+      Relacionamento com organismos notificados e organismos de certificação nacionais até à emissão da aprovação de tipo.
+  BC-1910.30.10:
+    name: Seleção do organismo notificado
+    description: |
+      Seleção de organismos notificados e organismos de certificação nacionais.
+  BC-1910.30.20:
+    name: Gestão da submissão de certificação
+    description: |
+      Submissão de dossiers de certificação e coordenação de acompanhamento.
+  BC-1910.30.30:
+    name: Coordenação de testes na presença de auditores
+    description: |
+      Coordenação de testes na presença de auditores em laboratórios de fornecedores ou internos.
+  BC-1910.30.40:
+    name: Acompanhamento da emissão de aprovações de tipo
+    description: |
+      Acompanhamento das aprovações de tipo emitidas e validade dos certificados.
+  BC-1910.40:
+    name: Licenciamento de marcas e conformidade de rotulagem
+    description: |
+      Licenciamento de marcas de certificação e controlo da arte gráfica de rotulagem do produto.
+  BC-1910.40.10:
+    name: Autorização de utilização de marcas
+    description: |
+      Autorização de utilização de marcas em produtos certificados.
+  BC-1910.40.20:
+    name: Controlo da arte gráfica de etiquetas do produto
+    description: |
+      Controlo do conteúdo, marcação e arte gráfica da placa de características das etiquetas.
+  BC-1910.40.30:
+    name: Relatório de royalties de marcas
+    description: |
+      Relatório de volumes unitários para obrigações de royalties de marcas.
+  BC-1910.50:
+    name: Vigilância e renovação de aprovações
+    description: |
+      Manutenção de aprovações através de auditorias de vigilância, variações e renovações.
+  BC-1910.50.10:
+    name: Coordenação de inspeções à fábrica
+    description: |
+      Coordenação de inspeções à fábrica pelo organismo de certificação e ações de seguimento.
+  BC-1910.50.20:
+    name: Teste de vigilância periódica
+    description: |
+      Reteste de vigilância de produtos certificados face à linha de base original.
+  BC-1910.50.30:
+    name: Submissão de variações de aprovação
+    description: |
+      Submissão de variações e alterações de engenharia face a aprovações emitidas.
+  BC-1910.50.40:
+    name: Gestão de renovação de aprovações
+    description: |
+      Renovação de aprovações e certificados com expiração próxima.
+  BC-1910.60:
+    name: Gestão de incidentes de conformidade em campo
+    description: |
+      Tratamento de não conformidades de produto descobertas após o lançamento no mercado.
+  BC-1910.60.10:
+    name: Triagem de incidentes de não conformidade
+    description: |
+      Triagem de suspeitas de não conformidades de produto reportadas em campo.
+  BC-1910.60.20:
+    name: Notificação às autoridades regulatórias
+    description: |
+      Notificação obrigatória às autoridades e organismos de certificação sobre não conformidades confirmadas.
+  BC-1910.60.30:
+    name: Coordenação de recolha e suspensão de expedição em campo
+    description: |
+      Coordenação de recolhas, ordens de suspensão de expedição e campanhas de ação corretiva.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-electrical-product-engineering-management.yaml
+++ b/catalogue/i18n/pt/L1-electrical-product-engineering-management.yaml
@@ -1,0 +1,172 @@
+locale: pt
+source: L1-electrical-product-engineering-management.yaml
+entries:
+  BC-1900:
+    name: Gestão de engenharia de produto elétrico
+    description: |
+      Engenharia multidisciplinar de produtos elétricos e eletrónicos: circuitos, eletrónica de potência,
+      sistemas embebidos, CEM, térmica e engenharia mecânica, até à verificação do projeto.
+  BC-1900.10:
+    name: Projeto de circuitos elétricos
+    description: |
+      Projeto esquemático de circuitos analógicos, digitais, de sinal misto e RF.
+  BC-1900.10.10:
+    name: Projeto de circuitos analógicos
+    description: |
+      Projeto de circuitos de sinal analógico e condicionamento de potência.
+  BC-1900.10.20:
+    name: Projeto de circuitos digitais
+    description: |
+      Projeto de circuitos de lógica digital e temporização.
+  BC-1900.10.30:
+    name: Projeto de circuitos de sinal misto
+    description: |
+      Projeto de interfaces de sinal misto, subsistemas ADC/DAC e estágios de conversão.
+  BC-1900.10.40:
+    name: Projeto de circuitos RF
+    description: |
+      Projeto de front-ends de radiofrequência, redes de adaptação e antenas.
+  BC-1900.20:
+    name: Projeto de eletrónica de potência
+    description: |
+      Projeto de conversão de potência, acionamento de motores e topologias de comutação.
+  BC-1900.20.10:
+    name: Projeto de conversores de potência
+    description: |
+      Projeto de conversores de potência AC/DC, DC/DC e DC/AC.
+  BC-1900.20.20:
+    name: Projeto de topologia de acionamento de motores
+    description: |
+      Seleção de topologia e projeto de acionamentos de motores de velocidade variável.
+  BC-1900.20.30:
+    name: Projeto de magnéticos e filtros
+    description: |
+      Projeto de indutores, transformadores e filtros CEM.
+  BC-1900.20.40:
+    name: Projeto de malha de controlo de comutação
+    description: |
+      Projeto de controlo em malha fechada para estágios de comutação de potência.
+  BC-1900.30:
+    name: Projeto de PCB e embalagem eletrónica
+    description: |
+      Layout de PCB, embalagem eletrónica e engenharia de interligação.
+  BC-1900.30.10:
+    name: Layout de PCB
+    description: |
+      Empilhamento e layout físico de PCB multicamada.
+  BC-1900.30.20:
+    name: Projeto de embalagem eletrónica
+    description: |
+      Projeto de embalagem de módulos, invólucros e ball-grid-array.
+  BC-1900.30.30:
+    name: Projeto de interligação e cablagem
+    description: |
+      Projeto de cablagem, barramentos e interligação entre placas.
+  BC-1900.30.40:
+    name: Gestão de biblioteca de footprints de componentes
+    description: |
+      Manutenção de bibliotecas de footprints e símbolos CAD.
+  BC-1900.40:
+    name: Projeto de hardware embebido
+    description: |
+      Projeto de hardware de microcontrolador, FPGA, interface de sensores e gestão de potência.
+  BC-1900.40.10:
+    name: Projeto de plataforma de microcontrolador
+    description: |
+      Seleção e integração de plataformas de microcontrolador.
+  BC-1900.40.20:
+    name: Integração de FPGA e SoC
+    description: |
+      Integração de dispositivos FPGA e SoC no hardware do produto.
+  BC-1900.40.30:
+    name: Projeto de interface com sensores e atuadores
+    description: |
+      Interfaces analógicas e digitais com sensores e atuadores.
+  BC-1900.40.40:
+    name: Projeto de circuito de gestão de potência
+    description: |
+      Circuitos de gestão e regulação de potência a bordo.
+  BC-1900.50:
+    name: Engenharia de firmware embebido
+    description: |
+      Desenvolvimento de firmware abrangendo RTOS, drivers, lógica aplicacional e verificação.
+  BC-1900.50.10:
+    name: Arquitetura de software em tempo real
+    description: |
+      Arquitetura de sistema operativo em tempo real e tarefas.
+  BC-1900.50.20:
+    name: Desenvolvimento de drivers de dispositivos
+    description: |
+      Desenvolvimento de drivers de baixo nível e pacotes de suporte de placa.
+  BC-1900.50.30:
+    name: Desenvolvimento de aplicações embebidas
+    description: |
+      Desenvolvimento de lógica aplicacional e funcionalidades embebidas.
+  BC-1900.50.40:
+    name: Verificação e teste de firmware
+    description: |
+      Verificação de firmware por teste unitário, de integração e hardware-in-the-loop.
+  BC-1900.60:
+    name: Engenharia de CEM e integridade de sinal
+    description: |
+      Gestão em fase de projeto da compatibilidade eletromagnética e da integridade de sinal.
+  BC-1900.60.10:
+    name: Análise de projeto CEM
+    description: |
+      Análise de emissões e imunidade em fase de projeto.
+  BC-1900.60.20:
+    name: Análise de integridade de sinal
+    description: |
+      Análise de integridade de sinal a alta velocidade e diafonias.
+  BC-1900.60.30:
+    name: Projeto de blindagem e ligação à terra
+    description: |
+      Estratégias de blindagem, ligação equipotencial e ligação à terra.
+  BC-1900.60.40:
+    name: Avaliação de pré-conformidade CEM
+    description: |
+      Varrimentos de pré-conformidade e avaliação CEM em fase de projeto.
+  BC-1900.70:
+    name: Engenharia térmica e mecânica
+    description: |
+      Engenharia térmica, de invólucro e mecânica de produtos elétricos.
+  BC-1900.70.10:
+    name: Análise térmica e projeto de arrefecimento
+    description: |
+      Modelação térmica e projeto de estratégia de arrefecimento.
+  BC-1900.70.20:
+    name: Projeto de invólucro e proteção contra penetração
+    description: |
+      Projeto mecânico de invólucro e conformidade com índice de proteção contra penetração.
+  BC-1900.70.30:
+    name: Engenharia de vibração e choque
+    description: |
+      Robustez mecânica face a cargas de vibração e choque.
+  BC-1900.70.40:
+    name: Projeto de conectores e interfaces mecânicas
+    description: |
+      Seleção de conectores e projeto de interfaces mecânicas.
+  BC-1900.80:
+    name: Verificação do projeto elétrico
+    description: |
+      Verificação em fase de projeto por simulação, construção de protótipo e teste.
+  BC-1900.80.10:
+    name: Simulação de projeto
+    description: |
+      Estudos de simulação de circuitos, eletromagnéticos e térmicos.
+  BC-1900.80.20:
+    name: Construção e arranque de protótipo
+    description: |
+      Montagem de protótipo e arranque funcional inicial.
+  BC-1900.80.30:
+    name: Teste de verificação do projeto
+    description: |
+      Teste de verificação face a especificações de projeto.
+  BC-1900.80.40:
+    name: Governação de revisões de projeto
+    description: |
+      Revisões de projeto por fases de aprovação e garantia da qualidade do projeto.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-electrical-product-qualification-management.yaml
+++ b/catalogue/i18n/pt/L1-electrical-product-qualification-management.yaml
@@ -1,0 +1,172 @@
+locale: pt
+source: L1-electrical-product-qualification-management.yaml
+entries:
+  BC-1920:
+    name: Gestão de qualificação de produto elétrico
+    description: |
+      Orquestração de testes de tipo em amostras representativas — dielétrico, curto-circuito, CEM, climático,
+      mecânico e testes de vida — incluindo operações de laboratório acreditado.
+  BC-1920.10:
+    name: Gestão de planos e especificações de teste
+    description: |
+      Elaboração e aprovação de planos e especificações de teste derivados de normas de produto.
+  BC-1920.10.10:
+    name: Elaboração de especificações de teste
+    description: |
+      Elaboração de especificações detalhadas de teste.
+  BC-1920.10.20:
+    name: Aprovação de planos de teste
+    description: |
+      Aprovação de planos de teste pelas partes interessadas de engenharia, qualidade e certificação.
+  BC-1920.10.30:
+    name: Afetação de amostras de teste
+    description: |
+      Afetação e gestão de amostras de teste representativas.
+  BC-1920.10.40:
+    name: Manutenção de procedimentos de teste
+    description: |
+      Manutenção e revisão de procedimentos de teste normalizados.
+  BC-1920.20:
+    name: Teste dielétrico e de alta tensão
+    description: |
+      Teste de isolamento, rigidez dielétrica, descarga parcial e impulso.
+  BC-1920.20.10:
+    name: Teste de resistência de isolamento
+    description: |
+      Medição da resistência de isolamento em condições especificadas.
+  BC-1920.20.20:
+    name: Teste de rigidez dielétrica
+    description: |
+      Testes de rigidez dielétrica AC e DC a níveis de tensão nominal.
+  BC-1920.20.30:
+    name: Medição de descarga parcial
+    description: |
+      Medição de descarga parcial em sistemas de isolamento.
+  BC-1920.20.40:
+    name: Teste de tensão de impulso
+    description: |
+      Testes de resistência a impulso de raio e de manobra.
+  BC-1920.30:
+    name: Teste de curto-circuito e comutação
+    description: |
+      Verificação do desempenho em curto-circuito e comutação em condições de falta nominal.
+  BC-1920.30.10:
+    name: Teste de capacidade de estabelecimento em curto-circuito
+    description: |
+      Verificação da capacidade de estabelecimento em curtos-circuitos nominais.
+  BC-1920.30.20:
+    name: Teste de capacidade de corte em curto-circuito
+    description: |
+      Verificação da capacidade de corte a níveis de falta nominais.
+  BC-1920.30.30:
+    name: Teste de endurância de comutação
+    description: |
+      Endurância mecânica e elétrica sob comutação repetitiva.
+  BC-1920.30.40:
+    name: Teste de falta de arco
+    description: |
+      Teste de contenção de falta de arco e desempenho em arco elétrico.
+  BC-1920.40:
+    name: Teste de CEM e EMI
+    description: |
+      Testes de emissões conduzidas e irradiadas e de imunidade.
+  BC-1920.40.10:
+    name: Teste de emissões conduzidas
+    description: |
+      Medição de emissões conduzidas em linhas de potência e sinal.
+  BC-1920.40.20:
+    name: Teste de emissões irradiadas
+    description: |
+      Medição de emissões eletromagnéticas irradiadas.
+  BC-1920.40.30:
+    name: Teste de imunidade CEM
+    description: |
+      Verificação da imunidade a perturbações conduzidas e irradiadas.
+  BC-1920.40.40:
+    name: Teste de imunidade a ESD e surtos
+    description: |
+      Testes de imunidade a descarga eletrostática e surtos.
+  BC-1920.50:
+    name: Teste ambiental e climático
+    description: |
+      Testes climáticos, de corrosão, de penetração e de exposição dos produtos.
+  BC-1920.50.10:
+    name: Ciclagem de temperatura e humidade
+    description: |
+      Ciclagem de temperatura e humidade e tensão em regime permanente.
+  BC-1920.50.20:
+    name: Teste de névoa salina e corrosão
+    description: |
+      Teste de exposição a névoa salina e atmosferas corrosivas.
+  BC-1920.50.30:
+    name: Teste de proteção contra penetração
+    description: |
+      Verificação do índice de proteção contra penetração de poeira e água.
+  BC-1920.50.40:
+    name: Teste de exposição solar e UV
+    description: |
+      Testes de exposição a radiação solar e ultravioleta.
+  BC-1920.60:
+    name: Teste mecânico e de vibração
+    description: |
+      Testes de vibração, choque, endurância mecânica e qualificação sísmica.
+  BC-1920.60.10:
+    name: Teste de vibração e choque
+    description: |
+      Testes de vibração sinusoidal, aleatória e de choque.
+  BC-1920.60.20:
+    name: Teste de endurância mecânica
+    description: |
+      Endurância mecânica sob ciclagem operacional.
+  BC-1920.60.30:
+    name: Teste de queda e impacto
+    description: |
+      Testes de queda, queda livre e impacto de produtos e embalagens.
+  BC-1920.60.40:
+    name: Teste de qualificação sísmica
+    description: |
+      Qualificação sísmica para equipamentos de energia e subestações.
+  BC-1920.70:
+    name: Teste de vida acelerada e fiabilidade
+    description: |
+      Testes de vida acelerada, rastreio de tensão e demonstração de fiabilidade.
+  BC-1920.70.10:
+    name: Teste de vida altamente acelerada
+    description: |
+      HALT para expor margens de projeto por tensão gradual.
+  BC-1920.70.20:
+    name: Rastreio de tensão altamente acelerada
+    description: |
+      Rastreio de produção HASS para detetar defeitos latentes.
+  BC-1920.70.30:
+    name: Teste de demonstração de fiabilidade
+    description: |
+      Testes de demonstração face a objetivos de fiabilidade.
+  BC-1920.70.40:
+    name: Teste de burn-in
+    description: |
+      Burn-in alimentado para precipitar falhas de mortalidade infantil.
+  BC-1920.80:
+    name: Gestão de operações do laboratório de teste
+    description: |
+      Operação de laboratórios de teste internos acreditados.
+  BC-1920.80.10:
+    name: Acreditação do laboratório de teste
+    description: |
+      Manutenção do âmbito de acreditação ISO/IEC 17025.
+  BC-1920.80.20:
+    name: Calibração de equipamento de teste
+    description: |
+      Calibração e rastreabilidade do equipamento de teste.
+  BC-1920.80.30:
+    name: Gestão de registos de dados de teste
+    description: |
+      Gestão de registos a longo prazo de dados e relatórios de teste.
+  BC-1920.80.40:
+    name: Comparação interlaboratorial
+    description: |
+      Testes de proficiência round-robin entre laboratórios.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-electricity-distribution-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-electricity-distribution-operations-management.yaml
@@ -1,0 +1,171 @@
+locale: pt
+source: L1-electricity-distribution-operations-management.yaml
+entries:
+  BC-3820:
+    name: Gestão de operações de distribuição de eletricidade
+    description: |
+      Operação de redes de distribuição de média e baixa tensão —
+      despacho da sala de controlo, resposta a avarias e reposição,
+      manobra, operações de subestações primárias e secundárias, e
+      coordenação de equipas de campo a fornecer energia aos clientes finais.
+  BC-3820.10:
+    name: Operações de controlo da distribuição
+    description: |
+      Operação 24/7 do centro de controlo da rede de distribuição usando
+      DMS / OMS / ADMS, consciência situacional e análise de fluxo de carga.
+  BC-3820.10.10:
+    name: Operações de ADMS
+    description: |
+      Operação de sistemas avançados de gestão da distribuição para
+      monitorização e controlo.
+  BC-3820.10.20:
+    name: Operações de SCADA de distribuição
+    description: |
+      Aquisição SCADA em tempo real e controlo de alimentadores e
+      seccionadores de distribuição.
+  BC-3820.10.30:
+    name: Gestão da topologia da rede
+    description: |
+      Manutenção da topologia da rede em operação no sistema de controlo.
+  BC-3820.20:
+    name: Operações de manobra e reposição
+    description: |
+      Reconfiguração da rede e reposição do abastecimento após indisponibilidades
+      planeadas e não planeadas, incluindo auto-recuperação por FLISR.
+  BC-3820.20.10:
+    name: Execução do programa de manobras
+    description: |
+      Execução autorizada de programas de manobras de distribuição.
+  BC-3820.20.20:
+    name: Localização de avarias, isolamento e reposição do serviço
+    description: |
+      Deteção, isolamento e reposição do abastecimento por FLISR em
+      alimentadores com avaria.
+  BC-3820.20.30:
+    name: Coordenação de retro-alimentação e ilhamento
+    description: |
+      Coordenação de retro-alimentação de alimentadores e ilhamento
+      intencional para reposição.
+  BC-3820.30:
+    name: Operações de resposta a avarias
+    description: |
+      Resposta ponta-a-ponta a avarias na rede de distribuição, desde a
+      deteção até à reparação em campo e comunicação ao cliente.
+  BC-3820.30.10:
+    name: Triagem de avarias
+    description: |
+      Triagem de relatórios de avaria provenientes de campo, clientes e
+      fontes de telemetria.
+  BC-3820.30.20:
+    name: Patrulha de avarias no campo
+    description: |
+      Patrulhas de campo para localizar e confirmar avarias em ativos
+      aéreos e subterrâneos.
+  BC-3820.30.30:
+    name: Rastreio da reposição após interrupção
+    description: |
+      Rastreio do progresso da reposição após interrupção e estatísticas
+      de minutos de cliente perdidos.
+  BC-3820.30.40:
+    name: Resposta a eventos maiores
+    description: |
+      Resposta de distribuição a tempestades e eventos maiores, incluindo
+      equipas de assistência mútua.
+  BC-3820.40:
+    name: Operações de despacho de equipas de campo
+    description: |
+      Despacho, encaminhamento e apoio à execução no campo de equipas de
+      distribuição que tratam avarias, trabalhos planeados e trabalhos de clientes.
+  BC-3820.40.10:
+    name: Calendarização de equipas
+    description: |
+      Calendarização diária de turnos de equipa e rotações de prevenção.
+  BC-3820.40.20:
+    name: Despacho e encaminhamento de trabalhos
+    description: |
+      Despacho e encaminhamento de trabalhos para equipas de campo a partir
+      de sistemas de gestão de trabalho.
+  BC-3820.40.30:
+    name: Encerramento de trabalhos de campo
+    description: |
+      Captura de alterações conforme construído, materiais utilizados e
+      tempo no encerramento de trabalhos.
+  BC-3820.50:
+    name: Operações de inspeção de ativos de distribuição
+    description: |
+      Inspeção de rotina e condicionada por estado de linhas aéreas, postes,
+      cabos subterrâneos e subestações de distribuição.
+  BC-3820.50.10:
+    name: Inspeção de postes e linhas aéreas
+    description: |
+      Inspeção cíclica de postes e linhas aéreas, incluindo levantamentos
+      termográficos.
+  BC-3820.50.20:
+    name: Inspeção da rede subterrânea
+    description: |
+      Inspeção e levantamentos de condição de alimentadores subterrâneos,
+      caixas de ligação e junções.
+  BC-3820.50.30:
+    name: Inspeção de subestações de distribuição
+    description: |
+      Inspeção de rotina de subestações primárias, secundárias e de clientes.
+  BC-3820.60:
+    name: Gestão de vegetação e servidão
+    description: |
+      Desobstrução de vegetação e manutenção de servidão em circuitos de
+      distribuição para gerir o risco de interrupção e a folga estatutária.
+  BC-3820.60.10:
+    name: Planeamento do ciclo de vegetação
+    description: |
+      Calendarização cíclica e baseada em risco de trabalhos de vegetação
+      em circuitos de distribuição.
+  BC-3820.60.20:
+    name: Operações de campo de vegetação
+    description: |
+      Execução no campo de poda, abate e aplicação de herbicidas.
+  BC-3820.60.30:
+    name: Operações de mitigação do risco de incêndio florestal
+    description: |
+      Operações de PSPS, disparo rápido e reforço de circuitos em áreas
+      de risco de incêndio florestal.
+  BC-3820.70:
+    name: Operações de novas ligações
+    description: |
+      Entrega de novas ligações elétricas e modificadas para clientes
+      domésticos, comerciais e industriais e promotores.
+  BC-3820.70.10:
+    name: Avaliação de candidaturas a nova ligação
+    description: |
+      Avaliação técnica de candidaturas a nova ligação e disponibilidade
+      de capacidade.
+  BC-3820.70.20:
+    name: Projeto de ligação
+    description: |
+      Projeto detalhado de ligação, ponto de ligação e requisitos de reforço.
+  BC-3820.70.30:
+    name: Comissionamento de ligações
+    description: |
+      Comissionamento de novas ligações e aceitação de energização.
+  BC-3820.80:
+    name: Gestão da qualidade de energia
+    description: |
+      Vigilância e remediação de níveis de tensão de distribuição, flicker,
+      harmónicos e reclamações de qualidade de energia de clientes.
+  BC-3820.80.10:
+    name: Vigilância de tensão
+    description: |
+      Vigilância de perfis de tensão de alimentadores contra limites
+      estatutários.
+  BC-3820.80.20:
+    name: Monitorização de harmónicos e flicker
+    description: |
+      Monitorização de rede de distorção harmónica e flicker de tensão.
+  BC-3820.80.30:
+    name: Investigação de qualidade de energia de clientes
+    description: |
+      Investigação e remediação de problemas de qualidade de energia
+      reportados por clientes.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-electricity-transmission-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-electricity-transmission-operations-management.yaml
@@ -1,0 +1,169 @@
+locale: pt
+source: L1-electricity-transmission-operations-management.yaml
+entries:
+  BC-3810:
+    name: Gestão de operações de transporte de eletricidade
+    description: |
+      Operação da rede elétrica de alta tensão — despacho da sala de
+      controlo, manobra, operações de linhas e subestações, coordenação
+      de indisponibilidades, proteção, e segurança física e cibernética
+      do sistema elétrico de serviço público.
+  BC-3810.10:
+    name: Operações de controlo da transmissão
+    description: |
+      Operação 24/7 da sala de controlo da rede de transporte usando
+      EMS / SCADA, consciência situacional e análise de contingências.
+  BC-3810.10.10:
+    name: Operações de EMS
+    description: |
+      Operação do sistema de gestão de energia, estimador de estado e
+      ferramentas de análise de contingências.
+  BC-3810.10.20:
+    name: Operações de SCADA de transmissão
+    description: |
+      Aquisição SCADA em tempo real e controlo supervisório de ativos
+      de transmissão.
+  BC-3810.10.30:
+    name: Gestão do livro de registo do operador de transmissão
+    description: |
+      Manutenção de livros de registo do operador, passagens de turno e
+      registos de eventos de operação.
+  BC-3810.20:
+    name: Manobra e isolamento de transmissão
+    description: |
+      Planeamento e execução de manobras, isolamento e operações de
+      acesso com tensão no sistema de transmissão.
+  BC-3810.20.10:
+    name: Preparação do programa de manobras
+    description: |
+      Preparação e verificação de programas de manobras para trabalhos
+      planeados.
+  BC-3810.20.20:
+    name: Emissão de autorização de trabalho
+    description: |
+      Emissão e controlo de autorizações de trabalho e sanções para
+      teste em instalações de transmissão.
+  BC-3810.20.30:
+    name: Operações com tensão e trabalho sob tensão
+    description: |
+      Coordenação de acesso com tensão e trabalho sob tensão em circuitos
+      energizados.
+  BC-3810.30:
+    name: Operações de linhas de transmissão
+    description: |
+      Operação, inspeção e trabalho sob tensão de linhas aéreas, torres
+      e cabos subterrâneos de transmissão.
+  BC-3810.30.10:
+    name: Inspeção de linhas aéreas
+    description: |
+      Inspeções de rotina, escalada e aéreas de linhas de transmissão
+      aéreas.
+  BC-3810.30.20:
+    name: Operações de cabo subterrâneo
+    description: |
+      Operação, vigilância de descarga parcial e gestão de câmaras de
+      junção de cabos de AT.
+  BC-3810.30.30:
+    name: Desobstrução de servidão e vegetação
+    description: |
+      Desobstrução de vegetação e manutenção de servidão ao abrigo das
+      normas NERC FAC-003 ou equivalentes.
+  BC-3810.30.40:
+    name: Manutenção de torres de transmissão
+    description: |
+      Pintura, fundações e trabalhos de integridade estrutural em torres
+      de transmissão.
+  BC-3810.40:
+    name: Operações de subestações
+    description: |
+      Operação e vigilância de subestações de AT, transformadores,
+      aparelhagem de manobra e instalações de compensação reativa.
+  BC-3810.40.10:
+    name: Operações de transformadores de potência
+    description: |
+      Vigilância, análise de gás dissolvido e operação de regulador de
+      tensão de transformadores de AT.
+  BC-3810.40.20:
+    name: Operações de aparelhagem de manobra
+    description: |
+      Operação e vigilância de condição de disjuntores e desligadores
+      de AT.
+  BC-3810.40.30:
+    name: Operações de compensação reativa
+    description: |
+      Operação de bancos de condensadores, reatores, SVCs e STATCOMs
+      para suporte reativo.
+  BC-3810.40.40:
+    name: Operações de estação conversora HVDC
+    description: |
+      Operação de estações conversoras HVDC e controlo de interligações DC.
+  BC-3810.50:
+    name: Coordenação de indisponibilidades de transmissão
+    description: |
+      Planeamento, calendarização e aprovação de indisponibilidades planeadas
+      e emergentes em elementos de transmissão, com avaliação de impacto no
+      sistema e no mercado.
+  BC-3810.50.10:
+    name: Submissão de planos de indisponibilidade
+    description: |
+      Submissão e revisão de planos de indisponibilidade de transmissão
+      ao operador de sistema.
+  BC-3810.50.20:
+    name: Avaliação do risco de indisponibilidade
+    description: |
+      Avaliação do impacto na segurança do sistema e no mercado das
+      indisponibilidades propostas.
+  BC-3810.50.30:
+    name: Comunicação de saídas forçadas
+    description: |
+      Comunicação de saídas forçadas e indisponibilidade ao operador e
+      ao regulador.
+  BC-3810.60:
+    name: Proteção e controlo da transmissão
+    description: |
+      Definição, vigilância e análise pós-evento de proteção de transmissão
+      e esquemas de proteção especiais.
+  BC-3810.60.10:
+    name: Gestão de parametrização da proteção
+    description: |
+      Cálculo, aprovação e emissão de parametrizações de relés de proteção.
+  BC-3810.60.20:
+    name: Operações de esquema de proteção especial
+    description: |
+      Operação e vigilância de ações corretivas e esquemas de proteção
+      especiais.
+  BC-3810.60.30:
+    name: Análise de eventos de perturbação
+    description: |
+      Análise de registos de perturbações e desempenho da proteção após
+      eventos na rede elétrica.
+  BC-3810.70:
+    name: Gestão de segurança do sistema de transmissão
+    description: |
+      Segurança cibernética e física do sistema elétrico de serviço público,
+      incluindo implementação de controlos NERC CIP, segurança do perímetro
+      e registo de ativos com impacto no sistema elétrico de serviço público.
+  BC-3810.70.10:
+    name: Identificação de ciberativos do sistema elétrico de serviço público
+    description: |
+      Identificação e classificação de sistemas cibernéticos do sistema
+      elétrico de serviço público nos termos do NERC CIP-002.
+  BC-3810.70.20:
+    name: Operações do perímetro de segurança eletrónica
+    description: |
+      Operação de perímetros de segurança eletrónica e controlos de acesso
+      remoto interativo.
+  BC-3810.70.30:
+    name: Operações do perímetro de segurança física
+    description: |
+      Controlos de segurança física para centros de controlo e subestações
+      críticas (NERC CIP-014).
+  BC-3810.70.40:
+    name: Gestão de evidências de conformidade NERC CIP
+    description: |
+      Recolha de evidências, atestação e resposta a auditoria para as
+      normas NERC CIP.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-electronic-component-sourcing-management.yaml
+++ b/catalogue/i18n/pt/L1-electronic-component-sourcing-management.yaml
@@ -1,0 +1,132 @@
+locale: pt
+source: L1-electronic-component-sourcing-management.yaml
+entries:
+  BC-1930:
+    name: Gestão de aprovisionamento de componentes eletrónicos
+    description: |
+      Aprovisionamento e gestão do ciclo de vida de componentes eletrónicos — listas de fornecedores aprovados,
+      gestão de obsolescência, alocação, prevenção de contrafação, qualificação e dados de substâncias.
+  BC-1930.10:
+    name: Gestão da lista de fornecedores aprovados
+    description: |
+      Manutenção de fontes de componentes aprovadas, alternativas e referências cruzadas.
+  BC-1930.10.10:
+    name: Gestão da lista de peças preferenciais
+    description: |
+      Manutenção de listas de componentes preferenciais com aprovação de engenharia.
+  BC-1930.10.20:
+    name: Qualificação de fontes alternativas
+    description: |
+      Qualificação de fontes alternativas de componentes.
+  BC-1930.10.30:
+    name: Gestão de referências cruzadas
+    description: |
+      Mapeamento de componentes equivalentes entre fabricantes.
+  BC-1930.20:
+    name: Gestão do ciclo de vida e obsolescência de componentes
+    description: |
+      Acompanhamento do estado do ciclo de vida dos componentes e gestão de eventos de obsolescência.
+  BC-1930.20.10:
+    name: Triagem de notificações de alteração de produto
+    description: |
+      Triagem e avaliação de impacto das notificações de alteração de produto do fornecedor.
+  BC-1930.20.20:
+    name: Triagem de avisos de fim de vida
+    description: |
+      Triagem de avisos de fim de vida e impacto nas listas de materiais.
+  BC-1930.20.30:
+    name: Decisão de última compra
+    description: |
+      Tomada de decisão sobre quantidades de última compra e stocks de transição.
+  BC-1930.20.40:
+    name: Previsão do ciclo de vida dos componentes
+    description: |
+      Previsão das fases do ciclo de vida dos componentes ao longo da lista de materiais.
+  BC-1930.30:
+    name: Gestão de alocação de semicondutores
+    description: |
+      Gestão da alocação de semicondutores em condições de escassez.
+  BC-1930.30.10:
+    name: Gestão de previsão de alocação
+    description: |
+      Previsão de procura para apoiar o posicionamento de alocação junto do fornecedor.
+  BC-1930.30.20:
+    name: Negociação de alocação com fornecedores
+    description: |
+      Negociação da quota de alocação com fornecedores de semicondutores.
+  BC-1930.30.30:
+    name: Priorização da procura de alocação
+    description: |
+      Priorização interna do fornecimento alocado entre linhas de produto.
+  BC-1930.40:
+    name: Prevenção de componentes contrafeitos
+    description: |
+      Deteção e prevenção de componentes eletrónicos contrafeitos na cadeia de abastecimento.
+  BC-1930.40.10:
+    name: Avaliação do risco de contrafação
+    description: |
+      Avaliação do risco de contrafação nos canais de aprovisionamento.
+  BC-1930.40.20:
+    name: Autenticação de componentes recebidos
+    description: |
+      Autenticação e inspeção de componentes recebidos.
+  BC-1930.40.30:
+    name: Rastreabilidade na cadeia de fornecedores
+    description: |
+      Rastreabilidade dos componentes até aos fabricantes autorizados.
+  BC-1930.50:
+    name: Qualificação de componentes eletrónicos
+    description: |
+      Qualificação de componentes eletrónicos para utilização em produção.
+  BC-1930.50.10:
+    name: Inspeção do primeiro artigo
+    description: |
+      Inspeção do primeiro artigo de componentes face a especificações.
+  BC-1930.50.20:
+    name: Qualificação de fiabilidade de componentes
+    description: |
+      Qualificação de fiabilidade de componentes face a perfis de operação.
+  BC-1930.50.30:
+    name: Qualificação automotiva AEC-Q
+    description: |
+      Qualificação de componentes segundo perfis de tensão AEC-Q100/AEC-Q200.
+  BC-1930.50.40:
+    name: Qualificação JEDEC de semicondutores
+    description: |
+      Qualificação de semicondutores segundo normas JEDEC.
+  BC-1930.60:
+    name: Gestão de distribuidores e corretores
+    description: |
+      Gestão de canais de distribuidores autorizados e corretores.
+  BC-1930.60.10:
+    name: Integração de distribuidores autorizados
+    description: |
+      Integração de distribuidores autorizados de componentes eletrónicos.
+  BC-1930.60.20:
+    name: Avaliação do risco de fonte corretora
+    description: |
+      Avaliação do risco de aprovisionamento por corretor independente.
+  BC-1930.60.30:
+    name: Revisão do desempenho de distribuidores
+    description: |
+      Revisão periódica do desempenho e conformidade dos distribuidores.
+  BC-1930.70:
+    name: Gestão de dados de conformidade de componentes
+    description: |
+      Recolha e gestão de dados de substâncias e conformidade de componentes.
+  BC-1930.70.10:
+    name: Recolha de dados de substâncias
+    description: |
+      Recolha de dados de composição de substâncias junto dos fornecedores de componentes.
+  BC-1930.70.20:
+    name: Dados de fundidores de minerais de conflito
+    description: |
+      Recolha de dados ao nível do fundidor para due diligence de minerais de conflito.
+  BC-1930.70.30:
+    name: Acompanhamento de SVHC REACH
+    description: |
+      Acompanhamento de substâncias altamente preocupantes ao nível dos componentes.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-energy-trading-settlement-management.yaml
+++ b/catalogue/i18n/pt/L1-energy-trading-settlement-management.yaml
@@ -1,0 +1,152 @@
+locale: pt
+source: L1-energy-trading-settlement-management.yaml
+entries:
+  BC-3850:
+    name: Gestão de negociação de energia e liquidação
+    description: |
+      Negociação grossista de eletricidade, gás e matérias-primas
+      ambientais — participação no mercado em horizontes temporais de
+      day-ahead, intraday e balanceamento, gestão do risco de energia,
+      calendarização e nomeações, participação no mercado de capacidade,
+      e liquidação de back-office e relatórios regulatórios ao abrigo
+      dos regimes REMIT / EMIR / Dodd-Frank.
+  BC-3850.10:
+    name: Negociação grossista de energia elétrica
+    description: |
+      Negociação de front-office de energia física e financeira nos
+      mercados day-ahead, intraday e a prazo.
+  BC-3850.10.10:
+    name: Negociação no mercado day-ahead
+    description: |
+      Submissão e gestão de ofertas e licitações no mercado day-ahead.
+  BC-3850.10.20:
+    name: Negociação intraday
+    description: |
+      Negociação intraday contínua e em leilão contra alterações de posição.
+  BC-3850.10.30:
+    name: Negociação a prazo e bilateral
+    description: |
+      Negociação física a prazo e bilateral OTC para cobertura e originação.
+  BC-3850.10.40:
+    name: Negociação de capacidade transfronteiriça
+    description: |
+      Negociação de produtos de capacidade de interligação transfronteiriça.
+  BC-3850.20:
+    name: Gestão do risco de energia
+    description: |
+      Vigilância do risco de mercado, crédito e operacional do portfólio
+      de negociação, com administração de limites e testes de esforço.
+  BC-3850.20.10:
+    name: Vigilância do risco de mercado
+    description: |
+      Vigilância de VaR, lucros em risco e exposição do livro de negociação.
+  BC-3850.20.20:
+    name: Gestão do risco de crédito de contraparte
+    description: |
+      Limites de crédito de contraparte, colateral e monitorização
+      de exposição.
+  BC-3850.20.30:
+    name: Gestão do programa de cobertura
+    description: |
+      Conceção e execução de programas de cobertura contra exposição
+      a combustível e energia.
+  BC-3850.30:
+    name: Gestão de posição e calendarização
+    description: |
+      Agregação de posições de negociação e físicas e submissão de
+      calendários e nomeações a operadores de sistema e de gasodutos.
+  BC-3850.30.10:
+    name: Agregação de posições de negociação
+    description: |
+      Agregação de posições em produtos, livros e contrapartes.
+  BC-3850.30.20:
+    name: Submissão de calendários de energia elétrica
+    description: |
+      Submissão de calendários físicos de energia elétrica a ORT e
+      partes responsáveis pelo balanceamento.
+  BC-3850.30.30:
+    name: Submissão de nomeações de gás
+    description: |
+      Submissão de nomeações de gás e rebalanceamento em gasodutos
+      de transporte.
+  BC-3850.40:
+    name: Participação no mercado de capacidade
+    description: |
+      Participação em mecanismos de mercado de capacidade e de segurança
+      de abastecimento, incluindo estratégia de leilão, qualificação e
+      monitorização da entrega.
+  BC-3850.40.10:
+    name: Estratégia de leilão de capacidade
+    description: |
+      Estratégia e preparação de propostas para leilões de mercado
+      de capacidade.
+  BC-3850.40.20:
+    name: Qualificação de fornecedores de capacidade
+    description: |
+      Qualificação de ativos e gestão de fatores de derating para
+      produtos de capacidade.
+  BC-3850.40.30:
+    name: Monitorização da entrega de capacidade
+    description: |
+      Monitorização da entrega de capacidade durante eventos de stress
+      e exposição a penalidades.
+  BC-3850.50:
+    name: Negociação de matérias-primas ambientais
+    description: |
+      Negociação e entrega de licenças de carbono, certificados de energia
+      renovável, garantias de origem e certificados brancos.
+  BC-3850.50.10:
+    name: Negociação de licenças de carbono
+    description: |
+      Negociação de EUA, CCA e outras licenças de carbono de conformidade.
+  BC-3850.50.20:
+    name: Negociação de certificados de energia renovável
+    description: |
+      Negociação de RECs, ROCs e Garantias de Origem.
+  BC-3850.50.30:
+    name: Operações de certificados brancos
+    description: |
+      Negociação e entrega de certificados brancos de eficiência energética.
+  BC-3850.60:
+    name: Operações de liquidação de negociações
+    description: |
+      Confirmação de back-office, cálculo de liquidação, faturação e gestão
+      de tesouraria de negociações grossistas de energia.
+  BC-3850.60.10:
+    name: Confirmação de negociações
+    description: |
+      Confirmações de negociações de saída e entrada e resolução de
+      discrepâncias.
+  BC-3850.60.20:
+    name: Cálculo de liquidação
+    description: |
+      Cálculo de montantes de liquidação física e financeira por contrato.
+  BC-3850.60.30:
+    name: Faturação e gestão de tesouraria de negociações
+    description: |
+      Faturação, pagamento e reconciliação de fluxos de caixa de negociações
+      grossistas.
+  BC-3850.70:
+    name: Relatórios regulatórios de negociações
+    description: |
+      Relatórios regulatórios de transações de energia grossista ao abrigo
+      dos regimes REMIT, EMIR, MiFID II e Dodd-Frank.
+  BC-3850.70.10:
+    name: Relatórios de transações REMIT
+    description: |
+      Relatórios dos Quadros 1 e 2 de transações de energia grossista
+      para a ACER.
+  BC-3850.70.20:
+    name: Relatórios EMIR e Dodd-Frank
+    description: |
+      Relatórios de negociações de derivados a repositórios de negociações
+      ao abrigo do EMIR e Dodd-Frank.
+  BC-3850.70.30:
+    name: Divulgação de informação privilegiada
+    description: |
+      Divulgação de informação privilegiada nos termos do Artigo 4.º
+      do REMIT.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-engagement-quality-management.yaml
+++ b/catalogue/i18n/pt/L1-engagement-quality-management.yaml
@@ -1,0 +1,142 @@
+locale: pt
+source: L1-engagement-quality-management.yaml
+entries:
+  BC-4340:
+    name: Gestão de qualidade de projetos
+    description: |
+      Sistema de gestão de qualidade ao nível da firma, revisões de qualidade
+      de projetos, revisões de ficheiros, consulta técnica, monitorização e
+      resposta a inspeções externas de prática em projetos de serviços
+      profissionais.
+  BC-4340.10:
+    name: Sistema de gestão de qualidade da firma
+    description: |
+      Design, implementação e operação do sistema de gestão de qualidade ao
+      nível da firma, alinhado com a ISQM 1 e regimes equivalentes.
+  BC-4340.10.10:
+    name: Avaliação de riscos de qualidade
+    description: |
+      Identificação e avaliação de riscos de qualidade nos projetos e
+      operações da firma.
+  BC-4340.10.20:
+    name: Design de respostas de qualidade
+    description: |
+      Design de políticas e procedimentos em resposta aos riscos de qualidade
+      identificados.
+  BC-4340.10.30:
+    name: Governação e responsabilidade de qualidade
+    description: |
+      Atribuição de responsabilidade pelo sistema de gestão de qualidade ao
+      sócio gestor, liderança de qualidade e sócios de projeto.
+  BC-4340.10.40:
+    name: Avaliação anual do sistema de gestão de qualidade
+    description: |
+      Avaliação anual da eficácia operacional do sistema de gestão de qualidade
+      da firma.
+  BC-4340.20:
+    name: Revisão de qualidade do projeto
+    description: |
+      Revisão de qualidade do projeto (EQR) independente por um revisor não
+      envolvido no projeto, realizada antes da emissão do relatório em projetos
+      que cumpram critérios de risco ou regulatórios.
+  BC-4340.20.10:
+    name: Avaliação de elegibilidade e critérios de EQR
+    description: |
+      Identificação dos projetos que requerem EQR com base em critérios
+      regulatórios, de risco ou de política da firma.
+  BC-4340.20.20:
+    name: Atribuição do revisor de qualidade do projeto
+    description: |
+      Atribuição de revisores de qualidade qualificados e independentes aos
+      projetos que cumprem os critérios.
+  BC-4340.20.30:
+    name: Execução e aprovação da EQR
+    description: |
+      Execução dos procedimentos de EQR e aprovação como condição prévia para
+      a emissão do entregável.
+  BC-4340.30:
+    name: Revisão do ficheiro do projeto
+    description: |
+      Revisões de ficheiro quente e frio pós-emissão numa amostra de ficheiros
+      de projetos concluídos para avaliar a conformidade com a metodologia da
+      firma e as normas profissionais.
+  BC-4340.30.10:
+    name: Revisão de ficheiro quente
+    description: |
+      Revisão de ficheiro pré-emissão em projetos selecionados onde é
+      necessária garantia adicional de conformidade.
+  BC-4340.30.20:
+    name: Revisão de ficheiro frio
+    description: |
+      Revisão retrospetiva pós-emissão de ficheiros numa base amostral para
+      avaliar a conformidade com a metodologia e a qualidade.
+  BC-4340.30.30:
+    name: Disposição das constatações da revisão de ficheiro
+    description: |
+      Disposição das constatações da revisão de ficheiro, incluindo correção,
+      implicações de formação e feedback ao sócio do projeto.
+  BC-4340.40:
+    name: Gestão de consulta técnica
+    description: |
+      Consulta técnica obrigatória e eletiva sobre matérias complexas do
+      projeto com funções de gabinete nacional, técnicas ou especializadas.
+  BC-4340.40.10:
+    name: Consulta técnica obrigatória
+    description: |
+      Consulta exigida pela política da firma em situações complexas definidas,
+      como continuidade, risco de fraude ou matérias novas.
+  BC-4340.40.20:
+    name: Consulta técnica eletiva
+    description: |
+      Consulta discricionária solicitada pela equipa do projeto sobre questões
+      técnicas complexas.
+  BC-4340.40.30:
+    name: Documentação da consulta técnica
+    description: |
+      Documentação dos pedidos de consulta, pareceres emitidos e conclusões
+      alcançadas no ficheiro do projeto.
+  BC-4340.50:
+    name: Monitorização e correção da qualidade
+    description: |
+      Atividades de monitorização contínua, análise de causa raiz de
+      deficiências de qualidade e programas de correção.
+  BC-4340.50.10:
+    name: Monitorização de indicadores de qualidade
+    description: |
+      Monitorização de indicadores de qualidade antecedentes e consequentes
+      no portefólio de projetos.
+  BC-4340.50.20:
+    name: Análise de causa raiz de deficiências
+    description: |
+      Análise de causa raiz de deficiências de qualidade identificadas e
+      constatações sistémicas.
+  BC-4340.50.30:
+    name: Gestão de ações de correção
+    description: |
+      Definição, execução e verificação de ações de correção resultantes de
+      monitorização e inspeções.
+  BC-4340.60:
+    name: Gestão da resposta a inspeções de prática
+    description: |
+      Coordenação das respostas a inspeções externas de prática por reguladores
+      e organismos de supervisão como PCAOB, FRC, IAASA, ICAEW e regimes
+      equivalentes.
+  BC-4340.60.10:
+    name: Coordenação da seleção de ficheiros para inspeção
+    description: |
+      Coordenação das seleções de ficheiros e pedidos de informação dos
+      organismos de inspeção.
+  BC-4340.60.20:
+    name: Resposta a constatações de inspeção
+    description: |
+      Elaboração e submissão de respostas formais a constatações de inspeção
+      e planos de ação corretiva necessários.
+  BC-4340.60.30:
+    name: Comunicação dos resultados da inspeção
+    description: |
+      Comunicação interna e, quando necessário, externa dos resultados das
+      inspeções.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-engineering-discipline-management.yaml
+++ b/catalogue/i18n/pt/L1-engineering-discipline-management.yaml
@@ -1,0 +1,151 @@
+locale: pt
+source: L1-engineering-discipline-management.yaml
+entries:
+  BC-1100:
+    name: Gestão das disciplinas de engenharia
+    description: |
+      Grupos de capacidades de engenharia multidisciplinar - mecânica, elétrica, civil, de processo, instrumentação e tubagem.
+  BC-1100.10:
+    name: Gestão da engenharia mecânica
+    description: |
+      Especialização na disciplina mecânica - equipamentos, maquinaria rotativa e sistemas mecânicos.
+  BC-1100.10.10:
+    name: Engenharia de equipamentos estáticos
+    description: |
+      Design de vasos de pressão, permutadores de calor e outros equipamentos estáticos.
+  BC-1100.10.20:
+    name: Engenharia de equipamentos rotativos
+    description: |
+      Engenharia de bombas, compressores, turbinas e maquinaria rotativa.
+  BC-1100.10.30:
+    name: Engenharia de AVAC
+    description: |
+      Design e análise de sistemas de AVAC.
+  BC-1100.10.40:
+    name: Engenharia de materiais mecânicos e soldadura
+    description: |
+      Seleção de materiais, especificações de soldadura e design anticorrosão.
+  BC-1100.20:
+    name: Gestão da engenharia elétrica
+    description: |
+      Engenharia de energia, distribuição elétrica e controlo elétrico.
+  BC-1100.20.10:
+    name: Engenharia de sistemas de energia
+    description: |
+      Engenharia de sistemas de energia de alta e média tensão.
+  BC-1100.20.20:
+    name: Design de distribuição elétrica
+    description: |
+      Distribuição de baixa tensão, quadros elétricos e tabelas de carga.
+  BC-1100.20.30:
+    name: Especificação de equipamentos elétricos
+    description: |
+      Especificação de motores, transformadores e equipamentos elétricos.
+  BC-1100.20.40:
+    name: Design de terra e proteção contra raios
+    description: |
+      Design de terra, ligação equipotencial e proteção contra raios.
+  BC-1100.30:
+    name: Gestão da engenharia civil e estrutural
+    description: |
+      Obras civis, estruturas metálicas, betão, fundações e geotecnia.
+  BC-1100.30.10:
+    name: Design de estruturas metálicas
+    description: |
+      Design de estruturas de aço e ligações.
+  BC-1100.30.20:
+    name: Design de betão e fundações
+    description: |
+      Estruturas de betão, fundações e design de armaduras.
+  BC-1100.30.30:
+    name: Engenharia geotécnica
+    description: |
+      Investigação geotécnica e engenharia do solo.
+  BC-1100.30.40:
+    name: Engenharia de obras civis em estaleiro
+    description: |
+      Design de terraplenagem, drenagem e infraestrutura civil em estaleiro.
+  BC-1100.40:
+    name: Gestão da engenharia de processo
+    description: |
+      Design de processo, simulação, P&IDs, balanços de massa e energia e hidráulica.
+  BC-1100.40.10:
+    name: Simulação e modelação de processo
+    description: |
+      Simulação de processo em regime estacionário e dinâmico.
+  BC-1100.40.20:
+    name: Desenvolvimento de P&ID e PFD
+    description: |
+      Diagramas de fluxo de processo e diagramas de tubagem e instrumentação.
+  BC-1100.40.30:
+    name: Engenharia de balanços de massa e energia
+    description: |
+      Balanços de calor e massa e dimensionamento de equipamentos de processo.
+  BC-1100.40.40:
+    name: Engenharia de segurança de processo
+    description: |
+      Sistemas de alívio e tocha, classificação SIL e segurança de processo.
+  BC-1100.50:
+    name: Gestão da engenharia de instrumentação e controlo
+    description: |
+      Instrumentação de campo, automação e engenharia de sistemas de controlo.
+  BC-1100.50.10:
+    name: Engenharia de instrumentação de campo
+    description: |
+      Especificação de transmissores, sensores e elementos finais de campo.
+  BC-1100.50.20:
+    name: Design de sistemas de controlo
+    description: |
+      Arquitetura de DCS e PLC e design de malhas de controlo.
+  BC-1100.50.30:
+    name: Design de sistemas instrumentados de segurança
+    description: |
+      Design de SIS segundo IEC 61511 e verificação SIL.
+  BC-1100.50.40:
+    name: Engenharia de software de automação e controlo
+    description: |
+      Configuração de lógica de controlo e engenharia de software de automação.
+  BC-1100.60:
+    name: Gestão da engenharia de tubagem
+    description: |
+      Design de tubagem, disposições, isométricos, análise de tensões e seleção de materiais.
+  BC-1100.60.10:
+    name: Design de disposição de tubagem
+    description: |
+      Disposições gerais e disposição 3D de tubagem.
+  BC-1100.60.20:
+    name: Análise de tensões em tubagem
+    description: |
+      Análise de tensões em tubagem e design de suportes.
+  BC-1100.60.30:
+    name: Seleção de materiais de tubagem
+    description: |
+      Classes de materiais de tubagem, juntas, válvulas e seleção de isolamento.
+  BC-1100.60.40:
+    name: Produção de desenhos isométricos
+    description: |
+      Produção de isométricos de tubagem e listas de materiais.
+  BC-1100.70:
+    name: Gestão de recursos e competências das disciplinas
+    description: |
+      Grupos de disciplinas, quadros de competências e percursos de carreira técnica.
+  BC-1100.70.10:
+    name: Gestão do grupo de recursos de engenharia
+    description: |
+      Alocação de recursos de disciplina entre projetos.
+  BC-1100.70.20:
+    name: Quadro de competências de engenharia
+    description: |
+      Quadros de competências de disciplina e matrizes de competências.
+  BC-1100.70.30:
+    name: Gestão do percurso de carreira técnica
+    description: |
+      Percursos de carreira técnica e desenvolvimento de engenheiro certificado.
+  BC-1100.70.40:
+    name: Gestão do conhecimento de engenharia
+    description: |
+      Partilha de conhecimento de engenharia, comunidades e lições aprendidas.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-engineering-document-management.yaml
+++ b/catalogue/i18n/pt/L1-engineering-document-management.yaml
@@ -1,0 +1,107 @@
+locale: pt
+source: L1-engineering-document-management.yaml
+entries:
+  BC-1130:
+    name: Gestão de documentos de engenharia
+    description: |
+      Documentos de engenharia controlados, desenhos, especificações e dados de fornecedores.
+  BC-1130.10:
+    name: Gestão do controlo de documentos
+    description: |
+      Numeração de documentos, controlo de revisões e registo mestre de documentos.
+  BC-1130.10.10:
+    name: Numeração e codificação de documentos
+    description: |
+      Esquemas de numeração, taxonomia e codificação de documentos.
+  BC-1130.10.20:
+    name: Controlo de revisões
+    description: |
+      Acompanhamento de revisões, estado e histórico de versões.
+  BC-1130.10.30:
+    name: Registo mestre de documentos
+    description: |
+      Manutenção do registo mestre de documentos e estados.
+  BC-1130.20:
+    name: Gestão de desenhos
+    description: |
+      Ciclo de vida, distribuição e aprovações de desenhos.
+  BC-1130.20.10:
+    name: Fluxo de trabalho de produção de desenhos
+    description: |
+      Fluxo de trabalho de produção de desenhos com verificação, revisão e emissão.
+  BC-1130.20.20:
+    name: Aprovação e emissão de desenhos
+    description: |
+      Aprovação e emissão de desenhos para a construção e partes interessadas.
+  BC-1130.20.30:
+    name: Acompanhamento do ciclo de vida de desenhos
+    description: |
+      Acompanhamento do ciclo de vida desde o preliminar até ao tela final.
+  BC-1130.30:
+    name: Gestão de especificações
+    description: |
+      Especificações técnicas, folhas de dados e conformidade com normas.
+  BC-1130.30.10:
+    name: Elaboração de especificações técnicas
+    description: |
+      Elaboração de especificações técnicas e folhas de dados.
+  BC-1130.30.20:
+    name: Biblioteca de normas de engenharia
+    description: |
+      Manutenção da biblioteca de normas de engenharia e referências.
+  BC-1130.30.30:
+    name: Aprovação e emissão de especificações
+    description: |
+      Aprovação e emissão de especificações para aprovisionamento.
+  BC-1130.40:
+    name: Gestão de documentos de fornecedores
+    description: |
+      Requisitos de dados de fornecedores, submissões, revisões e disposições.
+  BC-1130.40.10:
+    name: Definição de requisitos de dados de fornecedores
+    description: |
+      Definição de listas de requisitos de dados de fornecedores para ordens de compra.
+  BC-1130.40.20:
+    name: Acompanhamento de submissões de documentos de fornecedores
+    description: |
+      Acompanhamento de submissões de documentos de fornecedores e estado.
+  BC-1130.40.30:
+    name: Revisão e disposição de documentos de fornecedores
+    description: |
+      Revisão e disposição de documentos de fornecedores (Código 1/2/3).
+  BC-1130.50:
+    name: Gestão de distribuição e transmissão de documentos
+    description: |
+      Transmissões, correspondência formal e acompanhamento de destinatários.
+  BC-1130.50.10:
+    name: Emissão de transmissões
+    description: |
+      Emissão formal de transmissões de documentos.
+  BC-1130.50.20:
+    name: Gestão da matriz de distribuição
+    description: |
+      Matrizes de distribuição e definições de destinatários.
+  BC-1130.50.30:
+    name: Acompanhamento de confirmações de receção
+    description: |
+      Confirmação e pista de auditoria de receções.
+  BC-1130.60:
+    name: Gestão de documentação tela final
+    description: |
+      Marcações a vermelho, consolidação tela final e pacotes de documentação de transferência.
+  BC-1130.60.10:
+    name: Captura de marcações a vermelho
+    description: |
+      Captura de marcações a vermelho de campo durante a construção.
+  BC-1130.60.20:
+    name: Consolidação tela final
+    description: |
+      Consolidação das marcações a vermelho em entregáveis tela final.
+  BC-1130.60.30:
+    name: Compilação do pacote de documentos de transferência
+    description: |
+      Compilação de pacotes de transferência de operações e manutenção.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-engineering-tendering-estimation-management.yaml
+++ b/catalogue/i18n/pt/L1-engineering-tendering-estimation-management.yaml
@@ -1,0 +1,115 @@
+locale: pt
+source: L1-engineering-tendering-estimation-management.yaml
+entries:
+  BC-1140:
+    name: Gestão de concursos e estimativas de engenharia
+    description: |
+      Preparação de propostas, desenvolvimento de propostas técnicas e comerciais.
+  BC-1140.10:
+    name: Gestão da decisão de concorrer ou não concorrer
+    description: |
+      Qualificação de oportunidades, decisões estratégicas de concurso e planeamento de captura.
+  BC-1140.10.10:
+    name: Qualificação de oportunidades
+    description: |
+      Qualificação de oportunidades face aos critérios de concurso.
+  BC-1140.10.20:
+    name: Governação da decisão de concorrer ou não concorrer
+    description: |
+      Governação das decisões de concorrer ou não concorrer e aprovações por portal.
+  BC-1140.10.30:
+    name: Planeamento de captura
+    description: |
+      Planos de captura, temas de vitória e posicionamento competitivo.
+  BC-1140.20:
+    name: Gestão da estimativa de engenharia
+    description: |
+      Horas de engenharia, fatores de complexidade e estimativa baseada em entregáveis.
+  BC-1140.20.10:
+    name: Estimativa de horas de engenharia
+    description: |
+      Estimativa bottom-up de horas de engenharia por disciplina.
+  BC-1140.20.20:
+    name: Normas e benchmarks de estimativa
+    description: |
+      Manutenção de normas, fatores e benchmarks de estimativa.
+  BC-1140.20.30:
+    name: Estimativa baseada em entregáveis
+    description: |
+      Estimativa baseada em entregáveis incluindo fatores de complexidade.
+  BC-1140.30:
+    name: Gestão da estimativa de custo e cronograma
+    description: |
+      Custo de construção, custo de equipamentos e estimativa do cronograma do projeto.
+  BC-1140.30.10:
+    name: Estimativa do custo de equipamentos
+    description: |
+      Estimativa do custo de equipamentos através de cotações e métodos paramétricos.
+  BC-1140.30.20:
+    name: Estimativa do custo de construção
+    description: |
+      Estimativa do custo de construção segundo a classe AACE.
+  BC-1140.30.30:
+    name: Estimativa do cronograma do projeto
+    description: |
+      Estimativa do cronograma do projeto de cima para baixo e de baixo para cima.
+  BC-1140.30.40:
+    name: Garantia da qualidade da estimativa
+    description: |
+      GA independente de estimativas e benchmarking.
+  BC-1140.40:
+    name: Gestão do desenvolvimento de propostas
+    description: |
+      Elaboração de propostas técnicas e comerciais, gestão de propostas.
+  BC-1140.40.10:
+    name: Elaboração da proposta técnica
+    description: |
+      Elaboração das secções técnicas da proposta.
+  BC-1140.40.20:
+    name: Elaboração da proposta comercial
+    description: |
+      Elaboração das secções comerciais da proposta e tabelas de preços.
+  BC-1140.40.30:
+    name: Produção e revisão da proposta
+    description: |
+      Produção, revisões coloridas e verificação final de conformidade da proposta.
+  BC-1140.50:
+    name: Gestão da submissão de concursos
+    description: |
+      Processo de submissão, esclarecimentos, negociações e adjudicação do contrato.
+  BC-1140.50.10:
+    name: Logística de submissão do concurso
+    description: |
+      Logística de submissão e conformidade com a plataforma.
+  BC-1140.50.20:
+    name: Gestão de esclarecimentos do concurso
+    description: |
+      Tratamento de esclarecimentos pré-concurso e pós-concurso.
+  BC-1140.50.30:
+    name: Negociação e adjudicação
+    description: |
+      Apoio à negociação e transferência da adjudicação do contrato para a entrega.
+  BC-1140.60:
+    name: Gestão de preços e margem do concurso
+    description: |
+      Estratégia de preços, análise de margem e preços de contingência e risco.
+  BC-1140.60.10:
+    name: Estratégia de preços do concurso
+    description: |
+      Estratégia de preços do concurso e posicionamento competitivo.
+  BC-1140.60.20:
+    name: Definição de margem e contingência
+    description: |
+      Decisões de margem, contingência e preços de risco.
+  BC-1140.60.30:
+    name: Provisão para risco do concurso
+    description: |
+      Provisões para risco incorporadas nos concursos com base no registo de riscos.
+  BC-1140.60.40:
+    name: Governação de aprovação do concurso
+    description: |
+      Portais de aprovação de preços do concurso e governação da gestão sénior.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-enterprise-risk-management.yaml
+++ b/catalogue/i18n/pt/L1-enterprise-risk-management.yaml
@@ -1,0 +1,111 @@
+locale: pt
+source: L1-enterprise-risk-management.yaml
+entries:
+  BC-120:
+    name: Gestão de risco empresarial
+    description: |
+      Identificação, avaliação, mitigação e monitorização de riscos ao nível empresarial.
+  BC-120.10:
+    name: Gestão do quadro e apetite de risco
+    description: |
+      Taxonomia de risco, quadro, apetite e tolerância.
+  BC-120.10.10:
+    name: Gestão da taxonomia de risco
+    description: |
+      Definição e manutenção da taxonomia e categorias de risco empresarial.
+  BC-120.10.20:
+    name: Definição do apetite de risco
+    description: |
+      Declarações de apetite de risco e limiares de tolerância aprovados pelo conselho.
+  BC-120.10.30:
+    name: Gestão de políticas e normas de risco
+    description: |
+      Políticas, normas e metodologias de risco a nível do grupo.
+  BC-120.10.40:
+    name: Gestão da cultura de risco
+    description: |
+      Avaliação, sensibilização e programas de responsabilização da cultura de risco.
+  BC-120.20:
+    name: Identificação e avaliação de risco
+    description: |
+      Descoberta, avaliação, pontuação e priorização de riscos.
+  BC-120.20.10:
+    name: Identificação de risco
+    description: |
+      Workshops, análises e contributos para identificar riscos novos e emergentes.
+  BC-120.20.20:
+    name: Análise e pontuação de risco
+    description: |
+      Análise de probabilidade, impacto, velocidade e risco inerente versus residual.
+  BC-120.20.30:
+    name: Análise de cenários e stress
+    description: |
+      Análise prospetiva de cenários, stress e stress inverso.
+  BC-120.20.40:
+    name: Vigilância de riscos emergentes
+    description: |
+      Análise de horizonte para riscos emergentes e sinais fracos.
+  BC-120.30:
+    name: Gestão do tratamento do risco
+    description: |
+      Decisões de mitigação, transferência, evitamento e aceitação.
+  BC-120.30.10:
+    name: Planeamento da mitigação de risco
+    description: |
+      Definição de ações de mitigação, responsáveis e datas-alvo.
+  BC-120.30.20:
+    name: Gestão da transferência de risco
+    description: |
+      Transferência de risco através de seguros, contratos e cobertura.
+  BC-120.30.30:
+    name: Governação da aceitação de risco
+    description: |
+      Aceitação formal de riscos residuais acima do apetite com aprovações.
+  BC-120.30.40:
+    name: Design e eficácia dos controlos
+    description: |
+      Definição e avaliação da eficácia dos controlos de risco.
+  BC-120.40:
+    name: Monitorização e reporte de risco
+    description: |
+      Indicadores de risco, dashboards e reporte a órgãos de governação.
+  BC-120.40.10:
+    name: Gestão de indicadores-chave de risco
+    description: |
+      Definição, estabelecimento de limiares e acompanhamento de indicadores-chave de risco.
+  BC-120.40.20:
+    name: Registo de eventos e perdas de risco
+    description: |
+      Registo de eventos de risco operacional, quase-acidentes e perdas.
+  BC-120.40.30:
+    name: Reporte e dashboards de risco
+    description: |
+      Reporte periódico ao comité executivo, conselho e comité de risco.
+  BC-120.40.40:
+    name: Agregação de risco e análise de concentração
+    description: |
+      Agregação de riscos em toda a empresa e perspetivas de concentração.
+  BC-120.50:
+    name: Gestão de seguros corporativos
+    description: |
+      Aquisição e gestão de programas de seguros corporativos.
+  BC-120.50.10:
+    name: Design do programa de seguros
+    description: |
+      Estratégia de cobertura, retenção e limites por linha de seguro.
+  BC-120.50.20:
+    name: Colocação e renovação de seguros
+    description: |
+      Gestão de corretores, colocação no mercado e renovação de apólices.
+  BC-120.50.30:
+    name: Gestão de sinistros de seguros
+    description: |
+      Notificação, tratamento e recuperação de sinistros de seguros corporativos.
+  BC-120.50.40:
+    name: Gestão de seguros cativos
+    description: |
+      Operação e governação de veículos de seguros cativos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-ev-charging-network-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-ev-charging-network-operations-management.yaml
@@ -1,0 +1,179 @@
+locale: pt
+source: L1-ev-charging-network-operations-management.yaml
+entries:
+  BC-3480:
+    name: Gestão de operações da rede de carregamento de VE
+    description: |
+      Operações de redes de carregamento de VE para operadores de pontos de
+      carregamento e fornecedores de serviços de mobilidade elétrica — planeamento
+      de locais, operações de pontos de carregamento, gestão de energia e tarifas,
+      operações de clientes e roaming, faturação e liquidação, manutenção de
+      carregadores e participação em serviços de rede.
+  BC-3480.10:
+    name: Planeamento e implementação de locais de carregamento
+    description: |
+      Seleção do local, licenciamento, ligação à rede e implementação física
+      da infraestrutura de carregamento.
+  BC-3480.10.10:
+    name: Seleção de locais de carregamento
+    description: |
+      Identificação e qualificação de locais de carregamento face a critérios
+      de procura, terreno e rede.
+  BC-3480.10.20:
+    name: Licenciamento e ligação à rede do local
+    description: |
+      Licenciamento, aprovação de planeamento e coordenação da ligação à rede
+      para locais de carregamento.
+  BC-3480.10.30:
+    name: Coordenação da instalação de carregadores
+    description: |
+      Coordenação da instalação, obras civis, comissionamento e entrega às
+      operações de carregadores.
+  BC-3480.20:
+    name: Operações dos pontos de carregamento
+    description: |
+      Operação diária dos pontos de carregamento, incluindo monitorização, ciclo
+      de vida das sessões e controlo de firmware via OCPP.
+  BC-3480.20.10:
+    name: Monitorização dos pontos de carregamento
+    description: |
+      Monitorização em tempo real da saúde, disponibilidade e estados de alarme
+      dos pontos de carregamento.
+  BC-3480.20.20:
+    name: Gestão do ciclo de vida das sessões de carregamento
+    description: |
+      Gestão do ciclo de vida das sessões de carregamento, desde a autorização
+      até à entrega de energia e término.
+  BC-3480.20.30:
+    name: Gestão de firmware e configuração de carregadores
+    description: |
+      Gestão de versões de firmware, perfis de configuração e atualizações
+      remotas de carregadores.
+  BC-3480.30:
+    name: Gestão de energia e tarifas de carregamento
+    description: |
+      Gestão da coordenação de aprovisionamento de energia, tarifas de
+      carregamento e otimização por hora de uso na rede de carregamento.
+  BC-3480.30.10:
+    name: Coordenação de aprovisionamento de energia grossista
+    description: |
+      Coordenação com o aprovisionamento de energia em volumes, cobertura e PPAs
+      de suporte às operações de carregamento.
+  BC-3480.30.20:
+    name: Definição de tarifas de carregamento
+    description: |
+      Definição de tarifas de carregamento público, de membro e de roaming nos
+      vários mercados.
+  BC-3480.30.30:
+    name: Otimização de encargos de procura e hora de uso
+    description: |
+      Otimização das operações de carregamento face a estruturas de energia de
+      encargo de procura e hora de uso.
+  BC-3480.40:
+    name: Gestão de clientes e subscrições de carregamento
+    description: |
+      Integração de clientes, planos de subscrição e autenticação para serviços
+      de carregamento.
+  BC-3480.40.10:
+    name: Integração de contas de carregamento
+    description: |
+      Integração de clientes de carregamento, incluindo identidade, pagamento e
+      seleção de plano.
+  BC-3480.40.20:
+    name: Gestão de planos de subscrição de carregamento
+    description: |
+      Gestão de planos de subscrição, associação e pré-pago para clientes de
+      carregamento.
+  BC-3480.40.30:
+    name: Autenticação e autorização de carregamento
+    description: |
+      Autenticação e autorização de sessões de carregamento via RFID, aplicação
+      ou Plug-and-Charge.
+  BC-3480.50:
+    name: Faturação e liquidação de carregamento
+    description: |
+      Faturação de sessões de carregamento, liquidação com parceiros de roaming
+      e gestão de recibos para clientes de carregamento.
+  BC-3480.50.10:
+    name: Faturação de sessões de carregamento
+    description: |
+      Tarifação e faturação de sessões de carregamento a clientes diretos e de
+      roaming.
+  BC-3480.50.20:
+    name: Liquidação de roaming
+    description: |
+      Liquidação de sessões de roaming com CPOs e EMSPs parceiros via OCPI e
+      protocolos equivalentes.
+  BC-3480.50.30:
+    name: Gestão de reembolsos e recibos
+    description: |
+      Emissão de recibos, apoio ao reembolso de despesas e documentação fiscal
+      para clientes de carregamento.
+  BC-3480.60:
+    name: Interoperabilidade da rede de carregamento
+    description: |
+      Interoperabilidade com parceiros de roaming e conformidade com normas de
+      carregamento em conectores e protocolos.
+  BC-3480.60.10:
+    name: Gestão de parceiros de roaming
+    description: |
+      Integração e gestão de parceiros e hubs de roaming.
+  BC-3480.60.20:
+    name: Operações de Plug-and-Charge
+    description: |
+      Operação de certificados de contrato Plug-and-Charge ISO 15118 e fluxos
+      de autenticação.
+  BC-3480.60.30:
+    name: Gestão da compatibilidade de conectores de carregadores
+    description: |
+      Gestão da compatibilidade de conectores CCS, NACS, CHAdeMO e GB/T e
+      estratégias de adaptadores.
+  BC-3480.70:
+    name: Serviço de campo e manutenção de carregamento
+    description: |
+      Serviço de campo e manutenção de ativos de carregamento, incluindo despacho,
+      manutenção preventiva e peças sobresselentes.
+  BC-3480.70.10:
+    name: Despacho de avarias de carregadores
+    description: |
+      Despacho de técnicos de campo em resposta a avarias de carregadores e
+      problemas comunicados por clientes.
+  BC-3480.70.20:
+    name: Manutenção preventiva de carregadores
+    description: |
+      Manutenção preventiva planeada e inspeção de ativos de carregamento.
+  BC-3480.70.30:
+    name: Gestão de peças sobresselentes de carregadores
+    description: |
+      Gestão do inventário de peças sobresselentes de carregadores, pools de
+      reparação e obsolescência.
+  BC-3480.80:
+    name: Participação em serviços de rede e energia
+    description: |
+      Participação de ativos de carregamento em mercados de rede e energia,
+      incluindo resposta à procura, V2G e carregamento inteligente.
+    in_scope:
+      - Serviços de exportação de energia e capacidade V2G
+      - Participação em programas de resposta à procura
+      - Otimização de calendários de carregamento inteligente
+    out_of_scope:
+      - Operações de ativos de geração e negociação de energia grossista
+  BC-3480.80.10:
+    name: Operações de serviços veículo-para-rede
+    description: |
+      Operação de serviços V2G que entregam produtos de energia e capacidade a
+      mercados de rede e balanço.
+  BC-3480.80.20:
+    name: Participação em programas de resposta à procura
+    description: |
+      Participação em programas de resposta à procura, incluindo resposta ao
+      despacho e liquidação.
+  BC-3480.80.30:
+    name: Gestão de calendários de carregamento inteligente
+    description: |
+      Carregamento inteligente baseado em calendários em locais e veículos para
+      otimizar custo e impacto na rede.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-events-group-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-events-group-operations-management.yaml
@@ -1,0 +1,204 @@
+locale: pt
+source: L1-events-group-operations-management.yaml
+entries:
+  BC-4110:
+    name: Gestão de eventos e operações de grupo
+    description: |
+      Operação de eventos de reuniões, incentivos, conferências, exposições
+      e banquetes em locais de hotelaria — incluindo vendas de grupo,
+      alocação de espaços de função, execução de ordens de evento de
+      banquete, gestão de blocos de quartos de grupo, audiovisual e
+      produção, faturação e relatórios pós-evento.
+    in_scope:
+      - Prospeção, contratação e preços de grupo
+      - Alocação de espaço de função e resolução de conflitos
+      - Elaboração e execução de ordens de evento de banquete
+      - Contrato, lista e ocupação de blocos de quartos de grupo
+      - AV, palco e produção de eventos híbridos
+      - Faturação de conta mestre e liquidação final
+      - Relatórios de blocos vs. ocupação e desempenho pós-evento
+    out_of_scope:
+      - Marketing de eventos empresariais genérico (BC-410)
+      - Produção de cozinha de banquete e segurança alimentar (BC-4070)
+      - Check-in da receção para chegadas de grupo (BC-4060.10)
+  BC-4110.10:
+    name: Gestão de vendas de grupos e eventos
+    description: |
+      Qualificação de prospeções de grupo, elaboração de propostas e
+      contratos, concessões de preços e relatórios de pipeline para
+      negócios de grupo.
+  BC-4110.10.10:
+    name: Qualificação de prospeções de grupo
+    description: |
+      Qualificação de prospeções de grupo recebidas em função do destino,
+      espaço e adequação de tarifa.
+  BC-4110.10.20:
+    name: Elaboração de proposta e contrato de grupo
+    description: |
+      Elaboração de propostas e execução de contratos de vendas de grupo.
+  BC-4110.10.30:
+    name: Gestão de preços e concessões de grupo
+    description: |
+      Gestão de preços de grupo e negociação de concessões em função
+      das orientações de receita.
+  BC-4110.10.40:
+    name: Relatórios de pipeline de grupo
+    description: |
+      Relatórios sobre o pipeline de vendas de grupo e conversão ao
+      longo das fases.
+  BC-4110.20:
+    name: Gestão de espaços de evento e diário de funções
+    description: |
+      Definição e alocação do inventário de espaços de função, resolução
+      de conflitos e planeamento de configuração e capacidade.
+  BC-4110.20.10:
+    name: Definição do inventário de espaços de função
+    description: |
+      Definição do inventário de espaços de função, incluindo capacidades,
+      configurações e salas combináveis.
+  BC-4110.20.20:
+    name: Reserva e alocação de espaços
+    description: |
+      Reserva e alocação de espaços de função para eventos confirmados
+      e provisórios.
+  BC-4110.20.30:
+    name: Resolução de conflitos de espaço
+    description: |
+      Resolução de conflitos de espaço entre pedidos sobrepostos e
+      dependências de espaços adjacentes.
+  BC-4110.20.40:
+    name: Planeamento de configuração e capacidade
+    description: |
+      Planeamento de configurações e capacidade por evento, tendo em
+      conta restrições de carga de incêndio e acessibilidade.
+  BC-4110.30:
+    name: Execução de ordens de evento de banquete
+    description: |
+      Elaboração de ordens de evento de banquete, distribuição às equipas
+      operacionais, execução de montagem, serviço e desmontagem, e gestão
+      de alterações ao BEO.
+  BC-4110.30.10:
+    name: Elaboração de ordens de evento de banquete
+    description: |
+      Elaboração de ordens de evento de banquete com informações de
+      alimentação e bebidas, AV, configuração e timings.
+  BC-4110.30.20:
+    name: Distribuição e briefing de BEO
+    description: |
+      Distribuição de BEOs às equipas operacionais e briefing do pessoal
+      de execução.
+  BC-4110.30.30:
+    name: Operações de montagem, serviço e desmontagem
+    description: |
+      Operações de montagem, serviço e desmontagem em conformidade com
+      o BEO e o timing do evento.
+  BC-4110.30.40:
+    name: Operações de alteração de BEO
+    description: |
+      Operações para gerir alterações ao BEO, incluindo atualizações
+      de requisitos de última hora.
+  BC-4110.40:
+    name: Gestão de bloco de quartos e lista de alojamento de grupo
+    description: |
+      Configuração de contratos de bloco de quartos de grupo, operações
+      de lista de alojamento, corte, redução e relatórios de ocupação
+      ao nível da entrega do evento.
+  BC-4110.40.10:
+    name: Configuração do contrato de bloco
+    description: |
+      Configuração dos termos do contrato de bloco nos sistemas operacionais
+      para o evento.
+  BC-4110.40.20:
+    name: Operações de lista de alojamento
+    description: |
+      Operações sobre listas de alojamento, incluindo atualizações, pedidos
+      especiais e sequenciamento de chegadas.
+  BC-4110.40.30:
+    name: Operações de corte e redução do bloco
+    description: |
+      Operações de corte e redução que libertam o inventário de bloco
+      não utilizado para venda geral.
+  BC-4110.40.40:
+    name: Relatórios de ocupação do bloco
+    description: |
+      Relatórios sobre a ocupação do bloco em relação ao contrato para
+      contabilização de receitas e desempenho.
+  BC-4110.50:
+    name: Operações de AV e produção de eventos
+    description: |
+      Operações audiovisuais e de produção, incluindo AV interno, palco,
+      transmissão em direto híbrida e coordenação de fornecedores externos.
+  BC-4110.50.10:
+    name: Operações de AV interno
+    description: |
+      Operação de equipamentos e equipas de AV internos para eventos.
+  BC-4110.50.20:
+    name: Palco e produção de cenário
+    description: |
+      Palco e produção de cenário para eventos, incluindo elementos de
+      decoração e rigging.
+  BC-4110.50.30:
+    name: Operações de transmissão em direto e eventos híbridos
+    description: |
+      Operação de transmissão em direto e entrega de eventos híbridos,
+      abrangendo audiências remotas e presenciais.
+  BC-4110.50.40:
+    name: Coordenação de fornecedores de AV externos
+    description: |
+      Coordenação de fornecedores de AV externos em função dos requisitos
+      do local e de seguro.
+  BC-4110.60:
+    name: Faturação de eventos e gestão de conta mestre
+    description: |
+      Configuração de contas mestre, faturação individual e de incidentais,
+      depósitos e liquidação e reconciliação final do evento.
+  BC-4110.60.10:
+    name: Configuração de conta mestre
+    description: |
+      Configuração de contas mestre de evento e regras de encaminhamento
+      para itens faturáveis.
+  BC-4110.60.20:
+    name: Operações de faturação individual e de incidentais
+    description: |
+      Operação de faturação individual e de incidentais para participantes
+      além da conta mestre.
+  BC-4110.60.30:
+    name: Gestão de depósitos e pré-pagamentos
+    description: |
+      Gestão de depósitos e pré-pagamentos em função das etapas
+      do evento.
+  BC-4110.60.40:
+    name: Liquidação e reconciliação final do evento
+    description: |
+      Liquidação e reconciliação final da conta mestre do evento em função
+      do contrato e do consumo.
+  BC-4110.70:
+    name: Desempenho do evento e relatórios pós-evento
+    description: |
+      Relatórios de desempenho de eventos de grupo, incluindo blocos vs.
+      ocupação, resultados financeiros, feedback dos participantes e
+      acompanhamento de renovações.
+  BC-4110.70.10:
+    name: Relatórios de blocos vs. ocupação
+    description: |
+      Relatórios sobre o desempenho de blocos vs. ocupação para eventos
+      concluídos.
+  BC-4110.70.20:
+    name: Relatórios de desempenho financeiro do evento
+    description: |
+      Relatórios sobre o desempenho financeiro do evento em relação ao
+      orçamento e previsão.
+  BC-4110.70.30:
+    name: Recolha de feedback dos participantes
+    description: |
+      Recolha de feedback dos participantes através de inquéritos
+      pós-evento e canais de sinal em direto.
+  BC-4110.70.40:
+    name: Acompanhamento de reservas repetidas e renovações
+    description: |
+      Acompanhamento de pipelines de reservas repetidas e oportunidades
+      de renovação decorrentes de eventos concluídos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-export-control-defense-trade-management.yaml
+++ b/catalogue/i18n/pt/L1-export-control-defense-trade-management.yaml
@@ -1,0 +1,95 @@
+locale: pt
+source: L1-export-control-defense-trade-management.yaml
+entries:
+  BC-1790:
+    name: Gestão de controlo de exportações e comércio de defesa
+    description: |
+      Licenciamento de exportações, conformidade com ITAR/EAR, controlo de transferência de tecnologia e divulgação a entidades estrangeiras.
+  BC-1790.10:
+    name: Gestão de licenciamento de exportações
+    description: |
+      Licenças ITAR e EAR, candidaturas e condições.
+  BC-1790.10.10:
+    name: Classificação e jurisdição de exportações
+    description: |
+      Determinação de jurisdição ITAR/EAR e classificação ECCN de artigos.
+  BC-1790.10.20:
+    name: Candidatura a licença de exportação
+    description: |
+      Candidatura a licenças DSP ao abrigo do ITAR e licenças BIS ao abrigo do EAR.
+  BC-1790.10.30:
+    name: Conformidade com condições da licença
+    description: |
+      Acompanhamento e conformidade com provisos e condições das licenças.
+  BC-1790.10.40:
+    name: Relatório de utilização de licença
+    description: |
+      Relatório periódico sobre a utilização das licenças concedidas.
+  BC-1790.20:
+    name: Gestão de rastreio de conformidade comercial
+    description: |
+      Rastreio de sanções, partes interditas e embargos.
+  BC-1790.20.10:
+    name: Rastreio de partes interditas
+    description: |
+      Rastreio contra listas de partes interditas e com acesso restrito.
+  BC-1790.20.20:
+    name: Rastreio de países sujeitos a sanções
+    description: |
+      Rastreio de sanções e países sujeitos a embargos.
+  BC-1790.20.30:
+    name: Rastreio de utilização final restrita
+    description: |
+      Rastreio de diligência relativa à utilização final e ao utilizador final.
+  BC-1790.30:
+    name: Gestão do controlo de transferência de tecnologia
+    description: |
+      Divulgação controlada de tecnologia e acordos de assistência técnica.
+  BC-1790.30.10:
+    name: Controlo de divulgação de dados técnicos
+    description: |
+      Controlo da divulgação de dados técnicos classificados.
+  BC-1790.30.20:
+    name: Gestão de acordos de assistência técnica
+    description: |
+      Gestão de TAA, MLA e acordos de armazém.
+  BC-1790.30.30:
+    name: Gestão de exportações consideradas
+    description: |
+      Gestão de exportações consideradas a nacionais estrangeiros.
+  BC-1790.40:
+    name: Gestão de conformidade aduaneira e pautal
+    description: |
+      Operações aduaneiras de defesa, carnets ATA e documentação de importação/exportação.
+  BC-1790.40.10:
+    name: Operações aduaneiras de defesa
+    description: |
+      Operações aduaneiras específicas para artigos de defesa.
+  BC-1790.40.20:
+    name: Gestão de carnets ATA
+    description: |
+      Gestão de carnets ATA para exportações temporárias de defesa.
+  BC-1790.40.30:
+    name: Classificação pautal e valoração aduaneira
+    description: |
+      Classificação pautal SH e valoração aduaneira.
+  BC-1790.50:
+    name: Gestão de divulgação a entidades estrangeiras
+    description: |
+      Decisões de divulgação a entidades estrangeiras, capacidade de divulgação e divulgações controladas.
+  BC-1790.50.10:
+    name: Decisão de divulgação a entidades estrangeiras
+    description: |
+      Tomada de decisão sobre a divulgação de informação classificada a entidades estrangeiras.
+  BC-1790.50.20:
+    name: Marcação de capacidade de divulgação
+    description: |
+      Marcação de capacidade de divulgação e controlo de disseminação.
+  BC-1790.50.30:
+    name: Controlo de visitas estrangeiras
+    description: |
+      Controlo de visitantes estrangeiros e aprovação de pedidos de visita.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-facilities-management.yaml
+++ b/catalogue/i18n/pt/L1-facilities-management.yaml
@@ -1,0 +1,119 @@
+locale: pt
+source: L1-facilities-management.yaml
+entries:
+  BC-700:
+    name: Gestão de instalações
+    description: |
+      Serviços de edifício, local de trabalho e gestão de instalações duras e suaves.
+  BC-700.10:
+    name: Gestão de serviços de local de trabalho
+    description: |
+      Receção, correspondência e serviços de experiência no local de trabalho.
+  BC-700.10.10:
+    name: Gestão de receção e visitantes
+    description: |
+      Pré-registo de visitantes, receção e controlo de acesso.
+  BC-700.10.20:
+    name: Serviços de correspondência e distribuição
+    description: |
+      Correspondência e encomendas de entrada e saída e distribuição interna.
+  BC-700.10.30:
+    name: Concierge e helpdesk do local de trabalho
+    description: |
+      Concierge do local de trabalho, helpdesk e tratamento de pedidos de serviço.
+  BC-700.10.40:
+    name: Serviços de salas de reunião e eventos
+    description: |
+      Reserva de salas de reunião, configuração AV e suporte a eventos.
+  BC-700.20:
+    name: Gestão de instalações duras
+    description: |
+      Sistemas de edifício — AVAC, elétrico, canalização e estrutura.
+  BC-700.20.10:
+    name: Operações de sistemas AVAC
+    description: |
+      Operação e manutenção de aquecimento, ventilação e arrefecimento.
+  BC-700.20.20:
+    name: Operações de sistemas elétricos
+    description: |
+      Operação e manutenção de sistemas elétricos de edifício.
+  BC-700.20.30:
+    name: Operações mecânicas e de canalização
+    description: |
+      Operações de sistemas mecânicos, de canalização e de água.
+  BC-700.20.40:
+    name: Manutenção da estrutura do edifício
+    description: |
+      Manutenção da estrutura, envelope e revestimento do edifício.
+  BC-700.20.50:
+    name: Gestão de energia do edifício
+    description: |
+      Monitorização e otimização de energia do edifício.
+  BC-700.30:
+    name: Gestão de instalações suaves
+    description: |
+      Limpeza, restauração, segurança e espaços exteriores.
+  BC-700.30.10:
+    name: Serviços de limpeza
+    description: |
+      Limpeza diária, limpeza profunda e serviços de higiene.
+  BC-700.30.20:
+    name: Restauração e serviços de alimentação
+    description: |
+      Restauração no local de trabalho, vending e serviços de hospitalidade.
+  BC-700.30.30:
+    name: Operações de segurança física
+    description: |
+      Vigilância, patrulhas, CCTV e operações de controlo de acesso.
+  BC-700.30.40:
+    name: Espaços exteriores e paisagismo
+    description: |
+      Manutenção de espaços exteriores, paisagismo e áreas externas.
+  BC-700.30.50:
+    name: Serviços de gestão de resíduos
+    description: |
+      Recolha, separação e reciclagem de resíduos nas instalações.
+  BC-700.40:
+    name: Gestão de espaços
+    description: |
+      Planeamento de espaços, gestão de ocupação e mudanças.
+  BC-700.40.10:
+    name: Planeamento de espaços
+    description: |
+      Planeamento, alocação e stack planning de espaços.
+  BC-700.40.20:
+    name: Monitorização de ocupação
+    description: |
+      Sensing de ocupação, análise de utilização e previsão.
+  BC-700.40.30:
+    name: Gestão de mudanças
+    description: |
+      Planeamento e execução de mudanças, adições e alterações.
+  BC-700.40.40:
+    name: Reserva de secretária e hot-desking
+    description: |
+      Plataformas de reserva de secretária e operações de local de trabalho híbrido.
+  BC-700.50:
+    name: Gestão de saúde e segurança das instalações
+    description: |
+      Segurança do edifício, incêndio e sistemas de emergência.
+  BC-700.50.10:
+    name: Gestão da segurança contra incêndio
+    description: |
+      Deteção de incêndio, supressão e simulacros de evacuação.
+  BC-700.50.20:
+    name: Coordenação da resposta de emergência
+    description: |
+      Resposta a emergências no local e coordenação de primeiros socorros.
+  BC-700.50.30:
+    name: Gestão de autorizações de trabalho
+    description: |
+      Governação de autorizações de trabalho para tarefas perigosas nas instalações.
+  BC-700.50.40:
+    name: Conformidade estatutária do edifício
+    description: |
+      Inspeções e certificações estatutárias de segurança do edifício.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-farm-land-asset-management.yaml
+++ b/catalogue/i18n/pt/L1-farm-land-asset-management.yaml
@@ -1,0 +1,132 @@
+locale: pt
+source: L1-farm-land-asset-management.yaml
+entries:
+  BC-3540:
+    name: Gestão de terra e ativos da exploração agrícola
+    description: |
+      Registos de posse e arrendamento de terra, gestão de campos e parcelas,
+      telemetria de equipamento e maquinaria na exploração, infraestrutura de
+      irrigação, edifícios agrícolas e ativos energéticos na exploração.
+  BC-3540.10:
+    name: Gestão da posse de terra e arrendamentos
+    description: |
+      Registos de título de propriedade, posse, arrendamentos e servidões que
+      suportam os direitos de exploração no conjunto da exploração agrícola.
+    in_scope:
+      - Registos de título e posse
+      - Administração de contratos de arrendamento
+      - Registos de servidões e direitos de acesso
+    out_of_scope:
+      - Imobiliário empresarial (BC-1410)
+  BC-3540.10.10:
+    name: Registos de título e posse de terra
+    description: |
+      Registos de posse em plena propriedade, arrendamento e posse consuetudinária
+      no conjunto da exploração agrícola.
+  BC-3540.10.20:
+    name: Administração de contratos de arrendamento
+    description: |
+      Administração de contratos de arrendamento agrícola e renovações.
+  BC-3540.10.30:
+    name: Gestão de servidões de terra
+    description: |
+      Gestão de servidões de acesso, direitos de passagem e servidões de
+      conservação.
+  BC-3540.20:
+    name: Gestão de campos e parcelas
+    description: |
+      Registos de limites de campos, histórico de campos e zonagem de
+      produtividade ao nível do campo e da parcela.
+  BC-3540.20.10:
+    name: Registo de limites de campos
+    description: |
+      Captura e manutenção de limites de campos em sistemas SIG da exploração.
+  BC-3540.20.20:
+    name: Registos históricos dos campos
+    description: |
+      Registos históricos plurianuais de campos com culturas, fatores de produção
+      e rendimentos.
+  BC-3540.20.30:
+    name: Zonagem de produtividade dos campos
+    description: |
+      Zonagem de produtividade e delimitação de zonas de gestão dentro dos campos.
+  BC-3540.30:
+    name: Gestão de equipamento agrícola
+    description: |
+      Inventário de equipamento na exploração, operações de maquinaria, telemetria
+      ISOBUS e acordos de partilha de equipamento.
+  BC-3540.30.10:
+    name: Inventário de equipamento agrícola
+    description: |
+      Inventário de tractores, alfaias e equipamento autopropulsado.
+  BC-3540.30.20:
+    name: Operações de maquinaria no campo
+    description: |
+      Mobilização diária de maquinaria no campo e alocação de operadores.
+  BC-3540.30.30:
+    name: Integração de telemetria ISOBUS
+    description: |
+      Integração de telemetria de maquinaria compatível com ISOBUS com sistemas
+      de gestão da exploração.
+  BC-3540.30.40:
+    name: Partilha de equipamento e contratação
+    description: |
+      Acordos de partilha de equipamento, contratação e operadores especializados.
+  BC-3540.40:
+    name: Gestão da infraestrutura de irrigação
+    description: |
+      Gestão do ciclo de vida de sistemas de irrigação, alocações de água e
+      manutenção da infraestrutura de irrigação.
+  BC-3540.40.10:
+    name: Conceção do sistema de irrigação
+    description: |
+      Conceção e dimensionamento da capacidade dos sistemas de irrigação da
+      exploração.
+  BC-3540.40.20:
+    name: Conformidade com alocações de água
+    description: |
+      Conformidade com alocações de águas superficiais e subterrâneas e medição.
+  BC-3540.40.30:
+    name: Manutenção da infraestrutura de irrigação
+    description: |
+      Manutenção de bombas, condutas principais, laterais e emissores.
+  BC-3540.50:
+    name: Gestão de edifícios e pátios da exploração
+    description: |
+      Operação e manutenção de edifícios de armazenamento, alojamento de animais,
+      pátios e caminhos na exploração.
+  BC-3540.50.10:
+    name: Operações de edifícios de armazenamento
+    description: |
+      Operação de edifícios de armazenamento de grão, feno e produtos agroquímicos.
+  BC-3540.50.20:
+    name: Operações de alojamento de animais
+    description: |
+      Operação e gestão de camas de alojamento de animais.
+  BC-3540.50.30:
+    name: Manutenção de pátios e caminhos
+    description: |
+      Manutenção de pátios, caminhos e instalações de maneio de animais na
+      exploração.
+  BC-3540.60:
+    name: Gestão de energia na exploração
+    description: |
+      Geração de energia na exploração, coordenação do aprovisionamento de
+      combustível e energia e registo do consumo de energia.
+  BC-3540.60.10:
+    name: Geração de energia na exploração
+    description: |
+      Geração de energia solar, eólica e biogás na exploração agrícola.
+  BC-3540.60.20:
+    name: Coordenação do aprovisionamento de combustível e energia
+    description: |
+      Coordenação do aprovisionamento de combustível, eletricidade e gás da
+      exploração.
+  BC-3540.60.30:
+    name: Registo do consumo de energia
+    description: |
+      Registo do consumo de energia da exploração por atividade e ativo.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-field-service-management.yaml
+++ b/catalogue/i18n/pt/L1-field-service-management.yaml
@@ -1,0 +1,115 @@
+locale: pt
+source: L1-field-service-management.yaml
+entries:
+  BC-1050:
+    name: Gestão do serviço de campo
+    description: |
+      Serviço da base instalada, técnicos de campo, reparação e colocação em serviço no local.
+  BC-1050.10:
+    name: Gestão de pedidos de serviço
+    description: |
+      Captura, triagem e qualificação de pedidos de serviço.
+  BC-1050.10.10:
+    name: Receção de pedidos de serviço
+    description: |
+      Receção multicanal de pedidos de serviço de clientes.
+  BC-1050.10.20:
+    name: Triagem de pedidos de serviço
+    description: |
+      Triagem, classificação e encaminhamento de pedidos de serviço.
+  BC-1050.10.30:
+    name: Diagnóstico e resolução remota
+    description: |
+      Diagnóstico remoto e resolução remota à primeira.
+  BC-1050.20:
+    name: Gestão do despacho de serviço
+    description: |
+      Programação, percursos e despacho de técnicos.
+  BC-1050.20.10:
+    name: Programação de técnicos
+    description: |
+      Programação de técnicos por competência e disponibilidade.
+  BC-1050.20.20:
+    name: Otimização de percursos
+    description: |
+      Otimização de percursos e deslocações para visitas de serviço.
+  BC-1050.20.30:
+    name: Execução do despacho
+    description: |
+      Despacho em tempo real e reatribuição de intervenções de serviço.
+  BC-1050.30:
+    name: Gestão da execução do serviço
+    description: |
+      Execução do serviço no local e relatório.
+  BC-1050.30.10:
+    name: Prestação de serviço no local
+    description: |
+      Execução no local das tarefas de serviço face à ordem de trabalho.
+  BC-1050.30.20:
+    name: Captura de documentação de serviço
+    description: |
+      Captura de notas de serviço, fotos e assinaturas.
+  BC-1050.30.30:
+    name: Gestão da aceitação do cliente
+    description: |
+      Aprovação e aceitação do cliente do serviço concluído.
+  BC-1050.40:
+    name: Gestão de peças de serviço
+    description: |
+      Peças distribuídas no campo, stock em viatura e reabastecimento.
+  BC-1050.40.10:
+    name: Gestão do stock em viatura
+    description: |
+      Definição e gestão do stock em viatura e de stocks avançados.
+  BC-1050.40.20:
+    name: Reabastecimento de peças de serviço
+    description: |
+      Reabastecimento de locais de stock avançado e de técnicos.
+  BC-1050.40.30:
+    name: Devoluções de peças de serviço
+    description: |
+      Devoluções de peças não utilizadas, defeituosas ou reparáveis do campo.
+  BC-1050.50:
+    name: Gestão de contratos de serviço
+    description: |
+      Acordos de serviço, SLAs e direitos.
+  BC-1050.50.10:
+    name: Elaboração de acordos de serviço
+    description: |
+      Elaboração de contratos de serviço, níveis e condições.
+  BC-1050.50.20:
+    name: Gestão de direitos de serviço
+    description: |
+      Verificação de direitos no pedido de serviço e no despacho.
+  BC-1050.50.30:
+    name: Renovação de contratos de serviço
+    description: |
+      Renovação e atualização de contratos de serviço.
+  BC-1050.50.40:
+    name: Faturação de serviços
+    description: |
+      Faturação de contratos de serviço e trabalhos por tempo e material.
+  BC-1050.60:
+    name: Gestão do desempenho do serviço de campo
+    description: |
+      Resolução à primeira, tempo de resposta, NPS, produtividade do técnico.
+  BC-1050.60.10:
+    name: Acompanhamento da resolução à primeira
+    description: |
+      Medição e melhoria da taxa de resolução à primeira intervenção.
+  BC-1050.60.20:
+    name: Acompanhamento do tempo de resposta e resolução
+    description: |
+      Acompanhamento do tempo de resposta e resolução com base em SLA.
+  BC-1050.60.30:
+    name: Relatório de produtividade do técnico
+    description: |
+      Relatório de utilização, tempo produtivo e produtividade do técnico.
+  BC-1050.60.40:
+    name: NPS e satisfação do serviço
+    description: |
+      Medição do NPS e da satisfação relacionada com o serviço.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-financial-crime-management.yaml
+++ b/catalogue/i18n/pt/L1-financial-crime-management.yaml
@@ -1,0 +1,107 @@
+locale: pt
+source: L1-financial-crime-management.yaml
+entries:
+  BC-1400:
+    name: Gestão de crime financeiro
+    description: |
+      Monitorização de transações AML, rastreio de sanções, deteção de fraude e comunicação de atividades suspeitas.
+  BC-1400.10:
+    name: Gestão da monitorização de transações AML
+    description: |
+      Regras, alertas e cenários de monitorização AML.
+  BC-1400.10.10:
+    name: Conceção de cenários e regras AML
+    description: |
+      Conceção de cenários, regras e limiares de AML.
+  BC-1400.10.20:
+    name: Geração de alertas AML
+    description: |
+      Geração de alertas AML a partir da monitorização de transações.
+  BC-1400.10.30:
+    name: Triagem de alertas AML
+    description: |
+      Triagem e priorização baseada em risco de alertas AML.
+  BC-1400.10.40:
+    name: Ajuste e validação de modelos AML
+    description: |
+      Ajuste, validação e revisão da eficácia de modelos AML.
+  BC-1400.20:
+    name: Gestão de rastreio de sanções
+    description: |
+      Listas de sanções, rastreio de nomes e transações e tratamento de ocorrências.
+  BC-1400.20.10:
+    name: Gestão de listas de sanções
+    description: |
+      Agregação e manutenção de listas de vigilância de sanções.
+  BC-1400.20.20:
+    name: Rastreio de nomes de clientes
+    description: |
+      Rastreio de clientes e contrapartes face a sanções.
+  BC-1400.20.30:
+    name: Rastreio de sanções em transações
+    description: |
+      Rastreio em tempo real de transações face a listas de sanções.
+  BC-1400.20.40:
+    name: Tratamento de ocorrências de sanções
+    description: |
+      Investigação e resolução de ocorrências de sanções.
+  BC-1400.30:
+    name: Gestão de deteção e investigação de fraude
+    description: |
+      Deteção de fraude em produtos e canais e respetivas investigações.
+  BC-1400.30.10:
+    name: Deteção de fraude em candidaturas
+    description: |
+      Deteção de fraude na fase de candidatura de cliente ou produto.
+  BC-1400.30.20:
+    name: Deteção de fraude em transações
+    description: |
+      Deteção em tempo real de transações fraudulentas.
+  BC-1400.30.30:
+    name: Investigação de fraude
+    description: |
+      Investigação e resolução de casos de fraude.
+  BC-1400.30.40:
+    name: Gestão de perdas e recuperação por fraude
+    description: |
+      Acompanhamento de perdas por fraude e esforços de recuperação.
+  BC-1400.30.50:
+    name: Tratamento de fraude por transferência autorizada
+    description: |
+      Tratamento de casos de fraude por transferência autorizada e reembolso.
+  BC-1400.40:
+    name: Gestão de comunicação de atividades suspeitas
+    description: |
+      Apresentação de SAR/STR e reporte regulatório.
+  BC-1400.40.10:
+    name: Elaboração e submissão de SAR
+    description: |
+      Elaboração e submissão de SAR/STR às Unidades de Informação Financeira.
+  BC-1400.40.20:
+    name: Reporte regulatório de crime financeiro
+    description: |
+      Reporte regulatório periódico sobre crime financeiro.
+  BC-1400.40.30:
+    name: Ligação com autoridades policiais
+    description: |
+      Ligação com autoridades policiais e respostas a pedidos de informação.
+  BC-1400.50:
+    name: Gestão de investigações de crime financeiro
+    description: |
+      Gestão de processos, investigações e escalada.
+  BC-1400.50.10:
+    name: Gestão de processos
+    description: |
+      Gestão de processos de investigações de crime financeiro.
+  BC-1400.50.20:
+    name: Execução de investigações
+    description: |
+      Execução de investigações e recolha de provas.
+  BC-1400.50.30:
+    name: Escalada e encerramento
+    description: |
+      Escalada, decisão e encerramento de investigações.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-financial-management.yaml
+++ b/catalogue/i18n/pt/L1-financial-management.yaml
@@ -1,0 +1,163 @@
+locale: pt
+source: L1-financial-management.yaml
+entries:
+  BC-200:
+    name: Gestão financeira
+    description: |
+      Contabilidade, controlo, reporte estatutário e de gestão e orçamentação.
+  BC-200.10:
+    name: Gestão do razão geral
+    description: |
+      Plano de contas, lançamentos e encerramento de período.
+  BC-200.10.10:
+    name: Gestão do plano de contas
+    description: |
+      Definição e governação do plano de contas e hierarquias de contas.
+  BC-200.10.20:
+    name: Processamento de lançamentos contabilísticos
+    description: |
+      Lançamentos manuais e automatizados com fluxo de aprovação.
+  BC-200.10.30:
+    name: Contabilidade intercompanhia
+    description: |
+      Transações intercompanhia, eliminações e reconciliações.
+  BC-200.10.40:
+    name: Encerramento de período
+    description: |
+      Calendário de encerramento, acréscimos e certificações de encerramento.
+  BC-200.10.50:
+    name: Reconciliação de contas
+    description: |
+      Reconciliações e substantiação de contas do balanço.
+  BC-200.20:
+    name: Gestão de contas a pagar
+    description: |
+      Processamento de faturas, pagamentos e contabilidade de fornecedores.
+  BC-200.20.10:
+    name: Receção e validação de faturas de fornecedores
+    description: |
+      Receção, captura e conferência a três vias de faturas de fornecedores.
+  BC-200.20.20:
+    name: Execução de pagamentos
+    description: |
+      Agendamento e execução de pagamentos a fornecedores.
+  BC-200.20.30:
+    name: Gestão de dados mestre contabilísticos de fornecedores
+    description: |
+      Dados mestre financeiros de fornecedores, dados bancários e atributos fiscais.
+  BC-200.20.40:
+    name: Processamento de despesas de viagem
+    description: |
+      Captura, aprovação e reembolso de despesas de colaboradores.
+  BC-200.20.50:
+    name: Reconciliação do razão de fornecedores
+    description: |
+      Reconciliação de extratos de fornecedores e do subrazão de contas a pagar.
+  BC-200.30:
+    name: Gestão de contas a receber
+    description: |
+      Faturação a clientes, cobranças e imputação de pagamentos.
+  BC-200.30.10:
+    name: Faturação a clientes
+    description: |
+      Geração e emissão de faturas e notas de crédito a clientes.
+  BC-200.30.20:
+    name: Imputação de pagamentos
+    description: |
+      Imputação de pagamentos recebidos de clientes a saldos em aberto.
+  BC-200.30.30:
+    name: Gestão de cobranças
+    description: |
+      Dunning, estratégia de cobrança e acompanhamento de pagamentos de clientes.
+  BC-200.30.40:
+    name: Risco de crédito e limites de clientes
+    description: |
+      Avaliação de crédito, definição de limites e bloqueios de crédito de clientes.
+  BC-200.30.50:
+    name: Gestão de disputas e deduções
+    description: |
+      Investigação e resolução de disputas e deduções de faturas.
+  BC-200.40:
+    name: Contabilidade de ativos fixos
+    description: |
+      Registos de ativos, depreciação e imparidade.
+  BC-200.40.10:
+    name: Manutenção do registo de ativos fixos
+    description: |
+      Capitalização, classificação e acompanhamento de ativos fixos.
+  BC-200.40.20:
+    name: Depreciação e amortização
+    description: |
+      Métodos, planos e lançamentos de depreciação.
+  BC-200.40.30:
+    name: Imparidade e revalorização de ativos
+    description: |
+      Testes de imparidade e revalorização de ativos segundo IFRS ou GAAP local.
+  BC-200.40.40:
+    name: Contabilização de alienações de ativos
+    description: |
+      Contabilização de abates, vendas e write-offs de ativos fixos.
+  BC-200.50:
+    name: Gestão da contabilidade de custos
+    description: |
+      Objetos de custo, alocações de custos e custeio standard.
+  BC-200.50.10:
+    name: Gestão de objetos e centros de custo
+    description: |
+      Definição de centros de custo, ordens internas e objetos de custo de projetos.
+  BC-200.50.20:
+    name: Custeio standard
+    description: |
+      Definição de custos standard, análise de desvios e revalorização.
+  BC-200.50.30:
+    name: Alocação e absorção de custos
+    description: |
+      Ciclos de alocação, drivers e absorção de custos gerais.
+  BC-200.50.40:
+    name: Custeio de produtos e serviços
+    description: |
+      Custeio de produtos, serviços e compromissos com clientes.
+  BC-200.60:
+    name: Gestão do reporte financeiro
+    description: |
+      Reporte financeiro interno e consolidação.
+  BC-200.60.10:
+    name: Consolidação financeira
+    description: |
+      Consolidação de entidades jurídicas incluindo eliminações e conversão cambial.
+  BC-200.60.20:
+    name: Reporte financeiro interno
+    description: |
+      Produção de relatórios internos de resultados, balanço e fluxos de caixa.
+  BC-200.60.30:
+    name: Reporte por segmento e de gestão
+    description: |
+      Reporte por segmento e segundo a perspetiva de gestão.
+  BC-200.60.40:
+    name: Elaboração de divulgações financeiras
+    description: |
+      Elaboração de notas e divulgações de suporte a relatórios financeiros.
+  BC-200.70:
+    name: Reporte estatutário e regulatório
+    description: |
+      Contas estatutárias e submissões financeiras regulatórias.
+  BC-200.70.10:
+    name: Preparação de contas estatutárias
+    description: |
+      Preparação de demonstrações financeiras estatutárias de entidades jurídicas.
+  BC-200.70.20:
+    name: Submissões financeiras regulatórias
+    description: |
+      Reportes financeiros regulatórios sectoriais e submissões prudenciais.
+  BC-200.70.30:
+    name: Coordenação da auditoria externa
+    description: |
+      Ligação com auditores externos e gestão de entregáveis de auditoria.
+  BC-200.70.40:
+    name: Reporte de sustentabilidade e não financeiro
+    description: |
+      Divulgações não financeiras e de sustentabilidade (p.ex. CSRD, IFRS S1/S2).
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-financial-planning-analysis.yaml
+++ b/catalogue/i18n/pt/L1-financial-planning-analysis.yaml
@@ -1,0 +1,111 @@
+locale: pt
+source: L1-financial-planning-analysis.yaml
+entries:
+  BC-230:
+    name: Planeamento e análise financeira
+    description: |
+      Previsão, planeamento, análise de desempenho e reporte de gestão.
+  BC-230.10:
+    name: Gestão de orçamentação
+    description: |
+      Processo de orçamento anual e consolidação.
+  BC-230.10.10:
+    name: Calendário orçamental e governação do processo
+    description: |
+      Calendário orçamental, modelos e governação do processo.
+  BC-230.10.20:
+    name: Definição de metas descendentes
+    description: |
+      Definição de metas financeiras descendentes alinhadas com a estratégia.
+  BC-230.10.30:
+    name: Construção do orçamento ascendente
+    description: |
+      Orçamentação ascendente por centro de custo, projeto e produto.
+  BC-230.10.40:
+    name: Consolidação e aprovação do orçamento
+    description: |
+      Consolidação do grupo, iteração e aprovação final do orçamento.
+  BC-230.20:
+    name: Gestão de previsões
+    description: |
+      Previsões contínuas e planeamento de cenários.
+  BC-230.20.10:
+    name: Produção de previsões contínuas
+    description: |
+      Previsões contínuas de receita, custo e caixa em cadência mensal ou trimestral.
+  BC-230.20.20:
+    name: Previsão baseada em drivers
+    description: |
+      Utilização de drivers operacionais para prever resultados financeiros.
+  BC-230.20.30:
+    name: Modelação de cenários e sensibilidade
+    description: |
+      Previsão multi-cenário e análise de sensibilidade.
+  BC-230.20.40:
+    name: Acompanhamento da precisão das previsões
+    description: |
+      Acompanhamento e melhoria da precisão das previsões por linha.
+  BC-230.30:
+    name: Reporte de gestão
+    description: |
+      Reporte periódico de gestão, KPIs e dashboards.
+  BC-230.30.10:
+    name: Reporte executivo e ao conselho
+    description: |
+      Dashboards executivos e relatórios de desempenho ao nível do conselho.
+  BC-230.30.20:
+    name: Reporte de desempenho por unidade de negócio
+    description: |
+      Reporte por unidade de negócio, segmento e linha de produto.
+  BC-230.30.30:
+    name: Definição e governação de KPIs
+    description: |
+      Taxonomia de KPIs, definições e governação sobre métricas.
+  BC-230.30.40:
+    name: Análise de gestão self-service
+    description: |
+      Capacitação de análise self-service para parceiros de negócio financeiros.
+  BC-230.40:
+    name: Gestão da análise de desempenho
+    description: |
+      Análise de desvios, rentabilidade e análises aprofundadas.
+  BC-230.40.10:
+    name: Análise de desvios e plano vs. real
+    description: |
+      Análise de desvios entre valores reais, orçamento e previsão.
+  BC-230.40.20:
+    name: Análise de rentabilidade
+    description: |
+      Análise de rentabilidade por cliente, produto e canal.
+  BC-230.40.30:
+    name: Análise de custos e eficiência
+    description: |
+      Análise de drivers de custo, rácios de eficiência e benchmarking.
+  BC-230.40.40:
+    name: Análise do capital circulante
+    description: |
+      Análise de ciclos de recebíveis, pagáveis e inventário.
+  BC-230.50:
+    name: Gestão de casos de negócio
+    description: |
+      Desenvolvimento de casos de negócio, avaliação e revisão pós-implementação.
+  BC-230.50.10:
+    name: Desenvolvimento de casos de negócio
+    description: |
+      Modelos e metodologias padronizados para casos de negócio.
+  BC-230.50.20:
+    name: Avaliação de investimentos
+    description: |
+      VAL, TIR, payback e avaliação qualitativa de investimentos.
+  BC-230.50.30:
+    name: Governação da alocação de capital
+    description: |
+      Comités de aprovação de capital, limiares e priorização.
+  BC-230.50.40:
+    name: Acompanhamento da realização de benefícios
+    description: |
+      Revisões pós-implementação e acompanhamento de benefícios.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-fleet-mobile-asset-management.yaml
+++ b/catalogue/i18n/pt/L1-fleet-mobile-asset-management.yaml
@@ -1,0 +1,136 @@
+locale: pt
+source: L1-fleet-mobile-asset-management.yaml
+entries:
+  BC-2430:
+    name: Gestão de frota e ativos móveis
+    description: |
+      Aprovisionamento, manutenção, utilização e alienação de veículos, navios,
+      aeronaves, material circulante e equipamento partilhado como contentores,
+      reboques e ULDs.
+  BC-2430.10:
+    name: Gestão de aquisição e alienação de frota
+    description: |
+      Especificação, aquisição, arrendamento, afretamento e alienação no fim de
+      vida de ativos móveis.
+    in_scope:
+      - Aprovisionamento de veículos, navios, aeronaves e material circulante
+      - Acordos de afretamento wet, dry e bareboat
+      - Decisões de fim de vida e revenda
+    out_of_scope:
+      - Aprovisionamento genérico de bens indiretos (BC-500)
+      - Contabilidade de ativos fixos (BC-200)
+  BC-2430.10.10:
+    name: Especificação e aprovisionamento de frota
+    description: |
+      Especificação e aprovisionamento de novos ativos de frota.
+  BC-2430.10.20:
+    name: Gestão de arrendamento e afretamento
+    description: |
+      Arrendamentos operacionais, arrendamentos financeiros e acordos de
+      afretamento de ativos de frota.
+  BC-2430.10.30:
+    name: Alienação no fim de vida
+    description: |
+      Revenda, abate e reciclagem de ativos de frota retirados.
+  BC-2430.20:
+    name: Gestão de manutenção de frota
+    description: |
+      Manutenção preventiva, corretiva e grande revisão de veículos, navios,
+      aeronaves e material circulante.
+  BC-2430.20.10:
+    name: Agendamento de manutenção preventiva
+    description: |
+      Agendamento de manutenção preventiva baseada em tempo e condição.
+  BC-2430.20.20:
+    name: Execução de manutenção corretiva
+    description: |
+      Reparação de avarias e trabalho corretivo em ativos móveis.
+  BC-2430.20.30:
+    name: Conformidade com inspeções obrigatórias
+    description: |
+      Conformidade com inspeções estatutárias e diretivas de aeronavegabilidade
+      ou navegabilidade.
+  BC-2430.20.40:
+    name: Grande revisão e revisão geral
+    description: |
+      Grandes revisões, dry-dockings e eventos de heavy check.
+  BC-2430.30:
+    name: Gestão do conjunto de equipamentos
+    description: |
+      Gestão de contentores, reboques, chassis e ULDs partilhados em depósitos,
+      clientes e parceiros.
+  BC-2430.30.10:
+    name: Gestão do conjunto de contentores
+    description: |
+      Rastreio e equilíbrio das frotas de contentores nos depósitos.
+  BC-2430.30.20:
+    name: Gestão do conjunto de reboques e chassis
+    description: |
+      Gestão do conjunto de reboques e chassis, incluindo partilha de grey-pool.
+  BC-2430.30.30:
+    name: Gestão do conjunto de ULDs
+    description: |
+      Rastreio, reparação e equilíbrio de ULDs nas estações.
+  BC-2430.30.40:
+    name: Operações de reposicionamento de equipamento vazio
+    description: |
+      Execução de movimentos de reposicionamento em vazio entre depósitos com
+      excesso e défice.
+  BC-2430.40:
+    name: Telemetria e monitorização de frota
+    description: |
+      Monitorização contínua da posição, condição e comportamento do operador dos
+      ativos para apoiar a manutenção e as operações.
+  BC-2430.40.10:
+    name: Operações de telemetria de frota
+    description: |
+      Operação de plataformas de telemetria que recebem dados de posição e motor.
+  BC-2430.40.20:
+    name: Monitorização da condição de ativos
+    description: |
+      Monitorização da condição de ativos móveis, incluindo estado de reefer e
+      carga.
+  BC-2430.40.30:
+    name: Monitorização do comportamento do condutor
+    description: |
+      Monitorização de sinais de comportamento do condutor, como travagem brusca
+      e excesso de velocidade.
+  BC-2430.50:
+    name: Gestão de conformidade e certificação de frota
+    description: |
+      Registo, certificação e conformidade ambiental de ativos de frota junto de
+      reguladores e sociedades de classificação.
+  BC-2430.50.10:
+    name: Registo de veículo, navio e aeronave
+    description: |
+      Registo inicial e contínuo junto de autoridades nacionais e internacionais.
+  BC-2430.50.20:
+    name: Inspeção estatutária e certificação
+    description: |
+      Certificados e auditorias de classe, aeronavegabilidade e aptidão para a
+      estrada.
+  BC-2430.50.30:
+    name: Conformidade ambiental e de emissões
+    description: |
+      Conformidade com regimes de emissões de veículos, navios e aeronaves.
+  BC-2430.60:
+    name: Gestão de utilização e desempenho da frota
+    description: |
+      Medição da utilização de ativos, tempos de rotação e custo total de
+      propriedade para orientar decisões de frota.
+  BC-2430.60.10:
+    name: Reporte de utilização de ativos
+    description: |
+      Reporte de utilização por tipo de ativo, rota e depósito.
+  BC-2430.60.20:
+    name: Análise do tempo de rotação de equipamento
+    description: |
+      Análise dos tempos de rotação de contentores, reboques e ULDs.
+  BC-2430.60.30:
+    name: Análise do custo total de propriedade
+    description: |
+      Análise do custo total de propriedade por tipo de frota e fornecedor.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-food-beverage-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-food-beverage-operations-management.yaml
@@ -1,0 +1,189 @@
+locale: pt
+source: L1-food-beverage-operations-management.yaml
+entries:
+  BC-4070:
+    name: Gestão de operações de alimentação e bebidas
+    description: |
+      Operação de serviços de alimentação e bebidas em restaurante, bar,
+      serviço de quarto, banquetes e cozinha — abrangendo engenharia de
+      receitas e menus, aprovisionamento, produção de cozinha, serviço,
+      higiene e conformidade com segurança alimentar.
+  BC-4070.10:
+    name: Engenharia de menus e gestão de receitas
+    description: |
+      Engenharia de menus e receitas, incluindo especificações, declarações
+      de alergénios e nutrição, custeio e versionamento.
+  BC-4070.10.10:
+    name: Gestão de receitas e especificações
+    description: |
+      Gestão de receitas, sub-receitas e especificações de produtos
+      nos pontos de venda.
+  BC-4070.10.20:
+    name: Declaração de alergénios e nutrição
+    description: |
+      Declaração de alergénios e dados nutricionais para itens de menu,
+      em conformidade com a regulamentação.
+  BC-4070.10.30:
+    name: Custeio de receitas e engenharia de margem
+    description: |
+      Custeio de receitas e engenharia da margem de menu contra o custo
+      de alimentação alvo.
+  BC-4070.10.40:
+    name: Versionamento e lançamento de menus
+    description: |
+      Versionamento e lançamento de menus entre épocas, pontos de venda
+      e mercados.
+  BC-4070.20:
+    name: Aprovisionamento e inventário de alimentação e bebidas
+    description: |
+      Fornecimento de abastecimentos de alimentação e bebidas, inventário
+      de adega, reabastecimento de nível par e análise de variância
+      teórico vs. real.
+  BC-4070.20.10:
+    name: Fornecimento de fornecedores de alimentação e bebidas
+    description: |
+      Fornecimento de fornecedores de alimentação e bebidas, incluindo
+      aprovação e condições contratuais.
+  BC-4070.20.20:
+    name: Gestão de inventário de bebidas e adega
+    description: |
+      Gestão de inventário de stock de bebidas e adega, incluindo rastreio
+      de safra e rotação.
+  BC-4070.20.30:
+    name: Gestão de nível par e reabastecimento
+    description: |
+      Gestão de níveis par e ciclos de reabastecimento nos pontos de venda.
+  BC-4070.20.40:
+    name: Análise de variância teórico vs. real
+    description: |
+      Análise da variância do custo teórico vs. real de alimentação e
+      bebidas com atribuição de causa raiz.
+  BC-4070.30:
+    name: Operações de produção de cozinha
+    description: |
+      Operação da produção de cozinha, incluindo planeamento, execução
+      em linha, empratamento e disciplina de custo de alimentação.
+  BC-4070.30.10:
+    name: Planeamento de produção e mise-en-place
+    description: |
+      Planeamento de ciclos de produção de cozinha e mise-en-place
+      antes do serviço.
+  BC-4070.30.20:
+    name: Operações de produção em linha e serviço
+    description: |
+      Produção em linha ao vivo e coordenação de passe durante os
+      períodos de serviço.
+  BC-4070.30.30:
+    name: Empratamento e controlo de qualidade
+    description: |
+      Empratamento e controlo de qualidade no passe antes do serviço
+      aos hóspedes.
+  BC-4070.30.40:
+    name: Operações de custo de alimentação de cozinha
+    description: |
+      Operações para gerir o custo de alimentação, incluindo verificações
+      de rendimento e captura de desperdício.
+  BC-4070.40:
+    name: Operações de serviço em restaurante e ponto de venda
+    description: |
+      Operações de serviço em restaurantes e pontos de venda, incluindo
+      reservas, lugares, gestão de cobertura e reset do ponto de venda.
+  BC-4070.40.10:
+    name: Gestão de reservas e lugares
+    description: |
+      Gestão de reservas, alocação de lugares e lista de espera nos
+      pontos de venda.
+  BC-4070.40.20:
+    name: Gestão de cobertura e ritmo
+    description: |
+      Gestão de contagens de cobertura e ritmo de serviço ao longo
+      dos períodos de serviço.
+  BC-4070.40.30:
+    name: Operações de serviço à mesa
+    description: |
+      Operações de serviço à mesa, incluindo tomada de pedidos, normas
+      de serviço e apresentação da conta.
+  BC-4070.40.40:
+    name: Operações de encerramento e reset do ponto de venda
+    description: |
+      Encerramento, fecho de caixa e reset do ponto de venda para o
+      próximo período de serviço.
+  BC-4070.50:
+    name: Operações de serviço de quarto e minibar
+    description: |
+      Captura e entrega de pedidos de serviço de quarto, reabastecimento
+      do minibar e operações de oferta de cortesia.
+  BC-4070.50.10:
+    name: Captura de pedidos de serviço de quarto
+    description: |
+      Captura de pedidos de serviço de quarto por telefone, aplicação
+      e cabide de porta.
+  BC-4070.50.20:
+    name: Operações de entrega de serviço de quarto
+    description: |
+      Entrega de pedidos de serviço de quarto dentro dos tempos de serviço
+      padrão.
+  BC-4070.50.30:
+    name: Operações de reabastecimento do minibar
+    description: |
+      Reabastecimento e captura de consumo do inventário do minibar.
+  BC-4070.50.40:
+    name: Operações de cortesia e oferta de boas-vindas
+    description: |
+      Operação de cortesias de quarto e provisionamento de ofertas de
+      boas-vindas para hóspedes VIP e de reconhecimento.
+  BC-4070.60:
+    name: Operações de banquetes e catering
+    description: |
+      Operações de banquetes e catering que abrangem montagem, serviço,
+      catering fora da propriedade e serviço de bebidas para eventos.
+  BC-4070.60.10:
+    name: Operações de montagem e reset de banquete
+    description: |
+      Montagem, alteração e reset de salas de banquete entre eventos
+      consecutivos.
+  BC-4070.60.20:
+    name: Operações de serviço com prato e buffet
+    description: |
+      Operações de serviço para eventos de banquete com prato, buffet
+      e estilo familiar.
+  BC-4070.60.30:
+    name: Operações de catering fora da propriedade
+    description: |
+      Operação de serviços de catering prestados fora da propriedade
+      de acolhimento.
+  BC-4070.60.40:
+    name: Operações de bebidas em banquete
+    description: |
+      Operações de serviço de bebidas em eventos de banquete, incluindo
+      montagem de bar e rastreio de consumo.
+  BC-4070.70:
+    name: Operações de higiene e segurança alimentar de alimentação e bebidas
+    description: |
+      Operações de higiene e segurança alimentar, incluindo execução
+      do plano HACCP, monitorização de temperatura, controlos de alergénios
+      e tratamento de incidentes.
+  BC-4070.70.10:
+    name: Execução do plano HACCP
+    description: |
+      Execução de planos HACCP nas etapas de receção, armazenamento,
+      preparação, cozedura e manutenção de temperatura.
+  BC-4070.70.20:
+    name: Monitorização de temperatura e cadeia de frio
+    description: |
+      Monitorização da temperatura e integridade da cadeia de frio no
+      armazenamento e serviço de alimentação e bebidas.
+  BC-4070.70.30:
+    name: Controlos de contaminação cruzada de alergénios
+    description: |
+      Operação de controlos de contaminação cruzada de alergénios na
+      receção, preparação e serviço.
+  BC-4070.70.40:
+    name: Tratamento de incidentes de segurança alimentar
+    description: |
+      Tratamento de incidentes de segurança alimentar, incluindo relatórios
+      de suspeita de doença de origem alimentar.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-food-beverage-processing-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-food-beverage-processing-operations-management.yaml
@@ -1,0 +1,177 @@
+locale: pt
+source: L1-food-beverage-processing-operations-management.yaml
+entries:
+  BC-3580:
+    name: Gestão de operações de transformação de alimentos e bebidas
+    description: |
+      Operações de fabrico industrial de alimentos e bebidas — receção de
+      matérias-primas, transformação primária e secundária, embalagem, fabrico
+      em cadeia de frio, saneamento, fabrico de alimentos compostos para animais
+      e valorização de subprodutos em carne, laticínios, moagem, cerveja,
+      padaria e produtos frescos.
+  BC-3580.10:
+    name: Receção e inspeção de matérias-primas
+    description: |
+      Receção, testes sensoriais e laboratoriais e aceitação de lotes de matérias-
+      primas agrícolas em instalações de transformação.
+  BC-3580.10.10:
+    name: Receção de matérias-primas
+    description: |
+      Receção de animais, leite, grão, frutos e produtos vegetais.
+  BC-3580.10.20:
+    name: Teste sensorial e de qualidade de matérias-primas
+    description: |
+      Testes sensoriais e laboratoriais de matérias-primas inbound.
+  BC-3580.10.30:
+    name: Aceitação de lotes de matérias-primas
+    description: |
+      Decisões de aceitação, rejeição e reclassificação de lotes.
+  BC-3580.20:
+    name: Operações de transformação primária
+    description: |
+      Transformação de primeira etapa de matérias-primas agrícolas — abate e
+      preparação de carcaças, separação de leite, moagem e preparação de produto.
+    in_scope:
+      - Abate e preparação de carcaças
+      - Receção e separação de leite
+      - Moagem de grão e esmagamento de oleaginosas
+      - Preparação de frutos e vegetais
+    out_of_scope:
+      - Operações genéricas de fabrico (BC-1010)
+  BC-3580.20.10:
+    name: Abate e preparação de carcaças
+    description: |
+      Abate, preparação e refrigeração de carcaças de animais e aves.
+  BC-3580.20.20:
+    name: Receção e separação de leite
+    description: |
+      Operações de receção, normalização e separação de nata do leite.
+  BC-3580.20.30:
+    name: Moagem de grão e esmagamento de oleaginosas
+    description: |
+      Moagem de grão e esmagamento de oleaginosas, incluindo extração por prensa
+      e por solvente.
+  BC-3580.20.40:
+    name: Preparação de frutos e vegetais
+    description: |
+      Lavagem, descasque, corte e branqueamento de frutos e vegetais.
+  BC-3580.30:
+    name: Operações de transformação secundária
+    description: |
+      Operações de mistura, cozimento, fermentação e concentração que produzem
+      produtos alimentares e bebidas acabados.
+  BC-3580.30.10:
+    name: Operações de mistura e blending
+    description: |
+      Mistura e blending de receitas formuladas de alimentos e bebidas.
+  BC-3580.30.20:
+    name: Cozimento e processamento térmico
+    description: |
+      Operações de cozimento, pasteurização e esterilização.
+  BC-3580.30.30:
+    name: Operações de fermentação e produção de cerveja
+    description: |
+      Fermentação, produção de cerveja e maturação de bebidas e produtos
+      fermentados.
+  BC-3580.30.40:
+    name: Operações de secagem e concentração
+    description: |
+      Secagem por atomização, evaporação e concentração de produtos líquidos.
+  BC-3580.40:
+    name: Operações de embalagem e enchimento
+    description: |
+      Enchimento, selagem, rotulagem e paletização de produtos alimentares e
+      bebidas acabados.
+  BC-3580.40.10:
+    name: Operações de enchimento e selagem
+    description: |
+      Enchimento e selagem de garrafas, latas, sacos e embalagens rígidas.
+  BC-3580.40.20:
+    name: Operações de rotulagem
+    description: |
+      Rotulagem, codificação de datas e aplicação de selos invioláveis.
+  BC-3580.40.30:
+    name: Embalagem em caixas e paletização
+    description: |
+      Embalagem em caixas, retráctil e paletização de produto acabado.
+  BC-3580.50:
+    name: Operações de fabrico em cadeia de frio
+    description: |
+      Refrigeração, congelação e monitorização da cadeia de frio em instalações
+      dentro das linhas de processamento e embalagem.
+  BC-3580.50.10:
+    name: Operações de refrigeração e congelação
+    description: |
+      Operação de câmaras de refrigeração, congeladores rápidos e túneis de
+      congelação dentro das instalações.
+  BC-3580.50.20:
+    name: Monitorização da cadeia de frio dentro das instalações
+    description: |
+      Monitorização da cadeia de frio em zonas dentro das instalações e salas de
+      armazenamento.
+  BC-3580.60:
+    name: Operações de saneamento e controlo de alergénios
+    description: |
+      Programas de limpeza no local, controlo de mudança de alergénios e
+      monitorização ambiental que salvaguardam a segurança do produto.
+    in_scope:
+      - Programas de limpeza no local
+      - Validação de mudança de alergénios
+      - Monitorização ambiental de agentes patogénicos
+    out_of_scope:
+      - Programas de segurança alimentar do lado do retalho (BC-2380.10)
+  BC-3580.60.10:
+    name: Operações de limpeza no local
+    description: |
+      Execução e validação de limpeza no local nas mudanças de produto.
+  BC-3580.60.20:
+    name: Controlo de mudança de alergénios
+    description: |
+      Controlos e verificação por zaragatoa de mudança de alergénios.
+  BC-3580.60.30:
+    name: Programas de monitorização ambiental
+    description: |
+      Monitorização de agentes patogénicos ambientais nas zonas das instalações.
+  BC-3580.70:
+    name: Operações de fabrico de alimentos compostos para animais
+    description: |
+      Fabrico de alimentos compostos para animais, incluindo receção de
+      ingredientes, mistura, pelletização e produção de alimentos medicamentosos
+      para uso pecuário a jusante.
+  BC-3580.70.10:
+    name: Receção de ingredientes alimentares
+    description: |
+      Receção de cereais, farinhas proteicas e aditivos nas fábricas de rações.
+  BC-3580.70.20:
+    name: Mistura e pelletização de rações
+    description: |
+      Mistura e pelletização de rações compostas face a formulações de rações.
+  BC-3580.70.30:
+    name: Produção de alimentos medicamentosos
+    description: |
+      Produção de alimentos medicamentosos com receita e controlos de
+      arrastamento.
+  BC-3580.80:
+    name: Gestão de subprodutos e coprodutos
+    description: |
+      Recuperação e encaminhamento de subprodutos e coprodutos de processo, como
+      transformação de subprodutos de carne, soro de leite e dreches de cerveja,
+      para usos a jusante.
+  BC-3580.80.10:
+    name: Operações de transformação de subprodutos
+    description: |
+      Transformação de subprodutos de processamento de carne em gordura animal
+      e farinha.
+  BC-3580.80.20:
+    name: Recuperação de soro de leite e permeado
+    description: |
+      Recuperação de fluxos de soro de leite e permeado do processamento de
+      laticínios.
+  BC-3580.80.30:
+    name: Recuperação de dreches
+    description: |
+      Recuperação e encaminhamento de dreches de cervejaria e destilaria.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-food-safety-traceability-management.yaml
+++ b/catalogue/i18n/pt/L1-food-safety-traceability-management.yaml
@@ -1,0 +1,144 @@
+locale: pt
+source: L1-food-safety-traceability-management.yaml
+entries:
+  BC-2380:
+    name: Gestão de segurança alimentar e rastreabilidade
+    description: |
+      Programas de segurança alimentar, rastreabilidade de lote e série,
+      coordenação de recolhas, gestão do prazo de validade de perecíveis e
+      conformidade da cadeia de frio para operações de comércio alimentar e
+      produção alimentar.
+  BC-2380.10:
+    name: Gestão do programa de segurança alimentar
+    description: |
+      Política de segurança alimentar, HACCP e programas de certificação (BRCGS,
+      SQF, FSSC 22000, IFS Food, ISO 22000) que regem o manuseamento e o
+      fornecimento de alimentos.
+    in_scope:
+      - HACCP e política de segurança alimentar
+      - Certificação por terceiros (BRCGS, SQF, FSSC 22000, IFS Food)
+      - Gestão de incidentes de segurança alimentar
+    out_of_scope:
+      - Gestão genérica da qualidade (BC-720)
+  BC-2380.10.10:
+    name: Gestão da política de segurança alimentar
+    description: |
+      Elaboração e salvaguarda da política de segurança alimentar em toda a rede.
+  BC-2380.10.20:
+    name: Gestão do plano HACCP
+    description: |
+      Desenvolvimento do plano HACCP, análise de perigos e monitorização de pontos
+      críticos de controlo.
+  BC-2380.10.30:
+    name: Gestão de certificação de segurança alimentar
+    description: |
+      Certificação de acordo com BRCGS, SQF, FSSC 22000, IFS Food e ISO 22000.
+  BC-2380.10.40:
+    name: Gestão de incidentes de segurança alimentar
+    description: |
+      Gestão de incidentes de segurança alimentar, incluindo deteções de agentes
+      patogénicos.
+  BC-2380.20:
+    name: Gestão de rastreabilidade de lote e série
+    description: |
+      Rastreabilidade de lote e série a um nível acima/abaixo ao longo da cadeia
+      de abastecimento, utilizando captura de eventos EPCIS da GS1 e troca de
+      dados com parceiros comerciais.
+  BC-2380.20.10:
+    name: Codificação de lote e série
+    description: |
+      Geração e impressão de códigos de lote e série de acordo com as normas GS1.
+  BC-2380.20.20:
+    name: Captura de eventos EPCIS
+    description: |
+      Captura de eventos EPCIS (comissionamento, expedição, receção) ao longo da
+      cadeia de abastecimento.
+  BC-2380.20.30:
+    name: Rastreio um nível acima/abaixo
+    description: |
+      Rastreio de entradas e saídas um nível acima/abaixo em cada nó de
+      manuseamento.
+  BC-2380.20.40:
+    name: Troca de dados de rastreio com parceiros comerciais
+    description: |
+      Troca de dados de rastreio com fornecedores e parceiros comerciais a
+      jusante.
+  BC-2380.30:
+    name: Gestão de coordenação de recolhas e retiradas
+    description: |
+      Coordenação de recolhas e retiradas de produtos alimentares e de bens de
+      consumo, incluindo notificação a reguladores e comunicação ao consumidor.
+    in_scope:
+      - Classificação e tomada de decisão sobre recolhas
+      - Notificação e reporte a reguladores
+      - Comunicação a consumidores e parceiros comerciais
+  BC-2380.30.10:
+    name: Decisão e classificação de recolha
+    description: |
+      Decisão e classificação do âmbito e gravidade da recolha.
+  BC-2380.30.20:
+    name: Notificação a reguladores
+    description: |
+      Notificação de reguladores de segurança alimentar de acordo com as regras
+      jurisdicionais.
+  BC-2380.30.30:
+    name: Comunicação a consumidores e parceiros comerciais
+    description: |
+      Comunicação a consumidores e parceiros comerciais sobre ações de recolha.
+  BC-2380.30.40:
+    name: Verificação da eficácia da recolha
+    description: |
+      Verificação da eficácia da recolha e taxas de recuperação.
+  BC-2380.40:
+    name: Gestão de perecíveis e prazo de validade
+    description: |
+      Monitorização de prazo de validade, rotação FEFO, disciplina de datas e
+      redução de desperdício em categorias de perecíveis.
+  BC-2380.40.10:
+    name: Prazo de validade e codificação de datas
+    description: |
+      Definição e impressão de prazos de validade e códigos de data de acordo
+      com as regras de mercado.
+  BC-2380.40.20:
+    name: Rotação primeiro-a-expirar-primeiro-a-sair
+    description: |
+      Rotação FEFO em lojas e centros de distribuição.
+  BC-2380.40.30:
+    name: Coordenação de markdowns de perecíveis
+    description: |
+      Coordenação de markdowns de perecíveis antes da expiração para reduzir
+      desperdício.
+  BC-2380.40.40:
+    name: Programas de redução de desperdício alimentar
+    description: |
+      Programas de redução de desperdício alimentar, doação e encaminhamento
+      circular.
+  BC-2380.50:
+    name: Gestão de conformidade da cadeia de frio
+    description: |
+      Integridade da cadeia de frio para alimentos refrigerados e congelados,
+      incluindo monitorização de temperatura, gestão de desvios e decisões de
+      disposição.
+    in_scope:
+      - Monitorização de temperatura da cadeia de frio em todos os nós
+      - Investigação de desvios e decisão de disposição
+      - POPs e auditorias da cadeia de frio
+    out_of_scope:
+      - Cadeia de frio farmacêutica (BC-1570.10)
+  BC-2380.50.10:
+    name: Monitorização de temperatura da cadeia de frio
+    description: |
+      Monitorização de temperatura de ponta a ponta ao longo da cadeia de frio
+      alimentar.
+  BC-2380.50.20:
+    name: Disposição de desvios na cadeia de frio
+    description: |
+      Investigação e disposição de desvios de temperatura na cadeia de frio.
+  BC-2380.50.30:
+    name: Auditoria e verificação da cadeia de frio
+    description: |
+      Auditoria e verificação das práticas da cadeia de frio em toda a rede.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-freight-billing-settlement-management.yaml
+++ b/catalogue/i18n/pt/L1-freight-billing-settlement-management.yaml
@@ -1,0 +1,110 @@
+locale: pt
+source: L1-freight-billing-settlement-management.yaml
+entries:
+  BC-2530:
+    name: Gestão de faturação e liquidação de frete
+    description: |
+      Emissão de faturas de frete, auditoria e pagamento de faturas de
+      transportadoras, liquidação interline e de conjuntos, reclamações de carga
+      e contabilidade de receita de frete.
+  BC-2530.10:
+    name: Gestão de faturação de frete
+    description: |
+      Geração e distribuição de faturas de frete, acessórios e autofaturação a
+      clientes.
+    in_scope:
+      - Geração de faturas de frete
+      - Reconciliação de autofaturação de clientes
+    out_of_scope:
+      - Processos genéricos de contas a receber (BC-200)
+      - Estratégia de preços ao cliente (BC-440)
+  BC-2530.10.10:
+    name: Geração de fatura de frete
+    description: |
+      Geração de faturas de frete a partir de movimentos concluídos.
+  BC-2530.10.20:
+    name: Geração de fatura de acessórios
+    description: |
+      Geração de faturas de acessórios e sobretaxas.
+  BC-2530.10.30:
+    name: Coordenação de autofaturação de clientes
+    description: |
+      Reconciliação de declarações de autofaturação de clientes face a envios.
+  BC-2530.20:
+    name: Gestão de auditoria e pagamento de frete
+    description: |
+      Auditoria de faturas de transportadoras e execução de pagamentos a
+      transportadoras por expedidores e transitários.
+  BC-2530.20.10:
+    name: Auditoria de faturas de transportadora
+    description: |
+      Auditoria de faturas de transportadoras face a contratos, tarifas e envios.
+  BC-2530.20.20:
+    name: Reconciliação pré-auditoria e pós-auditoria
+    description: |
+      Reconciliação pré-auditoria e pós-auditoria de faturas de transportadoras.
+  BC-2530.20.30:
+    name: Execução de pagamento a transportadora
+    description: |
+      Execução de pagamentos a transportadoras e reporte de remessas.
+  BC-2530.30:
+    name: Gestão de liquidação interline e multi-transportadora
+    description: |
+      Liquidação de receita e custos entre parceiros interline, alianças e
+      escritórios de transitários.
+  BC-2530.30.10:
+    name: Cálculo pro-rata interline
+    description: |
+      Cálculo da receita pro-rata interline entre parceiros.
+  BC-2530.30.20:
+    name: Operações de liquidação IATA CASS
+    description: |
+      Operação de liquidação IATA CASS para carga aérea.
+  BC-2530.30.30:
+    name: Liquidação entre escritórios
+    description: |
+      Liquidação entre escritórios de receita e custos de transitário.
+  BC-2530.40:
+    name: Gestão de reclamações de carga
+    description: |
+      Receção, avaliação e liquidação de reclamações de carga ao abrigo de
+      convenções de responsabilidade de transporte.
+  BC-2530.40.10:
+    name: Receção e confirmação de reclamação
+    description: |
+      Receção e confirmação de reclamações de perda e dano de carga.
+  BC-2530.40.20:
+    name: Avaliação de responsabilidade
+    description: |
+      Avaliação da responsabilidade da transportadora ao abrigo de Hague-Visby,
+      Montreal, CMR e COTIF.
+  BC-2530.40.30:
+    name: Liquidação e recuperação de reclamação
+    description: |
+      Liquidação de reclamações aceites e pagamento ao cliente.
+  BC-2530.40.40:
+    name: Recurso e sub-rogação de reclamação
+    description: |
+      Recurso contra transportadoras subjacentes e sub-rogação contra seguradoras.
+  BC-2530.50:
+    name: Gestão de contabilidade de receita de frete
+    description: |
+      Reconhecimento, acompanhamento e reporte de receita de frete, incluindo
+      posições por faturar e diferidas.
+  BC-2530.50.10:
+    name: Reconhecimento de receita de frete
+    description: |
+      Reconhecimento de receita de frete de acordo com as normas contabilísticas
+      aplicáveis.
+  BC-2530.50.20:
+    name: Acompanhamento de receita por faturar
+    description: |
+      Acompanhamento da receita de frete por faturar e acumulada.
+  BC-2530.50.30:
+    name: Reporte de receita de frete
+    description: |
+      Reporte da receita de frete para as funções financeiras e comerciais.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-freight-capacity-management.yaml
+++ b/catalogue/i18n/pt/L1-freight-capacity-management.yaml
@@ -1,0 +1,120 @@
+locale: pt
+source: L1-freight-capacity-management.yaml
+entries:
+  BC-2400:
+    name: Gestão de capacidade de frete
+    description: |
+      Venda, alocação e gestão de yield da capacidade de transporte em viagens de
+      navios, voos, rotas de camião e comboio e conjuntos de equipamento.
+  BC-2400.10:
+    name: Gestão de inventário de capacidade
+    description: |
+      Manutenção da capacidade de transporte disponível por modo, rota, horário e
+      tipo de equipamento como fonte para alocação e reserva.
+    in_scope:
+      - Registos de capacidade de navio, voo, veículo e material circulante
+      - Capacidade de conjunto de equipamento (contentores, reboques, ULDs)
+      - Capacidade de rota ligada a horário
+    out_of_scope:
+      - Conceção de rede e horário a longo prazo (BC-2410)
+      - Aceitação de reservas (BC-2400.40)
+  BC-2400.10.10:
+    name: Inventário de capacidade de navio e conveyance
+    description: |
+      Registo da capacidade de carga útil, convés e cabine por navio, aeronave,
+      comboio ou veículo.
+  BC-2400.10.20:
+    name: Inventário de capacidade de equipamento
+    description: |
+      Inventário de contentores, reboques, chassis e ULDs disponíveis por
+      localização e condição.
+  BC-2400.10.30:
+    name: Capacidade de rota e horário
+    description: |
+      Capacidade por serviço programado numa rota, incluindo escalas de ligação.
+  BC-2400.10.40:
+    name: Partilha de capacidade e troca de slots
+    description: |
+      Capacidade partilhada em alianças e acordos de troca de slots com
+      transportadoras parceiras.
+  BC-2400.20:
+    name: Gestão de alocação de capacidade
+    description: |
+      Alocação da capacidade disponível a contratos de clientes, segmentos de
+      mercado e procura spot.
+  BC-2400.20.10:
+    name: Alocação de capacidade contratual
+    description: |
+      Alocação de capacidade a clientes abrangidos por compromissos de quantidade
+      mínima e acordos de conta nomeada.
+  BC-2400.20.20:
+    name: Alocação de capacidade no mercado spot
+    description: |
+      Alocação de capacidade disponibilizada para canais de reserva no mercado
+      spot.
+  BC-2400.20.30:
+    name: Realocação e recuperação de capacidade
+    description: |
+      Realocação de capacidade não utilizada ou recuperada antes do corte.
+  BC-2400.30:
+    name: Gestão de yield e receita
+    description: |
+      Otimização da receita por unidade de capacidade através de decisões de
+      preço, mix e overbooking.
+  BC-2400.30.10:
+    name: Previsão de procura de capacidade
+    description: |
+      Previsão de reservas, no-shows e risco de offload por serviço.
+  BC-2400.30.20:
+    name: Otimização de yield
+    description: |
+      Otimização do mix de classes tarifárias para maximizar o yield por tonelada,
+      slot ou TEU.
+  BC-2400.30.30:
+    name: Gestão de overbooking
+    description: |
+      Definição e monitorização de limites de overbooking e exposição a offload.
+  BC-2400.30.40:
+    name: Gestão do mix de receita
+    description: |
+      Gestão do mix de receita entre linhas contratuais, spot e acessórias.
+  BC-2400.40:
+    name: Gestão de reservas
+    description: |
+      Aceitação, modificação e cancelamento de reservas de capacidade face a
+      horários e cotações publicados.
+  BC-2400.40.10:
+    name: Reserva de capacidade
+    description: |
+      Aceitação de reservas face à capacidade disponível e validade de tarifas.
+  BC-2400.40.20:
+    name: Modificação e cancelamento de reservas
+    description: |
+      Alterações, deslocamentos e cancelamentos de reservas, incluindo taxas de
+      no-show.
+  BC-2400.40.30:
+    name: Gestão de stand-by e lista de espera
+    description: |
+      Gestão de carga em stand-by e em lista de espera para capacidade confirmada.
+  BC-2400.50:
+    name: Gestão do desempenho de capacidade
+    description: |
+      Monitorização do fator de carga, preenchimento e utilização para orientar
+      decisões de mix de capacidade e alterações de rede.
+  BC-2400.50.10:
+    name: Análise do fator de carga
+    description: |
+      Análise do fator de carga por serviço, rota e segmento.
+  BC-2400.50.20:
+    name: Reporte de utilização de capacidade
+    description: |
+      Reporte da utilização de capacidade para equipas comerciais e de operações.
+  BC-2400.50.30:
+    name: Melhoria do desempenho de capacidade
+    description: |
+      Iniciativas para melhorar a receita por slot e reduzir o reposicionamento
+      em vazio.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-freight-forwarding-brokerage-management.yaml
+++ b/catalogue/i18n/pt/L1-freight-forwarding-brokerage-management.yaml
@@ -1,0 +1,105 @@
+locale: pt
+source: L1-freight-forwarding-brokerage-management.yaml
+entries:
+  BC-2450:
+    name: Gestão de transitário e corretagem de frete
+    description: |
+      Organização de transporte em nome de expedidores como transitário, NVOCC,
+      corretor de frete ou despachante aduaneiro, incluindo coordenação
+      multimodal e operações de rede de parceiros.
+  BC-2450.10:
+    name: Gestão de cotações para expedidores
+    description: |
+      Receção de pedidos de cotação de expedidores e emissão de tarifas de
+      transitário em vários modos e transportadoras.
+    in_scope:
+      - Pesquisa de tarifas de múltiplas transportadoras para consultas de
+        expedidores
+      - Acompanhamento de validade e confirmação de cotações
+    out_of_scope:
+      - Gestão de tarifas e tabelas pelo lado da transportadora (BC-2520)
+  BC-2450.10.10:
+    name: Captura de pedido de cotação
+    description: |
+      Captura de pedidos de cotação de expedidores por vários canais.
+  BC-2450.10.20:
+    name: Pesquisa de tarifas em múltiplas transportadoras
+    description: |
+      Pesquisa e comparação de tarifas em transportadoras subjacentes.
+  BC-2450.10.30:
+    name: Emissão e validade de cotação
+    description: |
+      Emissão de cotações vinculativas e indicativas e acompanhamento da validade.
+  BC-2450.20:
+    name: Gestão de aprovisionamento e alocação de transportadoras
+    description: |
+      Reserva de capacidade junto de transportadoras subjacentes e gestão de
+      alocações e despesas de transportadoras.
+  BC-2450.20.10:
+    name: Seleção de transportadora
+    description: |
+      Seleção de transportadoras subjacentes por envio.
+  BC-2450.20.20:
+    name: Execução de reserva com transportadora
+    description: |
+      Reserva de capacidade junto das transportadoras selecionadas.
+  BC-2450.20.30:
+    name: Otimização de despesas de alocação
+    description: |
+      Otimização das despesas do transitário pelas alocações de transportadoras.
+  BC-2450.30:
+    name: Coordenação de transitário multimodal
+    description: |
+      Coordenação de movimentos multi-etapa e multimodais, incluindo consolidação,
+      desconsolidação e guias de casa.
+  BC-2450.30.10:
+    name: Emissão de conhecimento de embarque de casa
+    description: |
+      Emissão de conhecimentos de embarque de casa de transitário para expedidores.
+  BC-2450.30.20:
+    name: Coordenação de movimento multi-etapa
+    description: |
+      Coordenação de movimentos multi-etapa em transportadoras e modos.
+  BC-2450.30.30:
+    name: Consolidação e desconsolidação
+    description: |
+      Consolidação de carga na origem e desconsolidação no destino.
+  BC-2450.40:
+    name: Gestão de despachante aduaneiro
+    description: |
+      Prestação de serviços de despachante aduaneiro em nome de importadores e
+      exportadores.
+  BC-2450.40.10:
+    name: Preparação de declarações aduaneiras
+    description: |
+      Preparação de declarações aduaneiras em nome de clientes.
+  BC-2450.40.20:
+    name: Cálculo de direitos e impostos
+    description: |
+      Cálculo e pagamento de direitos e impostos indiretos para clientes.
+  BC-2450.40.30:
+    name: Acompanhamento do estado do despacho aduaneiro
+    description: |
+      Acompanhamento do progresso do despacho aduaneiro e resolução de exceções.
+  BC-2450.50:
+    name: Coordenação da rede de transitários
+    description: |
+      Coordenação com agentes de origem, destino e parceiros numa rede de
+      transitários, incluindo liquidação entre escritórios.
+  BC-2450.50.10:
+    name: Coordenação com agentes de origem e destino
+    description: |
+      Coordenação de atividades com agentes de origem e destino.
+  BC-2450.50.20:
+    name: Liquidação entre escritórios
+    description: |
+      Liquidação inter-escritórios e inter-agentes de receita e custos de
+      transitário.
+  BC-2450.50.30:
+    name: Gestão do desempenho de agentes parceiros
+    description: |
+      Gestão da qualidade de serviço e conformidade de agentes parceiros.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-freight-rating-tariff-management.yaml
+++ b/catalogue/i18n/pt/L1-freight-rating-tariff-management.yaml
@@ -1,0 +1,109 @@
+locale: pt
+source: L1-freight-rating-tariff-management.yaml
+entries:
+  BC-2520:
+    name: Gestão de tarifação e tarifa de frete
+    description: |
+      Definição e operação de tarifas de frete, tabelas, preços contratuais,
+      preços spot, acessórios e o motor de tarifação que calcula o preço dos
+      movimentos de frete.
+  BC-2520.10:
+    name: Gestão de tabelas de tarifas e preços
+    description: |
+      Definição, publicação e versionamento de tarifas públicas e tabelas de
+      preços de base.
+    in_scope:
+      - Definição de tabela de preços de base por rota e unidade
+      - Submissão de tarifas públicas quando exigido
+    out_of_scope:
+      - Cotação ao cliente no contexto de transitário (BC-2450.10)
+      - Métodos de preços empresariais genéricos (BC-440)
+  BC-2520.10.10:
+    name: Definição de tarifa de base
+    description: |
+      Definição de tarifas de frete de base por rota, unidade e nível de serviço.
+  BC-2520.10.20:
+    name: Submissão de tarifa pública
+    description: |
+      Submissão de tarifas públicas junto de reguladores e conferências quando
+      exigido.
+  BC-2520.10.30:
+    name: Versionamento de tabela de preços
+    description: |
+      Controlo de versões e gestão de datas de vigência de tabelas de preços.
+  BC-2520.20:
+    name: Gestão de tarifas contratuais
+    description: |
+      Configuração e manutenção de tarifas contratuais negociadas com clientes
+      nomeados e compromissos de volume.
+  BC-2520.20.10:
+    name: Configuração de tarifa contratual
+    description: |
+      Configuração de tarifas negociadas face a contratos de clientes nomeados.
+  BC-2520.20.20:
+    name: Acompanhamento de compromissos de volume
+    description: |
+      Acompanhamento de compromissos de volume de clientes e objetivos de
+      quantidade mínima.
+  BC-2520.20.30:
+    name: Renovação de tarifa contratual
+    description: |
+      Renovação e renegociação de tarifas contratuais a expirar.
+  BC-2520.30:
+    name: Gestão de tarifas spot
+    description: |
+      Definição de preços, aceitação e benchmarking de tarifas de frete no
+      mercado spot.
+  BC-2520.30.10:
+    name: Cotação de tarifa spot
+    description: |
+      Cotação de tarifas de mercado spot por envio.
+  BC-2520.30.20:
+    name: Aceitação de tarifa spot
+    description: |
+      Aceitação e confirmação de reservas a tarifa spot.
+  BC-2520.30.30:
+    name: Benchmarking de índice de tarifas spot
+    description: |
+      Benchmarking de tarifas spot face a índices de mercado.
+  BC-2520.40:
+    name: Gestão de acessórios e sobretaxas
+    description: |
+      Definição e aplicação de acessórios, sobretaxas, tarifas de demurrage e
+      detenção.
+  BC-2520.40.10:
+    name: Gestão de sobretaxa de combustível
+    description: |
+      Definição e aplicação de sobretaxas de combustível e bunker.
+  BC-2520.40.20:
+    name: Definição de encargos acessórios
+    description: |
+      Definição de encargos acessórios para espera, manuseamento especial e
+      equipamento.
+  BC-2520.40.30:
+    name: Tarifas de demurrage e detenção
+    description: |
+      Definição de tarifas de demurrage e detenção para uso de equipamento e
+      terminal.
+  BC-2520.50:
+    name: Gestão de operações do motor de tarifação
+    description: |
+      Operação do motor de tarifação que calcula e valida os encargos de frete
+      em encomendas e envios.
+  BC-2520.50.10:
+    name: Execução de cálculo de tarifa
+    description: |
+      Execução de cálculos de tarifa em encomendas e envios.
+  BC-2520.50.20:
+    name: Distribuição de folhas de tarifa
+    description: |
+      Distribuição de folhas de tarifa a clientes, parceiros e canais.
+  BC-2520.50.30:
+    name: Auditoria e validação de tarifas
+    description: |
+      Validação das tarifas aplicadas face a bases de referência contratuais e
+      de tabela.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-functional-safety-reliability-management.yaml
+++ b/catalogue/i18n/pt/L1-functional-safety-reliability-management.yaml
@@ -1,0 +1,132 @@
+locale: pt
+source: L1-functional-safety-reliability-management.yaml
+entries:
+  BC-1970:
+    name: Gestão de segurança funcional e fiabilidade
+    description: |
+      Análise de segurança funcional ao nível do produto (IEC 61508/61511/13849, ISO 26262) e
+      engenharia de fiabilidade — distinta da Qualidade genérica e da execução de testes em produção.
+  BC-1970.10:
+    name: Gestão de análise de segurança funcional
+    description: |
+      Análise de perigo, risco e conceito de segurança para produtos elétricos relacionados com a segurança.
+  BC-1970.10.10:
+    name: Análise de perigo e risco
+    description: |
+      Identificação de perigos e análise de risco para produtos relacionados com a segurança.
+  BC-1970.10.20:
+    name: Definição do conceito de segurança
+    description: |
+      Definição de conceitos de segurança funcional e técnica.
+  BC-1970.10.30:
+    name: Alocação de requisitos de segurança
+    description: |
+      Alocação de requisitos de segurança a subsistemas e componentes.
+  BC-1970.10.40:
+    name: Elaboração do caso de segurança
+    description: |
+      Elaboração de casos de segurança de suporte ao lançamento do produto.
+  BC-1970.20:
+    name: Determinação do nível de integridade de segurança
+    description: |
+      Definição de objetivos de integridade segundo IEC 61508, ISO 26262 e ISO 13849.
+  BC-1970.20.10:
+    name: Definição de objetivo SIL
+    description: |
+      Determinação de níveis de integridade de segurança segundo IEC 61508.
+  BC-1970.20.20:
+    name: Decomposição ASIL
+    description: |
+      Decomposição ASIL para eletrónica automóvel relacionada com segurança.
+  BC-1970.20.30:
+    name: Determinação do nível de desempenho
+    description: |
+      Determinação do nível de desempenho segundo ISO 13849.
+  BC-1970.30:
+    name: Gestão de engenharia de fiabilidade
+    description: |
+      Definição de requisitos de fiabilidade, previsão, alocação e planeamento de crescimento.
+  BC-1970.30.10:
+    name: Definição de requisitos de fiabilidade
+    description: |
+      Definição de requisitos de fiabilidade alinhados com perfis de missão.
+  BC-1970.30.20:
+    name: Modelação de previsão de fiabilidade
+    description: |
+      Modelação de previsão por métodos de contagem de peças e tensão.
+  BC-1970.30.30:
+    name: Alocação de fiabilidade
+    description: |
+      Alocação descendente de budgets de fiabilidade a subsistemas.
+  BC-1970.30.40:
+    name: Planeamento de crescimento de fiabilidade
+    description: |
+      Planeamento de crescimento de fiabilidade e ações corretivas.
+  BC-1970.40:
+    name: Análise de derating e tensão de componentes
+    description: |
+      Análise de tensão elétrica, térmica e mecânica e derating de componentes.
+  BC-1970.40.10:
+    name: Derating de tensão elétrica
+    description: |
+      Aplicação de regras de derating elétrico a componentes.
+  BC-1970.40.20:
+    name: Derating térmico
+    description: |
+      Análise de derating térmico de componentes no seu ambiente de operação.
+  BC-1970.40.30:
+    name: Análise de tensão mecânica
+    description: |
+      Análise de tensão mecânica e fadiga em componentes.
+  BC-1970.50:
+    name: Análise de modos de falha
+    description: |
+      FMEA de projeto e processo e análise de criticidade FMECA.
+  BC-1970.50.10:
+    name: FMEA de projeto
+    description: |
+      Análise de modos de falha e efeitos de projeto nos produtos.
+  BC-1970.50.20:
+    name: FMEA de processo
+    description: |
+      Análise de modos de falha e efeitos de processo na produção.
+  BC-1970.50.30:
+    name: Análise de criticidade FMECA
+    description: |
+      Análise de criticidade sobreposta aos resultados de FMEA.
+  BC-1970.60:
+    name: Gestão de falhas em campo e crescimento de fiabilidade
+    description: |
+      Captura e análise de dados de falhas em campo para crescimento de fiabilidade.
+  BC-1970.60.10:
+    name: Captura de dados de falhas em campo
+    description: |
+      Captura de dados de falhas da base instalada.
+  BC-1970.60.20:
+    name: Análise de tendências de modos de falha
+    description: |
+      Análise de tendências de modos de falha observados.
+  BC-1970.60.30:
+    name: Acompanhamento do crescimento de fiabilidade
+    description: |
+      Acompanhamento do crescimento de fiabilidade entre gerações de produto.
+  BC-1970.70:
+    name: Coordenação de certificação de segurança funcional
+    description: |
+      Relacionamento com avaliadores de segurança funcional e organismos de certificação.
+  BC-1970.70.10:
+    name: Relacionamento com avaliadores de segurança funcional
+    description: |
+      Relacionamento com avaliadores independentes de segurança funcional.
+  BC-1970.70.20:
+    name: Submissão de certificação de segurança
+    description: |
+      Submissão de dossiers de segurança funcional para certificação.
+  BC-1970.70.30:
+    name: Vigilância de segurança funcional
+    description: |
+      Auditorias de vigilância periódicas dos processos de segurança funcional.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-gas-processing-lng-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-gas-processing-lng-operations-management.yaml
@@ -1,0 +1,127 @@
+locale: pt
+source: L1-gas-processing-lng-operations-management.yaml
+entries:
+  BC-3070:
+    name: Gestão de operações de processamento de gás e GNL
+    description: |
+      Operação de tratamento de gás, fraccionamento de NGL, liquefacção de GNL,
+      carregamento e envio, regasificação e garantia de qualidade do gás em cadeias
+      de valor de gás midstream.
+  BC-3070.10:
+    name: Operações da unidade de gás
+    description: |
+      Operação de recepção de entrada, tratamento, desidratação e instalações de
+      recuperação de enxofre em unidades de processamento de gás.
+  BC-3070.10.10:
+    name: Recepção de gás e gestão de entrada
+    description: |
+      Recepção, separação de golfadas e condicionamento de entrada de gás de
+      alimentação.
+  BC-3070.10.20:
+    name: Operações de tratamento de gás ácido
+    description: |
+      Operações de tratamento de gás ácido com amina e solvente físico.
+  BC-3070.10.30:
+    name: Operações de desidratação de gás
+    description: |
+      Desidratação de gás natural com glicol e peneiro molecular.
+  BC-3070.10.40:
+    name: Operações de recuperação de enxofre
+    description: |
+      Operações Claus e de tratamento de gás de cauda para recuperação de enxofre.
+  BC-3070.20:
+    name: Operações de fraccionamento de NGL
+    description: |
+      Operação de desmetanizadores, desetanizadores e torres de fraccionamento
+      a jusante que produzem etano, propano, butano e gasolina natural.
+  BC-3070.20.10:
+    name: Operações do desmetanizador
+    description: |
+      Operação de colunas criogénicas de desmetanização para recuperação de etano.
+  BC-3070.20.20:
+    name: Operações do desetanizador e despropanizador
+    description: |
+      Operação de colunas de desetanização, despropanização e desbutanização.
+  BC-3070.20.30:
+    name: Operações de armazenamento de NGL
+    description: |
+      Operação de armazenamento de NGL pressurizado e refrigerado.
+  BC-3070.30:
+    name: Operações de liquefacção de GNL
+    description: |
+      Operação de trens de liquefacção, ciclos de refrigeração e reservatórios de
+      armazenamento de GNL.
+  BC-3070.30.10:
+    name: Operações do ciclo de refrigeração
+    description: |
+      Operação de circuitos de refrigeração com refrigerante misto e em cascata.
+  BC-3070.30.20:
+    name: Operações do trem de GNL
+    description: |
+      Operação end-to-end de trens de liquefacção de GNL.
+  BC-3070.30.30:
+    name: Operações de reservatórios de armazenamento de GNL
+    description: |
+      Operação de reservatórios criogénicos de armazenamento de GNL, incluindo
+      prevenção de rollover.
+  BC-3070.40:
+    name: Operações de carregamento e envio de GNL
+    description: |
+      Carregamento de navios, arrefecimento de carga e vaporização de envio por
+      gasoduto em terminais de liquefacção.
+  BC-3070.40.10:
+    name: Carregamento de navios de GNL
+    description: |
+      Operações de carregamento de navios em cais de exportação de GNL.
+  BC-3070.40.20:
+    name: Vaporização de envio
+    description: |
+      Vaporização de envio e exportação por gasoduto a partir de locais de
+      liquefacção.
+  BC-3070.40.30:
+    name: Coordenação de arrefecimento de carga
+    description: |
+      Coordenação do arrefecimento de transportadores de GNL antes do carregamento.
+  BC-3070.50:
+    name: Operações de regasificação de GNL
+    description: |
+      Operação de terminais de importação de GNL — vaporização, controlo de pressão
+      de envio e manuseamento de gás de evaporação.
+  BC-3070.50.10:
+    name: Operações de vaporizadores
+    description: |
+      Operação de vaporizadores de rack aberto, de combustão submersa e de casco
+      e tubos.
+  BC-3070.50.20:
+    name: Controlo de pressão de envio
+    description: |
+      Controlo de pressão de envio e injecção na rede a partir de terminais de
+      importação.
+  BC-3070.50.30:
+    name: Manuseamento de gás de evaporação
+    description: |
+      Re-liquefacção ou envio de gás de evaporação de reservatórios de
+      armazenamento.
+  BC-3070.60:
+    name: Gestão da qualidade do gás
+    description: |
+      Conformidade com especificações de qualidade de gás de gasodutos e GNL e
+      gestão de correntes fora de especificação.
+  BC-3070.60.10:
+    name: Monitorização de conformidade com especificações
+    description: |
+      Monitorização contínua de especificações de qualidade de gás de gasoduto e
+      GNL.
+  BC-3070.60.20:
+    name: Amostragem e análise de gás
+    description: |
+      Amostragem rotineira de gás, cromatografia e geração de certificados.
+  BC-3070.60.30:
+    name: Manuseamento de gás fora de especificação
+    description: |
+      Encaminhamento, mistura e reprocessamento de correntes de gás fora de
+      especificação.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-government-grants-funding-management.yaml
+++ b/catalogue/i18n/pt/L1-government-grants-funding-management.yaml
@@ -1,0 +1,136 @@
+locale: pt
+source: L1-government-grants-funding-management.yaml
+entries:
+  BC-3260:
+    name: Gestão de subvenções do Estado e financiamento
+    description: |
+      Atribuição e administração de subvenções competitivas e por fórmula e de
+      financiamento público a organizações, comunidades e indivíduos, incluindo
+      publicação de concursos, análise de candidaturas, atribuição, monitorização e
+      encerramento.
+  BC-3260.10:
+    name: Conceção de programas de subvenções
+    description: |
+      Conceção de programas de subvenções, incluindo objetivos, elegibilidade,
+      fórmulas de financiamento e critérios de avaliação.
+  BC-3260.10.10:
+    name: Definição de objetivos do programa
+    description: |
+      Definição dos objetivos, resultados e teoria da mudança do programa de subvenções.
+  BC-3260.10.20:
+    name: Modelação da afetação de financiamento
+    description: |
+      Modelação das afetações de financiamento, incluindo desenhos de fórmulas,
+      competição e cofinanciamento.
+  BC-3260.10.30:
+    name: Definição de critérios de avaliação
+    description: |
+      Definição dos critérios de avaliação por mérito e seleção para atribuição de
+      subvenções.
+  BC-3260.20:
+    name: Gestão de publicação e avisos de concurso
+    description: |
+      Publicação de oportunidades de financiamento, avisos de disponibilidade de
+      fundos e documentação de concursos.
+  BC-3260.20.10:
+    name: Publicação de oportunidades de financiamento
+    description: |
+      Publicação de concursos, avisos de disponibilidade de financiamento e
+      documentação de candidatura.
+  BC-3260.20.20:
+    name: Sensibilização e apoio a candidatos
+    description: |
+      Sensibilização, sessões informativas e apoio a candidatos em programas de
+      subvenções.
+  BC-3260.20.30:
+    name: Gestão de perguntas pré-atribuição
+    description: |
+      Tratamento de perguntas e esclarecimentos pré-atribuição de potenciais
+      candidatos.
+  BC-3260.30:
+    name: Receção e análise de candidaturas
+    description: |
+      Receção, triagem e avaliação por mérito de candidaturas a subvenções,
+      incluindo análise em painel e pontuação.
+  BC-3260.30.10:
+    name: Submissão de candidaturas
+    description: |
+      Submissão e receção de candidaturas a subvenções e documentação de suporte.
+  BC-3260.30.20:
+    name: Triagem de elegibilidade
+    description: |
+      Triagem de candidaturas face aos critérios de elegibilidade e limiares
+      mínimos.
+  BC-3260.30.30:
+    name: Avaliação por mérito e pontuação
+    description: |
+      Análise em painel, pontuação e ordenação de candidaturas face aos critérios
+      publicados.
+  BC-3260.30.40:
+    name: Gestão de avaliadores e conflitos de interesse
+    description: |
+      Recrutamento de avaliadores e gestão de conflitos de interesses.
+  BC-3260.40:
+    name: Decisão de atribuição e financiamento
+    description: |
+      Decisões de atribuição, emissão de contratos de subvenção e compromisso de
+      fundos a beneficiários.
+  BC-3260.40.10:
+    name: Seleção de candidaturas a atribuir
+    description: |
+      Seleção final das candidaturas aprovadas e respetivos montantes de subvenção.
+  BC-3260.40.20:
+    name: Emissão de contratos de subvenção
+    description: |
+      Redação e celebração de contratos de subvenção e termos e condições.
+  BC-3260.40.30:
+    name: Configuração de compromissos e desembolsos
+    description: |
+      Compromisso de fundos e configuração de calendários de desembolso.
+  BC-3260.50:
+    name: Monitorização e reporte de beneficiários
+    description: |
+      Monitorização do desempenho dos beneficiários, reporte financeiro e
+      conformidade com os termos da subvenção.
+  BC-3260.50.10:
+    name: Análise de relatórios de desempenho
+    description: |
+      Análise dos relatórios de desempenho e progresso dos beneficiários face
+      a marcos acordados.
+  BC-3260.50.20:
+    name: Análise de relatórios financeiros
+    description: |
+      Análise dos relatórios financeiros e pedidos de levantamento dos
+      beneficiários.
+  BC-3260.50.30:
+    name: Visitas de monitorização e verificação
+    description: |
+      Visitas de acompanhamento e verificação das atividades e entregas dos
+      beneficiários.
+  BC-3260.50.40:
+    name: Supervisão de sub-beneficiários
+    description: |
+      Supervisão de acordos de transferência e sub-beneficiários.
+  BC-3260.60:
+    name: Encerramento e resolução de auditorias de subvenções
+    description: |
+      Reporte final, encerramento, resolução de auditorias e recuperação de
+      custos não elegíveis.
+  BC-3260.60.10:
+    name: Aceitação de relatórios finais e entregas
+    description: |
+      Aceitação de relatórios finais e entregas no términus do programa.
+  BC-3260.60.20:
+    name: Resolução de auditorias únicas e de conformidade
+    description: |
+      Resolução de conclusões de auditorias únicas e de conformidade relativas a
+      beneficiários de subvenções.
+  BC-3260.60.30:
+    name: Recuperação de custos não elegíveis
+    description: |
+      Recuperação de custos não elegíveis e saldos não comprometidos no
+      encerramento.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-grid-control-balancing-management.yaml
+++ b/catalogue/i18n/pt/L1-grid-control-balancing-management.yaml
@@ -1,0 +1,145 @@
+locale: pt
+source: L1-grid-control-balancing-management.yaml
+entries:
+  BC-3830:
+    name: Gestão de controlo e balanceamento da rede elétrica
+    description: |
+      Função de operador de sistema para o sistema elétrico de potência —
+      balanceamento em tempo real de geração e procura, controlo de frequência
+      e tensão, reservas e serviços ancilares, planeamento operacional,
+      coordenação transfronteiriça e preparação para arranque negro.
+  BC-3830.10:
+    name: Operações do sistema em tempo real
+    description: |
+      Supervisão e controlo contínuos em tempo real da geração, procura e
+      intercâmbio do sistema para manter a operação segura.
+  BC-3830.10.10:
+    name: Consciência situacional do sistema
+    description: |
+      Consciência contínua de geração, carga e margens de contingência a
+      partir do centro de controlo.
+  BC-3830.10.20:
+    name: Análise de contingências em tempo real
+    description: |
+      Análise de contingências N-1 e N-1-1 em tempo real e acionamento
+      de ações corretivas.
+  BC-3830.10.30:
+    name: Emissão de instruções operacionais
+    description: |
+      Emissão de instruções operacionais a partes responsáveis pelo
+      balanceamento e ORT.
+  BC-3830.20:
+    name: Controlo de frequência e tensão
+    description: |
+      Regulação ativa de frequência e tensão através do controlo automático
+      de geração e despacho de energia reativa.
+  BC-3830.20.10:
+    name: Controlo automático de geração
+    description: |
+      Despacho de AGC e gestão do erro de controlo de área para regulação
+      de frequência.
+  BC-3830.20.20:
+    name: Despacho de energia reativa
+    description: |
+      Despacho de recursos reativos para manter o perfil de tensão na
+      rede elétrica.
+  BC-3830.20.30:
+    name: Gestão de inércia e resposta de frequência
+    description: |
+      Gestão de inércia, resposta rápida de frequência e serviços de droop.
+  BC-3830.30:
+    name: Planeamento operacional
+    description: |
+      Análise de segurança do sistema em day-ahead e intraday, avaliação
+      de indisponibilidades e planeamento de margens operacionais.
+  BC-3830.30.10:
+    name: Análise de segurança em day-ahead
+    description: |
+      Comprometimento de unidades com restrições de segurança e análise
+      de contingências para o dia de operação.
+  BC-3830.30.20:
+    name: Re-despacho intraday
+    description: |
+      Re-despacho intraday de geração e procura contra atualizações
+      de previsão.
+  BC-3830.30.30:
+    name: Avaliação sazonal da margem operacional
+    description: |
+      Avaliação sazonal da margem de capacidade e adequação.
+  BC-3830.40:
+    name: Reservas e serviços ancilares
+    description: |
+      Contratação e ativação de reservas operacionais e serviços ancilares,
+      incluindo produtos de frequência, tensão e inércia.
+  BC-3830.40.10:
+    name: Contratação de reservas
+    description: |
+      Contratação de produtos de reserva primária, secundária e terciária.
+  BC-3830.40.20:
+    name: Ativação de serviços ancilares
+    description: |
+      Ativação e despacho de prestadores de serviços ancilares contratados.
+  BC-3830.40.30:
+    name: Monitorização do desempenho das reservas
+    description: |
+      Monitorização do desempenho e disponibilidade dos prestadores de reservas.
+  BC-3830.50:
+    name: Operações de liquidação de desequilíbrio
+    description: |
+      Cálculo e notificação do operador de sistema de volumes e preços de
+      desequilíbrio para partes responsáveis pelo balanceamento.
+  BC-3830.50.10:
+    name: Agregação de volumes medidos
+    description: |
+      Agregação de volumes medidos por parte responsável pelo balanceamento.
+  BC-3830.50.20:
+    name: Cálculo do preço de desequilíbrio
+    description: |
+      Cálculo dos preços de desequilíbrio do sistema de acordo com as
+      regras de mercado.
+  BC-3830.50.30:
+    name: Notificação de liquidação a partes responsáveis pelo balanceamento
+    description: |
+      Notificação de volumes e encargos de desequilíbrio a partes responsáveis
+      pelo balanceamento.
+  BC-3830.60:
+    name: Coordenação transfronteiriça
+    description: |
+      Coordenação de fluxos de interligação, re-despacho e segurança com
+      ORT vizinhos e coordenadores regionais de segurança.
+  BC-3830.60.10:
+    name: Calendarização de interligações
+    description: |
+      Calendarização de fluxos físicos e comerciais em interligações.
+  BC-3830.60.20:
+    name: Cálculo coordenado de capacidade
+    description: |
+      Cálculo coordenado de capacidade entre zonas de licitação com
+      vizinhos.
+  BC-3830.60.30:
+    name: Re-despacho e contrataçao transfronteiriça
+    description: |
+      Re-despacho e contrataçao transfronteiriça para aliviar congestionamentos.
+  BC-3830.70:
+    name: Planeamento de arranque negro e reposição
+    description: |
+      Manutenção de contratos de arranque negro, planos de reposição e
+      exercícios de reposição para cenários de colapso total ou parcial
+      do sistema.
+  BC-3830.70.10:
+    name: Gestão de contratos de arranque negro
+    description: |
+      Contratação e vigilância de contratos de serviço de arranque negro.
+  BC-3830.70.20:
+    name: Manutenção do plano de reposição do sistema
+    description: |
+      Manutenção de sequências de reposição e planos de ilhamento.
+  BC-3830.70.30:
+    name: Exercícios e simulações de reposição
+    description: |
+      Exercícios de reposição de operadores e interutilitários e revisões
+      pós-ação.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-guest-traveller-management.yaml
+++ b/catalogue/i18n/pt/L1-guest-traveller-management.yaml
@@ -1,0 +1,168 @@
+locale: pt
+source: L1-guest-traveller-management.yaml
+entries:
+  BC-4040:
+    name: Gestão de hóspedes e viajantes
+    description: |
+      Custódia do registo único de hóspede e viajante em toda a empresa
+      — identidade, preferências, consentimento, reconhecimento, segmentação
+      e dados de documento de viagem/conformidade — independentemente de
+      qualquer canal ou propriedade única.
+  BC-4040.10:
+    name: Gestão do perfil e identidade do hóspede
+    description: |
+      Criação, deduplicação e verificação de identidade do perfil único
+      de hóspede em sistemas de reserva e operacionais.
+  BC-4040.10.10:
+    name: Criação do perfil do hóspede
+    description: |
+      Criação de perfis de hóspede a partir de qualquer canal ou ponto
+      de contacto originador.
+  BC-4040.10.20:
+    name: Deduplicação do perfil do hóspede
+    description: |
+      Deduplicação de perfis de hóspede usando correspondência determinística
+      e probabilística.
+  BC-4040.10.30:
+    name: Verificação de identidade do hóspede
+    description: |
+      Verificação da identidade do hóspede para interações de elevado valor
+      ou reguladas.
+  BC-4040.10.40:
+    name: Fusão e sobrevivência de perfil
+    description: |
+      Fusão de perfis duplicados e resolução da sobrevivência de atributos.
+  BC-4040.20:
+    name: Gestão de preferências e personalização do hóspede
+    description: |
+      Captura e custódia de preferências do hóspede relativas a estadia,
+      alimentação e requisitos de acessibilidade, além de regras de
+      personalização.
+  BC-4040.20.10:
+    name: Captura de preferências de estadia
+    description: |
+      Captura de preferências de estadia, como tipo de cama, andar e
+      preferências de hora de chegada.
+  BC-4040.20.20:
+    name: Gestão de preferências alimentares e de alergénios
+    description: |
+      Gestão de preferências alimentares, religiosas e de alergénios
+      para o serviço de alimentação e bebidas e a bordo.
+  BC-4040.20.30:
+    name: Gestão de requisitos de acessibilidade
+    description: |
+      Gestão de requisitos de acessibilidade e necessidades de assistência
+      especial em pontos de contacto de viagem.
+  BC-4040.20.40:
+    name: Definição de regras de personalização
+    description: |
+      Definição de regras de personalização que aplicam preferências a
+      interações de serviço e merchandising.
+  BC-4040.30:
+    name: Gestão de consentimento e privacidade do hóspede
+    description: |
+      Gestão do consentimento do hóspede, permissão de marketing, direitos
+      do titular dos dados e conformidade de transferência transfronteiriça
+      de dados de viagem.
+  BC-4040.30.10:
+    name: Captura e gestão de consentimento
+    description: |
+      Captura e gestão contínua de registos de consentimento entre
+      finalidades e canais.
+  BC-4040.30.20:
+    name: Gestão de permissões de marketing
+    description: |
+      Gestão de permissões de marketing, incluindo estados de opt-in e
+      opt-out específicos por canal.
+  BC-4040.30.30:
+    name: Tratamento de pedidos de titulares de dados
+    description: |
+      Tratamento de pedidos de acesso, portabilidade, retificação e
+      eliminação de titulares de dados.
+  BC-4040.30.40:
+    name: Conformidade de transferência transfronteiriça
+    description: |
+      Conformidade com os requisitos de transferência transfronteiriça
+      aplicáveis a dados de viajantes e hóspedes.
+  BC-4040.40:
+    name: Reconhecimento do hóspede e entrega do estado de nível
+    description: |
+      Entrega de sinais de reconhecimento e estado de nível às equipas
+      operacionais para que os hóspedes sejam reconhecidos de forma
+      consistente em todos os pontos de contacto.
+  BC-4040.40.10:
+    name: Sinalização de reconhecimento pré-chegada
+    description: |
+      Sinalização das expectativas de reconhecimento às equipas operacionais
+      antes da chegada do hóspede.
+  BC-4040.40.20:
+    name: Entrega do reconhecimento na propriedade
+    description: |
+      Entrega de reconhecimento pelas equipas de receção, alimentação e
+      bebidas e concierge durante a estadia do hóspede.
+  BC-4040.40.30:
+    name: Registo do serviço de reconhecimento
+    description: |
+      Registo de eventos de entrega de reconhecimento para auditoria de
+      serviço e ciclos de feedback.
+  BC-4040.40.40:
+    name: Relatórios de encerramento do reconhecimento
+    description: |
+      Relatórios sobre as taxas de encerramento do reconhecimento contra
+      as sinalizações de reconhecimento pré-chegada.
+  BC-4040.50:
+    name: Gestão de segmentação e informações analíticas do hóspede
+    description: |
+      Definição de segmentos de hóspedes, modelação do valor vitalício e
+      da perda de clientes, e geração de informações analíticas por coorte
+      e comportamentais.
+  BC-4040.50.10:
+    name: Definição de segmentação de hóspedes
+    description: |
+      Definição e manutenção de segmentos de hóspedes utilizados em
+      marketing e merchandising.
+  BC-4040.50.20:
+    name: Modelação do valor vitalício
+    description: |
+      Modelação do valor vitalício do hóspede como entrada para decisões
+      de investimento e reconhecimento.
+  BC-4040.50.30:
+    name: Análise de perda e retenção de hóspedes
+    description: |
+      Análise dos fatores de perda de hóspedes e oportunidades de retenção
+      entre segmentos.
+  BC-4040.50.40:
+    name: Informações analíticas por coorte e comportamentais
+    description: |
+      Geração de informações analíticas por coorte e comportamentais a
+      partir de eventos de reserva, estadia e envolvimento.
+  BC-4040.60:
+    name: Gestão de documentos de viagem e dados de conformidade do viajante
+    description: |
+      Gestão de dados de documento de viagem, APIS, visto e lista de
+      vigilância necessários para satisfazer obrigações de transporte e
+      controlo de fronteiras.
+  BC-4040.60.10:
+    name: Captura de documentos de viagem
+    description: |
+      Captura de dados de passaporte, bilhete de identidade e visto para
+      verificações de elegibilidade e de documento de viagem.
+  BC-4040.60.20:
+    name: Submissão de APIS e informação antecipada sobre passageiros
+    description: |
+      Submissão de APIS e informação antecipada sobre passageiros a
+      autoridades de controlo de fronteiras.
+  BC-4040.60.30:
+    name: Referência de elegibilidade de visto e ESTA
+    description: |
+      Verificações de referência contra regimes de elegibilidade de visto,
+      ESTA e equivalentes.
+  BC-4040.60.40:
+    name: Triagem de Secure Flight e lista de proibição de voo
+    description: |
+      Triagem de viajantes contra Secure Flight e programas equivalentes
+      de proibição de voo e lista de vigilância.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-harvest-post-harvest-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-harvest-post-harvest-operations-management.yaml
@@ -1,0 +1,132 @@
+locale: pt
+source: L1-harvest-post-harvest-operations-management.yaml
+entries:
+  BC-3560:
+    name: Gestão de operações de colheita e pós-colheita
+    description: |
+      Calendarização e execução da colheita, condicionamento no campo e pós-
+      colheita, armazenamento na exploração, classificação e embalagem e receção
+      no ponto seguinte da cadeia agroalimentar.
+  BC-3560.10:
+    name: Planeamento e calendarização da colheita
+    description: |
+      Planeamento da janela de colheita, calendarização de equipas e equipamentos
+      e coordenação logística da colheita entre campos e culturas.
+  BC-3560.10.10:
+    name: Planeamento da janela de colheita
+    description: |
+      Planeamento da janela de colheita campo a campo face à maturação e às
+      condições meteorológicas.
+  BC-3560.10.20:
+    name: Calendarização de equipas e equipamentos de colheita
+    description: |
+      Calendarização de equipas de colheita, empreiteiros e maquinaria.
+  BC-3560.10.30:
+    name: Coordenação logística da colheita
+    description: |
+      Coordenação de camiões, contentores e reboques nas frentes de colheita
+      ativas.
+  BC-3560.20:
+    name: Operações de colheita no campo
+    description: |
+      Operações de colheita mecânica e manual, incluindo triagem no campo e
+      transferência na borda do campo.
+  BC-3560.20.10:
+    name: Colheita mecânica
+    description: |
+      Colheita mecânica com ceifeiras-debulhadoras, cortadores-condicionadores
+      e equipamentos especializados.
+  BC-3560.20.20:
+    name: Colheita manual
+    description: |
+      Colheita manual e seletiva de culturas hortícolas.
+  BC-3560.20.30:
+    name: Triagem no campo
+    description: |
+      Triagem e aparamento de produto colhido no campo.
+  BC-3560.30:
+    name: Condicionamento pós-colheita
+    description: |
+      Secagem, arrefecimento, cura e descontaminação do produto colhido para
+      o estabilizar para armazenamento ou uso a jusante.
+    in_scope:
+      - Secagem de grão e semente
+      - Pré-arrefecimento de produto hortícola
+      - Cura de tubérculos e bolbos
+      - Limpeza e descontaminação no campo
+  BC-3560.30.10:
+    name: Operações de secagem
+    description: |
+      Secagem de grão, semente e forragem até níveis de humidade seguros.
+  BC-3560.30.20:
+    name: Operações de arrefecimento e pré-arrefecimento
+    description: |
+      Pré-arrefecimento por hidro, vácuo e ar forçado de produto hortícola.
+  BC-3560.30.30:
+    name: Operações de cura
+    description: |
+      Cura de batatas, cebolas, batata-doce e culturas similares.
+  BC-3560.30.40:
+    name: Limpeza e descontaminação
+    description: |
+      Limpeza e descontaminação do produto colhido antes do armazenamento.
+  BC-3560.40:
+    name: Operações de armazenamento na exploração
+    description: |
+      Operação de silos, contentores e armazéns frigoríficos na exploração,
+      incluindo arejamento e gestão de pragas em armazém.
+  BC-3560.40.10:
+    name: Gestão de contentores e silos
+    description: |
+      Carregamento, monitorização e descarga de contentores e silos de grão.
+  BC-3560.40.20:
+    name: Operações de armazenamento em frio
+    description: |
+      Operação de armazéns refrigerados e em atmosfera controlada na exploração.
+  BC-3560.40.30:
+    name: Arejamento de grão armazenado
+    description: |
+      Gestão do arejamento de grão armazenado para manter temperatura e humidade.
+  BC-3560.40.40:
+    name: Gestão de pragas em armazém
+    description: |
+      Monitorização e tratamento da pressão de insetos e roedores em armazéns.
+  BC-3560.50:
+    name: Classificação e embalagem de produto
+    description: |
+      Operações de classificação, embalagem e rotulagem de lotes que preparam
+      o produto para o movimento a jusante.
+  BC-3560.50.10:
+    name: Operações de classificação de qualidade
+    description: |
+      Classificação de produto face a especificações de calibre, cor e defeitos.
+  BC-3560.50.20:
+    name: Operações de casa de embalagem
+    description: |
+      Operações de linha de embalagem, incluindo lavagem, enceramento e
+      embalagem.
+  BC-3560.50.30:
+    name: Identificação e rotulagem de lotes
+    description: |
+      Atribuição de lote, rastreio e identificadores GS1 e impressão de etiquetas.
+  BC-3560.60:
+    name: Receção inbound no processador
+    description: |
+      Coordenação da receção inbound da exploração ou agregador em instalações
+      de processador ou comprador.
+  BC-3560.60.10:
+    name: Calendarização e receção de camiões
+    description: |
+      Calendarização e receção de camiões inbound nas portagens do processador.
+  BC-3560.60.20:
+    name: Amostragem na receção
+    description: |
+      Amostragem inbound de cargas de grão, animais, leite e produto.
+  BC-3560.60.30:
+    name: Teste de qualidade na receção
+    description: |
+      Teste de qualidade de cargas inbound que suporta aceitação e preçário.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-health-information-management.yaml
+++ b/catalogue/i18n/pt/L1-health-information-management.yaml
@@ -1,0 +1,147 @@
+locale: pt
+source: L1-health-information-management.yaml
+entries:
+  BC-2900:
+    name: Gestão de informação de saúde
+    description: |
+      Índice mestre de doentes, operações de codificação, divulgação de informação,
+      ciclo de vida do processo clínico, submissões a registos clínicos e operações
+      de interoperabilidade em cuidados de saúde para a organização prestadora.
+  BC-2900.10:
+    name: Gestão do índice mestre de doentes
+    description: |
+      Gestão do índice mestre de doentes e resolução de registos duplicados e
+      sobrepostos.
+  BC-2900.10.10:
+    name: Gestão do índice mestre de doentes
+    description: |
+      Gestão do quotidiano do índice mestre de doentes da organização.
+  BC-2900.10.20:
+    name: Resolução de duplicados
+    description: |
+      Identificação e resolução de registos de doentes duplicados e sobrepostos.
+  BC-2900.10.30:
+    name: Algoritmos de correspondência de doentes
+    description: |
+      Configuração e ajuste de algoritmos de correspondência de doentes.
+  BC-2900.10.40:
+    name: Referência cruzada de identidades
+    description: |
+      Referência cruzada de identidades de doentes entre organizações afiliadas e
+      sistemas de troca.
+  BC-2900.20:
+    name: Operações de codificação
+    description: |
+      Operações de codificação de produção para encontros de internamento e
+      ambulatório, incluindo auditoria e gestão de pendências.
+  BC-2900.20.10:
+    name: Produção de codificação em internamento
+    description: |
+      Fluxo de trabalho e atribuição de codificação de internamento em produção.
+  BC-2900.20.20:
+    name: Produção de codificação em ambulatório
+    description: |
+      Fluxo de trabalho de codificação em ambulatório e hospital de dia em
+      produção.
+  BC-2900.20.30:
+    name: Gestão de pendências de codificação
+    description: |
+      Gestão de doentes com alta sem faturação final e pendências de codificação.
+  BC-2900.20.40:
+    name: Auditoria de codificadores
+    description: |
+      Auditoria interna da exactidão dos codificadores e feedback.
+  BC-2900.30:
+    name: Divulgação de informação
+    description: |
+      Recepção, validação e satisfação de pedidos de informação de saúde protegida.
+  BC-2900.30.10:
+    name: Recepção de pedidos de informação
+    description: |
+      Recepção de pedidos de doentes, pagadores, entidades legais e prestadores de
+      informação de saúde.
+  BC-2900.30.20:
+    name: Validação de autorizações
+    description: |
+      Validação de autorizações e divulgações permitidas ao abrigo da regulamentação
+      de privacidade.
+  BC-2900.30.30:
+    name: Acompanhamento de divulgações
+    description: |
+      Acompanhamento de divulgações de informação de saúde protegida para efeitos
+      de contabilização.
+  BC-2900.30.40:
+    name: Intimações e pedidos legais
+    description: |
+      Gestão de intimações, ordens judiciais e pedidos legais de processos.
+  BC-2900.40:
+    name: Ciclo de vida do processo clínico
+    description: |
+      Gestão do ciclo de vida dos processos clínicos, desde a criação até à
+      conservação e destruição.
+  BC-2900.40.10:
+    name: Encerramento de encontros
+    description: |
+      Verificação e acompanhamento dos pré-requisitos de encerramento de encontros.
+  BC-2900.40.20:
+    name: Acompanhamento da conclusão do processo
+    description: |
+      Acompanhamento de conclusão de processos em atraso e seguimento junto do
+      prestador.
+  BC-2900.40.30:
+    name: Agendamento da conservação de registos
+    description: |
+      Agendamento da conservação de processos clínicos conforme os requisitos
+      regulatórios.
+  BC-2900.40.40:
+    name: Destruição de registos
+    description: |
+      Destruição autorizada de processos clínicos no fim do período de conservação.
+  BC-2900.50:
+    name: Registos clínicos e submissões
+    description: |
+      Submissão a registos de doenças, oncológicos, de trauma e de qualidade.
+  BC-2900.50.10:
+    name: Submissão a registos de doenças
+    description: |
+      Submissão a registos de saúde pública e de doenças.
+  BC-2900.50.20:
+    name: Operações de registo oncológico
+    description: |
+      Operações de abstracção e submissão ao registo oncológico.
+  BC-2900.50.30:
+    name: Operações de registo de trauma
+    description: |
+      Operações de abstracção e submissão ao registo de trauma.
+  BC-2900.50.40:
+    name: Submissão a registos de qualidade
+    description: |
+      Submissão a registos de qualidade de especialidade que apoiam investigação
+      clínica e benchmarking.
+  BC-2900.60:
+    name: Operações de interoperabilidade em cuidados de saúde
+    description: |
+      Operação de ligações de troca de informação de saúde, endpoints FHIR,
+      partilha de dados iniciada pelo doente e directório de prestadores.
+  BC-2900.60.10:
+    name: Operações de troca de informação de saúde
+    description: |
+      Operações de ligações de troca de informação de saúde de entrada e saída.
+  BC-2900.60.20:
+    name: Gestão de endpoints FHIR
+    description: |
+      Gestão de endpoints FHIR para integração com aplicações e parceiros.
+  BC-2900.60.30:
+    name: Partilha de dados iniciada pelo doente
+    description: |
+      Partilha dirigida pelo doente de informação de saúde com aplicações de
+      terceiros.
+  BC-2900.60.40:
+    name: Manutenção do directório de prestadores
+    description: |
+      Manutenção de dados do directório de prestadores para consumidores internos e
+      externos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-health-safety-environment-management.yaml
+++ b/catalogue/i18n/pt/L1-health-safety-environment-management.yaml
@@ -1,0 +1,119 @@
+locale: pt
+source: L1-health-safety-environment-management.yaml
+entries:
+  BC-730:
+    name: Gestão de saúde, segurança e ambiente
+    description: |
+      Política de SSA, incidentes, segurança no local e saúde ocupacional.
+  BC-730.10:
+    name: Gestão da saúde ocupacional
+    description: |
+      Saúde ocupacional, ergonomia e bem-estar.
+  BC-730.10.10:
+    name: Vigilância da saúde
+    description: |
+      Vigilância médica periódica para grupos de trabalhadores em risco.
+  BC-730.10.20:
+    name: Ergonomia e saúde no local de trabalho
+    description: |
+      Avaliações ergonómicas e programas de saúde no local de trabalho.
+  BC-730.10.30:
+    name: Monitorização de higiene ocupacional
+    description: |
+      Monitorização de exposições a ruído, poeiras, agentes químicos e biológicos.
+  BC-730.10.40:
+    name: Programas de bem-estar dos colaboradores
+    description: |
+      Programas de bem-estar mental, físico e social.
+  BC-730.20:
+    name: Gestão da segurança
+    description: |
+      Segurança no local de trabalho, segurança comportamental e EPI.
+  BC-730.20.10:
+    name: Identificação de perigos e avaliação de risco
+    description: |
+      Identificação de perigos e avaliação de risco para tarefas e locais.
+  BC-730.20.20:
+    name: Autorização de trabalho e sistemas de trabalho seguros
+    description: |
+      Autorização de trabalho, isolamento e sistemas de trabalho seguros.
+  BC-730.20.30:
+    name: Gestão de equipamento de proteção individual
+    description: |
+      Seleção, distribuição, formação e inspeção de EPI.
+  BC-730.20.40:
+    name: Programa de segurança comportamental
+    description: |
+      Observações de segurança comportamental, visitas de liderança e coaching.
+  BC-730.20.50:
+    name: Gestão da segurança de empreiteiros
+    description: |
+      Pré-qualificação, indução e supervisão de segurança no local de empreiteiros.
+  BC-730.30:
+    name: Gestão ambiental
+    description: |
+      Emissões, água, resíduos e conformidade ambiental.
+  BC-730.30.10:
+    name: Avaliação de aspetos e impactos ambientais
+    description: |
+      Identificação de aspetos ambientais e avaliação de impactos.
+  BC-730.30.20:
+    name: Gestão de emissões
+    description: |
+      Gestão de emissões atmosféricas, GEE e poluentes nos locais.
+  BC-730.30.30:
+    name: Gestão de água e efluentes
+    description: |
+      Consumo de água, tratamento de efluentes e gestão de descargas.
+  BC-730.30.40:
+    name: Gestão de resíduos
+    description: |
+      Gestão e eliminação de resíduos perigosos e não perigosos.
+  BC-730.30.50:
+    name: Biodiversidade e gestão do território
+    description: |
+      Atividades de biodiversidade, uso do solo e remediação.
+  BC-730.40:
+    name: Gestão de incidentes e investigação
+    description: |
+      Incidentes de SSA, quase-acidentes e investigações.
+  BC-730.40.10:
+    name: Reporte de incidentes e quase-acidentes
+    description: |
+      Captura e classificação de incidentes de SSA e quase-acidentes.
+  BC-730.40.20:
+    name: Investigação de incidentes de SSA
+    description: |
+      Metodologia de investigação, análise de causa raiz e lições aprendidas.
+  BC-730.40.30:
+    name: Preparação e resposta de emergência
+    description: |
+      Planos de emergência no local, simulacros e coordenação de resposta.
+  BC-730.40.40:
+    name: Gestão da segurança de processo
+    description: |
+      Perigos de segurança de processo, MOC e controlos de perigos de acidente grave.
+  BC-730.50:
+    name: Conformidade e reporte de SSA
+    description: |
+      Reporte regulatório e auditorias de SSA.
+  BC-730.50.10:
+    name: Conformidade regulatória de SSA
+    description: |
+      Identificação e acompanhamento de obrigações regulatórias de SSA.
+  BC-730.50.20:
+    name: Auditoria e inspeção de SSA
+    description: |
+      Auditorias e inspeções internas e externas de SSA.
+  BC-730.50.30:
+    name: Reporte de desempenho de SSA
+    description: |
+      Acompanhamento de KPIs de SSA e reporte de gestão (TRIR, LTIFR).
+  BC-730.50.40:
+    name: Certificação do sistema de gestão de SSA
+    description: |
+      Certificação do sistema de gestão ISO 45001 / ISO 14001.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-healthcare-revenue-cycle-management.yaml
+++ b/catalogue/i18n/pt/L1-healthcare-revenue-cycle-management.yaml
@@ -1,0 +1,167 @@
+locale: pt
+source: L1-healthcare-revenue-cycle-management.yaml
+entries:
+  BC-2870:
+    name: Gestão do ciclo de receita em cuidados de saúde
+    description: |
+      Captura de cobranças e gestão do mapa de preços, codificação médica, produção
+      e submissão de reclamações, negações e recursos, registo de pagamentos,
+      serviços financeiros ao doente e gestão de contratos com pagadores para
+      organizações prestadoras.
+  BC-2870.10:
+    name: Gestão de captura de cobranças e mapa de preços
+    description: |
+      Captura de cobranças clínicas e gestão do mapa de preços em todas as linhas
+      de serviço.
+  BC-2870.10.10:
+    name: Captura de cobranças
+    description: |
+      Captura de cobranças a partir da documentação clínica e sistemas auxiliares.
+  BC-2870.10.20:
+    name: Manutenção do mapa de preços
+    description: |
+      Manutenção de itens, códigos e preços do mapa de preços.
+  BC-2870.10.30:
+    name: Reconciliação de cobranças
+    description: |
+      Reconciliação de cobranças esperadas versus capturadas por área de serviço.
+  BC-2870.10.40:
+    name: Auditoria de cobranças
+    description: |
+      Auditoria interna e externa da exactidão e completude das cobranças.
+  BC-2870.20:
+    name: Gestão de codificação médica
+    description: |
+      Produção de codificação de internamento, ambulatório e honorários
+      profissionais e auditoria de conformidade.
+  BC-2870.20.10:
+    name: Codificação em internamento
+    description: |
+      Codificação de encontros de internamento utilizando a metodologia de grupos
+      de diagnóstico relacionados.
+  BC-2870.20.20:
+    name: Codificação em ambulatório
+    description: |
+      Codificação de encontros em ambulatório utilizando a metodologia de
+      classificação de pagamento ambulatório.
+  BC-2870.20.30:
+    name: Codificação de honorários profissionais
+    description: |
+      Codificação de serviços de honorários profissionais com códigos de
+      procedimentos e de avaliação e gestão.
+  BC-2870.20.40:
+    name: Auditoria e conformidade de codificação
+    description: |
+      Programas de auditoria, conformidade e educação em codificação.
+  BC-2870.30:
+    name: Produção e submissão de reclamações
+    description: |
+      Produção, verificação, submissão e acompanhamento do estado de reclamações
+      junto dos pagadores.
+  BC-2870.30.10:
+    name: Edição e verificação de reclamações
+    description: |
+      Aplicação de edições de pré-submissão e regras de verificação de reclamações.
+  BC-2870.30.20:
+    name: Submissão de reclamações
+    description: |
+      Submissão electrónica de reclamações a pagadores e câmaras de compensação.
+  BC-2870.30.30:
+    name: Consulta do estado de reclamações
+    description: |
+      Consulta electrónica e manual do estado de reclamações e seguimento.
+  BC-2870.30.40:
+    name: Sequenciamento de coordenação de benefícios
+    description: |
+      Sequenciamento de reclamações primárias, secundárias e terciárias entre
+      pagadores.
+  BC-2870.40:
+    name: Gestão de negações e recursos
+    description: |
+      Triagem, recurso e prevenção de negações e pagamentos insuficientes dos
+      pagadores.
+  BC-2870.40.10:
+    name: Triagem de negações
+    description: |
+      Triagem e encaminhamento de reclamações negadas por motivo e probabilidade
+      de recuperação.
+  BC-2870.40.20:
+    name: Redacção e submissão de recursos
+    description: |
+      Redacção e submissão de recursos clínicos e técnicos.
+  BC-2870.40.30:
+    name: Análise de pagamentos insuficientes
+    description: |
+      Identificação e recuperação de pagamentos insuficientes dos pagadores face às
+      taxas contratuais.
+  BC-2870.40.40:
+    name: Análise para prevenção de negações
+    description: |
+      Análise de causa raiz para prevenir negações recorrentes.
+  BC-2870.50:
+    name: Registo de pagamentos e reconciliação com pagadores
+    description: |
+      Registo de remessas dos pagadores e pagamentos dos doentes e reconciliação
+      face ao reembolso esperado.
+  BC-2870.50.10:
+    name: Registo de remessas
+    description: |
+      Registo e reconciliação de avisos de remessa electrónica.
+  BC-2870.50.20:
+    name: Registo de pagamentos do doente
+    description: |
+      Registo de pagamentos do doente através de múltiplos canais.
+  BC-2870.50.30:
+    name: Aplicação de ajustamentos contratuais
+    description: |
+      Aplicação de ajustamentos contratuais com base em acordos com pagadores.
+  BC-2870.50.40:
+    name: Resolução de pagamentos não aplicados
+    description: |
+      Resolução e aplicação de pagamentos não identificados e não aplicados.
+  BC-2870.60:
+    name: Serviços financeiros ao doente
+    description: |
+      Faturação, cobrança, planos de pagamento e transferência para dívida
+      incobrável.
+  BC-2870.60.10:
+    name: Geração de extractos do doente
+    description: |
+      Geração de extractos do doente em canais em papel e digital.
+  BC-2870.60.20:
+    name: Cobranças ao doente
+    description: |
+      Operações de cobrança e contacto com doentes de pagamento directo.
+  BC-2870.60.30:
+    name: Gestão de planos de pagamento
+    description: |
+      Configuração e gestão de planos de pagamento do doente.
+  BC-2870.60.40:
+    name: Transferência para dívida incobrável
+    description: |
+      Transferência e gestão de contas para agências de cobrança externas.
+  BC-2870.70:
+    name: Gestão de contratos com pagadores
+    description: |
+      Modelação, apoio à negociação, análise de variância e monitorização do
+      desempenho de contratos com pagadores.
+  BC-2870.70.10:
+    name: Modelação de contratos
+    description: |
+      Modelação de termos de contrato com pagadores e metodologias de reembolso.
+  BC-2870.70.20:
+    name: Análise de variância de reembolso
+    description: |
+      Análise de variância entre o reembolso contratado e o efectivo.
+  BC-2870.70.30:
+    name: Apoio à negociação de contratos
+    description: |
+      Apoio analítico e operacional às negociações de contratos com pagadores.
+  BC-2870.70.40:
+    name: Monitorização do desempenho do pagador
+    description: |
+      Monitorização contínua do desempenho do pagador face aos SLA contratuais.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-human-capital-management.yaml
+++ b/catalogue/i18n/pt/L1-human-capital-management.yaml
@@ -1,0 +1,211 @@
+locale: pt
+source: L1-human-capital-management.yaml
+entries:
+  BC-300:
+    name: Gestão de capital humano
+    description: |
+      Ciclo de vida completo do colaborador. Também designado por gestão de recursos humanos.
+  BC-300.10:
+    name: Gestão da aquisição de talento
+    description: |
+      Sourcing, recrutamento, contratação e integração.
+  BC-300.10.10:
+    name: Sourcing de força de trabalho
+    description: |
+      Sourcing de candidatos através de canais, referências e pipelines de talento.
+  BC-300.10.20:
+    name: Triagem e seleção de candidatos
+    description: |
+      Triagem de candidatos, avaliações e gestão de entrevistas.
+  BC-300.10.30:
+    name: Gestão de propostas e contratação
+    description: |
+      Elaboração de propostas, negociação, verificações de antecedentes e contratação.
+  BC-300.10.40:
+    name: Integração de colaboradores
+    description: |
+      Pré-integração, experiência no primeiro dia e percursos de integração.
+  BC-300.10.50:
+    name: Gestão da marca empregadora
+    description: |
+      Proposta de valor do empregador, campanhas de marca empregadora e reputação.
+  BC-300.20:
+    name: Gestão de talento
+    description: |
+      Desempenho, sucessão e desenvolvimento de carreira.
+  BC-300.20.10:
+    name: Gestão do desempenho
+    description: |
+      Definição de objetivos, avaliações de desempenho e ciclos de feedback.
+  BC-300.20.20:
+    name: Planeamento de sucessão
+    description: |
+      Identificação e desenvolvimento de candidatos a sucessão para funções-chave.
+  BC-300.20.30:
+    name: Desenvolvimento de carreira e mobilidade interna
+    description: |
+      Percursos de carreira, mobilidade interna e planeamento de desenvolvimento.
+  BC-300.20.40:
+    name: Revisão de talento e calibração
+    description: |
+      Sessões de revisão de talento, calibração e avaliações 9-box.
+  BC-300.20.50:
+    name: Desenvolvimento de liderança
+    description: |
+      Pipelines de liderança, desenvolvimento executivo e coaching.
+  BC-300.30:
+    name: Gestão de remuneração e benefícios
+    description: |
+      Estruturas salariais, bónus, capital próprio e administração de benefícios.
+  BC-300.30.10:
+    name: Arquitetura de funções e classificação
+    description: |
+      Catálogo de funções, nivelamento e estruturas de classificação.
+  BC-300.30.20:
+    name: Gestão da remuneração base
+    description: |
+      Escalões salariais, benchmarking de mercado e ciclos de revisão salarial.
+  BC-300.30.30:
+    name: Gestão de remuneração variável e incentivos
+    description: |
+      Administração de bónus, incentivos de vendas e planos de incentivo de curto prazo.
+  BC-300.30.40:
+    name: Administração de capital próprio e incentivos de longo prazo
+    description: |
+      Planos de capital próprio, RSUs, opções e planos de incentivo de longo prazo.
+  BC-300.30.50:
+    name: Administração de benefícios
+    description: |
+      Administração de benefícios de saúde, reforma e outros benefícios dos colaboradores.
+  BC-300.40:
+    name: Gestão de aprendizagem e desenvolvimento
+    description: |
+      Formação, desenvolvimento de competências e certificações.
+  BC-300.40.10:
+    name: Análise de necessidades de formação
+    description: |
+      Identificação de lacunas de competências e necessidades de formação por função.
+  BC-300.40.20:
+    name: Curadoria de conteúdos de aprendizagem
+    description: |
+      Curadoria e criação de conteúdos de aprendizagem internos e de terceiros.
+  BC-300.40.30:
+    name: Entrega e administração de aprendizagem
+    description: |
+      Entrega e acompanhamento de formação, salas de aula e aprendizagem digital.
+  BC-300.40.40:
+    name: Gestão de competências e certificações
+    description: |
+      Inventário de competências, capacidades e acompanhamento de certificações.
+  BC-300.40.50:
+    name: Avaliação da eficácia da aprendizagem
+    description: |
+      Avaliação do impacto da aprendizagem e ROI do investimento em formação.
+  BC-300.50:
+    name: Gestão do planeamento da força de trabalho
+    description: |
+      Planeamento estratégico da oferta e procura de força de trabalho.
+  BC-300.50.10:
+    name: Previsão da procura de força de trabalho
+    description: |
+      Previsão da procura de força de trabalho por competência, função e localização.
+  BC-300.50.20:
+    name: Análise da oferta de força de trabalho
+    description: |
+      Análise da oferta interna, atrito e mercado laboral.
+  BC-300.50.30:
+    name: Desenvolvimento do plano estratégico de força de trabalho
+    description: |
+      Planos e cenários estratégicos de força de trabalho plurianuais.
+  BC-300.50.40:
+    name: Planeamento e controlo de headcount
+    description: |
+      Orçamentação operacional de headcount e fluxos de aprovação.
+  BC-300.60:
+    name: Gestão da experiência do colaborador
+    description: |
+      Envolvimento, comunicações internas e experiência no local de trabalho.
+  BC-300.60.10:
+    name: Medição do envolvimento dos colaboradores
+    description: |
+      Inquéritos de envolvimento, pulso e programas de escuta.
+  BC-300.60.20:
+    name: Design da jornada do colaborador
+    description: |
+      Design dos momentos que importam e mapas de jornada dos colaboradores.
+  BC-300.60.30:
+    name: Bem-estar no local de trabalho
+    description: |
+      Programas de bem-estar mental, físico e financeiro.
+  BC-300.60.40:
+    name: Reconhecimento e recompensas
+    description: |
+      Programas de reconhecimento e esquemas de recompensa não monetária.
+  BC-300.70:
+    name: Gestão de operações de RH
+    description: |
+      Registos de colaboradores, administração de vencimentos e prestação de serviços de RH.
+  BC-300.70.10:
+    name: Gestão de dados mestre de colaboradores
+    description: |
+      Registos de colaboradores, eventos do ciclo de vida e integridade dos dados mestre.
+  BC-300.70.20:
+    name: Administração de vencimentos
+    description: |
+      Processamento de vencimentos, deduções obrigatórias e distribuição de recibos.
+  BC-300.70.30:
+    name: Gestão de tempo e ausências
+    description: |
+      Controlo de tempo, licenças e gestão de ausências.
+  BC-300.70.40:
+    name: Serviço de apoio e helpdesk de RH
+    description: |
+      Helpdesk de RH, gestão de casos e tratamento de consultas de nível 1.
+  BC-300.70.50:
+    name: Análise e reporte de RH
+    description: |
+      Análise de força de trabalho, dashboards e reporte estatutário de RH.
+  BC-300.80:
+    name: Relações laborais e com colaboradores
+    description: |
+      Comissões de trabalhadores, sindicatos, queixas e legislação laboral.
+  BC-300.80.10:
+    name: Negociação coletiva e relacionamento sindical
+    description: |
+      Negociação coletiva, acordos e relações sindicais.
+  BC-300.80.20:
+    name: Comissão de trabalhadores e representação dos colaboradores
+    description: |
+      Consulta à comissão de trabalhadores e órgãos representativos dos colaboradores.
+  BC-300.80.30:
+    name: Gestão de queixas e processos disciplinares
+    description: |
+      Tratamento de queixas, processos disciplinares e investigações.
+  BC-300.80.40:
+    name: Conformidade com a legislação laboral
+    description: |
+      Conformidade com a legislação laboral, tempo de trabalho e normas laborais.
+  BC-300.90:
+    name: Gestão de diversidade, equidade e inclusão
+    description: |
+      Estratégia, programas e reporte de DEI.
+  BC-300.90.10:
+    name: Estratégia e governação de DEI
+    description: |
+      Estratégia, patrocínio e estruturas de governação de DEI.
+  BC-300.90.20:
+    name: Práticas de talento inclusivas
+    description: |
+      Práticas inclusivas de sourcing, contratação e progressão.
+  BC-300.90.30:
+    name: Entrega de programas de DEI
+    description: |
+      Grupos de recursos de colaboradores, sensibilização e programas de DEI.
+  BC-300.90.40:
+    name: Equidade salarial e reporte de DEI
+    description: |
+      Análise de equidade salarial e métricas e divulgações de DEI.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-hvac-bas-service-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-hvac-bas-service-operations-management.yaml
@@ -1,0 +1,191 @@
+locale: pt
+source: L1-hvac-bas-service-operations-management.yaml
+entries:
+  BC-2060:
+    name: Gestão de operações de serviço HVAC e BAS
+    description: |
+      Serviço liderado pelo OEM e por contratantes no equipamento HVAC instalado e BAS — gestão
+      de configuração da base instalada, manutenção preventiva e reativa, reprogramação BAS e
+      serviço de software, retrofit e modernização de equipamentos, contratos de serviço baseados
+      em desempenho e serviço remoto conectado.
+  BC-2060.10:
+    name: Gestão de configuração da base instalada
+    description: |
+      Manutenção dos dados de configuração tal como instalada e tal como mantida para a base instalada global.
+  BC-2060.10.10:
+    name: Registo de ativos de equipamento
+    description: |
+      Registo de equipamentos HVAC instalados por número de série, local e cliente.
+  BC-2060.10.20:
+    name: Registo de configuração BAS
+    description: |
+      Registo de configurações BAS, controladores, pontos e sequências em serviço.
+  BC-2060.10.30:
+    name: Registos tal como mantido
+    description: |
+      Registos de configuração tal como mantida após cada evento de assistência.
+  BC-2060.10.40:
+    name: Registos de modificação da base instalada
+    description: |
+      Registos de modificações pós-entrega no equipamento instalado e BAS.
+  BC-2060.20:
+    name: Operações de serviço de manutenção preventiva
+    description: |
+      Prestação de manutenção preventiva programada ao abrigo do contrato.
+  BC-2060.20.10:
+    name: Execução do contrato de manutenção
+    description: |
+      Execução da manutenção preventiva face ao âmbito contratado.
+  BC-2060.20.20:
+    name: Encaminhamento de visitas programadas
+    description: |
+      Encaminhamento e despacho de visitas de assistência programadas.
+  BC-2060.20.30:
+    name: Serviço de filtros e correias
+    description: |
+      Serviço de substituição de filtros, correias e consumíveis de rotina.
+  BC-2060.20.40:
+    name: Serviço de refrigerante e serpentinas
+    description: |
+      Serviço de recarga de refrigerante e limpeza de serpentinas de rotina.
+  BC-2060.20.50:
+    name: Relatório de conformidade de manutenção
+    description: |
+      Relatório de conformidade de manutenção preventiva aos clientes.
+  BC-2060.30:
+    name: Operações de serviço reativo e de emergência
+    description: |
+      Serviço reativo e de emergência fora de horas no equipamento instalado.
+  BC-2060.30.10:
+    name: Triagem de pedidos de assistência
+    description: |
+      Triagem de pedidos de assistência recebidos por urgência e capacidade.
+  BC-2060.30.20:
+    name: Despacho de resposta de emergência
+    description: |
+      Despacho de socorristas para avarias críticas de equipamento.
+  BC-2060.30.30:
+    name: Execução de reparação no local
+    description: |
+      Execução de reparação no local por técnicos de assistência.
+  BC-2060.30.40:
+    name: Resposta de emergência a fuga de refrigerante
+    description: |
+      Resposta de emergência a libertações e fugas maiores de refrigerante.
+  BC-2060.40:
+    name: Reprogramação BAS e serviço de software
+    description: |
+      Serviço do lado do software no BAS instalado — atualizações de sequências, atualização de firmware e alterações de configuração.
+  BC-2060.40.10:
+    name: Implementação de atualização de sequências
+    description: |
+      Implementação de sequências de operação atualizadas nos controladores instalados.
+  BC-2060.40.20:
+    name: Atualização de firmware do controlador
+    description: |
+      Atualização de firmware dos controladores BAS instalados.
+  BC-2060.40.30:
+    name: Modificação de pontos e programas
+    description: |
+      Modificação em campo de pontos, programas e tendências BAS.
+  BC-2060.40.40:
+    name: Operações de backup e recuperação BAS
+    description: |
+      Backup da configuração BAS e recuperação em eventos de falha.
+  BC-2060.50:
+    name: Serviço de retrofit e modernização de equipamentos HVAC
+    description: |
+      Serviços de retrofit, substituição e modernização prestados na base HVAC instalada.
+  BC-2060.50.10:
+    name: Engenharia de retrofit no local
+    description: |
+      Engenharia no local de pacotes de retrofit adaptados à instalação.
+  BC-2060.50.20:
+    name: Execução de substituição de equipamento
+    description: |
+      Execução no local de âmbitos de substituição de equipamento.
+  BC-2060.50.30:
+    name: Serviço de conversão de refrigerante
+    description: |
+      Conversão do equipamento instalado para refrigerantes alternativos.
+  BC-2060.50.40:
+    name: Testes de validação de retrofit
+    description: |
+      Testes de validação após trabalho de retrofit ou modernização.
+  BC-2060.60:
+    name: Operações de contratos de serviço baseados em desempenho
+    description: |
+      Operação de contratos de serviço baseados em desempenho e resultados.
+  BC-2060.60.10:
+    name: Execução de contrato de desempenho
+    description: |
+      Execução de obrigações de serviço baseadas em desempenho.
+  BC-2060.60.20:
+    name: Acompanhamento de poupanças garantidas
+    description: |
+      Acompanhamento de resultados de poupanças garantidas face à linha de base.
+  BC-2060.60.30:
+    name: Operações do mecanismo de partilha de risco
+    description: |
+      Operação de mecanismos de bónus e penalização por partilha de risco.
+  BC-2060.60.40:
+    name: Relatório de resultados
+    description: |
+      Relatório de resultados contratados e métricas de nível de serviço.
+  BC-2060.70:
+    name: Operações de serviço remoto conectado
+    description: |
+      Operações de centro de serviço remoto aproveitando dados de HVAC e BAS conectados.
+  BC-2060.70.10:
+    name: Operações do centro de diagnóstico remoto
+    description: |
+      Operações do centro de diagnóstico remoto para equipamentos conectados.
+  BC-2060.70.20:
+    name: Triagem remota de problemas
+    description: |
+      Triagem de problemas identificados por telemetria remota.
+  BC-2060.70.30:
+    name: Execução de resolução remota
+    description: |
+      Execução de resoluções apenas remotas quando o problema não requer visita ao local.
+  BC-2060.70.40:
+    name: Integração de clientes no serviço conectado
+    description: |
+      Integração de clientes em ofertas de serviço conectado.
+  BC-2060.80:
+    name: Gestão de qualidade de serviço e SLA
+    description: |
+      Gestão da qualidade de serviço, acordos de nível de serviço e satisfação do cliente.
+  BC-2060.80.10:
+    name: Acompanhamento do acordo de nível de serviço
+    description: |
+      Acompanhamento do desempenho do acordo de nível de serviço.
+  BC-2060.80.20:
+    name: Captura da satisfação do cliente
+    description: |
+      Captura da satisfação do cliente nas interações de assistência.
+  BC-2060.80.30:
+    name: Gestão de escaladas de assistência
+    description: |
+      Gestão de escaladas de assistência e ações de recuperação.
+  BC-2060.80.40:
+    name: Relatório de desempenho de assistência
+    description: |
+      Relatório periódico do desempenho de assistência a clientes e gestão.
+  in_scope:
+    - Registo de equipamento instalado e configuração BAS
+    - Prestação de contrato de manutenção preventiva e serviço reativo/de emergência
+    - Reprogramação BAS, atualizações de firmware e operações de backup/recuperação
+    - Execução de retrofit e modernização no equipamento HVAC instalado
+    - Contratos de serviço baseados em desempenho e resultados
+    - Operações de serviço remoto conectado e de centro de diagnóstico
+    - Gestão de acordo de nível de serviço e satisfação do cliente
+  out_of_scope:
+    - Assistência de campo genérica multissetorial (BC-1050) e peças sobressalentes (BC-1060)
+    - Colocação em serviço de projeto e prestação de Cx (BC-2050)
+    - Aprovisionamento e relatório de refrigerante (BC-2040)
+    - Engenharia de produto de equipamento HVAC (BC-2000)
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-hvac-bas-service-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-hvac-bas-service-operations-management.yaml
@@ -8,6 +8,19 @@ entries:
       de configuração da base instalada, manutenção preventiva e reativa, reprogramação BAS e
       serviço de software, retrofit e modernização de equipamentos, contratos de serviço baseados
       em desempenho e serviço remoto conectado.
+    in_scope:
+      - Registo de equipamento instalado e configuração BAS
+      - Prestação de contrato de manutenção preventiva e serviço reativo/de emergência
+      - Reprogramação BAS, atualizações de firmware e operações de backup/recuperação
+      - Execução de retrofit e modernização no equipamento HVAC instalado
+      - Contratos de serviço baseados em desempenho e resultados
+      - Operações de serviço remoto conectado e de centro de diagnóstico
+      - Gestão de acordo de nível de serviço e satisfação do cliente
+    out_of_scope:
+      - Assistência de campo genérica multissetorial (BC-1050) e peças sobressalentes (BC-1060)
+      - Colocação em serviço de projeto e prestação de Cx (BC-2050)
+      - Aprovisionamento e relatório de refrigerante (BC-2040)
+      - Engenharia de produto de equipamento HVAC (BC-2000)
   BC-2060.10:
     name: Gestão de configuração da base instalada
     description: |
@@ -172,19 +185,6 @@ entries:
     name: Relatório de desempenho de assistência
     description: |
       Relatório periódico do desempenho de assistência a clientes e gestão.
-  in_scope:
-    - Registo de equipamento instalado e configuração BAS
-    - Prestação de contrato de manutenção preventiva e serviço reativo/de emergência
-    - Reprogramação BAS, atualizações de firmware e operações de backup/recuperação
-    - Execução de retrofit e modernização no equipamento HVAC instalado
-    - Contratos de serviço baseados em desempenho e resultados
-    - Operações de serviço remoto conectado e de centro de diagnóstico
-    - Gestão de acordo de nível de serviço e satisfação do cliente
-  out_of_scope:
-    - Assistência de campo genérica multissetorial (BC-1050) e peças sobressalentes (BC-1060)
-    - Colocação em serviço de projeto e prestação de Cx (BC-2050)
-    - Aprovisionamento e relatório de refrigerante (BC-2040)
-    - Engenharia de produto de equipamento HVAC (BC-2000)
 metadata:
   status: draft
   translator: claude-ai

--- a/catalogue/i18n/pt/L1-hvac-equipment-certification-management.yaml
+++ b/catalogue/i18n/pt/L1-hvac-equipment-certification-management.yaml
@@ -1,0 +1,161 @@
+locale: pt
+source: L1-hvac-equipment-certification-management.yaml
+entries:
+  BC-2030:
+    name: Gestão de certificação de equipamentos HVAC
+    description: |
+      Certificação de produto HVAC em múltiplas jurisdições — certificação de desempenho (AHRI, Eurovent),
+      listagem de segurança (UL, CSA, IEC 60335-2-40, marcação CE), aprovações de refrigerante (F-Gas, EPA SNAP),
+      e rotulagem de eficiência energética (ENERGY STAR, Ecodesign UE/ErP, MEPS) — até ao
+      licenciamento de marcas, conformidade de rotulagem e vigilância de normas.
+  BC-2030.10:
+    name: Estratégia e roteiro de certificação
+    description: |
+      Definição do âmbito, esquemas e sequência de certificação nos mercados-alvo.
+  BC-2030.10.10:
+    name: Análise de requisitos de acesso ao mercado
+    description: |
+      Identificação de obrigações de certificação e rotulagem por mercado-alvo.
+  BC-2030.10.20:
+    name: Seleção de esquemas de certificação
+    description: |
+      Seleção de esquemas de certificação e vias de reconhecimento para equipamentos HVAC.
+  BC-2030.10.30:
+    name: Planeamento do roteiro de certificação
+    description: |
+      Sequenciamento de certificações face a marcos de lançamento de equipamentos.
+  BC-2030.20:
+    name: Gestão de certificação de desempenho
+    description: |
+      Relacionamento com programas de certificação de desempenho HVAC e publicação de desempenho classificado.
+  BC-2030.20.10:
+    name: Coordenação do programa de teste de desempenho
+    description: |
+      Coordenação de testes de classificação de equipamentos com laboratórios acreditados.
+  BC-2030.20.20:
+    name: Submissão de classificação de desempenho
+    description: |
+      Submissão de classificações certificadas a programas de certificação de desempenho.
+  BC-2030.20.30:
+    name: Acompanhamento da emissão de marca de desempenho
+    description: |
+      Acompanhamento de certificados de desempenho emitidos e janelas de validade.
+  BC-2030.20.40:
+    name: Participação em programas voluntários
+    description: |
+      Participação em programas voluntários de desempenho e qualidade.
+  BC-2030.30:
+    name: Gestão de listagem de segurança de equipamentos
+    description: |
+      Relacionamento com esquemas de listagem de segurança de equipamentos HVAC nas diferentes jurisdições.
+  BC-2030.30.10:
+    name: Submissão de listagem de segurança
+    description: |
+      Submissão de listagens de segurança face à IEC 60335-2-40 e normas equivalentes.
+  BC-2030.30.20:
+    name: Verificação de conformidade com normas de segurança
+    description: |
+      Verificação de conformidade com normas de segurança por auditoria interna.
+  BC-2030.30.30:
+    name: Coordenação de marcas de segurança internacionais
+    description: |
+      Coordenação entre múltiplas marcas de segurança nacionais e acordos de reconhecimento.
+  BC-2030.30.40:
+    name: Gestão de modificações de segurança em campo
+    description: |
+      Gestão de modificações de segurança em campo e ações corretivas que afetam as listagens.
+  BC-2030.40:
+    name: Gestão de conformidade de refrigerante
+    description: |
+      Aprovações de refrigerante ao nível do produto, conformidade de eliminação gradual e divulgação de substâncias para certificação.
+  BC-2030.40.10:
+    name: Acompanhamento de aprovação de refrigerante
+    description: |
+      Acompanhamento de refrigerantes aprovados para cada família de produto por jurisdição.
+  BC-2030.40.20:
+    name: Conformidade com a eliminação gradual de refrigerante
+    description: |
+      Conformidade com os calendários de eliminação gradual de HFC e compromissos de Kigali ao nível do produto.
+  BC-2030.40.30:
+    name: Registos de conformidade de PGA e ODP
+    description: |
+      Registos de potencial de aquecimento global e potencial de destruição do ozono face a limiares regulatórios.
+  BC-2030.40.40:
+    name: Relatório de substâncias refrigerante
+    description: |
+      Relatório de substâncias exigido como parte dos dossiers de certificação de produto.
+  BC-2030.50:
+    name: Gestão de rótulos de energia e eficiência
+    description: |
+      Registo e conformidade contínua com rotulagem de eficiência energética e programas de eficiência mínima.
+  BC-2030.50.10:
+    name: Registo de rótulo de energia
+    description: |
+      Registo de rótulos de energia de equipamentos em programas nacionais.
+  BC-2030.50.20:
+    name: Conformidade com Ecodesign
+    description: |
+      Conformidade com o Ecodesign UE e regimes equivalentes.
+  BC-2030.50.30:
+    name: Conformidade com padrões mínimos de eficiência
+    description: |
+      Conformidade com padrões mínimos de eficiência nos diferentes mercados.
+  BC-2030.50.40:
+    name: Participação em ecodesign voluntário
+    description: |
+      Participação em programas voluntários de ecodesign para equipamentos sustentáveis.
+  BC-2030.60:
+    name: Gestão de conformidade de marcas e rótulos de certificação
+    description: |
+      Gestão do ciclo de vida de marcas de certificação e arte gráfica de rótulos no produto.
+  BC-2030.60.10:
+    name: Emissão de marca
+    description: |
+      Emissão e aplicação no produto de marcas de certificação.
+  BC-2030.60.20:
+    name: Renovação de marca
+    description: |
+      Renovação de marcas de certificação antes da expiração.
+  BC-2030.60.30:
+    name: Retirada de marca
+    description: |
+      Retirada de marcas de certificação para equipamentos retirados ou não conformes.
+  BC-2030.60.40:
+    name: Conformidade do rótulo no produto
+    description: |
+      Controlo da arte gráfica do rótulo no produto face ao conteúdo de certificação aprovado.
+  BC-2030.70:
+    name: Gestão de vigilância de normas
+    description: |
+      Vigilância de normas e regulamentos HVAC, com avaliação de impacto e comunicação do roteiro.
+  BC-2030.70.10:
+    name: Informação sobre normas HVAC
+    description: |
+      Informação sobre normas HVAC emergentes e revistas.
+  BC-2030.70.20:
+    name: Avaliação do impacto de alterações de normas
+    description: |
+      Avaliação do impacto das alterações de normas nas certificações existentes.
+  BC-2030.70.30:
+    name: Participação em organismos do setor
+    description: |
+      Participação em organismos de normalização do setor e comités técnicos.
+  BC-2030.70.40:
+    name: Comunicação do roteiro de normas
+    description: |
+      Comunicação dos roteiros de normas às equipas de engenharia e produto.
+  in_scope:
+    - Estratégia e roteiro de certificação nos diferentes mercados
+    - Submissões de certificação de desempenho e publicação de classificações
+    - Listagem de segurança de equipamentos e avaliação de conformidade CE
+    - Aprovação regulatória de refrigerante ao nível do produto
+    - Registo e conformidade de rótulo de energia e eficiência
+    - Licenciamento de marcas, conformidade de arte gráfica de rótulos e vigilância de normas
+  out_of_scope:
+    - Contabilidade operacional de refrigerante no equipamento instalado (BC-2040)
+    - Certificação genérica de produto elétrico/eletrónico (BC-1910)
+    - Investigação de não conformidade em campo decorrente de assistência (BC-2060)
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-hvac-equipment-certification-management.yaml
+++ b/catalogue/i18n/pt/L1-hvac-equipment-certification-management.yaml
@@ -8,6 +8,17 @@ entries:
       listagem de segurança (UL, CSA, IEC 60335-2-40, marcação CE), aprovações de refrigerante (F-Gas, EPA SNAP),
       e rotulagem de eficiência energética (ENERGY STAR, Ecodesign UE/ErP, MEPS) — até ao
       licenciamento de marcas, conformidade de rotulagem e vigilância de normas.
+    in_scope:
+      - Estratégia e roteiro de certificação nos diferentes mercados
+      - Submissões de certificação de desempenho e publicação de classificações
+      - Listagem de segurança de equipamentos e avaliação de conformidade CE
+      - Aprovação regulatória de refrigerante ao nível do produto
+      - Registo e conformidade de rótulo de energia e eficiência
+      - Licenciamento de marcas, conformidade de arte gráfica de rótulos e vigilância de normas
+    out_of_scope:
+      - Contabilidade operacional de refrigerante no equipamento instalado (BC-2040)
+      - Certificação genérica de produto elétrico/eletrónico (BC-1910)
+      - Investigação de não conformidade em campo decorrente de assistência (BC-2060)
   BC-2030.10:
     name: Estratégia e roteiro de certificação
     description: |
@@ -144,17 +155,6 @@ entries:
     name: Comunicação do roteiro de normas
     description: |
       Comunicação dos roteiros de normas às equipas de engenharia e produto.
-  in_scope:
-    - Estratégia e roteiro de certificação nos diferentes mercados
-    - Submissões de certificação de desempenho e publicação de classificações
-    - Listagem de segurança de equipamentos e avaliação de conformidade CE
-    - Aprovação regulatória de refrigerante ao nível do produto
-    - Registo e conformidade de rótulo de energia e eficiência
-    - Licenciamento de marcas, conformidade de arte gráfica de rótulos e vigilância de normas
-  out_of_scope:
-    - Contabilidade operacional de refrigerante no equipamento instalado (BC-2040)
-    - Certificação genérica de produto elétrico/eletrónico (BC-1910)
-    - Investigação de não conformidade em campo decorrente de assistência (BC-2060)
 metadata:
   status: draft
   translator: claude-ai

--- a/catalogue/i18n/pt/L1-hvac-equipment-engineering-management.yaml
+++ b/catalogue/i18n/pt/L1-hvac-equipment-engineering-management.yaml
@@ -1,0 +1,204 @@
+locale: pt
+source: L1-hvac-equipment-engineering-management.yaml
+entries:
+  BC-2000:
+    name: Gestão de engenharia de equipamentos HVAC
+    description: |
+      Engenharia mecânica, de refrigeração e termofluidodinâmica de equipamentos HVAC —
+      chillers, bombas de calor, UTA, RTU, VRF, ventiloconvectores e unidades terminais — até à
+      verificação de desempenho e prontidão para testes de classificação AHRI/Eurovent.
+  BC-2000.10:
+    name: Engenharia do ciclo de refrigeração
+    description: |
+      Engenharia de ciclos de compressão de vapor, absorção e bomba de calor para equipamentos HVAC.
+  BC-2000.10.10:
+    name: Projeto do ciclo de compressão de vapor
+    description: |
+      Projeto de ciclos de refrigeração por compressão de vapor para equipamentos de arrefecimento e aquecimento.
+  BC-2000.10.20:
+    name: Projeto do ciclo de absorção
+    description: |
+      Projeto de chillers e bombas de calor por ciclo de absorção.
+  BC-2000.10.30:
+    name: Projeto do ciclo de bomba de calor
+    description: |
+      Projeto de ciclos reversíveis de bomba de calor em variantes de fonte de ar, água e solo.
+  BC-2000.10.40:
+    name: Engenharia de seleção de refrigerante
+    description: |
+      Seleção de refrigerantes face a objetivos termodinâmicos, regulatórios, de PGA e de inflamabilidade.
+  BC-2000.10.50:
+    name: Otimização do desempenho do ciclo
+    description: |
+      Otimização do desempenho do ciclo em pontos de classificação e condições de carga parcial.
+  BC-2000.20:
+    name: Engenharia de transferência de calor e serpentinas
+    description: |
+      Engenharia de evaporadores, condensadores, rodas de recuperação e permutadores de calor de placas brasadas/casco e tubos utilizados em equipamentos HVAC.
+  BC-2000.20.10:
+    name: Projeto de serpentina de evaporador
+    description: |
+      Projeto de serpentinas de evaporador de tubo aletado e microcanal.
+  BC-2000.20.20:
+    name: Projeto de serpentina de condensador
+    description: |
+      Projeto de serpentinas de condensador arrefecidas a ar e a água.
+  BC-2000.20.30:
+    name: Projeto de recuperação de calor ar-ar
+    description: |
+      Projeto de rodas de recuperação de energia, permutadores de placas e ciclos de corrida.
+  BC-2000.20.40:
+    name: Projeto de placas brasadas e casco e tubos
+    description: |
+      Projeto de permutadores de calor de placas brasadas e casco e tubos para aplicações hídricas e de refrigerante.
+  BC-2000.20.50:
+    name: Engenharia de materiais e revestimentos de serpentinas
+    description: |
+      Seleção de metalurgia e revestimentos protetores de serpentinas para durabilidade ambiental.
+  BC-2000.30:
+    name: Engenharia de equipamentos de movimentação de ar
+    description: |
+      Engenharia de ventiladores, sopradores, unidades de tratamento de ar, registos e conjuntos de filtração.
+  BC-2000.30.10:
+    name: Projeto de ventilador centrífugo
+    description: |
+      Projeto aerodinâmico e mecânico de ventiladores centrífugos.
+  BC-2000.30.20:
+    name: Projeto de ventilador axial e plug
+    description: |
+      Projeto aerodinâmico e mecânico de ventiladores axiais e plug.
+  BC-2000.30.30:
+    name: Engenharia de unidade de tratamento de ar
+    description: |
+      Engenharia de secções modulares de UTA, carcaça e escoamento de ar.
+  BC-2000.30.40:
+    name: Engenharia de registos e grelhas
+    description: |
+      Engenharia de registos de controlo, registos corta-fogo/fumo e grelhas de intempérie.
+  BC-2000.30.50:
+    name: Engenharia de sistemas de filtração
+    description: |
+      Engenharia de secções de filtração de partículas, gás e HEPA.
+  BC-2000.40:
+    name: Engenharia de sistemas hídricos e fluidos
+    description: |
+      Engenharia de bombas, tubagens, circuitos hídricos e acessórios de suporte dentro de equipamentos HVAC.
+  BC-2000.40.10:
+    name: Engenharia de bombas
+    description: |
+      Seleção e integração de bombas circuladoras e de aspiração simples em conjuntos de equipamento.
+  BC-2000.40.20:
+    name: Projeto de tubagem e coletores
+    description: |
+      Projeto de tubagem interna, coletores e distribuidores em equipamentos de pacote.
+  BC-2000.40.30:
+    name: Engenharia de circuito de água gelada e quente
+    description: |
+      Engenharia de circuitos integrados de água gelada e quente ao nível do equipamento.
+  BC-2000.40.40:
+    name: Engenharia de acessórios hídricos
+    description: |
+      Engenharia de vasos de expansão, separadores de ar e filtros como acessórios de pacote.
+  BC-2000.50:
+    name: Engenharia de compressores e acionamentos
+    description: |
+      Engenharia de famílias de compressores e dos acionamentos que os alimentam.
+  BC-2000.50.10:
+    name: Engenharia de compressor de espiral
+    description: |
+      Engenharia de compressores de espiral utilizados em equipamentos light-commercial.
+  BC-2000.50.20:
+    name: Engenharia de compressor de parafuso
+    description: |
+      Engenharia de compressores de parafuso utilizados em chillers comerciais e industriais.
+  BC-2000.50.30:
+    name: Engenharia de compressor centrífugo
+    description: |
+      Engenharia de compressores centrífugos utilizados em chillers de grande tonelagem.
+  BC-2000.50.40:
+    name: Engenharia de compressor alternativo
+    description: |
+      Engenharia de compressores alternativos utilizados em bombas de calor e refrigeração.
+  BC-2000.50.50:
+    name: Integração de variador de velocidade
+    description: |
+      Integração de variadores de velocidade com compressores e ventiladores HVAC.
+  BC-2000.60:
+    name: Engenharia acústica e de vibração HVAC
+    description: |
+      Engenharia acústica, de vibração e de ruído ao nível do equipamento.
+  BC-2000.60.10:
+    name: Modelação de potência sonora
+    description: |
+      Modelação de potência e pressão sonora de equipamentos HVAC.
+  BC-2000.60.20:
+    name: Projeto de isolamento de vibração
+    description: |
+      Projeto de isolamento de vibração para compressores, ventiladores e bombas.
+  BC-2000.60.30:
+    name: Engenharia de recintos acústicos
+    description: |
+      Engenharia de recintos acústicos e atenuadores integrados com o equipamento.
+  BC-2000.60.40:
+    name: Afinação psicoacústica do desempenho
+    description: |
+      Afinação da qualidade sonora percebida para além das métricas agregadas de potência sonora.
+  BC-2000.70:
+    name: Engenharia de controlo de equipamento e sistemas embebidos
+    description: |
+      Engenharia de controladores de equipamento a bordo, firmware e pilhas de conectividade nos equipamentos HVAC.
+  BC-2000.70.10:
+    name: Engenharia de controlador a bordo
+    description: |
+      Engenharia de controladores residentes no equipamento e controladores de unidade.
+  BC-2000.70.20:
+    name: Engenharia de firmware de equipamento
+    description: |
+      Desenvolvimento de firmware para equipamentos HVAC, incluindo controladores de unidade e acionamentos.
+  BC-2000.70.30:
+    name: Engenharia de comunicação de equipamento inteligente
+    description: |
+      Engenharia de comunicação BAS do lado do equipamento, incluindo BACnet e Modbus.
+  BC-2000.70.40:
+    name: Engenharia de lógica de diagnóstico de equipamento
+    description: |
+      Engenharia de lógica de diagnóstico, alarme e código de avaria no equipamento.
+  BC-2000.80:
+    name: Verificação e teste de equipamentos HVAC
+    description: |
+      Verificação do desempenho ao nível do equipamento, execução de testes de classificação AHRI/Eurovent e testes de durabilidade.
+  BC-2000.80.10:
+    name: Teste em câmara psicrométrica
+    description: |
+      Teste de equipamentos HVAC em câmaras psicrométricas em condições controladas.
+  BC-2000.80.20:
+    name: Execução de teste de classificação de desempenho
+    description: |
+      Execução de testes de classificação de desempenho normalizados em equipamentos HVAC.
+  BC-2000.80.30:
+    name: Verificação do desempenho térmico
+    description: |
+      Verificação de capacidade, COP, IPLV e outras métricas de desempenho térmico.
+  BC-2000.80.40:
+    name: Testes de endurância e fiabilidade
+    description: |
+      Testes de endurância, vida acelerada e fiabilidade de equipamentos HVAC.
+  BC-2000.80.50:
+    name: Elaboração de plano de teste de equipamento
+    description: |
+      Elaboração de planos de teste de verificação e qualificação ao nível do equipamento.
+  in_scope:
+    - Projeto do ciclo de refrigeração e ciclo de bomba de calor
+    - Engenharia de permutadores de calor e serpentinas
+    - Engenharia de equipamentos de movimentação de ar e hídricos
+    - Engenharia de compressores, acionamentos e controlo a bordo
+    - Verificação de desempenho acústico, de vibração e ao nível do equipamento
+  out_of_scope:
+    - Seleção e integração de sistema ao nível do projeto (BC-2020)
+    - Engenharia de produto de controlador BAS (BC-2010)
+    - Submissões de certificação de tipo e licenciamento de marcas (BC-2030)
+    - Contabilidade operacional de refrigerante (BC-2040)
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-hvac-equipment-engineering-management.yaml
+++ b/catalogue/i18n/pt/L1-hvac-equipment-engineering-management.yaml
@@ -7,6 +7,17 @@ entries:
       Engenharia mecânica, de refrigeração e termofluidodinâmica de equipamentos HVAC —
       chillers, bombas de calor, UTA, RTU, VRF, ventiloconvectores e unidades terminais — até à
       verificação de desempenho e prontidão para testes de classificação AHRI/Eurovent.
+    in_scope:
+      - Projeto do ciclo de refrigeração e ciclo de bomba de calor
+      - Engenharia de permutadores de calor e serpentinas
+      - Engenharia de equipamentos de movimentação de ar e hídricos
+      - Engenharia de compressores, acionamentos e controlo a bordo
+      - Verificação de desempenho acústico, de vibração e ao nível do equipamento
+    out_of_scope:
+      - Seleção e integração de sistema ao nível do projeto (BC-2020)
+      - Engenharia de produto de controlador BAS (BC-2010)
+      - Submissões de certificação de tipo e licenciamento de marcas (BC-2030)
+      - Contabilidade operacional de refrigerante (BC-2040)
   BC-2000.10:
     name: Engenharia do ciclo de refrigeração
     description: |
@@ -187,17 +198,6 @@ entries:
     name: Elaboração de plano de teste de equipamento
     description: |
       Elaboração de planos de teste de verificação e qualificação ao nível do equipamento.
-  in_scope:
-    - Projeto do ciclo de refrigeração e ciclo de bomba de calor
-    - Engenharia de permutadores de calor e serpentinas
-    - Engenharia de equipamentos de movimentação de ar e hídricos
-    - Engenharia de compressores, acionamentos e controlo a bordo
-    - Verificação de desempenho acústico, de vibração e ao nível do equipamento
-  out_of_scope:
-    - Seleção e integração de sistema ao nível do projeto (BC-2020)
-    - Engenharia de produto de controlador BAS (BC-2010)
-    - Submissões de certificação de tipo e licenciamento de marcas (BC-2030)
-    - Contabilidade operacional de refrigerante (BC-2040)
 metadata:
   status: draft
   translator: claude-ai

--- a/catalogue/i18n/pt/L1-hvac-system-integration-management.yaml
+++ b/catalogue/i18n/pt/L1-hvac-system-integration-management.yaml
@@ -1,0 +1,185 @@
+locale: pt
+source: L1-hvac-system-integration-management.yaml
+entries:
+  BC-2020:
+    name: Gestão de integração de sistemas HVAC
+    description: |
+      Engenharia ao nível do projeto de soluções integradas de HVAC e BAS para um edifício específico —
+      cálculo de cargas, seleção de equipamentos, projeto esquemático, lista de pontos BAS e arquitetura,
+      elaboração de sequências de operação, coordenação BIM/MEP, especificações de projeto, gestão de
+      submissões e suporte de engenharia em campo.
+  BC-2020.10:
+    name: Dimensionamento e seleção de HVAC predial
+    description: |
+      Dimensionamento de cargas e seleção de equipamentos HVAC específicos do projeto para satisfazer a intenção de projeto.
+  BC-2020.10.10:
+    name: Cálculo de cargas de arrefecimento e aquecimento
+    description: |
+      Cálculo das cargas de arrefecimento e aquecimento do edifício.
+  BC-2020.10.20:
+    name: Seleção e programa de equipamentos
+    description: |
+      Seleção de modelos de equipamento face a cargas calculadas e programas.
+  BC-2020.10.30:
+    name: Dimensionamento de circuito hídrico
+    description: |
+      Dimensionamento de circuitos hídricos, bombas e diâmetros de tubagem.
+  BC-2020.10.40:
+    name: Dimensionamento de condutas e análise de queda de pressão
+    description: |
+      Dimensionamento de condutas e análise da queda de pressão do sistema.
+  BC-2020.10.50:
+    name: Modelação energética para seleção
+    description: |
+      Simulação energética de suporte à análise de compromissos na seleção de equipamentos.
+  BC-2020.20:
+    name: Projeto esquemático do sistema HVAC
+    description: |
+      Projeto esquemático dos sistemas mecânicos, hídricos e de refrigerante integrados.
+  BC-2020.20.10:
+    name: Projeto esquemático mecânico
+    description: |
+      Projeto a nível esquemático dos sistemas mecânicos do lado do ar.
+  BC-2020.20.20:
+    name: Projeto esquemático hídrico
+    description: |
+      Projeto a nível esquemático de circuitos de água gelada, quente e de condensação.
+  BC-2020.20.30:
+    name: Projeto esquemático de tubagem de refrigerante
+    description: |
+      Projeto a nível esquemático de tubagem de refrigerante para sistemas VRF e split.
+  BC-2020.20.40:
+    name: Projeto esquemático de controlo monofio
+    description: |
+      Esquemas monofio que representam a sobreposição de controlo BAS nos sistemas mecânicos.
+  BC-2020.30:
+    name: Projeto de lista de pontos e arquitetura BAS
+    description: |
+      Listas de pontos específicas do projeto, topologia de rede BAS e alocação de painéis.
+  BC-2020.30.10:
+    name: Elaboração da lista de pontos
+    description: |
+      Elaboração de listas de pontos BAS específicas do projeto.
+  BC-2020.30.20:
+    name: Projeto de topologia de rede BAS
+    description: |
+      Projeto de topologia e segmentação de rede BAS para o projeto.
+  BC-2020.30.30:
+    name: Alocação de controladores e layout de painel
+    description: |
+      Alocação de controladores e projeto de painéis de controlo para o projeto.
+  BC-2020.30.40:
+    name: Aplicação de convenção de tags e nomenclatura
+    description: |
+      Aplicação de convenções de tags e nomenclatura a pontos e ativos do projeto.
+  BC-2020.40:
+    name: Elaboração de sequências de operação
+    description: |
+      Elaboração de sequências de operação específicas do projeto para sistemas HVAC.
+  BC-2020.40.10:
+    name: Elaboração de sequências de zona
+    description: |
+      Elaboração de sequências de controlo de zona ao nível do projeto.
+  BC-2020.40.20:
+    name: Elaboração de sequências de central
+    description: |
+      Elaboração de sequências de controlo de central ao nível do projeto.
+  BC-2020.40.30:
+    name: Elaboração de estratégias de poupança de energia
+    description: |
+      Elaboração de estratégias de controlo de poupança de energia ao nível do projeto.
+  BC-2020.40.40:
+    name: Elaboração de sequências de alarme e substituição
+    description: |
+      Elaboração de lógica de alarme e sequências de substituição do operador ao nível do projeto.
+  BC-2020.50:
+    name: Coordenação BIM e MEP
+    description: |
+      Modelação BIM e coordenação multidisciplinar do âmbito HVAC no projeto.
+  BC-2020.50.10:
+    name: Modelação BIM HVAC
+    description: |
+      Modelação BIM do âmbito HVAC para o projeto.
+  BC-2020.50.20:
+    name: Deteção de conflitos MEP
+    description: |
+      Deteção de conflitos de coordenação entre disciplinas MEP.
+  BC-2020.50.30:
+    name: Coordenação de troca de modelos
+    description: |
+      Coordenação de formatos de troca de modelos BIM e entregáveis.
+  BC-2020.50.40:
+    name: Emissão do modelo de coordenação
+    description: |
+      Emissão de modelos BIM coordenados às partes interessadas do projeto.
+  BC-2020.60:
+    name: Elaboração de especificações de projeto HVAC
+    description: |
+      Elaboração de especificações de projeto para âmbito HVAC e de controlo.
+  BC-2020.60.10:
+    name: Elaboração de especificações mecânicas
+    description: |
+      Elaboração de especificações mecânicas para o projeto.
+  BC-2020.60.20:
+    name: Elaboração de especificações de controlo
+    description: |
+      Elaboração de especificações BAS e de controlo para o projeto.
+  BC-2020.60.30:
+    name: Elaboração de critérios de desempenho e aceitação
+    description: |
+      Elaboração de critérios de desempenho e testes de aceitação para o projeto.
+  BC-2020.70:
+    name: Gestão de submissões de integração de sistema
+    description: |
+      Gestão de submissões, desenhos de oficina e RFI durante a fase de execução do projeto.
+  BC-2020.70.10:
+    name: Preparação de pacotes de submissão
+    description: |
+      Preparação de pacotes de submissão para revisão do dono de obra e engenheiro.
+  BC-2020.70.20:
+    name: Coordenação de desenhos de oficina
+    description: |
+      Coordenação de desenhos de oficina com a intenção de projeto.
+  BC-2020.70.30:
+    name: Gestão de respostas a RFI
+    description: |
+      Gestão de RFI de projeto do empreiteiro e integrador.
+  BC-2020.70.40:
+    name: Revisão de substituições
+    description: |
+      Revisão de pedidos de substituição de equipamentos e materiais.
+  BC-2020.80:
+    name: Suporte de engenharia no local
+    description: |
+      Suporte de engenharia durante a construção e instalação, incluindo resoluções em campo e registos tal como instalado.
+  BC-2020.80.10:
+    name: Resolução de engenharia em campo
+    description: |
+      Resolução de questões de engenharia em campo durante a instalação.
+  BC-2020.80.20:
+    name: Engenharia de ordens de alteração
+    description: |
+      Trabalho de engenharia de suporte a ordens de alteração durante a construção.
+  BC-2020.80.30:
+    name: Atualização de desenhos tal como instalado
+    description: |
+      Atualização de desenhos para refletir as condições tal como instalado.
+  BC-2020.80.40:
+    name: Inspeção de testemunho de instalação
+    description: |
+      Testemunho de marcos de instalação para aceitação de engenharia.
+  in_scope:
+    - Cálculos de carga e seleção de equipamentos específicos do edifício
+    - Projeto esquemático mecânico, hídrico e de refrigerante à escala do projeto
+    - Listas de pontos BAS, topologia de rede e layout de painel para projetos
+    - Elaboração de sequências de operação específicas do projeto
+    - Coordenação BIM, especificações de projeto e gestão de submissões
+  out_of_scope:
+    - Engenharia de produto de equipamento (BC-2000) e engenharia de produto BAS (BC-2010)
+    - Prática de disciplina MEP multidisciplinar (BC-1100)
+    - Prestação de serviço de colocação em serviço (BC-2050)
+    - Gestão genérica de projetos de engenharia (BC-1110)
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-hvac-system-integration-management.yaml
+++ b/catalogue/i18n/pt/L1-hvac-system-integration-management.yaml
@@ -8,6 +8,17 @@ entries:
       cálculo de cargas, seleção de equipamentos, projeto esquemático, lista de pontos BAS e arquitetura,
       elaboração de sequências de operação, coordenação BIM/MEP, especificações de projeto, gestão de
       submissões e suporte de engenharia em campo.
+    in_scope:
+      - Cálculos de carga e seleção de equipamentos específicos do edifício
+      - Projeto esquemático mecânico, hídrico e de refrigerante à escala do projeto
+      - Listas de pontos BAS, topologia de rede e layout de painel para projetos
+      - Elaboração de sequências de operação específicas do projeto
+      - Coordenação BIM, especificações de projeto e gestão de submissões
+    out_of_scope:
+      - Engenharia de produto de equipamento (BC-2000) e engenharia de produto BAS (BC-2010)
+      - Prática de disciplina MEP multidisciplinar (BC-1100)
+      - Prestação de serviço de colocação em serviço (BC-2050)
+      - Gestão genérica de projetos de engenharia (BC-1110)
   BC-2020.10:
     name: Dimensionamento e seleção de HVAC predial
     description: |
@@ -168,17 +179,6 @@ entries:
     name: Inspeção de testemunho de instalação
     description: |
       Testemunho de marcos de instalação para aceitação de engenharia.
-  in_scope:
-    - Cálculos de carga e seleção de equipamentos específicos do edifício
-    - Projeto esquemático mecânico, hídrico e de refrigerante à escala do projeto
-    - Listas de pontos BAS, topologia de rede e layout de painel para projetos
-    - Elaboração de sequências de operação específicas do projeto
-    - Coordenação BIM, especificações de projeto e gestão de submissões
-  out_of_scope:
-    - Engenharia de produto de equipamento (BC-2000) e engenharia de produto BAS (BC-2010)
-    - Prática de disciplina MEP multidisciplinar (BC-1100)
-    - Prestação de serviço de colocação em serviço (BC-2050)
-    - Gestão genérica de projetos de engenharia (BC-1110)
 metadata:
   status: draft
   translator: claude-ai

--- a/catalogue/i18n/pt/L1-hydrocarbon-exploration-management.yaml
+++ b/catalogue/i18n/pt/L1-hydrocarbon-exploration-management.yaml
@@ -1,0 +1,166 @@
+locale: pt
+source: L1-hydrocarbon-exploration-management.yaml
+entries:
+  BC-3000:
+    name: Gestão de exploração de hidrocarbonetos
+    description: |
+      Identificação e aquisição de novos recursos de hidrocarbonetos através de
+      levantamentos geofísicos, avaliação de bacias e prospectos, aquisição de
+      licenças e concessões, e decisões de perfuração de exploração.
+  BC-3000.10:
+    name: Gestão de levantamentos geofísicos
+    description: |
+      Aquisição, processamento e interpretação de dados geofísicos sísmicos e
+      não sísmicos para imagiar a subsuperfície.
+    in_scope:
+      - Campanhas de aquisição sísmica 2D e 3D
+      - Processamento e reprocessamento sísmico
+      - Interpretação sísmica para geração de prospectos
+    out_of_scope:
+      - Geomodelação à escala do reservatório para activos em desenvolvimento (BC-3010)
+  BC-3000.10.10:
+    name: Aquisição sísmica 3D
+    description: |
+      Operações de aquisição sísmica 3D marítima, terrestre e em fundo oceânico.
+  BC-3000.10.20:
+    name: Aquisição sísmica 2D
+    description: |
+      Operações de aquisição sísmica 2D de reconhecimento regional.
+  BC-3000.10.30:
+    name: Aquisição geofísica não sísmica
+    description: |
+      Levantamentos de gravimetria, magnéticos, electromagnéticos e outros não
+      sísmicos.
+  BC-3000.10.40:
+    name: Processamento de dados sísmicos
+    description: |
+      Processamento pré-stack e pós-stack, migração em profundidade e
+      reprocessamento de dados sísmicos.
+  BC-3000.10.50:
+    name: Interpretação de dados sísmicos
+    description: |
+      Interpretação estrutural e estratigráfica de volumes sísmicos para geração
+      de prospectos.
+  BC-3000.20:
+    name: Avaliação de bacias e prospectos
+    description: |
+      Análise de sistemas petrolíferos, mapeamento de fairways de jogo e avaliação
+      de risco-volume de prospectos de exploração.
+    in_scope:
+      - Modelação de sistemas petrolíferos
+      - Inventário e ranking de prospectos
+      - Estimativa volumétrica ponderada pelo risco
+    out_of_scope:
+      - Classificação de reservas de volumes descobertos (BC-3010.30)
+  BC-3000.20.10:
+    name: Análise de sistemas petrolíferos
+    description: |
+      Análise de fonte, reservatório, selante, armadilha e timing para qualificar
+      sistemas petrolíferos.
+  BC-3000.20.20:
+    name: Mapeamento de fairways de jogo
+    description: |
+      Mapeamento de jogos regionais e segmentos de risco comum na acreagem.
+  BC-3000.20.30:
+    name: Gestão do inventário de prospectos
+    description: |
+      Manutenção do inventário de prospectos e leads ordenado por ranking e a sua
+      maturação.
+  BC-3000.20.40:
+    name: Avaliação de risco de prospectos
+    description: |
+      Avaliação probabilística da probabilidade geológica de sucesso de prospectos.
+  BC-3000.20.50:
+    name: Estimativa volumétrica
+    description: |
+      Estimativa probabilística pré-perfuração de volumes in-situ e recuperáveis.
+  BC-3000.30:
+    name: Aquisição de licenças e concessões
+    description: |
+      Aquisição de acreagem de exploração através de rondas de licenciamento,
+      negociação directa e transacções de farm-in.
+    in_scope:
+      - Triagem e participação em rondas de licitação
+      - Licitação de concessões e PSC
+      - Negociação de farm-in e farm-out
+    out_of_scope:
+      - Acompanhamento contínuo de obrigações de licença (BC-3110.40)
+  BC-3000.30.10:
+    name: Triagem de rondas de licenciamento
+    description: |
+      Triagem de rondas de licenciamento governamentais para decisões de entrada.
+  BC-3000.30.20:
+    name: Licitação de concessões
+    description: |
+      Preparação e submissão de propostas competitivas para concessões e contratos
+      de partilha de produção.
+  BC-3000.30.30:
+    name: Negociação de farm-in e farm-out
+    description: |
+      Negociação de transacções de farm-in, farm-out e permuta de acreagem.
+  BC-3000.30.40:
+    name: Gestão do portefólio de acreagem
+    description: |
+      Manutenção do portefólio de acreagem de exploração e decisões de
+      racionalização.
+  BC-3000.40:
+    name: Gestão do programa de perfuração de exploração
+    description: |
+      Definição, aprovação e avaliação pós-poço de programas de perfuração de
+      poços wildcat e de avaliação.
+  BC-3000.40.10:
+    name: Definição do programa de poços de exploração
+    description: |
+      Definição dos objectivos e sequenciamento de poços wildcat e de avaliação.
+  BC-3000.40.20:
+    name: Aprovação de poços wildcat
+    description: |
+      Governação de aprovação interna e de parceiros para poços de exploração
+      wildcat.
+  BC-3000.40.30:
+    name: Gestão do programa de poços de avaliação
+    description: |
+      Gestão de programas de poços de avaliação após descoberta.
+  BC-3000.40.40:
+    name: Avaliação pós-poço
+    description: |
+      Avaliação de subsuperfície pós-poço e captura de aprendizagens para o
+      inventário de prospectos.
+  BC-3000.50:
+    name: Orientação do portefólio de exploração
+    description: |
+      Orientação estratégica do portefólio de exploração em geografias, jogos e
+      classes de risco.
+  BC-3000.50.10:
+    name: Definição da estratégia de exploração
+    description: |
+      Definição da estratégia de exploração em bacias, jogos e classes de risco.
+  BC-3000.50.20:
+    name: Alocação de investimento em exploração
+    description: |
+      Alocação de capital de exploração por geografias e tipos de jogo.
+  BC-3000.50.30:
+    name: Acompanhamento do desempenho da exploração
+    description: |
+      Acompanhamento do custo de encontro na exploração, rácios de sucesso e
+      adições de recursos.
+  BC-3000.60:
+    name: Reporte de descobertas de subsuperfície
+    description: |
+      Notificação de descobertas a governos anfitriões, parceiros e mercados de
+      capitais, e acompanhamento da maturação de recursos até à sanção do
+      desenvolvimento.
+  BC-3000.60.10:
+    name: Notificação de descobertas
+    description: |
+      Notificação de descobertas a governos anfitriões, parceiros e divulgações aos
+      mercados de capitais.
+  BC-3000.60.20:
+    name: Acompanhamento da maturação de recursos
+    description: |
+      Acompanhamento de recursos contingentes desde a descoberta até à sanção do
+      desenvolvimento.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-hydrocarbon-logistics-management.yaml
+++ b/catalogue/i18n/pt/L1-hydrocarbon-logistics-management.yaml
@@ -1,0 +1,116 @@
+locale: pt
+source: L1-hydrocarbon-logistics-management.yaml
+entries:
+  BC-3100:
+    name: Gestão de logística de hidrocarbonetos
+    description: |
+      Operações marítimas de carga, terminais e armazenamento a granel para crude,
+      produtos refinados e GNL, mais coordenação de levantamentos e gestão de
+      combustível para navios. Distinto do transporte transversal à indústria
+      (série BC-2400), que abrange redes de frete, gestão de frotas e transporte
+      intermodal.
+  BC-3100.10:
+    name: Operações de carga marítima
+    description: |
+      Operação de petroleiros de crude, petroleiros de produtos, transportadores de
+      GNL e transferências navio-a-navio em serviço petrolífero.
+    in_scope:
+      - Coordenação operacional de petroleiros e transportadores de gás
+      - Aliviamento e aliviamento inverso navio-a-navio
+    out_of_scope:
+      - Gestão genérica de frotas de navegação (BC-2430)
+      - Reservas de carga de linha regular (BC-2400)
+  BC-3100.10.10:
+    name: Operações de petroleiros de crude
+    description: |
+      Coordenação operacional de petroleiros de crude em fretamento por viagem e a
+      prazo.
+  BC-3100.10.20:
+    name: Operações de petroleiros de produtos
+    description: |
+      Coordenação operacional de petroleiros de produtos refinados, incluindo
+      cargas parciais.
+  BC-3100.10.30:
+    name: Operações de transportadores de GNL
+    description: |
+      Coordenação operacional de transportadores de GNL, incluindo arrefecimento e
+      gestão de pressão de tanques.
+  BC-3100.10.40:
+    name: Coordenação de transferência navio-a-navio
+    description: |
+      Coordenação de transferências STS para crude, produtos e GNL.
+  BC-3100.20:
+    name: Operações de terminais
+    description: |
+      Operação de terminais petrolíferos de importação, exportação e intermédios —
+      cais, braços de carregamento e recepção em tanques.
+  BC-3100.20.10:
+    name: Operações de braços de carregamento e cais
+    description: |
+      Operação de equipamento de cais e braços de carregamento marítimo.
+  BC-3100.20.20:
+    name: Operações de recepção em tanques
+    description: |
+      Recepção e medição de cargas em armazenamento de terminal.
+  BC-3100.20.30:
+    name: Operações de carregamento de tanques
+    description: |
+      Carregamento de armazenamento de terminal para navios e gasodutos.
+  BC-3100.20.40:
+    name: Agendamento de berços
+    description: |
+      Alocação e agendamento de berços para chegadas de navios.
+  BC-3100.30:
+    name: Gestão de armazenamento a granel
+    description: |
+      Alocação de capacidade de tanques, acompanhamento de movimentos e calibração
+      de tanques para crude, produtos e NGLs.
+  BC-3100.30.10:
+    name: Alocação de capacidade de tanques
+    description: |
+      Alocação de capacidade de tanques a qualidades, proprietários e pools.
+  BC-3100.30.20:
+    name: Acompanhamento de movimentos tanque-a-tanque
+    description: |
+      Acompanhamento de movimentos internos de terminal e posições de inventário.
+  BC-3100.30.30:
+    name: Calibração de tanques
+    description: |
+      Manutenção de tabelas de cordeamento e calibração de tanques para exactidão
+      fiscal.
+  BC-3100.40:
+    name: Agendamento de cargas e coordenação de levantamentos
+    description: |
+      Nomeações de levantamentos, confirmação de stems de navios e acompanhamento
+      de sobre-estadia para cargas de petróleo.
+  BC-3100.40.10:
+    name: Gestão de nomeações de levantamentos
+    description: |
+      Recepção e confirmação de nomeações de levantamentos de clientes e de
+      participação accionista.
+  BC-3100.40.20:
+    name: Confirmação de stem de navio
+    description: |
+      Confirmação de stem e parcela face a obrigações contratuais.
+  BC-3100.40.30:
+    name: Acompanhamento operacional de sobre-estadia
+    description: |
+      Acompanhamento operacional de eventos de sobre-estadia em portos de
+      carregamento e descarga.
+  BC-3100.50:
+    name: Gestão de combustível para navios e combustível marítimo
+    description: |
+      Aquisição de combustível e garantia de qualidade para a frota operada e
+      fretada.
+  BC-3100.50.10:
+    name: Aquisição de combustível para navios
+    description: |
+      Aquisição spot e a prazo de combustíveis marítimos para a frota.
+  BC-3100.50.20:
+    name: Garantia de qualidade do combustível para navios
+    description: |
+      Amostragem, ensaio e gestão de litígios de combustíveis fornecidos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-hydrocarbon-measurement-allocation-management.yaml
+++ b/catalogue/i18n/pt/L1-hydrocarbon-measurement-allocation-management.yaml
@@ -1,0 +1,111 @@
+locale: pt
+source: L1-hydrocarbon-measurement-allocation-management.yaml
+entries:
+  BC-3040:
+    name: Gestão de medição e alocação de hidrocarbonetos
+    description: |
+      Medição de qualidade fiscal e alocação de hidrocarbonetos produzidos —
+      medição de transferência de custódia, alocação entre reservatórios e
+      co-proprietários, contabilidade de produção, demonstrações de exploração de
+      concessão e investigação de perdas e variâncias.
+  BC-3040.10:
+    name: Medição fiscal e de transferência de custódia
+    description: |
+      Operação, calibração e garantia de medidores de qualidade fiscal em pontos
+      de transferência de custódia.
+  BC-3040.10.10:
+    name: Operação de medidores fiscais
+    description: |
+      Operação do quotidiano de medidores fiscais de líquidos e gás.
+  BC-3040.10.20:
+    name: Provação e calibração de medidores
+    description: |
+      Provação e calibração periódicas de instalações de medição fiscal.
+  BC-3040.10.30:
+    name: Documentação de transferência de custódia
+    description: |
+      Emissão e troca de tickets e certificados de transferência de custódia.
+  BC-3040.10.40:
+    name: Investigação de medicão incorrecta
+    description: |
+      Investigação e remediação de eventos suspeitos de medição incorrecta.
+  BC-3040.20:
+    name: Alocação de produção
+    description: |
+      Alocação de volumes medidos a poços, reservatórios e co-proprietários.
+  BC-3040.20.10:
+    name: Alocação a poços
+    description: |
+      Alocação da produção das instalações aos poços contribuintes.
+  BC-3040.20.20:
+    name: Alocação a reservatórios
+    description: |
+      Alocação entre reservatórios e pools em produção conjunta.
+  BC-3040.20.30:
+    name: Alocação a co-proprietários
+    description: |
+      Alocação de volumes de produção entre proprietários de participação activa.
+  BC-3040.20.40:
+    name: Reconciliação de alocação
+    description: |
+      Reconciliação dos resultados de alocação com dados de medição, testes de
+      poços e contabilidade.
+  BC-3040.30:
+    name: Contabilidade de produção
+    description: |
+      Reporte diário de produção, balanço de massas e fecho mensal da contabilidade
+      de produção.
+  BC-3040.30.10:
+    name: Reporte diário de produção
+    description: |
+      Reporte diário de volumes de produção a partes interessadas internas e
+      externas.
+  BC-3040.30.20:
+    name: Balanço de massas de hidrocarbonetos
+    description: |
+      Balanço de massas de hidrocarbonetos end-to-end nos sistemas produtores.
+  BC-3040.30.30:
+    name: Fecho da contabilidade de produção
+    description: |
+      Fecho mensal dos livros de contabilidade de produção e alimentação de
+      sistemas financeiros.
+  BC-3040.40:
+    name: Gestão de demonstrações de exploração de concessão
+    description: |
+      Preparação de demonstrações de exploração de concessão, cálculo de volumes de
+      royalties e reporte de impostos de produção.
+  BC-3040.40.10:
+    name: Preparação de demonstrações de exploração de concessão
+    description: |
+      Preparação de relatórios LOS para proprietários de participação activa.
+  BC-3040.40.20:
+    name: Cálculo de volumes de royalties
+    description: |
+      Cálculo dos volumes e valor dos proprietários de royalties ao nível da
+      concessão.
+  BC-3040.40.30:
+    name: Reporte de impostos de produção
+    description: |
+      Reporte de impostos de produção às autoridades fiscais.
+  BC-3040.50:
+    name: Análise de perdas e variâncias
+    description: |
+      Investigação de variâncias de medição, eventos de perda e desequilíbrios de
+      inventário de hidrocarbonetos.
+  BC-3040.50.10:
+    name: Análise de variâncias de medição
+    description: |
+      Análise de variâncias de medição face às bandas de tolerância.
+  BC-3040.50.20:
+    name: Investigação de perdas
+    description: |
+      Investigação de perdas não contabilizadas entre pontos de medição.
+  BC-3040.50.30:
+    name: Reconciliação do inventário de hidrocarbonetos
+    description: |
+      Reconciliação do inventário físico de hidrocarbonetos com os registos
+      contabilísticos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-hydrocarbon-production-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-hydrocarbon-production-operations-management.yaml
@@ -1,0 +1,154 @@
+locale: pt
+source: L1-hydrocarbon-production-operations-management.yaml
+entries:
+  BC-3030:
+    name: Gestão de operações de produção de hidrocarbonetos
+    description: |
+      Operação de instalações de superfície a montante desde a cabeça de poço até
+      à exportação — separação, tratamento, elevação artificial, garantia de fluxo,
+      vigilância de produção e manutenção de pressão do reservatório.
+  BC-3030.10:
+    name: Gestão de operações na cabeça de poço
+    description: |
+      Operação do quotidiano de equipamentos de cabeça de poço, gestão de
+      estranguladores e testes de poços.
+  BC-3030.10.10:
+    name: Vigilância da cabeça de poço
+    description: |
+      Vigilância contínua de parâmetros de pressão, temperatura e caudal na cabeça
+      de poço.
+  BC-3030.10.20:
+    name: Gestão de estranguladores de cabeça de poço
+    description: |
+      Ajuste de estranguladores de superfície para gerir o caudal do poço e a
+      depressão.
+  BC-3030.10.30:
+    name: Operações de testes de poços
+    description: |
+      Testes de poços rotineiros e de vigilância para alocação e dados do
+      reservatório.
+  BC-3030.20:
+    name: Operações de separação e tratamento de superfície
+    description: |
+      Operação de instalações de superfície para separação óleo-água-gás,
+      estabilização de crude, tratamento de água produzida e condicionamento de gás.
+  BC-3030.20.10:
+    name: Separação de óleo, água e gás
+    description: |
+      Separação trifásica de fluidos produzidos em instalações a montante.
+  BC-3030.20.20:
+    name: Estabilização de crude
+    description: |
+      Estabilização do crude produzido para especificações de exportação.
+  BC-3030.20.30:
+    name: Tratamento de água produzida
+    description: |
+      Tratamento de água produzida para reinjecção ou descarga.
+  BC-3030.20.40:
+    name: Desidratação e adoçamento de gás
+    description: |
+      Desidratação e adoçamento de campo de correntes de gás associado.
+  BC-3030.30:
+    name: Gestão de elevação artificial
+    description: |
+      Selecção, operação e optimização de sistemas de elevação artificial.
+  BC-3030.30.10:
+    name: Operações de gas lift
+    description: |
+      Operações de gas lift contínuo e intermitente e vigilância.
+  BC-3030.30.20:
+    name: Operações de bombas submersíveis eléctricas
+    description: |
+      Operação, vigilância e gestão do tempo de vida de instalações ESP.
+  BC-3030.30.30:
+    name: Operações de bombas de haste
+    description: |
+      Operação e vigilância por dinamómetro de bombas de haste.
+  BC-3030.30.40:
+    name: Optimização de elevação artificial
+    description: |
+      Optimização cruzada da selecção e parâmetros de elevação artificial.
+  BC-3030.40:
+    name: Optimização e vigilância de produção
+    description: |
+      Vigilância e optimização em tempo real de caudais de produção, estrangulamentos
+      e desempenho de poços face à previsão.
+  BC-3030.40.10:
+    name: Vigilância de produção em tempo real
+    description: |
+      Vigilância em tempo real de produção de poços e campo a partir de centros
+      operacionais.
+  BC-3030.40.20:
+    name: Diagnóstico do desempenho de poços
+    description: |
+      Análise diagnóstica de poços com fraco desempenho e recomendações
+      remediatórias.
+  BC-3030.40.30:
+    name: Contabilização de perdas de produção
+    description: |
+      Categorização e reporte de perdas de produção face ao potencial.
+  BC-3030.40.40:
+    name: Identificação de estrangulamentos
+    description: |
+      Identificação de estrangulamentos do sistema no reservatório, poço e
+      instalação.
+  BC-3030.50:
+    name: Gestão da garantia de fluxo
+    description: |
+      Prevenção e gestão de problemas de garantia de fluxo como hidratos, cera,
+      asfaltenos e erosão-corrosão em sistemas produtores.
+  BC-3030.50.10:
+    name: Gestão de hidratos
+    description: |
+      Prevenção e remediação de hidratos em linhas de fluxo e risers.
+  BC-3030.50.20:
+    name: Gestão de cera e asfaltenos
+    description: |
+      Prevenção e remediação de deposição de cera e asfaltenos.
+  BC-3030.50.30:
+    name: Monitorização de erosão e corrosão
+    description: |
+      Monitorização de erosão e corrosão em linhas de fluxo e equipamentos
+      produtores.
+  BC-3030.50.40:
+    name: Operações de pigging
+    description: |
+      Pigging operacional de linhas de fluxo para limpeza e inspecção.
+  BC-3030.60:
+    name: Gestão de químicos de produção
+    description: |
+      Selecção, dosagem e monitorização da eficácia de químicos de produção.
+  BC-3030.60.10:
+    name: Selecção e dosagem de químicos
+    description: |
+      Estratégia de selecção e dosagem de químicos de produção a nível de poço e
+      instalação.
+  BC-3030.60.20:
+    name: Gestão de inibidores de corrosão
+    description: |
+      Aplicação e monitorização de programas de inibição de corrosão.
+  BC-3030.60.30:
+    name: Gestão de inibidores de incrustações
+    description: |
+      Gestão de squeeze e tratamento contínuo de inibidores de incrustações.
+  BC-3030.70:
+    name: Operações de manutenção de pressão do reservatório
+    description: |
+      Operação de sistemas de injecção de água e gás e acompanhamento da
+      substituição de voidage.
+  BC-3030.70.10:
+    name: Operações de injecção de água
+    description: |
+      Operação de tratamento de água de injecção e poços injectores.
+  BC-3030.70.20:
+    name: Operações de injecção de gás
+    description: |
+      Operação de compressão de injecção de gás e poços injectores de gás.
+  BC-3030.70.30:
+    name: Acompanhamento da substituição de voidage
+    description: |
+      Acompanhamento dos rácios de substituição de voidage nos activos produtores.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-hydrocarbon-trading-marketing-management.yaml
+++ b/catalogue/i18n/pt/L1-hydrocarbon-trading-marketing-management.yaml
@@ -1,0 +1,149 @@
+locale: pt
+source: L1-hydrocarbon-trading-marketing-management.yaml
+entries:
+  BC-3090:
+    name: Gestão de negociação e comercialização de hidrocarbonetos
+    description: |
+      Negociação física e financeira de crude, produtos refinados, gás natural e
+      GNL; gestão de risco de matérias-primas; liquidação e conformidade de
+      operações; comercialização por contrato de prazo; e fretamento de navios
+      para negociação.
+  BC-3090.10:
+    name: Operações de negociação física
+    description: |
+      Mesas de negociação física de crude, produtos refinados, gás natural e GNL.
+  BC-3090.10.10:
+    name: Negociação de crude
+    description: |
+      Negociação física de qualidades de crude em mercados regionais.
+  BC-3090.10.20:
+    name: Negociação de produtos refinados
+    description: |
+      Negociação física de gasolina, destilados, querosene, fuelóleo e NGLs.
+  BC-3090.10.30:
+    name: Negociação de gás natural
+    description: |
+      Negociação física de gás natural em gasoduto em hubs.
+  BC-3090.10.40:
+    name: Negociação de GNL
+    description: |
+      Negociação física de cargas de GNL, incluindo negócios de desvio e
+      recarregamento.
+  BC-3090.20:
+    name: Negociação de derivados e financeira
+    description: |
+      Negociação de derivados em bolsa e OTC para cobertura e posicionamento
+      proprietário.
+  BC-3090.20.10:
+    name: Negociação de futuros e opções
+    description: |
+      Negociação de futuros e opções cotados em bolsa sobre matérias-primas
+      energéticas.
+  BC-3090.20.20:
+    name: Swaps e operações de cobertura
+    description: |
+      Negociação de swaps OTC para cobertura de preço e base.
+  BC-3090.20.30:
+    name: Gestão de exposição a índices de matérias-primas
+    description: |
+      Gestão da exposição a instrumentos de índice de matérias-primas.
+  BC-3090.30:
+    name: Gestão de risco de negociação
+    description: |
+      Gestão de risco de posição, risco de crédito de contraparte e VaR de
+      matérias-primas para actividades de negociação.
+  BC-3090.30.10:
+    name: Gestão de risco de posição
+    description: |
+      Monitorização de posições face a mandatos e limites de negociação aprovados.
+  BC-3090.30.20:
+    name: Valorização mark-to-market
+    description: |
+      Valorização diária mark-to-market de posições e curvas de negociação.
+  BC-3090.30.30:
+    name: Gestão de risco de crédito de contraparte
+    description: |
+      Definição de limites de crédito de contraparte específicos de negociação e
+      acompanhamento de exposição.
+  BC-3090.30.40:
+    name: Cálculo de VaR de matérias-primas
+    description: |
+      Cálculo do valor em risco e cenários de stress para portefólios de
+      matérias-primas.
+  BC-3090.40:
+    name: Confirmação e liquidação de operações
+    description: |
+      Captura, confirmação e liquidação e reconciliação pós-operação.
+  BC-3090.40.10:
+    name: Captura de operações
+    description: |
+      Captura de operações executadas do front-office nos sistemas de negociação.
+  BC-3090.40.20:
+    name: Confirmação de operações
+    description: |
+      Emissão e reconciliação de confirmações de operações com contrapartes.
+  BC-3090.40.30:
+    name: Liquidação de operações
+    description: |
+      Liquidação financeira e física de operações até ao vencimento.
+  BC-3090.40.40:
+    name: Reconciliação de operações
+    description: |
+      Reconciliação de operações com registos de corretores, bolsa e contrapartes.
+  BC-3090.50:
+    name: Gestão de conformidade de negociação
+    description: |
+      Rastreio de sanções, vigilância de conduta de mercado e reporte regulatório
+      para actividades de negociação de energia.
+  BC-3090.50.10:
+    name: Rastreio de sanções
+    description: |
+      Rastreio de sanções pré- e pós-operação de contrapartes e cargas.
+  BC-3090.50.20:
+    name: Vigilância de conduta de mercado
+    description: |
+      Vigilância da conduta de negociação face a normas de abuso de mercado
+      (REMIT, Dodd-Frank).
+  BC-3090.50.30:
+    name: Reporte regulatório de operações
+    description: |
+      Reporte de operações a reguladores segundo REMIT, EMIR e Dodd-Frank.
+  BC-3090.60:
+    name: Gestão de comercialização e contratos de prazo
+    description: |
+      Gestão de contratos de venda a prazo e programas de levantamento com clientes.
+  BC-3090.60.10:
+    name: Negociação de contratos de prazo
+    description: |
+      Negociação de contratos de venda a prazo com refinarias e concessionárias.
+  BC-3090.60.20:
+    name: Gestão de programas de levantamento
+    description: |
+      Gestão de programas de levantamento mensais e trimestrais face a contratos
+      de prazo.
+  BC-3090.60.30:
+    name: Gestão de alocação a clientes
+    description: |
+      Alocação de fornecimento limitado entre clientes de prazo e spot.
+  BC-3090.70:
+    name: Fretamento de navios para negociação
+    description: |
+      Fretamento por viagem e a prazo e gestão de sobre-estadia em suporte de
+      posições de negociação.
+  BC-3090.70.10:
+    name: Fretamento por viagem
+    description: |
+      Fretamento por viagem de petroleiros e transportadores de gás para cargas de
+      negociação.
+  BC-3090.70.20:
+    name: Fretamento a prazo
+    description: |
+      Fretamento a prazo e optimização de posições de navios.
+  BC-3090.70.30:
+    name: Gestão de sobre-estadia e laytime
+    description: |
+      Cálculo e liquidação de reclamações de sobre-estadia e laytime.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-independence-and-conflicts-management.yaml
+++ b/catalogue/i18n/pt/L1-independence-and-conflicts-management.yaml
@@ -1,0 +1,142 @@
+locale: pt
+source: L1-independence-and-conflicts-management.yaml
+entries:
+  BC-4350:
+    name: Gestão de independência e conflitos de interesses
+    description: |
+      Independência do auditor, conflitos de interesses profissionais, operação
+      de barreiras éticas, declarações de interesse pessoal e aprovação de
+      aceitação e continuação de projetos específicos de firmas de serviços
+      profissionais.
+  BC-4350.10:
+    name: Gestão da independência do auditor
+    description: |
+      Aplicação das regras de independência da firma de auditoria, incluindo
+      serviços proibidos, rotação de sócios, limites de dependência de
+      honorários e requisitos específicos de entidades de interesse público.
+  BC-4350.10.10:
+    name: Identificação de clientes de auditoria
+    description: |
+      Identificação e manutenção da população de clientes de auditoria
+      restritos, incluindo afiliadas e relações de beneficiário.
+  BC-4350.10.20:
+    name: Pré-aprovação de serviços proibidos
+    description: |
+      Pré-aprovação de serviços não relacionados com auditoria a clientes de
+      auditoria face às listas de serviços proibidos.
+  BC-4350.10.30:
+    name: Gestão de rotação de sócios de auditoria
+    description: |
+      Acompanhamento e aplicação da rotação para sócios responsáveis e sócios
+      de EQR em clientes de auditoria.
+  BC-4350.10.40:
+    name: Monitorização de dependência de honorários
+    description: |
+      Monitorização dos honorários de auditoria e totais relativamente ao
+      rendimento da firma para identificar ameaças de dependência de honorários.
+  BC-4350.20:
+    name: Gestão de conflitos de interesses
+    description: |
+      Identificação, avaliação e resolução de conflitos de interesses entre
+      projetos, entre clientes e entre interesses do cliente e da firma.
+  BC-4350.20.10:
+    name: Pesquisa e identificação de conflitos
+    description: |
+      Pesquisa de registos de clientes e processos para identificar potenciais
+      conflitos em projetos prospetivos.
+  BC-4350.20.20:
+    name: Avaliação e categorização de conflitos
+    description: |
+      Avaliação dos conflitos identificados face à política da firma e às
+      normas profissionais para determinar a categoria e o tratamento do
+      conflito.
+  BC-4350.20.30:
+    name: Resolução de conflitos e gestão de renúncias
+    description: |
+      Resolução de conflitos, incluindo obtenção de consentimento informado,
+      renúncias e recusa do projeto, conforme adequado.
+  BC-4350.30:
+    name: Gestão de barreiras de informação
+    description: |
+      Design, implementação e operação de barreiras éticas, barreiras de
+      informação e acordos de triagem para projetos sensíveis.
+  BC-4350.30.10:
+    name: Design de barreiras de informação
+    description: |
+      Definição do âmbito da barreira, pessoal triado e controlos físicos ou
+      de sistema para um projeto.
+  BC-4350.30.20:
+    name: Implementação de barreiras de informação
+    description: |
+      Implementação operacional de restrições de acesso em sistemas de
+      documentos, email e prática.
+  BC-4350.30.30:
+    name: Deteção e resposta a violações de barreira
+    description: |
+      Deteção e resposta a potenciais ou reais violações de barreira, incluindo
+      escalamento e correção.
+  BC-4350.40:
+    name: Gestão de interesses e relações pessoais
+    description: |
+      Captura, declaração e monitorização de interesses financeiros pessoais,
+      relações familiares e empregos anteriores que possam ameaçar a
+      independência ou criar conflitos.
+  BC-4350.40.10:
+    name: Declaração de investimentos pessoais
+    description: |
+      Captura e manutenção de declarações de investimentos pessoais de sócios
+      e colaboradores face à lista de entidades restritas.
+  BC-4350.40.20:
+    name: Declaração de familiares e associados próximos
+    description: |
+      Captura de declarações relativas a familiares próximos e outras
+      associações próximas relevantes para a independência.
+  BC-4350.40.30:
+    name: Acompanhamento de empregos anteriores e períodos de quarentena
+    description: |
+      Acompanhamento de empregos anteriores em clientes de auditoria e períodos
+      de quarentena antes do envolvimento no projeto.
+  BC-4350.50:
+    name: Aprovação de aceitação de projetos
+    description: |
+      Fluxo de trabalho que combina aprovações de independência, conflitos e
+      integridade numa única contribuição para a decisão de aceitação do projeto.
+  BC-4350.50.10:
+    name: Coordenação do fluxo de trabalho de aprovação
+    description: |
+      Orquestração das aprovações de independência, conflitos e AML necessárias
+      antes da aceitação do projeto.
+  BC-4350.50.20:
+    name: Registo de decisões de aprovação
+    description: |
+      Registo das decisões de aprovação, condições e fundamentos no ficheiro
+      do projeto.
+  BC-4350.50.30:
+    name: Gestão de reaprovação de continuação
+    description: |
+      Reaprovação periódica de independência e conflitos em projetos em curso
+      e relações de auditoria recorrentes.
+  BC-4350.60:
+    name: Monitorização de independência e conflitos
+    description: |
+      Monitorização contínua da posição de independência e conflitos durante
+      a execução do projeto e em todo o portefólio de projetos.
+  BC-4350.60.10:
+    name: Vigilância de novos serviços a clientes de auditoria
+    description: |
+      Vigilância de novos serviços propostos a clientes de auditoria existentes
+      para exposição a serviços proibidos.
+  BC-4350.60.20:
+    name: Manutenção da lista de entidades restritas
+    description: |
+      Manutenção e distribuição da lista de entidades restritas e avisos
+      relacionados aos profissionais.
+  BC-4350.60.30:
+    name: Investigação de violações de independência
+    description: |
+      Investigação e reporte de violações de independência suspeitas ou reais
+      e ação corretiva.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-information-data-management.yaml
+++ b/catalogue/i18n/pt/L1-information-data-management.yaml
@@ -1,0 +1,143 @@
+locale: pt
+source: L1-information-data-management.yaml
+entries:
+  BC-610:
+    name: Gestão de informação e dados
+    description: |
+      Governação de dados, dados mestre, qualidade de dados, análise e IA.
+  BC-610.10:
+    name: Gestão da governação de dados
+    description: |
+      Propriedade, gestão, políticas e normas de dados.
+  BC-610.10.10:
+    name: Propriedade e gestão de dados
+    description: |
+      Atribuição e operação das funções de proprietário e gestor de dados.
+  BC-610.10.20:
+    name: Política e normas de dados
+    description: |
+      Definição de políticas, normas e quadros de referência de dados.
+  BC-610.10.30:
+    name: Catalogação e lineage de dados
+    description: |
+      Catálogo de dados, glossário e lineage de dados ponta a ponta.
+  BC-610.10.40:
+    name: Privacidade e classificação de dados
+    description: |
+      Classificação de dados e aplicação de controlos de privacidade.
+  BC-610.10.50:
+    name: Monitorização do risco e conformidade de dados
+    description: |
+      Monitorização do risco de dados e conformidade regulatória (p.ex. BCBS 239, RGPD).
+  BC-610.20:
+    name: Gestão de dados mestre
+    description: |
+      MDM para clientes, produtos, fornecedores, colaboradores, etc.
+  BC-610.20.10:
+    name: Dados mestre de clientes
+    description: |
+      Mastering e governação de dados mestre de clientes.
+  BC-610.20.20:
+    name: Dados mestre de produtos
+    description: |
+      Mastering e governação de dados mestre de produtos e materiais.
+  BC-610.20.30:
+    name: Dados mestre de fornecedores
+    description: |
+      Mastering e governação de dados mestre de fornecedores.
+  BC-610.20.40:
+    name: Dados mestre de colaboradores
+    description: |
+      Mastering e governação de dados mestre de colaboradores.
+  BC-610.20.50:
+    name: Gestão de dados de referência
+    description: |
+      Conjuntos de dados de referência, listas de códigos e hierarquias.
+  BC-610.30:
+    name: Gestão da qualidade de dados
+    description: |
+      Monitorização, perfilagem e remediação da qualidade de dados.
+  BC-610.30.10:
+    name: Perfilagem da qualidade de dados
+    description: |
+      Perfilagem, baseline e avaliação da qualidade de dados.
+  BC-610.30.20:
+    name: Gestão de regras de qualidade de dados
+    description: |
+      Definição, implementação e monitorização de regras de qualidade de dados.
+  BC-610.30.30:
+    name: Resolução de problemas de qualidade de dados
+    description: |
+      Triagem, remediação e análise de causa raiz de problemas de qualidade de dados.
+  BC-610.30.40:
+    name: Reporte de qualidade de dados
+    description: |
+      Scorecards de qualidade de dados e reporte a proprietários de dados e executivos.
+  BC-610.40:
+    name: Gestão da arquitetura de dados
+    description: |
+      Arquitetura de dados lógica e física.
+  BC-610.40.10:
+    name: Modelação de dados conceptual e lógica
+    description: |
+      Modelos de dados conceptuais e lógicos empresariais.
+  BC-610.40.20:
+    name: Arquitetura da plataforma de dados
+    description: |
+      Arquitetura de data lakes, armazéns de dados, lakehouses e mesh.
+  BC-610.40.30:
+    name: Arquitetura de integração de dados
+    description: |
+      Padrões de integração de dados em batch, streaming e CDC.
+  BC-610.40.40:
+    name: Design de armazenamento e retenção de dados
+    description: |
+      Design de armazenamento incluindo retenção, arquivo e tiering.
+  BC-610.50:
+    name: Gestão de análise e BI
+    description: |
+      Entrega de reporte, análise e business intelligence.
+  BC-610.50.10:
+    name: Entrega de relatórios e dashboards
+    description: |
+      Entrega de relatórios operacionais e de gestão e dashboards.
+  BC-610.50.20:
+    name: Análise self-service
+    description: |
+      Capacitação de análise self-service e produtos de dados para o negócio.
+  BC-610.50.30:
+    name: Análise avançada e ciência de dados
+    description: |
+      Análise avançada, modelos de ciência de dados e experimentação.
+  BC-610.50.40:
+    name: Operações da plataforma de análise
+    description: |
+      Operação de plataformas de BI e análise e bibliotecas de conteúdo.
+  BC-610.60:
+    name: Gestão de inteligência artificial
+    description: |
+      Ciclo de vida de modelos de IA/ML, MLOps e IA responsável.
+  BC-610.60.10:
+    name: Identificação de casos de uso de IA
+    description: |
+      Identificação e priorização de casos de uso de IA/ML.
+  BC-610.60.20:
+    name: Desenvolvimento de modelos de ML
+    description: |
+      Engenharia de features, treino e validação de modelos de ML.
+  BC-610.60.30:
+    name: MLOps e implementação de modelos
+    description: |
+      Implementação, monitorização e gestão do ciclo de vida de modelos (MLOps).
+  BC-610.60.40:
+    name: Governação de IA responsável
+    description: |
+      Princípios de IA responsável, avaliação de risco e monitorização de viés.
+  BC-610.60.50:
+    name: Gestão de IA generativa
+    description: |
+      Casos de uso de IA generativa, seleção de modelo de fundação e guardrails.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-information-technology-management.yaml
+++ b/catalogue/i18n/pt/L1-information-technology-management.yaml
@@ -1,0 +1,195 @@
+locale: pt
+source: L1-information-technology-management.yaml
+entries:
+  BC-600:
+    name: Gestão de tecnologia de informação
+    description: |
+      Estratégia de TI, arquitetura, serviços e operações.
+  BC-600.10:
+    name: Gestão da estratégia e arquitetura de TI
+    description: |
+      Estratégia de TI, arquitetura empresarial e normas tecnológicas.
+  BC-600.10.10:
+    name: Desenvolvimento da estratégia de TI
+    description: |
+      Definição da estratégia de TI alinhada com a estratégia de negócio.
+  BC-600.10.20:
+    name: Gestão da arquitetura empresarial
+    description: |
+      Arquitetura empresarial alinhada com TOGAF em negócio, dados, aplicações e tecnologia.
+  BC-600.10.30:
+    name: Gestão de normas tecnológicas
+    description: |
+      Definição e governação de normas e padrões tecnológicos.
+  BC-600.10.40:
+    name: Gestão do roadmap tecnológico
+    description: |
+      Roadmaps tecnológicos plurianuais e evolução de capacidades.
+  BC-600.10.50:
+    name: Governação e revisão de arquitetura
+    description: |
+      Conselho de revisão de arquitetura, autoridade de design e governação de exceções.
+  BC-600.20:
+    name: Gestão do portefólio e procura de TI
+    description: |
+      Portefólio de TI, receção de procura e priorização.
+  BC-600.20.10:
+    name: Receção de procura de TI
+    description: |
+      Captura e triagem de nova procura de TI do negócio.
+  BC-600.20.20:
+    name: Gestão do portefólio de investimentos de TI
+    description: |
+      Vista de portefólio de investimentos, projetos e benefícios de TI.
+  BC-600.20.30:
+    name: Planeamento de capacidade e recursos de TI
+    description: |
+      Planeamento da capacidade de entrega de TI em equipas e competências.
+  BC-600.20.40:
+    name: Gestão do relacionamento com o negócio
+    description: |
+      Parceria de negócio entre TI e funções do negócio.
+  BC-600.30:
+    name: Gestão de serviços de TI
+    description: |
+      Incidentes, problemas, mudanças, catálogo de serviços e ITSM.
+  BC-600.30.10:
+    name: Gestão do catálogo de serviços
+    description: |
+      Definição e manutenção do catálogo de serviços e SLAs.
+  BC-600.30.20:
+    name: Gestão de incidentes
+    description: |
+      Deteção, triagem, resolução e comunicação de incidentes.
+  BC-600.30.30:
+    name: Gestão de problemas
+    description: |
+      Análise de causa raiz e prevenção de incidentes recorrentes.
+  BC-600.30.40:
+    name: Gestão de mudanças e releases
+    description: |
+      Aprovação de mudanças de TI e gestão de releases.
+  BC-600.30.50:
+    name: Gestão do nível de serviço
+    description: |
+      Definição, medição e reporte de níveis de serviço.
+  BC-600.30.60:
+    name: Gestão de configurações
+    description: |
+      Itens de configuração, CMDB e gestão de dependências.
+  BC-600.40:
+    name: Gestão das operações de TI
+    description: |
+      Operações quotidianas de TI, monitorização e automação.
+  BC-600.40.10:
+    name: Gestão de eventos e monitorização
+    description: |
+      Telemetria, observabilidade, correlação de eventos e alertas.
+  BC-600.40.20:
+    name: Agendamento de jobs e operações batch de TI
+    description: |
+      Agendamento de jobs, orquestração batch e automação de workloads.
+  BC-600.40.30:
+    name: Gestão da capacidade e desempenho de TI
+    description: |
+      Planeamento de capacidade e otimização de desempenho entre serviços.
+  BC-600.40.40:
+    name: Operações de continuidade do serviço de TI
+    description: |
+      Testes de continuidade do serviço de TI e operações de recuperação.
+  BC-600.40.50:
+    name: Gestão da automação de TI
+    description: |
+      Automação, runbooks e orquestração para operações de TI.
+  BC-600.50:
+    name: Gestão da infraestrutura de TI
+    description: |
+      Computação, armazenamento, rede e infraestrutura cloud.
+  BC-600.50.10:
+    name: Gestão de computação e servidores
+    description: |
+      Aprovisionamento e operação de computação física e virtual.
+  BC-600.50.20:
+    name: Gestão de armazenamento
+    description: |
+      Aprovisionamento, tiering e proteção de armazenamento.
+  BC-600.50.30:
+    name: Gestão de rede
+    description: |
+      Gestão de LAN, WAN, SD-WAN e serviços de rede.
+  BC-600.50.40:
+    name: Gestão de plataforma cloud
+    description: |
+      Operações de plataforma cloud pública, privada e híbrida.
+  BC-600.50.50:
+    name: Gestão de computação para utilizadores finais
+    description: |
+      Dispositivos de local de trabalho, gestão de endpoints e ferramentas de colaboração.
+  BC-600.60:
+    name: Gestão de aplicações de TI
+    description: |
+      Ciclo de vida de aplicações, racionalização e AMS.
+  BC-600.60.10:
+    name: Gestão do portefólio de aplicações
+    description: |
+      Catálogo de aplicações, propriedade e estado do ciclo de vida.
+  BC-600.60.20:
+    name: Desenvolvimento e engenharia de aplicações
+    description: |
+      Desenvolvimento de software, práticas de engenharia e DevOps.
+  BC-600.60.30:
+    name: Manutenção e suporte de aplicações
+    description: |
+      AMS, resolução de defeitos e entrega de pequenas melhorias.
+  BC-600.60.40:
+    name: Racionalização de aplicações
+    description: |
+      Racionalização, consolidação e desativação de aplicações.
+  BC-600.60.50:
+    name: Gestão de integração e API
+    description: |
+      Plataformas de integração, APIs e streaming de eventos.
+  BC-600.70:
+    name: Gestão de fornecedores de TI
+    description: |
+      Contratos, desempenho e ecossistema de fornecedores de TI.
+  BC-600.70.10:
+    name: Integração de fornecedores de TI
+    description: |
+      Integração e contratação de fornecedores e parceiros de TI.
+  BC-600.70.20:
+    name: Gestão do desempenho de fornecedores de TI
+    description: |
+      Scorecards de desempenho e gestão de SLAs para fornecedores de TI.
+  BC-600.70.30:
+    name: Gestão de licenças de software
+    description: |
+      Licenciamento de software, direitos e gestão de auditorias.
+  BC-600.70.40:
+    name: Estratégia de sourcing de TI
+    description: |
+      Estratégia de build vs. buy e serviços geridos de sourcing para TI.
+  BC-600.80:
+    name: Gestão financeira de TI
+    description: |
+      Despesa de TI, chargeback/showback e otimização de custos de TI.
+  BC-600.80.10:
+    name: Orçamentação e previsão de TI
+    description: |
+      Planeamento orçamental, previsão e análise de desvios de TI.
+  BC-600.80.20:
+    name: Alocação de custos e chargeback de TI
+    description: |
+      Showback, chargeback e alocação de custos baseada em TBM.
+  BC-600.80.30:
+    name: Gestão de cloud FinOps
+    description: |
+      Práticas de FinOps para visibilidade e otimização de custos cloud.
+  BC-600.80.40:
+    name: Acompanhamento de valor e benefícios de TI
+    description: |
+      Acompanhamento do valor do investimento em TI e realização de benefícios.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-innovation-management.yaml
+++ b/catalogue/i18n/pt/L1-innovation-management.yaml
@@ -1,0 +1,107 @@
+locale: pt
+source: L1-innovation-management.yaml
+entries:
+  BC-800:
+    name: Gestão da inovação
+    description: |
+      Geração de ideias, incubação, portefólio de inovação e ventures.
+  BC-800.10:
+    name: Gestão de ideias e oportunidades
+    description: |
+      Captura de ideias, triagem e avaliação de oportunidades.
+  BC-800.10.10:
+    name: Captura e submissão de ideias
+    description: |
+      Canais de captura de ideias provenientes de crowd, colaboradores e parceiros.
+  BC-800.10.20:
+    name: Triagem e avaliação de ideias
+    description: |
+      Triagem, avaliação e pré-seleção de ideias.
+  BC-800.10.30:
+    name: Enquadramento de oportunidades
+    description: |
+      Enquadramento de oportunidades de negócio, declarações de problema e casos de valor.
+  BC-800.20:
+    name: Gestão do portefólio de inovação
+    description: |
+      Portefólio de inovação em horizontes (H1/H2/H3).
+  BC-800.20.10:
+    name: Gestão do pipeline de inovação
+    description: |
+      Pipeline de iniciativas de inovação em diferentes fases.
+  BC-800.20.20:
+    name: Equilíbrio do portefólio nos três horizontes
+    description: |
+      Equilíbrio do portefólio nos horizontes H1, H2 e H3.
+  BC-800.20.30:
+    name: Governação por fases
+    description: |
+      Revisão por fases e governação de decisão para inovações.
+  BC-800.20.40:
+    name: Gestão do financiamento de inovação
+    description: |
+      Alocação de financiamento entre iniciativas de inovação.
+  BC-800.30:
+    name: Incubação e aceleração de inovação
+    description: |
+      Incubadoras, aceleradoras e venturing interno.
+  BC-800.30.10:
+    name: Operações do incubador de inovação
+    description: |
+      Operação de incubadoras corporativas e laboratórios de inovação.
+  BC-800.30.20:
+    name: Venturing interno
+    description: |
+      Criação de spin-outs e ventures internos.
+  BC-800.30.30:
+    name: Desenvolvimento do produto mínimo viável
+    description: |
+      Desenvolvimento de MVP, validação com clientes e iteração.
+  BC-800.30.40:
+    name: Escalonamento de inovações
+    description: |
+      Transição de inovações validadas para ofertas em escala.
+  BC-800.40:
+    name: Gestão de venturing corporativo
+    description: |
+      Investimentos de VC corporativo e parcerias com startups.
+  BC-800.40.10:
+    name: Sourcing e scouting de startups
+    description: |
+      Identificação de startups alinhadas com temas estratégicos.
+  BC-800.40.20:
+    name: Investimento corporativo em ventures
+    description: |
+      Investimento direto em capital próprio e operações de fundo CVC.
+  BC-800.40.30:
+    name: Gestão de parcerias com startups
+    description: |
+      Parcerias comerciais e pilotos com startups.
+  BC-800.40.40:
+    name: Gestão do portefólio de ventures
+    description: |
+      Monitorização do desempenho de investimentos do portefólio de ventures.
+  BC-800.50:
+    name: Gestão da inovação aberta
+    description: |
+      Redes de inovação externa, crowdsourcing e parcerias académicas.
+  BC-800.50.10:
+    name: Parcerias académicas e de investigação
+    description: |
+      Parcerias com universidades e instituições de investigação.
+  BC-800.50.20:
+    name: Desafios de inovação e crowdsourcing
+    description: |
+      Desafios de inovação externos, hackathons e crowdsourcing.
+  BC-800.50.30:
+    name: Relacionamento com o ecossistema de inovação
+    description: |
+      Relacionamento com hubs de inovação, aceleradoras e ecossistemas.
+  BC-800.50.40:
+    name: Sourcing de tecnologia externa
+    description: |
+      Licenciamento de entrada e aquisição de tecnologia externa.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-institutional-advancement-alumni-management.yaml
+++ b/catalogue/i18n/pt/L1-institutional-advancement-alumni-management.yaml
@@ -1,0 +1,150 @@
+locale: pt
+source: L1-institutional-advancement-alumni-management.yaml
+entries:
+  BC-4800:
+    name: Gestão de desenvolvimento institucional e alumni
+    description: |
+      Envolvimento com comunidades de alumni, cultivo de doadores e gestão de
+      campanhas de angariação de fundos, donativos, gestão de mecenas e reporte
+      a doadores relacionado com dotações.
+  BC-4800.10:
+    name: Envolvimento de alumni
+    description: |
+      Envolvimento de comunidades de alumni através de programas, eventos e
+      comunicações que sustentam relações vitalícias com a instituição.
+    in_scope:
+      - Operações de comunidade de alumni
+      - Eventos e reuniões de alumni
+      - Comunicações com alumni
+    out_of_scope:
+      - Serviços de carreira para estudantes atuais (abrangidos em Gestão de Apoio ao Estudante e Bem-Estar)
+  BC-4800.10.10:
+    name: Operações de comunidade de alumni
+    description: |
+      Operação de associações, grupos regionais e comunidades online de alumni.
+  BC-4800.10.20:
+    name: Eventos e reuniões de alumni
+    description: |
+      Planeamento e realização de eventos e reuniões de alumni.
+  BC-4800.10.30:
+    name: Comunicações com alumni
+    description: |
+      Canais editoriais e de comunicação para públicos de alumni.
+  BC-4800.20:
+    name: Gestão de relações com doadores
+    description: |
+      Identificação, cultivo e gestão de relações com doadores potenciais e existentes.
+    in_scope:
+      - Pesquisa e identificação de candidatos a doadores
+      - Cultivo e solicitação de doadores
+      - Gestão de relações de grandes donativos
+    out_of_scope:
+      - Operações genéricas de CRM (abrangidas em Gestão de Relações com Clientes transversal)
+  BC-4800.20.10:
+    name: Pesquisa e identificação de candidatos a doadores
+    description: |
+      Pesquisa e identificação de candidatos a doadores.
+  BC-4800.20.20:
+    name: Cultivo e solicitação de doadores
+    description: |
+      Cultivo e solicitação de apoio de doadores.
+  BC-4800.20.30:
+    name: Gestão de relações de grandes donativos
+    description: |
+      Gestão personalizada de relações com doadores de grandes donativos.
+  BC-4800.30:
+    name: Gestão de campanhas de angariação de fundos
+    description: |
+      Planeamento e operação de campanhas de angariação de fundos em donativos
+      anuais, capitais e canais digitais.
+    in_scope:
+      - Campanhas de donativos anuais
+      - Gestão de campanhas de capital
+      - Campanhas de crowdfunding e peer-to-peer
+    out_of_scope:
+      - Campanhas de marketing não relacionadas com angariação de fundos (abrangidas em Gestão de Marketing transversal)
+  BC-4800.30.10:
+    name: Campanhas de donativos anuais
+    description: |
+      Operação de campanhas de donativos anuais e donativos recorrentes.
+  BC-4800.30.20:
+    name: Gestão de campanhas de capital
+    description: |
+      Gestão de campanhas de capital plurianuais.
+  BC-4800.30.30:
+    name: Campanhas de crowdfunding e peer-to-peer
+    description: |
+      Operação de campanhas de crowdfunding e angariação de fundos peer-to-peer.
+  BC-4800.40:
+    name: Administração de donativos e compromissos
+    description: |
+      Receção, registo e administração de donativos e compromissos, incluindo
+      instrumentos de doação planeada.
+    in_scope:
+      - Receção e processamento de donativos
+      - Monitorização de compromissos
+      - Administração de doações planeadas e diferidas
+    out_of_scope:
+      - Contas a receber genéricas (abrangidas em Gestão Financeira transversal)
+  BC-4800.40.10:
+    name: Receção e processamento de donativos
+    description: |
+      Receção e processamento de donativos em numerário, cheque, online e em espécie.
+  BC-4800.40.20:
+    name: Monitorização de compromissos
+    description: |
+      Monitorização de compromissos e calendários de pagamento de compromissos.
+  BC-4800.40.30:
+    name: Administração de doações planeadas e diferidas
+    description: |
+      Administração de legados, fundos fiduciários de beneficência e outros instrumentos de doação planeada.
+  BC-4800.50:
+    name: Gestão de mecenas e reconhecimento
+    description: |
+      Gestão de mecenas através de agradecimento, reconhecimento e envolvimento
+      contínuo de doadores de fundos com nome.
+    in_scope:
+      - Agradecimento a doadores
+      - Programas de reconhecimento de doadores
+      - Gestão de mecenas de fundos com dotação
+    out_of_scope:
+      - Comunicações de relações públicas (abrangidas em Gestão de Comunicação Corporativa transversal)
+  BC-4800.50.10:
+    name: Agradecimento a doadores
+    description: |
+      Agradecimento de donativos e compromissos de doadores.
+  BC-4800.50.20:
+    name: Programas de reconhecimento de doadores
+    description: |
+      Operação de programas e sociedades de reconhecimento de doadores.
+  BC-4800.50.30:
+    name: Gestão de mecenas de fundos com dotação
+    description: |
+      Gestão de mecenas de fundos com dotação e fundos com nome.
+  BC-4800.60:
+    name: Reporte a doadores relacionado com dotações
+    description: |
+      Reporte a doadores sobre o uso, desempenho e impacto de fundos restritos e com dotação.
+    in_scope:
+      - Reporte do uso de fundos restritos
+      - Reporte do desempenho de dotações com nome
+      - Reporte de impacto a doadores
+    out_of_scope:
+      - Reporte financeiro institucional (abrangido em Gestão Financeira transversal)
+      - Gestão de investimentos de dotação em si (abrangida em Gestão de Tesouraria transversal)
+  BC-4800.60.10:
+    name: Reporte do uso de fundos restritos
+    description: |
+      Reporte do uso de fundos restritos e designados por doadores.
+  BC-4800.60.20:
+    name: Reporte do desempenho de dotações com nome
+    description: |
+      Reporte de desempenho de fundos com dotação com nome aos seus doadores.
+  BC-4800.60.30:
+    name: Reporte de impacto a doadores
+    description: |
+      Reporte de narrativas e resultados de impacto voltados para doadores.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-insurance-claims-management.yaml
+++ b/catalogue/i18n/pt/L1-insurance-claims-management.yaml
@@ -1,0 +1,169 @@
+locale: pt
+source: L1-insurance-claims-management.yaml
+entries:
+  BC-2160:
+    name: Gestão de sinistros de seguros
+    description: |
+      Primeira comunicação de sinistro, triagem, investigação, provisionamento, regulação,
+      liquidação, recuperação e sub-rogação, litigância, fraude/SIU e resposta a catástrofes
+      em todos os ramos de seguros.
+  BC-2160.10:
+    name: Gestão da primeira comunicação de sinistro
+    description: |
+      Receção multi-canal de FNOL, verificação de cobertura, registo e confirmação.
+  BC-2160.10.10:
+    name: Receção multi-canal de FNOL
+    description: |
+      Receção da primeira comunicação de sinistro por telefone, digital, mediador e canais IoT.
+  BC-2160.10.20:
+    name: Verificação inicial de cobertura
+    description: |
+      Verificação de que o sinistro se enquadra na cobertura na data do sinistro.
+  BC-2160.10.30:
+    name: Registo do sinistro
+    description: |
+      Registo de novos sinistros e atribuição de identificadores de sinistro.
+  BC-2160.10.40:
+    name: Confirmação e comunicação
+    description: |
+      Confirmação inicial ao lesado e comunicação contínua do estado do sinistro.
+  BC-2160.20:
+    name: Triagem e segmentação de sinistros
+    description: |
+      Pontuação de gravidade, encaminhamento direto, atribuição de regulador e encaminhamento para especialista.
+  BC-2160.20.10:
+    name: Pontuação de gravidade e complexidade
+    description: |
+      Pontuação da gravidade e complexidade do sinistro para decisões de encaminhamento.
+  BC-2160.20.20:
+    name: Encaminhamento de processamento direto
+    description: |
+      Encaminhamento de sinistros de baixa gravidade por processamento direto.
+  BC-2160.20.30:
+    name: Atribuição de regulador
+    description: |
+      Atribuição de sinistros a reguladores com base em competências, capacidade e geografia.
+  BC-2160.20.40:
+    name: Encaminhamento para especialista e litigância
+    description: |
+      Encaminhamento de sinistros complexos, de especialistas e litigados para equipas dedicadas.
+  BC-2160.30:
+    name: Investigação e regulação de sinistros
+    description: |
+      Regulação em campo e secretaria, avaliação de danos, determinação de responsabilidade e consulta a peritos.
+  BC-2160.30.10:
+    name: Regulação em campo e secretaria
+    description: |
+      Regulação em campo e secretaria de sinistros, incluindo inspeções ao local.
+  BC-2160.30.20:
+    name: Avaliação de danos e perdas
+    description: |
+      Avaliação de danos, quantum da perda e âmbito de reparação/substituição.
+  BC-2160.30.30:
+    name: Determinação de responsabilidade
+    description: |
+      Determinação de responsabilidade e resposta da apólice em sinistros de terceiros.
+  BC-2160.30.40:
+    name: Consulta a peritos
+    description: |
+      Consulta a vistoriadores, engenheiros, peritos médicos e contabilistas forenses.
+  BC-2160.40:
+    name: Gestão de provisionamento de sinistros
+    description: |
+      Constituição inicial de provisão por caso, reestimação e coordenação de IBNR.
+  BC-2160.40.10:
+    name: Constituição inicial de provisão por caso
+    description: |
+      Constituição de provisões iniciais por caso em sinistros registados.
+  BC-2160.40.20:
+    name: Reestimação de provisão
+    description: |
+      Reestimação periódica de provisões por caso à medida que surgem novas informações.
+  BC-2160.40.30:
+    name: Coordenação de IBNR com a função atuarial
+    description: |
+      Coordenação com a função atuarial sobre provisões IBNR para provisionamento ao nível do portefólio.
+  BC-2160.50:
+    name: Liquidação e pagamento de sinistros
+    description: |
+      Negociação de liquidação, pagamentos de indemnização e despesas, salvado e recuperação/sub-rogação.
+  BC-2160.50.10:
+    name: Negociação de liquidação
+    description: |
+      Negociação de montantes de liquidação com lesados e terceiros.
+  BC-2160.50.20:
+    name: Emissão de pagamentos de indemnização
+    description: |
+      Emissão de pagamentos de indemnização a segurados e terceiros.
+  BC-2160.50.30:
+    name: Emissão de pagamentos de despesas
+    description: |
+      Emissão de pagamentos de despesas de regulação alocadas e não alocadas.
+  BC-2160.50.40:
+    name: Disposição de salvado
+    description: |
+      Disposição e recuperação de salvado em sinistros liquidados.
+  BC-2160.50.50:
+    name: Recuperação e sub-rogação
+    description: |
+      Recuperação e sub-rogação contra terceiros e outros seguradores.
+  BC-2160.60:
+    name: Gestão de litigância de sinistros
+    description: |
+      Estratégia de litigância, coordenação com advogados de defesa e acompanhamento de custos de litigância.
+  BC-2160.60.10:
+    name: Estratégia de litigância
+    description: |
+      Definição de estratégia para sinistros litigados e decisões de liquidação vs julgamento.
+  BC-2160.60.20:
+    name: Coordenação com advogados de defesa
+    description: |
+      Coordenação com advogados de defesa de painel e instruídos.
+  BC-2160.60.30:
+    name: Acompanhamento de custos de litigância
+    description: |
+      Acompanhamento de custos de litigância face às taxas de painel e orçamentos.
+  BC-2160.70:
+    name: Gestão de fraude e SIU em sinistros
+    description: |
+      Deteção de sinistros suspeitos, investigação SIU, referência de fraude e análise anti-fraude.
+  BC-2160.70.10:
+    name: Deteção de sinistros suspeitos
+    description: |
+      Deteção de sinistros suspeitos utilizando regras, modelos e indicadores de alerta.
+  BC-2160.70.20:
+    name: Investigação SIU
+    description: |
+      Trabalho de investigação de unidade especial de sinistros suspeitos de fraude.
+  BC-2160.70.30:
+    name: Referência e processo judicial de fraude
+    description: |
+      Referência de casos de fraude às forças de segurança e registos do setor.
+  BC-2160.70.40:
+    name: Análise anti-fraude
+    description: |
+      Análise anti-fraude em portefólios de sinistros e análise de rede.
+  BC-2160.80:
+    name: Gestão de sinistros de catástrofes
+    description: |
+      Ativação de evento CAT, capacidade de pico, acompanhamento de sinistros CAT e coordenação de recuperação CAT.
+  BC-2160.80.10:
+    name: Ativação de evento CAT
+    description: |
+      Ativação de procedimentos de resposta a catástrofes em eventos declarados.
+  BC-2160.80.20:
+    name: Mobilização de capacidade de pico
+    description: |
+      Mobilização de reguladores de pico, empreiteiros e capacidade de call center.
+  BC-2160.80.30:
+    name: Triagem e acompanhamento de sinistros CAT
+    description: |
+      Triagem e acompanhamento de sinistros codificados como CAT até à liquidação.
+  BC-2160.80.40:
+    name: Coordenação de recuperação CAT
+    description: |
+      Coordenação de recuperações de resseguro e pool em eventos CAT.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-insurance-customer-management.yaml
+++ b/catalogue/i18n/pt/L1-insurance-customer-management.yaml
@@ -1,0 +1,112 @@
+locale: pt
+source: L1-insurance-customer-management.yaml
+entries:
+  BC-2120:
+    name: Gestão de cliente de seguros
+    description: |
+      Identidade do tomador de apólice, agregação de agregado familiar e grupo, KYC, consentimentos
+      e assistência ao longo do ciclo de vida de clientes de seguros em todos os canais.
+  BC-2120.10:
+    name: Gestão de integração de tomadores de apólice
+    description: |
+      Captura de candidatura, verificação de identidade, ativação e comunicações de integração.
+  BC-2120.10.10:
+    name: Captura de candidatura
+    description: |
+      Captura de novas candidaturas de tomadores de apólice nos canais.
+  BC-2120.10.20:
+    name: Verificação de identidade e propriedade beneficiária
+    description: |
+      Verificação de identidade e identificação de propriedade beneficiária para tomadores de apólice individuais e empresariais.
+  BC-2120.10.30:
+    name: Ativação do tomador de apólice
+    description: |
+      Ativação de registos, contas e acesso a canais do tomador de apólice.
+  BC-2120.10.40:
+    name: Comunicação de integração
+    description: |
+      Comunicação do estado de integração, pacotes de boas-vindas e passos seguintes.
+  BC-2120.20:
+    name: Gestão de KYC e sanções de seguros
+    description: |
+      Classificação de risco do cliente, documentação KYC, rastreio de sanções e PEP e atualização periódica.
+  BC-2120.20.10:
+    name: Classificação de risco do cliente
+    description: |
+      Classificação de risco de clientes de seguros com base em fatores de risco de AML e conduta.
+  BC-2120.20.20:
+    name: Recolha de documentação KYC
+    description: |
+      Recolha e validação de documentação KYC para clientes de seguros.
+  BC-2120.20.30:
+    name: Rastreio de sanções e PEP
+    description: |
+      Rastreio de sanções, PEP e média adversa de tomadores de apólice e beneficiários.
+  BC-2120.20.40:
+    name: Atualização periódica de KYC
+    description: |
+      Atualização periódica de informação KYC e reclassificação de risco.
+  BC-2120.30:
+    name: Gestão de assistência ao tomador de apólice
+    description: |
+      Manutenção em autoatendimento, tratamento de pedidos de assistência, fornecimento de documentos e manutenção de beneficiários.
+  BC-2120.30.10:
+    name: Manutenção de conta em autoatendimento
+    description: |
+      Atualizações em autoatendimento de morada, contacto e dados de preferências.
+  BC-2120.30.20:
+    name: Tratamento de pedidos de assistência recebidos
+    description: |
+      Tratamento de pedidos de assistência recebidos do tomador de apólice nos canais.
+  BC-2120.30.30:
+    name: Fornecimento de documentos e extratos
+    description: |
+      Fornecimento de documentos de apólice, extratos e certificados de seguro.
+  BC-2120.30.40:
+    name: Manutenção de beneficiários e nomeados
+    description: |
+      Captura e manutenção de beneficiários e nomeados em contratos de vida e pensões.
+  BC-2120.40:
+    name: Gestão de informação e consentimentos do cliente
+    description: |
+      Perfil, agregação de agregado familiar e grupo, gestão de consentimentos e registo dourado.
+  BC-2120.40.10:
+    name: Manutenção do perfil do tomador de apólice
+    description: |
+      Manutenção do perfil e dados demográficos do tomador de apólice.
+  BC-2120.40.20:
+    name: Agregação de agregado familiar e grupo
+    description: |
+      Agregação de tomadores de apólice em agregados familiares, grupos e empresas-mãe.
+  BC-2120.40.30:
+    name: Consentimentos de marketing e partilha de dados
+    description: |
+      Captura e aplicação de consentimentos de marketing e partilha de dados.
+  BC-2120.40.40:
+    name: Gestão do registo dourado do cliente
+    description: |
+      Manutenção do registo dourado do tomador de apólice nos sistemas.
+  BC-2120.50:
+    name: Gestão da experiência e retenção do cliente
+    description: |
+      Captura de feedback, programas de fidelização, tratamento de reclamações e previsão de abandono.
+  BC-2120.50.10:
+    name: Captura de feedback do cliente
+    description: |
+      Captura de feedback do cliente, sinais NPS e CSAT.
+  BC-2120.50.20:
+    name: Operações de programas de fidelização e retenção
+    description: |
+      Operação de programas de fidelização, retenção e recompensas por antiguidade.
+  BC-2120.50.30:
+    name: Tratamento de reclamações e escaladas
+    description: |
+      Tratamento de reclamações, escaladas e casos de provedor do tomador de apólice.
+  BC-2120.50.40:
+    name: Previsão de abandono e caducidade
+    description: |
+      Análise preditiva do risco de abandono e caducidade para intervenção de retenção.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-insurance-distribution-management.yaml
+++ b/catalogue/i18n/pt/L1-insurance-distribution-management.yaml
@@ -1,0 +1,137 @@
+locale: pt
+source: L1-insurance-distribution-management.yaml
+entries:
+  BC-2110:
+    name: Gestão de distribuição de seguros
+    description: |
+      Relações com produtores, mediadores, agentes, MGA e canais diretos,
+      incluindo nomeações, comissões, licenciamento, autoridades delegadas
+      e fluxo de cotações e submissões para subscrição.
+  BC-2110.10:
+    name: Gestão de produtores e intermediários
+    description: |
+      Integração, hierarquia, acompanhamento do desempenho e saída de produtores e intermediários.
+  BC-2110.10.10:
+    name: Integração de produtores
+    description: |
+      Integração de produtores, intermediários, mediadores e MGA.
+  BC-2110.10.20:
+    name: Hierarquia e manutenção de conta de produtor
+    description: |
+      Manutenção da hierarquia de produtor, estruturas de conta e dados de contacto.
+  BC-2110.10.30:
+    name: Acompanhamento do desempenho de produtores
+    description: |
+      Acompanhamento da produção, rácio de sinistros e rentabilidade do produtor.
+  BC-2110.10.40:
+    name: Saída de produtores
+    description: |
+      Saída de produtores, gestão de carteiras em run-off e liquidação final.
+  BC-2110.20:
+    name: Gestão de licenciamento e nomeação de produtores
+    description: |
+      Verificação de licenças, nomeações jurisdicionais, formação contínua e conformidade do produtor.
+  BC-2110.20.10:
+    name: Verificação de licenças
+    description: |
+      Verificação das licenças do produtor junto de registos estaduais e jurisdicionais.
+  BC-2110.20.20:
+    name: Gestão de nomeações jurisdicionais
+    description: |
+      Gestão de nomeações, rescisões e renovações estaduais e jurisdicionais.
+  BC-2110.20.30:
+    name: Acompanhamento de formação contínua
+    description: |
+      Acompanhamento de créditos de formação contínua do produtor e elegibilidade para renovação.
+  BC-2110.20.40:
+    name: Monitorização de conformidade do produtor
+    description: |
+      Monitorização de conduta, reclamações e ações disciplinares do produtor.
+  BC-2110.30:
+    name: Gestão de comissões e incentivos
+    description: |
+      Configuração de tabelas de comissão, cálculo, substituição e bónus e geração de extratos.
+  BC-2110.30.10:
+    name: Configuração de tabelas de comissão
+    description: |
+      Configuração de tabelas e taxas de comissão por produto e produtor.
+  BC-2110.30.20:
+    name: Cálculo de comissões
+    description: |
+      Cálculo de comissões em eventos de prémio, incluindo reversões por cancelamento.
+  BC-2110.30.30:
+    name: Cálculo de substituição e bónus
+    description: |
+      Cálculo de substituições, partilha de lucros e bónus de incentivo.
+  BC-2110.30.40:
+    name: Geração de extratos de comissão
+    description: |
+      Geração e distribuição de extratos de comissão do produtor.
+  BC-2110.40:
+    name: Gestão do canal de distribuição
+    description: |
+      Operação de canais de agente, mediador, digital direto, bancasseguros, afinidade e agregador.
+  BC-2110.40.10:
+    name: Operações do canal de agentes
+    description: |
+      Operação de canais de agentes vinculados e independentes.
+  BC-2110.40.20:
+    name: Operações do canal de mediadores
+    description: |
+      Operação de canais de mediadores e mediadores grossistas.
+  BC-2110.40.30:
+    name: Operações do canal digital direto
+    description: |
+      Operação de canais de seguros digitais diretos ao cliente.
+  BC-2110.40.40:
+    name: Operações do canal de bancasseguros e afinidade
+    description: |
+      Operação de parcerias de bancasseguros e canais de grupos de afinidade.
+  BC-2110.40.50:
+    name: Operações do canal de agregadores e comparadores
+    description: |
+      Operação de canais de agregadores e sites de comparação de preços.
+  BC-2110.50:
+    name: Gestão de autoridade delegada
+    description: |
+      Configuração de autoridade do tomador de cobertura, monitorização do desempenho, receção de bordereau e auditoria de autoridade.
+  BC-2110.50.10:
+    name: Configuração de autoridade delegada
+    description: |
+      Configuração de autoridades vinculantes e acordos de subscrição delegada.
+  BC-2110.50.20:
+    name: Monitorização do desempenho do tomador de cobertura
+    description: |
+      Monitorização do desempenho de subscrição e cumprimento da autoridade do tomador de cobertura.
+  BC-2110.50.30:
+    name: Receção e reconciliação de bordereau
+    description: |
+      Receção, ingestão e reconciliação de bordereaux de prémio e sinistros.
+  BC-2110.50.40:
+    name: Auditoria e retirada de autoridade
+    description: |
+      Auditoria das operações do tomador de cobertura e retirada da autoridade vinculante quando necessário.
+  BC-2110.60:
+    name: Gestão de cotações e submissões
+    description: |
+      Receção de submissões, geração de cotações, comparação e acompanhamento da conversão de cotação para vínculo.
+  BC-2110.60.10:
+    name: Receção de submissões
+    description: |
+      Receção de submissões de seguros nos canais e portais de mediadores.
+  BC-2110.60.20:
+    name: Geração de cotações
+    description: |
+      Geração de cotações de seguros a partir da configuração de produto e tarifação.
+  BC-2110.60.30:
+    name: Comparação de cotações e contracotação
+    description: |
+      Comparação de cotações multi-segurador e tratamento de contracotações.
+  BC-2110.60.40:
+    name: Acompanhamento da conversão de cotação para vínculo
+    description: |
+      Acompanhamento das taxas de conversão de cotação para vínculo e razões de não conversão.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-insurance-investment-management.yaml
+++ b/catalogue/i18n/pt/L1-insurance-investment-management.yaml
@@ -1,0 +1,113 @@
+locale: pt
+source: L1-insurance-investment-management.yaml
+entries:
+  BC-2200:
+    name: Gestão de investimentos de seguros
+    description: |
+      Gestão do lado dos ativos dos passivos de seguros pelo segurador enquanto proprietário de ativos —
+      política de investimento, ALM, alocação estratégica e tática de ativos, supervisão de gestores,
+      risco e conformidade de investimento, e relato de investimento.
+  BC-2200.10:
+    name: Gestão de política e estratégia de investimento
+    description: |
+      Declaração de política de investimento, definição de mandatos e integração da política de investimento ESG.
+  BC-2200.10.10:
+    name: Manutenção da declaração de política de investimento
+    description: |
+      Manutenção da declaração de política de investimento e alinhamento com o princípio da pessoa prudente.
+  BC-2200.10.20:
+    name: Definição de mandatos de investimento
+    description: |
+      Definição de mandatos de investimento por portefólio, linha de negócio e perfil de risco.
+  BC-2200.10.30:
+    name: Integração da política de investimento ESG
+    description: |
+      Integração de políticas ESG e de gestão responsável nos mandatos de investimento.
+  BC-2200.20:
+    name: Gestão de ativos e passivos
+    description: |
+      Modelação ALM e correspondência de fluxos de caixa, monitorização de duração e convexidade, e dimensionamento de reservas de liquidez.
+  BC-2200.20.10:
+    name: Modelação ALM e correspondência de fluxos de caixa
+    description: |
+      Modelação ALM e correspondência de fluxos de caixa de ativos com passivos de seguros.
+  BC-2200.20.20:
+    name: Monitorização de duração e convexidade
+    description: |
+      Monitorização de desfasamentos de duração e convexidade entre ativos e passivos.
+  BC-2200.20.30:
+    name: Dimensionamento de reservas de liquidez
+    description: |
+      Dimensionamento de reservas de liquidez para fazer face a saídas de sinistros esperadas e em stress.
+  BC-2200.30:
+    name: Alocação estratégica e tática de ativos
+    description: |
+      Decisões de alocação estratégica e tática de ativos e reequilíbrio.
+  BC-2200.30.10:
+    name: Definição de alocação estratégica de ativos
+    description: |
+      Definição de alocações estratégicas de ativos de longo prazo por classes de ativos.
+  BC-2200.30.20:
+    name: Decisão de alocação tática de ativos
+    description: |
+      Decisões de alocação tática dentro dos intervalos estratégicos.
+  BC-2200.30.30:
+    name: Reequilíbrio de alocação
+    description: |
+      Reequilíbrio periódico e orientado por eventos para alocações-alvo.
+  BC-2200.40:
+    name: Supervisão de mandatos e gestores de investimento
+    description: |
+      Seleção de gestores externos, conformidade com mandatos, revisão de desempenho e supervisão de honorários de gestores.
+  BC-2200.40.10:
+    name: Seleção de gestores externos
+    description: |
+      Seleção e integração de gestores de investimento externos.
+  BC-2200.40.20:
+    name: Monitorização de conformidade com mandatos
+    description: |
+      Monitorização da conformidade com mandatos e tratamento de violações.
+  BC-2200.40.30:
+    name: Revisão do desempenho de gestores
+    description: |
+      Revisão periódica do desempenho de gestores de investimento externos.
+  BC-2200.40.40:
+    name: Supervisão de honorários de gestores
+    description: |
+      Supervisão de honorários de gestores e avaliações de relação qualidade-preço.
+  BC-2200.50:
+    name: Monitorização de risco e conformidade de investimento
+    description: |
+      Monitorização de limites de investimento, limites de contraparte e emitente, e elegibilidade de ativos Solvência II.
+  BC-2200.50.10:
+    name: Monitorização de limites de investimento
+    description: |
+      Monitorização de limites de investimento por classes de ativos e fatores de risco.
+  BC-2200.50.20:
+    name: Monitorização de limites de contraparte e emitente
+    description: |
+      Monitorização de concentração e limites de contraparte e emitente.
+  BC-2200.50.30:
+    name: Monitorização de elegibilidade de ativos Solvência II
+    description: |
+      Monitorização da elegibilidade de ativos face às regras Solvência II e equivalentes.
+  BC-2200.60:
+    name: Desempenho e relato de investimento
+    description: |
+      Medição de desempenho, atribuição e relato de investimento ao conselho de administração e regulador.
+  BC-2200.60.10:
+    name: Medição do desempenho do portefólio
+    description: |
+      Medição do desempenho do portefólio face a benchmarks e passivos.
+  BC-2200.60.20:
+    name: Análise de atribuição
+    description: |
+      Atribuição do desempenho por alocação, seleção e moeda.
+  BC-2200.60.30:
+    name: Relato de investimento ao conselho e regulador
+    description: |
+      Produção de relato de investimento para o conselho de administração, ALCO e regulador.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-insurance-product-management.yaml
+++ b/catalogue/i18n/pt/L1-insurance-product-management.yaml
@@ -1,0 +1,127 @@
+locale: pt
+source: L1-insurance-product-management.yaml
+entries:
+  BC-2100:
+    name: Gestão de produto de seguros
+    description: |
+      Fábrica de produtos de seguros — definições de cobertura, condições, tabelas de tarifação,
+      agregados e ciclo de vida para ramos vida, não-vida, saúde e especialidades,
+      incluindo as estruturas de produto de programa e tomador de cobertura utilizadas em
+      mercados de autoridade delegada.
+  BC-2100.10:
+    name: Gestão do catálogo de produto de seguros
+    description: |
+      Catálogo de produto de seguros, dados mestre, biblioteca de coberturas e formulários,
+      documentação de divulgação e publicação do catálogo.
+  BC-2100.10.10:
+    name: Gestão de dados mestre de produto
+    description: |
+      Manutenção de dados mestre de produto de seguros e hierarquias de produto.
+  BC-2100.10.20:
+    name: Biblioteca de coberturas e formulários
+    description: |
+      Manutenção de definições de cobertura normalizadas, formulários de apólice e biblioteca de endorsements.
+  BC-2100.10.30:
+    name: Documentação de divulgação de produto
+    description: |
+      Produção e manutenção de documentos de divulgação de produto e declarações de factos fundamentais.
+  BC-2100.10.40:
+    name: Publicação do catálogo de produto
+    description: |
+      Publicação do catálogo de produto de seguros nos canais e parceiros.
+  BC-2100.20:
+    name: Configuração de tarifação e preço de produto
+    description: |
+      Configuração de algoritmos de tarifação, fatores, taxas registadas, descontos e sobretaxas.
+  BC-2100.20.10:
+    name: Configuração de algoritmos de tarifação
+    description: |
+      Configuração de algoritmos de tarifação e modelos de preço para produtos de seguros.
+  BC-2100.20.20:
+    name: Manutenção de fatores e variáveis de tarifação
+    description: |
+      Manutenção de fatores, tabelas e variáveis de tarifação.
+  BC-2100.20.30:
+    name: Gestão de taxas registadas
+    description: |
+      Gestão de taxas registadas, desvios e aprovações nas diferentes jurisdições.
+  BC-2100.20.40:
+    name: Configuração de descontos e sobretaxas
+    description: |
+      Configuração de descontos de prémio, sobretaxas e programas de crédito.
+  BC-2100.30:
+    name: Configuração de elegibilidade de produto e regras de subscrição
+    description: |
+      Configuração de elegibilidade, diretrizes de subscrição e regras de referência e recusa incorporadas no produto.
+  BC-2100.30.10:
+    name: Configuração de regras de elegibilidade
+    description: |
+      Configuração de regras de elegibilidade de cliente e risco por produto.
+  BC-2100.30.20:
+    name: Codificação de diretrizes de subscrição
+    description: |
+      Codificação de diretrizes de subscrição na configuração do produto.
+  BC-2100.30.30:
+    name: Configuração de regras de referência e recusa
+    description: |
+      Configuração de regras automatizadas de referência e recusa por produto.
+  BC-2100.40:
+    name: Gestão do ciclo de vida do produto de seguros
+    description: |
+      Introdução de novo produto, registo regulatório, prontidão para lançamento, revisão de desempenho e retirada.
+  BC-2100.40.10:
+    name: Conceito de novo produto
+    description: |
+      Definição de conceito para novos produtos de seguros e governação do comité de produto.
+  BC-2100.40.20:
+    name: Registo e aprovação de produto
+    description: |
+      Registo regulatório de produtos de seguros e acompanhamento de aprovações nas diferentes jurisdições.
+  BC-2100.40.30:
+    name: Prontidão para lançamento de produto
+    description: |
+      Prontidão operacional e de canal para o lançamento de produtos de seguros.
+  BC-2100.40.40:
+    name: Revisão do desempenho de produto
+    description: |
+      Revisões periódicas de desempenho e valor monetário de produtos de seguros.
+  BC-2100.40.50:
+    name: Retirada e substituição de produto
+    description: |
+      Retirada, substituição e migração de tomadores de apólice para produtos sucessores.
+  BC-2100.50:
+    name: Gestão de agregados de produto de seguros
+    description: |
+      Agregados multirramo, produtos de pacote e acompanhamento do desempenho dos agregados.
+  BC-2100.50.10:
+    name: Definição de agregado multirramo
+    description: |
+      Definição de agregados de produto multirramo e regras de empacotamento.
+  BC-2100.50.20:
+    name: Configuração de regras de elegibilidade de agregado
+    description: |
+      Regras de elegibilidade e qualificação para agregados de produto de seguros.
+  BC-2100.50.30:
+    name: Acompanhamento do desempenho do agregado
+    description: |
+      Acompanhamento da adesão, retenção e economias dos agregados.
+  BC-2100.60:
+    name: Gestão de produto de especialidades e programa
+    description: |
+      Definição de negócio de programa, autoridade de produto do tomador de cobertura e biblioteca de redações de especialidades.
+  BC-2100.60.10:
+    name: Definição de programa
+    description: |
+      Definição de negócio de programa e estruturas de produto de autoridade vinculante.
+  BC-2100.60.20:
+    name: Autoridade de produto do tomador de cobertura
+    description: |
+      Definição do âmbito de produto e autoridade concedida aos tomadores de cobertura.
+  BC-2100.60.30:
+    name: Biblioteca de redações e endorsements de especialidades
+    description: |
+      Biblioteca de redações de especialidades, endorsements manuscritos e cláusulas de mercado.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-insurance-risk-management.yaml
+++ b/catalogue/i18n/pt/L1-insurance-risk-management.yaml
@@ -1,0 +1,141 @@
+locale: pt
+source: L1-insurance-risk-management.yaml
+entries:
+  BC-2190:
+    name: Gestão do risco de seguros
+    description: |
+      Tipos de risco específicos de seguros — risco de subscrição, catástrofe e acumulação,
+      reserva, solvência e capital, contraparte de resseguro, vida e longevidade,
+      caducidade, e risco operacional e de conduta de seguros — distinto do risco empresarial genérico.
+  BC-2190.10:
+    name: Gestão do risco de subscrição
+    description: |
+      Apetite de risco de subscrição, monitorização de limites e vigilância de antiseleção.
+  BC-2190.10.10:
+    name: Apetite de risco de subscrição
+    description: |
+      Definição e articulação do apetite de risco de subscrição.
+  BC-2190.10.20:
+    name: Monitorização de limites de subscrição
+    description: |
+      Monitorização de autoridade de subscrição e limites de agregação.
+  BC-2190.10.30:
+    name: Vigilância de antiseleção
+    description: |
+      Vigilância de padrões de seleção adversa e antiseleção.
+  BC-2190.20:
+    name: Gestão do risco de catástrofe e acumulação
+    description: |
+      Monitorização de agregação de exposição, gestão de PML e cenários de desastre realista, e planeamento de mitigação CAT.
+  BC-2190.20.10:
+    name: Monitorização de agregação de exposição
+    description: |
+      Monitorização da agregação de exposição por peril, geografia e ocupação.
+  BC-2190.20.20:
+    name: Gestão de PML e cenários de desastre realista
+    description: |
+      Gestão de PML e cenários de desastre realista.
+  BC-2190.20.30:
+    name: Planeamento de mitigação do risco CAT
+    description: |
+      Planeamento de ações de mitigação incluindo resseguro e transferência de risco.
+  BC-2190.30:
+    name: Gestão do risco de provisão e provisionamento de seguros
+    description: |
+      Monitorização da adequação de provisões, análise de volatilidade de provisões e testes de stress de risco de provisão.
+  BC-2190.30.10:
+    name: Monitorização da adequação de provisões
+    description: |
+      Monitorização da adequação de provisões face à melhor estimativa e benchmarks externos.
+  BC-2190.30.20:
+    name: Análise de volatilidade de provisões
+    description: |
+      Análise da volatilidade de provisões e risco de provisão a um ano.
+  BC-2190.30.30:
+    name: Testes de stress de risco de provisão
+    description: |
+      Testes de stress e de cenário da adequação de provisões.
+  BC-2190.40:
+    name: Gestão do risco de solvência e capital
+    description: |
+      Monitorização da adequação de capital, operações ORSA, testes de stress de solvência e planeamento de recuperação e resolução.
+  BC-2190.40.10:
+    name: Monitorização da adequação de capital
+    description: |
+      Monitorização de rácios de capital de solvência e gatilhos de capital.
+  BC-2190.40.20:
+    name: Operações ORSA
+    description: |
+      Operação do ciclo de Avaliação Própria do Risco e da Solvência.
+  BC-2190.40.30:
+    name: Testes de stress e de cenário de solvência
+    description: |
+      Testes de stress e de stress inverso de posições de solvência.
+  BC-2190.40.40:
+    name: Planeamento de recuperação e resolução
+    description: |
+      Planeamento de recuperação e resolução para cenários de liquidação de seguradores.
+  BC-2190.50:
+    name: Gestão do risco de contraparte de resseguro e de crédito
+    description: |
+      Monitorização de contrapartes de resseguradores, adequação de colateral e testes de stress de incumprimento de contraparte.
+  BC-2190.50.10:
+    name: Monitorização de contrapartes de resseguradores
+    description: |
+      Monitorização da solidez financeira e concentração de exposição de resseguradores.
+  BC-2190.50.20:
+    name: Monitorização da adequação de colateral e cartas de crédito
+    description: |
+      Monitorização da adequação de colateral e cartas de crédito de resseguradores.
+  BC-2190.50.30:
+    name: Testes de stress de incumprimento de contraparte
+    description: |
+      Testes de stress dos impactos de incumprimento de ressegurador sobre a solvência.
+  BC-2190.60:
+    name: Gestão do risco de vida e longevidade
+    description: |
+      Monitorização do risco de mortalidade, supervisão da cobertura de risco de longevidade e gestão do risco pandémico.
+  BC-2190.60.10:
+    name: Monitorização do risco de mortalidade
+    description: |
+      Monitorização do risco de mortalidade em portefólios de vida e proteção.
+  BC-2190.60.20:
+    name: Supervisão da cobertura de risco de longevidade
+    description: |
+      Supervisão de instrumentos de cobertura de longevidade e exposição a contrapartes.
+  BC-2190.60.30:
+    name: Gestão do risco pandémico
+    description: |
+      Gestão do risco de mortalidade e morbilidade por pandemia e epidemia.
+  BC-2190.70:
+    name: Gestão do risco de caducidade e persistência
+    description: |
+      Monitorização do risco de caducidade e testes de stress de persistência.
+  BC-2190.70.10:
+    name: Monitorização do risco de caducidade
+    description: |
+      Monitorização de taxas de caducidade e perdas por caducidade em produtos de vida e poupança.
+  BC-2190.70.20:
+    name: Testes de stress de persistência
+    description: |
+      Testes de stress de pressupostos de persistência e comportamento dinâmico de caducidade.
+  BC-2190.80:
+    name: Gestão do risco operacional e de conduta de seguros
+    description: |
+      Risco de conduta de seguros, risco de gestão de sinistros e monitorização do risco de distribuição.
+  BC-2190.80.10:
+    name: Monitorização do risco de conduta de seguros
+    description: |
+      Monitorização de indicadores de risco de conduta em produto, distribuição e sinistros.
+  BC-2190.80.20:
+    name: Supervisão do risco de gestão de sinistros
+    description: |
+      Supervisão do risco de gestão de sinistros e resultados de equidade para tomadores de apólice.
+  BC-2190.80.30:
+    name: Monitorização do risco de distribuição
+    description: |
+      Monitorização do risco de distribuição incluindo venda inadequada e conduta de intermediários.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-insurance-underwriting-management.yaml
+++ b/catalogue/i18n/pt/L1-insurance-underwriting-management.yaml
@@ -1,0 +1,125 @@
+locale: pt
+source: L1-insurance-underwriting-management.yaml
+entries:
+  BC-2130:
+    name: Gestão de subscrição de seguros
+    description: |
+      Avaliação de risco, tarifação, aceitação, recusa e vinculação de
+      candidaturas de seguros nos ramos pessoais, comerciais e de especialidades,
+      incluindo aplicação de autoridade de subscrição e orientação do portefólio.
+  BC-2130.10:
+    name: Receção de risco de subscrição
+    description: |
+      Triagem de submissão, recolha de dados de risco, obtenção de histórico de sinistros e enriquecimento com dados de terceiros.
+  BC-2130.10.10:
+    name: Triagem de submissão
+    description: |
+      Triagem de submissões de subscrição e encaminhamento para equipas de subscrição.
+  BC-2130.10.20:
+    name: Recolha de dados de risco
+    description: |
+      Recolha de dados relevantes para o risco junto do candidato, mediador e fontes de vistoria.
+  BC-2130.10.30:
+    name: Obtenção de histórico de sinistros
+    description: |
+      Obtenção de históricos de sinistros de bureaux, seguradores anteriores e registos partilhados.
+  BC-2130.10.40:
+    name: Enriquecimento com dados de terceiros
+    description: |
+      Enriquecimento de submissões com dados de terceiros, telemática e IoT.
+  BC-2130.20:
+    name: Avaliação e seleção de risco
+    description: |
+      Pontuação de risco, agregação de exposição, vistorias de controlo de perdas e referências de subscrição.
+  BC-2130.20.10:
+    name: Pontuação e modelação de risco
+    description: |
+      Aplicação de modelos de subscrição, scorecards e pontuações de risco de machine learning.
+  BC-2130.20.20:
+    name: Avaliação de agregação de exposição
+    description: |
+      Avaliação da agregação de exposição face ao portefólio em vigor.
+  BC-2130.20.30:
+    name: Coordenação de vistorias de controlo de perdas
+    description: |
+      Coordenação de vistorias de controlo de perdas e relatórios de engenharia de risco.
+  BC-2130.20.40:
+    name: Tratamento de referências de subscrição
+    description: |
+      Tratamento de referências para subscritores seniores, autoridades de linha e resseguradores.
+  BC-2130.30:
+    name: Gestão de tarifação de subscrição
+    description: |
+      Tarifação manual, créditos de tarifação por programa, tarifação por experiência e tarifação especial de especialidades.
+  BC-2130.30.10:
+    name: Aplicação de tarifação manual
+    description: |
+      Aplicação de taxas manuais da configuração de produto registada.
+  BC-2130.30.20:
+    name: Aplicação de créditos de tarifação por programa
+    description: |
+      Aplicação de créditos e débitos de tarifação por programa.
+  BC-2130.30.30:
+    name: Tarifação por experiência
+    description: |
+      Tarifação baseada na experiência utilizando o histórico de sinistros do tomador de apólice.
+  BC-2130.30.40:
+    name: Tarifação especial e por medida
+    description: |
+      Tarifação por medida para riscos de especialidades, grandes contas e complexos.
+  BC-2130.40:
+    name: Decisão de subscrição e gestão de autoridade
+    description: |
+      Decisão de aceitação e recusa, definição de termos e condições, aplicação de autoridade e vinculação.
+  BC-2130.40.10:
+    name: Decisão de aceitação e recusa
+    description: |
+      Decisão sobre aceitação, recusa ou contraproposta de submissões.
+  BC-2130.40.20:
+    name: Definição de termos e condições de cobertura
+    description: |
+      Definição de termos, condições, exclusões e garantias de cobertura.
+  BC-2130.40.30:
+    name: Aplicação de autoridade de subscrição
+    description: |
+      Aplicação de limites de autoridade de subscrição e limiares de referência.
+  BC-2130.40.40:
+    name: Emissão de cotação e vinculação
+    description: |
+      Emissão de cotações vinculantes e confirmação de cobertura.
+  BC-2130.50:
+    name: Gestão do portefólio de subscrição
+    description: |
+      Monitorização do mix e limites do portefólio, análise de rentabilidade e planeamento de ações de subscrição.
+  BC-2130.50.10:
+    name: Monitorização do mix e limites do portefólio
+    description: |
+      Monitorização do mix do portefólio face ao apetite e limites de concentração.
+  BC-2130.50.20:
+    name: Análise de rentabilidade de subscrição
+    description: |
+      Análise da rentabilidade de subscrição por segmento, produto e produtor.
+  BC-2130.50.30:
+    name: Planeamento de ações de subscrição
+    description: |
+      Planeamento de ações de subscrição, remediação e saída de segmentos.
+  BC-2130.60:
+    name: Gestão de fraude e deturpação na subscrição
+    description: |
+      Rastreio de fraude em candidaturas, investigação de deturpação material e relatório de fraude na subscrição.
+  BC-2130.60.10:
+    name: Rastreio de fraude em candidaturas
+    description: |
+      Rastreio de candidaturas de seguros para indicadores de fraude.
+  BC-2130.60.20:
+    name: Investigação de deturpação material
+    description: |
+      Investigação de suspeita de deturpação material em candidaturas.
+  BC-2130.60.30:
+    name: Relatório de fraude na subscrição
+    description: |
+      Relatório de fraude de subscrição confirmada a registos do setor e reguladores.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-intellectual-property-management.yaml
+++ b/catalogue/i18n/pt/L1-intellectual-property-management.yaml
@@ -1,0 +1,103 @@
+locale: pt
+source: L1-intellectual-property-management.yaml
+entries:
+  BC-840:
+    name: Gestão da propriedade intelectual
+    description: |
+      Patentes, marcas, direitos de autor, segredos comerciais e licenciamento.
+  BC-840.10:
+    name: Gestão do portefólio de patentes
+    description: |
+      Estratégia de patentes, registo, manutenção e revisão do portefólio.
+  BC-840.10.10:
+    name: Gestão de divulgação de invenções
+    description: |
+      Captura, avaliação e decisão sobre divulgações de invenções.
+  BC-840.10.20:
+    name: Registo e instrução de patentes
+    description: |
+      Redação, registo e instrução de pedidos de patente.
+  BC-840.10.30:
+    name: Manutenção de patentes
+    description: |
+      Pagamento de anuidades e manutenção de patentes concedidas.
+  BC-840.10.40:
+    name: Revisão do portefólio de patentes
+    description: |
+      Revisão periódica e racionalização do portefólio de patentes.
+  BC-840.20:
+    name: Gestão de marcas
+    description: |
+      Registo de marcas, vigilância e defesa.
+  BC-840.20.10:
+    name: Pesquisa de disponibilidade e registo de marcas
+    description: |
+      Pesquisas de disponibilidade e registos de marcas.
+  BC-840.20.20:
+    name: Vigilância e monitorização de marcas
+    description: |
+      Vigilância de registos e utilizações de marcas conflituantes.
+  BC-840.20.30:
+    name: Gestão de renovação de marcas
+    description: |
+      Renovação e manutenção de registos de marcas.
+  BC-840.30:
+    name: Gestão de direitos de autor e segredos comerciais
+    description: |
+      Ativos protegidos por direitos de autor, segredos comerciais e confidencialidade.
+  BC-840.30.10:
+    name: Registo de ativos com direitos de autor
+    description: |
+      Identificação e registo de ativos passíveis de proteção por direitos de autor.
+  BC-840.30.20:
+    name: Identificação e proteção de segredos comerciais
+    description: |
+      Identificação e proteção de segredos comerciais.
+  BC-840.30.30:
+    name: Gestão de confidencialidade e NDA
+    description: |
+      NDAs, acordos de confidencialidade e controlos de acesso.
+  BC-840.40:
+    name: Gestão de licenciamento de PI
+    description: |
+      Licenciamento de entrada, licenciamento de saída, royalties.
+  BC-840.40.10:
+    name: Negociação de licenciamento de entrada
+    description: |
+      Negociação e execução de licenças de PI de entrada.
+  BC-840.40.20:
+    name: Licenciamento de saída e comercialização
+    description: |
+      Licenciamento de saída de PI e comercialização de patentes.
+  BC-840.40.30:
+    name: Administração de royalties
+    description: |
+      Cálculo, cobrança e pagamento de royalties de PI.
+  BC-840.40.40:
+    name: Licenciamento cruzado e agrupamento
+    description: |
+      Acordos de licenciamento cruzado e participação em pools de patentes.
+  BC-840.50:
+    name: Defesa e aplicação da PI
+    description: |
+      Deteção de infrações, ações de aplicação.
+  BC-840.50.10:
+    name: Monitorização de infrações
+    description: |
+      Monitorização de suspeitas de infrações à PI.
+  BC-840.50.20:
+    name: Ação de aplicação da PI
+    description: |
+      Notificações de cessação, oposições e litígios de aplicação.
+  BC-840.50.30:
+    name: Defesa e reconvenção em PI
+    description: |
+      Defesa contra reclamações de PI e litígios de reconvenção.
+  BC-840.50.40:
+    name: Proteção anti-contrafação e de marca
+    description: |
+      Deteção e remoção de produtos contrafeitos e abuso de marca.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-intelligence-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-intelligence-operations-management.yaml
@@ -1,0 +1,103 @@
+locale: pt
+source: L1-intelligence-operations-management.yaml
+entries:
+  BC-1730:
+    name: Gestão de operações de informações
+    description: |
+      Recolha, análise, disseminação e fusão de informações.
+  BC-1730.10:
+    name: Gestão da recolha de informações
+    description: |
+      Recolha HUMINT, SIGINT, GEOINT, IMINT e OSINT.
+  BC-1730.10.10:
+    name: Gestão dos requisitos de recolha
+    description: |
+      Definição e gestão dos requisitos de recolha de informações.
+  BC-1730.10.20:
+    name: Recolha HUMINT
+    description: |
+      Operações de recolha de informações humanas.
+  BC-1730.10.30:
+    name: Recolha SIGINT
+    description: |
+      Operações de recolha de informações de sinais.
+  BC-1730.10.40:
+    name: Recolha GEOINT e IMINT
+    description: |
+      Recolha de informações geoespaciais e de imagem.
+  BC-1730.10.50:
+    name: Recolha OSINT
+    description: |
+      Recolha e curadoria de informações de fonte aberta.
+  BC-1730.20:
+    name: Gestão de análise de informações
+    description: |
+      Análise de todas as fontes, fusão e produtos de informações.
+  BC-1730.20.10:
+    name: Análise de todas as fontes
+    description: |
+      Análise e avaliação de informações de todas as fontes.
+  BC-1730.20.20:
+    name: Fusão de informações
+    description: |
+      Fusão de dados multi-INT em avaliações integradas.
+  BC-1730.20.30:
+    name: Redação de produtos de informações
+    description: |
+      Redação de produtos e avaliações de informações.
+  BC-1730.20.40:
+    name: Garantia de qualidade de informações
+    description: |
+      Garantia de qualidade sobre os produtos de informações.
+  BC-1730.30:
+    name: Gestão da disseminação de informações
+    description: |
+      Reporte, disseminação e suporte à decisão em informações.
+  BC-1730.30.10:
+    name: Reporte de informações
+    description: |
+      Produção de relatórios e briefings de informações.
+  BC-1730.30.20:
+    name: Controlo de disseminação de informações
+    description: |
+      Controlo da disseminação e aplicação do princípio da necessidade de conhecer.
+  BC-1730.30.30:
+    name: Envolvimento com utilizadores de informações
+    description: |
+      Envolvimento com utilizadores de informações e recolha de feedback.
+  BC-1730.40:
+    name: Gestão de contrainformação
+    description: |
+      CI, ameaça interna e deteção de engano.
+  BC-1730.40.10:
+    name: Operações de contrainformação
+    description: |
+      Operações de contrainformação contra serviços estrangeiros.
+  BC-1730.40.20:
+    name: Programa de ameaça interna
+    description: |
+      Deteção e gestão de ameaças internas.
+  BC-1730.40.30:
+    name: Deteção de engano e negação
+    description: |
+      Deteção de atividade de engano e negação.
+  BC-1730.50:
+    name: Gestão de fontes e métodos de informações
+    description: |
+      Gestão de fontes, proteção de métodos e técnicas de trabalho.
+  BC-1730.50.10:
+    name: Gestão de fontes
+    description: |
+      Gestão e proteção de fontes de informações.
+  BC-1730.50.20:
+    name: Gestão de normas de técnicas de trabalho
+    description: |
+      Manutenção das normas de técnicas de trabalho analíticas (ICD 203).
+  BC-1730.50.30:
+    name: Proteção de métodos
+    description: |
+      Proteção dos métodos de recolha de informações.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-internal-audit-management.yaml
+++ b/catalogue/i18n/pt/L1-internal-audit-management.yaml
@@ -1,0 +1,79 @@
+locale: pt
+source: L1-internal-audit-management.yaml
+entries:
+  BC-140:
+    name: Gestão da auditoria interna
+    description: |
+      Garantia independente sobre a eficácia da governação, risco e controlo.
+  BC-140.10:
+    name: Gestão do planeamento de auditoria
+    description: |
+      Planeamento de auditoria baseado no risco e gestão do universo de auditoria.
+  BC-140.10.10:
+    name: Gestão do universo de auditoria
+    description: |
+      Definição e manutenção do universo auditável e classificações de risco.
+  BC-140.10.20:
+    name: Desenvolvimento do plano anual baseado no risco
+    description: |
+      Plano anual de auditoria priorizado por risco e alocação de recursos.
+  BC-140.10.30:
+    name: Definição do âmbito de trabalhos de auditoria
+    description: |
+      Objetivos, âmbito, critérios e design do programa de cada trabalho.
+  BC-140.20:
+    name: Gestão da execução de auditoria
+    description: |
+      Trabalho de campo, recolha de evidências e reporte de auditoria.
+  BC-140.20.10:
+    name: Trabalho de campo de auditoria
+    description: |
+      Walkthrough, teste de controlos e recolha de evidências.
+  BC-140.20.20:
+    name: Gestão de papéis de trabalho de auditoria
+    description: |
+      Documentação de evidências, conclusões e revisão supervisora.
+  BC-140.20.30:
+    name: Reporte de auditoria
+    description: |
+      Elaboração, clearance e emissão de relatórios e pareceres de auditoria.
+  BC-140.20.40:
+    name: Auditoria contínua e baseada em dados
+    description: |
+      Utilização de análise de dados e monitorização contínua nos trabalhos de auditoria.
+  BC-140.30:
+    name: Gestão de constatações e remediação de auditoria
+    description: |
+      Acompanhamento de constatações, ações de gestão e seguimento.
+  BC-140.30.10:
+    name: Registo e classificação de constatações
+    description: |
+      Registo e classificação padronizados de constatações de auditoria.
+  BC-140.30.20:
+    name: Acompanhamento de ações de gestão
+    description: |
+      Acompanhamento das ações de gestão acordadas até ao seu encerramento.
+  BC-140.30.30:
+    name: Validação da remediação
+    description: |
+      Validação independente da eficácia da remediação.
+  BC-140.40:
+    name: Garantia de qualidade da auditoria
+    description: |
+      Garantia de qualidade sobre a metodologia e execução da auditoria.
+  BC-140.40.10:
+    name: Gestão da metodologia de auditoria
+    description: |
+      Manutenção da metodologia de auditoria alinhada com as Normas do IIA.
+  BC-140.40.20:
+    name: Revisões de qualidade internas
+    description: |
+      Revisões periódicas internas de qualidade dos trabalhos de auditoria.
+  BC-140.40.30:
+    name: Avaliação de qualidade externa
+    description: |
+      Avaliações externas de qualidade e conformidade com normas profissionais.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-inventory-management.yaml
+++ b/catalogue/i18n/pt/L1-inventory-management.yaml
@@ -1,0 +1,95 @@
+locale: pt
+source: L1-inventory-management.yaml
+entries:
+  BC-530:
+    name: Gestão de inventário
+    description: |
+      Níveis de stock, reaprovisionamento e alocação em toda a rede de abastecimento.
+  BC-530.10:
+    name: Gestão dos níveis de stock
+    description: |
+      Níveis de stock alvo, stock de segurança e pontos de reaprovisionamento.
+  BC-530.10.10:
+    name: Definição de stock alvo e stock de segurança
+    description: |
+      Definição de níveis de stock alvo e stock de segurança por SKU e localização.
+  BC-530.10.20:
+    name: Gestão de ponto de reaprovisionamento e min/max
+    description: |
+      Pontos de reaprovisionamento e políticas de stock mínimo e máximo.
+  BC-530.10.30:
+    name: Otimização do nível de serviço
+    description: |
+      Otimização do trade-off entre nível de serviço e custo de inventário.
+  BC-530.10.40:
+    name: Segmentação de inventário e análise ABC
+    description: |
+      Segmentação ABC/XYZ para diferenciar a política de inventário.
+  BC-530.20:
+    name: Gestão de reaprovisionamento
+    description: |
+      Políticas de reaprovisionamento e reaprovisionamento automatizado.
+  BC-530.20.10:
+    name: Definição da política de reaprovisionamento
+    description: |
+      Definição de políticas de reaprovisionamento (push, pull, kanban).
+  BC-530.20.20:
+    name: Execução de reaprovisionamento automatizado
+    description: |
+      Execução de ordens de reaprovisionamento automatizadas para nós de abastecimento.
+  BC-530.20.30:
+    name: Operações de inventário gerido pelo fornecedor
+    description: |
+      Arranjos de VMI e stock em consignação com fornecedores.
+  BC-530.30:
+    name: Gestão da alocação de inventário
+    description: |
+      Alocação em toda a rede e reservas.
+  BC-530.30.10:
+    name: Alocação em toda a rede
+    description: |
+      Alocação de inventário disponível em centros de distribuição, lojas e canais.
+  BC-530.30.20:
+    name: Reservas de clientes e encomendas
+    description: |
+      Reserva de inventário face a encomendas ou contas de clientes.
+  BC-530.30.30:
+    name: Reequilíbrio de inventário
+    description: |
+      Reequilíbrio de stock entre localizações para corresponder à procura.
+  BC-530.40:
+    name: Gestão da exatidão do inventário
+    description: |
+      Contagens cíclicas, inventário físico e resolução de discrepâncias.
+  BC-530.40.10:
+    name: Contagem cíclica
+    description: |
+      Programas de contagem cíclica por frequência e classificação ABC.
+  BC-530.40.20:
+    name: Contagem física de inventário
+    description: |
+      Programas de contagem física completa do inventário anual ou periódica.
+  BC-530.40.30:
+    name: Investigação e ajuste de discrepâncias
+    description: |
+      Investigação, causa raiz e ajuste de discrepâncias de inventário.
+  BC-530.50:
+    name: Gestão de stock de movimento lento e obsoleto
+    description: |
+      Identificação de SLOB, abate e disposição.
+  BC-530.50.10:
+    name: Identificação de stock de movimento lento
+    description: |
+      Identificação e envelhecimento de stock de movimento lento e obsoleto.
+  BC-530.50.20:
+    name: Provisionamento e abate de stock
+    description: |
+      Provisionamento, imparidade e abate de stock obsoleto.
+  BC-530.50.30:
+    name: Disposição de inventário
+    description: |
+      Disposição de stock obsoleto por liquidação ou sucata.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-investor-relations-management.yaml
+++ b/catalogue/i18n/pt/L1-investor-relations-management.yaml
@@ -1,0 +1,83 @@
+locale: pt
+source: L1-investor-relations-management.yaml
+entries:
+  BC-240:
+    name: Gestão de relações com investidores
+    description: |
+      Comunicações com acionistas, analistas e mercados de capitais.
+  BC-240.10:
+    name: Comunicação com os mercados de capitais
+    description: |
+      Estratégia de relações com investidores, equity story e dias dos mercados de capitais.
+  BC-240.10.10:
+    name: Estratégia de relações com investidores e equity story
+    description: |
+      Definição da estratégia de relações com investidores e da equity story.
+  BC-240.10.20:
+    name: Gestão do dia dos mercados de capitais
+    description: |
+      Planeamento e execução de dias dos mercados de capitais e eventos para investidores.
+  BC-240.10.30:
+    name: Gestão de divulgações de relações com investidores
+    description: |
+      Controlos de divulgação, fair disclosure e comunicação de eventos materiais.
+  BC-240.10.40:
+    name: Comunicação de ESG e sustentabilidade
+    description: |
+      Narrativa de ESG para mercados de capitais e relacionamento com agências de rating.
+  BC-240.20:
+    name: Gestão do ciclo de resultados
+    description: |
+      Comunicados de resultados trimestrais, conference calls e transcrições.
+  BC-240.20.10:
+    name: Preparação do comunicado de resultados
+    description: |
+      Elaboração e emissão de comunicados de imprensa sobre resultados.
+  BC-240.20.20:
+    name: Gestão da conference call de resultados
+    description: |
+      Guiões, preparação de Q&A e execução de calls com analistas.
+  BC-240.20.30:
+    name: Gestão de consenso e guidance
+    description: |
+      Acompanhamento de estimativas de consenso e fornecimento de guidance.
+  BC-240.30:
+    name: Gestão do relacionamento com acionistas
+    description: |
+      Assembleia geral, reuniões com acionistas e divulgação a investidores de retalho.
+  BC-240.30.10:
+    name: Relacionamento com investidores institucionais
+    description: |
+      Roadshows, reuniões individuais e diálogo contínuo com investidores institucionais.
+  BC-240.30.20:
+    name: Relacionamento com acionistas de retalho
+    description: |
+      Comunicações e programas de contacto com acionistas de retalho.
+  BC-240.30.30:
+    name: Coordenação da assembleia geral anual
+    description: |
+      Contribuição da área de relações com investidores para a logística, materiais e Q&A da assembleia geral.
+  BC-240.30.40:
+    name: Relacionamento com consultores de proxy e de governação
+    description: |
+      Relacionamento com consultores de proxy e investidores focados em governação.
+  BC-240.40:
+    name: Gestão do relacionamento com analistas
+    description: |
+      Relacionamento com analistas do lado da venda e da compra.
+  BC-240.40.10:
+    name: Gestão da cobertura de analistas do lado da venda
+    description: |
+      Desenvolvimento de cobertura, revisões de modelos e relacionamento com analistas sell-side.
+  BC-240.40.20:
+    name: Identificação de investidores buy-side
+    description: |
+      Identificação e targeting de investidores buy-side.
+  BC-240.40.30:
+    name: Estudos de perceção de investidores
+    description: |
+      Estudos de perceção e inquéritos de feedback junto da base de investidores.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-justice-court-administration-management.yaml
+++ b/catalogue/i18n/pt/L1-justice-court-administration-management.yaml
@@ -1,0 +1,174 @@
+locale: pt
+source: L1-justice-court-administration-management.yaml
+entries:
+  BC-3320:
+    name: Gestão da justiça e administração judicial
+    description: |
+      Administração judicial, incluindo apresentação de processos, gestão de
+      agenda e calendarização, operações de audiências e julgamentos, execução
+      de sentenças e decisões, correções e custódia, liberdade condicional e
+      liberdade antecipada, e acesso a registos judiciais.
+  BC-3320.10:
+    name: Apresentação e iniciação de processos
+    description: |
+      Apresentação de processos cíveis, penais, de família e administrativos,
+      incluindo submissão eletrónica, avaliação de custas e classificação inicial.
+    in_scope:
+      - Apresentação de processos cíveis e penais
+      - Submissão eletrónica e receção de documentos
+      - Avaliação de custas judiciais
+    out_of_scope:
+      - Apreciação de impugnações de concursos públicos (coberta pela Gestão de Contratação Pública)
+  BC-3320.10.10:
+    name: Iniciação do processo
+    description: |
+      Receção de queixas, acusações e documentos iniciais para abertura de
+      processos.
+  BC-3320.10.20:
+    name: Submissão eletrónica de documentos judiciais
+    description: |
+      Submissão eletrónica de documentos judiciais pelas partes e mandatários.
+  BC-3320.10.30:
+    name: Classificação e numeração de processos
+    description: |
+      Classificação de processos por tipo, secção e atribuição de números de
+      processo.
+  BC-3320.10.40:
+    name: Avaliação de custas judiciais
+    description: |
+      Avaliação, cobrança e dispensa de custas de apresentação e requerimentos.
+  BC-3320.20:
+    name: Gestão de agenda e calendarização judicial
+    description: |
+      Manutenção da agenda dos tribunais, calendarização e distribuição judicial
+      de processos, audiências e julgamentos.
+  BC-3320.20.10:
+    name: Manutenção de agenda
+    description: |
+      Manutenção da agenda geral e de secção e cronologia de atos processuais.
+  BC-3320.20.20:
+    name: Agendamento de audiências e julgamentos
+    description: |
+      Agendamento de audiências, julgamentos e calendários de requerimentos em
+      tribunais e juízes.
+  BC-3320.20.30:
+    name: Distribuição judicial
+    description: |
+      Distribuição de processos a juízes e rotação entre secções.
+  BC-3320.20.40:
+    name: Tratamento de adiamentos e adiamentos
+    description: |
+      Tratamento de pedidos de adiamento e reagendamento.
+  BC-3320.30:
+    name: Operações de audiências e julgamentos
+    description: |
+      Apoio operacional a audiências e julgamentos, incluindo gestão de jurados,
+      logística de sala de audiências e interpretação.
+  BC-3320.30.10:
+    name: Gestão de jurados
+    description: |
+      Convocação, qualificação, seleção e administração do serviço de jurados.
+  BC-3320.30.20:
+    name: Operações de sala de audiências
+    description: |
+      Logística de sala de audiências, coordenação de segurança e gravação
+      audiovisual.
+  BC-3320.30.30:
+    name: Serviços de interpretação judicial
+    description: |
+      Prestação de serviços de interpretação e tradução judicial.
+  BC-3320.30.40:
+    name: Apoio a testemunhas e vítimas
+    description: |
+      Serviços de apoio a testemunhas e vítimas e coordenação de medidas
+      especiais.
+  BC-3320.40:
+    name: Execução de sentenças e decisões
+    description: |
+      Registo de sentenças e acórdãos, coimas e indemnizações e execução de
+      decisões judiciais.
+  BC-3320.40.10:
+    name: Registo de sentenças e acórdãos
+    description: |
+      Registo de sentenças, condenações e decisões dispositivas.
+  BC-3320.40.20:
+    name: Administração de coimas e indemnizações
+    description: |
+      Administração de coimas, ordens de indemnização e compensação a vítimas.
+  BC-3320.40.30:
+    name: Execução de sentenças cíveis
+    description: |
+      Execução de sentenças cíveis por meio de mandados, penhoras e apreensões.
+  BC-3320.40.40:
+    name: Emissão de mandados judiciais
+    description: |
+      Emissão de mandados de detenção, de condução e de busca por autoridade
+      judicial.
+  BC-3320.50:
+    name: Administração de correções e custódia
+    description: |
+      Administração da custódia de detidos preventivos e condenados em estabelecimentos
+      prisionais.
+  BC-3320.50.10:
+    name: Receção e registo de reclusos
+    description: |
+      Receção, registo e classificação de risco de reclusos na entrada em custódia.
+  BC-3320.50.20:
+    name: Operações de custódia
+    description: |
+      Operações diárias de custódia, incluindo gestão populacional e movimentos.
+  BC-3320.50.30:
+    name: Coordenação de cuidados de saúde a reclusos
+    description: |
+      Coordenação de cuidados de saúde, saúde mental e serviços de adição a
+      reclusos.
+  BC-3320.50.40:
+    name: Programas de reabilitação de reclusos
+    description: |
+      Administração de programas de educação, formação profissional e reabilitação
+      em custódia.
+  BC-3320.60:
+    name: Gestão de liberdade condicional e antecipada
+    description: |
+      Supervisão comunitária de condenados em liberdade condicional, liberdade
+      antecipada e liberdade com condições.
+  BC-3320.60.10:
+    name: Investigação pré-sentencial
+    description: |
+      Relatórios de investigação pré-sentencial e avaliações de risco-necessidade
+      para o tribunal.
+  BC-3320.60.20:
+    name: Supervisão comunitária
+    description: |
+      Supervisão diária de condenados na comunidade.
+  BC-3320.60.30:
+    name: Administração de audiências do conselho de liberdade condicional
+    description: |
+      Administração de audiências do conselho de liberdade condicional e decisões
+      de libertação condicional.
+  BC-3320.60.40:
+    name: Tratamento de violações e revogações
+    description: |
+      Tratamento de violações de supervisão e processos de revogação.
+  BC-3320.70:
+    name: Registos judiciais e acesso público
+    description: |
+      Manutenção dos registos judiciais e prestação de acesso público sujeito a
+      sigilo, redação e restrições legais.
+  BC-3320.70.10:
+    name: Manutenção de registos judiciais
+    description: |
+      Manutenção dos registos judiciais e processos autorizados.
+  BC-3320.70.20:
+    name: Acesso público e serviços equivalentes ao PACER
+    description: |
+      Prestação de acesso público a registos judiciais através de serviços
+      equivalentes ao PACER.
+  BC-3320.70.30:
+    name: Sigilo e expurgação de registos
+    description: |
+      Processamento de ordens de sigilo, expurgação e supressão de registos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-knowledge-management.yaml
+++ b/catalogue/i18n/pt/L1-knowledge-management.yaml
@@ -1,0 +1,75 @@
+locale: pt
+source: L1-knowledge-management.yaml
+entries:
+  BC-830:
+    name: Gestão do conhecimento
+    description: |
+      Captura, curadoria e partilha do conhecimento organizacional.
+  BC-830.10:
+    name: Gestão da captura do conhecimento
+    description: |
+      Captura de especialistas, projetos e lições aprendidas.
+  BC-830.10.10:
+    name: Elicitação do conhecimento tácito
+    description: |
+      Elicitação do conhecimento tácito de especialistas através de entrevistas e acompanhamento.
+  BC-830.10.20:
+    name: Captura de lições aprendidas
+    description: |
+      Captura de lições aprendidas em projetos e operações.
+  BC-830.10.30:
+    name: Elaboração de ativos de conhecimento
+    description: |
+      Elaboração de artigos, manuais de procedimentos e ativos processuais.
+  BC-830.20:
+    name: Gestão de curadoria e taxonomia do conhecimento
+    description: |
+      Taxonomias, ontologias, curadoria de conteúdo.
+  BC-830.20.10:
+    name: Gestão de taxonomia e ontologia
+    description: |
+      Manutenção de taxonomias, ontologias e esquemas de metadados.
+  BC-830.20.20:
+    name: Curadoria e revisão de conteúdo
+    description: |
+      Ciclos de curadoria e revisões de atualidade do conteúdo de conhecimento.
+  BC-830.20.30:
+    name: Gestão de pesquisa e descoberta
+    description: |
+      Pesquisa empresarial e experiências de descoberta de conteúdo.
+  BC-830.30:
+    name: Gestão da partilha e colaboração do conhecimento
+    description: |
+      Comunidades de prática, plataformas de colaboração.
+  BC-830.30.10:
+    name: Operações da comunidade de prática
+    description: |
+      Gestão e operação de comunidades de prática.
+  BC-830.30.20:
+    name: Gestão da plataforma de colaboração
+    description: |
+      Operação de plataformas de colaboração e intranet para partilha de conhecimento.
+  BC-830.30.30:
+    name: Eventos e fóruns de conhecimento
+    description: |
+      Eventos internos, sessões informais e fóruns de aprendizagem.
+  BC-830.40:
+    name: Gestão de boas práticas
+    description: |
+      Identificação, codificação e disseminação de boas práticas.
+  BC-830.40.10:
+    name: Identificação de boas práticas
+    description: |
+      Identificação de boas práticas internas e externas.
+  BC-830.40.20:
+    name: Codificação de boas práticas
+    description: |
+      Codificação de boas práticas em ativos reutilizáveis e normas.
+  BC-830.40.30:
+    name: Disseminação de boas práticas
+    description: |
+      Disseminação, formação e apoio à adoção de boas práticas.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-legal-management.yaml
+++ b/catalogue/i18n/pt/L1-legal-management.yaml
@@ -1,0 +1,111 @@
+locale: pt
+source: L1-legal-management.yaml
+entries:
+  BC-150:
+    name: Gestão jurídica
+    description: |
+      Consultoria jurídica, contratos, litígios e assuntos jurídicos corporativos.
+  BC-150.10:
+    name: Gestão de contratos
+    description: |
+      Ciclo de vida contratual desde a elaboração até ao encerramento.
+  BC-150.10.10:
+    name: Elaboração de contratos e modelos
+    description: |
+      Manutenção de bibliotecas de cláusulas, modelos e playbooks.
+  BC-150.10.20:
+    name: Apoio à negociação de contratos
+    description: |
+      Apoio jurídico à negociação, redline e posição de risco.
+  BC-150.10.30:
+    name: Gestão da execução de contratos
+    description: |
+      Fluxos de aprovação, assinatura e controlo de execução.
+  BC-150.10.40:
+    name: Repositório de contratos e acompanhamento de obrigações
+    description: |
+      Repositório central, datas-chave e monitorização de obrigações.
+  BC-150.10.50:
+    name: Renovação e rescisão de contratos
+    description: |
+      Administração de renovações, alterações e rescisões.
+  BC-150.20:
+    name: Gestão de litígios e disputas
+    description: |
+      Disputas, litígios e arbitragem.
+  BC-150.20.10:
+    name: Tratamento de disputas pré-contencioso
+    description: |
+      Cartas de notificação, mediação e negociação pré-contencioso.
+  BC-150.20.20:
+    name: Gestão de processos de litigância
+    description: |
+      Gestão ponta a ponta de processos judiciais.
+  BC-150.20.30:
+    name: Arbitragem e resolução alternativa de litígios
+    description: |
+      Arbitragem, mediação e outros mecanismos de RAL.
+  BC-150.20.40:
+    name: Preservação legal e ediscovery
+    description: |
+      Avisos de preservação legal, conservação e descoberta eletrónica.
+  BC-150.30:
+    name: Direito societário e comercial
+    description: |
+      Direito societário, apoio jurídico a fusões e aquisições e transações comerciais.
+  BC-150.30.10:
+    name: Consultoria em direito societário
+    description: |
+      Aconselhamento em direito societário, governação e estruturação de entidades.
+  BC-150.30.20:
+    name: Apoio jurídico a fusões e aquisições
+    description: |
+      Due diligence jurídica, documentação de transações e fecho.
+  BC-150.30.30:
+    name: Consultoria em transações comerciais
+    description: |
+      Apoio jurídico a negócios comerciais, parcerias e licenciamento.
+  BC-150.30.40:
+    name: Consultoria jurídica em valores mobiliários e mercados de capitais
+    description: |
+      Direito dos valores mobiliários, cotação e transações nos mercados de capitais.
+  BC-150.40:
+    name: Assuntos jurídicos regulatórios
+    description: |
+      Interpretação jurídica de regulamentos e relacionamento regulatório.
+  BC-150.40.10:
+    name: Interpretação jurídica regulatória
+    description: |
+      Pareceres jurídicos sobre aplicabilidade e interpretação de regulamentos.
+  BC-150.40.20:
+    name: Ligação com reguladores e submissões
+    description: |
+      Apoio jurídico às interações com reguladores e submissões formais.
+  BC-150.40.30:
+    name: Apoio jurídico a assuntos governamentais e públicos
+    description: |
+      Apoio jurídico ao lobbying, consultas públicas e advocacia política.
+  BC-150.50:
+    name: Gestão de operações jurídicas
+    description: |
+      Operações do departamento jurídico, faturação eletrónica e gestão de processos.
+  BC-150.50.10:
+    name: Gestão de processos
+    description: |
+      Receção, alocação e acompanhamento do ciclo de vida dos processos.
+  BC-150.50.20:
+    name: Gestão de assessores externos
+    description: |
+      Gestão do painel, contratação e desempenho dos advogados externos.
+  BC-150.50.30:
+    name: Despesas jurídicas e faturação eletrónica
+    description: |
+      Orçamentação jurídica, faturação eletrónica e análise de despesas.
+  BC-150.50.40:
+    name: Gestão do conhecimento jurídico
+    description: |
+      Precedentes, know-how e capacitação tecnológica jurídica.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-legislative-regulatory-drafting-management.yaml
+++ b/catalogue/i18n/pt/L1-legislative-regulatory-drafting-management.yaml
@@ -1,0 +1,138 @@
+locale: pt
+source: L1-legislative-regulatory-drafting-management.yaml
+entries:
+  BC-3210:
+    name: Gestão de redação legislativa e regulatória
+    description: |
+      Redacção, revisão jurídica, avaliação de impacto, coordenação do processo
+      parlamentar ou legislativo e codificação de legislação primária, regulamentos
+      secundários, instrumentos estatutários e decretos executivos.
+  BC-3210.10:
+    name: Redacção legislativa
+    description: |
+      Redacção de legislação primária, projectos de lei e emendas por consultores
+      parlamentares ou redactores legislativos.
+    in_scope:
+      - Redacção de projectos de lei e emendas
+      - Gestão de instruções de redacção
+      - Redacção em linguagem simples e bilingue
+    out_of_scope:
+      - Regulamentos e instrumentos estatutários (abrangidos pela Redação Regulatória)
+  BC-3210.10.10:
+    name: Recepção de instruções de redacção
+    description: |
+      Recepção e clarificação de instruções de redacção dos patrocinadores políticos
+      e ministeriais.
+  BC-3210.10.20:
+    name: Redacção de projectos de lei e emendas
+    description: |
+      Redacção de projectos de lei, emendas e disposições consequentes.
+  BC-3210.10.30:
+    name: Revisão de qualidade da redacção
+    description: |
+      Revisão por advogado sénior da legislação rascunho quanto à clareza,
+      coerência e efeito.
+  BC-3210.20:
+    name: Redacção regulatória
+    description: |
+      Redacção de regulamentos secundários, instrumentos estatutários, decretos
+      executivos e regras administrativas.
+  BC-3210.20.10:
+    name: Redacção de regulamentos e instrumentos estatutários
+    description: |
+      Redacção de regulamentos e instrumentos estatutários ao abrigo da legislação
+      habilitante.
+  BC-3210.20.20:
+    name: Redacção de decretos executivos
+    description: |
+      Redacção de decretos executivos, decretos-lei e proclamações.
+  BC-3210.20.30:
+    name: Redacção de regras administrativas
+    description: |
+      Redacção de regras e avisos administrativos de agências.
+  BC-3210.30:
+    name: Revisão jurídica e conformidade constitucional
+    description: |
+      Verificação jurídica de instrumentos rascunho para conformidade
+      constitucional, de direitos humanos e de direito internacional.
+  BC-3210.30.10:
+    name: Revisão de conformidade constitucional
+    description: |
+      Revisão de rascunhos face a poderes, direitos e limitações constitucionais.
+  BC-3210.30.20:
+    name: Avaliação de compatibilidade com direitos humanos
+    description: |
+      Avaliação da compatibilidade com tratados e cartas de direitos humanos.
+  BC-3210.30.30:
+    name: Revisão de conformidade com o direito internacional
+    description: |
+      Revisão de rascunhos quanto à conformidade com obrigações de tratados e
+      supranacionais.
+  BC-3210.40:
+    name: Avaliação de impacto regulatório
+    description: |
+      Avaliação dos custos, benefícios e efeitos distributivos esperados dos
+      instrumentos propostos segundo os princípios de melhor regulação da OCDE.
+  BC-3210.40.10:
+    name: Delimitação do impacto
+    description: |
+      Delimitação de avaliações de impacto regulatório e determinação da
+      proporcionalidade.
+  BC-3210.40.20:
+    name: Análise custo-benefício
+    description: |
+      Quantificação de custos e benefícios regulatórios, incluindo encargos de
+      conformidade.
+  BC-3210.40.30:
+    name: Teste de pequenas empresas e PME
+    description: |
+      Avaliação de impactos desproporcionados sobre pequenas empresas e PME.
+  BC-3210.40.40:
+    name: Publicação da avaliação de impacto
+    description: |
+      Publicação de avaliações de impacto juntamente com o instrumento e evidências
+      de suporte.
+  BC-3210.50:
+    name: Coordenação do processo legislativo
+    description: |
+      Coordenação da passagem parlamentar ou legislativa de projectos de lei,
+      incluindo evidências em comissão, emendas e sanção régia ou promulgação.
+  BC-3210.50.10:
+    name: Ligação parlamentar
+    description: |
+      Ligação com órgãos parlamentares ou legislativos sobre projectos de lei do
+      governo.
+  BC-3210.50.20:
+    name: Preparação de evidências em comissão
+    description: |
+      Preparação de evidências, briefings e testemunhas para comissões legislativas.
+  BC-3210.50.30:
+    name: Acompanhamento de emendas
+    description: |
+      Acompanhamento e avaliação de emendas legislativas ao longo das fases.
+  BC-3210.50.40:
+    name: Coordenação de promulgação e sanção régia
+    description: |
+      Coordenação da promulgação final, sanção régia ou assinatura executiva.
+  BC-3210.60:
+    name: Codificação e publicação jurídica
+    description: |
+      Compilação, consolidação, publicação no diário oficial e manutenção de textos
+      legislativos e regulatórios.
+  BC-3210.60.10:
+    name: Publicação no diário oficial
+    description: |
+      Publicação de instrumentos promulgados no diário oficial ou jornal.
+  BC-3210.60.20:
+    name: Consolidação e codificação
+    description: |
+      Consolidação de emendas e codificação em códigos legislativos.
+  BC-3210.60.30:
+    name: Manutenção de textos jurídicos
+    description: |
+      Manutenção contínua e publicação em formato legível por máquina de textos
+      legislativos e regulatórios.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-livestock-production-management.yaml
+++ b/catalogue/i18n/pt/L1-livestock-production-management.yaml
@@ -1,0 +1,198 @@
+locale: pt
+source: L1-livestock-production-management.yaml
+entries:
+  BC-3510:
+    name: Gestão da produção pecuária
+    description: |
+      Produção de pecuária terrestre na exploração agrícola — planeamento de
+      rebanhos e bandos, reprodução, nutrição, saúde animal, bem-estar,
+      parturição, registo de crescimento e prontidão para abate em bovinos,
+      ovinos, suínos e aves.
+  BC-3510.10:
+    name: Planeamento de rebanhos e bandos
+    description: |
+      Planeamento de efetivo, substituição e ciclo de produção nas diferentes
+      espécies.
+  BC-3510.10.10:
+    name: Planeamento de carga animal
+    description: |
+      Decisões de carga animal adequadas à disponibilidade de forragem e
+      capacidade de suporte.
+  BC-3510.10.20:
+    name: Planeamento de animais de substituição
+    description: |
+      Planeamento da taxa de substituição de reprodutores e bandos de postura.
+  BC-3510.10.30:
+    name: Planeamento do ciclo de produção
+    description: |
+      Planeamento calendário dos ciclos de produção, incluindo parições em lotes
+      e épocas de parto sazonais.
+  BC-3510.20:
+    name: Gestão da reprodução animal
+    description: |
+      Seleção genética, acasalamento, inseminação, registo de pedigree e
+      acompanhamento do desempenho reprodutivo.
+    in_scope:
+      - Decisões de seleção genética e de características
+      - Acasalamento natural e inseminação artificial
+      - Registo de pedigree e parentalidade
+      - Avaliação de valor de reprodução
+  BC-3510.20.10:
+    name: Decisões de seleção genética
+    description: |
+      Seleção de reprodutores com base em valores de reprodução estimados e
+      metas de características.
+  BC-3510.20.20:
+    name: Operações de acasalamento e inseminação
+    description: |
+      Operações de acasalamento natural, inseminação artificial e transferência
+      de embriões.
+  BC-3510.20.30:
+    name: Registo de pedigree e parentalidade
+    description: |
+      Registo de pedigree, parentalidade e inscrições no livro genealógico.
+  BC-3510.20.40:
+    name: Avaliação do desempenho reprodutivo
+    description: |
+      Avaliação do desempenho reprodutivo e atualização de valores de reprodução.
+  BC-3510.30:
+    name: Gestão da nutrição animal
+    description: |
+      Formulação de rações, distribuição de alimentos, gestão de pastagem e
+      acompanhamento da conversão alimentar nas diferentes classes pecuárias.
+  BC-3510.30.10:
+    name: Formulação de rações
+    description: |
+      Formulação de rações de menor custo face às necessidades da espécie e
+      estádio produtivo.
+  BC-3510.30.20:
+    name: Distribuição de alimentos
+    description: |
+      Distribuição diária de alimentos, mistura e entrega a parques, abrigos e
+      prados.
+  BC-3510.30.30:
+    name: Gestão de pastagem
+    description: |
+      Gestão de pastoreio rotacional e contínuo e monitorização do resíduo de
+      pastagem.
+  BC-3510.30.40:
+    name: Acompanhamento da conversão alimentar
+    description: |
+      Acompanhamento das métricas de conversão alimentar e ganho médio diário.
+  BC-3510.40:
+    name: Gestão da saúde animal
+    description: |
+      Tratamento veterinário, vacinação, controlo de parasitas, vigilância de
+      doenças e gestão de intervalos de segurança.
+    in_scope:
+      - Registos de tratamentos veterinários
+      - Programas de vacinação e controlo de parasitas
+      - Vigilância de doenças de declaração obrigatória
+      - Acompanhamento de intervalos de segurança de medicamentos
+    out_of_scope:
+      - Auditorias de bem-estar animal (BC-3510.50)
+      - Monitorização de resíduos de LMR (BC-3590.50)
+  BC-3510.40.10:
+    name: Registos de tratamentos veterinários
+    description: |
+      Registo de tratamentos veterinários, prescrições e resultados.
+  BC-3510.40.20:
+    name: Execução de programas de vacinação
+    description: |
+      Execução de programas de vacinação de rebanhos e bandos.
+  BC-3510.40.30:
+    name: Programas de controlo de parasitas
+    description: |
+      Programas de controlo de parasitas internos e externos e gestão da
+      resistência.
+  BC-3510.40.40:
+    name: Vigilância e reporte de doenças
+    description: |
+      Vigilância e reporte estatutário de doenças de declaração obrigatória e
+      zoonoses.
+  BC-3510.40.50:
+    name: Gestão de intervalos de segurança
+    description: |
+      Acompanhamento de intervalos de segurança de medicamentos veterinários e
+      aditivos alimentares.
+  BC-3510.50:
+    name: Gestão do bem-estar animal
+    description: |
+      Práticas diárias de bem-estar que abrangem alojamento, maneio e
+      monitorização do bem-estar face a normas de certificação.
+  BC-3510.50.10:
+    name: Condições de alojamento e densidade animal
+    description: |
+      Gestão de alojamento, ventilação e densidade animal para as diferentes
+      classes pecuárias.
+  BC-3510.50.20:
+    name: Normas de práticas de maneio
+    description: |
+      Normas de práticas de maneio de baixo stress e de tratador de animais.
+  BC-3510.50.30:
+    name: Monitorização de resultados de bem-estar
+    description: |
+      Medição de resultados de bem-estar e revisões de bem-estar na exploração.
+  BC-3510.60:
+    name: Operações de reprodução e parturição
+    description: |
+      Operações de deteção de cio, parturição e cuidados neonatais em bovinos,
+      ovinos, suínos e aves.
+  BC-3510.60.10:
+    name: Operações de deteção de cio
+    description: |
+      Deteção de cio por observação, sensores e programas de sincronização.
+  BC-3510.60.20:
+    name: Operações de parturição
+    description: |
+      Operações de parto em bovinos, ovinos, suínos e eclosão em aves e
+      assistência.
+  BC-3510.60.30:
+    name: Operações de cuidados neonatais
+    description: |
+      Nutrição neonatal, gestão de colostro e cuidados em fases iniciais de vida.
+  BC-3510.70:
+    name: Registo de crescimento e desempenho produtivo
+    description: |
+      Registo do crescimento e do desempenho em leite, ovos e carcaça para
+      decisões de produção e reprodução.
+  BC-3510.70.10:
+    name: Registo de ganho de peso
+    description: |
+      Pesagem periódica e registo de ganho médio diário.
+  BC-3510.70.20:
+    name: Registo de produção de leite
+    description: |
+      Registo de produção e composição de leite por vaca e em tanque de recolha.
+  BC-3510.70.30:
+    name: Registo de produção de ovos
+    description: |
+      Registo diário de produção de ovos por aviário e bando.
+  BC-3510.70.40:
+    name: Acompanhamento do desempenho de carcaça
+    description: |
+      Acompanhamento do rendimento de carcaça, classificação e desempenho de
+      peças primárias.
+  BC-3510.80:
+    name: Prontidão para abate e expedição
+    description: |
+      Seleção de animais acabados e coordenação da expedição para matadouros,
+      incluindo documentação de movimentos.
+  BC-3510.80.10:
+    name: Seleção pré-abate
+    description: |
+      Seleção de animais acabados face a especificações de peso, gordura e
+      contrato.
+  BC-3510.80.20:
+    name: Documentação de movimentos de animais
+    description: |
+      Documentação de movimentos e transferências de informação sobre a cadeia
+      alimentar.
+  BC-3510.80.30:
+    name: Coordenação da expedição para matadouro
+    description: |
+      Coordenação do despacho e transporte da exploração para o matadouro.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-manufacturing-engineering-management.yaml
+++ b/catalogue/i18n/pt/L1-manufacturing-engineering-management.yaml
@@ -1,0 +1,119 @@
+locale: pt
+source: L1-manufacturing-engineering-management.yaml
+entries:
+  BC-1020:
+    name: Gestão da engenharia de fabricação
+    description: |
+      Engenharia de processos, ferramentas, design de equipamentos e industrialização.
+  BC-1020.10:
+    name: Gestão da engenharia do processo de produção
+    description: |
+      Design do processo de produção, roteiros e instruções de trabalho.
+  BC-1020.10.10:
+    name: Design de processo e roteiro
+    description: |
+      Definição de roteiros de fabricação e etapas do processo.
+  BC-1020.10.20:
+    name: Elaboração de instruções de trabalho
+    description: |
+      Elaboração de trabalho padronizado e instruções de trabalho visuais.
+  BC-1020.10.30:
+    name: Validação de processo
+    description: |
+      Validação de processos de produção e estudos de capacidade.
+  BC-1020.10.40:
+    name: Controlo de alterações de processo
+    description: |
+      Controlo de alterações em processos e roteiros de fabricação.
+  BC-1020.20:
+    name: Gestão de ferramentas e dispositivos de fixação
+    description: |
+      Ciclo de vida de ferramentas, gabaritos e dispositivos de fixação.
+  BC-1020.20.10:
+    name: Design de ferramentas
+    description: |
+      Design de ferramentas, gabaritos e dispositivos de fixação para produção.
+  BC-1020.20.20:
+    name: Aprovisionamento e fabrico de ferramentas
+    description: |
+      Aprovisionamento, fabrico e validação de ferramentas.
+  BC-1020.20.30:
+    name: Manutenção e inspeção de ferramentas
+    description: |
+      Manutenção, inspeção e recondicionamento de ferramentas de produção.
+  BC-1020.20.40:
+    name: Gestão do inventário de ferramentas
+    description: |
+      Gestão do armazém de ferramentas e rastreabilidade.
+  BC-1020.30:
+    name: Gestão da engenharia de equipamentos
+    description: |
+      Especificação, qualificação e modificação de equipamentos.
+  BC-1020.30.10:
+    name: Especificação de equipamentos
+    description: |
+      Especificação de utilizador e funcional de equipamentos de produção.
+  BC-1020.30.20:
+    name: Qualificação de equipamentos
+    description: |
+      Qualificação IQ, OQ, PQ de equipamentos de produção.
+  BC-1020.30.30:
+    name: Gestão de modificações de equipamentos
+    description: |
+      Alterações de engenharia e atualizações a equipamentos instalados.
+  BC-1020.40:
+    name: Gestão da industrialização
+    description: |
+      Transferência de I&D para produção, arranque.
+  BC-1020.40.10:
+    name: Gestão da transferência para produção
+    description: |
+      Transferência de produtos de I&D ou piloto para produção.
+  BC-1020.40.20:
+    name: Produção pré-série e piloto
+    description: |
+      Produção pré-série e em lote piloto e aprendizagem.
+  BC-1020.40.30:
+    name: Gestão do arranque de produção
+    description: |
+      Arranque de produção para volumes e taxas de conformidade nominais.
+  BC-1020.50:
+    name: Gestão dos métodos de fabricação
+    description: |
+      Métodos, estudos de tempos e ergonomia.
+  BC-1020.50.10:
+    name: Estudos de tempos e movimentos
+    description: |
+      Estudos de tempos, MTM e definição de tempo padrão.
+  BC-1020.50.20:
+    name: Ergonomia do local de trabalho
+    description: |
+      Design ergonómico de postos de trabalho e tarefas.
+  BC-1020.50.30:
+    name: Definição de trabalho padronizado
+    description: |
+      Definição de trabalho padronizado e melhores sequências operativas.
+  BC-1020.60:
+    name: Gestão da melhoria contínua de fabricação
+    description: |
+      Kaizen em processos de produção, transformações lean.
+  BC-1020.60.10:
+    name: Realização de eventos Kaizen
+    description: |
+      Realização de eventos Kaizen em processos de produção.
+  BC-1020.60.20:
+    name: Gestão da transformação lean
+    description: |
+      Programas de transformação lean de ponta a ponta em instalações.
+  BC-1020.60.30:
+    name: Mapeamento da cadeia de valor
+    description: |
+      Mapeamento do estado atual e futuro da cadeia de valor.
+  BC-1020.60.40:
+    name: Desenvolvimento de capacidades de MC
+    description: |
+      Desenvolvimento de capacidades e orientação em métodos de melhoria contínua.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-manufacturing-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-manufacturing-operations-management.yaml
@@ -1,0 +1,139 @@
+locale: pt
+source: L1-manufacturing-operations-management.yaml
+entries:
+  BC-1010:
+    name: Gestão das operações de fabricação
+    description: |
+      Execução no chão de fábrica, gestão de ordens de trabalho, operações ao nível MES.
+  BC-1010.10:
+    name: Gestão de ordens de trabalho
+    description: |
+      Criação, lançamento, acompanhamento e encerramento de ordens de trabalho.
+  BC-1010.10.10:
+    name: Criação de ordens de trabalho
+    description: |
+      Criação de ordens de trabalho a partir de ordens de produção e BOM/roteiros.
+  BC-1010.10.20:
+    name: Lançamento de ordens de trabalho
+    description: |
+      Lançamento de ordens de trabalho para o chão de fábrica com verificações de materiais.
+  BC-1010.10.30:
+    name: Confirmação de ordens de trabalho
+    description: |
+      Confirmação de atividades, quantidades e tempos face às ordens de trabalho.
+  BC-1010.10.40:
+    name: Encerramento de ordens de trabalho
+    description: |
+      Encerramento final e liquidação de ordens de trabalho.
+  BC-1010.20:
+    name: Gestão da execução no chão de fábrica
+    description: |
+      Controlo do chão de fábrica, execução MES.
+  BC-1010.20.10:
+    name: Gestão da definição de produção
+    description: |
+      Definição de produção ISA-95 para produtos e processos.
+  BC-1010.20.20:
+    name: Gestão dos recursos de produção
+    description: |
+      Gestão da disponibilidade e capacidade dos recursos de produção.
+  BC-1010.20.30:
+    name: Coordenação da execução da produção
+    description: |
+      Coordenação em tempo real da execução entre centros de trabalho.
+  BC-1010.20.40:
+    name: Rastreabilidade e genealogia da produção
+    description: |
+      Genealogia de lote, grupo e número de série e registos de fabrico.
+  BC-1010.30:
+    name: Gestão das operações de máquinas
+    description: |
+      Configuração, funcionamento, mudança e monitorização de máquinas.
+  BC-1010.30.10:
+    name: Configuração e mudança de máquinas
+    description: |
+      Configuração de máquinas, mudança baseada em SMED e qualificação.
+  BC-1010.30.20:
+    name: Operações de funcionamento de máquinas
+    description: |
+      Funcionamento de máquinas, controlo de parâmetros e supervisão de processo.
+  BC-1010.30.30:
+    name: Monitorização de máquinas
+    description: |
+      Monitorização em tempo real e acompanhamento do estado das máquinas.
+  BC-1010.40:
+    name: Gestão de orientação de operadores
+    description: |
+      Instruções de trabalho, andon digital e apoio ao operador.
+  BC-1010.40.10:
+    name: Entrega de instruções de trabalho digitais
+    description: |
+      Entrega de instruções de trabalho digitais no posto de trabalho.
+  BC-1010.40.20:
+    name: Gestão de andon e escalada
+    description: |
+      Sinais de andon, escalada e apoio ao operador.
+  BC-1010.40.30:
+    name: Qualificação e autorização do operador
+    description: |
+      Certificação e autorização do operador para tarefas.
+  BC-1010.50:
+    name: Gestão das operações de manuseamento de materiais
+    description: |
+      Movimentação interna de materiais, kitting e abastecimento de linhas.
+  BC-1010.50.10:
+    name: Reabastecimento lateral de linha
+    description: |
+      Reabastecimento lateral de linha just-in-time e percursos de abastecimento.
+  BC-1010.50.20:
+    name: Kitting de materiais
+    description: |
+      Kitting e pré-montagem de componentes para linhas de produção.
+  BC-1010.50.30:
+    name: Movimentação interna de materiais
+    description: |
+      Logística interna e transporte entre operações.
+  BC-1010.60:
+    name: Gestão da aquisição de dados de fabricação
+    description: |
+      Dados de sensores, dados de máquinas, integração OT-TI.
+  BC-1010.60.10:
+    name: Recolha de dados de máquinas
+    description: |
+      Recolha de sinais de máquinas e dados de processo.
+  BC-1010.60.20:
+    name: Integração de sensores e IoT
+    description: |
+      Integração de sensores e dispositivos IIoT no chão de fábrica.
+  BC-1010.60.30:
+    name: Integração de dados OT-TI
+    description: |
+      Integração de dados OT com sistemas de TI alinhada com ISA-95.
+  BC-1010.60.40:
+    name: Operações do historiador de dados de fabricação
+    description: |
+      Captura e acesso a dados de séries temporais baseados em historiador.
+  BC-1010.70:
+    name: Gestão do desempenho de fabricação
+    description: |
+      Desempenho em tempo real, paragens, análise de microparagens.
+  BC-1010.70.10:
+    name: Monitorização do desempenho em tempo real
+    description: |
+      Monitorização em tempo real da OEE e dos KPIs do chão de fábrica.
+  BC-1010.70.20:
+    name: Análise de microparagens
+    description: |
+      Análise de microparagens e perdas recorrentes.
+  BC-1010.70.30:
+    name: Relatório de transferência de turno
+    description: |
+      Relatórios estruturados de transferência de turno e quadros digitais.
+  BC-1010.70.40:
+    name: Deteção de anomalias de produção
+    description: |
+      Deteção de anomalias e alertas sobre dados de produção.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-market-access-reimbursement-management.yaml
+++ b/catalogue/i18n/pt/L1-market-access-reimbursement-management.yaml
@@ -1,0 +1,95 @@
+locale: pt
+source: L1-market-access-reimbursement-management.yaml
+entries:
+  BC-1600:
+    name: Gestão de acesso ao mercado e comparticipação
+    description: |
+      Estratégia de pagadores, HEOR, submissões de preço/comparticipação, concursos e preços governamentais.
+  BC-1600.10:
+    name: Gestão da estratégia de pagadores
+    description: |
+      Envolvimento com pagadores, panorama de pagadores e proposta de valor.
+  BC-1600.10.10:
+    name: Análise do panorama de pagadores
+    description: |
+      Análise do panorama de pagadores e órgãos de decisão.
+  BC-1600.10.20:
+    name: Desenvolvimento da proposta de valor para pagadores
+    description: |
+      Desenvolvimento de propostas de valor orientadas para pagadores.
+  BC-1600.10.30:
+    name: Operações de envolvimento com pagadores
+    description: |
+      Envolvimento operacional com pagadores e gestores de conta.
+  BC-1600.20:
+    name: Gestão de economia da saúde e investigação de resultados
+    description: |
+      Estudos HEOR, custo-efetividade e evidência do mundo real para pagadores.
+  BC-1600.20.10:
+    name: Modelação de custo-efetividade
+    description: |
+      Modelação de custo-efetividade e impacto orçamental.
+  BC-1600.20.20:
+    name: Realização de estudos HEOR
+    description: |
+      Realização de estudos HEOR e análises económicas.
+  BC-1600.20.30:
+    name: Evidência do mundo real para acesso
+    description: |
+      Geração de RWE em suporte dos requisitos de evidência dos pagadores.
+  BC-1600.20.40:
+    name: Comparação indireta de tratamentos
+    description: |
+      Comparação indireta de tratamentos e meta-análise em rede.
+  BC-1600.30:
+    name: Gestão de submissões de preço e comparticipação
+    description: |
+      Dossiers de preço, submissões de HTA e pedidos de comparticipação.
+  BC-1600.30.10:
+    name: Redação de dossiers de HTA
+    description: |
+      Redação de dossiers de HTA (NICE, IQWiG, HAS, CADTH).
+  BC-1600.30.20:
+    name: Pedido de comparticipação
+    description: |
+      Pedidos de comparticipação e candidaturas de preço.
+  BC-1600.30.30:
+    name: Negociação e recurso de HTA
+    description: |
+      Negociação, resposta e recursos de HTA.
+  BC-1600.40:
+    name: Gestão de concursos e preços governamentais
+    description: |
+      Concursos governamentais, preços de concurso e contratação pública.
+  BC-1600.40.10:
+    name: Gestão de propostas de concurso
+    description: |
+      Preparação e submissão de propostas de concurso público.
+  BC-1600.40.20:
+    name: Operações de preços governamentais
+    description: |
+      Operações de preços governamentais e declarações de preços estatutários.
+  BC-1600.40.30:
+    name: Administração de descontos e abatimentos
+    description: |
+      Administração de descontos e abatimentos estatutários.
+  BC-1600.50:
+    name: Gestão de programas de acesso de doentes
+    description: |
+      Programas de assistência a doentes e apoio à comparticipação.
+  BC-1600.50.10:
+    name: Operações de programas de assistência a doentes
+    description: |
+      Operação de programas de assistência e acesso de doentes.
+  BC-1600.50.20:
+    name: Gestão de programas de comparticipação e cupão
+    description: |
+      Gestão de programas de assistência à comparticipação e cupões.
+  BC-1600.50.30:
+    name: Operações de programas de acesso gerido
+    description: |
+      Operações de uso compassivo e programas de acesso gerido.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-marketing-management.yaml
+++ b/catalogue/i18n/pt/L1-marketing-management.yaml
@@ -1,0 +1,155 @@
+locale: pt
+source: L1-marketing-management.yaml
+entries:
+  BC-400:
+    name: Gestão de marketing
+    description: |
+      Marca, inteligência de mercado, geração de procura e operações de marketing.
+  BC-400.10:
+    name: Gestão da estratégia de marketing
+    description: |
+      Estratégia de marketing, posicionamento e planeamento de go-to-market.
+  BC-400.10.10:
+    name: Segmentação de mercado e targeting
+    description: |
+      Definição de mercados-alvo, segmentos e personas.
+  BC-400.10.20:
+    name: Posicionamento e proposta de valor
+    description: |
+      Articulação do posicionamento, mensagens e propostas de valor.
+  BC-400.10.30:
+    name: Planeamento de go-to-market
+    description: |
+      Modelos de go-to-market, planos de lançamento e estratégia de canal.
+  BC-400.10.40:
+    name: Planeamento do marketing mix
+    description: |
+      Marketing mix, alocação de canais e planos de marketing integrado.
+  BC-400.20:
+    name: Gestão de marca
+    description: |
+      Estratégia, identidade, equity e governação da marca.
+  BC-400.20.10:
+    name: Estratégia e arquitetura de marca
+    description: |
+      Portefólio de marcas, arquitetura e estratégia de marca.
+  BC-400.20.20:
+    name: Identidade e normas de marca
+    description: |
+      Identidade visual, voz, tom e normas de marca.
+  BC-400.20.30:
+    name: Medição do equity de marca
+    description: |
+      Acompanhamento da notoriedade, consideração e equity de marca.
+  BC-400.20.40:
+    name: Conformidade e gestão da marca
+    description: |
+      Gestão do uso da marca em canais e parceiros.
+  BC-400.30:
+    name: Gestão de inteligência de mercado
+    description: |
+      Investigação de mercado, inteligência competitiva e insights de clientes.
+  BC-400.30.10:
+    name: Investigação de mercado
+    description: |
+      Investigação de mercado primária e secundária e análise de tendências.
+  BC-400.30.20:
+    name: Inteligência competitiva
+    description: |
+      Monitorização de concorrentes, battlecards e análise competitiva.
+  BC-400.30.30:
+    name: Geração de insights de clientes
+    description: |
+      Síntese de insights de clientes a partir de dados e investigação qualitativa.
+  BC-400.30.40:
+    name: Dimensionamento e previsão de mercado
+    description: |
+      Dimensionamento de mercado, quota e previsão de procura.
+  BC-400.40:
+    name: Gestão de geração de procura
+    description: |
+      Campanhas de geração de leads e marketing de ciclo de vida.
+  BC-400.40.10:
+    name: Planeamento de campanhas
+    description: |
+      Planeamento de campanhas, seleção de audiência e desenvolvimento de oferta.
+  BC-400.40.20:
+    name: Geração de leads
+    description: |
+      Geração de leads inbound, outbound e orientada por eventos.
+  BC-400.40.30:
+    name: Nutrição e pontuação de leads
+    description: |
+      Pontuação de leads, percursos de nurturing e entrega de MQL às vendas.
+  BC-400.40.40:
+    name: Marketing de ciclo de vida e retenção
+    description: |
+      Marketing de ciclo de vida, cross-sell e campanhas de retenção de clientes.
+  BC-400.50:
+    name: Gestão de operações de marketing
+    description: |
+      Orçamento, tecnologia, processos e medição de marketing.
+  BC-400.50.10:
+    name: Gestão do orçamento de marketing
+    description: |
+      Orçamentação, alocação e acompanhamento de despesas de marketing.
+  BC-400.50.20:
+    name: Gestão do stack tecnológico de marketing
+    description: |
+      Seleção e integração de ferramentas de automação e análise de marketing.
+  BC-400.50.30:
+    name: Medição do desempenho de marketing
+    description: |
+      Atribuição de marketing, ROI e dashboards de desempenho.
+  BC-400.50.40:
+    name: Gestão da conformidade de marketing
+    description: |
+      Conformidade de marketing com consentimento, privacidade e regras de publicidade.
+  BC-400.60:
+    name: Gestão de marketing digital
+    description: |
+      Web, SEO, meios pagos, redes sociais e automação de marketing.
+  BC-400.60.10:
+    name: Gestão da experiência do website
+    description: |
+      Propriedades web corporativas, gestão de conteúdos e personalização.
+  BC-400.60.20:
+    name: Otimização para motores de busca
+    description: |
+      Otimização de pesquisa orgânica e descoberta de conteúdos.
+  BC-400.60.30:
+    name: Gestão de meios pagos
+    description: |
+      Compra de meios pagos de pesquisa, display, vídeo e programática.
+  BC-400.60.40:
+    name: Gestão de redes sociais
+    description: |
+      Presença orgânica nas redes sociais, gestão de comunidade e relacionamento com influenciadores.
+  BC-400.60.50:
+    name: Operações de automação de marketing
+    description: |
+      Operações de e-mail, orquestração de percursos e automação de marketing.
+  BC-400.70:
+    name: Gestão de marketing de conteúdo
+    description: |
+      Planeamento editorial, produção e distribuição de conteúdo.
+  BC-400.70.10:
+    name: Planeamento editorial
+    description: |
+      Calendário editorial, temas e estratégia de conteúdo.
+  BC-400.70.20:
+    name: Produção de conteúdo
+    description: |
+      Produção de artigos, vídeos, podcasts e ativos multimédia.
+  BC-400.70.30:
+    name: Gestão de ativos digitais
+    description: |
+      Armazenamento, etiquetagem e reutilização de ativos digitais de marketing.
+  BC-400.70.40:
+    name: Distribuição e sindicação de conteúdo
+    description: |
+      Distribuição de conteúdo em canais próprios, ganhos e pagos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-materials-management.yaml
+++ b/catalogue/i18n/pt/L1-materials-management.yaml
@@ -1,0 +1,95 @@
+locale: pt
+source: L1-materials-management.yaml
+entries:
+  BC-1070:
+    name: Gestão de materiais
+    description: |
+      Gestão ao nível da instalação de matérias-primas, trabalho em curso e lista de materiais.
+  BC-1070.10:
+    name: Gestão da lista de materiais
+    description: |
+      Estrutura da BOM, BOMs de engenharia e de fabricação.
+  BC-1070.10.10:
+    name: Gestão da BOM de engenharia
+    description: |
+      BOMs de engenharia alinhadas com o design do produto e revisões.
+  BC-1070.10.20:
+    name: Gestão da BOM de fabricação
+    description: |
+      BOMs de fabricação que refletem sequências de montagem específicas da instalação.
+  BC-1070.10.30:
+    name: Gestão de alterações e efetividade da BOM
+    description: |
+      Controlo de alterações da BOM, revisão e datação de efetividade.
+  BC-1070.10.40:
+    name: Gestão de variantes da BOM
+    description: |
+      BOMs configuráveis e de variantes para opções de produto.
+  BC-1070.20:
+    name: Gestão de matérias-primas
+    description: |
+      Stock, qualidade e rastreabilidade de matérias-primas.
+  BC-1070.20.10:
+    name: Controlo do stock de matérias-primas
+    description: |
+      Acompanhamento do stock de matérias-primas na instalação e locais de armazenamento.
+  BC-1070.20.20:
+    name: Inspeção de qualidade de matérias-primas
+    description: |
+      Inspeção de entrada, amostragem e libertação de matérias-primas.
+  BC-1070.20.30:
+    name: Rastreabilidade de matérias-primas
+    description: |
+      Rastreabilidade de lote, grupo e número de série para matérias-primas.
+  BC-1070.30:
+    name: Gestão do trabalho em curso
+    description: |
+      Acompanhamento, valorização e controlo do WIP.
+  BC-1070.30.10:
+    name: Acompanhamento do WIP
+    description: |
+      Acompanhamento do trabalho em curso ao longo das operações de fabricação.
+  BC-1070.30.20:
+    name: Valorização do WIP
+    description: |
+      Acumulação de custos e valorização das posições de WIP.
+  BC-1070.30.30:
+    name: Controlo e envelhecimento do WIP
+    description: |
+      Envelhecimento e controlo do WIP paralisado ou bloqueado.
+  BC-1070.40:
+    name: Gestão de produtos acabados
+    description: |
+      Stock de produtos acabados ao nível da instalação.
+  BC-1070.40.10:
+    name: Receção de produtos acabados
+    description: |
+      Receção de produtos acabados da produção para o inventário da instalação.
+  BC-1070.40.20:
+    name: Armazenamento de produtos acabados
+    description: |
+      Armazenamento e manuseamento de produtos acabados nos armazéns da instalação.
+  BC-1070.40.30:
+    name: Expedição de produtos acabados
+    description: |
+      Expedição e envio de produtos acabados para nós a jusante.
+  BC-1070.50:
+    name: Gestão do planeamento de materiais
+    description: |
+      MRP, requisitos de materiais, planeamento de fornecimento ao nível da instalação.
+  BC-1070.50.10:
+    name: Planeamento das necessidades de materiais
+    description: |
+      Execuções de MRP para derivar as necessidades líquidas de materiais a partir da procura e da BOM.
+  BC-1070.50.20:
+    name: Análise de cobertura de materiais
+    description: |
+      Análise de cobertura, mensagens de exceção e propostas de encomenda.
+  BC-1070.50.30:
+    name: Execução do plano de fornecimento ao nível da instalação
+    description: |
+      Conversão de planos de materiais em ordens de compra e produção.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-media-asset-management.yaml
+++ b/catalogue/i18n/pt/L1-media-asset-management.yaml
@@ -1,0 +1,138 @@
+locale: pt
+source: L1-media-asset-management.yaml
+entries:
+  BC-3710:
+    name: Gestão de ativos de média
+    description: |
+      Ingestão, catalogação, armazenamento, transformação, preservação em
+      arquivo e gestão de identificadores de ativos de média ao longo do ciclo
+      de vida do conteúdo, desde a produção até à distribuição.
+  BC-3710.10:
+    name: Ingestão e controlo de qualidade de ativos
+    description: |
+      Integração de material de origem na plataforma de ativos com controlo
+      de qualidade técnico e editorial antes de utilização posterior.
+  BC-3710.10.10:
+    name: Ingestão de ativos de origem
+    description: |
+      Ingestão de ficheiros de origem e captura de fita-para-ficheiro ou
+      feed-para-ficheiro na plataforma de ativos.
+  BC-3710.10.20:
+    name: Inspeção de controlo de qualidade
+    description: |
+      Inspeção de controlo de qualidade automatizada e conduzida por operador
+      para defeitos de imagem, áudio e metadados.
+  BC-3710.10.30:
+    name: Validação de conformidade técnica
+    description: |
+      Validação face às especificações de entrega, incluindo formato, taxa
+      de fotogramas, loudness e conformidade de sinal.
+  BC-3710.20:
+    name: Catalogação de metadados
+    description: |
+      Criação e curadoria de metadados descritivos, técnicos e de direitos que
+      tornam os ativos descobríveis e utilizáveis.
+  BC-3710.20.10:
+    name: Criação de metadados descritivos
+    description: |
+      Catalogação de títulos, sinopses, colaboradores e atributos editoriais
+      face a um esquema controlado.
+  BC-3710.20.20:
+    name: Captura de metadados técnicos
+    description: |
+      Extração e armazenamento de metadados técnicos de essência, contentor
+      e nível de sinal.
+  BC-3710.20.30:
+    name: Ligação de metadados de direitos
+    description: |
+      Ligação de registos de ativos a registos de direitos que abrangem
+      restrições de território, janela e plataforma.
+  BC-3710.20.40:
+    name: Gestão de taxonomia e vocabulário controlado
+    description: |
+      Gestão responsável de taxonomias, géneros e vocabulários controlados
+      utilizados em todo o catálogo.
+  BC-3710.30:
+    name: Armazenamento e hierarquização de ativos
+    description: |
+      Armazenamento hierarquizado de ativos de média em camadas online,
+      nearline e de arquivo para equilibrar latência de acesso e custo.
+  BC-3710.30.10:
+    name: Armazenamento online de ativos
+    description: |
+      Armazenamento de alto desempenho para ativos em uso ativo de produção
+      e distribuição.
+  BC-3710.30.20:
+    name: Gestão de camada nearline e de arquivo
+    description: |
+      Movimentação do ciclo de vida de ativos para camadas nearline e de
+      arquivo com níveis de serviço de recuperação.
+  BC-3710.30.30:
+    name: Otimização de custos de armazenamento
+    description: |
+      Otimização da política de camadas de armazenamento, deduplicação e
+      redução da pegada em todo o parque de ativos.
+  BC-3710.40:
+    name: Transcodificação e conversão de formatos
+    description: |
+      Produção de representações intermediárias e de distribuição através de
+      pipelines de transcodificação e empacotamento.
+  BC-3710.40.10:
+    name: Geração de mezzanine
+    description: |
+      Produção de masters mezzanine de alta qualidade como intermediários
+      para codificações de distribuição a jusante.
+  BC-3710.40.20:
+    name: Codificação de formato de distribuição
+    description: |
+      Codificação de representações de distribuição para especificações de
+      entrega de difusão, OTT e parceiros.
+  BC-3710.40.30:
+    name: Empacotamento de bitrate adaptativo
+    description: |
+      Empacotamento de escadas de bitrate adaptativo para entrega por
+      streaming HLS, MPEG-DASH e CMAF.
+  BC-3710.50:
+    name: Arquivo de longa duração e preservação
+    description: |
+      Preservação a longo prazo de ativos master e históricos, incluindo
+      restauro de material legado.
+  BC-3710.50.10:
+    name: Catalogação de arquivo
+    description: |
+      Catalogação de acervos de arquivo de longa duração, incluindo suportes
+      legados e registos de elementos físicos.
+  BC-3710.50.20:
+    name: Migração de preservação
+    description: |
+      Migração periódica de material arquivado entre gerações de
+      armazenamento para mitigar a obsolescência de formatos e suportes.
+  BC-3710.50.30:
+    name: Restauro e remasterização
+    description: |
+      Restauro e remasterização de imagem e áudio de material legado para
+      normas de entrega modernas.
+  BC-3710.60:
+    name: Gestão de identificadores de conteúdo e versões
+    description: |
+      Atribuição e linhagem de identificadores de conteúdo e registos de
+      versão que descrevem de forma única cada edição e representação.
+  BC-3710.60.10:
+    name: Atribuição de identificadores de conteúdo
+    description: |
+      Atribuição de identificadores internos e de registo (EIDR, ISAN, ISRC,
+      ISWC) a obras e representações.
+  BC-3710.60.20:
+    name: Gestão de linhagem de versões e edições
+    description: |
+      Acompanhamento da linhagem de versões de edição, idioma, regulamentares
+      e de plataforma face aos registos de master principal.
+  BC-3710.60.30:
+    name: Mapeamento de referências cruzadas de identificadores externos
+    description: |
+      Mapeamento de referências cruzadas entre identificadores internos e
+      identificadores de parceiros, retalhistas e registos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-medical-affairs-management.yaml
+++ b/catalogue/i18n/pt/L1-medical-affairs-management.yaml
@@ -1,0 +1,123 @@
+locale: pt
+source: L1-medical-affairs-management.yaml
+entries:
+  BC-1580:
+    name: Gestão de assuntos médicos
+    description: |
+      Intercâmbio científico com profissionais de saúde, KOLs, MSL e evidência do mundo real.
+  BC-1580.10:
+    name: Gestão da estratégia médica
+    description: |
+      Estratégia médica, plataforma científica e plano de geração de evidência.
+  BC-1580.10.10:
+    name: Definição da plataforma científica
+    description: |
+      Definição da plataforma científica e mensagens-chave.
+  BC-1580.10.20:
+    name: Planeamento da geração de evidência
+    description: |
+      Planeamento da geração de evidência incluindo estudos IIS e RWE.
+  BC-1580.10.30:
+    name: Planeamento do ciclo de vida médico
+    description: |
+      Plano de assuntos médicos ao longo do ciclo de vida por ativo.
+  BC-1580.20:
+    name: Gestão do envolvimento com KOLs e profissionais de saúde
+    description: |
+      Envolvimento com líderes de opinião-chave e profissionais de saúde.
+  BC-1580.20.10:
+    name: Mapeamento e perfilagem de KOLs
+    description: |
+      Identificação e perfilagem de líderes de opinião-chave.
+  BC-1580.20.20:
+    name: Gestão de painéis consultivos de profissionais de saúde
+    description: |
+      Planeamento e condução de painéis consultivos de profissionais de saúde.
+  BC-1580.20.30:
+    name: Acompanhamento do envolvimento científico
+    description: |
+      Acompanhamento de envolvimentos e interações científicas.
+  BC-1580.30:
+    name: Gestão de informação médica
+    description: |
+      Pedidos de informação médica e geração de respostas.
+  BC-1580.30.10:
+    name: Receção de pedidos de informação médica
+    description: |
+      Receção multicanal de pedidos de informação médica.
+  BC-1580.30.20:
+    name: Biblioteca de documentos de resposta padrão
+    description: |
+      Manutenção da biblioteca de documentos de resposta padrão.
+  BC-1580.30.30:
+    name: Geração de respostas médicas personalizadas
+    description: |
+      Geração de respostas personalizadas a questões médicas.
+  BC-1580.40:
+    name: Gestão de comunicações médicas
+    description: |
+      Publicações, estratégia de congressos e comunicações científicas.
+  BC-1580.40.10:
+    name: Planeamento de publicações
+    description: |
+      Planeamento de publicações alinhado com GPP3 e ICMJE.
+  BC-1580.40.20:
+    name: Produção de manuscritos científicos
+    description: |
+      Redação e submissão de manuscritos científicos.
+  BC-1580.40.30:
+    name: Gestão de congressos e simpósios
+    description: |
+      Estratégia de congressos, resumos e gestão de simpósios.
+  BC-1580.50:
+    name: Gestão de estudos iniciados por investigadores
+    description: |
+      Programas IIS e investigação patrocinada por investigadores.
+  BC-1580.50.10:
+    name: Governação do programa IIS
+    description: |
+      Governação de programas de estudos iniciados por investigadores.
+  BC-1580.50.20:
+    name: Revisão de propostas IIS
+    description: |
+      Revisão e decisão sobre propostas IIS.
+  BC-1580.50.30:
+    name: Financiamento e apoio a IIS
+    description: |
+      Financiamento e apoio a investigadores IIS.
+  BC-1580.60:
+    name: Gestão de educação médica
+    description: |
+      Educação médica contínua, subsídios e programas.
+  BC-1580.60.10:
+    name: Subsídios de educação médica independente
+    description: |
+      Atribuição de subsídios para educação médica independente.
+  BC-1580.60.20:
+    name: Educação médica promocional
+    description: |
+      Programas de educação médica promocional.
+  BC-1580.60.30:
+    name: Desenvolvimento de conteúdo educativo
+    description: |
+      Desenvolvimento de conteúdo educativo acreditado.
+  BC-1580.70:
+    name: Gestão de operações de MSL
+    description: |
+      Operações da força de campo MSL, planeamento e desempenho.
+  BC-1580.70.10:
+    name: Território e targeting de MSL
+    description: |
+      Conceção de territórios MSL e targeting de KOLs.
+  BC-1580.70.20:
+    name: Planeamento de atividades de MSL
+    description: |
+      Planeamento de atividades MSL e planeamento de visitas.
+  BC-1580.70.30:
+    name: Acompanhamento do desempenho de MSL
+    description: |
+      Desempenho, recolha de insights e reporte de MSL.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-medical-staff-credentialing-management.yaml
+++ b/catalogue/i18n/pt/L1-medical-staff-credentialing-management.yaml
@@ -1,0 +1,149 @@
+locale: pt
+source: L1-medical-staff-credentialing-management.yaml
+entries:
+  BC-2890:
+    name: Gestão de pessoal médico e credenciamento
+    description: |
+      Credenciamento e privilegiamento de profissionais, avaliação de desempenho
+      e revisão entre pares, governação do corpo clínico, inscrição de prestadores
+      e programas de saúde do profissional.
+  BC-2890.10:
+    name: Credenciamento de profissionais
+    description: |
+      Credenciamento inicial e contínuo de profissionais, incluindo verificação de
+      fonte primária.
+  BC-2890.10.10:
+    name: Recepção de candidaturas
+    description: |
+      Recepção e revisão de completude de candidaturas de credenciamento.
+  BC-2890.10.20:
+    name: Verificação de fonte primária
+    description: |
+      Verificação de fonte primária de formação, treino, licença e referências.
+  BC-2890.10.30:
+    name: Gestão do processo de credenciamento
+    description: |
+      Manutenção e auditoria de processos de credenciamento e documentação de
+      suporte.
+  BC-2890.10.40:
+    name: Re-credenciamento
+    description: |
+      Re-credenciamento periódico de pessoal médico activo e profissionais de
+      saúde aliados.
+  BC-2890.20:
+    name: Gestão de privilegiamento
+    description: |
+      Delineação, concessão e renovação de privilégios clínicos.
+  BC-2890.20.10:
+    name: Delineação de privilégios
+    description: |
+      Definição e manutenção de delineações de privilégios por departamento e
+      especialidade.
+  BC-2890.20.20:
+    name: Privilegiamento inicial
+    description: |
+      Concessão de privilégios clínicos iniciais a novos profissionais.
+  BC-2890.20.30:
+    name: Renovação de privilégios
+    description: |
+      Renovação periódica de privilégios clínicos com base em dados de desempenho
+      e competência.
+  BC-2890.20.40:
+    name: Gestão de privilégios de especialidade
+    description: |
+      Gestão de pedidos de privilégios de especialidade, avançados e de
+      procedimentos.
+  BC-2890.30:
+    name: Avaliação de desempenho e revisão entre pares
+    description: |
+      Avaliação contínua e focalizada do desempenho do profissional e revisão entre
+      pares.
+  BC-2890.30.10:
+    name: Avaliação contínua do desempenho
+    description: |
+      Avaliação contínua da prática profissional em indicadores específicos de
+      especialidade.
+  BC-2890.30.20:
+    name: Avaliação focalizada do desempenho
+    description: |
+      Avaliação focalizada da prática profissional desencadeada por sinais de
+      desempenho ou novos privilégios.
+  BC-2890.30.30:
+    name: Revisão de casos entre pares
+    description: |
+      Revisão estruturada de casos clínicos entre pares com implicações no
+      desempenho.
+  BC-2890.30.40:
+    name: Reporte do desempenho do profissional
+    description: |
+      Reporte do desempenho do profissional a comissões do corpo clínico e
+      indivíduos.
+  BC-2890.40:
+    name: Governação do corpo clínico
+    description: |
+      Governação do corpo clínico, incluindo estatutos, comissão executiva e
+      operações departamentais.
+  BC-2890.40.10:
+    name: Manutenção dos estatutos
+    description: |
+      Manutenção e alteração dos estatutos e regulamentos do corpo clínico.
+  BC-2890.40.20:
+    name: Apoio à comissão executiva médica
+    description: |
+      Apoio operacional e analítico à comissão executiva médica.
+  BC-2890.40.30:
+    name: Operações de comissões departamentais
+    description: |
+      Operações de comissões departamentais, sectoriais e permanentes.
+  BC-2890.40.40:
+    name: Apoio a eleições de dirigentes
+    description: |
+      Apoio à nomeação e eleição de dirigentes do corpo clínico.
+  BC-2890.50:
+    name: Gestão de inscrição de prestadores
+    description: |
+      Inscrição de prestadores junto de pagadores e programas governamentais.
+  BC-2890.50.10:
+    name: Inscrição junto de pagadores
+    description: |
+      Inscrição de prestadores nas redes de pagadores comerciais.
+  BC-2890.50.20:
+    name: Manutenção do repositório centralizado de credenciais
+    description: |
+      Manutenção de dados centralizados de credenciamento de prestadores
+      partilhados com pagadores.
+  BC-2890.50.30:
+    name: Inscrição em programas governamentais
+    description: |
+      Inscrição de prestadores em programas de seguro governamentais.
+  BC-2890.50.40:
+    name: Acompanhamento de re-inscrição
+    description: |
+      Acompanhamento e processamento atempado de ciclos de re-inscrição de
+      prestadores.
+  BC-2890.60:
+    name: Saúde e bem-estar do profissional
+    description: |
+      Programas de suporte à saúde do profissional, prevenção do esgotamento e
+      apoio confidencial.
+  BC-2890.60.10:
+    name: Gestão de profissionais com incapacidade
+    description: |
+      Identificação, intervenção e monitorização de profissionais com incapacidade.
+  BC-2890.60.20:
+    name: Operações de programas de bem-estar
+    description: |
+      Operação de programas de bem-estar e resiliência do profissional.
+  BC-2890.60.30:
+    name: Vigilância do esgotamento
+    description: |
+      Vigilância de indicadores de esgotamento e bem-estar do profissional.
+  BC-2890.60.40:
+    name: Recursos de apoio confidencial
+    description: |
+      Recursos confidenciais de saúde mental, apoio entre pares e aconselhamento
+      para profissionais.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-merchandising-management.yaml
+++ b/catalogue/i18n/pt/L1-merchandising-management.yaml
@@ -1,0 +1,162 @@
+locale: pt
+source: L1-merchandising-management.yaml
+entries:
+  BC-2300:
+    name: Gestão de merchandising
+    description: |
+      Decisões de gama, categoria, espaço, compra, marca própria e redução de preço
+      que determinam quais os produtos vendidos aos consumidores, onde e com que profundidade de escolha.
+  BC-2300.10:
+    name: Planeamento de sortido e gama
+    description: |
+      Arquitetura de gama, contagens de escolha e planos de sortido por cluster de loja
+      que traduzem a estratégia em SKUs disponíveis em cada localização.
+    in_scope:
+      - Arquitetura de gama e estrutura bom-melhor-óptimo
+      - Planos de sortido por cluster e canal
+      - Slots de introdução e descontinuação de novos artigos
+    out_of_scope:
+      - Gestão genérica do ciclo de vida do produto (BC-820)
+      - Previsão de procura (BC-520.10)
+  BC-2300.10.10:
+    name: Definição da arquitetura de gama
+    description: |
+      Definição da arquitetura de gama, hierarquia e estrutura bom-melhor-óptimo por categorias.
+  BC-2300.10.20:
+    name: Planeamento de sortido por cluster de loja
+    description: |
+      Planos de sortido adaptados a clusters de loja por área de comércio e missão de compra.
+  BC-2300.10.30:
+    name: Otimização da contagem de escolhas
+    description: |
+      Otimização do número de SKUs por categoria para equilibrar variedade, complexidade e margem.
+  BC-2300.10.40:
+    name: Planeamento de introdução de novos artigos
+    description: |
+      Alocação de slots e ranging de novos artigos incluindo cadência de introdução e decisões de substituição.
+  BC-2300.10.50:
+    name: Planeamento de descontinuação
+    description: |
+      Decisões de saída de gama, escolhas de substituição e disposição de artigos descontinuados.
+  BC-2300.20:
+    name: Gestão de categorias
+    description: |
+      Estratégia de categoria, definição de papel e gestão do desempenho tratando
+      cada categoria como uma unidade de negócio segundo a prática CGF/ECR.
+    in_scope:
+      - Estratégia de categoria e definição de papel
+      - Desempenho de categoria e scorecards
+      - Colaboração com capitão de categoria junto de fornecedores
+  BC-2300.20.10:
+    name: Definição da estratégia de categoria
+    description: |
+      Definição da estratégia de categoria, comprador-alvo e posicionamento competitivo.
+  BC-2300.20.20:
+    name: Atribuição do papel de categoria
+    description: |
+      Atribuição de papéis de categoria como destino, rotina, conveniência ou sazonal.
+  BC-2300.20.30:
+    name: Análise do desempenho de categoria
+    description: |
+      Scorecards de categoria, análise de quota, crescimento e margem.
+  BC-2300.20.40:
+    name: Envolvimento com o capitão de categoria
+    description: |
+      Envolvimento de fornecedores capitães de categoria com controlos de barreira de informação.
+  BC-2300.30:
+    name: Gestão de espaço e planograma
+    description: |
+      Alocação de espaço de chão e prateleira, planogramas e layouts de expositor que
+      traduzem o plano de sortido numa prateleira física ou digital.
+  BC-2300.30.10:
+    name: Conceção de planograma
+    description: |
+      Conceção de planogramas por categoria, cluster de loja e tipo de expositor.
+  BC-2300.30.20:
+    name: Alocação de espaço de prateleira
+    description: |
+      Alocação de espaço de prateleira por categorias e marcas por desempenho.
+  BC-2300.30.30:
+    name: Layout de expositores e chão de loja
+    description: |
+      Layout de chão de loja e colocação de expositores para apoiar adjacências e fluxo de comprador.
+  BC-2300.30.40:
+    name: Acompanhamento de conformidade com planograma
+    description: |
+      Acompanhamento da conformidade com planograma por auditorias de loja e feeds de reconhecimento de imagem.
+  BC-2300.40:
+    name: Gestão de compras e open-to-buy
+    description: |
+      Planeamento de open-to-buy, execução do plano de compras e alocação a lojas que
+      convertem planos de sortido em compromissos de compra a fornecedores.
+    in_scope:
+      - Orçamentos de open-to-buy por departamento e época
+      - Execução do plano de compras com fornecedores
+      - Alocação de mercadorias recebidas por lojas
+    out_of_scope:
+      - Aprovisionamento genérico (BC-500)
+  BC-2300.40.10:
+    name: Planeamento de open-to-buy
+    description: |
+      Orçamentação de open-to-buy por departamento, classe e época.
+  BC-2300.40.20:
+    name: Execução do plano de compras
+    description: |
+      Execução de planos de compras com fornecedores incluindo seleção de estilo e SKU.
+  BC-2300.40.30:
+    name: Alocação por loja e canal
+    description: |
+      Alocação de mercadorias recebidas a lojas e canais por atributo e desempenho.
+  BC-2300.40.40:
+    name: Gestão de compras de reposição
+    description: |
+      Decisões de compra de reposição para artigos de base e artigos nunca fora de stock.
+  BC-2300.50:
+    name: Gestão de desenvolvimento de marca própria
+    description: |
+      Estratégia, especificação, aprovisionamento e gestão de marca de linhas de produto
+      de marca própria e private label.
+  BC-2300.50.10:
+    name: Estratégia de marca própria
+    description: |
+      Estratégia do portefólio de marca própria e hierarquia entre marcas próprias.
+  BC-2300.50.20:
+    name: Especificação de marca própria
+    description: |
+      Especificações de produto, briefings de embalagem e padrões de qualidade para marcas próprias.
+  BC-2300.50.30:
+    name: Aprovisionamento de marca própria
+    description: |
+      Aprovisionamento de fabricantes por contrato e co-packers para produção de marca própria.
+  BC-2300.50.40:
+    name: Gestão da marca própria
+    description: |
+      Gestão da identidade de marca própria, governação de embalagem e capital de marca.
+  BC-2300.60:
+    name: Gestão de reduções de preço e disposição de stock
+    description: |
+      Decisões de cadência de redução de preço, liquidação e disposição que retiram
+      o stock de retalho em excesso e no fim de vida.
+    in_scope:
+      - Decisões de cadência e profundidade de reduções de preço
+      - Planos de liquidação de fim de época
+      - Disposição por liquidação, outlet, doação e destruição
+    out_of_scope:
+      - Alterações de preço do dia-a-dia (BC-440.20.20)
+      - Descontos promocionais (BC-440.30)
+  BC-2300.60.10:
+    name: Estratégia de redução de preço
+    description: |
+      Estratégia de profundidade, cadência e timing de reduções de preço por categorias.
+  BC-2300.60.20:
+    name: Planeamento de liquidação de fim de época
+    description: |
+      Planos de liquidação de fim de época e gestão de preço de saída.
+  BC-2300.60.30:
+    name: Encaminhamento de disposição de stock
+    description: |
+      Encaminhamento de stock residual para outlet, liquidação, doação ou destruição.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-mine-closure-rehabilitation-management.yaml
+++ b/catalogue/i18n/pt/L1-mine-closure-rehabilitation-management.yaml
@@ -1,0 +1,123 @@
+locale: pt
+source: L1-mine-closure-rehabilitation-management.yaml
+entries:
+  BC-4470:
+    name: Gestão de encerramento e reabilitação de minas
+    description: |
+      Planeamento do encerramento, provisão financeira, reabilitação progressiva,
+      desativação e gestão pós-encerramento de terrenos e infraestrutura mineira.
+  BC-4470.10:
+    name: Planeamento de encerramento
+    description: |
+      Desenvolvimento de planos de encerramento desde a fase conceptual até ao
+      detalhe, com envolvimento das partes interessadas e aprovação regulatória.
+    in_scope:
+      - Planos de encerramento conceptuais e de duração do ativo
+      - Revisões detalhadas do plano de encerramento antes da cessação
+      - Consulta de reguladores e comunidade sobre encerramento
+    out_of_scope:
+      - Instrumentos de provisão financeira (BC-4470.20)
+  BC-4470.10.10:
+    name: Desenvolvimento do plano conceptual de encerramento
+    description: |
+      Desenvolvimento de planos conceptuais de encerramento nas fases iniciais
+      do projeto.
+  BC-4470.10.20:
+    name: Desenvolvimento do plano detalhado de encerramento
+    description: |
+      Desenvolvimento de planos detalhados de encerramento para aprovação
+      regulatória antes da cessação.
+  BC-4470.10.30:
+    name: Envolvimento das partes interessadas no encerramento
+    description: |
+      Envolvimento de reguladores, comunidades e proprietários tradicionais
+      sobre os resultados do encerramento.
+  BC-4470.20:
+    name: Provisão financeira para encerramento
+    description: |
+      Estimativa de custos, gestão de instrumentos de garantia financeira e
+      contabilização das provisões de encerramento.
+  BC-4470.20.10:
+    name: Estimativa de custos de encerramento
+    description: |
+      Estimativa dos custos de encerramento abrangendo reabilitação, desativação
+      e atividades pós-encerramento.
+  BC-4470.20.20:
+    name: Gestão de instrumentos de garantia financeira
+    description: |
+      Gestão de obrigações, garantias e instrumentos de afiançamento depositados
+      junto dos reguladores.
+  BC-4470.20.30:
+    name: Contabilização de provisões de encerramento
+    description: |
+      Remensuração periódica e reconhecimento das provisões de encerramento
+      nas demonstrações financeiras.
+  BC-4470.30:
+    name: Operações de reabilitação progressiva
+    description: |
+      Reabilitação simultânea de terrenos perturbados durante as operações,
+      incluindo modelação do terreno, revegetação e reinstalação de cursos
+      de água.
+  BC-4470.30.10:
+    name: Remodelação do terreno
+    description: |
+      Remodelação de depósitos de resíduos, paredes de cava e terrenos de
+      resíduos para perfis de encerramento estáveis.
+  BC-4470.30.20:
+    name: Substituição de solo e revegetação
+    description: |
+      Substituição de solo superficial armazenado e estabelecimento de cobertura
+      vegetal nativa.
+  BC-4470.30.30:
+    name: Reinstalação de cursos de água
+    description: |
+      Reinstalação de cursos de água naturais e construídos em terrenos
+      reabilitados.
+  BC-4470.30.40:
+    name: Desativação de infraestrutura
+    description: |
+      Desativação progressiva de infraestrutura operacional redundante durante
+      as operações.
+  BC-4470.40:
+    name: Desativação do sítio mineiro
+    description: |
+      Desmantelamento no fim de vida, eliminação de ativos e limpeza do sítio
+      na cessação das operações.
+  BC-4470.40.10:
+    name: Desmantelamento da instalação
+    description: |
+      Desmantelamento da instalação de processamento, infraestrutura mineira
+      e edifícios à superfície.
+  BC-4470.40.20:
+    name: Eliminação e salvado de ativos
+    description: |
+      Eliminação, salvado ou transferência de ativos de mineração e processamento
+      na desativação.
+  BC-4470.40.30:
+    name: Operações de limpeza do sítio
+    description: |
+      Limpeza de solos contaminados, hidrocarbonetos e materiais armazenados
+      na desativação.
+  BC-4470.50:
+    name: Gestão pós-encerramento
+    description: |
+      Monitorização de longo prazo, relinquishment e gestão de passivos legados
+      após a cessação das operações.
+  BC-4470.50.10:
+    name: Operações de monitorização a longo prazo
+    description: |
+      Operação de programas de monitorização de longo prazo de água, geotécnica
+      e revegetação.
+  BC-4470.50.20:
+    name: Gestão de relinquishment e restituição
+    description: |
+      Gestão do relinquishment de terrenos, restituição de concessões e
+      aprovação regulatória.
+  BC-4470.50.30:
+    name: Acompanhamento de passivos legados
+    description: |
+      Acompanhamento e divulgação de passivos ambientais legados retidos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-mine-planning-engineering-management.yaml
+++ b/catalogue/i18n/pt/L1-mine-planning-engineering-management.yaml
@@ -1,0 +1,166 @@
+locale: pt
+source: L1-mine-planning-engineering-management.yaml
+entries:
+  BC-4420:
+    name: Gestão de planeamento e engenharia mineira
+    description: |
+      Planeamento mineiro estratégico, de longo prazo e de curto prazo,
+      juntamente com as disciplinas de engenharia mineira, geotécnica e
+      hidrogeologia que traduzem o recurso em planos de produção executáveis.
+  BC-4420.10:
+    name: Planeamento mineiro estratégico
+    description: |
+      Definição da estratégia de extração ao longo da vida da mina, seleção
+      do método de mineração, limites de cava e sequenciamento de projetos de
+      capital.
+    in_scope:
+      - Plano de vida da mina e conchas de cava
+      - Seleção do método de mineração subterrânea
+      - Sequenciamento e aprovações de projetos de capital
+    out_of_scope:
+      - Planeamento de produção orçamentado anual (BC-4420.20)
+  BC-4420.10.10:
+    name: Planeamento de vida da mina
+    description: |
+      Definição da estratégia de extração ao longo da vida da mina, sequência
+      e envelope de capital.
+  BC-4420.10.20:
+    name: Otimização de cava
+    description: |
+      Otimização de conchas de cava pelo método de Lerchs-Grossmann e
+      equivalentes face a inputs económicos e geotécnicos.
+  BC-4420.10.30:
+    name: Seleção do método de mineração subterrânea
+    description: |
+      Seleção de métodos de mineração subterrânea como block caving, sub-level
+      caving ou stoping para determinada geometria do corpo mineralizado.
+  BC-4420.10.40:
+    name: Sequenciamento de projetos de capital
+    description: |
+      Sequenciamento de projetos de capital de grande envergadura ao longo
+      do horizonte de vida da mina.
+  BC-4420.20:
+    name: Planeamento mineiro de longo prazo
+    description: |
+      Planeamento de produção anual e plurianual, estratégia de pilha e
+      planeamento de equipamento de capital.
+  BC-4420.20.10:
+    name: Definição do plano de produção anual
+    description: |
+      Definição do plano de produção mineira anual e do orçamento.
+  BC-4420.20.20:
+    name: Planeamento da estratégia de pilhas
+    description: |
+      Planeamento plurianual da estratégia de construção, extração e remanuseio
+      de pilhas.
+  BC-4420.20.30:
+    name: Estratégia de teor de corte
+    description: |
+      Estratégia de teor de corte variável no tempo ao longo da vida da mina.
+  BC-4420.20.40:
+    name: Planeamento de equipamento de capital
+    description: |
+      Planeamento de longo prazo para substituição da frota mineira e adições
+      de equipamento de capital.
+  BC-4420.30:
+    name: Planeamento mineiro de curto prazo
+    description: |
+      Agendamento mineiro trimestral, semanal e diário que orienta a execução
+      da produção e o controlo de teor.
+  BC-4420.30.10:
+    name: Agendamento de produção trimestral
+    description: |
+      Preparação do programa de produção trimestral alinhado com o plano anual.
+  BC-4420.30.20:
+    name: Definição do programa semanal de mina
+    description: |
+      Definição do programa semanal de mineração por bancada, stope e
+      equipamento.
+  BC-4420.30.30:
+    name: Planeamento de despacho diário
+    description: |
+      Planeamento de despacho de atribuições da frota mineira a nível diário
+      e por turno.
+  BC-4420.30.40:
+    name: Planeamento de controlo de teor
+    description: |
+      Planeamento da amostragem de controlo de teor e encaminhamento de blocos
+      de minério para execução de curto prazo.
+  BC-4420.40:
+    name: Engenharia de design mineiro
+    description: |
+      Design de engenharia de cavas, escavações subterrâneas, padrões de
+      perfuração e detonação, estradas de transporte e infraestrutura de
+      ventilação mineira.
+  BC-4420.40.10:
+    name: Design de cava a céu aberto
+    description: |
+      Design de engenharia de bancadas, rampas e concha de cava para operações
+      a céu aberto.
+  BC-4420.40.20:
+    name: Design de mina subterrânea
+    description: |
+      Design de engenharia de galerias, declines, poços e stopes para operações
+      subterrâneas.
+  BC-4420.40.30:
+    name: Design de perfuração e detonação
+    description: |
+      Design de padrão, carga e temporização para perfuração e detonação de
+      produção.
+  BC-4420.40.40:
+    name: Design de estradas de transporte
+    description: |
+      Design geométrico e estrutural de redes de estradas de transporte mineiro.
+  BC-4420.40.50:
+    name: Design de ventilação e serviços
+    description: |
+      Design de engenharia de sistemas de ventilação, drenagem, energia e
+      ar comprimido para minas subterrâneas.
+  BC-4420.50:
+    name: Engenharia geotécnica
+    description: |
+      Engenharia geotécnica para estabilidade de taludes, suporte de terreno e
+      gestão de geoperigos em minas a céu aberto e subterrâneas.
+  BC-4420.50.10:
+    name: Engenharia de estabilidade de taludes
+    description: |
+      Análise de estabilidade de taludes e design de paredes de cava para
+      operações a céu aberto.
+  BC-4420.50.20:
+    name: Design de suporte de terreno subterrâneo
+    description: |
+      Design de engenharia de parafusos, malha, betão projetado e suporte de
+      cabos para escavações subterrâneas.
+  BC-4420.50.30:
+    name: Definição do programa de monitorização geotécnica
+    description: |
+      Definição de programas de monitorização geotécnica, incluindo densidade
+      de instrumentação, limiares e ciclos de revisão.
+  BC-4420.50.40:
+    name: Avaliação de risco de geoperigos
+    description: |
+      Avaliação de perigos de queda de blocos, sísmicos e de subsidência em
+      operações mineiras.
+  BC-4420.60:
+    name: Engenharia hidrogeológica mineira
+    description: |
+      Engenharia hidrogeológica que abrange modelação de águas subterrâneas,
+      design de drenagem mineira e balanço hídrico do sítio.
+  BC-4420.60.10:
+    name: Modelação de águas subterrâneas
+    description: |
+      Modelação numérica do comportamento das águas subterrâneas em torno
+      da área de influência da mina.
+  BC-4420.60.20:
+    name: Design de drenagem mineira
+    description: |
+      Design de engenharia de sistemas de drenagem de cava e subterrâneos.
+  BC-4420.60.30:
+    name: Modelação do balanço hídrico
+    description: |
+      Modelação do balanço hídrico de todo o sítio para planeamento operacional
+      e de encerramento.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-mine-production-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-mine-production-operations-management.yaml
@@ -1,0 +1,177 @@
+locale: pt
+source: L1-mine-production-operations-management.yaml
+entries:
+  BC-4430:
+    name: Gestão de operações de produção mineira
+    description: |
+      Execução da produção mineira através de ciclos de perfuração-detonação-carga-
+      transporte, stoping subterrâneo, controlo de teor, controlo de terreno,
+      ventilação mineira e drenagem em operações a céu aberto e subterrâneas.
+  BC-4430.10:
+    name: Operações de perfuração e detonação
+    description: |
+      Perfuração de produção, carregamento, iniciação e análise de desempenho
+      pós-detonação em operações a céu aberto e subterrâneas.
+    in_scope:
+      - Perfuração de furos de pega de produção
+      - Carregamento e iniciação
+      - Análise de fragmentação e movimento pós-detonação
+    out_of_scope:
+      - Sondagem de exploração (BC-4400.30)
+      - Design de padrão de perfuração e detonação (BC-4420.40.30)
+  BC-4430.10.10:
+    name: Perfuração de produção
+    description: |
+      Perfuração de furos de pega de produção de acordo com o design do padrão
+      de detonação.
+  BC-4430.10.20:
+    name: Carregamento de detonação
+    description: |
+      Carregamento de explosivos e acessórios nos furos de pega.
+  BC-4430.10.30:
+    name: Iniciação e limpeza de detonação
+    description: |
+      Ligação, limpeza, iniciação e limpeza pós-detonação das pegas de produção.
+  BC-4430.10.40:
+    name: Análise de desempenho de detonação
+    description: |
+      Análise de fragmentação, movimento e vibração das detonações executadas.
+  BC-4430.20:
+    name: Operações de carga e transporte
+    description: |
+      Carga, transporte e despacho de rocha desmontada da frente à instalação
+      de processamento ou depósito de resíduos.
+  BC-4430.20.10:
+    name: Operações de pá e escavadora
+    description: |
+      Operação de pás de cabo, escavadoras hidráulicas e carregadoras de frente.
+  BC-4430.20.20:
+    name: Operações de transporte em camião
+    description: |
+      Operação de camiões de transporte off-highway e transporte por trolei
+      assistido.
+  BC-4430.20.30:
+    name: Despacho e telemática de frota
+    description: |
+      Despacho em tempo real da frota, atribuição e gestão de produtividade
+      baseada em telemática.
+  BC-4430.20.40:
+    name: Reconciliação de movimentação de material
+    description: |
+      Reconciliação de toneladas movimentadas face a levantamento topográfico,
+      despacho e saldos de pilha.
+  BC-4430.30:
+    name: Operações de produção subterrânea
+    description: |
+      Desenvolvimento de stope, produção, enchimento e manuseio de materiais
+      subterrâneos específicos de métodos de mineração subterrânea.
+  BC-4430.30.10:
+    name: Desenvolvimento de stope
+    description: |
+      Desenvolvimento de acesso subterrâneo, galerias e infraestrutura de
+      stope.
+  BC-4430.30.20:
+    name: Produção de stope
+    description: |
+      Detonação de produção e limpeza de stopes subterrâneos.
+  BC-4430.30.30:
+    name: Colocação de enchimento
+    description: |
+      Colocação de enchimento cimentado ou rochoso em stopes minerados.
+  BC-4430.30.40:
+    name: Manuseio de materiais subterrâneos
+    description: |
+      Operação de correias transportadoras subterrâneas, passes de minério e
+      içamento por poço.
+  BC-4430.40:
+    name: Operações de controlo de teor
+    description: |
+      Discriminação operacional minério-resíduo através de amostragem, definição
+      de blocos de minério e decisões de encaminhamento na frente de mineração.
+  BC-4430.40.10:
+    name: Amostragem de controlo de teor
+    description: |
+      Amostragem em fase de produção de rocha desmontada e frentes para
+      determinação de teor.
+  BC-4430.40.20:
+    name: Definição de blocos de minério
+    description: |
+      Definição de blocos de minério extraíveis para execução de curto prazo.
+  BC-4430.40.30:
+    name: Marcação do limite minério-resíduo
+    description: |
+      Marcação em campo dos limites minério-resíduo para operadores de pás
+      e carregadoras.
+  BC-4430.40.40:
+    name: Alocação a pilha de minério de lavra
+    description: |
+      Alocação de material extraído a pilhas de minério de lavra e de teor.
+  BC-4430.50:
+    name: Controlo de terreno e monitorização geotécnica
+    description: |
+      Controlo operacional de terreno através de monitorização e resposta de
+      ação-gatilho em taludes de cava e escavações subterrâneas.
+  BC-4430.50.10:
+    name: Monitorização de taludes
+    description: |
+      Monitorização em tempo real de taludes de cava utilizando radar, prismas
+      e inclinómetros.
+  BC-4430.50.20:
+    name: Instalação de suporte de terreno
+    description: |
+      Instalação de parafusos, malha, betão projetado e suporte de cabos
+      subterrâneos.
+  BC-4430.50.30:
+    name: Monitorização sísmica subterrânea
+    description: |
+      Monitorização microssísmica de escavações subterrâneas para gestão de
+      rockburst e tensões.
+  BC-4430.50.40:
+    name: Resposta de ação-gatilho geotécnica
+    description: |
+      Execução de planos de resposta de ação-gatilho quando os limiares de
+      monitorização são excedidos.
+  BC-4430.60:
+    name: Ventilação mineira e gestão da atmosfera
+    description: |
+      Operação de sistemas de ventilação primária e auxiliar e monitorização
+      da qualidade da atmosfera mineira.
+  BC-4430.60.10:
+    name: Operações de ventilação primária
+    description: |
+      Operação de ventiladores de ventilação primária à superfície e subterrâneos
+      e vias de ar.
+  BC-4430.60.20:
+    name: Operações de ventilação auxiliar
+    description: |
+      Operação de ventiladores auxiliares e condutas na frente de trabalho.
+  BC-4430.60.30:
+    name: Monitorização da atmosfera mineira
+    description: |
+      Monitorização em tempo real e de rotina de níveis de poeiras, gases e
+      oxigénio na atmosfera mineira.
+  BC-4430.60.40:
+    name: Gestão de partículas de diesel
+    description: |
+      Gestão da exposição a partículas de diesel em trabalhos subterrâneos.
+  BC-4430.70:
+    name: Operações de drenagem mineira
+    description: |
+      Operação de sistemas de drenagem de cava e subterrâneos e infraestrutura
+      de estações de bombagem.
+  BC-4430.70.10:
+    name: Operações de drenagem de cava a céu aberto
+    description: |
+      Operação de bombagem na cava e furos de drenagem perimetrais.
+  BC-4430.70.20:
+    name: Operações de drenagem subterrânea
+    description: |
+      Operação de sumidouros, bombas e reticularização de drenagem subterrânea.
+  BC-4430.70.30:
+    name: Gestão de estações de bombagem
+    description: |
+      Operação e manutenção de estações de bombagem fixas e condutas ascendentes.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-mineral-exploration-management.yaml
+++ b/catalogue/i18n/pt/L1-mineral-exploration-management.yaml
@@ -1,0 +1,197 @@
+locale: pt
+source: L1-mineral-exploration-management.yaml
+entries:
+  BC-4400:
+    name: Gestão de exploração mineral
+    description: |
+      Descoberta de nova mineralização e qualificação de prospectos de exploração
+      através de levantamentos geológicos, geoquímicos e geofísicos, sondagem
+      de exploração e ensaio de amostras de sondagem, culminando no reporte
+      de descobertas e decisões de maturação de prospectos.
+  BC-4400.10:
+    name: Gestão de levantamentos geocientíficos
+    description: |
+      Aquisição, processamento e interpretação de dados de levantamentos
+      geofísicos, geoquímicos e geológicos aéreos e terrestres sobre concessões
+      mineiras de exploração.
+    in_scope:
+      - Levantamentos magnéticos e eletromagnéticos aéreos
+      - Levantamentos gravimétricos, IP e sísmicos terrestres
+      - Geoquímica de solos, sedimentos de curso de água e fragmentos de rocha
+      - Cartografia geológica à escala 1:50.000 e de projeto
+    out_of_scope:
+      - Diagrafia geológica de sondagens de qualificação de reservas (BC-4400.30)
+      - Reconciliação geológica em fase de produção (BC-4410.60)
+  BC-4400.10.10:
+    name: Levantamento geofísico aéreo
+    description: |
+      Aquisição de levantamentos aéreos magnéticos, eletromagnéticos,
+      radiométricos e gravimétricos sobre áreas de exploração.
+  BC-4400.10.20:
+    name: Levantamento geofísico terrestre
+    description: |
+      Aquisição de levantamentos gravimétricos, de polarização induzida,
+      eletromagnéticos e sísmicos terrestres à escala do prospecto.
+  BC-4400.10.30:
+    name: Amostragem geoquímica
+    description: |
+      Programas de amostragem de solos, sedimentos de curso de água,
+      biogeoquímica e fragmentos de rocha para delineação de anomalias
+      geoquímicas.
+  BC-4400.10.40:
+    name: Cartografia geológica
+    description: |
+      Cartografia geológica de afloramentos e à escala do prospecto para
+      definir litologia, estrutura e alteração.
+  BC-4400.10.50:
+    name: Interpretação de dados de levantamento
+    description: |
+      Interpretação integrada de conjuntos de dados geofísicos e geoquímicos
+      para geração de alvos.
+  BC-4400.20:
+    name: Geração de alvos de exploração
+    description: |
+      Conversão de dados regionais e de prospecto em alvos de sondagem
+      classificados através de análise de sistemas minerais e modelação
+      de prospetividade.
+    in_scope:
+      - Aplicação de modelos de sistemas minerais e de depósitos
+      - Modelação de prospetividade orientada por dados
+      - Classificação de leads e alvos
+    out_of_scope:
+      - Estimativa de recursos em mineralização descoberta (BC-4410.20)
+  BC-4400.20.10:
+    name: Análise de sistemas minerais
+    description: |
+      Aplicação de critérios de fonte, transporte, armadilha e preservação
+      para definir sistemas mineralizados.
+  BC-4400.20.20:
+    name: Modelação de prospetividade
+    description: |
+      Cartografia de prospetividade orientada pelo conhecimento e por dados
+      para prever localizações de alvos.
+  BC-4400.20.30:
+    name: Classificação de alvos
+    description: |
+      Classificação probabilística de alvos gerados por probabilidade de
+      descoberta e tonelagem potencial.
+  BC-4400.20.40:
+    name: Gestão do inventário de leads de exploração
+    description: |
+      Manutenção do inventário classificado de leads e alvos de exploração
+      e o seu percurso de maturação.
+  BC-4400.30:
+    name: Operações de sondagem de exploração
+    description: |
+      Execução de programas de sondagem de circulação reversa, carotagem
+      de diamante e outros programas de exploração, incluindo levantamento de
+      furos, diagrafia de amostras e supervisão de empreiteiros de sondagem.
+    in_scope:
+      - Sondagem de circulação reversa e aircore
+      - Sondagem de carotagem de diamante
+      - Levantamento de desvio de furos de sondagem
+    out_of_scope:
+      - Sondagem de produção para carregamento de furos de pega (BC-4430.10)
+      - Sondagem geotécnica para design de taludes (BC-4420.50)
+  BC-4400.30.10:
+    name: Sondagem de circulação reversa
+    description: |
+      Sondagem de circulação reversa e aircore para recuperação de amostras
+      de exploração.
+  BC-4400.30.20:
+    name: Sondagem de carotagem de diamante
+    description: |
+      Sondagem de carotagem de diamante para recuperação de amostras
+      litológicas orientadas e contínuas.
+  BC-4400.30.30:
+    name: Diagrafia de amostras de sondagem
+    description: |
+      Diagrafia geológica, geotécnica e estrutural de fragmentos e carotes
+      de sondagem.
+  BC-4400.30.40:
+    name: Gestão de levantamentos de furos de sondagem
+    description: |
+      Levantamento de desvio de furo e controlo de posição da boca do furo.
+  BC-4400.30.50:
+    name: Gestão de empreiteiros de sondagem
+    description: |
+      Contratação, mobilização e gestão do desempenho de empreiteiros de
+      sondagem.
+  BC-4400.40:
+    name: Gestão de amostras e ensaios
+    description: |
+      Custódia, preparação e coordenação de ensaios de amostras de exploração
+      ao abrigo de regimes de garantia de qualidade documentados que satisfazem
+      as normas de reporte público.
+    in_scope:
+      - Cadeia de custódia de amostras
+      - Seleção de laboratório e gestão do prazo de retorno
+      - Inserção e monitorização de controlos de qualidade
+    out_of_scope:
+      - Ensaios da instalação de processamento (BC-4440.60)
+      - Ensaios de liquidação da fundição (BC-4450.70)
+  BC-4400.40.10:
+    name: Preparação de amostras
+    description: |
+      Britagem, divisão e pulverização de amostras de exploração para ensaio
+      analítico.
+  BC-4400.40.20:
+    name: Coordenação de ensaios laboratoriais
+    description: |
+      Seleção, envio e gestão do prazo de retorno do trabalho analítico
+      laboratorial.
+  BC-4400.40.30:
+    name: Gestão do programa de garantia de qualidade
+    description: |
+      Inserção e monitorização de padrões, brancos e duplicados para suportar
+      a qualidade dos ensaios reportáveis.
+  BC-4400.40.40:
+    name: Gestão de materiais de referência
+    description: |
+      Aquisição, caracterização e distribuição de materiais de referência
+      certificados.
+  BC-4400.50:
+    name: Orientação do programa de exploração
+    description: |
+      Direção estratégica do portefólio de exploração em commodities, jurisdições
+      e classes de risco, incluindo alocação de investimento e acompanhamento
+      do desempenho de descoberta.
+  BC-4400.50.10:
+    name: Definição da estratégia de exploração
+    description: |
+      Definição da estratégia de exploração por commodity, jurisdição e classe
+      de depósito.
+  BC-4400.50.20:
+    name: Alocação de investimento em exploração
+    description: |
+      Alocação de capital de exploração em programas regionais e de prospecto.
+  BC-4400.50.30:
+    name: Acompanhamento do desempenho de descoberta
+    description: |
+      Acompanhamento do custo de descoberta, adições de recursos e conversão
+      em reservas.
+  BC-4400.60:
+    name: Reporte de descobertas
+    description: |
+      Comunicação interna e externa de resultados de exploração, incluindo
+      divulgações a parceiros e ao mercado de capitais alinhadas com os códigos
+      de reporte público.
+  BC-4400.60.10:
+    name: Reporte interno de descobertas
+    description: |
+      Comunicação interna de resultados de exploração, intercepções e estado
+      de maturação de alvos.
+  BC-4400.60.20:
+    name: Divulgação pública de resultados de exploração
+    description: |
+      Divulgação de intercepções e resultados de exploração ao abrigo dos
+      códigos JORC, NI 43-101, SAMREC e equivalentes.
+  BC-4400.60.30:
+    name: Reporte de joint-ventures de exploração
+    description: |
+      Reporte do progresso, despesas e resultados de exploração a parceiros
+      e operadores de joint-ventures.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-mineral-processing-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-mineral-processing-operations-management.yaml
@@ -1,0 +1,170 @@
+locale: pt
+source: L1-mineral-processing-operations-management.yaml
+entries:
+  BC-4440:
+    name: Gestão de operações de processamento de minérios
+    description: |
+      Operações de concentrador e hidrometalúrgicas que convertem o minério
+      de lavra em concentrados ou produtos intermédios vendáveis através de
+      cominuição, beneficiação, lixiviação e manuseio de concentrado.
+  BC-4440.10:
+    name: Gestão de pilha de minério de lavra
+    description: |
+      Gestão de pilhas de minério de lavra entre a mina e a instalação de
+      processamento, incluindo recuperação, mistura e reconciliação de inventário.
+    in_scope:
+      - Recuperação e mistura de pilha de minério de lavra
+      - Reconciliação de inventário de pilha
+    out_of_scope:
+      - Alocação de blocos de minério na cava (BC-4430.40.40)
+      - Armazenamento de concentrado (BC-4440.50.30)
+  BC-4440.10.10:
+    name: Recuperação de pilha de minério de lavra
+    description: |
+      Recuperação de pilhas de minério de lavra para alimentação da instalação
+      através de alimentadores de avental ou carregadoras de frente.
+  BC-4440.10.20:
+    name: Mistura de minério
+    description: |
+      Mistura de material de pilha para atingir o teor alvo e características
+      metalúrgicas.
+  BC-4440.10.30:
+    name: Reconciliação do inventário de pilha
+    description: |
+      Reconciliação de dados de levantamento, despacho e recuperação em saldos
+      de inventário de pilha.
+  BC-4440.20:
+    name: Operações de cominuição
+    description: |
+      Operações de britagem, moagem e otimização de circuito que reduzem o
+      minério ao tamanho de libertação.
+  BC-4440.20.10:
+    name: Operações de britagem
+    description: |
+      Operação de estações de britagem primária, secundária e terciária.
+  BC-4440.20.20:
+    name: Operações de moinho de moagem
+    description: |
+      Operação de moinhos SAG, AG, de bolas e de barras com classificação
+      associada.
+  BC-4440.20.30:
+    name: Otimização do circuito de cominuição
+    description: |
+      Otimização de processo dos circuitos de cominuição para débito, P80 e
+      intensidade energética.
+  BC-4440.30:
+    name: Operações de beneficiação
+    description: |
+      Concentração física de minerais valiosos através de flotação, gravidade,
+      separação magnética e por meio denso.
+  BC-4440.30.10:
+    name: Operações do circuito de flotação
+    description: |
+      Operação de circuitos de flotação rougher, scavenger e cleaner com
+      dosagem de reagentes.
+  BC-4440.30.20:
+    name: Concentração gravítica
+    description: |
+      Operação de jigues, espirais e concentradores centrífugos para minerais
+      susceptíveis à gravidade.
+  BC-4440.30.30:
+    name: Separação magnética
+    description: |
+      Separação magnética de baixa e alta intensidade para minerais ferromagnéticos
+      e paramagnéticos.
+  BC-4440.30.40:
+    name: Separação por meio denso
+    description: |
+      Operação de ciclones e tambores de meio denso para pré-concentração.
+  BC-4440.40:
+    name: Operações hidrometalúrgicas
+    description: |
+      Extração aquosa de metais através de lixiviação em pilha, em tanque e
+      em vat, extração por solventes e circuitos de adsorção.
+  BC-4440.40.10:
+    name: Operações de lixiviação em pilha
+    description: |
+      Operação de plataformas de lixiviação em pilha, incluindo empilhamento,
+      irrigação e coleta de solução carregada.
+  BC-4440.40.20:
+    name: Operações de lixiviação em tanque e vat
+    description: |
+      Operação de circuitos de lixiviação em tanque e vat para minério e
+      concentrado.
+  BC-4440.40.30:
+    name: Operações de extração por solventes
+    description: |
+      Operação de circuitos de extração por solventes para transferência
+      seletiva de metal para eletrólito.
+  BC-4440.40.40:
+    name: Operações de adsorção em carvão
+    description: |
+      Operação de circuitos de adsorção-eluição-recuperação em carbono na
+      polpa, carbono na lixiviação e carbono em coluna.
+  BC-4440.50:
+    name: Manuseio e filtração de concentrado
+    description: |
+      Espessamento, filtração e armazenamento de concentrados para expedição
+      à fundição ou venda.
+  BC-4440.50.10:
+    name: Operações de espessamento
+    description: |
+      Operação de espessadores de alta taxa e de pasta para desaguamento de
+      concentrado e resíduos de mineração.
+  BC-4440.50.20:
+    name: Filtração e desaguamento
+    description: |
+      Operação de filtros de pressão, vácuo e de correia para desaguamento
+      de concentrado.
+  BC-4440.50.30:
+    name: Armazenamento de concentrado
+    description: |
+      Armazenamento em interior e exterior de concentrado desaguado antes da
+      expedição.
+  BC-4440.60:
+    name: Contabilidade metalúrgica da instalação de processamento
+    description: |
+      Amostragem, ensaio e reconciliação do balanço de metal da alimentação
+      da instalação, produtos e resíduos de mineração.
+  BC-4440.60.10:
+    name: Amostragem e ensaio da instalação
+    description: |
+      Amostragem e ensaio entre-fluxos da alimentação da instalação, concentrado
+      e resíduos de mineração.
+  BC-4440.60.20:
+    name: Balanço metalúrgico
+    description: |
+      Reconciliação periódica do balanço de metal em todo o fluxograma da
+      instalação.
+  BC-4440.60.30:
+    name: Reporte de recuperação
+    description: |
+      Reporte da recuperação de metal face ao plano e ao design.
+  BC-4440.60.40:
+    name: Reporte da qualidade do concentrado
+    description: |
+      Reporte do teor do concentrado, elementos deletérios e humidade face
+      à especificação.
+  BC-4440.70:
+    name: Gestão de reagentes e consumíveis de processo
+    description: |
+      Gestão de reagentes e consumíveis de processo, incluindo controlo de
+      dosagem, inventário e gestão de reagentes perigosos.
+  BC-4440.70.10:
+    name: Controlo de dosagem de reagentes
+    description: |
+      Controlo em tempo real da dosagem de reagentes em circuitos de flotação
+      e hidrometalúrgicos.
+  BC-4440.70.20:
+    name: Gestão do inventário de reagentes
+    description: |
+      Gestão de inventário e consumo de reagentes a granel e meios de moagem.
+  BC-4440.70.30:
+    name: Gestão de cianeto
+    description: |
+      Gestão do cianeto e outros reagentes perigosos em linha com o Código
+      Internacional de Gestão do Cianeto.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-mineral-product-marketing-management.yaml
+++ b/catalogue/i18n/pt/L1-mineral-product-marketing-management.yaml
@@ -1,0 +1,145 @@
+locale: pt
+source: L1-mineral-product-marketing-management.yaml
+entries:
+  BC-4480:
+    name: Gestão de comercialização de produtos minerais
+    description: |
+      Vendas, offtake, negociação de encargos de tratamento e refinação,
+      liquidação de preços provisórios, coordenação logística e gestão do
+      risco de negociação de concentrados, intermédios e produtos metálicos
+      acabados.
+  BC-4480.10:
+    name: Vendas de concentrado e metal
+    description: |
+      Execução de vendas à vista e a prazo e planeamento de alocação a clientes
+      de concentrados e metais acabados.
+    in_scope:
+      - Vendas à vista e contratos a prazo
+      - Planeamento de alocação a clientes em minas e refinarias
+    out_of_scope:
+      - Cálculos de liquidação ao abrigo de preços provisórios (BC-4480.40)
+  BC-4480.10.10:
+    name: Execução de vendas à vista
+    description: |
+      Execução de vendas à vista de concentrados e metais a traders e clientes
+      finais.
+  BC-4480.10.20:
+    name: Gestão de contratos a prazo
+    description: |
+      Gestão de contratos de venda a prazo plurianuais para concentrados e
+      metais.
+  BC-4480.10.30:
+    name: Planeamento de alocação a clientes
+    description: |
+      Alocação da produção disponível entre clientes e contratos.
+  BC-4480.20:
+    name: Gestão de acordos de offtake
+    description: |
+      Negociação e administração contínua de acordos de offtake, incluindo
+      offtakes de streaming e royalty.
+  BC-4480.20.10:
+    name: Negociação de contratos de offtake
+    description: |
+      Negociação comercial e jurídica de acordos de offtake e streaming.
+  BC-4480.20.20:
+    name: Nomeação de volumes de offtake
+    description: |
+      Nomeação de volumes de offtake face a direitos contratuais.
+  BC-4480.20.30:
+    name: Monitorização do desempenho de offtake
+    description: |
+      Monitorização da entrega, qualidade e desempenho da contraparte do
+      offtake.
+  BC-4480.30:
+    name: Negociação de encargos de tratamento e refinação
+    description: |
+      Negociação anual de referência e bilateral de encargos de tratamento e
+      refinação e termos de penalização de concentrado.
+  BC-4480.30.10:
+    name: Negociação anual de referência
+    description: |
+      Negociação anual de referência de encargos de tratamento e refinação
+      com fundições e clientes.
+  BC-4480.30.20:
+    name: Acompanhamento das liquidações de encargos de tratamento
+    description: |
+      Acompanhamento das liquidações de encargos de tratamento e refinação
+      face à referência e aos termos do contrato.
+  BC-4480.30.30:
+    name: Gestão de elementos penalizadores
+    description: |
+      Gestão de termos de penalização para arsénio, antimônio, flúor e outros
+      elementos deletérios.
+  BC-4480.40:
+    name: Preços provisórios e liquidação
+    description: |
+      Gestão do período de cotação, faturação provisória, cálculo da liquidação
+      final e coordenação de cobertura de risco para o conteúdo metálico
+      precificado.
+  BC-4480.40.10:
+    name: Gestão do período de cotação
+    description: |
+      Gestão dos períodos de cotação que regem a precificação final das
+      expedições.
+  BC-4480.40.20:
+    name: Emissão de faturas provisórias
+    description: |
+      Emissão de faturas provisórias na expedição com base em ensaios e preços
+      assumidos.
+  BC-4480.40.30:
+    name: Cálculo da liquidação final
+    description: |
+      Liquidação final de expedições utilizando ensaios de árbitro e preços
+      médios do período de cotação.
+  BC-4480.40.40:
+    name: Coordenação de cobertura de risco
+    description: |
+      Coordenação com programas de cobertura de risco da tesouraria para
+      exposição a metal com preço provisório.
+  BC-4480.50:
+    name: Coordenação logística de produtos minerais
+    description: |
+      Nomeação de expedições a granel, gestão de warrants de armazém, amostragem
+      na descarga e conformidade regulatória de carga a granel.
+  BC-4480.50.10:
+    name: Nomeação de expedições a granel
+    description: |
+      Nomeação de navios, composições ferroviárias e barcaças para expedições
+      de concentrado e minério.
+  BC-4480.50.20:
+    name: Gestão de warrants de armazém
+    description: |
+      Gestão de warrants de armazém da LME e de outras bolsas para stocks de
+      metais acabados.
+  BC-4480.50.30:
+    name: Amostragem de concentrado na descarga
+    description: |
+      Coordenação de amostragem e ensaio independentes nos portos de descarga.
+  BC-4480.50.40:
+    name: Conformidade com o código de carga a granel
+    description: |
+      Conformidade com o Código IMSBC da IMO e regulamentos equivalentes para
+      carga sólida a granel.
+  BC-4480.60:
+    name: Gestão do risco de negociação de metais
+    description: |
+      Gestão dos riscos de preço de metais, crédito de contraparte e
+      documentação comercial em toda a carteira de comercialização.
+  BC-4480.60.10:
+    name: Monitorização da posição de risco de preço
+    description: |
+      Monitorização de posições de metal precificadas e não precificadas em
+      toda a carteira de comercialização.
+  BC-4480.60.20:
+    name: Gestão de crédito de contraparte
+    description: |
+      Avaliação de crédito de contraparte, limites e monitorização de exposição
+      para parceiros comerciais.
+  BC-4480.60.30:
+    name: Confirmação e documentação de operações
+    description: |
+      Confirmação, documentação e arquivo de bilhetes e contratos de operação.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-mineral-resource-reserve-management.yaml
+++ b/catalogue/i18n/pt/L1-mineral-resource-reserve-management.yaml
@@ -1,0 +1,163 @@
+locale: pt
+source: L1-mineral-resource-reserve-management.yaml
+entries:
+  BC-4410:
+    name: Gestão de recursos e reservas minerais
+    description: |
+      Modelação geológica, estimativa geoestatística, classificação, governação
+      de pessoa competente e reporte público de recursos minerais e reservas
+      mineiras ao abrigo de códigos alinhados com a CRIRSCO.
+  BC-4410.10:
+    name: Modelação geológica
+    description: |
+      Construção de modelos geológicos tridimensionais de litologia, estrutura,
+      alteração e domínios de mineralização como input para a estimativa de
+      recursos.
+    in_scope:
+      - Modelação litológica e estratigráfica
+      - Modelação estrutural e de falhas
+      - Wireframing de domínios de mineralização
+    out_of_scope:
+      - Wireframes de design de cava e de stope (BC-4420.40)
+  BC-4410.10.10:
+    name: Modelação litológica
+    description: |
+      Modelação tridimensional de unidades litológicas e estratigráficas a
+      partir de diagrafia de sondagens.
+  BC-4410.10.20:
+    name: Modelação estrutural
+    description: |
+      Modelação de falhas, dobras e zonas de cisalhamento que controlam a
+      geometria da mineralização.
+  BC-4410.10.30:
+    name: Modelação de domínios de mineralização
+    description: |
+      Wireframing de envolventes de mineralização e domínios de teor utilizados
+      como limites de estimativa.
+  BC-4410.10.40:
+    name: Fluxos de trabalho de modelação implícita
+    description: |
+      Fluxos de trabalho de modelação geológica implícita e de atualização
+      rápida para refinamento iterativo de modelos.
+  BC-4410.20:
+    name: Estimativa de recursos
+    description: |
+      Estimativa geoestatística de teor e tonelagem em modelos de blocos e
+      classificação do material estimado como Inferido, Indicado ou Medido
+      ao abrigo de códigos de reporte público.
+  BC-4410.20.10:
+    name: Estimativa geoestatística
+    description: |
+      Variografia e estimativa por krigagem ou simulação de teor em modelos
+      de blocos.
+  BC-4410.20.20:
+    name: Construção de modelos de blocos
+    description: |
+      Construção e população de modelos de blocos regularizados para
+      planeamento a jusante.
+  BC-4410.20.30:
+    name: Validação da estimativa
+    description: |
+      Validação estatística e visual dos teores estimados face aos dados
+      compostos.
+  BC-4410.20.40:
+    name: Classificação de recursos
+    description: |
+      Classificação da mineralização estimada nas categorias Inferida,
+      Indicada e Medida.
+  BC-4410.30:
+    name: Estimativa de reservas
+    description: |
+      Aplicação de fatores modificadores de mineração, metalúrgicos, económicos
+      e outros para converter Recursos Indicados e Medidos em Reservas Mineiras
+      Prováveis e Provadas.
+  BC-4410.30.10:
+    name: Aplicação de fatores modificadores
+    description: |
+      Aplicação de fatores modificadores de mineração, metalúrgicos, de
+      infraestrutura e económicos a recursos.
+  BC-4410.30.20:
+    name: Determinação do teor de corte
+    description: |
+      Cálculo de teores de corte que suportam a definição de reservas com
+      base em preços e custos assumidos.
+  BC-4410.30.30:
+    name: Modelação de recuperação mineira e diluição
+    description: |
+      Modelação de recuperação mineira, diluição e efeitos de fronteira
+      aplicados a recursos in situ.
+  BC-4410.30.40:
+    name: Classificação de reservas mineiras
+    description: |
+      Classificação das reservas mineiras nas categorias Provável e Provada.
+  BC-4410.40:
+    name: Governação de pessoa competente
+    description: |
+      Governação de pessoas competentes e qualificadas que assumem
+      responsabilidade pelas declarações de recursos e reservas ao abrigo
+      de códigos de reporte público.
+  BC-4410.40.10:
+    name: Aprovação da pessoa competente
+    description: |
+      Revisão e aprovação das declarações de recursos e reservas pela pessoa
+      competente ou qualificada.
+  BC-4410.40.20:
+    name: Revisão interna de recursos
+    description: |
+      Revisão por pares e de comité técnico interno das estimativas de recursos
+      e reservas.
+  BC-4410.40.30:
+    name: Coordenação de auditoria externa de recursos
+    description: |
+      Coordenação de auditorias independentes de terceiros a recursos e reservas.
+  BC-4410.50:
+    name: Reporte público de recursos e reservas
+    description: |
+      Preparação e divulgação de declarações públicas de recursos minerais e
+      reservas mineiras exigidas por reguladores de valores mobiliários e
+      regras de cotação.
+  BC-4410.50.10:
+    name: Preparação da declaração de recursos
+    description: |
+      Preparação de declarações públicas de recursos minerais alinhadas com
+      os códigos da família CRIRSCO.
+  BC-4410.50.20:
+    name: Preparação da declaração de reservas
+    description: |
+      Preparação de declarações públicas de reservas mineiras alinhadas com
+      os códigos da família CRIRSCO.
+  BC-4410.50.30:
+    name: Atualização anual da declaração de reservas
+    description: |
+      Atualização anual das declarações de recursos e reservas refletindo
+      o esgotamento e novas estimativas.
+  BC-4410.50.40:
+    name: Coordenação de relatório técnico independente
+    description: |
+      Coordenação de relatórios técnicos de pessoa qualificada para mercados
+      de capitais, transações e eventos de divulgação.
+  BC-4410.60:
+    name: Reconciliação de recursos
+    description: |
+      Reconciliação dos recursos e reservas estimados face ao controlo de
+      teor, alimentação da instalação e produção de metal para informar o
+      desempenho do modelo.
+  BC-4410.60.10:
+    name: Reconciliação mina-instalação
+    description: |
+      Reconciliação de toneladas e teor extraídos face à alimentação da
+      instalação e ao metal recuperado.
+  BC-4410.60.20:
+    name: Acompanhamento do esgotamento de recursos
+    description: |
+      Acompanhamento do esgotamento de recursos e reservas resultante da
+      atividade mineira.
+  BC-4410.60.30:
+    name: Análise do desempenho do modelo
+    description: |
+      Análise do desempenho do modelo de recursos face aos valores reais para
+      informar estimativas futuras.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-mining-community-social-performance-management.yaml
+++ b/catalogue/i18n/pt/L1-mining-community-social-performance-management.yaml
@@ -1,0 +1,166 @@
+locale: pt
+source: L1-mining-community-social-performance-management.yaml
+entries:
+  BC-4500:
+    name: Gestão de comunidade e desempenho social mineiro
+    description: |
+      Manutenção da licença social para operar através do envolvimento com
+      comunidades anfitriãs, proprietários indígenas e tradicionais, reassentamento
+      e acesso à terra, investimento comunitário, conteúdo local, direitos humanos
+      e reporte do desempenho social.
+  BC-4500.10:
+    name: Envolvimento com a comunidade anfitriã
+    description: |
+      Identificação, consulta e gestão de reclamações junto das comunidades
+      anfitriãs afetadas pelas operações mineiras.
+    in_scope:
+      - Identificação e mapeamento de partes interessadas
+      - Programas de consulta comunitária
+      - Mecanismos de reclamação comunitária
+    out_of_scope:
+      - Envolvimento específico com indígenas (BC-4500.20)
+      - Reassentamento (BC-4500.30)
+  BC-4500.10.10:
+    name: Mapeamento de partes interessadas da comunidade
+    description: |
+      Identificação e mapeamento das partes interessadas na área de influência
+      mineira.
+  BC-4500.10.20:
+    name: Programa de consulta comunitária
+    description: |
+      Operação de fóruns estruturados de consulta comunitária e divulgação
+      de informação.
+  BC-4500.10.30:
+    name: Gestão de reclamações comunitárias
+    description: |
+      Mecanismo operacional de reclamações comunitárias alinhado com os
+      critérios de eficácia dos Princípios Orientadores das Nações Unidas.
+  BC-4500.20:
+    name: Envolvimento com proprietários indígenas e tradicionais
+    description: |
+      Envolvimento com grupos indígenas e proprietários tradicionais, incluindo
+      título nativo, património cultural e acordos de partilha de benefícios.
+  BC-4500.20.10:
+    name: Envolvimento em título nativo e direitos sobre a terra
+    description: |
+      Envolvimento sobre título nativo e direitos fundiários consuetudinários
+      que afetam as operações mineiras.
+  BC-4500.20.20:
+    name: Gestão do património cultural
+    description: |
+      Identificação, proteção e gestão de sítios e valores do património cultural.
+  BC-4500.20.30:
+    name: Administração de acordos de uso de terra indígena
+    description: |
+      Administração de acordos de uso de terra indígena e de partilha de
+      benefícios.
+  BC-4500.30:
+    name: Gestão de reassentamento e acesso à terra
+    description: |
+      Aquisição de terras, reassentamento involuntário e restauração de meios
+      de subsistência para pessoas afetadas pelo projeto.
+  BC-4500.30.10:
+    name: Negociação de aquisição de terras
+    description: |
+      Negociação de aquisições voluntárias de terras para mineração e
+      infraestrutura associada.
+  BC-4500.30.20:
+    name: Planeamento de reassentamento involuntário
+    description: |
+      Planeamento do reassentamento involuntário alinhado com as Normas de
+      Desempenho da IFC e regimes equivalentes.
+  BC-4500.30.30:
+    name: Implementação do plano de ação de reassentamento
+    description: |
+      Implementação dos planos de ação de reassentamento para agregados
+      familiares afetados pelo projeto.
+  BC-4500.30.40:
+    name: Operações do programa de restauração de meios de subsistência
+    description: |
+      Operação de programas de restauração de meios de subsistência para
+      agregados familiares deslocados e comunidades anfitriãs.
+  BC-4500.40:
+    name: Investimento e desenvolvimento comunitário
+    description: |
+      Design e realização de programas de investimento comunitário e co-investimento
+      em infraestrutura e projetos de desenvolvimento locais.
+  BC-4500.40.10:
+    name: Design de programas de investimento comunitário
+    description: |
+      Design de programas plurianuais de investimento comunitário alinhados
+      com os planos de desenvolvimento local.
+  BC-4500.40.20:
+    name: Co-investimento em infraestrutura local
+    description: |
+      Co-investimento em estradas, água, energia e infraestrutura social
+      partilhada com as comunidades anfitriãs.
+  BC-4500.40.30:
+    name: Realização de projetos de desenvolvimento comunitário
+    description: |
+      Realização de projetos de desenvolvimento comunitário nas áreas de saúde,
+      educação e meios de subsistência.
+  BC-4500.50:
+    name: Gestão de conteúdo local e compras
+    description: |
+      Desenvolvimento de fornecedores locais, programas de emprego local e
+      reporte face a compromissos de conteúdo local.
+  BC-4500.50.10:
+    name: Desenvolvimento de fornecedores locais
+    description: |
+      Desenvolvimento e reforço da capacidade de fornecedores locais e de
+      propriedade indígena.
+  BC-4500.50.20:
+    name: Gestão de programas de emprego local
+    description: |
+      Gestão de programas de emprego, formação e aprendizagem local para
+      trabalhadores das comunidades anfitriãs.
+  BC-4500.50.30:
+    name: Reporte de conteúdo local
+    description: |
+      Reporte face a compromissos de conteúdo local do governo anfitrião e
+      contratuais.
+  BC-4500.60:
+    name: Gestão de direitos humanos e segurança
+    description: |
+      Diligência devida em direitos humanos, alinhamento com os Princípios
+      Voluntários sobre Segurança e Direitos Humanos e supervisão da conduta
+      dos prestadores de serviços de segurança.
+  BC-4500.60.10:
+    name: Diligência devida em direitos humanos
+    description: |
+      Avaliação e diligência devida do impacto nos direitos humanos ao nível
+      do sítio de acordo com os Princípios Orientadores das Nações Unidas.
+  BC-4500.60.20:
+    name: Conformidade com os Princípios Voluntários
+    description: |
+      Conformidade com os Princípios Voluntários sobre Segurança e Direitos
+      Humanos nas operações de segurança.
+  BC-4500.60.30:
+    name: Supervisão da conduta dos prestadores de segurança
+    description: |
+      Supervisão da conduta de prestadores de serviços de segurança públicos
+      e privados em torno dos sítios mineiros.
+  BC-4500.70:
+    name: Reporte do desempenho social
+    description: |
+      Acompanhamento de indicadores de desempenho social, avaliação de impacto
+      social e divulgação externa do desempenho social.
+  BC-4500.70.10:
+    name: Acompanhamento de indicadores de desempenho social
+    description: |
+      Acompanhamento de indicadores de desempenho social em operações e
+      investimentos.
+  BC-4500.70.20:
+    name: Avaliação de impacto social
+    description: |
+      Avaliação periódica do impacto social das operações mineiras nas
+      comunidades anfitriãs.
+  BC-4500.70.30:
+    name: Divulgação externa do desempenho social
+    description: |
+      Divulgação externa do desempenho social em relatórios de sustentabilidade
+      e regulatórios.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-mining-tenement-royalty-management.yaml
+++ b/catalogue/i18n/pt/L1-mining-tenement-royalty-management.yaml
@@ -1,0 +1,146 @@
+locale: pt
+source: L1-mining-tenement-royalty-management.yaml
+entries:
+  BC-4490:
+    name: Gestão de concessões mineiras e royalties
+    description: |
+      Aquisição, conformidade e gestão do portefólio de licenças de exploração
+      e concessões mineiras, juntamente com o cálculo, reporte e divulgação de
+      obrigações de royalties governamentais, privados e indígenas.
+  BC-4490.10:
+    name: Aquisição de concessões mineiras
+    description: |
+      Candidatura, concurso e diligência devida de aquisição de licenças de
+      exploração, concessões mineiras e outros títulos mineiros.
+    in_scope:
+      - Candidaturas a licenças de exploração em áreas virgens
+      - Candidaturas e renovações de concessões mineiras
+      - Diligência devida de aquisição de concessões
+    out_of_scope:
+      - Maturação de prospectos em fase de descoberta (BC-4400.20)
+  BC-4490.10.10:
+    name: Candidatura a licença de exploração
+    description: |
+      Preparação e entrega de candidaturas a licenças de exploração em áreas
+      virgens e de trabalho adicional.
+  BC-4490.10.20:
+    name: Candidatura a concessão mineira
+    description: |
+      Preparação e entrega de candidaturas a concessões mineiras e conversões
+      de títulos de exploração.
+  BC-4490.10.30:
+    name: Participação em concursos de concessões
+    description: |
+      Participação em concursos e leilões competitivos de concessões.
+  BC-4490.10.40:
+    name: Diligência devida na aquisição de concessões
+    description: |
+      Diligência devida de título, encargos e obrigações em aquisições de
+      concessões.
+  BC-4490.20:
+    name: Conformidade e manutenção de concessões
+    description: |
+      Conformidade com as obrigações anuais de gastos, programa de trabalho,
+      renda e renovação associadas a títulos mineiros.
+  BC-4490.20.10:
+    name: Reporte de gastos anuais
+    description: |
+      Reporte dos gastos anuais de exploração e desenvolvimento face aos
+      compromissos da concessão.
+  BC-4490.20.20:
+    name: Conformidade com o programa de trabalho
+    description: |
+      Demonstração de conformidade com os programas de trabalho comprometidos
+      em concessões de exploração e mineiras.
+  BC-4490.20.30:
+    name: Pagamento de rendas e taxas estatutárias
+    description: |
+      Pagamento de rendas anuais, taxas estatutárias e depósitos de garantia
+      em concessões.
+  BC-4490.20.40:
+    name: Gestão de renovação de concessões
+    description: |
+      Gestão de candidaturas de renovação de concessões e variações de condições.
+  BC-4490.30:
+    name: Gestão do portefólio de concessões
+    description: |
+      Manutenção do registo de concessões, cartografia de limites e decisões
+      de relinquishment em todo o portefólio.
+  BC-4490.30.10:
+    name: Gestão do registo de concessões
+    description: |
+      Manutenção do registo corporativo de concessões e atributos da fonte de
+      verdade.
+  BC-4490.30.20:
+    name: Cartografia dos limites das concessões
+    description: |
+      Cartografia espacial e reconciliação dos limites das concessões face aos
+      registos governamentais.
+  BC-4490.30.30:
+    name: Decisões de relinquishment de concessões
+    description: |
+      Decisões de relinquishment parcial e total de concessões para racionalizar
+      o portefólio.
+  BC-4490.40:
+    name: Gestão de royalties governamentais
+    description: |
+      Cálculo, entrega e resposta a auditorias de royalties sobre a produção
+      e ad valorem pagáveis aos governos anfitriões.
+  BC-4490.40.10:
+    name: Cálculo de royalties de produção
+    description: |
+      Cálculo de royalties baseados na produção e ad valorem sobre o output
+      mineral.
+  BC-4490.40.20:
+    name: Entrega de declarações de royalties
+    description: |
+      Entrega de declarações periódicas de royalties às autoridades de receita
+      do governo anfitrião.
+  BC-4490.40.30:
+    name: Resposta a auditorias de royalties
+    description: |
+      Resposta a auditorias e avaliações de royalties governamentais.
+  BC-4490.50:
+    name: Gestão de royalties privados e indígenas
+    description: |
+      Administração de fluxos de royalties privados e de obrigações de royalties
+      de partilha de benefícios indígenas.
+  BC-4490.50.10:
+    name: Administração de fluxos de royalties privados
+    description: |
+      Administração de direitos de royalties de vendedores, financiadores e
+      empresas de streaming.
+  BC-4490.50.20:
+    name: Administração de royalties de partilha de benefícios indígenas
+    description: |
+      Administração de pagamentos de royalties e acordos de partilha de
+      benefícios com grupos indígenas e proprietários tradicionais.
+  BC-4490.50.30:
+    name: Reporte de divulgação de royalties
+    description: |
+      Divulgação de pagamentos de royalties a investidores, reguladores e
+      comunidades afetadas.
+  BC-4490.60:
+    name: Reporte de transparência extrativa
+    description: |
+      Pagamentos a governos, EITI e reporte de beneficiário efetivo ao abrigo
+      de regimes de transparência extrativa.
+  BC-4490.60.10:
+    name: Reporte de pagamentos a governos
+    description: |
+      Reporte obrigatório de pagamentos a governos ao abrigo de regimes da
+      UE e equivalentes.
+  BC-4490.60.20:
+    name: Divulgação de transparência extrativa
+    description: |
+      Reporte de transparência EITI e equivalente voluntário sobre fluxos de
+      receita.
+  BC-4490.60.30:
+    name: Divulgação de beneficiário efetivo
+    description: |
+      Divulgação do beneficiário efetivo das entidades operadoras ao abrigo
+      do EITI e de regras equivalentes.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-mission-management.yaml
+++ b/catalogue/i18n/pt/L1-mission-management.yaml
@@ -1,0 +1,103 @@
+locale: pt
+source: L1-mission-management.yaml
+entries:
+  BC-1700:
+    name: Gestão de missões
+    description: |
+      Planeamento de missões, comando e controlo, execução e revisão pós-ação.
+  BC-1700.10:
+    name: Gestão do planeamento de missões
+    description: |
+      Objetivos da missão, rota, alvo e planeamento de força.
+  BC-1700.10.10:
+    name: Definição dos objetivos da missão
+    description: |
+      Definição dos objetivos da missão e intenção do comandante.
+  BC-1700.10.20:
+    name: Planeamento de força e meios
+    description: |
+      Planeamento da composição da força e atribuição de meios.
+  BC-1700.10.30:
+    name: Planeamento de rota e alvo
+    description: |
+      Planeamento de rota e seleção de alvos.
+  BC-1700.10.40:
+    name: Avaliação do risco da missão
+    description: |
+      Avaliação do risco operacional e confirmação das ROE.
+  BC-1700.10.50:
+    name: Produção da ordem de missão
+    description: |
+      Produção de ordens de missão e documentação de tarefas.
+  BC-1700.20:
+    name: Gestão de operações de comando e controlo
+    description: |
+      Operações C2, consciência situacional e suporte à decisão.
+  BC-1700.20.10:
+    name: Gestão do quadro operacional comum
+    description: |
+      Manutenção do quadro operacional comum.
+  BC-1700.20.20:
+    name: Suporte à decisão tática
+    description: |
+      Ferramentas e recomendações de suporte à decisão.
+  BC-1700.20.30:
+    name: Gestão das comunicações C2
+    description: |
+      Redes de comunicação C2 e mensagens táticas.
+  BC-1700.20.40:
+    name: Coordenação entre escalões
+    description: |
+      Coordenação entre escalões operacionais e táticos.
+  BC-1700.30:
+    name: Gestão da execução de missões
+    description: |
+      Execução de missões em tempo real e controlo tático.
+  BC-1700.30.10:
+    name: Coordenação da execução tática
+    description: |
+      Coordenação tática em tempo real dos elementos da missão.
+  BC-1700.30.20:
+    name: Reatribuição dinâmica de tarefas
+    description: |
+      Reatribuição dinâmica de tarefas e replaneamento durante a execução.
+  BC-1700.30.30:
+    name: Avaliação dos efeitos da missão
+    description: |
+      Avaliação em tempo real e de danos de batalha dos efeitos da missão.
+  BC-1700.40:
+    name: Gestão de ensaio e simulação de missões
+    description: |
+      Ensaio de missões e formação baseada em simulação.
+  BC-1700.40.10:
+    name: Conceção de exercícios de ensaio de missões
+    description: |
+      Conceção de exercícios de ensaio de missões.
+  BC-1700.40.20:
+    name: Simulação LVC (Live, Virtual e Constructive)
+    description: |
+      Gestão do ambiente de simulação LVC.
+  BC-1700.40.30:
+    name: Avaliação do desempenho em ensaio
+    description: |
+      Avaliação do desempenho da unidade durante os ensaios.
+  BC-1700.50:
+    name: Gestão de debriefing e lições aprendidas de missões
+    description: |
+      Revisão pós-ação, debriefing e registo de lições aprendidas.
+  BC-1700.50.10:
+    name: Condução do debriefing de missão
+    description: |
+      Condução de debriefings de missão e revisões pós-ação.
+  BC-1700.50.20:
+    name: Registo de lições aprendidas
+    description: |
+      Registo e codificação de lições aprendidas.
+  BC-1700.50.30:
+    name: Acompanhamento da implementação de lições
+    description: |
+      Acompanhamento da implementação de melhorias identificadas.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-mobility-services-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-mobility-services-operations-management.yaml
@@ -1,0 +1,178 @@
+locale: pt
+source: L1-mobility-services-operations-management.yaml
+entries:
+  BC-3490:
+    name: Gestão de operações de serviços de mobilidade
+    description: |
+      Operações de serviços de mobilidade partilhada e a pedido — transporte por
+      aplicação, partilha de carros e micromobilidade e agregação de
+      Mobilidade-como-Serviço — incluindo catálogo de serviços, operações de
+      viagens, reequilíbrio de frota, operações de condutores e utilizadores,
+      preçário dinâmico, integração de parceiros e envolvimento com cidades e
+      reguladores.
+  BC-3490.10:
+    name: Gestão do catálogo de serviços de mobilidade
+    description: |
+      Definição de tipos de serviços de mobilidade, planos de preçário e zonas
+      de cobertura geográfica.
+  BC-3490.10.10:
+    name: Definição de tipos de serviço
+    description: |
+      Definição de tipos de serviço como ponto a ponto, livre flutuação, baseado
+      em estação e viagens partilhadas.
+  BC-3490.10.20:
+    name: Configuração de planos de preçário de serviço
+    description: |
+      Configuração de tarifas base, preçário por tempo e distância e planos de
+      subscrição.
+  BC-3490.10.30:
+    name: Gestão de geofence e cobertura de serviço
+    description: |
+      Gestão de geofences operacionais, zonas de exclusão e áreas de cobertura.
+  BC-3490.20:
+    name: Operações de viagens e reservas
+    description: |
+      Captura, correspondência, despacho e gestão do ciclo de vida de reservas
+      e viagens de mobilidade.
+  BC-3490.20.10:
+    name: Captura de reservas de viagens
+    description: |
+      Captura de reservas de viagens nos canais de aplicação, web e parceiros.
+  BC-3490.20.20:
+    name: Correspondência e despacho de viagens
+    description: |
+      Correspondência de utilizadores a veículos ou condutores e despacho de
+      viagens confirmadas.
+  BC-3490.20.30:
+    name: Gestão do ciclo de vida das viagens
+    description: |
+      Gestão do ciclo de vida de viagens em curso, incluindo cancelamento,
+      reencaminhamento e conclusão.
+  BC-3490.30:
+    name: Operações de frota partilhada
+    description: |
+      Gestão operacional da frota partilhada, incluindo reequilíbrio, serviço
+      no local e controlo de danos.
+    in_scope:
+      - Reequilíbrio de veículos entre zonas e estações
+      - Limpeza, carregamento e reabastecimento na rua
+      - Gestão de danos e perdas de veículos partilhados
+    out_of_scope:
+      - Contabilidade genérica de ativos de frota empresarial (BC-2430)
+      - Operações de postos de carregamento de VE (BC-3480)
+  BC-3490.30.10:
+    name: Operações de reequilíbrio de veículos
+    description: |
+      Reequilíbrio de veículos partilhados entre zonas, estações e pontos de
+      alta procura.
+  BC-3490.30.20:
+    name: Coordenação de limpeza e carregamento de veículos
+    description: |
+      Coordenação de atividades de limpeza, carregamento e reabastecimento de
+      veículos no campo.
+  BC-3490.30.30:
+    name: Gestão de danos e perdas de veículos
+    description: |
+      Gestão da avaliação de danos, encaminhamento de reparação e recuperação
+      de perdas de veículos partilhados.
+  BC-3490.40:
+    name: Operações de condutores e prestadores
+    description: |
+      Integração, conformidade, liquidação e gestão do desempenho de condutores
+      e outros prestadores de serviços.
+  BC-3490.40.10:
+    name: Integração e conformidade de condutores
+    description: |
+      Integração de condutores, incluindo verificação de carta de condução,
+      verificação de antecedentes e conformidade contínua.
+  BC-3490.40.20:
+    name: Ganhos e liquidação de condutores
+    description: |
+      Cálculo e pagamento de ganhos, gorjetas e incentivos de condutores.
+  BC-3490.40.30:
+    name: Gestão do desempenho de condutores
+    description: |
+      Gestão do desempenho de condutores, incluindo classificações, coaching e
+      desativação.
+  BC-3490.50:
+    name: Operações de utilizadores
+    description: |
+      Integração, suporte e operações de confiança e segurança para utilizadores
+      e clientes finais de serviços de mobilidade.
+  BC-3490.50.10:
+    name: Integração e identidade de utilizadores
+    description: |
+      Integração de utilizadores, incluindo verificação de identidade, método de
+      pagamento e consentimento.
+  BC-3490.50.20:
+    name: Operações de suporte a utilizadores
+    description: |
+      Suporte a utilizadores antes, durante e após a viagem.
+  BC-3490.50.30:
+    name: Gestão de segurança e confiança de utilizadores
+    description: |
+      Operações de confiança e segurança, incluindo tratamento de incidentes,
+      prevenção de abuso e funcionalidades de segurança.
+  BC-3490.60:
+    name: Preçário dinâmico e gestão da procura
+    description: |
+      Previsão de procura e operação de motores de preçário dinâmico, sobretaxa
+      e promoção para serviços de mobilidade.
+  BC-3490.60.10:
+    name: Previsão de procura
+    description: |
+      Previsão de procura a curto prazo por zona, horário e tipo de serviço.
+  BC-3490.60.20:
+    name: Operações do motor de preçário dinâmico
+    description: |
+      Operação de motores de preçário dinâmico e de sobretaxa, incluindo limites
+      de preço e auditoria.
+  BC-3490.60.30:
+    name: Operações de promoção e incentivos
+    description: |
+      Operação de promoções e incentivos para utilizadores e condutores em
+      campanhas.
+  BC-3490.70:
+    name: Agregação multimodal e operações de parceiros
+    description: |
+      Agregação de parceiros MaaS, composição de viagens multimodais e liquidação
+      entre operadores de mobilidade.
+  BC-3490.70.10:
+    name: Integração de parceiros MaaS
+    description: |
+      Integração de parceiros de transporte público, transporte por aplicação e
+      micromobilidade na plataforma MaaS.
+  BC-3490.70.20:
+    name: Composição de viagens multimodais
+    description: |
+      Composição de viagens multimodais que combinam transporte público e
+      mobilidade a pedido.
+  BC-3490.70.30:
+    name: Liquidação entre operadores
+    description: |
+      Liquidação de receitas e comissões entre agregadores MaaS e operadores de
+      mobilidade subjacentes.
+  BC-3490.80:
+    name: Operações regulatórias e com cidades de mobilidade
+    description: |
+      Envolvimento com cidades e reguladores em licenças, partilha de dados e
+      operações de parque/passeio.
+  BC-3490.80.10:
+    name: Gestão de licenças e autorizações municipais
+    description: |
+      Gestão de licenças de operação municipais, limites de veículos e
+      autorizações em várias jurisdições.
+  BC-3490.80.20:
+    name: Partilha de dados operacionais com cidades
+    description: |
+      Partilha de dados operacionais com cidades ao abrigo de MDS, GBFS e
+      especificações equivalentes.
+  BC-3490.80.30:
+    name: Coordenação de paragem e estacionamento
+    description: |
+      Coordenação de acesso a paragem, estacionamento e zonas de espera com
+      autoridades municipais.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-omnichannel-order-fulfilment-management.yaml
+++ b/catalogue/i18n/pt/L1-omnichannel-order-fulfilment-management.yaml
@@ -1,0 +1,123 @@
+locale: pt
+source: L1-omnichannel-order-fulfilment-management.yaml
+entries:
+  BC-2330:
+    name: Gestão de processamento de encomendas omnicanal
+    description: |
+      Orquestração de encomendas de consumidores entre canais — captura em qualquer
+      canal, promessa a partir de qualquer nó e processamento através de loja,
+      centro de distribuição, marketplace, drop-ship de fornecedor ou parceiro de
+      última milha.
+  BC-2330.10:
+    name: Gestão de orquestração de canais
+    description: |
+      Visão única das encomendas dos consumidores entre canais, encaminhamento de
+      mix de canais e estado consistente em digital, loja e marketplace.
+    in_scope:
+      - Regras de encaminhamento de canal e seleção de nó
+      - Visão única de encomendas entre canais
+      - Economia do mix de canais e trade-offs de custo de processamento
+    out_of_scope:
+      - Processamento genérico de encomendas (BC-520.40)
+  BC-2330.10.10:
+    name: Gestão de regras de encaminhamento de canal
+    description: |
+      Definição de regras de encaminhamento para seleção do nó de processamento
+      com base em custo e serviço.
+  BC-2330.10.20:
+    name: Visão de encomendas omnicanal
+    description: |
+      Visão unificada de encomendas, estado e histórico entre canais.
+  BC-2330.10.30:
+    name: Economia do mix de canais
+    description: |
+      Análise de unit economics por canal e rota de processamento.
+  BC-2330.20:
+    name: Gestão de operações click-and-collect
+    description: |
+      Operações de compra online com levantamento em loja, à porta e em cacifo,
+      que ligam as encomendas digitais aos pontos de levantamento físicos.
+  BC-2330.20.10:
+    name: Operações de pick-and-pack em loja
+    description: |
+      Picking e embalagem de encomendas online por colaboradores de loja.
+  BC-2330.20.20:
+    name: Entrega ao cliente no levantamento
+    description: |
+      Entrega ao cliente no levantamento, incluindo verificação de identidade e
+      gestão de exceções.
+  BC-2330.20.30:
+    name: Levantamento à porta e em cacifo
+    description: |
+      Operações de entrega à porta e levantamento em cacifo.
+  BC-2330.30:
+    name: Gestão de processamento de encomendas distribuído
+    description: |
+      Processamento de encomendas a partir de loja, dark store e drop-ship de
+      fornecedor, a partir de um conjunto distribuído de inventário para destinos
+      de consumidores.
+    in_scope:
+      - Operações de ship-from-store
+      - Operações de dark store e micro-centro de processamento
+      - Orquestração de drop-ship de fornecedor
+  BC-2330.30.10:
+    name: Operações de ship-from-store
+    description: |
+      Picking, embalagem e expedição de encomendas online a partir de lojas físicas.
+  BC-2330.30.20:
+    name: Operações de dark store e micro-processamento
+    description: |
+      Operações de dark stores e micro-centros de processamento para encomendas
+      digitais.
+  BC-2330.30.30:
+    name: Orquestração de drop-ship de fornecedor
+    description: |
+      Orquestração de drop-ship de fornecedor, incluindo encaminhamento de PO e
+      rastreio.
+  BC-2330.40:
+    name: Gestão de operações de vendedor em marketplace
+    description: |
+      Operação de listings do retalhista como vendedor em marketplaces de terceiros
+      e gestão de vendedores de terceiros num marketplace próprio.
+  BC-2330.40.10:
+    name: Gestão de listings em marketplace
+    description: |
+      Listagem de artigos em marketplaces de terceiros, incluindo adaptação de
+      conteúdo.
+  BC-2330.40.20:
+    name: Captura de encomendas de marketplace
+    description: |
+      Captura e tradução de encomendas de marketplace para o pipeline de encomendas
+      do anfitrião.
+  BC-2330.40.30:
+    name: Integração de vendedores de terceiros
+    description: |
+      Integração de vendedores de terceiros no marketplace do retalhista.
+  BC-2330.40.40:
+    name: Gestão do desempenho de vendedores de terceiros
+    description: |
+      Gestão do desempenho e conformidade com as políticas de vendedores de
+      terceiros.
+  BC-2330.50:
+    name: Gestão de slots de entrega ao consumidor
+    description: |
+      Marcação de slots de entrega pelo consumidor, definição de preços de janelas
+      horárias e coordenação de despacho de estafetas para entrega em casa.
+  BC-2330.50.10:
+    name: Reserva de slot de entrega
+    description: |
+      Reserva de slots de entrega pelo consumidor com lógica de disponibilidade e
+      capacidade.
+  BC-2330.50.20:
+    name: Preço de janela horária
+    description: |
+      Preço dinâmico de janelas horárias de entrega por procura e densidade de
+      rota.
+  BC-2330.50.30:
+    name: Coordenação de despacho de estafeta
+    description: |
+      Coordenação de despacho com estafetas de última milha próprios e de terceiros.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-patient-access-management.yaml
+++ b/catalogue/i18n/pt/L1-patient-access-management.yaml
@@ -1,0 +1,155 @@
+locale: pt
+source: L1-patient-access-management.yaml
+entries:
+  BC-2800:
+    name: Gestão de acesso do doente
+    description: |
+      Admissão pré-encontro, agendamento, registo, verificação de elegibilidade,
+      aconselhamento financeiro, admissões, transferências e altas em contextos de
+      internamento, ambulatório, consulta externa e urgência.
+  BC-2800.10:
+    name: Gestão de agendamento e marcações
+    description: |
+      Agendamento de prestadores e recursos, marcação de consultas, gestão de
+      listas de espera e lembretes proactivos para optimizar a utilização da
+      capacidade.
+  BC-2800.10.10:
+    name: Optimização da agenda do prestador
+    description: |
+      Optimização das agendas de prestadores, salas e equipamentos segundo
+      modelos e sobreposições.
+  BC-2800.10.20:
+    name: Marcação de consultas
+    description: |
+      Marcação de consultas iniciada pelo doente e pelo médico referenciador,
+      através de múltiplos canais.
+  BC-2800.10.30:
+    name: Gestão de lista de espera
+    description: |
+      Manutenção e priorização de listas de espera para consultas e procedimentos.
+  BC-2800.10.40:
+    name: Lembretes de consulta e mitigação de faltas
+    description: |
+      Lembretes multicanal, confirmação e intervenções de mitigação de faltas.
+  BC-2800.20:
+    name: Gestão do registo do doente
+    description: |
+      Captura e gestão de dados demográficos, de identidade e de consentimento
+      necessários para registar um doente para um encontro clínico.
+  BC-2800.20.10:
+    name: Captura de dados demográficos
+    description: |
+      Captura de dados demográficos do doente no momento do registo.
+  BC-2800.20.20:
+    name: Verificação da identidade do doente
+    description: |
+      Verificação da identidade do doente utilizando documentação e verificações
+      biométricas.
+  BC-2800.20.30:
+    name: Captura de consentimento e autorização
+    description: |
+      Captura de consentimentos e autorizações de tratamento, financeiros e de
+      partilha de informação.
+  BC-2800.20.40:
+    name: Gestão de identificadores do doente
+    description: |
+      Emissão e manutenção de números de processo clínico e identificadores
+      empresariais do doente.
+  BC-2800.30:
+    name: Verificação de elegibilidade e benefícios
+    description: |
+      Verificação da cobertura de seguro, benefícios e requisitos de autorização
+      prévia antes da prestação de serviços.
+  BC-2800.30.10:
+    name: Verificação de cobertura de seguro
+    description: |
+      Verificação da cobertura de seguro activa e dos detalhes do plano.
+  BC-2800.30.20:
+    name: Determinação de benefícios
+    description: |
+      Determinação dos benefícios do doente, franquias, copagamentos e limites de
+      cobertura.
+  BC-2800.30.30:
+    name: Gestão de autorização prévia
+    description: |
+      Submissão, acompanhamento e seguimento de pedidos de autorização prévia junto
+      dos pagadores.
+  BC-2800.30.40:
+    name: Consulta de elegibilidade em tempo real
+    description: |
+      Consulta electrónica de elegibilidade e benefícios em tempo real junto dos
+      sistemas dos pagadores.
+  BC-2800.40:
+    name: Aconselhamento financeiro e estimativa de custos
+    description: |
+      Aconselhamento financeiro ao doente, estimativa de encargos próprios e
+      inscrição em regimes de apoio financeiro ou de pagamento directo.
+  BC-2800.40.10:
+    name: Avaliação financeira do doente
+    description: |
+      Avaliação da capacidade financeira do doente e das opções de pagamento.
+  BC-2800.40.20:
+    name: Estimativa de custos
+    description: |
+      Produção de estimativas de encargos próprios e de custo total para serviços
+      planeados.
+  BC-2800.40.30:
+    name: Cuidados de beneficência e apoio financeiro
+    description: |
+      Determinação de elegibilidade e inscrição em programas de cuidados de
+      beneficência e apoio financeiro.
+  BC-2800.40.40:
+    name: Configuração de pagamento directo
+    description: |
+      Configuração de planos de pagamento directo, pré-pagamentos e planos
+      prestacionais.
+  BC-2800.50:
+    name: Gestão de admissões, transferências e altas
+    description: |
+      Gestão operacional de admissões em internamento, transferências entre
+      unidades, atribuição de camas e registo de destino de alta.
+  BC-2800.50.10:
+    name: Admissão em internamento
+    description: |
+      Admissão de doentes em serviços de internamento a partir de fontes
+      programadas e não programadas.
+  BC-2800.50.20:
+    name: Transferência entre unidades
+    description: |
+      Coordenação de transferências de doentes entre unidades e níveis de cuidados.
+  BC-2800.50.30:
+    name: Atribuição de cama
+    description: |
+      Atribuição e reatribuição de camas de internamento com base na acuidade,
+      isolamento e capacidade.
+  BC-2800.50.40:
+    name: Registo do destino de alta
+    description: |
+      Registo do destino de alta, colocação pós-aguda e destino de transferência.
+  BC-2800.60:
+    name: Gestão de prontidão pré-serviço
+    description: |
+      Autorização pré-procedimento, verificação de documentação e actividades de
+      preparação do doente concluídas antes da prestação do serviço.
+  BC-2800.60.10:
+    name: Autorização pré-procedimento
+    description: |
+      Autorização clínica e anestésica para procedimentos programados.
+  BC-2800.60.20:
+    name: Verificação da documentação necessária
+    description: |
+      Verificação da completude de prescrições, consentimentos e documentação de
+      história clínica e exame físico.
+  BC-2800.60.30:
+    name: Contacto pré-consulta
+    description: |
+      Contacto prévio ao doente para formulários, história clínica e pré-registo.
+  BC-2800.60.40:
+    name: Instruções de preparação do doente
+    description: |
+      Entrega de instruções de preparação pré-procedimento e pré-consulta aos
+      doentes.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-patient-experience-management.yaml
+++ b/catalogue/i18n/pt/L1-patient-experience-management.yaml
@@ -1,0 +1,147 @@
+locale: pt
+source: L1-patient-experience-management.yaml
+entries:
+  BC-2910:
+    name: Gestão da experiência do doente
+    description: |
+      Envolvimento do doente, serviços digitais, medição da satisfação, defesa e
+      queixas, direitos do doente e ética, e serviços de voluntariado e auxiliares
+      em todo o continuum de cuidados.
+  BC-2910.10:
+    name: Envolvimento e comunicação com o doente
+    description: |
+      Comunicação multicanal com doentes e famílias, incluindo educação e serviços
+      de língua.
+  BC-2910.10.10:
+    name: Comunicação multicanal com o doente
+    description: |
+      Comunicação coordenada com o doente por telefone, mensagem segura, correio e
+      canais digitais.
+  BC-2910.10.20:
+    name: Prestação de educação para a saúde
+    description: |
+      Prestação de educação sobre doenças, tratamentos e prevenção aos doentes.
+  BC-2910.10.30:
+    name: Comunicação com famílias e cuidadores
+    description: |
+      Comunicação com famílias e cuidadores autorizados durante episódios de
+      cuidados.
+  BC-2910.10.40:
+    name: Serviços de língua e interpretação
+    description: |
+      Prestação de serviços de interpretação e tradução linguística.
+  BC-2910.20:
+    name: Portal do doente e serviços digitais
+    description: |
+      Operação de serviços digitais orientados ao doente, incluindo portais,
+      aplicações móveis e ferramentas de autoatendimento.
+  BC-2910.20.10:
+    name: Operações do portal do doente
+    description: |
+      Operação de serviços do portal do doente, incluindo mensagens e acesso ao
+      processo clínico.
+  BC-2910.20.20:
+    name: Operações da aplicação móvel de saúde
+    description: |
+      Operação de aplicações móveis de saúde orientadas ao doente.
+  BC-2910.20.30:
+    name: Ferramentas de autoatendimento do doente
+    description: |
+      Ferramentas de autoatendimento para agendamento, pagamento e conclusão
+      pré-consulta.
+  BC-2910.20.40:
+    name: Gestão de identidade digital do doente
+    description: |
+      Gestão da identidade digital, autenticação e acesso por procurador do doente.
+  BC-2910.30:
+    name: Medição da satisfação do doente
+    description: |
+      Medição da satisfação e experiência do doente por inquérito e em tempo real.
+  BC-2910.30.10:
+    name: Operações de inquéritos de experiência em internamento
+    description: |
+      Operação de programas de inquérito de experiência em internamento e análise
+      de resultados.
+  BC-2910.30.20:
+    name: Inquéritos de experiência em ambulatório
+    description: |
+      Operação de programas de inquérito de experiência em ambulatório e
+      especialidade.
+  BC-2910.30.30:
+    name: Captura de feedback em tempo real
+    description: |
+      Captura de feedback em tempo real e no ponto de encontro pelos doentes.
+  BC-2910.30.40:
+    name: Análise da experiência
+    description: |
+      Análise dos factores determinantes da experiência, temas e oportunidades de
+      melhoria.
+  BC-2910.40:
+    name: Defesa e queixas do doente
+    description: |
+      Defesa do doente, gestão de reclamações e queixas, e recuperação do serviço.
+  BC-2910.40.10:
+    name: Recepção de reclamações do doente
+    description: |
+      Recepção de reclamações do doente através de múltiplos canais.
+  BC-2910.40.20:
+    name: Investigação de queixas
+    description: |
+      Investigação formal e resolução de queixas do doente.
+  BC-2910.40.30:
+    name: Ligação de defesa do doente
+    description: |
+      Serviços de ligação para defesa do doente durante episódios de cuidados.
+  BC-2910.40.40:
+    name: Recuperação do serviço
+    description: |
+      Intervenções de recuperação do serviço para eventos de falha do serviço.
+  BC-2910.50:
+    name: Direitos do doente e ética
+    description: |
+      Supervisão dos direitos do doente, processos de consentimento informado,
+      directivas antecipadas de vontade e consulta de ética.
+  BC-2910.50.10:
+    name: Supervisão do processo de consentimento informado
+    description: |
+      Supervisão dos processos de consentimento informado para tratamento e
+      investigação.
+  BC-2910.50.20:
+    name: Gestão de directivas antecipadas de vontade
+    description: |
+      Captura, armazenamento e apresentação de directivas antecipadas de vontade e
+      objectivos de cuidados.
+  BC-2910.50.30:
+    name: Consulta de ética clínica
+    description: |
+      Serviços de consulta de ética clínica para doentes, famílias e clínicos.
+  BC-2910.50.40:
+    name: Educação sobre direitos do doente
+    description: |
+      Educação dos doentes sobre os seus direitos e responsabilidades.
+  BC-2910.60:
+    name: Serviços de voluntariado e auxiliares
+    description: |
+      Operação de programas de voluntariado e auxiliares de suporte a doentes e
+      famílias.
+  BC-2910.60.10:
+    name: Integração de voluntários
+    description: |
+      Recrutamento, triagem e integração de voluntários.
+  BC-2910.60.20:
+    name: Prestação de serviços de voluntariado
+    description: |
+      Coordenação e prestação de serviços de voluntariado em departamentos.
+  BC-2910.60.30:
+    name: Programas auxiliares
+    description: |
+      Operação de programas auxiliares, filantrópicos e comunitários.
+  BC-2910.60.40:
+    name: Serviços de apoio ao doente
+    description: |
+      Serviços de apoio como navegação do doente, capelania e salas de espera para
+      famílias.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-payments-card-management.yaml
+++ b/catalogue/i18n/pt/L1-payments-card-management.yaml
@@ -1,0 +1,147 @@
+locale: pt
+source: L1-payments-card-management.yaml
+entries:
+  BC-1340:
+    name: Gestão de pagamentos e cartões
+    description: |
+      Iniciação, processamento, compensação/liquidação de pagamentos, emissão de cartões e processamento de transações com cartão.
+  BC-1340.10:
+    name: Gestão de iniciação de pagamentos
+    description: |
+      Captura, validação e autorização de instruções de pagamento.
+  BC-1340.10.10:
+    name: Captura de instruções de pagamento
+    description: |
+      Captura de instruções de pagamento em todos os canais.
+  BC-1340.10.20:
+    name: Validação de pagamentos
+    description: |
+      Validação de instruções de pagamento e dados do beneficiário.
+  BC-1340.10.30:
+    name: Autorização de pagamentos
+    description: |
+      Autorização, autenticação e aplicação de SCA.
+  BC-1340.10.40:
+    name: Pré-notificação de pagamento
+    description: |
+      Pré-notificação de pagamentos e confirmação de beneficiário.
+  BC-1340.20:
+    name: Gestão do processamento de pagamentos
+    description: |
+      Processamento, encaminhamento, formatação e ISO 20022 de pagamentos.
+  BC-1340.20.10:
+    name: Enriquecimento e formatação de pagamentos
+    description: |
+      Enriquecimento e formatação ISO 20022 de mensagens de pagamento.
+  BC-1340.20.20:
+    name: Encaminhamento de pagamentos
+    description: |
+      Encaminhamento de pagamentos para os circuitos e correspondentes adequados.
+  BC-1340.20.30:
+    name: Rastreio de sanções em pagamentos
+    description: |
+      Rastreio de sanções e partes restritas em pagamentos.
+  BC-1340.20.40:
+    name: Investigação de pagamentos
+    description: |
+      Investigação de pagamentos falhados, devolvidos e questionados.
+  BC-1340.30:
+    name: Gestão de compensação e liquidação
+    description: |
+      Compensação doméstica — ACH, BACS, SEPA, FPS — e liquidação.
+  BC-1340.30.10:
+    name: ACH e compensação em lote
+    description: |
+      Operação de sistemas de compensação ACH, BACS e em lote.
+  BC-1340.30.20:
+    name: Operações de compensação SEPA
+    description: |
+      Operações de Transferência a Crédito SEPA e Débito Direto SEPA.
+  BC-1340.30.30:
+    name: RTGS e liquidação líquida
+    description: |
+      Liquidação em RTGS e operações de liquidação líquida diferida.
+  BC-1340.30.40:
+    name: Reconciliação de contas nostro e vostro
+    description: |
+      Reconciliação de contas nostro/vostro e gestão de divergências.
+  BC-1340.40:
+    name: Gestão de pagamentos transfronteiriços
+    description: |
+      Pagamentos internacionais, banca correspondente e câmbio.
+  BC-1340.40.10:
+    name: Gestão de banca correspondente
+    description: |
+      Relações de banca correspondente e gestão de RMA.
+  BC-1340.40.20:
+    name: Encaminhamento de pagamentos transfronteiriços
+    description: |
+      Encaminhamento de pagamentos transfronteiriços via SWIFT e circuitos alternativos.
+  BC-1340.40.30:
+    name: Conversão cambial para pagamentos
+    description: |
+      Conversão cambial, obtenção de taxas e preços para pagamentos.
+  BC-1340.40.40:
+    name: Acompanhamento SWIFT GPI
+    description: |
+      Acompanhamento do estado SWIFT GPI e transparência para o cliente.
+  BC-1340.50:
+    name: Gestão de pagamentos em tempo real
+    description: |
+      Circuitos de pagamento em tempo real / instantâneo.
+  BC-1340.50.10:
+    name: Operações de sistemas de pagamento instantâneo
+    description: |
+      Operação de FPS, SCT Inst e outros sistemas de pagamento instantâneo.
+  BC-1340.50.20:
+    name: Operações de pedido de pagamento
+    description: |
+      Mensagens de pedido de pagamento e gestão do ciclo de vida.
+  BC-1340.50.30:
+    name: Liquidez de pagamentos em tempo real
+    description: |
+      Gestão de liquidez para circuitos de pagamento instantâneo 24/7.
+  BC-1340.60:
+    name: Gestão de emissão de cartões
+    description: |
+      Produção, personalização, expedição e ativação de cartões.
+  BC-1340.60.10:
+    name: Produção e personalização de cartões
+    description: |
+      Operações de produção, gravação e personalização de cartões.
+  BC-1340.60.20:
+    name: Expedição e entrega de cartões
+    description: |
+      Expedição de cartões físicos e entrega de PIN.
+  BC-1340.60.30:
+    name: Ativação de cartões
+    description: |
+      Fluxos de trabalho de ativação de cartões e gestão de PIN.
+  BC-1340.60.40:
+    name: Provisionamento de cartão digital e carteira eletrónica
+    description: |
+      Emissão de cartão digital e provisionamento de carteira eletrónica (tokenização).
+  BC-1340.70:
+    name: Gestão do processamento de transações com cartão
+    description: |
+      Comutação, autorização, rastreio de fraude e estornos.
+  BC-1340.70.10:
+    name: Comutação de autorização de cartões
+    description: |
+      Comutação e encaminhamento de autorização em tempo real.
+  BC-1340.70.20:
+    name: Rastreio de fraude em cartões
+    description: |
+      Rastreio em tempo real de fraude em transações com cartão.
+  BC-1340.70.30:
+    name: Liquidação e intercâmbio de cartões
+    description: |
+      Liquidação, intercâmbio e compensação com sistemas.
+  BC-1340.70.40:
+    name: Gestão de estornos e litígios
+    description: |
+      Tratamento de estornos e resolução de litígios junto dos sistemas.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-permits-licences-authorisations-management.yaml
+++ b/catalogue/i18n/pt/L1-permits-licences-authorisations-management.yaml
@@ -1,0 +1,141 @@
+locale: pt
+source: L1-permits-licences-authorisations-management.yaml
+entries:
+  BC-3240:
+    name: Gestão de licenças, autorizações e alvarás
+    description: |
+      Emissão, renovação, suspensão, revogação e manutenção de registos de
+      licenças, autorizações e alvarás concedidos pelo governo a pessoas,
+      empresas e actividades, incluindo permissões ocupacionais, ambientais,
+      profissionais e operacionais.
+  BC-3240.10:
+    name: Recepção e triagem de candidaturas
+    description: |
+      Recepção, verificação de completude e triagem de candidaturas a licenças,
+      autorizações e alvarás.
+  BC-3240.10.10:
+    name: Submissão de candidaturas
+    description: |
+      Submissão multicanal de candidaturas a licenças e autorizações.
+  BC-3240.10.20:
+    name: Verificação de completude
+    description: |
+      Verificação de que as submissões estão completas e cumprem os requisitos
+      documentais.
+  BC-3240.10.30:
+    name: Encaminhamento de candidaturas
+    description: |
+      Encaminhamento de candidaturas para a autoridade e revisor de licenciamento
+      adequados.
+  BC-3240.10.40:
+    name: Avaliação e cobrança de taxas
+    description: |
+      Avaliação e cobrança de taxas estatutárias de candidatura e de licença.
+  BC-3240.20:
+    name: Avaliação de elegibilidade e qualificações
+    description: |
+      Avaliação da idoneidade, qualificações e critérios estatutários do requerente
+      para a autorização solicitada.
+  BC-3240.20.10:
+    name: Avaliação de idoneidade
+    description: |
+      Avaliação da idoneidade, integridade e historial desqualificante do
+      requerente.
+  BC-3240.20.20:
+    name: Verificação de qualificações
+    description: |
+      Verificação de qualificações, competências e pré-requisitos para a licença.
+  BC-3240.20.30:
+    name: Coordenação de verificação de antecedentes
+    description: |
+      Coordenação de verificações de antecedentes, registo criminal e verificações
+      de segurança quando necessário.
+  BC-3240.20.40:
+    name: Avaliação de interesse público
+    description: |
+      Avaliação de critérios estatutários de interesse público, ambientais ou de
+      uso do solo.
+  BC-3240.30:
+    name: Operações de emissão e renovação
+    description: |
+      Decisão, emissão e renovação de licenças, autorizações e alvarás, incluindo
+      condições, prazo e credenciais.
+  BC-3240.30.10:
+    name: Decisão de licenciamento
+    description: |
+      Decisão sobre concessão, recusa ou concessão condicional de licenças e
+      autorizações.
+  BC-3240.30.20:
+    name: Emissão de credenciais
+    description: |
+      Produção e emissão de credenciais de licença físicas e digitais.
+  BC-3240.30.30:
+    name: Processamento de renovações
+    description: |
+      Processamento de candidaturas de renovação e verificações de elegibilidade
+      contínua.
+  BC-3240.30.40:
+    name: Processamento de variações e anotações
+    description: |
+      Processamento de variações, anotações e alterações de condições.
+  BC-3240.40:
+    name: Inspecção e verificação de conformidade
+    description: |
+      Inspecção, auditoria e verificação da conformidade dos titulares com as
+      condições de licença e obrigações estatutárias.
+  BC-3240.40.10:
+    name: Planeamento de inspecções
+    description: |
+      Planeamento e agendamento baseados em risco de inspecções de conformidade.
+  BC-3240.40.20:
+    name: Execução de inspecções no terreno
+    description: |
+      Execução de inspecções no local e captura de evidências.
+  BC-3240.40.30:
+    name: Revisão de relatórios de conformidade
+    description: |
+      Revisão de relatórios de conformidade obrigatórios e autocertificações
+      submetidos pelos titulares.
+  BC-3240.50:
+    name: Suspensão, revogação e sanção
+    description: |
+      Acções de execução, incluindo avisos, suspensão, revogação, coima civil e
+      sanção a titulares não conformes.
+  BC-3240.50.10:
+    name: Investigação de não conformidade
+    description: |
+      Investigação de suspeitas de violação de condições de licença.
+  BC-3240.50.20:
+    name: Decisão de acção de execução
+    description: |
+      Decisão sobre acções de execução, desde avisos até revogação.
+  BC-3240.50.30:
+    name: Emissão de coimas civis
+    description: |
+      Emissão, registo e cobrança de coimas civis.
+  BC-3240.50.40:
+    name: Execução de suspensão e revogação
+    description: |
+      Execução de ordens de suspensão e revogação e retirada de credenciais.
+  BC-3240.60:
+    name: Gestão do registo de licenças
+    description: |
+      Manutenção e divulgação pública de registos de licenças e autorizações
+      emitidas, suspensas e revogadas.
+  BC-3240.60.10:
+    name: Manutenção do registo
+    description: |
+      Manutenção de registos autoritativos de licenças e autorizações.
+  BC-3240.60.20:
+    name: Divulgação do registo público
+    description: |
+      Publicação de registos públicos e serviços de pesquisa.
+  BC-3240.60.30:
+    name: Serviços de verificação do registo
+    description: |
+      Prestação de serviços de verificação de credenciais a partes que confiam nas
+      mesmas.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-petroleum-joint-venture-management.yaml
+++ b/catalogue/i18n/pt/L1-petroleum-joint-venture-management.yaml
@@ -1,0 +1,127 @@
+locale: pt
+source: L1-petroleum-joint-venture-management.yaml
+entries:
+  BC-3110:
+    name: Gestão de empresa conjunta de petróleo
+    description: |
+      Administração de acordos operacionais conjuntos a montante, concessões e
+      contratos de partilha de produção — comités operacionais, aprovações de AFE,
+      facturação de interesse conjunto, pedidos de fundos, obrigações de licença e
+      reporte a parceiros e ao governo anfitrião.
+  BC-3110.10:
+    name: Administração do acordo operacional conjunto
+    description: |
+      Redacção, administração e governação de acordos operacionais conjuntos,
+      incluindo processos do comité operacional e aprovações de AFE.
+  BC-3110.10.10:
+    name: Redacção e renegociação de JOA
+    description: |
+      Redacção, revisão e renegociação periódica de acordos operacionais conjuntos.
+  BC-3110.10.20:
+    name: Coordenação do comité operacional
+    description: |
+      Coordenação de reuniões do OPCOM, TECCOM e sub-comités.
+  BC-3110.10.30:
+    name: Gestão de autorizações de despesa
+    description: |
+      Emissão, aprovação e acompanhamento de autorizações de despesa (AFE).
+  BC-3110.10.40:
+    name: Acompanhamento de direitos de voto e aprovações
+    description: |
+      Acompanhamento de direitos de voto de parceiros e limiares de aprovação do
+      JOA.
+  BC-3110.20:
+    name: Facturação de interesse conjunto
+    description: |
+      Preparação, auditoria e resolução de litígios de facturas de interesse
+      conjunto.
+  BC-3110.20.10:
+    name: Preparação de facturas de interesse conjunto
+    description: |
+      Preparação de facturas mensais de interesse conjunto para parceiros.
+  BC-3110.20.20:
+    name: Coordenação de auditoria de interesse conjunto
+    description: |
+      Coordenação de auditorias de interesse conjunto lideradas pelos parceiros.
+  BC-3110.20.30:
+    name: Resolução de litígios JIB
+    description: |
+      Investigação e resolução de litígios de facturação de interesse conjunto.
+  BC-3110.30:
+    name: Gestão de pedidos de fundos e financiamento
+    description: |
+      Emissão de pedidos de fundos, recepção de financiamento de parceiros e gestão
+      de incumprimento.
+  BC-3110.30.10:
+    name: Emissão de pedidos de fundos
+    description: |
+      Emissão de pedidos de fundos mensais e suplementares a parceiros.
+  BC-3110.30.20:
+    name: Recepção de financiamento de parceiros
+    description: |
+      Recepção e reconciliação do financiamento de pedidos de fundos de parceiros.
+  BC-3110.30.30:
+    name: Gestão de incumprimento de financiamento
+    description: |
+      Gestão de posições de parceiros incumpridores segundo os meios JOA.
+  BC-3110.40:
+    name: Gestão de obrigações de licença e concessão
+    description: |
+      Acompanhamento de compromissos de programa de trabalho, royalties e obrigações
+      de relinquishment de licenças.
+  BC-3110.40.10:
+    name: Acompanhamento de compromissos de programa de trabalho
+    description: |
+      Acompanhamento das obrigações mínimas de trabalho e compromissos de
+      exploração.
+  BC-3110.40.20:
+    name: Cálculo de royalties de concessão
+    description: |
+      Cálculo de royalties a pagar aos governos anfitriões ao abrigo dos termos de
+      concessão.
+  BC-3110.40.30:
+    name: Gestão de relinquishment de licenças
+    description: |
+      Gestão de relinquishment parcial e total de licenças.
+  BC-3110.50:
+    name: Reporte ao governo anfitrião e parceiros
+    description: |
+      Reporte a governos anfitriões ao abrigo de termos PSC e a parceiros ao abrigo
+      de termos JOA.
+  BC-3110.50.10:
+    name: Reporte ao governo anfitrião
+    description: |
+      Reporte de operações, custos e produção a governos anfitriões.
+  BC-3110.50.20:
+    name: Reporte de contratos de partilha de produção
+    description: |
+      Reporte de recuperação de custos, profit oil e levantamentos ao abrigo de
+      termos PSC.
+  BC-3110.50.30:
+    name: Reporte de desempenho a parceiros
+    description: |
+      Reporte operacional e financeiro periódico a parceiros da empresa conjunta.
+  BC-3110.60:
+    name: Gestão de participação não operada
+    description: |
+      Gestão de participação accionista em empresas conjuntas operadas por outras
+      partes.
+  BC-3110.60.10:
+    name: Monitorização de posição não operada
+    description: |
+      Monitorização das actividades do operador e desempenho da empresa conjunta
+      do ponto de vista não operado.
+  BC-3110.60.20:
+    name: Votação conjunta não operada
+    description: |
+      Revisão interna e votação sobre programas de trabalho propostos pelo
+      operador.
+  BC-3110.60.30:
+    name: Verificação de custos não operados
+    description: |
+      Verificação de custos imputados pelo operador face aos procedimentos
+      contabilísticos do JOA.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-petroleum-process-safety-management.yaml
+++ b/catalogue/i18n/pt/L1-petroleum-process-safety-management.yaml
@@ -1,0 +1,162 @@
+locale: pt
+source: L1-petroleum-process-safety-management.yaml
+entries:
+  BC-3050:
+    name: Gestão de segurança de processo de petróleo
+    description: |
+      Prevenção de acidentes major em instalações de manuseamento de hidrocarbonetos
+      — análise de perigos de processo, integridade mecânica de sistemas de pressão,
+      garantia de elementos de segurança críticos, procedimentos operacionais,
+      reporte de desempenho e resposta a emergências. Distinto da gestão SSA
+      transversal à indústria (BC-730), que abrange saúde ocupacional, ambiente e
+      segurança pessoal.
+  BC-3050.10:
+    name: Análise de perigos de processo
+    description: |
+      Identificação e análise estruturada de perigos de acidentes major ao longo do
+      ciclo de vida do activo.
+    in_scope:
+      - HAZID, HAZOP, LOPA e análise bow-tie
+      - Avaliação quantitativa de risco
+    out_of_scope:
+      - Avaliação de risco de segurança pessoal (BC-730)
+  BC-3050.10.10:
+    name: Estudos HAZOP
+    description: |
+      Estudos de Análise de Perigos e Operabilidade em instalações novas e
+      modificadas.
+  BC-3050.10.20:
+    name: Estudos HAZID
+    description: |
+      Estudos de Identificação de Perigos durante as fases iniciais de conceito e
+      concepção.
+  BC-3050.10.30:
+    name: Estudos LOPA
+    description: |
+      Análise de Camadas de Protecção para definir níveis de integridade de
+      segurança.
+  BC-3050.10.40:
+    name: Análise bow-tie
+    description: |
+      Análise bow-tie para mapear barreiras face a cenários de acidente major.
+  BC-3050.20:
+    name: Gestão da integridade mecânica
+    description: |
+      Inspecção e gestão da integridade de equipamentos sob pressão e dispositivos
+      de segurança e alívio.
+  BC-3050.20.10:
+    name: Inspecção de vasos de pressão
+    description: |
+      Inspecção baseada em risco de vasos de pressão segundo API 510.
+  BC-3050.20.20:
+    name: Inspecção de integridade de tubagens e gasodutos
+    description: |
+      Inspecção de tubagens de processo e gasodutos segundo API 570 e ASME B31G.
+  BC-3050.20.30:
+    name: Inspecção de reservatórios de armazenamento
+    description: |
+      Inspecção de reservatórios de armazenamento atmosféricos e sob pressão
+      segundo API 653.
+  BC-3050.20.40:
+    name: Gestão de dispositivos de alívio de pressão
+    description: |
+      Dimensionamento, teste e gestão do ciclo de vida de válvulas de segurança e
+      discos de ruptura.
+  BC-3050.30:
+    name: Gestão de elementos de segurança críticos
+    description: |
+      Identificação e garantia do desempenho de elementos de segurança críticos e
+      manutenção do caso de segurança.
+  BC-3050.30.10:
+    name: Identificação de elementos de segurança críticos
+    description: |
+      Identificação de ESC a partir da análise de perigos de acidentes major.
+  BC-3050.30.20:
+    name: Definição de normas de desempenho
+    description: |
+      Definição de normas de desempenho para cada ESC.
+  BC-3050.30.30:
+    name: Verificação do desempenho de elementos de segurança críticos
+    description: |
+      Verificação do desempenho dos ESC face às normas definidas.
+  BC-3050.30.40:
+    name: Manutenção do caso de segurança
+    description: |
+      Manutenção dos casos de segurança da instalação e submissão aos reguladores.
+  BC-3050.40:
+    name: Procedimentos operacionais de segurança de processo
+    description: |
+      Redacção, revisão e definição do envelope operacional para procedimentos
+      críticos de segurança de processo.
+  BC-3050.40.10:
+    name: Redacção de procedimentos operacionais
+    description: |
+      Redacção de procedimentos operacionais críticos de segurança de processo.
+  BC-3050.40.20:
+    name: Revisão e actualização de procedimentos
+    description: |
+      Revisão e actualização periódicas de procedimentos de segurança de processo.
+  BC-3050.40.30:
+    name: Definição do envelope operacional
+    description: |
+      Definição de envelopes operacionais seguros para unidades de processo.
+  BC-3050.50:
+    name: Gestão de mudança de segurança de processo
+    description: |
+      Governação de segurança de processo sobre mudanças de planta, procedimentos e
+      pessoal, incluindo revisão de segurança pré-arranque.
+  BC-3050.50.10:
+    name: Revisão de pedidos de mudança PSM
+    description: |
+      Revisão de pedidos de mudança com impacto PSM face a normas de perigos.
+  BC-3050.50.20:
+    name: Revisão de segurança pré-arranque
+    description: |
+      Revisões de segurança pré-arranque para instalações novas e modificadas.
+  BC-3050.50.30:
+    name: Gestão de mudanças temporárias
+    description: |
+      Gestão de mudanças temporárias de processo dentro do seu prazo autorizado.
+  BC-3050.60:
+    name: Gestão do desempenho de segurança de processo
+    description: |
+      Acompanhamento e reporte de indicadores de segurança de processo antecipados
+      e de resultado segundo API RP 754 e enquadramentos equivalentes.
+  BC-3050.60.10:
+    name: Reporte de eventos de segurança de processo de Nível 1 e 2
+    description: |
+      Captura e reporte de eventos de segurança de processo de Nível 1 e Nível 2.
+  BC-3050.60.20:
+    name: Monitorização de indicadores antecipados
+    description: |
+      Monitorização de indicadores de segurança de processo antecipados de Nível 3
+      e Nível 4.
+  BC-3050.60.30:
+    name: Reporte de KPI de segurança de processo
+    description: |
+      Reporte externo e interno do desempenho de KPI de segurança de processo.
+  BC-3050.70:
+    name: Preparação e resposta a emergências
+    description: |
+      Planeamento de resposta a emergências, execução de simulacros e coordenação
+      da resposta a derrames para cenários de acidentes major.
+  BC-3050.70.10:
+    name: Planeamento de resposta a emergências
+    description: |
+      Manutenção de planos de resposta a emergências da instalação e corporativos.
+  BC-3050.70.20:
+    name: Coordenação de exercícios e simulacros
+    description: |
+      Coordenação de simulacros de emergência e exercícios de incidentes major.
+  BC-3050.70.30:
+    name: Coordenação de resposta a derrames
+    description: |
+      Coordenação de operações de resposta a derrames de petróleo e químicos.
+  BC-3050.70.40:
+    name: Coordenação de auxílio mútuo
+    description: |
+      Coordenação de auxílio mútuo com cooperativas de resposta da indústria.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-pharmaceutical-commercial-management.yaml
+++ b/catalogue/i18n/pt/L1-pharmaceutical-commercial-management.yaml
@@ -1,0 +1,111 @@
+locale: pt
+source: L1-pharmaceutical-commercial-management.yaml
+entries:
+  BC-1590:
+    name: Gestão comercial farmacêutica
+    description: |
+      Envolvimento com profissionais de saúde, amostras, materiais promocionais, força de vendas, marca e envolvimento com doentes.
+  BC-1590.10:
+    name: Gestão do envolvimento com profissionais de saúde
+    description: |
+      Programas de envolvimento com profissionais de saúde e interações da força de vendas.
+  BC-1590.10.10:
+    name: Targeting e segmentação de profissionais de saúde
+    description: |
+      Targeting e segmentação de profissionais de saúde.
+  BC-1590.10.20:
+    name: Envolvimento multicanal com profissionais de saúde
+    description: |
+      Orquestração do envolvimento multicanal com profissionais de saúde.
+  BC-1590.10.30:
+    name: Reporte de transparência a profissionais de saúde
+    description: |
+      Reporte de transparência Sunshine Act e EFPIA.
+  BC-1590.20:
+    name: Gestão de amostras
+    description: |
+      Distribuição de amostras, responsabilização e conformidade regulamentar.
+  BC-1590.20.10:
+    name: Pedido e distribuição de amostras
+    description: |
+      Tratamento de pedidos de amostras e distribuição a profissionais de saúde.
+  BC-1590.20.20:
+    name: Responsabilização e reconciliação de amostras
+    description: |
+      Responsabilização e reconciliação de amostras em conformidade com PDMA.
+  BC-1590.20.30:
+    name: Auditoria de conformidade de amostras
+    description: |
+      Auditoria às práticas de distribuição de amostras.
+  BC-1590.30:
+    name: Gestão de materiais promocionais
+    description: |
+      Desenvolvimento de materiais promocionais, revisão MLR e governação.
+  BC-1590.30.10:
+    name: Redação de materiais promocionais
+    description: |
+      Redação de materiais e conteúdo promocional.
+  BC-1590.30.20:
+    name: Revisão médica, jurídica e regulamentar
+    description: |
+      Fluxo de revisão e aprovação MLR para conteúdo promocional.
+  BC-1590.30.30:
+    name: Distribuição de materiais promocionais
+    description: |
+      Distribuição de materiais promocionais aprovados.
+  BC-1590.40:
+    name: Gestão da força de vendas farmacêutica
+    description: |
+      Planeamento da força de campo, território, targeting e implementação.
+  BC-1590.40.10:
+    name: Dimensionamento da força de vendas
+    description: |
+      Dimensionamento e conceção da estrutura da força de vendas.
+  BC-1590.40.20:
+    name: Conceção de território de vendas
+    description: |
+      Conceção e alinhamento de territórios de vendas farmacêuticos.
+  BC-1590.40.30:
+    name: Targeting da força de vendas
+    description: |
+      Targeting e planeamento de visitas para representantes de vendas farmacêuticos.
+  BC-1590.40.40:
+    name: Medição da eficácia da força de vendas
+    description: |
+      Medição e melhoria da eficácia da força de vendas.
+  BC-1590.50:
+    name: Gestão de marca farmacêutica
+    description: |
+      Estratégia de marca, posicionamento e ciclo de vida.
+  BC-1590.50.10:
+    name: Estratégia de marca farmacêutica
+    description: |
+      Estratégia e posicionamento de marca por indicação.
+  BC-1590.50.20:
+    name: Previsão de marca
+    description: |
+      Previsão ao nível da marca e deteção de procura.
+  BC-1590.50.30:
+    name: Planeamento de marca ao longo do ciclo de vida
+    description: |
+      Planeamento de marca ao longo do ciclo de vida incluindo perda de exclusividade.
+  BC-1590.60:
+    name: Gestão do envolvimento com doentes
+    description: |
+      Programas de doentes, serviços de suporte e advocacy.
+  BC-1590.60.10:
+    name: Operações de programas de suporte a doentes
+    description: |
+      Operação de programas de suporte e adesão de doentes.
+  BC-1590.60.20:
+    name: Envolvimento com grupos de advocacy de doentes
+    description: |
+      Envolvimento com organizações de advocacy de doentes.
+  BC-1590.60.30:
+    name: Recolha de insights de doentes
+    description: |
+      Recolha e integração de insights de doentes e PROs.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-pharmaceutical-manufacturing-management.yaml
+++ b/catalogue/i18n/pt/L1-pharmaceutical-manufacturing-management.yaml
@@ -1,0 +1,139 @@
+locale: pt
+source: L1-pharmaceutical-manufacturing-management.yaml
+entries:
+  BC-1550:
+    name: Gestão de fabricação farmacêutica
+    description: |
+      Fabricação de IFA e medicamentos em conformidade com GMP.
+  BC-1550.10:
+    name: Gestão de fabricação de IFA
+    description: |
+      Fabricação de ingrediente farmacêutico ativo.
+  BC-1550.10.10:
+    name: Síntese de IFA de pequena molécula
+    description: |
+      Síntese de ingredientes farmacêuticos ativos de pequena molécula.
+  BC-1550.10.20:
+    name: Produção de IFA de biológicos
+    description: |
+      Produção de IFAs biológicos por cultura celular e fermentação.
+  BC-1550.10.30:
+    name: Purificação de IFA
+    description: |
+      Purificação a jusante de ingredientes farmacêuticos ativos.
+  BC-1550.20:
+    name: Gestão de fabricação de medicamentos
+    description: |
+      Fabricação de medicamentos — comprimidos, cápsulas, líquidos e biológicos.
+  BC-1550.20.10:
+    name: Fabricação de formas farmacêuticas sólidas
+    description: |
+      Operações de fabricação de comprimidos e cápsulas.
+  BC-1550.20.20:
+    name: Fabricação de formas líquidas e semissólidas
+    description: |
+      Fabricação de formas farmacêuticas líquidas, em suspensão e semissólidas.
+  BC-1550.20.30:
+    name: Enchimento e acabamento de medicamentos biológicos
+    description: |
+      Enchimento e acabamento de medicamentos biológicos.
+  BC-1550.20.40:
+    name: Fabricação de formas inalatórias e especiais
+    description: |
+      Fabricação de formas inalatórias, transdérmicas e especiais.
+  BC-1550.30:
+    name: Gestão de fabricação estéril
+    description: |
+      Fabricação asséptica e por esterilização terminal.
+  BC-1550.30.10:
+    name: Operações de enchimento asséptico
+    description: |
+      Enchimento asséptico conforme requisitos do Anexo 1.
+  BC-1550.30.20:
+    name: Operações de esterilização terminal
+    description: |
+      Processamento de esterilização terminal.
+  BC-1550.30.30:
+    name: Operações de sala limpa
+    description: |
+      Operação de salas limpas classificadas e monitorização ambiental.
+  BC-1550.40:
+    name: Gestão de embalagem e rotulagem
+    description: |
+      Embalagem primária e secundária e operações de rotulagem.
+  BC-1550.40.10:
+    name: Operações de embalagem primária
+    description: |
+      Embalagem primária de medicamentos.
+  BC-1550.40.20:
+    name: Operações de embalagem secundária
+    description: |
+      Embalagem secundária, encaixotamento e agrupamento.
+  BC-1550.40.30:
+    name: Aplicação de rótulos
+    description: |
+      Aplicação de rótulos e marcas de serialização.
+  BC-1550.40.40:
+    name: Personalização em fase tardia
+    description: |
+      Personalização em fase tardia e embalagem específica por país.
+  BC-1550.50:
+    name: Gestão de validação e qualificação
+    description: |
+      Validação de processos, equipamentos, limpeza e sistemas computorizados.
+  BC-1550.50.10:
+    name: Validação de processos
+    description: |
+      Validação de processos alinhada com ICH Q7.
+  BC-1550.50.20:
+    name: Qualificação de equipamentos
+    description: |
+      Qualificação IQ, OQ, PQ de equipamentos GMP.
+  BC-1550.50.30:
+    name: Validação de limpeza
+    description: |
+      Validação de limpeza entre mudanças de produto.
+  BC-1550.50.40:
+    name: Validação de sistemas computorizados
+    description: |
+      CSV conforme GAMP 5 e 21 CFR Part 11.
+  BC-1550.60:
+    name: Gestão de transferência tecnológica
+    description: |
+      Transferência tecnológica entre instalações e atividades de scale-up.
+  BC-1550.60.10:
+    name: Planeamento de transferência tecnológica
+    description: |
+      Planeamento da transferência tecnológica entre instalações.
+  BC-1550.60.20:
+    name: Scale-up do processo
+    description: |
+      Scale-up de piloto para escala de produção comercial.
+  BC-1550.60.30:
+    name: Verificação da prontidão do local recetor
+    description: |
+      Verificação da prontidão do local recetor para a transferência tecnológica.
+  BC-1550.70:
+    name: Gestão de operações de produção GMP
+    description: |
+      Produção GMP quotidiana e execução de registos de lote.
+  BC-1550.70.10:
+    name: Execução do registo de lote
+    description: |
+      Execução de registos de lote em papel ou eletrónicos.
+  BC-1550.70.20:
+    name: Amostragem de controlo em processo
+    description: |
+      Amostragem e ensaio de controlo em processo.
+  BC-1550.70.30:
+    name: Limpeza da linha de produção
+    description: |
+      Operações de limpeza de linha e mudança de produto.
+  BC-1550.70.40:
+    name: Formação GMP de operadores
+    description: |
+      Formação e qualificação GMP de operadores.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-pharmaceutical-quality-management.yaml
+++ b/catalogue/i18n/pt/L1-pharmaceutical-quality-management.yaml
@@ -1,0 +1,143 @@
+locale: pt
+source: L1-pharmaceutical-quality-management.yaml
+entries:
+  BC-1560:
+    name: Gestão de qualidade farmacêutica
+    description: |
+      Sistemas de qualidade GxP, desvios/CAPA, controlo de alterações e libertação de lotes.
+  BC-1560.10:
+    name: Gestão da conformidade GMP
+    description: |
+      Framework de conformidade GMP e prontidão para inspeções regulamentares.
+  BC-1560.10.10:
+    name: Sistema de gestão da qualidade GMP
+    description: |
+      Manutenção do SGQ alinhado com ICH Q10.
+  BC-1560.10.20:
+    name: Prontidão para inspeções GMP
+    description: |
+      Prontidão para inspeções da FDA, EMA e PMDA.
+  BC-1560.10.30:
+    name: Programa de auditoria GMP
+    description: |
+      Programa de auditoria interna GMP.
+  BC-1560.20:
+    name: Gestão do controlo de qualidade GxP
+    description: |
+      Laboratórios de CQ, ensaios analíticos e ensaios de estabilidade.
+  BC-1560.20.10:
+    name: Operações de laboratório de CQ
+    description: |
+      Operação de laboratórios de CQ em GMP.
+  BC-1560.20.20:
+    name: Transferência de métodos analíticos
+    description: |
+      Transferência de métodos analíticos para locais de CQ.
+  BC-1560.20.30:
+    name: Ensaios de estabilidade
+    description: |
+      Ensaios de estabilidade conforme ICH Q1.
+  BC-1560.20.40:
+    name: Investigação de resultados fora de especificação
+    description: |
+      Investigação de resultados fora de especificação.
+  BC-1560.30:
+    name: Gestão de garantia da qualidade GxP
+    description: |
+      Revisão de QA, revisão de registos de lote e supervisão.
+  BC-1560.30.10:
+    name: Revisão de registos de lote
+    description: |
+      Revisão de QA de registos de lote executados.
+  BC-1560.30.20:
+    name: Gestão de documentos GxP
+    description: |
+      Gestão de documentos controlados para GxP.
+  BC-1560.30.30:
+    name: Supervisão de QA das operações
+    description: |
+      Supervisão de QA no terreno das operações.
+  BC-1560.40:
+    name: Gestão de desvios e CAPA
+    description: |
+      Tratamento de desvios, CAPA e verificações de eficácia.
+  BC-1560.40.10:
+    name: Tratamento de desvios GxP
+    description: |
+      Registo, investigação e encerramento de desvios GxP.
+  BC-1560.40.20:
+    name: Gestão de CAPA GxP
+    description: |
+      Gestão de CAPA com análise de causa raiz.
+  BC-1560.40.30:
+    name: Verificação da eficácia de CAPA
+    description: |
+      Verificação da eficácia dos CAPAs implementados.
+  BC-1560.50:
+    name: Gestão de controlo de alterações GxP
+    description: |
+      Controlo de alterações GxP e avaliação de impacto.
+  BC-1560.50.10:
+    name: Registo de pedidos de alteração GxP
+    description: |
+      Registo e classificação de pedidos de alteração GxP.
+  BC-1560.50.20:
+    name: Avaliação do impacto de alterações GxP
+    description: |
+      Avaliação do impacto das alterações GxP na qualidade do produto.
+  BC-1560.50.30:
+    name: Acompanhamento da implementação de alterações GxP
+    description: |
+      Acompanhamento da implementação de alterações GxP aprovadas.
+  BC-1560.60:
+    name: Gestão da qualidade de fornecedores farmacêuticos
+    description: |
+      Qualificação de fornecedores, auditorias e acordos de qualidade.
+  BC-1560.60.10:
+    name: Qualificação de fornecedores GMP
+    description: |
+      Qualificação de fornecedores de materiais e serviços GMP.
+  BC-1560.60.20:
+    name: Auditoria de fornecedores GMP
+    description: |
+      Auditorias GMP presenciais a fornecedores.
+  BC-1560.60.30:
+    name: Gestão de acordos de qualidade
+    description: |
+      Negociação e manutenção de acordos de qualidade.
+  BC-1560.70:
+    name: Gestão de libertação de lotes
+    description: |
+      Libertação pela Pessoa Qualificada e certificação de lotes.
+  BC-1560.70.10:
+    name: Decisão de disposição de lotes
+    description: |
+      Decisão de disposição sobre lotes fabricados.
+  BC-1560.70.20:
+    name: Certificação pela Pessoa Qualificada
+    description: |
+      Certificação pela PQ conforme o Anexo 16 da UE.
+  BC-1560.70.30:
+    name: Coordenação da libertação para o mercado
+    description: |
+      Coordenação da libertação para o mercado em todas as regiões.
+  BC-1560.80:
+    name: Gestão da revisão anual da qualidade do produto
+    description: |
+      APQR/APR e análise de tendências de qualidade do produto.
+  BC-1560.80.10:
+    name: Produção de APQR
+    description: |
+      Produção de revisões anuais da qualidade do produto.
+  BC-1560.80.20:
+    name: Análise de tendências da qualidade do produto
+    description: |
+      Análise de tendências dos dados de qualidade do produto ao longo do tempo.
+  BC-1560.80.30:
+    name: Acompanhamento de ações do APQR
+    description: |
+      Acompanhamento de ações decorrentes das conclusões do APQR.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-pharmaceutical-supply-chain-management.yaml
+++ b/catalogue/i18n/pt/L1-pharmaceutical-supply-chain-management.yaml
@@ -1,0 +1,99 @@
+locale: pt
+source: L1-pharmaceutical-supply-chain-management.yaml
+entries:
+  BC-1570:
+    name: Gestão da cadeia de abastecimento farmacêutica
+    description: |
+      Cadeia de frio, serialização, distribuição e logística farmacêutica.
+  BC-1570.10:
+    name: Gestão da cadeia de frio
+    description: |
+      Cadeia de abastecimento a temperatura controlada e GDP.
+  BC-1570.10.10:
+    name: Conceção da cadeia de frio
+    description: |
+      Conceção e qualificação de soluções de cadeia de frio.
+  BC-1570.10.20:
+    name: Monitorização da temperatura
+    description: |
+      Monitorização da temperatura de ponta a ponta na cadeia de frio.
+  BC-1570.10.30:
+    name: Gestão de excursões de temperatura
+    description: |
+      Investigação e disposição de excursões de temperatura.
+  BC-1570.20:
+    name: Gestão de serialização e rastreabilidade
+    description: |
+      Serialização, agregação e anti-contrafação.
+  BC-1570.20.10:
+    name: Gestão de números de série
+    description: |
+      Geração e atribuição de números de série por mercado.
+  BC-1570.20.20:
+    name: Gestão de agregação e hierarquia
+    description: |
+      Agregação de unidades serializadas em feixes e paletes.
+  BC-1570.20.30:
+    name: Reporte regulatório e verificação
+    description: |
+      Reporte regulatório (DSCSA, EU FMD) e verificação na dispensa.
+  BC-1570.30:
+    name: Gestão da distribuição farmacêutica
+    description: |
+      Distribuição a grossistas, hospitais e farmácias.
+  BC-1570.30.10:
+    name: Operações de grossistas e distribuidores
+    description: |
+      Operações de distribuição a grossistas e distribuidores.
+  BC-1570.30.20:
+    name: Distribuição direta a hospitais
+    description: |
+      Distribuição direta a hospitais e farmácias.
+  BC-1570.30.30:
+    name: Distribuição especializada
+    description: |
+      Distribuição especializada para produtos de distribuição limitada.
+  BC-1570.40:
+    name: Gestão de inventário farmacêutico
+    description: |
+      Inventário, prazos de validade e alocação de produtos farmacêuticos.
+  BC-1570.40.10:
+    name: Planeamento do inventário farmacêutico
+    description: |
+      Planeamento de inventário para produtos farmacêuticos.
+  BC-1570.40.20:
+    name: Gestão de prazos de validade e durabilidade
+    description: |
+      Gestão FEFO e monitorização da durabilidade.
+  BC-1570.40.30:
+    name: Alocação farmacêutica
+    description: |
+      Alocação de aprovisionamento restrito entre mercados.
+  BC-1570.40.40:
+    name: Coordenação de recalls e retiradas
+    description: |
+      Coordenação de operações de recall e retirada de produtos.
+  BC-1570.50:
+    name: Gestão de logística farmacêutica
+    description: |
+      Transporte, armazenagem e logística em conformidade com GDP.
+  BC-1570.50.10:
+    name: Transporte em conformidade com GDP
+    description: |
+      Operações de transporte em conformidade com GDP.
+  BC-1570.50.20:
+    name: Armazenagem em conformidade com GDP
+    description: |
+      Operações de armazenagem em conformidade com GDP.
+  BC-1570.50.30:
+    name: Operações aduaneiras farmacêuticas
+    description: |
+      Operações aduaneiras e de importação/exportação farmacêuticas.
+  BC-1570.50.40:
+    name: Gestão de prestadores de serviços logísticos
+    description: |
+      Gestão de fornecedores 3PL na cadeia de abastecimento farmacêutica.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-pharmacovigilance-management.yaml
+++ b/catalogue/i18n/pt/L1-pharmacovigilance-management.yaml
@@ -1,0 +1,99 @@
+locale: pt
+source: L1-pharmacovigilance-management.yaml
+entries:
+  BC-1540:
+    name: Gestão de farmacovigilância
+    description: |
+      Monitorização de eventos adversos, deteção de sinais e reporte de segurança.
+  BC-1540.10:
+    name: Gestão de casos de eventos adversos
+    description: |
+      Processamento de ICSR e reporte expedito.
+  BC-1540.10.10:
+    name: Receção e triagem de ICSR
+    description: |
+      Receção e triagem de relatórios individuais de segurança de casos.
+  BC-1540.10.20:
+    name: Processamento de casos ICSR
+    description: |
+      Processamento, codificação e redação de narrativas de ICSRs.
+  BC-1540.10.30:
+    name: Reporte expedito e periódico
+    description: |
+      Reporte expedito conforme ICH E2D e EU GVP.
+  BC-1540.10.40:
+    name: Revisão médica e avaliação de causalidade
+    description: |
+      Revisão médica e avaliação da causalidade de casos.
+  BC-1540.20:
+    name: Gestão de deteção e sinalização
+    description: |
+      Deteção, avaliação e escalada de sinais.
+  BC-1540.20.10:
+    name: Deteção de sinais
+    description: |
+      Deteção quantitativa e qualitativa de sinais.
+  BC-1540.20.20:
+    name: Avaliação de sinais
+    description: |
+      Avaliação e validação de sinais detetados.
+  BC-1540.20.30:
+    name: Decisão e ação sobre sinais
+    description: |
+      Decisão sobre sinais e conversão em ações e alterações de rotulagem.
+  BC-1540.30:
+    name: Gestão de reporte periódico de segurança
+    description: |
+      PSURs/PBRERs, DSURs e relatórios periódicos.
+  BC-1540.30.10:
+    name: Produção de PSUR/PBRER
+    description: |
+      Produção de PSURs e PBRERs.
+  BC-1540.30.20:
+    name: Produção de DSUR
+    description: |
+      Produção de relatórios de atualização de segurança do desenvolvimento.
+  BC-1540.30.30:
+    name: Reporte de segurança agregado
+    description: |
+      Produção de outros relatórios de segurança agregados.
+  BC-1540.40:
+    name: Gestão do plano de gestão do risco
+    description: |
+      RMPs, medidas de minimização do risco e REMS.
+  BC-1540.40.10:
+    name: Redação do plano de gestão do risco
+    description: |
+      Redação de RMPs da UE e documentos REMS.
+  BC-1540.40.20:
+    name: Implementação de minimização do risco
+    description: |
+      Implementação de minimização do risco rotineira e adicional.
+  BC-1540.40.30:
+    name: Avaliação da eficácia da minimização do risco
+    description: |
+      Avaliação da eficácia das medidas de minimização do risco.
+  BC-1540.50:
+    name: Gestão de auditorias e inspeções de farmacovigilância
+    description: |
+      Auditorias de FV, inspeções regulamentares e CAPAs.
+  BC-1540.50.10:
+    name: Programa de auditoria do sistema de FV
+    description: |
+      Programa de auditoria interna que cobre o sistema de FV.
+  BC-1540.50.20:
+    name: Prontidão para inspeções de FV
+    description: |
+      Prontidão para inspeções de FV das autoridades de saúde.
+  BC-1540.50.30:
+    name: Gestão de CAPAs de FV
+    description: |
+      Gestão de CAPAs resultantes de auditorias e inspeções.
+  BC-1540.50.40:
+    name: Manutenção do ficheiro mestre do sistema de FV
+    description: |
+      Manutenção do ficheiro mestre do sistema de farmacovigilância (PSMF).
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-pharmacy-medication-management.yaml
+++ b/catalogue/i18n/pt/L1-pharmacy-medication-management.yaml
@@ -1,0 +1,152 @@
+locale: pt
+source: L1-pharmacy-medication-management.yaml
+entries:
+  BC-2850:
+    name: Gestão de farmácia e medicação
+    description: |
+      Operações farmacêuticas do lado do prestador, incluindo formulário,
+      distribuição em internamento e ambulatório, administração e reconciliação de
+      medicação, gestão de substâncias controladas e serviços clínicos de farmácia.
+  BC-2850.10:
+    name: Gestão do formulário
+    description: |
+      Gestão do formulário de medicamentos, intercâmbio terapêutico e resposta a
+      escassez de medicamentos.
+  BC-2850.10.10:
+    name: Tomada de decisão sobre o formulário
+    description: |
+      Decisões baseadas em evidências sobre inclusão, exclusão e nível dos
+      medicamentos no formulário.
+  BC-2850.10.20:
+    name: Intercâmbio terapêutico
+    description: |
+      Gestão e execução de protocolos de intercâmbio terapêutico.
+  BC-2850.10.30:
+    name: Apoio à comissão de farmácia e terapêutica
+    description: |
+      Apoio operacional à Comissão de Farmácia e Terapêutica.
+  BC-2850.10.40:
+    name: Gestão de escassez de medicamentos
+    description: |
+      Identificação, mitigação e planeamento de substituição para escassez de
+      medicamentos.
+  BC-2850.20:
+    name: Operações de farmácia hospitalar
+    description: |
+      Verificação de ordens, preparação estéril e não estéril, distribuição e
+      misturas intravenosas para serviços de internamento.
+  BC-2850.20.10:
+    name: Verificação de ordens
+    description: |
+      Verificação farmacêutica de ordens de medicação quanto à segurança e
+      adequação.
+  BC-2850.20.20:
+    name: Preparação estéril
+    description: |
+      Operações de preparação estéril, incluindo preparação de medicamentos
+      perigosos.
+  BC-2850.20.30:
+    name: Distribuição em dose unitária
+    description: |
+      Preparação e distribuição em dose unitária para administração em internamento.
+  BC-2850.20.40:
+    name: Preparação de misturas intravenosas
+    description: |
+      Preparação de misturas intravenosas, infusões e nutrição parentérica.
+  BC-2850.30:
+    name: Operações de farmácia de ambulatório e especialidade
+    description: |
+      Operações de farmácia de retalho, de especialidade e por correio, incluindo
+      programas de medicamentos a preços reduzidos.
+  BC-2850.30.10:
+    name: Distribuição de retalho
+    description: |
+      Distribuição de receitas em farmácias de ambulatório.
+  BC-2850.30.20:
+    name: Gestão de medicamentos de especialidade
+    description: |
+      Operações de farmácia de especialidade para medicamentos de custo elevado e
+      distribuição limitada.
+  BC-2850.30.30:
+    name: Distribuição por correio
+    description: |
+      Operações de distribuição e entrega de receitas por correio.
+  BC-2850.30.40:
+    name: Operações de programas de medicamentos a preços reduzidos
+    description: |
+      Operações para programas de desconto de medicamentos por estatuto e
+      conformidade das entidades qualificadas.
+  BC-2850.40:
+    name: Administração e reconciliação de medicação
+    description: |
+      Administração de medicação à cabeceira, reconciliação nas transições e gestão
+      de medicamentos trazidos pelo doente.
+  BC-2850.40.10:
+    name: Administração de medicação à cabeceira
+    description: |
+      Administração de medicação à cabeceira verificada por código de barras pela
+      enfermagem.
+  BC-2850.40.20:
+    name: Reconciliação de medicação
+    description: |
+      Reconciliação de medicação domiciliária e prescrita na admissão, transferência
+      e alta.
+  BC-2850.40.30:
+    name: Operações do registo de administração de medicação
+    description: |
+      Operação do registo electrónico de administração de medicação.
+  BC-2850.40.40:
+    name: Gestão de medicamentos trazidos pelo doente
+    description: |
+      Identificação, armazenamento e administração autorizada de medicamentos
+      trazidos pelo doente.
+  BC-2850.50:
+    name: Gestão de substâncias controladas
+    description: |
+      Conformidade, monitorização de desvio, inventário e eliminação de
+      medicamentos controlados.
+  BC-2850.50.10:
+    name: Conformidade regulatória de substâncias controladas
+    description: |
+      Conformidade com a regulamentação de substâncias controladas, incluindo
+      registo e manutenção de registos.
+  BC-2850.50.20:
+    name: Monitorização de desvio
+    description: |
+      Vigilância e investigação de suspeita de desvio de medicamentos.
+  BC-2850.50.30:
+    name: Inventário de medicamentos controlados
+    description: |
+      Inventário perpétuo e reconciliação de stocks de medicamentos controlados.
+  BC-2850.50.40:
+    name: Eliminação e destruição de medicamentos controlados
+    description: |
+      Eliminação, destruição testemunhada e distribuição inversa de medicamentos
+      controlados.
+  BC-2850.60:
+    name: Serviços clínicos de farmácia
+    description: |
+      Serviços clínicos de farmácia, incluindo gestão de anticoagulação, gestão de
+      antimicrobianos, gestão da terapêutica medicamentosa e monitorização
+      terapêutica de fármacos.
+  BC-2850.60.10:
+    name: Gestão de anticoagulação
+    description: |
+      Serviços de dosagem e monitorização de anticoagulação liderados por
+      farmacêutico.
+  BC-2850.60.20:
+    name: Farmácia de gestão de antimicrobianos
+    description: |
+      Contribuição da farmácia para os programas de gestão de antimicrobianos.
+  BC-2850.60.30:
+    name: Gestão da terapêutica medicamentosa
+    description: |
+      Consultas de gestão da terapêutica medicamentosa prestadas pelo farmacêutico.
+  BC-2850.60.40:
+    name: Monitorização terapêutica de fármacos
+    description: |
+      Serviços de monitorização terapêutica de fármacos e individualização da dose.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-physical-asset-management.yaml
+++ b/catalogue/i18n/pt/L1-physical-asset-management.yaml
@@ -1,0 +1,99 @@
+locale: pt
+source: L1-physical-asset-management.yaml
+entries:
+  BC-1040:
+    name: Gestão de ativos físicos
+    description: |
+      Gestão do ciclo de vida de instalações, equipamentos, frotas e infraestrutura.
+  BC-1040.10:
+    name: Gestão de estratégia e ciclo de vida de ativos
+    description: |
+      Estratégia de ativos, ciclo de vida e planeamento de substituição.
+  BC-1040.10.10:
+    name: Estratégia por classe de ativo
+    description: |
+      Estratégia por classe de ativo alinhada com ISO 55000.
+  BC-1040.10.20:
+    name: Planeamento do ciclo de vida de ativos
+    description: |
+      Planeamento de ciclo de vida completo dos ativos através das fases de aquisição, operação e alienação.
+  BC-1040.10.30:
+    name: Planeamento de substituição de ativos
+    description: |
+      Planeamento de substituição com base na vida útil esperada e condição.
+  BC-1040.10.40:
+    name: Planeamento de capital de ativos
+    description: |
+      Planeamento de capital para investimentos e renovações de ativos.
+  BC-1040.20:
+    name: Gestão do desempenho de ativos
+    description: |
+      KPIs de ativos, disponibilidade e utilização.
+  BC-1040.20.10:
+    name: Definição de KPIs de ativos
+    description: |
+      Definição de KPIs e metas de desempenho de ativos.
+  BC-1040.20.20:
+    name: Monitorização da disponibilidade de ativos
+    description: |
+      Monitorização da disponibilidade e tempo de funcionamento dos ativos.
+  BC-1040.20.30:
+    name: Relatório de utilização de ativos
+    description: |
+      Relatório de utilização e desempenho de ativos.
+  BC-1040.20.40:
+    name: Gestão do índice de saúde dos ativos
+    description: |
+      Índices de saúde compostos e pontuação do estado dos ativos.
+  BC-1040.30:
+    name: Gestão de risco e criticidade de ativos
+    description: |
+      Classificação de criticidade, priorização baseada em risco.
+  BC-1040.30.10:
+    name: Classificação da criticidade dos ativos
+    description: |
+      Classificação da criticidade dos ativos por impacto.
+  BC-1040.30.20:
+    name: Avaliação do risco dos ativos
+    description: |
+      Avaliação do risco dos ativos incluindo consequências de falha.
+  BC-1040.30.30:
+    name: Priorização de manutenção baseada em risco
+    description: |
+      Priorização de ações de manutenção e capital com base em risco.
+  BC-1040.40:
+    name: Gestão da informação de ativos
+    description: |
+      Dados mestre de ativos, documentação técnica.
+  BC-1040.40.10:
+    name: Gestão dos dados mestre de ativos
+    description: |
+      Dados mestre, hierarquias e registos de equipamentos dos ativos.
+  BC-1040.40.20:
+    name: Documentação técnica de ativos
+    description: |
+      Fichas técnicas, desenhos e documentação do fabricante.
+  BC-1040.40.30:
+    name: Gestão do gémeo digital de ativos
+    description: |
+      Modelos de gémeo digital para operações e análise de ativos.
+  BC-1040.50:
+    name: Gestão do descomissionamento e alienação de ativos
+    description: |
+      Descomissionamento, alienação e retirada de ativos.
+  BC-1040.50.10:
+    name: Planeamento do descomissionamento
+    description: |
+      Planeamento do descomissionamento de ativos incluindo HSE.
+  BC-1040.50.20:
+    name: Execução da remoção de ativos
+    description: |
+      Remoção física e desmontagem de ativos retirados.
+  BC-1040.50.30:
+    name: Alienação e revenda de ativos
+    description: |
+      Revenda, sucata e reciclagem de ativos retirados.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-pipeline-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-pipeline-operations-management.yaml
@@ -1,0 +1,130 @@
+locale: pt
+source: L1-pipeline-operations-management.yaml
+entries:
+  BC-3060:
+    name: Gestão de operações de gasodutos e oleodutos
+    description: |
+      Operação, integridade e gestão comercial de gasodutos e oleodutos de recolha e
+      transmissão de hidrocarbonetos — despacho em sala de controlo, inspecção
+      interna, detecção de fugas, agendamento e nomeações, e administração de
+      tarifas.
+  BC-3060.10:
+    name: Operações de controlo de gasodutos
+    description: |
+      Despacho em sala de controlo e operação de SCADA de gasodutos de líquidos e
+      gás.
+  BC-3060.10.10:
+    name: Despacho e controlo de gasodutos
+    description: |
+      Despacho de operações de gasodutos em sala de controlo 24/7.
+  BC-3060.10.20:
+    name: Operações de SCADA
+    description: |
+      Operação de sistemas SCADA de gasodutos e telemetria de campo.
+  BC-3060.10.30:
+    name: Modelação hidráulica de gasodutos
+    description: |
+      Modelação hidráulica em tempo real e off-line de regimes de escoamento em
+      gasodutos.
+  BC-3060.10.40:
+    name: Gestão de simuladores de treino de operadores
+    description: |
+      Manutenção de simuladores de treino de controladores de gasodutos segundo
+      requisitos regulatórios.
+  BC-3060.20:
+    name: Gestão da integridade de gasodutos
+    description: |
+      Inspecção interna, protecção catódica e avaliação de defeitos para garantia de
+      integridade de gasodutos.
+  BC-3060.20.10:
+    name: Inspecção interna
+    description: |
+      Campanhas de inspecção interna com pig inteligente para integridade de
+      gasodutos.
+  BC-3060.20.20:
+    name: Gestão da protecção catódica
+    description: |
+      Concepção, operação e levantamento de protecção catódica de gasodutos.
+  BC-3060.20.30:
+    name: Avaliação de defeitos em gasodutos
+    description: |
+      Avaliação crítica de engenharia de defeitos de perda de metal e tipo fenda.
+  BC-3060.20.40:
+    name: Patrulha da faixa de servidão
+    description: |
+      Patrulha aérea e terrestre das faixas de servidão dos gasodutos.
+  BC-3060.30:
+    name: Detecção de fugas e vigilância de gasodutos
+    description: |
+      Sistemas de detecção de fugas computacional e externos e vigilância de
+      gasodutos.
+  BC-3060.30.10:
+    name: Detecção computacional de fugas
+    description: |
+      Sistemas de detecção de fugas em tempo real baseados em modelos transientes e
+      estatísticos.
+  BC-3060.30.20:
+    name: Detecção externa de fugas
+    description: |
+      Detecção externa de fugas por fibra óptica, acústica e detecção de vapores.
+  BC-3060.30.30:
+    name: Levantamento aéreo e a pé
+    description: |
+      Levantamentos aéreos e a pé rotineiros de corredores de gasodutos.
+  BC-3060.40:
+    name: Agendamento e nomeações de gasodutos
+    description: |
+      Nomeação de capacidade, sequenciamento de lotes e gestão de linefill para
+      volumes transportados.
+  BC-3060.40.10:
+    name: Gestão de nomeações de capacidade
+    description: |
+      Recepção, confirmação e agendamento de nomeações de expedidores.
+  BC-3060.40.20:
+    name: Sequenciamento de lotes
+    description: |
+      Sequenciamento de lotes multiproduto em gasodutos de líquidos.
+  BC-3060.40.30:
+    name: Gestão de linefill
+    description: |
+      Gestão da propriedade de linefill e posições de inventário nos gasodutos.
+  BC-3060.50:
+    name: Gestão de tarifas de gasodutos
+    description: |
+      Registo e administração de tarifas reguladas e contratuais de gasodutos,
+      facturação de expedidores e liquidação de desequilíbrios.
+  BC-3060.50.10:
+    name: Registo e manutenção de tarifas
+    description: |
+      Registo e manutenção de tarifas de gasodutos junto dos reguladores.
+  BC-3060.50.20:
+    name: Facturação de expedidores
+    description: |
+      Cálculo e emissão de facturas de transporte para expedidores.
+  BC-3060.50.30:
+    name: Liquidação de desequilíbrios
+    description: |
+      Liquidação de desequilíbrios operacionais entre expedidores.
+  BC-3060.60:
+    name: Operações de construção e reparação de gasodutos
+    description: |
+      Reparações em serviço, operações de hot-tap e coordenação de substituição
+      para gasodutos de transmissão e recolha.
+  BC-3060.60.10:
+    name: Coordenação de substituição de gasodutos
+    description: |
+      Coordenação de substituição de troços de gasodutos e reconfigurações de
+      traçado.
+  BC-3060.60.20:
+    name: Operações de reparação em serviço
+    description: |
+      Reparações por compósito, manga e sobreposição por soldadura de gasodutos
+      em serviço.
+  BC-3060.60.30:
+    name: Operações de hot-tap
+    description: |
+      Operações de hot-tap e stopple para ligações em gasodutos pressurizados.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-plant-maintenance-management.yaml
+++ b/catalogue/i18n/pt/L1-plant-maintenance-management.yaml
@@ -1,0 +1,131 @@
+locale: pt
+source: L1-plant-maintenance-management.yaml
+entries:
+  BC-1030:
+    name: Gestão da manutenção de instalações
+    description: |
+      Manutenção preventiva, preditiva e corretiva de instalações e equipamentos.
+  BC-1030.10:
+    name: Gestão da estratégia de manutenção
+    description: |
+      Estratégia de manutenção por classe de ativo, RCM.
+  BC-1030.10.10:
+    name: Análise de manutenção centrada na fiabilidade
+    description: |
+      Análise RCM para definir estratégias de manutenção por classe de ativo.
+  BC-1030.10.20:
+    name: Definição de planos de manutenção
+    description: |
+      Definição de planos de manutenção, tarefas e intervalos.
+  BC-1030.10.30:
+    name: Gestão de normas de manutenção
+    description: |
+      Procedimentos, normas e boas práticas de manutenção.
+  BC-1030.20:
+    name: Gestão da manutenção preventiva
+    description: |
+      Planos de MP, programação e execução.
+  BC-1030.20.10:
+    name: Gestão do programa de MP
+    description: |
+      Geração e gestão de programas de manutenção preventiva.
+  BC-1030.20.20:
+    name: Execução de MP
+    description: |
+      Execução de tarefas de MP e verificação da conclusão.
+  BC-1030.20.30:
+    name: Acompanhamento da conformidade de MP
+    description: |
+      Acompanhamento da conformidade de MP e tarefas em atraso.
+  BC-1030.30:
+    name: Gestão da manutenção corretiva
+    description: |
+      Resposta a avarias, reparações.
+  BC-1030.30.10:
+    name: Resposta a avarias
+    description: |
+      Primeira resposta a avarias de equipamentos e eventos não planeados.
+  BC-1030.30.20:
+    name: Execução de reparações de equipamentos
+    description: |
+      Execução de reparações corretivas e verificação.
+  BC-1030.30.30:
+    name: Análise e relatório de falhas
+    description: |
+      Análise de causa raiz e relatório de falhas após trabalho corretivo.
+  BC-1030.40:
+    name: Gestão da manutenção preditiva
+    description: |
+      Manutenção baseada em condição e impulsionada por análise preditiva.
+  BC-1030.40.10:
+    name: Monitorização de condição
+    description: |
+      Monitorização de condição por vibração, termografia, óleo e acústica.
+  BC-1030.40.20:
+    name: Modelação de análise preditiva
+    description: |
+      Previsão de falhas baseada em aprendizagem automática.
+  BC-1030.40.30:
+    name: Ação de manutenção prescritiva
+    description: |
+      Geração de ações de manutenção prescritivas a partir de previsões.
+  BC-1030.50:
+    name: Gestão de ordens de trabalho de manutenção
+    description: |
+      Ciclo de vida das ordens de trabalho de manutenção.
+  BC-1030.50.10:
+    name: Captura de notificações de manutenção
+    description: |
+      Captura de notificações e pedidos de manutenção.
+  BC-1030.50.20:
+    name: Planeamento de ordens de trabalho de manutenção
+    description: |
+      Planeamento de ordens de trabalho incluindo recursos e peças.
+  BC-1030.50.30:
+    name: Execução de ordens de trabalho de manutenção
+    description: |
+      Execução e confirmação de ordens de trabalho de manutenção.
+  BC-1030.50.40:
+    name: Encerramento de ordens de trabalho de manutenção
+    description: |
+      Encerramento, liquidação e registos de ordens de trabalho de manutenção.
+  BC-1030.60:
+    name: Gestão do inventário de peças sobresselentes de manutenção
+    description: |
+      Stock e utilização de peças sobresselentes MRO.
+  BC-1030.60.10:
+    name: Estratégia de stock MRO
+    description: |
+      Estratégia de stock e níveis de stockagem para peças MRO.
+  BC-1030.60.20:
+    name: Aprovisionamento de peças MRO
+    description: |
+      Aprovisionamento de peças MRO e consumíveis.
+  BC-1030.60.30:
+    name: Operações do armazém MRO
+    description: |
+      Operações do armazém incluindo emissão e devolução de peças MRO.
+  BC-1030.60.40:
+    name: Gestão de peças críticas
+    description: |
+      Identificação e gestão de peças críticas e de segurança.
+  BC-1030.70:
+    name: Gestão da fiabilidade de equipamentos
+    description: |
+      Engenharia de fiabilidade, análise de falhas, MTBF/MTTR.
+  BC-1030.70.10:
+    name: Análise de engenharia de fiabilidade
+    description: |
+      Análise de fiabilidade (FMEA, FTA, RBD) de ativos críticos.
+  BC-1030.70.20:
+    name: Acompanhamento de MTBF e MTTR
+    description: |
+      Acompanhamento do tempo médio entre falhas e tempos de reparação.
+  BC-1030.70.30:
+    name: Programas de melhoria da fiabilidade
+    description: |
+      Programas para melhorar a fiabilidade de ativos com elevada taxa de falha.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-point-of-sale-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-point-of-sale-operations-management.yaml
@@ -1,0 +1,168 @@
+locale: pt
+source: L1-point-of-sale-operations-management.yaml
+entries:
+  BC-2320:
+    name: Gestão de operações de ponto de venda
+    description: |
+      Camada de transação voltada para o cliente no retalho — registo de vendas,
+      aceitação de pagamentos, devoluções e reembolsos, gestão de numerário,
+      configuração do ponto de venda e continuidade de vendas durante falhas de
+      sistema.
+  BC-2320.10:
+    name: Gestão de transações de venda
+    description: |
+      Registo de transações de venda ao consumidor, incluindo criação do cabaz,
+      leitura de artigos, aplicação de promoções, processamento de impostos e
+      recibos digitais.
+    in_scope:
+      - Criação do cabaz e leitura de artigos
+      - Aplicação de promoções e fidelização na caixa
+      - Cálculo de impostos e emissão de recibos digitais ou em papel
+    out_of_scope:
+      - Conceção de promoções (BC-440.30)
+      - Checkout de comércio eletrónico (BC-2330)
+  BC-2320.10.10:
+    name: Leitura de artigos e criação de cabaz
+    description: |
+      Leitura de artigos e montagem do cabaz na caixa, incluindo artigos por peso.
+  BC-2320.10.20:
+    name: Aplicação de promoções e fidelização
+    description: |
+      Aplicação de promoções, cupões e resgates de fidelização durante a venda.
+  BC-2320.10.30:
+    name: Processamento de impostos sobre vendas e IVA
+    description: |
+      Cálculo do imposto sobre vendas, IVA e regras específicas de jurisdição na
+      caixa.
+  BC-2320.10.40:
+    name: Emissão de recibo e recibo digital
+    description: |
+      Emissão de recibos em papel e digitais, incluindo associação ao consumidor.
+  BC-2320.20:
+    name: Gestão de aceitação de meios de pagamento
+    description: |
+      Aceitação de meios de pagamento na caixa, incluindo EMV, contactless,
+      carteiras digitais, cartões presente e métodos de pagamento alternativos,
+      com conformidade PCI-DSS.
+  BC-2320.20.10:
+    name: Aceitação de pagamento por cartão e contactless
+    description: |
+      Aceitação de pagamentos EMV, contactless e carteiras digitais em caixas de
+      retalho.
+  BC-2320.20.20:
+    name: Aceitação de numerário e cheque
+    description: |
+      Aceitação de numerário, moedas e cheques, incluindo gestão de denominações.
+  BC-2320.20.30:
+    name: Aceitação de cartão presente e valor armazenado
+    description: |
+      Aceitação e emissão de cartões presente e instrumentos de valor armazenado.
+  BC-2320.20.40:
+    name: Aceitação de métodos de pagamento alternativos
+    description: |
+      Aceitação de compra agora-pague depois, QR e outros meios de pagamento
+      alternativos.
+  BC-2320.20.50:
+    name: Operações de conformidade PCI-DSS
+    description: |
+      Tratamento de dados de titulares de cartão em conformidade com PCI-DSS no
+      ponto de venda.
+  BC-2320.30:
+    name: Gestão de devoluções, reembolsos e trocas
+    description: |
+      Processamento na loja de devoluções, reembolsos e trocas de consumidores,
+      incluindo casos de reembolso no meio original, crédito em loja e
+      omnicanal.
+    in_scope:
+      - Devoluções e reembolsos de consumidores na loja
+      - Gestão de crédito em loja e trocas
+      - Devoluções omnicanal de encomendas online na loja
+    out_of_scope:
+      - Logística inversa para o centro de distribuição (BC-520.40.40)
+  BC-2320.30.10:
+    name: Aceitação de devolução do consumidor
+    description: |
+      Aceitação de devoluções de consumidores na caixa de acordo com a política
+      de devoluções.
+  BC-2320.30.20:
+    name: Emissão de reembolso e crédito em loja
+    description: |
+      Emissão de reembolsos no meio de pagamento original ou em instrumentos de
+      crédito em loja.
+  BC-2320.30.30:
+    name: Processamento de trocas
+    description: |
+      Transações de troca em igual valor e valor diferente, incluindo
+      reconciliação de preço.
+  BC-2320.30.40:
+    name: Processamento de devoluções omnicanal
+    description: |
+      Aceitação na loja de encomendas de outros canais para devolução.
+  BC-2320.40:
+    name: Gestão de numerário e meios de pagamento no ponto de venda
+    description: |
+      Processos de gestão da gaveta de caixa, cofre, depósito e reconciliação de
+      meios de pagamento de fim de dia para proteger as receitas da caixa.
+  BC-2320.40.10:
+    name: Gestão da gaveta de caixa
+    description: |
+      Abertura, monitorização e reconciliação das gavetas de caixa.
+  BC-2320.40.20:
+    name: Operações de cofre e recolha de numerário
+    description: |
+      Gestão do cofre, recolhas intercalares e preparação para transporte de
+      valores.
+  BC-2320.40.30:
+    name: Reconciliação de meios de pagamento de fim de dia
+    description: |
+      Reconciliação de todos os meios de pagamento com os registos de vendas do
+      ponto de venda no fim do dia.
+  BC-2320.40.40:
+    name: Preparação de depósito bancário
+    description: |
+      Preparação de depósitos bancários e entrega para transporte de valores.
+  BC-2320.50:
+    name: Gestão de configuração do ponto de venda
+    description: |
+      Configuração de tipos de pagamento, regras fiscais, lógica de promoções,
+      periféricos e comportamento da caixa em toda a rede de lojas.
+  BC-2320.50.10:
+    name: Configuração de meios de pagamento
+    description: |
+      Configuração dos meios de pagamento aceites, limites e encaminhamento por
+      loja.
+  BC-2320.50.20:
+    name: Configuração de regras fiscais
+    description: |
+      Configuração das regras fiscais e exceções por jurisdição e por loja.
+  BC-2320.50.30:
+    name: Configuração do motor de promoções
+    description: |
+      Configuração do motor de promoções do ponto de venda e regras de priorização
+      de ofertas.
+  BC-2320.50.40:
+    name: Configuração de periféricos do ponto de venda
+    description: |
+      Configuração de balanças, leitores, impressoras e PIN pads na caixa.
+  BC-2320.60:
+    name: Resiliência e operações offline do ponto de venda
+    description: |
+      Continuidade de vendas durante falhas de conectividade ou de sistema,
+      incluindo ponto de venda offline, store-and-forward e gestão de filas.
+  BC-2320.60.10:
+    name: Operação offline do ponto de venda
+    description: |
+      Operação continuada do ponto de venda durante perda de conectividade.
+  BC-2320.60.20:
+    name: Processamento de transações em store-and-forward
+    description: |
+      Armazenamento e reenvio de transações offline após restabelecimento da
+      ligação.
+  BC-2320.60.30:
+    name: Gestão de filas durante interrupção
+    description: |
+      Gestão de filas de clientes durante interrupções do sistema de checkout.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-policy-administration-management.yaml
+++ b/catalogue/i18n/pt/L1-policy-administration-management.yaml
@@ -1,0 +1,117 @@
+locale: pt
+source: L1-policy-administration-management.yaml
+entries:
+  BC-2140:
+    name: Gestão de administração de apólices
+    description: |
+      Emissão, endorsements, ajustamentos de meio-prazo, renovações, cancelamentos,
+      caducidades, reativações, gestão de documentos e administração de apólices
+      de grupo/mestre de contratos de seguros em vigor.
+  BC-2140.10:
+    name: Gestão de emissão de apólices
+    description: |
+      Geração, montagem e ativação de novos contratos de apólice e documentos de suporte.
+  BC-2140.10.10:
+    name: Geração de documentos de apólice
+    description: |
+      Geração de documentos de apólice a partir de modelos de produto e termos vinculados.
+  BC-2140.10.20:
+    name: Montagem de programa e redação de apólice
+    description: |
+      Montagem de programas, redações e endorsements de apólice no contrato.
+  BC-2140.10.30:
+    name: Ativação de apólice
+    description: |
+      Ativação de novas apólices e notificação aos sistemas a jusante.
+  BC-2140.20:
+    name: Endorsement e ajustamento de meio-prazo de apólice
+    description: |
+      Captura, tarifação, aprovação e emissão de endorsements e ajustamentos de meio-prazo.
+  BC-2140.20.10:
+    name: Captura de pedidos de endorsement
+    description: |
+      Captura de pedidos de endorsement de tomadores de apólice e produtores.
+  BC-2140.20.20:
+    name: Tarifação e aprovação de endorsement
+    description: |
+      Tarifação de endorsements e aprovação de subscrição quando necessário.
+  BC-2140.20.30:
+    name: Emissão e comunicação de endorsement
+    description: |
+      Emissão de documentos de endorsement e comunicação ao tomador de apólice.
+  BC-2140.30:
+    name: Gestão de renovação de apólice
+    description: |
+      Elegibilidade para renovação, retarifação, geração de oferta e tratamento de não renovação.
+  BC-2140.30.10:
+    name: Avaliação de elegibilidade para renovação
+    description: |
+      Avaliação da elegibilidade para renovação com base na experiência de sinistros e regras de subscrição.
+  BC-2140.30.20:
+    name: Retarifação de renovação
+    description: |
+      Retarifação de apólices em renovação ao abrigo dos registos de taxas e experiência atuais.
+  BC-2140.30.30:
+    name: Geração de oferta de renovação
+    description: |
+      Geração e envio de ofertas de renovação aos tomadores de apólice.
+  BC-2140.30.40:
+    name: Tratamento de não renovação
+    description: |
+      Tratamento de não renovações, incluindo prazos de aviso e comunicações regulatórias.
+  BC-2140.40:
+    name: Gestão de cancelamento e caducidade de apólice
+    description: |
+      Processamento de cancelamento, ajustamento de prémio, caducidade e reativação.
+  BC-2140.40.10:
+    name: Processamento de pedidos de cancelamento
+    description: |
+      Processamento de pedidos de cancelamento de tomadores de apólice, produtores ou seguradora.
+  BC-2140.40.20:
+    name: Cálculo pro-rata e short-rate
+    description: |
+      Cálculo de ajustamentos de prémio pro-rata e short-rate no cancelamento.
+  BC-2140.40.30:
+    name: Tratamento de caducidade
+    description: |
+      Processamento de caducidade por falta de pagamento e notificação ao tomador de apólice.
+  BC-2140.40.40:
+    name: Processamento de reativação
+    description: |
+      Reativação de apólices caducadas ou canceladas sujeita a verificações de subscrição.
+  BC-2140.50:
+    name: Gestão de documentos e registos de apólice
+    description: |
+      Repositório de documentos de apólice, retenção de registos regulatórios e trilhas de auditoria de apólice.
+  BC-2140.50.10:
+    name: Repositório de documentos de apólice
+    description: |
+      Repositório de documentos de apólice e correspondência de suporte.
+  BC-2140.50.20:
+    name: Retenção de registos regulatórios
+    description: |
+      Retenção de registos de apólice segundo os requisitos regulatórios de seguros.
+  BC-2140.50.30:
+    name: Manutenção da trilha de auditoria de apólice
+    description: |
+      Manutenção de trilhas de auditoria imutáveis sobre alterações e decisões de apólice.
+  BC-2140.60:
+    name: Administração de apólice de grupo e mestre
+    description: |
+      Configuração de apólice de grupo, manutenção de certificados e ciclos de renovação de grupo.
+  BC-2140.60.10:
+    name: Configuração de apólice de grupo
+    description: |
+      Configuração de contratos de apólice de grupo e mestre para esquemas de entidade patronal e afinidade.
+  BC-2140.60.20:
+    name: Manutenção de membros e certificados
+    description: |
+      Manutenção de membros de grupo, certificados e dependentes.
+  BC-2140.60.30:
+    name: Gestão do ciclo de renovação de grupo
+    description: |
+      Gestão de ciclos de renovação de grupo, retarifação e re-inscrição de membros.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-population-health-management.yaml
+++ b/catalogue/i18n/pt/L1-population-health-management.yaml
@@ -1,0 +1,147 @@
+locale: pt
+source: L1-population-health-management.yaml
+entries:
+  BC-2880:
+    name: Gestão da saúde da população
+    description: |
+      Estratificação de risco, cuidados preventivos, gestão de doenças crónicas,
+      operações de cuidados baseados em valor, gestão de painéis e atribuição de
+      doentes, e análise de populações atribuídas e em risco.
+  BC-2880.10:
+    name: Estratificação e identificação de risco
+    description: |
+      Modelação preditiva e identificação de populações em risco crescente e com
+      lacunas de cuidados.
+  BC-2880.10.10:
+    name: Modelação preditiva de risco
+    description: |
+      Desenvolvimento e operação de modelos preditivos de risco para custos e
+      resultados clínicos.
+  BC-2880.10.20:
+    name: Identificação de risco crescente
+    description: |
+      Identificação de doentes em risco crescente para intervenção precoce.
+  BC-2880.10.30:
+    name: Definição de coortes
+    description: |
+      Definição e manutenção de coortes clínicas para programas populacionais.
+  BC-2880.10.40:
+    name: Identificação de lacunas de cuidados
+    description: |
+      Identificação de lacunas de cuidados baseadas em evidências nas populações.
+  BC-2880.20:
+    name: Cuidados preventivos e bem-estar
+    description: |
+      Programas de rastreio, imunização, avaliação do risco de saúde e coaching
+      de bem-estar.
+  BC-2880.20.10:
+    name: Contacto para rastreios
+    description: |
+      Contacto para rastreios preventivos baseados em evidências.
+  BC-2880.20.20:
+    name: Programas de imunização
+    description: |
+      Prestação de programas de imunização de adultos e pediátricos.
+  BC-2880.20.30:
+    name: Avaliação do risco de saúde
+    description: |
+      Prestação e seguimento de avaliação do risco de saúde.
+  BC-2880.20.40:
+    name: Coaching de bem-estar
+    description: |
+      Prestação de programas de coaching de estilo de vida e bem-estar.
+  BC-2880.30:
+    name: Gestão de doenças crónicas
+    description: |
+      Programas de gestão específicos de doenças para as principais condições
+      crónicas.
+  BC-2880.30.10:
+    name: Programas de cuidados em diabetes
+    description: |
+      Programas de gestão da diabetes, incluindo educação e monitorização remota.
+  BC-2880.30.20:
+    name: Programas de doença cardiovascular
+    description: |
+      Programas de gestão de doença cardiovascular e hipertensão.
+  BC-2880.30.30:
+    name: Integração de saúde mental
+    description: |
+      Integração da saúde mental na gestão de cuidados primários e crónicos.
+  BC-2880.30.40:
+    name: Programas de doença respiratória
+    description: |
+      Programas de asma, doença pulmonar obstrutiva crónica e doença respiratória.
+  BC-2880.40:
+    name: Operações de cuidados baseados em valor
+    description: |
+      Operações de suporte a programas de cuidados de responsabilização, pagamento
+      por episódio e contratuais baseados em valor.
+  BC-2880.40.10:
+    name: Operações de cuidados de responsabilização
+    description: |
+      Operações de organizações de cuidados de responsabilização e programas de
+      partilha de poupanças.
+  BC-2880.40.20:
+    name: Operações de pagamento por episódio
+    description: |
+      Operações de suporte a programas de pagamento por episódio.
+  BC-2880.40.30:
+    name: Acompanhamento do desempenho em qualidade
+    description: |
+      Acompanhamento do desempenho em qualidade face aos requisitos dos programas
+      baseados em valor.
+  BC-2880.40.40:
+    name: Reconciliação de partilha de poupanças
+    description: |
+      Reconciliação de liquidações de partilha de poupanças e partilha de risco com
+      pagadores.
+  BC-2880.50:
+    name: Gestão de painel e atribuição
+    description: |
+      Atribuição de doentes a prestadores, dimensionamento do painel,
+      acompanhamento da continuidade e reconciliação de atribuições.
+  BC-2880.50.10:
+    name: Atribuição do doente ao prestador
+    description: |
+      Atribuição de doentes a prestadores de cuidados primários e equipas de
+      cuidados.
+  BC-2880.50.20:
+    name: Gestão da dimensão do painel
+    description: |
+      Gestão da dimensão, composição e capacidade do painel.
+  BC-2880.50.30:
+    name: Acompanhamento da continuidade de cuidados
+    description: |
+      Acompanhamento de métricas de continuidade de cuidados nos painéis.
+  BC-2880.50.40:
+    name: Reconciliação de atribuições
+    description: |
+      Reconciliação das listas de atribuição do pagador com os dados internos do
+      painel.
+  BC-2880.60:
+    name: Análise e reporte populacional
+    description: |
+      Análise a nível populacional sobre equidade, desempenho de programas de
+      qualidade, custo, utilização e benchmarking de resultados.
+  BC-2880.60.10:
+    name: Análise de equidade em saúde
+    description: |
+      Análise de disparidades, determinantes sociais e resultados de equidade.
+  BC-2880.60.20:
+    name: Reporte de programas de qualidade
+    description: |
+      Reporte relativo a programas de qualidade, como classificações de estrelas e
+      medidas de qualidade.
+  BC-2880.60.30:
+    name: Análise de custos e utilização
+    description: |
+      Análise de custos, utilização e gastos evitáveis.
+  BC-2880.60.40:
+    name: Benchmarking de resultados
+    description: |
+      Benchmarking de resultados clínicos face a conjuntos de dados de pares e
+      nacionais.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-power-generation-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-power-generation-operations-management.yaml
@@ -1,0 +1,203 @@
+locale: pt
+source: L1-power-generation-operations-management.yaml
+entries:
+  BC-3800:
+    name: Gestão de operações de geração de energia elétrica
+    description: |
+      Operação do parque de geração em ativos térmicos, nucleares,
+      hídricos, eólicos, solares e de armazenamento — abrangendo
+      despacho e calendarização, operação de centrais por tecnologia,
+      gestão de combustível e emissões, e gestão de desempenho ao
+      nível do parque.
+  BC-3800.10:
+    name: Despacho e calendarização da geração
+    description: |
+      Comprometimento de unidades, instruções de despacho e calendários
+      de curto prazo para o parque de geração contra nomeações do operador
+      de sistema e posições de mercado.
+  BC-3800.10.10:
+    name: Comprometimento de unidades
+    description: |
+      Seleção de unidades geradoras para serviço em day-ahead e intraday.
+  BC-3800.10.20:
+    name: Despacho económico
+    description: |
+      Despacho por ordem de mérito em tempo real de unidades comprometidas
+      contra a carga.
+  BC-3800.10.30:
+    name: Coordenação de indisponibilidades
+    description: |
+      Coordenação de indisponibilidades de unidades planeadas e forçadas
+      com o operador de sistema e os calendários de mercado.
+  BC-3800.20:
+    name: Operações de central térmica
+    description: |
+      Operação diária de centrais geradoras a carvão, gás e fuel, incluindo
+      centrais de ciclo combinado e de cogeração.
+  BC-3800.20.10:
+    name: Operações de caldeira
+    description: |
+      Operação de instalações de produção de vapor e controlo de combustão.
+  BC-3800.20.20:
+    name: Operações de turbina a vapor
+    description: |
+      Operação de turbinas a vapor e sistemas de condensado e alimentação
+      de água.
+  BC-3800.20.30:
+    name: Operações de turbina a gás
+    description: |
+      Operação de turbinas a gás de ciclo aberto e combinado.
+  BC-3800.20.40:
+    name: Operações de calor e energia combinados
+    description: |
+      Operação de centrais de cogeração a fornecer eletricidade e calor
+      de processo ou de distrito.
+  BC-3800.30:
+    name: Operações de central hidroelétrica
+    description: |
+      Operação de centrais hidroelétricas convencionais, de bombagem
+      e de fio de água, incluindo gestão de barragens e passagens de água.
+  BC-3800.30.10:
+    name: Operações de unidade hídrica
+    description: |
+      Arranque, paragem, regulação e controlo de carga de unidades
+      geradoras hídricas.
+  BC-3800.30.20:
+    name: Gestão do nível de albufeira
+    description: |
+      Calendarização do nível da albufeira contra restrições energéticas,
+      de cheia e ambientais.
+  BC-3800.30.30:
+    name: Operações de ciclo de bombagem
+    description: |
+      Ciclagem de bombagem e geração de centrais hidroelétricas de
+      armazenamento por bombagem.
+  BC-3800.30.40:
+    name: Vigilância da segurança de barragens
+    description: |
+      Vigilância do comportamento estrutural e de infiltrações das barragens
+      contra critérios de segurança.
+  BC-3800.40:
+    name: Operações de central nuclear
+    description: |
+      Operação de centrais nucleares — controlo do reator, paragens para
+      recarga e vigilância de segurança radiológica sob condições de licença
+      do regulador nuclear.
+  BC-3800.40.10:
+    name: Operações de reator
+    description: |
+      Controlo do reator, gestão da reatividade e operações de seguimento
+      de carga.
+  BC-3800.40.20:
+    name: Operações de paragem para recarga
+    description: |
+      Planeamento e execução de paragens para recarga e de manutenção maior.
+  BC-3800.40.30:
+    name: Vigilância radiológica
+    description: |
+      Vigilância de libertação radiológica e dose de trabalhadores contra
+      limites.
+  BC-3800.40.40:
+    name: Operações de piscina de combustível usado
+    description: |
+      Operação e vigilância do arrefecimento e inventário da piscina de
+      combustível usado.
+  BC-3800.50:
+    name: Operações de geração renovável
+    description: |
+      Operação de ativos de geração eólica, solar fotovoltaica e outras
+      energias renováveis variáveis, incluindo curtailment e previsão.
+  BC-3800.50.10:
+    name: Operações de parque eólico
+    description: |
+      Operação de parques eólicos onshore e offshore e gestão de
+      disponibilidade de turbinas.
+  BC-3800.50.20:
+    name: Operações de central solar fotovoltaica
+    description: |
+      Operação de centrais solares fotovoltaicas de escala de serviço
+      público e monitorização de strings.
+  BC-3800.50.30:
+    name: Operações de curtailment de renováveis
+    description: |
+      Execução de instruções de curtailment de operadores de sistema em
+      renováveis variáveis.
+  BC-3800.50.40:
+    name: Previsão de geração renovável
+    description: |
+      Previsão de curto prazo da produção eólica e solar para entradas
+      de despacho e negociação.
+  BC-3800.60:
+    name: Operações de armazenamento de energia
+    description: |
+      Operação de ativos de armazenamento de energia em bateria de escala
+      de rede elétrica e outros, incluindo gestão do estado de carga e
+      ciclagem contra posições de mercado e de serviços de sistema.
+  BC-3800.60.10:
+    name: Operações de armazenamento em bateria
+    description: |
+      Operação e gestão do estado de carga de instalações de baterias
+      de escala de rede elétrica.
+  BC-3800.60.20:
+    name: Otimização de ciclos de armazenamento
+    description: |
+      Otimização da ciclagem de carga-descarga contra pilhas de valor
+      de energia e serviços ancilares.
+  BC-3800.60.30:
+    name: Rastreio da degradação do armazenamento
+    description: |
+      Rastreio da eficiência de ciclo completo e da degradação de
+      capacidade de ativos de bateria.
+  BC-3800.70:
+    name: Gestão do desempenho da geração
+    description: |
+      Vigilância ao nível do parque da disponibilidade, taxa de calor,
+      fator de capacidade e taxa de saída forçada em tecnologias de geração.
+  BC-3800.70.10:
+    name: Relatórios de disponibilidade e fiabilidade
+    description: |
+      Relatórios alinhados com GADS de disponibilidade equivalente e
+      estatísticas de saída forçada.
+  BC-3800.70.20:
+    name: Rastreio de taxa de calor e eficiência
+    description: |
+      Rastreio da taxa de calor e eficiência térmica contra alvos de
+      projeto e contratuais.
+  BC-3800.70.30:
+    name: Rastreio do desempenho de capacidade
+    description: |
+      Rastreio do fator de capacidade e classificações de capacidade
+      dependável.
+  BC-3800.80:
+    name: Gestão de combustível e emissões
+    description: |
+      Gestão do abastecimento, stock e subprodutos de combustão do parque
+      de geração, incluindo vigilância de emissões atmosféricas e CO2.
+  BC-3800.80.10:
+    name: Operações de stock de combustível
+    description: |
+      Operações de parque de carvão, fuel e biomassa e controlo de stocks.
+  BC-3800.80.20:
+    name: Nomeações de abastecimento de gás
+    description: |
+      Nomeações de gás natural em gasodutos e balanceamento para geração
+      a gás.
+  BC-3800.80.30:
+    name: Monitorização de emissões atmosféricas
+    description: |
+      Monitorização contínua de emissões de NOx, SOx, partículas e
+      relatórios.
+  BC-3800.80.40:
+    name: Reconciliação de CO2 e licenças de emissão
+    description: |
+      Reconciliação de emissões de CO2 com licenças entregues ao abrigo
+      de regimes de cap-and-trade.
+  BC-3800.80.50:
+    name: Operações de cinzas e resíduos de combustão
+    description: |
+      Manuseamento e eliminação de cinzas volantes, cinzas de fundo e
+      resíduos de dessulfuração de gases de combustão.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-practice-pursuit-and-proposal-management.yaml
+++ b/catalogue/i18n/pt/L1-practice-pursuit-and-proposal-management.yaml
@@ -1,0 +1,145 @@
+locale: pt
+source: L1-practice-pursuit-and-proposal-management.yaml
+entries:
+  BC-4360:
+    name: Gestão de prospeção e proposta da prática
+    description: |
+      Atividades de fase de prospeção para firmas de serviços profissionais —
+      qualificação de oportunidades, estratégia de prospeção, desenvolvimento
+      de propostas e apresentações, modelação de honorários e análise de
+      ganhos/perdas — distinto da Gestão de Vendas genérica.
+  BC-4360.10:
+    name: Gestão de qualificação de oportunidades
+    description: |
+      Qualificação de oportunidades de prospeção de entrada e saída quanto
+      ao alinhamento estratégico, viabilidade de entrega e atratividade
+      comercial.
+  BC-4360.10.10:
+    name: Captura de oportunidades
+    description: |
+      Captura de oportunidades de prospeção de RFPs, referências e originação
+      por relação.
+  BC-4360.10.20:
+    name: Pontuação de qualificação de oportunidades
+    description: |
+      Pontuação de oportunidades face a critérios de alinhamento estratégico,
+      capacidade e comerciais.
+  BC-4360.10.30:
+    name: Coordenação de pré-aprovação da prospeção
+    description: |
+      Pré-aprovação de oportunidades através de verificações indicativas de
+      independência e conflitos antes do investimento formal em prospeção.
+  BC-4360.20:
+    name: Gestão da estratégia de prospeção
+    description: |
+      Definição da estratégia de prospeção, plano de sucesso, composição da
+      equipa de prospeção e posicionamento competitivo para oportunidades
+      qualificadas.
+  BC-4360.20.10:
+    name: Desenvolvimento do plano de sucesso
+    description: |
+      Desenvolvimento do plano de sucesso da prospeção, incluindo mensagens-chave,
+      diferenciadores e mapeamento de partes interessadas.
+  BC-4360.20.20:
+    name: Composição da equipa de prospeção
+    description: |
+      Composição da equipa de prospeção, incluindo o responsável da prospeção,
+      especialistas e apoio à definição de preços.
+  BC-4360.20.30:
+    name: Síntese de inteligência competitiva
+    description: |
+      Síntese de inteligência competitiva sobre firmas concorrentes esperadas
+      para a mesma oportunidade.
+  BC-4360.30:
+    name: Gestão do desenvolvimento de propostas
+    description: |
+      Elaboração, revisão e submissão de propostas escritas e respostas a
+      RFPs de acordo com as especificações do cliente.
+  BC-4360.30.10:
+    name: Elaboração de propostas
+    description: |
+      Elaboração das secções da proposta, incluindo abordagem, equipa e
+      experiência relevante.
+  BC-4360.30.20:
+    name: Revisão e aprovação de propostas
+    description: |
+      Revisão e aprovação interna do conteúdo, afirmações e compromissos
+      comerciais da proposta.
+  BC-4360.30.30:
+    name: Gestão de submissão de propostas
+    description: |
+      Submissão da proposta no formato e canal exigidos pelo cliente, com
+      registo de auditoria da submissão.
+  BC-4360.30.40:
+    name: Reutilização de ativos de propostas
+    description: |
+      Reutilização e etiquetagem de conteúdo de propostas, estudos de caso e
+      credenciais em diferentes prospeções.
+  BC-4360.40:
+    name: Gestão de apresentações e pitches
+    description: |
+      Preparação e realização de pitches, beauty parades e apresentações orais
+      como parte das prospeções competitivas.
+  BC-4360.40.10:
+    name: Preparação de materiais de pitch
+    description: |
+      Preparação de apresentações de pitch, ativos de demonstração e materiais
+      de apoio para apresentações orais.
+  BC-4360.40.20:
+    name: Ensaio e treino de pitch
+    description: |
+      Ensaio de equipas de pitch e treino em mensagens, dinâmicas e gestão
+      de perguntas e respostas.
+  BC-4360.40.30:
+    name: Gestão da realização de pitches
+    description: |
+      Realização de pitches e beauty parades, incluindo logística e materiais
+      de seguimento.
+  BC-4360.50:
+    name: Modelação de honorários e definição de preços da prospeção
+    description: |
+      Design da estrutura de honorários e modelação de preços para oportunidades
+      de prospeção, incluindo acordos de honorários alternativos e estruturas
+      de partilha de risco.
+    out_of_scope:
+      - Gestão de honorários em fase de projeto (BC-4330.40)
+      - Estratégia de preços da firma (BC-290)
+  BC-4360.50.10:
+    name: Design da estrutura de honorários da prospeção
+    description: |
+      Design de estruturas de honorários em opções por hora, honorários fixos,
+      honorários com teto, contingentes e baseados em resultados.
+  BC-4360.50.20:
+    name: Modelação de rentabilidade da prospeção
+    description: |
+      Modelação da rentabilidade da prospeção em diferentes cenários de equipa,
+      honorários e risco.
+  BC-4360.50.30:
+    name: Aprovação de preços da prospeção
+    description: |
+      Aprovação interna dos preços da prospeção face a limites de desconto,
+      margem e risco.
+  BC-4360.60:
+    name: Análise de ganhos e perdas da prospeção
+    description: |
+      Debriefing estruturado dos resultados da prospeção, análise de taxa de
+      sucesso e captura de insights na prática de prospeção e proposta.
+  BC-4360.60.10:
+    name: Debriefing dos resultados da prospeção
+    description: |
+      Debriefings internos e com o cliente dos resultados da prospeção,
+      incluindo avaliação de concorrentes.
+  BC-4360.60.20:
+    name: Análise de taxa de sucesso
+    description: |
+      Análise de taxa de sucesso segmentada por prática, cliente, tipo de
+      oportunidade e responsável da prospeção.
+  BC-4360.60.30:
+    name: Captura de lições da prospeção
+    description: |
+      Captura de lições da prospeção e feedback em manuais de prospeção
+      e formação.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-premium-accounting-management.yaml
+++ b/catalogue/i18n/pt/L1-premium-accounting-management.yaml
@@ -1,0 +1,120 @@
+locale: pt
+source: L1-premium-accounting-management.yaml
+entries:
+  BC-2150:
+    name: Gestão de contabilidade de prémios
+    description: |
+      Faturação de prémios, cobrança de numerário, liquidação de contas de mediadores e comissões,
+      mecanismos de reserva e ganho de prémios, cobrança e contabilidade de imposto sobre prémios de seguros.
+  BC-2150.10:
+    name: Gestão de faturação de prémios
+    description: |
+      Geração de faturas, agendamento de prestações, encaminhamento de faturação e ajustamentos.
+  BC-2150.10.10:
+    name: Geração de faturas de prémio
+    description: |
+      Geração de faturas e extratos de prémio por ciclo de faturação.
+  BC-2150.10.20:
+    name: Configuração do calendário de prestações
+    description: |
+      Configuração de calendários de prestações de prémio e encargos financeiros.
+  BC-2150.10.30:
+    name: Encaminhamento de faturação direta e de agência
+    description: |
+      Encaminhamento de faturação entre acordos de faturação direta e de agência.
+  BC-2150.10.40:
+    name: Ajustamento de faturação e nota de crédito
+    description: |
+      Emissão de ajustamentos de faturação e notas de crédito após endorsements e cancelamentos.
+  BC-2150.20:
+    name: Gestão de cobrança de prémios
+    description: |
+      Receção e aplicação de pagamentos, operações de pagamentos recorrentes, reembolsos e lockbox.
+  BC-2150.20.10:
+    name: Receção e aplicação de pagamentos
+    description: |
+      Receção de pagamentos de prémio e aplicação nas contas das apólices.
+  BC-2150.20.20:
+    name: Operações de débito direto e pagamento recorrente
+    description: |
+      Operação de esquemas de débito direto, cartão recorrente e ordem permanente.
+  BC-2150.20.30:
+    name: Processamento de reembolso de prémio
+    description: |
+      Processamento de reembolsos de prémio após endorsements e cancelamentos.
+  BC-2150.20.40:
+    name: Lockbox e alocação de numerário
+    description: |
+      Receção de lockbox, alocação de numerário e tratamento de exceções.
+  BC-2150.30:
+    name: Liquidação de contas de mediadores e produtores
+    description: |
+      Extratos de produtor, liquidação prémio-menos-comissão e reconciliação de contas fiduciárias.
+  BC-2150.30.10:
+    name: Geração de extratos de produtor
+    description: |
+      Geração de extratos de prémio e comissão para produtores.
+  BC-2150.30.20:
+    name: Liquidação prémio-menos-comissão
+    description: |
+      Liquidação de prémio líquido de comissão com e de produtores.
+  BC-2150.30.30:
+    name: Reconciliação de conta fiduciária do produtor
+    description: |
+      Reconciliação de contas fiduciárias do produtor e saldos IBA.
+  BC-2150.40:
+    name: Gestão de reservas e ganhos de prémio
+    description: |
+      Cálculo de prémio não ganho, reconhecimento de prémio ganho e acompanhamento de custos de aquisição diferidos.
+  BC-2150.40.10:
+    name: Cálculo do prémio não ganho
+    description: |
+      Cálculo das reservas de prémio não ganho nas apólices em vigor.
+  BC-2150.40.20:
+    name: Reconhecimento do prémio ganho
+    description: |
+      Reconhecimento do prémio ganho por período contabilístico.
+  BC-2150.40.30:
+    name: Acompanhamento de custos de aquisição diferidos
+    description: |
+      Acompanhamento de custos de aquisição diferidos (DAC) por coortes de produto.
+  BC-2150.50:
+    name: Gestão de cobrança e dunning
+    description: |
+      Monitorização de receitas vencidas, operações de dunning, cancelamento por falta de pagamento e imparidade de dívidas.
+  BC-2150.50.10:
+    name: Monitorização de receitas vencidas
+    description: |
+      Monitorização de receitas de prémio vencidas em tomadores de apólice e produtores.
+  BC-2150.50.20:
+    name: Operações de dunning e lembretes
+    description: |
+      Avisos de dunning, lembretes e comunicações de atraso.
+  BC-2150.50.30:
+    name: Tratamento de cancelamento por falta de pagamento
+    description: |
+      Desencadeamento de processos de cancelamento por prémio não pago.
+  BC-2150.50.40:
+    name: Imparidade de dívidas incobráveis
+    description: |
+      Aprovação e lançamento de imparidades de dívidas incobráveis em prémios não recuperáveis.
+  BC-2150.60:
+    name: Contabilidade de impostos e taxas
+    description: |
+      Cálculo do imposto sobre prémios de seguros, cobrança de imposto de selo e taxas e suporte ao registo de imposto sobre prémios.
+  BC-2150.60.10:
+    name: Cálculo do imposto sobre prémios de seguros
+    description: |
+      Cálculo do imposto sobre prémios de seguros nas diferentes jurisdições e tipos de produto.
+  BC-2150.60.20:
+    name: Cobrança de imposto de selo e taxas
+    description: |
+      Cobrança e remessa de impostos de selo e taxas legais.
+  BC-2150.60.30:
+    name: Suporte ao registo de imposto sobre prémios
+    description: |
+      Produção de dados e reconciliações de suporte aos registos de imposto sobre prémios.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-pricing-management.yaml
+++ b/catalogue/i18n/pt/L1-pricing-management.yaml
@@ -1,0 +1,87 @@
+locale: pt
+source: L1-pricing-management.yaml
+entries:
+  BC-440:
+    name: Gestão de tarifação
+    description: |
+      Definição de preços, estrutura, descontos e promoções.
+  BC-440.10:
+    name: Gestão da estratégia de tarifação
+    description: |
+      Modelos de tarifação, tarifação baseada em valor e tarifação por segmento.
+  BC-440.10.10:
+    name: Definição do modelo de tarifação
+    description: |
+      Definição de modelos de tarifação (custo-acrescido, baseado em valor, subscrição).
+  BC-440.10.20:
+    name: Tarifação baseada em valor
+    description: |
+      Análise do valor para o cliente e disposição a pagar para informar o preço.
+  BC-440.10.30:
+    name: Benchmarking competitivo de preços
+    description: |
+      Benchmarking de preços de concorrentes e posicionamento de preços.
+  BC-440.10.40:
+    name: Tarifação por segmento e geográfica
+    description: |
+      Diferenciação de tarifação por segmento, canal e geografia.
+  BC-440.20:
+    name: Gestão de listas de preços
+    description: |
+      Preços de tabela, preços regionais e manutenção de price books.
+  BC-440.20.10:
+    name: Manutenção do price book
+    description: |
+      Manutenção de price books, preços de tabela e variantes de moeda.
+  BC-440.20.20:
+    name: Gestão de alterações de preços
+    description: |
+      Aprovação, comunicação e implementação de alterações de preços.
+  BC-440.20.30:
+    name: Governação de dados mestre de preços
+    description: |
+      Governação da qualidade e lineage de dados mestre de preços.
+  BC-440.30:
+    name: Gestão de descontos e promoções
+    description: |
+      Políticas de desconto, ofertas promocionais e rebates.
+  BC-440.30.10:
+    name: Gestão da política de descontos
+    description: |
+      Definição de níveis de desconto, regras e limiares de aprovação.
+  BC-440.30.20:
+    name: Planeamento e execução de promoções
+    description: |
+      Calendário promocional, configuração de oferta e execução.
+  BC-440.30.30:
+    name: Gestão de rebates e allowances comerciais
+    description: |
+      Provisionamentos, reclamações e liquidação de rebates com clientes e canais.
+  BC-440.30.40:
+    name: Análise da eficácia das promoções
+    description: |
+      Medição do ROI promocional, lift e canibalização.
+  BC-440.40:
+    name: Gestão da realização e conformidade de preços
+    description: |
+      Gestão de exceções de preços e análise de leakage.
+  BC-440.40.10:
+    name: Aprovação de exceções de preços
+    description: |
+      Fluxo e aprovação de exceções de tarifação fora de política.
+  BC-440.40.20:
+    name: Análise de preço de bolso e margem
+    description: |
+      Análise do preço líquido realizado e margem de bolso por transação.
+  BC-440.40.30:
+    name: Investigação de leakage de preços
+    description: |
+      Identificação e remediação de leakage de preços e descontos.
+  BC-440.40.40:
+    name: Monitorização da conformidade de tarifação
+    description: |
+      Conformidade com a política de tarifação, regras antitrust e de comércio justo.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-procurement-management.yaml
+++ b/catalogue/i18n/pt/L1-procurement-management.yaml
@@ -1,0 +1,139 @@
+locale: pt
+source: L1-procurement-management.yaml
+entries:
+  BC-500:
+    name: Gestão de aprovisionamento
+    description: |
+      Sourcing, contratação, compras e operações procure-to-pay.
+  BC-500.10:
+    name: Gestão de sourcing
+    description: |
+      Sourcing estratégico, RFx e seleção de fornecedores.
+  BC-500.10.10:
+    name: Definição da estratégia de sourcing
+    description: |
+      Definição da estratégia de sourcing por categoria e mercado.
+  BC-500.10.20:
+    name: Execução de RFx
+    description: |
+      Preparação, emissão e avaliação de eventos de RFI, RFQ e RFP.
+  BC-500.10.30:
+    name: Negociação com fornecedores
+    description: |
+      Negociação comercial e contratual com fornecedores pré-selecionados.
+  BC-500.10.40:
+    name: Seleção e adjudicação de fornecedores
+    description: |
+      Seleção final de fornecedor, decisão de adjudicação e notificação.
+  BC-500.10.50:
+    name: Operações de leilão inverso
+    description: |
+      Configuração, condução e adjudicação de e-leilões para lotes competitivos.
+  BC-500.20:
+    name: Gestão de contratos de aprovisionamento
+    description: |
+      Contratos de aprovisionamento, termos e ciclo de vida.
+  BC-500.20.10:
+    name: Elaboração de contratos e modelos
+    description: |
+      Modelos de contratos de aprovisionamento, cláusulas e playbooks.
+  BC-500.20.20:
+    name: Aprovação e execução de contratos
+    description: |
+      Fluxo de aprovação, assinatura e execução de contratos de aprovisionamento.
+  BC-500.20.30:
+    name: Monitorização da conformidade contratual
+    description: |
+      Monitorização das compras face a fornecedores e preços contratualizados.
+  BC-500.20.40:
+    name: Renovação e renegociação de contratos
+    description: |
+      Gestão do ciclo de renovação e renegociação de contratos de aprovisionamento.
+  BC-500.30:
+    name: Gestão de ordens de compra
+    description: |
+      Criação, aprovação e execução de ordens de compra.
+  BC-500.30.10:
+    name: Criação de ordens de compra
+    description: |
+      Geração de ordens de compra a partir de requisições, contratos ou catálogos.
+  BC-500.30.20:
+    name: Aprovação de ordens de compra
+    description: |
+      Fluxos de aprovação baseados em limiares para ordens de compra.
+  BC-500.30.30:
+    name: Confirmação e alteração de ordens de compra
+    description: |
+      Confirmação pelo fornecedor e gestão de alterações de ordem.
+  BC-500.30.40:
+    name: Encerramento de ordens de compra
+    description: |
+      Conclusão de receção, conferência de faturas e encerramento de ordens de compra.
+  BC-500.40:
+    name: Gestão de operações procure-to-pay
+    description: |
+      Operações quotidianas de P2P, requisições e receções.
+  BC-500.40.10:
+    name: Gestão de requisições
+    description: |
+      Captura, aprovação e conversão de requisições de compra.
+  BC-500.40.20:
+    name: Gestão de catálogos e punch-out
+    description: |
+      Catálogos internos e punch-out de fornecedores para compras self-service.
+  BC-500.40.30:
+    name: Receção de bens e aceitação de serviços
+    description: |
+      Registo de receção de bens e folhas de entrada de serviços.
+  BC-500.40.40:
+    name: Conferência e reconciliação de faturas
+    description: |
+      Conferência a dois e três vias de faturas com ordens de compra e receções.
+  BC-500.40.50:
+    name: Helpdesk P2P e apoio ao comprador
+    description: |
+      Apoio a compradores e fornecedores em transações P2P.
+  BC-500.50:
+    name: Gestão de categorias de aprovisionamento
+    description: |
+      Estratégia de categoria e análise de despesa por categoria.
+  BC-500.50.10:
+    name: Desenvolvimento da estratégia de categoria
+    description: |
+      Estratégia plurianual de categoria e avaliação do mercado de fornecimento.
+  BC-500.50.20:
+    name: Gestão do desempenho por categoria
+    description: |
+      Acompanhamento de KPIs, poupanças e criação de valor por categoria.
+  BC-500.50.30:
+    name: Agregação de procura e standardização
+    description: |
+      Consolidação de procura e standardização de especificações entre unidades de negócio.
+  BC-500.50.40:
+    name: Sourcing de inovação por categoria
+    description: |
+      Identificação de inovação através dos mercados de fornecedores.
+  BC-500.60:
+    name: Gestão da análise de despesa de aprovisionamento
+    description: |
+      Visibilidade de despesa, reporte e acompanhamento de poupanças.
+  BC-500.60.10:
+    name: Agregação e limpeza de dados de despesa
+    description: |
+      Agregação, limpeza e classificação de dados de despesa empresarial.
+  BC-500.60.20:
+    name: Reporte e análise de despesa
+    description: |
+      Análise de despesa, dashboards e identificação de despesa endereçável.
+  BC-500.60.30:
+    name: Acompanhamento e validação de poupanças
+    description: |
+      Captura, validação e reporte de poupanças de aprovisionamento.
+  BC-500.60.40:
+    name: Gestão de despesa de cauda
+    description: |
+      Identificação e racionalização da despesa de cauda.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-product-information-management.yaml
+++ b/catalogue/i18n/pt/L1-product-information-management.yaml
@@ -1,0 +1,117 @@
+locale: pt
+source: L1-product-information-management.yaml
+entries:
+  BC-2370:
+    name: Gestão de informação de produto
+    description: |
+      Atributos autoritativos de artigos, conteúdo de marketing e dados de produto
+      prontos para o canal — desde a criação do artigo até à sincronização
+      GS1/GDSN e sindicação multicanal e prontidão de conteúdo.
+  BC-2370.10:
+    name: Gestão de dados mestre de artigos
+    description: |
+      Atributos mestre de artigos, GTINs, hierarquias e taxonomia que formam o
+      registo canónico de produto em toda a empresa.
+    in_scope:
+      - Criação de artigos e manutenção de atributos
+      - Identificação ao nível de GTIN, GLN e embalagem
+      - Taxonomia e classificação de produto (ex. GS1 GPC)
+    out_of_scope:
+      - Governação genérica de dados mestre (BC-610)
+  BC-2370.10.10:
+    name: Criação e atribuição de artigos
+    description: |
+      Criação de registos de artigos e preenchimento de valores de atributos.
+  BC-2370.10.20:
+    name: Atribuição de GTIN e identificadores
+    description: |
+      Atribuição de GTINs e identificadores ao nível de embalagem de acordo com
+      as regras GS1.
+  BC-2370.10.30:
+    name: Hierarquia e taxonomia de produto
+    description: |
+      Manutenção da hierarquia de produto e taxonomia (ex. GS1 GPC).
+  BC-2370.10.40:
+    name: Estado e fase do ciclo de vida do artigo
+    description: |
+      Acompanhamento das fases do ciclo de vida do artigo, desde conceito até
+      descontinuado.
+  BC-2370.20:
+    name: Gestão de criação de conteúdo de produto
+    description: |
+      Criação de texto de marketing, fotografia, vídeo e rich media que
+      transformam um registo de artigo num produto comercializável para o
+      consumidor.
+  BC-2370.20.10:
+    name: Criação de texto de marketing
+    description: |
+      Criação de títulos, descrições e texto de venda por canal.
+  BC-2370.20.20:
+    name: Produção de fotografia e vídeo de produto
+    description: |
+      Produção de fotografia de produto, imagens de lifestyle e vídeo.
+  BC-2370.20.30:
+    name: Produção de rich media e ativos 3D
+    description: |
+      Produção de ativos de produto em 360 graus, AR e 3D.
+  BC-2370.20.40:
+    name: Tradução e localização
+    description: |
+      Tradução e localização de conteúdo de produto para mercados-alvo.
+  BC-2370.30:
+    name: Gestão de sindicação de canal
+    description: |
+      Publicação de conteúdo de produto em canais próprios, feeds de retalhistas,
+      marketplaces e parceiros comerciais, com adaptação específica por canal.
+  BC-2370.30.10:
+    name: Publicação em canais próprios
+    description: |
+      Publicação de conteúdo nos canais web, mobile e loja próprios.
+  BC-2370.30.20:
+    name: Sindicação de feeds em marketplace
+    description: |
+      Sindicação de feeds para marketplaces de terceiros e agregadores.
+  BC-2370.30.30:
+    name: Catálogo EDI 832 para retalhistas
+    description: |
+      Disponibilização de catálogos de produto EDI 832 a parceiros retalhistas.
+  BC-2370.40:
+    name: Gestão de sincronização GS1/GDSN
+    description: |
+      Sincronização de dados mestre de produto com parceiros comerciais através
+      de data pools GDSN, registo de partes e subscrições de destinatários.
+  BC-2370.40.10:
+    name: Operações de data pool GDSN
+    description: |
+      Operação da relação com o data pool GDSN e submissões.
+  BC-2370.40.20:
+    name: Registo de partes e destinatários
+    description: |
+      Registo de partes e subscrições de destinatários no GDSN.
+  BC-2370.40.30:
+    name: Gestão de exceções de sincronização GDSN
+    description: |
+      Gestão de exceções de sincronização GDSN e discrepâncias com parceiros
+      comerciais.
+  BC-2370.50:
+    name: Gestão da qualidade do conteúdo de produto
+    description: |
+      Pontuação de prontidão de conteúdo, medição de completude e validação
+      face a normas de qualidade específicas por canal.
+  BC-2370.50.10:
+    name: Pontuação de completude de conteúdo
+    description: |
+      Pontuação da completude de conteúdo face a requisitos de prontidão de canal.
+  BC-2370.50.20:
+    name: Validação e conformidade de conteúdo
+    description: |
+      Validação de conteúdo face a regras regulatórias e de canal.
+  BC-2370.50.30:
+    name: Remediação da qualidade de conteúdo
+    description: |
+      Fluxo de trabalho de remediação para artigos que falham as verificações de
+      qualidade de conteúdo.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-product-lifecycle-management.yaml
+++ b/catalogue/i18n/pt/L1-product-lifecycle-management.yaml
@@ -1,0 +1,143 @@
+locale: pt
+source: L1-product-lifecycle-management.yaml
+entries:
+  BC-820:
+    name: Gestão do ciclo de vida do produto
+    description: |
+      Gestão de ponta a ponta de produtos desde o conceito até à retirada.
+  BC-820.10:
+    name: Gestão do conceito de produto
+    description: |
+      Desenvolvimento de conceitos, ideação, validação de mercado.
+  BC-820.10.10:
+    name: Ideação de produto
+    description: |
+      Ideação de novos conceitos de produto a partir de informações de mercado e de clientes.
+  BC-820.10.20:
+    name: Validação do conceito
+    description: |
+      Validação de conceitos de produto através de testes com clientes e mercado.
+  BC-820.10.30:
+    name: Definição do caso de negócio
+    description: |
+      Caso de negócio e justificação económica para novos produtos.
+  BC-820.20:
+    name: Gestão do design de produto
+    description: |
+      Design, engenharia e revisões de design do produto.
+  BC-820.20.10:
+    name: Engenharia de design de produto
+    description: |
+      Design detalhado de produto e análise de engenharia.
+  BC-820.20.20:
+    name: Revisão e aprovação do design
+    description: |
+      Revisões formais de design e portais de aprovação.
+  BC-820.20.30:
+    name: Design para X
+    description: |
+      Design para fabricabilidade, sustentabilidade, manutenibilidade e custo.
+  BC-820.20.40:
+    name: Verificação e validação do design
+    description: |
+      Verificação e validação do design face aos requisitos.
+  BC-820.30:
+    name: Gestão de especificações de produto
+    description: |
+      Especificações, requisitos e definição da BOM do produto.
+  BC-820.30.10:
+    name: Gestão de requisitos do produto
+    description: |
+      Captura e rastreabilidade dos requisitos do produto.
+  BC-820.30.20:
+    name: Elaboração de especificações do produto
+    description: |
+      Elaboração de especificações do produto e documentação técnica.
+  BC-820.30.30:
+    name: Definição da BOM do produto
+    description: |
+      Definição das estruturas da BOM e revisões do produto.
+  BC-820.30.40:
+    name: Gestão de dados do produto
+    description: |
+      PDM para dados, desenhos e conjuntos CAD do produto.
+  BC-820.40:
+    name: Gestão de configuração e variantes do produto
+    description: |
+      Configurações, variantes, opções e pacotes.
+  BC-820.40.10:
+    name: Modelação de configuração do produto
+    description: |
+      Modelos de configuração, opções e regras.
+  BC-820.40.20:
+    name: Gestão de variantes
+    description: |
+      Gestão de variantes e plataformas de produto.
+  BC-820.40.30:
+    name: Definição de pacotes e soluções
+    description: |
+      Definição de pacotes, kits e soluções combinadas.
+  BC-820.50:
+    name: Gestão de lançamento e disponibilização de produto
+    description: |
+      Planeamento de lançamento, execução e arranque.
+  BC-820.50.10:
+    name: Planeamento de lançamento
+    description: |
+      Planeamento de lançamento e definição de âmbito de conteúdo.
+  BC-820.50.20:
+    name: Execução do lançamento
+    description: |
+      Execução multifuncional do lançamento e avaliação de prontidão.
+  BC-820.50.30:
+    name: Arranque de produção
+    description: |
+      Arranque de produção e prontidão da cadeia de abastecimento após o lançamento.
+  BC-820.50.40:
+    name: Acompanhamento do desempenho do lançamento
+    description: |
+      Acompanhamento dos KPIs de lançamento e ações corretivas pós-lançamento.
+  BC-820.60:
+    name: Gestão do desempenho e feedback do produto
+    description: |
+      Desempenho em utilização, feedback de clientes, análise do produto.
+  BC-820.60.10:
+    name: Monitorização do desempenho do produto em utilização
+    description: |
+      Monitorização do desempenho do produto através de métricas em utilização.
+  BC-820.60.20:
+    name: Síntese do feedback de clientes
+    description: |
+      Síntese do feedback de clientes para informar o roteiro do produto.
+  BC-820.60.30:
+    name: Gestão do roteiro do produto
+    description: |
+      Definição e manutenção dos roteiros do produto.
+  BC-820.60.40:
+    name: Análise do produto
+    description: |
+      Análise de utilização, telemetria e instrumentação do produto.
+  BC-820.70:
+    name: Gestão do fim de vida do produto
+    description: |
+      Planeamento de fim de vida, descontinuação e estratégias de substituição.
+  BC-820.70.10:
+    name: Planeamento do fim de vida
+    description: |
+      Planeamento do fim de vida, dependências e calendário.
+  BC-820.70.20:
+    name: Estratégia de migração e substituição
+    description: |
+      Migração de clientes para produtos sucessores e substituições.
+  BC-820.70.30:
+    name: Última compra e sustentação
+    description: |
+      Gestão de última compra, peças sobresselentes e sustentação de fim de vida.
+  BC-820.70.40:
+    name: Comunicações de descontinuação do produto
+    description: |
+      Comunicação da descontinuação do produto a clientes e canais.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-product-substance-circularity-management.yaml
+++ b/catalogue/i18n/pt/L1-product-substance-circularity-management.yaml
@@ -1,0 +1,144 @@
+locale: pt
+source: L1-product-substance-circularity-management.yaml
+entries:
+  BC-1980:
+    name: Gestão de substâncias e circularidade de produto
+    description: |
+      Restrições de substâncias, recolha no fim de vida, reparação, recondicionamento, refabrico e
+      divulgação da pegada ambiental de produtos elétricos.
+  BC-1980.10:
+    name: Gestão de conformidade de substâncias restritas
+    description: |
+      Conformidade com regimes de restrição de substâncias como RoHS, SVHC REACH e Proposição 65.
+  BC-1980.10.10:
+    name: Verificação de conformidade RoHS
+    description: |
+      Verificação dos produtos face aos limites de substâncias RoHS.
+  BC-1980.10.20:
+    name: Conformidade SVHC REACH
+    description: |
+      Conformidade com as obrigações relativas a substâncias altamente preocupantes do REACH.
+  BC-1980.10.30:
+    name: Conformidade sem halogénios
+    description: |
+      Verificação de alegações de produto sem halogénios.
+  BC-1980.10.40:
+    name: Conformidade com a Proposição 65
+    description: |
+      Conformidade com as obrigações de aviso da Proposição 65 da Califórnia.
+  BC-1980.20:
+    name: Gestão de dados de declaração de substâncias
+    description: |
+      Recolha e gestão de dados de declaração de substâncias ao longo da lista de materiais.
+  BC-1980.20.10:
+    name: Recolha de declarações de materiais
+    description: |
+      Recolha de declarações completas de materiais junto dos fornecedores.
+  BC-1980.20.20:
+    name: Manutenção da base de dados de conformidade de substâncias
+    description: |
+      Manutenção da base de dados mestre de conformidade de substâncias.
+  BC-1980.20.30:
+    name: Divulgação de substâncias ao cliente
+    description: |
+      Prestação de divulgações de substâncias a clientes e autoridades.
+  BC-1980.30:
+    name: Due diligence de minerais de conflito
+    description: |
+      Due diligence sobre fontes de estanho, tungsténio, tântalo e ouro segundo regimes alinhados com a OCDE.
+  BC-1980.30.10:
+    name: Mapeamento de fundidores e refinadores
+    description: |
+      Mapeamento de fundidores e refinadores que alimentam a cadeia de abastecimento.
+  BC-1980.30.20:
+    name: Inquérito ao país de origem
+    description: |
+      Inquérito razoável ao país de origem dos minerais abrangidos.
+  BC-1980.30.30:
+    name: Relatório de minerais de conflito
+    description: |
+      Relatório estatutário e dirigido ao cliente sobre minerais de conflito.
+  BC-1980.40:
+    name: Gestão de conformidade de baterias e embalagens
+    description: |
+      Conformidade com regimes de baterias e embalagens incluindo o Regulamento Europeu de Baterias.
+  BC-1980.40.10:
+    name: Conformidade com o regulamento de baterias
+    description: |
+      Conformidade com o Regulamento Europeu de Baterias e equivalentes.
+  BC-1980.40.20:
+    name: Gestão de dados do passaporte de bateria
+    description: |
+      Elaboração e manutenção de dados do passaporte de bateria.
+  BC-1980.40.30:
+    name: Conformidade de resíduos de embalagem
+    description: |
+      Conformidade com as obrigações relativas a embalagens e resíduos de embalagem.
+  BC-1980.50:
+    name: Operações de recolha no fim de vida
+    description: |
+      Recolha, logística inversa e relatório de responsabilidade do produtor de produtos elétricos.
+  BC-1980.50.10:
+    name: Operações de esquema de recolha WEEE
+    description: |
+      Operação de acordos de esquema de conformidade do produtor WEEE.
+  BC-1980.50.20:
+    name: Relatório de responsabilidade do produtor
+    description: |
+      Relatório de tonelagens colocadas no mercado e recuperadas.
+  BC-1980.50.30:
+    name: Operações de logística inversa
+    description: |
+      Logística inversa para produtos e componentes no fim de vida.
+  BC-1980.60:
+    name: Operações de reparação e recondicionamento
+    description: |
+      Rede de assistência de reparação e operações de documentação de direito à reparação.
+  BC-1980.60.10:
+    name: Operações da rede de assistência de reparação
+    description: |
+      Operação de redes de assistência de reparação autorizadas.
+  BC-1980.60.20:
+    name: Documentação de direito à reparação
+    description: |
+      Fornecimento de documentação de reparação segundo os regimes de direito à reparação.
+  BC-1980.60.30:
+    name: Operações do processo de recondicionamento
+    description: |
+      Recondicionamento de produtos devolvidos para condição revendável.
+  BC-1980.70:
+    name: Operações de refabrico e reutilização
+    description: |
+      Refabrico e reutilização de núcleos e componentes em novas construções.
+  BC-1980.70.10:
+    name: Recuperação e desmontagem de núcleos
+    description: |
+      Recuperação e desmontagem de núcleos devolvidos.
+  BC-1980.70.20:
+    name: Execução do processo de refabrico
+    description: |
+      Execução dos processos de refabrico em núcleos recuperados.
+  BC-1980.70.30:
+    name: Rastreabilidade de componentes reutilizados
+    description: |
+      Rastreabilidade de componentes reutilizados em novas construções de produto.
+  BC-1980.80:
+    name: Relatório de pegada ambiental do produto
+    description: |
+      Elaboração e divulgação de dados de pegada ambiental ao nível do produto.
+  BC-1980.80.10:
+    name: Cálculo da pegada de carbono do produto
+    description: |
+      Cálculo das pegadas de carbono ao nível do produto.
+  BC-1980.80.20:
+    name: Declaração ambiental de produto
+    description: |
+      Elaboração de declarações ambientais de produto.
+  BC-1980.80.30:
+    name: Operações de passaporte digital de produto
+    description: |
+      Operação de passaportes digitais de produto segundo a regulamentação emergente.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-product-telemetry-experimentation-management.yaml
+++ b/catalogue/i18n/pt/L1-product-telemetry-experimentation-management.yaml
@@ -1,0 +1,124 @@
+locale: pt
+source: L1-product-telemetry-experimentation-management.yaml
+entries:
+  BC-4280:
+    name: Gestão de telemetria e experimentação de produto
+    description: |
+      Instrumentação, governação e análise da telemetria de utilização do
+      produto, e o design e execução de experimentos de funcionalidades que
+      moldam as decisões de produto.
+  BC-4280.10:
+    name: Instrumentação de telemetria de produto
+    description: |
+      Captura de eventos de utilização do produto a partir de runtimes de
+      cliente e servidor de acordo com esquemas de eventos definidos.
+  BC-4280.10.10:
+    name: Definição de esquemas de eventos
+    description: |
+      Definição de esquemas de eventos de produto, incluindo propriedades
+      obrigatórias e opcionais.
+  BC-4280.10.20:
+    name: Instrumentação de telemetria do cliente
+    description: |
+      Instrumentação de runtimes de cliente para emitir eventos de produto.
+  BC-4280.10.30:
+    name: Instrumentação de telemetria do servidor
+    description: |
+      Instrumentação de runtimes de servidor para emitir eventos de produto.
+  BC-4280.20:
+    name: Qualidade e governação de telemetria
+    description: |
+      Governação de esquemas, monitorização da qualidade do pipeline e filtragem
+      de privacidade da telemetria de produto.
+  BC-4280.20.10:
+    name: Governação de esquemas de telemetria
+    description: |
+      Governação de esquemas de eventos de produto em todas as superfícies
+      do produto.
+  BC-4280.20.20:
+    name: Monitorização da qualidade do pipeline de telemetria
+    description: |
+      Monitorização da correção, integridade e atualidade do pipeline de
+      telemetria.
+  BC-4280.20.30:
+    name: Filtragem de privacidade da telemetria
+    description: |
+      Filtragem, redação e minimização da telemetria em conformidade com os
+      compromissos de privacidade.
+  BC-4280.30:
+    name: Análise de utilização do produto
+    description: |
+      Vistas analíticas da utilização do produto, incluindo funis, coortes
+      de retenção e envolvimento com funcionalidades.
+  BC-4280.30.10:
+    name: Análise de funis
+    description: |
+      Análise de funis de conversão e abandono em percursos do produto.
+  BC-4280.30.20:
+    name: Análise de coortes de retenção
+    description: |
+      Análise baseada em coortes da retenção de utilizadores ao longo do tempo.
+  BC-4280.30.30:
+    name: Relatórios de envolvimento com funcionalidades
+    description: |
+      Relatórios sobre o envolvimento com funcionalidades específicas em toda
+      a base de utilizadores.
+  BC-4280.40:
+    name: Gestão do programa de experimentação
+    description: |
+      Metodologia, revisão de design e adjudicação de experimentos que orientam
+      as decisões de produto.
+  BC-4280.40.10:
+    name: Normas de metodologia de experimentação
+    description: |
+      Normas para metodologia de experimentação válida em todas as equipas
+      de produto.
+  BC-4280.40.20:
+    name: Revisão de design de experimentos
+    description: |
+      Revisão dos designs de experimentos face às normas de metodologia e ética.
+  BC-4280.40.30:
+    name: Adjudicação de resultados de experimentos
+    description: |
+      Adjudicação dos resultados de experimentos e consequentes decisões
+      de produto.
+  BC-4280.50:
+    name: Execução de testes A/B
+    description: |
+      Configuração, direcionamento e monitorização de testes A/B e
+      multivariados em execução.
+  BC-4280.50.10:
+    name: Configuração de experimentos
+    description: |
+      Configuração de variantes de experimentos e regras de atribuição.
+  BC-4280.50.20:
+    name: Direcionamento de experimentos
+    description: |
+      Direcionamento de coortes de experimentos para audiências adequadas.
+  BC-4280.50.30:
+    name: Monitorização de experimentos
+    description: |
+      Monitorização de experimentos em execução para proteções e paragem
+      precoce.
+  BC-4280.60:
+    name: Síntese de insights de clientes
+    description: |
+      Síntese de sinais quantitativos e qualitativos em decisões de produto
+      e memorandos de decisão.
+  BC-4280.60.10:
+    name: Síntese de insights quantitativos
+    description: |
+      Síntese de descobertas quantitativas de telemetria e experimentação.
+  BC-4280.60.20:
+    name: Síntese de insights qualitativos
+    description: |
+      Síntese de descobertas de investigação qualitativa em insights de produto.
+  BC-4280.60.30:
+    name: Elaboração de memorandos de decisão
+    description: |
+      Elaboração de memorandos de decisão que registam evidências, escolhas
+      e raciocínio.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-production-management.yaml
+++ b/catalogue/i18n/pt/L1-production-management.yaml
@@ -1,0 +1,127 @@
+locale: pt
+source: L1-production-management.yaml
+entries:
+  BC-1000:
+    name: Gestão da produção
+    description: |
+      Produção de bens físicos - planeamento, programação e execução ao nível empresarial.
+  BC-1000.10:
+    name: Gestão da estratégia de produção
+    description: |
+      Implantação industrial, decisão de fazer/comprar, estratégia de capacidade.
+  BC-1000.10.10:
+    name: Estratégia de implantação industrial
+    description: |
+      Definição da implantação industrial de longo prazo e do papel de cada instalação.
+  BC-1000.10.20:
+    name: Estratégia de fazer ou comprar
+    description: |
+      Estratégia de fazer ou comprar e externalização por linha de produto.
+  BC-1000.10.30:
+    name: Estratégia de capacidade
+    description: |
+      Estratégia de capacidade de longo prazo e planeamento de expansão de capital.
+  BC-1000.10.40:
+    name: Design do modelo operativo de fabricação
+    description: |
+      Design do modelo operativo e de governação da fabricação.
+  BC-1000.20:
+    name: Gestão do planeamento da produção
+    description: |
+      Programa-mestre de produção, planeamento a médio prazo (semanas a meses).
+  BC-1000.20.10:
+    name: Programação-mestre da produção
+    description: |
+      Geração do programa-mestre de produção em todas as instalações.
+  BC-1000.20.20:
+    name: Planeamento de capacidade por estimativa global
+    description: |
+      Validação de capacidade por estimativa global face ao programa-mestre.
+  BC-1000.20.30:
+    name: Planeamento da produção a médio prazo
+    description: |
+      Planeamento semanal e mensal da produção por linha.
+  BC-1000.20.40:
+    name: Reconciliação do plano de produção
+    description: |
+      Reconciliação do plano de produção com a oferta e a procura.
+  BC-1000.30:
+    name: Gestão da programação da produção
+    description: |
+      Programação detalhada, sequenciamento (horas a dias).
+  BC-1000.30.10:
+    name: Programação finita detalhada
+    description: |
+      Programação de capacidade finita ao nível de máquinas e linhas.
+  BC-1000.30.20:
+    name: Otimização da sequência
+    description: |
+      Otimização da sequência para minimizar mudanças e desperdício.
+  BC-1000.30.30:
+    name: Monitorização da aderência ao programa
+    description: |
+      Monitorização da aderência ao programa e replanificação.
+  BC-1000.30.40:
+    name: Lançamento de ordens de produção
+    description: |
+      Lançamento de ordens de produção para o chão de fábrica.
+  BC-1000.40:
+    name: Gestão da execução da produção
+    description: |
+      Supervisão da execução, despacho e controlo em tempo real.
+  BC-1000.40.10:
+    name: Despacho de ordens de produção
+    description: |
+      Despacho de ordens para centros de trabalho.
+  BC-1000.40.20:
+    name: Acompanhamento do estado da produção
+    description: |
+      Acompanhamento em tempo real do estado das ordens de produção.
+  BC-1000.40.30:
+    name: Tratamento de exceções de produção
+    description: |
+      Tratamento de exceções de produção e escaladas.
+  BC-1000.40.40:
+    name: Encerramento de ordens de produção
+    description: |
+      Confirmação, liquidação e encerramento de ordens de produção.
+  BC-1000.50:
+    name: Gestão do desempenho da produção
+    description: |
+      OEE, rendimento, taxa de conformidade, KPIs de produção.
+  BC-1000.50.10:
+    name: Medição da OEE
+    description: |
+      Medição e relatório da eficácia global dos equipamentos.
+  BC-1000.50.20:
+    name: Análise de rendimento e taxa de conformidade
+    description: |
+      Análise do rendimento, taxa de conformidade e conformidade à primeira.
+  BC-1000.50.30:
+    name: Análise de paragens e perdas
+    description: |
+      Classificação de paragens e análise da árvore de perdas.
+  BC-1000.50.40:
+    name: Relatório de desempenho da produção
+    description: |
+      Relatório de desempenho da instalação e benchmarking.
+  BC-1000.60:
+    name: Gestão dos custos de produção
+    description: |
+      Custos padrão, desvios de produção e análise de custos.
+  BC-1000.60.10:
+    name: Definição de custo padrão
+    description: |
+      Definição e reavaliação do custo padrão dos itens produzidos.
+  BC-1000.60.20:
+    name: Análise de desvios de produção
+    description: |
+      Análise de desvios de materiais, mão de obra e gastos gerais.
+  BC-1000.60.30:
+    name: Relatório de custos de produção
+    description: |
+      Relatório periódico de custos de produção e benchmarking.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-professional-licensing-and-standards-management.yaml
+++ b/catalogue/i18n/pt/L1-professional-licensing-and-standards-management.yaml
@@ -1,0 +1,144 @@
+locale: pt
+source: L1-professional-licensing-and-standards-management.yaml
+entries:
+  BC-4380:
+    name: Gestão de licenciamento e normas profissionais
+    description: |
+      Licenciamento e registo de firma e individual, declarações a organismos
+      profissionais, desenvolvimento profissional contínuo, adoção de novas
+      normas profissionais e investigação de conduta profissional específicos
+      de firmas de serviços profissionais.
+  BC-4380.10:
+    name: Gestão de licenciamento e registo da firma
+    description: |
+      Manutenção de licenças e registos profissionais ao nível da firma junto
+      de organismos de supervisão de auditoria, reguladores da ordem dos
+      advogados e autoridades equivalentes em diversas jurisdições.
+  BC-4380.10.10:
+    name: Manutenção do registo da firma
+    description: |
+      Manutenção dos registos da firma, como PCAOB, RSB FRC, registo de firma
+      ICAEW, organismo reconhecido SRA e autorizações ABS.
+  BC-4380.10.20:
+    name: Gestão de renovação de licenças da firma
+    description: |
+      Renovações periódicas, pagamentos de taxas e declarações de apoio para
+      licenças da firma.
+  BC-4380.10.30:
+    name: Coordenação de licenças entre jurisdições
+    description: |
+      Coordenação do licenciamento da firma em redes de firmas-membro e
+      jurisdições.
+  BC-4380.20:
+    name: Gestão de certificados de prática individuais
+    description: |
+      Captura e manutenção de certificados de prática individuais, admissões
+      à ordem dos advogados, qualificações de auditoria e outras licenças
+      pessoais dos profissionais.
+  BC-4380.20.10:
+    name: Captura de certificados de prática
+    description: |
+      Captura e verificação de certificados de prática e qualificações
+      individuais.
+  BC-4380.20.20:
+    name: Acompanhamento da renovação de certificados de prática
+    description: |
+      Acompanhamento dos ciclos de renovação e pré-requisitos para certificados
+      de prática individuais.
+  BC-4380.20.30:
+    name: Gestão de admissão transfronteiriça
+    description: |
+      Gestão de admissão transfronteiriça, estatuto de advogado estrangeiro
+      registado e acordos de equivalência.
+  BC-4380.30:
+    name: Gestão do desenvolvimento profissional contínuo
+    description: |
+      Planeamento, entrega e evidenciação das horas de desenvolvimento
+      profissional contínuo (DPC/CPE) exigidas por organismos profissionais
+      e pela política da firma.
+    in_scope:
+      - Planeamento do currículo de DPC
+      - Entrega e registo de cursos de DPC
+      - Evidência de DPC e correção de défices
+    out_of_scope:
+      - Aprendizagem e desenvolvimento genérico (BC-300)
+  BC-4380.30.10:
+    name: Acompanhamento dos requisitos de DPC
+    description: |
+      Acompanhamento dos requisitos de horas de DPC por profissional, qualificação
+      e jurisdição.
+  BC-4380.30.20:
+    name: Entrega e registo de cursos de DPC
+    description: |
+      Entrega de cursos de DPC acreditados e registo de presença e evidências
+      de conclusão.
+  BC-4380.30.30:
+    name: Correção de défices de DPC
+    description: |
+      Identificação e correção de profissionais em risco de défice de DPC
+      antes dos prazos de reporte.
+  BC-4380.40:
+    name: Reporte a organismos profissionais
+    description: |
+      Declarações e notificações periódicas a organismos profissionais,
+      autoridades de supervisão e reguladores sobre matérias da firma e individuais.
+  BC-4380.40.10:
+    name: Preparação de declarações anuais
+    description: |
+      Preparação de declarações anuais e comunicações estatísticas a organismos
+      profissionais e autoridades de supervisão.
+  BC-4380.40.20:
+    name: Reporte de eventos notificáveis
+    description: |
+      Reporte de eventos notificáveis, como demissões, mudanças de liderança
+      e violações materiais.
+  BC-4380.40.30:
+    name: Produção de relatórios de transparência
+    description: |
+      Produção de relatórios de transparência estatutários ou voluntários
+      exigidos de firmas de auditoria e outras firmas reguladas.
+  BC-4380.50:
+    name: Gestão da adoção de normas profissionais
+    description: |
+      Adoção de normas profissionais novas e revistas na metodologia, política
+      e execução de projetos da firma.
+  BC-4380.50.10:
+    name: Análise do horizonte de alterações de normas
+    description: |
+      Análise de alterações iminentes às normas profissionais e regulatórias
+      relevantes para as práticas da firma.
+  BC-4380.50.20:
+    name: Avaliação do impacto das normas
+    description: |
+      Avaliação do impacto na metodologia, formação e ferramentas resultante
+      de normas novas ou revistas.
+  BC-4380.50.30:
+    name: Implementação da adoção de normas
+    description: |
+      Implementação de atualizações de metodologia, política e ferramentas
+      que aplicam as normas adotadas.
+  BC-4380.60:
+    name: Gestão de investigações de conduta profissional
+    description: |
+      Investigação interna, resposta a investigações de organismos profissionais
+      e gestão de reclamações de responsabilidade profissional relacionadas
+      com alegada conduta profissional indevida.
+  BC-4380.60.10:
+    name: Investigação interna de conduta
+    description: |
+      Investigação interna de alegadas violações de normas profissionais ou
+      da política de conduta da firma.
+  BC-4380.60.20:
+    name: Resposta a investigações de organismos profissionais
+    description: |
+      Coordenação das respostas da firma a investigações de organismos
+      profissionais e tribunais disciplinares.
+  BC-4380.60.30:
+    name: Gestão de reclamações de responsabilidade profissional
+    description: |
+      Gestão de reclamações de responsabilidade profissional e notificações
+      a seguradoras resultantes do trabalho dos projetos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-professional-practice-knowledge-management.yaml
+++ b/catalogue/i18n/pt/L1-professional-practice-knowledge-management.yaml
@@ -1,0 +1,133 @@
+locale: pt
+source: L1-professional-practice-knowledge-management.yaml
+entries:
+  BC-4370:
+    name: Gestão do conhecimento da prática profissional
+    description: |
+      Manutenção e reutilização de precedentes de prática, ativos de metodologia,
+      liderança de pensamento, modelos de entregáveis e bibliotecas de investigação
+      que sustentam a prestação de projetos em firmas de serviços profissionais.
+  BC-4370.10:
+    name: Gestão de precedentes e modelos
+    description: |
+      Curadoria, versionamento e controlo de acesso a precedentes jurídicos,
+      modelos de contratos e produtos de trabalho padrão disponíveis para
+      reutilização.
+  BC-4370.10.10:
+    name: Curadoria de precedentes
+    description: |
+      Seleção, redação e curadoria de outputs de projetos de alta qualidade
+      para a biblioteca de precedentes da firma.
+  BC-4370.10.20:
+    name: Manutenção de modelos
+    description: |
+      Manutenção e controlo de versões de modelos de contratos, esqueletos de
+      pareceres e modelos padrão de entregáveis.
+  BC-4370.10.30:
+    name: Governação do acesso a precedentes
+    description: |
+      Governação do acesso a precedentes para equilibrar a reutilização com a
+      confidencialidade do cliente e as restrições de barreira ética.
+  BC-4370.20:
+    name: Gestão de metodologia e ferramentas
+    description: |
+      Definição, evolução e implementação de metodologia de projeto, quadros
+      analíticos e ferramentas proprietárias utilizadas nos projetos.
+  BC-4370.20.10:
+    name: Definição de metodologia
+    description: |
+      Definição de metodologias de auditoria, assessoria e jurídicas alinhadas
+      com as normas profissionais e a política da firma.
+  BC-4370.20.20:
+    name: Versionamento e lançamento de metodologia
+    description: |
+      Versionamento, gestão de lançamento e descontinuação de componentes de
+      metodologia e aceleradores.
+  BC-4370.20.30:
+    name: Implementação e formação em metodologia
+    description: |
+      Implementação de novos lançamentos de metodologia, incluindo formação,
+      FAQs e acompanhamento da adoção.
+  BC-4370.30:
+    name: Gestão de insights de prática e liderança de pensamento
+    description: |
+      Produção e distribuição de pontos de vista de prática, alertas, inquéritos
+      e publicações de liderança de pensamento.
+  BC-4370.30.10:
+    name: Planeamento de tópicos de insight
+    description: |
+      Planeamento de tópicos de insight e liderança de pensamento alinhados com
+      a estratégia da prática e os interesses dos clientes.
+  BC-4370.30.20:
+    name: Produção de insights
+    description: |
+      Produção de artigos, alertas, pontos de vista e relatórios de inquéritos.
+  BC-4370.30.30:
+    name: Distribuição de insights e acompanhamento do envolvimento
+    description: |
+      Distribuição de insights a audiências de clientes e prospetos e
+      acompanhamento do envolvimento.
+  BC-4370.40:
+    name: Gestão de reutilização de ativos de projetos
+    description: |
+      Identificação, recolha e etiquetagem de outputs de projetos de alto valor
+      como ativos reutilizáveis, equilibrada com a confidencialidade do cliente.
+  BC-4370.40.10:
+    name: Identificação de ativos reutilizáveis
+    description: |
+      Identificação de outputs de projetos com valor de reutilização para além
+      do projeto de origem.
+  BC-4370.40.20:
+    name: Sanitização e redação de ativos
+    description: |
+      Sanitização e redação de ativos de projetos para remover informação
+      confidencial do cliente antes da reutilização.
+  BC-4370.40.30:
+    name: Etiquetagem e descoberta de ativos
+    description: |
+      Etiquetagem e enriquecimento de metadados de ativos reutilizáveis para
+      promover a descoberta entre práticas.
+  BC-4370.50:
+    name: Gestão da biblioteca da prática
+    description: |
+      Curadoria e licenciamento de bases de dados de investigação externas,
+      bibliotecas jurídicas e fiscais e conteúdo de subscrição utilizados
+      pelos profissionais.
+  BC-4370.50.10:
+    name: Gestão de subscrições de investigação externa
+    description: |
+      Aquisição e renovação de subscrições a bases de dados jurídicas, fiscais
+      e de investigação externas.
+  BC-4370.50.20:
+    name: Catálogo e pesquisa da biblioteca
+    description: |
+      Catálogo e pesquisa federada em fontes de investigação internas e externas.
+  BC-4370.50.30:
+    name: Análise de utilização da biblioteca
+    description: |
+      Análise de utilização de bases de dados de investigação para informar
+      decisões de renovação e racionalização.
+  BC-4370.60:
+    name: Gestão de comunidade da prática
+    description: |
+      Operação de grupos de prática, comunidades de prática e redes temáticas
+      que partilham conhecimento em toda a firma.
+  BC-4370.60.10:
+    name: Operação de grupos de prática
+    description: |
+      Operação de grupos de prática, incluindo adesão, liderança e cadência
+      de fóruns.
+  BC-4370.60.20:
+    name: Facilitação de comunidades de prática
+    description: |
+      Facilitação de comunidades de prática transversais sobre tópicos e
+      métodos emergentes.
+  BC-4370.60.30:
+    name: Rede de campeões de conhecimento
+    description: |
+      Operação de uma rede de campeões de conhecimento distribuída por
+      práticas e escritórios.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-professional-services-delivery-management.yaml
+++ b/catalogue/i18n/pt/L1-professional-services-delivery-management.yaml
@@ -1,0 +1,173 @@
+locale: pt
+source: L1-professional-services-delivery-management.yaml
+entries:
+  BC-4310:
+    name: Gestão de prestação de serviços profissionais
+    description: |
+      Execução de projetos de assessoria, jurídicos, auditoria e consultoria
+      — planeamento do trabalho, trabalho de campo, produção de entregáveis,
+      revisão interna e reporte do projeto face ao âmbito acordado.
+  BC-4310.10:
+    name: Gestão do planeamento do projeto
+    description: |
+      Planeamento detalhado do trabalho do projeto, marcos, estrutura de
+      entregáveis e procedimentos adaptados ao risco, em conformidade com as
+      normas profissionais aplicáveis.
+  BC-4310.10.10:
+    name: Definição do plano de trabalho do projeto
+    description: |
+      Definição da decomposição do trabalho, marcos e dependências para
+      o projeto.
+  BC-4310.10.20:
+    name: Adaptação dos procedimentos ao risco do projeto
+    description: |
+      Adaptação dos procedimentos de auditoria, análises de assessoria ou
+      etapas jurídicas ao risco e materialidade específicos do projeto.
+  BC-4310.10.30:
+    name: Definição do plano de entregáveis do projeto
+    description: |
+      Definição da estrutura, formato e pontos de controlo de revisão dos
+      entregáveis.
+  BC-4310.10.40:
+    name: Gestão do calendário do projeto
+    description: |
+      Agendamento diário das atividades do projeto e disponibilidade de
+      recursos face ao plano de trabalho.
+  BC-4310.20:
+    name: Gestão da execução do projeto
+    description: |
+      Entrega diária do trabalho do projeto — trabalho de campo, análise de
+      assessoria, testes de auditoria, elaboração e interação com o cliente.
+  BC-4310.20.10:
+    name: Execução de procedimentos de auditoria
+    description: |
+      Realização de procedimentos de auditoria e garantia, incluindo testes
+      substantivos, testes de controlos e procedimentos analíticos.
+  BC-4310.20.20:
+    name: Execução de análise de assessoria
+    description: |
+      Realização de análises de consultoria, modelação, benchmarking e
+      desenvolvimento de recomendações.
+  BC-4310.20.30:
+    name: Execução de matéria jurídica
+    description: |
+      Trabalho jurídico substantivo, incluindo elaboração, pareceres,
+      peças processuais, execução transacional e aconselhamento.
+  BC-4310.20.40:
+    name: Gestão da interação com o cliente
+    description: |
+      Interação diária com o cliente durante a execução — entrevistas,
+      pedidos de informação, chamadas de estado e workshops de partes
+      interessadas.
+  BC-4310.30:
+    name: Gestão de entregáveis do projeto
+    description: |
+      Elaboração, controlo de versões e finalização de entregáveis do projeto,
+      como relatórios de auditoria, pareceres, relatórios de assessoria e
+      documentação transacional.
+  BC-4310.30.10:
+    name: Elaboração de entregáveis
+    description: |
+      Produção de rascunhos de entregáveis utilizando modelos da firma,
+      metodologia e resultados do projeto.
+  BC-4310.30.20:
+    name: Controlo de versões de entregáveis
+    description: |
+      Versionamento, ramificação e registo de auditoria em rascunhos de
+      entregáveis ao longo dos ciclos de revisão.
+  BC-4310.30.30:
+    name: Finalização de entregáveis
+    description: |
+      Formatação final, blocos de assinatura e embalagem de lançamento de
+      entregáveis concluídos.
+  BC-4310.40:
+    name: Gestão de papéis de trabalho do projeto
+    description: |
+      Captura, organização e retenção dos papéis de trabalho do projeto e
+      evidências que suportam entregáveis e conclusões.
+    in_scope:
+      - Papéis de trabalho do ficheiro do projeto
+      - Indexação e referência cruzada de evidências
+      - Montagem e bloqueio do ficheiro
+    out_of_scope:
+      - Ativos de metodologia e precedente reutilizáveis (BC-4370)
+  BC-4310.40.10:
+    name: Captura de papéis de trabalho
+    description: |
+      Captura de evidências, análises e notas no ficheiro de papéis de trabalho
+      do projeto.
+  BC-4310.40.20:
+    name: Indexação e referência cruzada de papéis de trabalho
+    description: |
+      Indexação e referência cruzada dos papéis de trabalho face às asserções
+      dos entregáveis e etapas dos procedimentos.
+  BC-4310.40.30:
+    name: Montagem e bloqueio do ficheiro do projeto
+    description: |
+      Montagem do ficheiro final do projeto e bloqueio para impedir alterações
+      pós-emissão fora dos controlos permitidos.
+  BC-4310.50:
+    name: Gestão de revisão interna do projeto
+    description: |
+      Ciclos de revisão interna do projeto por revisores, gestores e sócios
+      antes da emissão do entregável; distinto da monitorização de qualidade
+      ao nível da firma.
+    out_of_scope:
+      - Monitorização de qualidade ao nível da firma e EQR (BC-4340)
+  BC-4310.50.10:
+    name: Revisão dos papéis de trabalho pelo gestor
+    description: |
+      Revisão dos papéis de trabalho e conclusões pelo gestor antes da
+      aprovação do sócio.
+  BC-4310.50.20:
+    name: Revisão e aprovação do sócio
+    description: |
+      Revisão e aprovação dos entregáveis e pareceres pelo sócio do projeto.
+  BC-4310.50.30:
+    name: Revisão técnica por especialista
+    description: |
+      Revisão por especialistas técnicos (fiscal, avaliação, TI, atuarial)
+      em áreas que requerem contribuição especializada.
+  BC-4310.60:
+    name: Gestão do envolvimento de especialistas externos
+    description: |
+      Envolvimento de co-advogados, peritos, subcontratados e especialistas
+      terceiros num projeto.
+  BC-4310.60.10:
+    name: Envolvimento de co-advogados e subcontratados
+    description: |
+      Seleção e envolvimento de co-advogados, advogados locais ou
+      subcontratados de consultoria.
+  BC-4310.60.20:
+    name: Envolvimento de peritos
+    description: |
+      Identificação, envolvimento e gestão de peritos e especialistas externos.
+  BC-4310.60.30:
+    name: Supervisão da qualidade de especialistas externos
+    description: |
+      Supervisão do produto de trabalho de especialistas externos e avaliação
+      de confiança para as conclusões do projeto.
+  BC-4310.70:
+    name: Reporte e comunicação do projeto
+    description: |
+      Relatórios de estado, comunicações intercalares e reporte final ao
+      cliente e à liderança do projeto durante a execução.
+  BC-4310.70.10:
+    name: Relatórios de estado do projeto
+    description: |
+      Atualizações periódicas de estado para a liderança do projeto e o
+      cliente, incluindo progresso, riscos e problemas.
+  BC-4310.70.20:
+    name: Comunicação de resultados intercalares
+    description: |
+      Comunicação intercalar de resultados preliminares, observações e
+      problemas significativos ao cliente durante a execução.
+  BC-4310.70.30:
+    name: Reporte final do projeto
+    description: |
+      Emissão de relatórios finais, pareceres e cartas de gestão como parte
+      do encerramento do projeto.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-professional-workforce-resourcing-management.yaml
+++ b/catalogue/i18n/pt/L1-professional-workforce-resourcing-management.yaml
@@ -1,0 +1,157 @@
+locale: pt
+source: L1-professional-workforce-resourcing-management.yaml
+entries:
+  BC-4320:
+    name: Gestão de afetação de recursos da força de trabalho profissional
+    description: |
+      Alocação, utilização, alavancagem e gestão de profissionais faturáveis
+      sem projeto no portefólio de projetos. Distinto da Gestão de Capital
+      Humano genérica — focado na força de trabalho faturável como principal
+      recurso de entrega da firma.
+  BC-4320.10:
+    name: Previsão da procura de recursos
+    description: |
+      Previsão da procura de recursos faturáveis a partir do pipeline de
+      projetos, projetos comprometidos e pressupostos de crescimento.
+  BC-4320.10.10:
+    name: Previsão de procura orientada pelo pipeline
+    description: |
+      Previsão da procura de recursos derivada do pipeline de prospeção,
+      ponderada pela probabilidade de sucesso.
+  BC-4320.10.20:
+    name: Planeamento da procura de projetos comprometidos
+    description: |
+      Planeamento da procura de recursos a partir de projetos aceites com
+      âmbito e prazo confirmados.
+  BC-4320.10.30:
+    name: Agregação de procura por competência
+    description: |
+      Agregação da procura prevista por competência, especialização, língua
+      e habilitação de segurança.
+  BC-4320.20:
+    name: Gestão de afetação de equipas
+    description: |
+      Alocação de profissionais nomeados a papéis do projeto, equilibrando
+      as necessidades do projeto, o desenvolvimento individual e os objetivos
+      de utilização.
+  BC-4320.20.10:
+    name: Gestão de pedidos de recursos para projetos
+    description: |
+      Captura e triagem de pedidos de recursos do lado do projeto face aos
+      profissionais disponíveis.
+  BC-4320.20.20:
+    name: Gestão de decisões de afetação
+    description: |
+      Tomada de decisão de alocação equilibrando adequação ao projeto,
+      necessidades de desenvolvimento e preferências do sócio.
+  BC-4320.20.30:
+    name: Confirmação e notificação de afetação
+    description: |
+      Confirmação das decisões de afetação à liderança do projeto e aos
+      profissionais designados.
+  BC-4320.30:
+    name: Correspondência de competências e especializações
+    description: |
+      Manutenção de perfis de competências de profissionais e correspondência
+      de perfis com os requisitos de competências dos projetos.
+  BC-4320.30.10:
+    name: Manutenção do perfil de competências do profissional
+    description: |
+      Captura e atualização de competências, qualificações, línguas e
+      experiência setorial de cada profissional.
+  BC-4320.30.20:
+    name: Definição dos requisitos de competências do projeto
+    description: |
+      Definição de requisitos de competências, especialização e habilitação
+      por papel no projeto.
+  BC-4320.30.30:
+    name: Correspondência baseada em competências
+    description: |
+      Correspondência de profissionais a papéis no projeto com base em
+      competências, especialização e disponibilidade.
+  BC-4320.40:
+    name: Gestão de utilização
+    description: |
+      Acompanhamento e orientação da utilização faturável face aos objetivos
+      da firma e individuais, incluindo análise de produtividade.
+  BC-4320.40.10:
+    name: Definição de objetivos de utilização
+    description: |
+      Definição de objetivos de utilização faturável por categoria, prática
+      e profissional.
+  BC-4320.40.20:
+    name: Acompanhamento da utilização
+    description: |
+      Acompanhamento diário de horas faturáveis, horas não faturáveis e
+      ausências.
+  BC-4320.40.30:
+    name: Ação sobre variâncias de utilização
+    description: |
+      Identificação e correção de profissionais com utilização abaixo ou
+      significativamente acima dos objetivos.
+  BC-4320.50:
+    name: Gestão de profissionais sem projeto
+    description: |
+      Gestão da capacidade faturável não alocada, incluindo planeamento de
+      integração, utilização de profissionais sem projeto em trabalho não
+      faturável e reafetação proativa.
+  BC-4320.50.10:
+    name: Gestão de visibilidade de profissionais sem projeto
+    description: |
+      Visibilidade da capacidade disponível por categoria, competência e
+      localização.
+  BC-4320.50.20:
+    name: Alocação de atividades a profissionais sem projeto
+    description: |
+      Alocação do tempo dos profissionais sem projeto a desenvolvimento,
+      apoio a propostas, trabalho de metodologia ou formação.
+  BC-4320.50.30:
+    name: Ação de redução de profissionais sem projeto
+    description: |
+      Reafetação proativa, destacamento ou ajuste de capacidade quando os
+      profissionais sem projeto excedem o objetivo.
+  BC-4320.60:
+    name: Afetação de recursos entre escritórios e transfronteiriça
+    description: |
+      Coordenação da partilha de recursos entre escritórios, práticas e
+      fronteiras, incluindo destacamentos e mobilidade global para profissionais
+      faturáveis.
+  BC-4320.60.10:
+    name: Empréstimo de recursos entre escritórios
+    description: |
+      Empréstimo e cedência de profissionais entre escritórios numa base
+      temporária.
+  BC-4320.60.20:
+    name: Gestão de destacamentos internacionais
+    description: |
+      Destacamentos internacionais de longa duração de profissionais entre
+      escritórios da firma ou jurisdições de firmas-membro.
+  BC-4320.60.30:
+    name: Reembolso e liquidação entre escritórios
+    description: |
+      Liquidação operacional de reembolsos de tempo e custo entre escritórios
+      em projetos partilhados.
+  BC-4320.70:
+    name: Gestão de alavancagem do projeto
+    description: |
+      Gestão dos rácios de alavancagem sócio-equipa nos projetos, equilibrando
+      economia, qualidade e desenvolvimento.
+  BC-4320.70.10:
+    name: Modelação de alavancagem do projeto
+    description: |
+      Modelação da mistura de sócio, gestor, sénior e júnior por tipo de
+      projeto.
+  BC-4320.70.20:
+    name: Monitorização de variâncias de alavancagem
+    description: |
+      Monitorização da alavancagem real face ao objetivo e análise da causa
+      raiz das variâncias.
+  BC-4320.70.30:
+    name: Análise da saúde da pirâmide
+    description: |
+      Análise da saúde da pirâmide de categorias, velocidade de promoção e
+      impacto da rotatividade na alavancagem.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-programming-scheduling-management.yaml
+++ b/catalogue/i18n/pt/L1-programming-scheduling-management.yaml
@@ -1,0 +1,114 @@
+locale: pt
+source: L1-programming-scheduling-management.yaml
+entries:
+  BC-3730:
+    name: Gestão de programação e calendarização
+    description: |
+      Calendarização de canais lineares, gestão do guia eletrónico de programas,
+      curadoria do catálogo de conteúdos a pedido, lista de transmissão e
+      continuidade, e reconciliação da procura de programação com os direitos
+      e os pipelines de aquisição.
+  BC-3730.10:
+    name: Calendarização de canais lineares
+    description: |
+      Calendarização de longo alcance, tática e de alterações de canais e
+      fluxos lineares.
+  BC-3730.10.10:
+    name: Planeamento de grelha a longo prazo
+    description: |
+      Planos de grelha para múltiplos trimestres e épocas, alinhados com
+      janelas de direitos e estratégia de audiência.
+  BC-3730.10.20:
+    name: Construção de grelha tática
+    description: |
+      Construção da grelha semanal ao nível do programa e do intervalo.
+  BC-3730.10.30:
+    name: Gestão de alterações de grelha
+    description: |
+      Tratamento controlado de alterações de grelha tardias e de emergência
+      com notificação a sistemas a jusante.
+  BC-3730.20:
+    name: Gestão do guia eletrónico de programas
+    description: |
+      Criação, distribuição e atualização dos dados do guia eletrónico de
+      programas para operadores e dispositivos dos consumidores.
+  BC-3730.20.10:
+    name: Criação de dados do guia eletrónico de programas
+    description: |
+      Criação de títulos, sinopses, classificações e metadados de eventos
+      do guia eletrónico de programas para publicação.
+  BC-3730.20.20:
+    name: Distribuição do guia eletrónico de programas a operadores
+    description: |
+      Distribuição de feeds do guia eletrónico de programas a operadores
+      de plataformas, agregadores e plataformas de dispositivos de consumo.
+  BC-3730.20.30:
+    name: Gestão de atualizações em tempo real do guia eletrónico de programas
+    description: |
+      Atualizações em tempo real dos dados do guia eletrónico de programas
+      para ultrapassagens de diretos, desporto e notícias de última hora.
+  BC-3730.30:
+    name: Curadoria do catálogo a pedido
+    description: |
+      Curadoria de títulos, coleções e regras de personalização nas
+      superfícies de conteúdos a pedido e em streaming.
+  BC-3730.30.10:
+    name: Seleção e curadoria de títulos
+    description: |
+      Seleção e enquadramento editorial de títulos no catálogo a pedido,
+      incluindo disponibilidade territorial.
+  BC-3730.30.20:
+    name: Gestão de coleções editoriais
+    description: |
+      Criação e ciclo de vida de coleções editoriais, temas e linhas
+      apresentadas aos telespectadores.
+  BC-3730.30.30:
+    name: Criação de regras de personalização
+    description: |
+      Criação de regras de negócio que regem a personalização em conjunto
+      com recomendações de aprendizagem automática.
+  BC-3730.40:
+    name: Gestão de lista de transmissão e continuidade
+    description: |
+      Construção de listas de transmissão e continuidade no ar para canais
+      lineares e de streaming 24/7.
+  BC-3730.40.10:
+    name: Construção de lista de transmissão
+    description: |
+      Construção de listas de transmissão temporizadas para emissão, incluindo
+      intervalos e elementos intersticiais.
+  BC-3730.40.20:
+    name: Gestão de continuidade e junção
+    description: |
+      Criação e gestão de anúncios de continuidade, identificadores e pacotes
+      de junção.
+  BC-3730.40.30:
+    name: Gestão de cortes de conformidade e inserção
+    description: |
+      Aplicação de cortes de conformidade e inserções de versões exigidas
+      para o canal e horário de destino.
+  BC-3730.50:
+    name: Planeamento de espaços de aquisição de programas
+    description: |
+      Tradução da procura de espaços de programação em listas de desejos de
+      aquisição e reconciliação dos direitos adquiridos com as necessidades
+      da grelha.
+  BC-3730.50.10:
+    name: Planeamento da procura de espaços
+    description: |
+      Quantificação da procura de espaços por género, período do dia e alvo
+      de audiência ao longo do horizonte de grelha.
+  BC-3730.50.20:
+    name: Gestão da lista de desejos de aquisição
+    description: |
+      Lista de desejos de títulos, formatos e pacotes priorizados para
+      aquisição a fim de preencher os espaços identificados.
+  BC-3730.50.30:
+    name: Reconciliação de programação com direitos
+    description: |
+      Reconciliação das emissões programadas com os direitos detidos, as
+      exibições e o consumo de janelas.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-project-engineering-management.yaml
+++ b/catalogue/i18n/pt/L1-project-engineering-management.yaml
@@ -1,0 +1,127 @@
+locale: pt
+source: L1-project-engineering-management.yaml
+entries:
+  BC-1110:
+    name: Gestão da engenharia de projeto
+    description: |
+      Engenharia de projetos desde o FEED até à transferência.
+  BC-1110.10:
+    name: Gestão do planeamento da engenharia de projeto
+    description: |
+      Decomposição do trabalho de engenharia, planos de entregáveis e programas de engenharia.
+  BC-1110.10.10:
+    name: Definição da decomposição do trabalho de engenharia
+    description: |
+      WBS de engenharia e decomposição por disciplina.
+  BC-1110.10.20:
+    name: Registo de entregáveis de engenharia
+    description: |
+      Registo de entregáveis, responsáveis e datas alvo.
+  BC-1110.10.30:
+    name: Desenvolvimento do programa de engenharia
+    description: |
+      Programa de engenharia com interdependências entre disciplinas.
+  BC-1110.10.40:
+    name: Carregamento de recursos de engenharia
+    description: |
+      Previsão de horas de engenharia e carregamento de recursos.
+  BC-1110.20:
+    name: Gestão da execução da engenharia de projeto
+    description: |
+      Supervisão e relatório da execução de engenharia multidisciplinar.
+  BC-1110.20.10:
+    name: Medição do progresso de engenharia
+    description: |
+      Medição do progresso dos entregáveis de engenharia e valor ganho.
+  BC-1110.20.20:
+    name: Controlo de homem-hora de engenharia
+    description: |
+      Acompanhamento e previsão do consumo de homem-hora de engenharia.
+  BC-1110.20.30:
+    name: Reuniões de coordenação de engenharia
+    description: |
+      Coordenação de engenharia interdisciplinar e relatório semanal.
+  BC-1110.20.40:
+    name: Melhoria da produtividade de engenharia
+    description: |
+      Iniciativas de produtividade como automação de design e reutilização.
+  BC-1110.30:
+    name: Gestão de alterações de engenharia
+    description: |
+      Pedidos de alteração, avaliação de impacto técnico e controlo de linha de base.
+  BC-1110.30.10:
+    name: Captura de pedidos de alteração de engenharia
+    description: |
+      Captura e classificação de pedidos de alteração de engenharia.
+  BC-1110.30.20:
+    name: Avaliação de impacto técnico
+    description: |
+      Avaliação de impacto técnico multidisciplinar das alterações.
+  BC-1110.30.30:
+    name: Controlo da linha de base de engenharia
+    description: |
+      Controlo das linhas de base de engenharia e itens de configuração.
+  BC-1110.30.40:
+    name: Aprovação e implementação de alterações de engenharia
+    description: |
+      Comités de aprovação de alterações e acompanhamento da implementação.
+  BC-1110.40:
+    name: Gestão de interfaces
+    description: |
+      Interfaces técnicas internas e externas, coordenação com partes interessadas.
+  BC-1110.40.10:
+    name: Identificação e registo de interfaces
+    description: |
+      Identificação e registo de interfaces técnicas.
+  BC-1110.40.20:
+    name: Gestão de acordos de interface
+    description: |
+      Acordos de interface com as partes e critérios de aceitação.
+  BC-1110.40.30:
+    name: Monitorização e encerramento de interfaces
+    description: |
+      Monitorização de entregáveis de interface e encerramento formal.
+  BC-1110.50:
+    name: Gestão da qualidade da engenharia de projeto
+    description: |
+      GA/CQ de engenharia, garantia técnica, revisões por pares e auditorias.
+  BC-1110.50.10:
+    name: Gestão do programa de GA de engenharia
+    description: |
+      Alinhamento do programa de GA de engenharia com ISO 9001.
+  BC-1110.50.20:
+    name: Revisão por pares da disciplina
+    description: |
+      Revisão por pares de disciplina dos entregáveis de engenharia.
+  BC-1110.50.30:
+    name: Auditoria técnica de engenharia
+    description: |
+      Auditorias técnicas independentes e revisões de garantia.
+  BC-1110.50.40:
+    name: Lições aprendidas de engenharia
+    description: |
+      Captura e disseminação de lições aprendidas de engenharia.
+  BC-1110.60:
+    name: Gestão de riscos e problemas da engenharia de projeto
+    description: |
+      Riscos técnicos, problemas técnicos e acompanhamento de mitigação.
+  BC-1110.60.10:
+    name: Identificação de riscos técnicos
+    description: |
+      Identificação de riscos técnicos e de engenharia.
+  BC-1110.60.20:
+    name: Avaliação de riscos técnicos
+    description: |
+      Avaliação da probabilidade e impacto dos riscos técnicos.
+  BC-1110.60.30:
+    name: Resolução de problemas técnicos
+    description: |
+      Acompanhamento e resolução de problemas técnicos com responsáveis.
+  BC-1110.60.40:
+    name: Acompanhamento de mitigação técnica
+    description: |
+      Acompanhamento de ações de mitigação e risco residual.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-project-portfolio-management.yaml
+++ b/catalogue/i18n/pt/L1-project-portfolio-management.yaml
@@ -1,0 +1,135 @@
+locale: pt
+source: L1-project-portfolio-management.yaml
+entries:
+  BC-900:
+    name: Gestão de projetos e portefólio
+    description: |
+      Execução de projetos, priorização de portefólio, PMO.
+  BC-900.10:
+    name: Gestão de portefólio
+    description: |
+      Composição, priorização e equilíbrio do portefólio.
+  BC-900.10.10:
+    name: Definição da composição do portefólio
+    description: |
+      Composição do portefólio por tema estratégico, tipo e risco.
+  BC-900.10.20:
+    name: Priorização e seleção do portefólio
+    description: |
+      Pontuação e seleção de iniciativas para inclusão no portefólio.
+  BC-900.10.30:
+    name: Equilíbrio do portefólio
+    description: |
+      Equilíbrio do portefólio entre horizontes, risco e retorno.
+  BC-900.10.40:
+    name: Relatório de desempenho do portefólio
+    description: |
+      Dashboards, estado e relatório de benefícios do portefólio.
+  BC-900.20:
+    name: Gestão de programas
+    description: |
+      Planeamento, execução e governação de programas.
+  BC-900.20.10:
+    name: Definição e mobilização do programa
+    description: |
+      Plano diretor, mandato e mobilização do programa.
+  BC-900.20.20:
+    name: Integração do plano do programa
+    description: |
+      Integração de planos de projeto, dependências e marcos.
+  BC-900.20.30:
+    name: Gestão de riscos e problemas do programa
+    description: |
+      Gestão de riscos, problemas e dependências ao nível do programa.
+  BC-900.20.40:
+    name: Encerramento do programa
+    description: |
+      Encerramento do programa, transferência e lições aprendidas.
+  BC-900.30:
+    name: Gestão de projetos
+    description: |
+      Execução, planeamento e acompanhamento de projetos.
+  BC-900.30.10:
+    name: Planeamento do projeto
+    description: |
+      Planeamento do âmbito, cronograma, custo e recursos do projeto.
+  BC-900.30.20:
+    name: Execução e acompanhamento do projeto
+    description: |
+      Execução diária do projeto e acompanhamento do progresso.
+  BC-900.30.30:
+    name: Gestão de riscos e problemas do projeto
+    description: |
+      Gestão de riscos, problemas e decisões do projeto.
+  BC-900.30.40:
+    name: Gestão da qualidade do projeto
+    description: |
+      Qualidade e aceitação de entregáveis do projeto.
+  BC-900.30.50:
+    name: Encerramento e transferência do projeto
+    description: |
+      Encerramento do projeto, transferência para operações e revisão pós-implementação.
+  BC-900.40:
+    name: Gestão da governação de projetos
+    description: |
+      Portais de fase, comités de direção e garantia.
+  BC-900.40.10:
+    name: Governação de portais de fase
+    description: |
+      Definições, critérios e aprovações de portais de fase.
+  BC-900.40.20:
+    name: Operações do comité de direção
+    description: |
+      Termos de referência, agendas e decisões do comité de direção.
+  BC-900.40.30:
+    name: Revisões de garantia do projeto
+    description: |
+      Revisões de garantia independentes e revisões de portal.
+  BC-900.40.40:
+    name: Auditoria e lições aprendidas do projeto
+    description: |
+      Auditoria pós-projeto, captura e disseminação de lições aprendidas.
+  BC-900.50:
+    name: Gestão das operações do PMO
+    description: |
+      Serviços, metodologia e ferramentas do PMO.
+  BC-900.50.10:
+    name: Metodologia e normas do PMO
+    description: |
+      Metodologia de projeto, modelos e normas (PRINCE2, PMI, ágil).
+  BC-900.50.20:
+    name: Ferramentas e relatório do PMO
+    description: |
+      Ferramentas de gestão de projetos, dashboards e relatórios.
+  BC-900.50.30:
+    name: Desenvolvimento de capacidades do PMO
+    description: |
+      Desenvolvimento de capacidades e certificação de gestores de projeto.
+  BC-900.50.40:
+    name: Gestão do desempenho do PMO
+    description: |
+      Scorecard, valor e acompanhamento do desempenho do PMO.
+  BC-900.60:
+    name: Gestão da procura e capacidade
+    description: |
+      Receção de procura de projetos, planeamento da capacidade de recursos.
+  BC-900.60.10:
+    name: Receção de procura de projetos
+    description: |
+      Captura, qualificação e aprovação de nova procura de projetos.
+  BC-900.60.20:
+    name: Planeamento da capacidade de recursos
+    description: |
+      Planeamento de capacidade entre equipas de entrega e competências.
+  BC-900.60.30:
+    name: Alocação e nivelamento de recursos
+    description: |
+      Alocação de recursos entre projetos e resolução de conflitos.
+  BC-900.60.40:
+    name: Relatório de utilização de recursos
+    description: |
+      Relatório de utilização de recursos, horas faturáveis e previsão de procura.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-property-management-operations.yaml
+++ b/catalogue/i18n/pt/L1-property-management-operations.yaml
@@ -1,0 +1,196 @@
+locale: pt
+source: L1-property-management-operations.yaml
+entries:
+  BC-4940:
+    name: Operações de gestão de propriedades
+    description: |
+      Operação do lado do senhorio e do gestor de propriedades de edifícios
+      comerciais, de retalho e residenciais multifamiliares — serviços de edifícios,
+      gestão de fornecedores e contratos, ordens de trabalho, serviços a inquilinos
+      durante a ocupação, segurança e proteção de vidas, energia/sustentabilidade
+      e contabilidade de propriedade, incluindo reconciliação de CAM. Distinto de
+      operações hoteleiras (BC-4060) e instalações de ocupante corporativo (BC-700).
+    in_scope:
+      - Operações diárias do edifício, incluindo BMS e áreas comuns
+      - Manutenção preventiva, reativa e estatutária
+      - Gestão de fornecedores e contratos de serviço (limpeza, segurança, jardinagem)
+      - Coordenação de mudança de inquilinos e obras de adaptação
+      - Segurança da propriedade, proteção contra incêndio/vidas e resposta a incidentes
+      - Energia, água, resíduos e ambiente interior da propriedade
+      - Contabilidade de propriedade, faturação a inquilinos e reporte operacional
+      - Reconciliação de CAM e encargos de serviço
+    out_of_scope:
+      - Operações de hotel e resort (BC-4060)
+      - Instalações de ocupante corporativo para uso próprio (BC-700)
+      - Planos de negócio de ativos consolidados e estratégia de capex (BC-4920)
+      - Aquisição de inquilinos e execução de arrendamentos (BC-4950)
+  BC-4940.10:
+    name: Gestão das operações do edifício
+    description: |
+      Operação diária dos serviços do edifício, sistemas de gestão do edifício,
+      áreas comuns, receção e horários de funcionamento em ativos comerciais,
+      de retalho e multifamiliares.
+  BC-4940.10.10:
+    name: Operações de áreas comuns
+    description: |
+      Operação de áreas comuns, incluindo átrios, corredores e amenidades partilhadas.
+  BC-4940.10.20:
+    name: Operações do sistema de gestão do edifício
+    description: |
+      Operação de sistemas de gestão do edifício, incluindo AVAC, iluminação e controlos de acesso.
+  BC-4940.10.30:
+    name: Operações de receção e acesso à propriedade
+    description: |
+      Operações de receção, concierge e acesso para inquilinos e visitantes na propriedade.
+  BC-4940.10.40:
+    name: Gestão de horários e agenda de operações
+    description: |
+      Gestão de horários de funcionamento, pedidos fora de horas e agendas de feriados.
+  BC-4940.20:
+    name: Gestão de manutenção de propriedade e ordens de trabalho
+    description: |
+      Manutenção preventiva, reativa e estatutária de sistemas do edifício e
+      ativos voltados para inquilinos através de fluxos de trabalho de ordens de trabalho.
+  BC-4940.20.10:
+    name: Operações de manutenção preventiva
+    description: |
+      Operação de manutenção preventiva face ao plano e dados de condição dos ativos.
+  BC-4940.20.20:
+    name: Manutenção reativa e ordens de trabalho
+    description: |
+      Tratamento de manutenção reativa acionada por pedidos de inquilinos e resultados de inspeção.
+  BC-4940.20.30:
+    name: Inspeções estatutárias e de conformidade
+    description: |
+      Inspeções estatutárias e de conformidade cobrindo elevadores, sistemas de incêndio,
+      gás e sistemas sob pressão.
+  BC-4940.20.40:
+    name: Reporte de manutenção
+    description: |
+      Reporte de atividade de manutenção, backlog e desempenho de SLA a proprietários e inquilinos.
+  BC-4940.30:
+    name: Gestão de fornecedores e contratos de serviço da propriedade
+    description: |
+      Integração e gestão de fornecedores e contratos de serviço ao nível da
+      propriedade para limpeza, segurança, jardinagem e fornecimento de utilidades.
+  BC-4940.30.10:
+    name: Integração de contratos de serviço
+    description: |
+      Integração de contratos de serviço e fornecedores ao nível da propriedade.
+  BC-4940.30.20:
+    name: Gestão do desempenho de fornecedores
+    description: |
+      Gestão do desempenho de fornecedores de propriedade face a SLA e KPI.
+  BC-4940.30.30:
+    name: Definição de especificações de serviço e SLA
+    description: |
+      Definição de especificações de serviço, âmbitos e SLA para serviços contratados de propriedade.
+  BC-4940.40:
+    name: Serviços a inquilinos e coordenação de mudanças
+    description: |
+      Coordenação da integração de inquilinos, mudança de entrada/saída, obras de
+      adaptação e tratamento contínuo de pedidos de serviço dos inquilinos na propriedade.
+  BC-4940.40.10:
+    name: Coordenação da mudança de entrada do inquilino
+    description: |
+      Coordenação da mudança de entrada do inquilino, incluindo acesso, sinalética e orientação.
+  BC-4940.40.20:
+    name: Coordenação de obras de adaptação do inquilino
+    description: |
+      Coordenação de obras de adaptação do inquilino, acesso de empreiteiros e aprovações do senhorio.
+  BC-4940.40.30:
+    name: Mudança de saída e reposição do inquilino
+    description: |
+      Coordenação da mudança de saída do inquilino e reposição das áreas arrendadas.
+  BC-4940.40.40:
+    name: Tratamento de pedidos de serviço dos inquilinos
+    description: |
+      Tratamento de pedidos de serviço de inquilinos durante a ocupação em múltiplos canais.
+  BC-4940.50:
+    name: Operações de segurança e proteção de vidas da propriedade
+    description: |
+      Operações de vigilância, sistemas de proteção contra incêndio e vidas, resposta
+      a incidentes e evacuação de emergência na propriedade.
+  BC-4940.50.10:
+    name: Operações de vigilância da propriedade
+    description: |
+      Operação de CCTV e vigilância nas áreas comuns e de serviço.
+  BC-4940.50.20:
+    name: Operações do sistema de proteção contra incêndio e vidas
+    description: |
+      Operação de sistemas de deteção de incêndio, supressão e proteção de vidas, incluindo simulacros.
+  BC-4940.50.30:
+    name: Resposta a incidentes na propriedade
+    description: |
+      Resposta a incidentes ao nível da propriedade cobrindo segurança, furto e eventos de segurança.
+  BC-4940.50.40:
+    name: Operações de evacuação de emergência
+    description: |
+      Execução de planos de evacuação de emergência e comando de incidentes na propriedade.
+  BC-4940.60:
+    name: Operações de energia e sustentabilidade da propriedade
+    description: |
+      Operação ao nível da propriedade de energia, água, resíduos, ambiente interior
+      e programas de subcontagem a inquilinos.
+  BC-4940.60.10:
+    name: Operações de energia da propriedade
+    description: |
+      Operação de sistemas de energia da propriedade e monitorização do consumo face a metas.
+  BC-4940.60.20:
+    name: Operações de água e resíduos
+    description: |
+      Operação de programas de água, águas residuais e segregação de resíduos da propriedade.
+  BC-4940.60.30:
+    name: Operações de qualidade do ambiente interior
+    description: |
+      Operação de programas de qualidade do ar interior, iluminação e conforto acústico.
+  BC-4940.60.40:
+    name: Subcontagem e alocação a inquilinos
+    description: |
+      Operação de subcontagem e alocação do consumo de utilidades a inquilinos.
+  BC-4940.70:
+    name: Contabilidade de propriedade e reporte operacional
+    description: |
+      Razão geral ao nível da propriedade, faturação e recebíveis de inquilinos,
+      pagamentos e reporte ao proprietário.
+  BC-4940.70.10:
+    name: Operações do razão geral da propriedade
+    description: |
+      Operação do razão geral ao nível da propriedade e balancete de verificação.
+  BC-4940.70.20:
+    name: Faturação e recebíveis de inquilinos
+    description: |
+      Faturação de rendas, recuperações e encargos acessórios e cobrança de recebíveis.
+  BC-4940.70.30:
+    name: Operações de pagamentos da propriedade
+    description: |
+      Contas a pagar ao nível da propriedade para utilidades, fornecedores e empreiteiros.
+  BC-4940.70.40:
+    name: Relatório ao proprietário
+    description: |
+      Relatórios periódicos ao proprietário cobrindo desempenho operacional e variâncias.
+  BC-4940.80:
+    name: Reconciliação de manutenção de áreas comuns
+    description: |
+      Ciclo contabilístico específico de senhorio-inquilino cobrindo orçamentação,
+      captura, reconciliação de CAM e encargos de serviço, e resposta a auditorias de inquilinos.
+  BC-4940.80.10:
+    name: Definição de orçamento e estimativas de CAM
+    description: |
+      Definição de orçamentos de CAM e encargos de serviço e estimativas para inquilinos no ano.
+  BC-4940.80.20:
+    name: Captura de despesas reais de CAM
+    description: |
+      Captura de despesas reais reembolsáveis no âmbito das categorias de CAM e encargos de serviço.
+  BC-4940.80.30:
+    name: Reconciliação e liquidação de CAM
+    description: |
+      Reconciliação dos valores reais de CAM face às estimativas e liquidação de ajustes com inquilinos.
+  BC-4940.80.40:
+    name: Resposta a auditoria de CAM de inquilinos
+    description: |
+      Resposta a pedidos de auditoria e inspeção de inquilinos sobre direitos de CAM e encargos de serviço.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-property-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-property-operations-management.yaml
@@ -1,0 +1,194 @@
+locale: pt
+source: L1-property-operations-management.yaml
+entries:
+  BC-4060:
+    name: Gestão de operações de propriedade
+    description: |
+      Operação diária de hotéis, resorts e propriedades de alojamento
+      com serviços — receção, limpeza, engenharia, concierge, segurança,
+      sustentabilidade e adesão a normas de marca e qualidade.
+  BC-4060.10:
+    name: Operações da receção
+    description: |
+      Operação da receção, abrangendo preparação pré-chegada, check-in,
+      atribuição de quarto, check-out, liquidação da ficha e emissão
+      de chave.
+  BC-4060.10.10:
+    name: Preparação pré-chegada
+    description: |
+      Atividades de preparação antes da chegada, incluindo relatórios de
+      chegada, atribuição de quartos e preparação de cortesias.
+  BC-4060.10.20:
+    name: Operações de check-in
+    description: |
+      Operações de check-in de hóspedes em balcão, canal móvel e quiosque.
+  BC-4060.10.30:
+    name: Atribuição de quarto e upgrade
+    description: |
+      Atribuição de quartos e execução de decisões de upgrade, incluindo
+      upgrades pagos e gratuitos.
+  BC-4060.10.40:
+    name: Check-out e liquidação da ficha
+    description: |
+      Operações de check-out de hóspedes e liquidação da ficha da
+      propriedade.
+  BC-4060.10.50:
+    name: Emissão de chave e credencial de acesso
+    description: |
+      Emissão e revogação de chaves de quarto físicas e digitais e
+      credenciais de acesso.
+  BC-4060.20:
+    name: Operações de limpeza
+    description: |
+      Operações de limpeza de quartos de hóspedes, serviço de turn-down,
+      limpeza profunda e achados e perdidos na propriedade.
+  BC-4060.20.10:
+    name: Operações de limpeza diária
+    description: |
+      Limpeza diária de quartos em ocupação e check-out contra as normas
+      da propriedade.
+  BC-4060.20.20:
+    name: Serviço de turn-down e de estadias
+    description: |
+      Serviços de turn-down e de estadia para hóspedes em residência.
+  BC-4060.20.30:
+    name: Operações de limpeza profunda e quartos fora de serviço
+    description: |
+      Operação de ciclos de limpeza profunda e gestão de quartos fora
+      de ordem e fora de serviço.
+  BC-4060.20.40:
+    name: Operações de achados e perdidos
+    description: |
+      Registo, armazenamento e devolução de achados e perdidos ao nível
+      da propriedade a hóspedes.
+  BC-4060.30:
+    name: Engenharia e manutenção da propriedade
+    description: |
+      Operações de engenharia e manutenção que abrangem trabalhos
+      preventivos, reativos e de renovação e inspeções de conformidade.
+  BC-4060.30.10:
+    name: Operações de manutenção preventiva
+    description: |
+      Operação de manutenção preventiva contra calendário e dados de
+      condição.
+  BC-4060.30.20:
+    name: Operações de manutenção reativa
+    description: |
+      Operação de manutenção reativa acionada por relatórios de hóspedes
+      e conclusões de inspeção.
+  BC-4060.30.30:
+    name: Substituição e renovação de ativos
+    description: |
+      Substituição e renovação de ativos da propriedade em quartos, espaços
+      comuns e áreas de serviço.
+  BC-4060.30.40:
+    name: Inspeções de conformidade de engenharia
+    description: |
+      Inspeções de conformidade que abrangem sistemas de incêndio, sistemas
+      de segurança de vida, elevadores e sistemas sob pressão.
+  BC-4060.40:
+    name: Concierge e serviços ao hóspede
+    description: |
+      Serviços de concierge, porteiro, valet e transporte de hóspedes
+      prestados ao longo da jornada do hóspede.
+  BC-4060.40.10:
+    name: Serviços de informação e reserva do concierge
+    description: |
+      Serviços de concierge que abrangem informações sobre o destino e
+      reservas de restaurantes e atividades.
+  BC-4060.40.20:
+    name: Operações de porteiro e bagagem
+    description: |
+      Operações de porteiro e manuseio de bagagem, incluindo armazenamento
+      e entrega.
+  BC-4060.40.30:
+    name: Operações de estacionamento valet
+    description: |
+      Serviços de estacionamento valet e manuseio de veículos nos pontos
+      de entrada da propriedade.
+  BC-4060.40.40:
+    name: Coordenação do transporte do hóspede
+    description: |
+      Coordenação do transporte terrestre do hóspede, incluindo shuttles
+      do hotel e arranjos de automóvel.
+  BC-4060.50:
+    name: Operações de segurança e proteção da propriedade
+    description: |
+      Operações de vigilância da propriedade, segurança de vida contra
+      incêndio, evacuação e tratamento de incidentes na propriedade.
+  BC-4060.50.10:
+    name: Operações de vigilância da propriedade
+    description: |
+      Vigilância de espaços públicos e operacionais, incluindo monitorização
+      e revisão.
+  BC-4060.50.20:
+    name: Operações de segurança de incêndio e vida
+    description: |
+      Operação de sistemas de segurança de incêndio e vida, incluindo
+      exercícios e prontidão de equipamento.
+  BC-4060.50.30:
+    name: Operações de evacuação de emergência
+    description: |
+      Execução de operações de evacuação de emergência e comando de
+      incidente na propriedade.
+  BC-4060.50.40:
+    name: Tratamento de incidentes com hóspedes
+    description: |
+      Tratamento de incidentes de segurança, furto e proteção de hóspedes
+      na propriedade.
+  BC-4060.60:
+    name: Operações de sustentabilidade da propriedade
+    description: |
+      Operação ao nível da propriedade de programas de energia, água,
+      resíduos e reutilização de roupa consistentes com os compromissos
+      de marca e certificação.
+  BC-4060.60.10:
+    name: Operações de energia da propriedade
+    description: |
+      Operação dos sistemas de energia da propriedade e monitorização
+      do consumo contra metas.
+  BC-4060.60.20:
+    name: Operações de gestão responsável da água
+    description: |
+      Gestão responsável do consumo de água da propriedade, incluindo
+      deteção de fugas e medidas de reutilização.
+  BC-4060.60.30:
+    name: Operações de resíduos e reciclagem
+    description: |
+      Operação de separação de resíduos, reciclagem e programas de
+      desperdício alimentar da propriedade.
+  BC-4060.60.40:
+    name: Programas de reutilização de roupa e toalhas
+    description: |
+      Operação de programas de reutilização de roupa e toalhas e mecânicas
+      de adesão voluntária dos hóspedes.
+  BC-4060.70:
+    name: Auditoria de qualidade e normas de marca da propriedade
+    description: |
+      Auditoria da conformidade da propriedade com as normas de marca e
+      operacionais, programas de cliente misterioso e operações de
+      recuperação de serviço.
+  BC-4060.70.10:
+    name: Operações de auditoria de normas de marca
+    description: |
+      Auditoria da conformidade da propriedade com as normas de marca
+      e operacionais.
+  BC-4060.70.20:
+    name: Operações do programa de cliente misterioso
+    description: |
+      Operação de programas de cliente misterioso que avaliam a experiência
+      do hóspede contra jornadas com guião.
+  BC-4060.70.30:
+    name: Registo de recuperação de serviço
+    description: |
+      Registo de ações de recuperação de serviço tomadas na propriedade,
+      incluindo compensação e acompanhamento.
+  BC-4060.70.40:
+    name: Encerramento de melhoria da qualidade
+    description: |
+      Encerramento de conclusões de auditoria e feedback contra planos
+      de melhoria da qualidade.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-public-benefits-entitlements-management.yaml
+++ b/catalogue/i18n/pt/L1-public-benefits-entitlements-management.yaml
@@ -1,0 +1,163 @@
+locale: pt
+source: L1-public-benefits-entitlements-management.yaml
+entries:
+  BC-3230:
+    name: Gestão de prestações sociais e direitos
+    description: |
+      Concepção, determinação de elegibilidade, cálculo, pagamento, monitorização e
+      recuperação de prestações de protecção social e direitos estatutários,
+      incluindo pensões, desemprego, invalidez, família e apoio alimentar.
+  BC-3230.10:
+    name: Concepção e configuração de programas de prestações
+    description: |
+      Configuração de programas de prestações estatutários, incluindo regras de
+      elegibilidade, fórmulas de prestações e parâmetros operacionais.
+    in_scope:
+      - Configuração de regras de elegibilidade
+      - Definição de fórmulas e taxas de prestações
+      - Gestão de parâmetros e indexação de programas
+    out_of_scope:
+      - Redacção de legislação habilitante (abrangida pela Gestão de Redação Legislativa e Regulatória)
+  BC-3230.10.10:
+    name: Configuração de regras de elegibilidade
+    description: |
+      Codificação de regras de elegibilidade estatutárias em forma executável por
+      máquina.
+  BC-3230.10.20:
+    name: Configuração de fórmulas e taxas de prestações
+    description: |
+      Configuração de fórmulas de cálculo de prestações, taxas e tetos.
+  BC-3230.10.30:
+    name: Indexação de parâmetros do programa
+    description: |
+      Indexação e ajuste periódicos dos parâmetros do programa à inflação ou
+      variações salariais.
+  BC-3230.20:
+    name: Determinação de elegibilidade
+    description: |
+      Determinação da elegibilidade de requerentes para prestações, incluindo
+      teste de meios, elegibilidade categórica e composição do agregado familiar.
+  BC-3230.20.10:
+    name: Recepção de candidaturas
+    description: |
+      Recepção de candidaturas a prestações por múltiplos canais, incluindo digital,
+      presencial e assistido.
+  BC-3230.20.20:
+    name: Teste de meios
+    description: |
+      Teste de rendimento, activos e circunstâncias do agregado familiar face aos
+      limiares do programa.
+  BC-3230.20.30:
+    name: Verificação de elegibilidade categórica
+    description: |
+      Verificação de elegibilidade categórica, como idade, invalidez ou estatuto
+      familiar.
+  BC-3230.20.40:
+    name: Decisão e notificação de elegibilidade
+    description: |
+      Registo de decisão e notificação ao requerente dos resultados de elegibilidade.
+  BC-3230.30:
+    name: Cálculo e atribuição de prestações
+    description: |
+      Cálculo dos montantes de atribuição, avaliação do registo de contribuições e
+      emissão de atribuições de prestações.
+  BC-3230.30.10:
+    name: Avaliação do registo de contribuições
+    description: |
+      Avaliação dos registos de contribuições para prestações contributivas, como
+      pensões e desemprego.
+  BC-3230.30.20:
+    name: Cálculo da atribuição
+    description: |
+      Cálculo dos montantes de atribuição, incluindo suplementos, deduções e
+      tapering.
+  BC-3230.30.30:
+    name: Emissão da atribuição
+    description: |
+      Emissão e registo de atribuições de prestações e cartas de atribuição.
+  BC-3230.40:
+    name: Operações de pagamento de prestações
+    description: |
+      Pagamento periódico de prestações por múltiplos canais de pagamento e
+      reconciliação face às atribuições.
+  BC-3230.40.10:
+    name: Gestão do calendário de pagamentos
+    description: |
+      Manutenção de calendários de pagamento, frequências e calendários de
+      execução.
+  BC-3230.40.20:
+    name: Execução de pagamentos
+    description: |
+      Execução de pagamentos por banco, cartão pré-pago, cheque e canais em
+      espécie.
+  BC-3230.40.30:
+    name: Reconciliação de pagamentos
+    description: |
+      Reconciliação de pagamentos face a atribuições e confirmações bancárias.
+  BC-3230.40.40:
+    name: Distribuição de prestações em espécie
+    description: |
+      Distribuição de prestações em espécie, como vales de apoio alimentar e
+      transferência electrónica de benefícios.
+  BC-3230.50:
+    name: Monitorização de beneficiários e elegibilidade contínua
+    description: |
+      Monitorização contínua das circunstâncias dos beneficiários e redeterminação
+      periódica da elegibilidade contínua.
+  BC-3230.50.10:
+    name: Captura de alteração de circunstâncias
+    description: |
+      Captura e processamento de alterações de circunstâncias reportadas pelo
+      beneficiário e detectadas.
+  BC-3230.50.20:
+    name: Redeterminação periódica
+    description: |
+      Redeterminação periódica da elegibilidade e nível de atribuição.
+  BC-3230.50.30:
+    name: Monitorização de condicionalidade e conformidade
+    description: |
+      Monitorização da conformidade dos beneficiários com a condicionalidade, como
+      requisitos de procura de emprego ou de formação.
+  BC-3230.60:
+    name: Gestão de pagamentos em excesso e recuperação
+    description: |
+      Detecção, cálculo e recuperação de pagamentos em excesso e pagamentos
+      indevidos.
+  BC-3230.60.10:
+    name: Detecção de pagamentos em excesso
+    description: |
+      Detecção de pagamentos em excesso através de reconciliação, cruzamento de
+      dados e revisões.
+  BC-3230.60.20:
+    name: Configuração de planos de recuperação
+    description: |
+      Configuração de planos de recuperação, incluindo prestações, deduções e
+      anulações.
+  BC-3230.60.30:
+    name: Operações de cobrança de dívidas
+    description: |
+      Cobrança de dívidas recuperáveis através de deduções, acções cíveis e
+      compensações.
+  BC-3230.70:
+    name: Investigação de fraude em prestações
+    description: |
+      Detecção, investigação e resolução de casos de fraude em prestações.
+  BC-3230.70.10:
+    name: Detecção de risco de fraude
+    description: |
+      Detecção baseada em risco de suspeita de fraude através de análise e
+      informações.
+  BC-3230.70.20:
+    name: Investigação de casos de fraude
+    description: |
+      Investigação de casos suspeitos de fraude, incluindo recolha de evidências e
+      entrevistas.
+  BC-3230.70.30:
+    name: Sanção e referenciação de fraude
+    description: |
+      Sanção de fraude confirmada e referenciação para processo judicial quando
+      aplicável.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-public-finance-budget-management.yaml
+++ b/catalogue/i18n/pt/L1-public-finance-budget-management.yaml
@@ -1,0 +1,151 @@
+locale: pt
+source: L1-public-finance-budget-management.yaml
+entries:
+  BC-3280:
+    name: Gestão das finanças públicas e do orçamento
+    description: |
+      Formulação do orçamento do setor público, execução de dotações, contabilidade
+      pública de fundos, gestão da dívida pública, operações de tesouraria e reporte
+      e divulgação fiscal alinhados com as IPSAS.
+  BC-3280.10:
+    name: Formulação do orçamento
+    description: |
+      Elaboração de orçamentos anuais e plurianuais, incluindo tetos, orçamentação
+      por programas e submissão à autoridade legislativa.
+    in_scope:
+      - Previsão macroeconómica
+      - Orçamentação por programas e orçamento de base zero
+      - Submissão do orçamento ao parlamento
+    out_of_scope:
+      - FP&A empresarial e contabilidade de gestão (coberta pela Planeamento e Análise Financeira)
+  BC-3280.10.10:
+    name: Previsão macroeconómica
+    description: |
+      Previsão de agregados de receita e despesa e cenários macroeconómicos.
+  BC-3280.10.20:
+    name: Definição de tetos orçamentais
+    description: |
+      Definição de tetos orçamentais por organismo e programa dentro do envelope
+      fiscal.
+  BC-3280.10.30:
+    name: Preparação do orçamento por programas
+    description: |
+      Elaboração de orçamentos por programas e desempenho pelos organismos de
+      despesa.
+  BC-3280.10.40:
+    name: Submissão do orçamento ao parlamento
+    description: |
+      Compilação e submissão do orçamento do executivo ao parlamento.
+  BC-3280.20:
+    name: Execução de dotações
+    description: |
+      Afetação, repartição, assunção de encargos, compromisso e pagamento de
+      fundos dotados em conformidade com a lei das dotações.
+  BC-3280.20.10:
+    name: Afetação e repartição
+    description: |
+      Repartição e afetação de dotações aos organismos de despesa.
+  BC-3280.20.20:
+    name: Registo de encargos e compromissos
+    description: |
+      Registo de encargos e compromissos face às dotações.
+  BC-3280.20.30:
+    name: Processamento de despesas e pagamentos
+    description: |
+      Processamento de despesas e pagamentos face a fundos comprometidos.
+  BC-3280.20.40:
+    name: Autoridade de reafetação e transferência
+    description: |
+      Administração de reafetações, transferências e ajustamentos de autoridade
+      estatutária.
+  BC-3280.30:
+    name: Contabilidade pública de fundos
+    description: |
+      Contabilidade de fundos governamentais, incluindo fundo geral, fundos
+      especiais, fundos fiduciários e fundos rotativos ao abrigo das IPSAS ou
+      equivalentes nacionais.
+  BC-3280.30.10:
+    name: Manutenção da estrutura de fundos
+    description: |
+      Manutenção das estruturas de fundos governamentais e plano de contas.
+  BC-3280.30.20:
+    name: Contabilidade ao nível do fundo
+    description: |
+      Lançamento e reconciliação de transações nos fundos geral, especiais,
+      fiduciários e rotativos.
+  BC-3280.30.30:
+    name: Liquidação entre organismos
+    description: |
+      Liquidação e reconciliação de transferências entre organismos e acordos
+      de reembolso.
+  BC-3280.40:
+    name: Gestão da dívida pública
+    description: |
+      Emissão, serviço e gestão do risco de instrumentos de dívida soberana e
+      subnacional.
+  BC-3280.40.10:
+    name: Estratégia e planeamento de emissão de dívida
+    description: |
+      Definição da estratégia de dívida e calendários de emissão por instrumento
+      e maturidade.
+  BC-3280.40.20:
+    name: Operações de emissão de dívida
+    description: |
+      Leilão, sindicação e emissão direta de instrumentos de dívida pública.
+  BC-3280.40.30:
+    name: Serviço da dívida
+    description: |
+      Pagamento de cupões, juros e reembolso de capital aos detentores da dívida.
+  BC-3280.40.40:
+    name: Gestão do risco da carteira de dívida
+    description: |
+      Gestão do risco cambial, de taxa de juro e de refinanciamento na carteira
+      de dívida.
+  BC-3280.50:
+    name: Operações de caixa e tesouraria
+    description: |
+      Gestão de tesouraria do Estado, operações de conta única do tesouro e
+      processamento de pagamentos e cobranças em nome dos organismos.
+  BC-3280.50.10:
+    name: Previsão de tesouraria
+    description: |
+      Previsão diária e contínua dos fluxos de caixa do Estado.
+  BC-3280.50.20:
+    name: Operações da conta única do tesouro
+    description: |
+      Operação da conta única do tesouro e acordos bancários consolidados.
+  BC-3280.50.30:
+    name: Operações de pagamentos do Estado
+    description: |
+      Execução de pagamentos do Estado em nome dos organismos de despesa.
+  BC-3280.50.40:
+    name: Processamento de cobranças do Estado
+    description: |
+      Processamento de cobranças do Estado e creditação aos organismos.
+  BC-3280.60:
+    name: Reporte e divulgação fiscal
+    description: |
+      Relatórios fiscais intercalares e de fim de ano, demonstrações financeiras
+      IPSAS e reporte estatístico COFOG/GFSM.
+  BC-3280.60.10:
+    name: Reporte fiscal intercalar
+    description: |
+      Produção de relatórios fiscais mensais e trimestrais face ao orçamento.
+  BC-3280.60.20:
+    name: Produção de demonstrações financeiras IPSAS
+    description: |
+      Preparação de demonstrações financeiras IPSAS do conjunto da administração
+      pública e de entidades individuais.
+  BC-3280.60.30:
+    name: Reporte estatístico GFSM e COFOG
+    description: |
+      Compilação de estatísticas fiscais ao abrigo do GFSM do FMI e das
+      classificações COFOG.
+  BC-3280.60.40:
+    name: Divulgação de despesas em dados abertos
+    description: |
+      Publicação em dados abertos de despesas, transações e execução orçamental.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-public-policy-management.yaml
+++ b/catalogue/i18n/pt/L1-public-policy-management.yaml
@@ -1,0 +1,149 @@
+locale: pt
+source: L1-public-policy-management.yaml
+entries:
+  BC-3200:
+    name: Gestão de políticas públicas
+    description: |
+      Formulação, análise, suporte de decisão, coordenação da implementação e
+      avaliação de políticas públicas ao longo do ciclo político, ancoradas na
+      evidência, consulta das partes interessadas e avaliação de impacto.
+  BC-3200.10:
+    name: Definição da agenda política
+    description: |
+      Identificação, priorização e recepção de mandatos de questões políticas que
+      requerem atenção governamental.
+    in_scope:
+      - Identificação de questões e análise de horizonte
+      - Recepção de mandatos ministeriais e políticos
+      - Priorização de políticas e gestão da agenda
+    out_of_scope:
+      - Redacção de legislação ou regulamentos (abrangido pela Gestão de Redação Legislativa e Regulatória)
+      - Execução de decisões do Conselho de Ministros (abrangida pelo Suporte de Decisão Política)
+  BC-3200.10.10:
+    name: Identificação de questões políticas
+    description: |
+      Identificação de questões emergentes e problemas políticos através de análise
+      de horizonte e sinais das partes interessadas.
+  BC-3200.10.20:
+    name: Recepção de mandatos políticos
+    description: |
+      Captura e estruturação de mandatos políticos e ministeriais em programas de
+      trabalho político.
+  BC-3200.10.30:
+    name: Priorização de políticas
+    description: |
+      Priorização de questões políticas concorrentes face à capacidade, urgência e
+      compromissos do governo.
+  BC-3200.20:
+    name: Análise de opções políticas
+    description: |
+      Revisão de evidências, modelação e análise comparativa de opções políticas,
+      incluindo custo, impacto e viabilidade.
+    in_scope:
+      - Revisão de evidências e literatura
+      - Modelação custo-benefício e económica
+      - Avaliação comparativa de opções
+      - Análise distributiva e de equidade
+    out_of_scope:
+      - Avaliação de Impacto Regulatório de instrumentos rascunho (abrangida pela Gestão de Redação Legislativa e Regulatória)
+  BC-3200.20.10:
+    name: Revisão de evidências e literatura
+    description: |
+      Recolha sistemática e síntese de evidências que informam as opções políticas.
+  BC-3200.20.20:
+    name: Modelação e previsão de políticas
+    description: |
+      Modelação quantitativa, microsimulação e previsão de resultados políticos.
+  BC-3200.20.30:
+    name: Avaliação de opções
+    description: |
+      Avaliação comparativa de opções políticas face a objectivos e restrições.
+  BC-3200.20.40:
+    name: Análise distributiva e de equidade
+    description: |
+      Análise dos efeitos distributivos e impactos na equidade entre grupos
+      populacionais.
+  BC-3200.30:
+    name: Consulta das partes interessadas e do público
+    description: |
+      Concepção, realização e análise de consultas com partes interessadas, o
+      público e parceiros intergovernamentais sobre propostas políticas.
+  BC-3200.30.10:
+    name: Concepção da consulta
+    description: |
+      Concepção de estratégias, instrumentos e planos de alcance de consulta.
+  BC-3200.30.20:
+    name: Realização da consulta
+    description: |
+      Operação de canais de consulta, incluindo portais online, audiências e
+      workshops.
+  BC-3200.30.30:
+    name: Análise das respostas à consulta
+    description: |
+      Codificação, análise e síntese das respostas à consulta.
+  BC-3200.30.40:
+    name: Coordenação intergovernamental
+    description: |
+      Coordenação com parceiros subnacionais e internacionais em políticas
+      partilhadas.
+  BC-3200.40:
+    name: Suporte de decisão política
+    description: |
+      Preparação de artefactos de decisão do Conselho de Ministros, ministeriais e
+      executivos, incluindo briefings, memorandos de decisão e recomendações.
+  BC-3200.40.10:
+    name: Preparação de briefings
+    description: |
+      Preparação de briefings ministeriais e executivos sobre matérias políticas.
+  BC-3200.40.20:
+    name: Gestão de submissões ao Conselho de Ministros
+    description: |
+      Redacção e coordenação de submissões ao Conselho de Ministros, executivo ou
+      conselho.
+  BC-3200.40.30:
+    name: Registo e comunicação de decisões
+    description: |
+      Registo de decisões, divulgação de resultados e atribuição de tarefas às
+      entidades de implementação.
+  BC-3200.50:
+    name: Coordenação da implementação de políticas
+    description: |
+      Coordenação da implementação de políticas interagências, incluindo concepção
+      de programas, sequenciamento e supervisão da entrega.
+  BC-3200.50.10:
+    name: Planeamento da implementação
+    description: |
+      Conversão de decisões políticas em planos de implementação, marcos e
+      responsabilizações.
+  BC-3200.50.20:
+    name: Coordenação interagências
+    description: |
+      Coordenação das agências de implementação e acordos de entrega conjunta.
+  BC-3200.50.30:
+    name: Acompanhamento da implementação
+    description: |
+      Acompanhamento do progresso da implementação de políticas face a compromissos
+      e prazos.
+  BC-3200.60:
+    name: Avaliação e revisão de políticas
+    description: |
+      Avaliação ex-post, revisões de extinção e pós-implementação, e
+      retroalimentação no ciclo político.
+  BC-3200.60.10:
+    name: Avaliação de resultados e impacto
+    description: |
+      Avaliação dos resultados e impactos das políticas face aos objectivos
+      previstos.
+  BC-3200.60.20:
+    name: Revisão de extinção e pós-implementação
+    description: |
+      Revisões estatutárias e discricionárias de políticas e instrumentos em
+      intervalos definidos.
+  BC-3200.60.30:
+    name: Captura de lições aprendidas
+    description: |
+      Captura e divulgação de lições aprendidas para futuros ciclos políticos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-public-procurement-contracting-management.yaml
+++ b/catalogue/i18n/pt/L1-public-procurement-contracting-management.yaml
@@ -1,0 +1,185 @@
+locale: pt
+source: L1-public-procurement-contracting-management.yaml
+entries:
+  BC-3270:
+    name: Gestão de contratação pública
+    description: |
+      Contratação pública nos regimes FAR/DFARS e da Diretiva Europeia de
+      Contratação Pública, incluindo planeamento de aquisições, publicação de
+      concursos, seleção de fornecedores, adjudicação e administração de
+      contratos, desempenho de fornecedores, impugnações e programas
+      socioeconómicos.
+  BC-3270.10:
+    name: Planeamento de aquisições
+    description: |
+      Formulação da estratégia de aquisição, estudo de mercado e planeamento de
+      concursos públicos.
+    in_scope:
+      - Estudo de mercado e consolidação da procura
+      - Estratégia e método de aquisição
+      - Preparação de estimativas de custo independentes do Estado
+    out_of_scope:
+      - Estratégia de aprovisionamento transversal para contratação não governamental (coberta pela Gestão de Aprovisionamento)
+  BC-3270.10.10:
+    name: Estudo de mercado
+    description: |
+      Estudo de mercado sobre a base de fornecedores, capacidade e preços para
+      o requisito.
+  BC-3270.10.20:
+    name: Estratégia de aquisição
+    description: |
+      Seleção do método de contratação, veículo e abordagem de concorrência.
+  BC-3270.10.30:
+    name: Estimativa de custo independente
+    description: |
+      Preparação de estimativas de custo independentes do Estado e reservas
+      orçamentais.
+  BC-3270.10.40:
+    name: Desenvolvimento de especificações e caderno de encargos
+    description: |
+      Desenvolvimento de especificações técnicas, cadernos de encargos e
+      declarações de trabalho de desempenho.
+  BC-3270.20:
+    name: Gestão de publicação de concursos
+    description: |
+      Emissão de concursos incluindo documentos de RFP, IFB e RFQ, adendas e
+      questões de concorrentes.
+  BC-3270.20.10:
+    name: Redação de documentos de concurso
+    description: |
+      Redação de RFP, IFB, RFQ e documentação de concurso público.
+  BC-3270.20.20:
+    name: Publicação de concursos
+    description: |
+      Publicação de concursos em sistemas oficiais de avisos e equivalentes
+      ao OJEU/SAM.gov.
+  BC-3270.20.30:
+    name: Gestão de questões de concorrentes
+    description: |
+      Tratamento de questões de concorrentes, adendas e esclarecimentos durante
+      o concurso.
+  BC-3270.20.40:
+    name: Conferência pré-proposta
+    description: |
+      Realização de conferências pré-proposta e visitas ao local.
+  BC-3270.30:
+    name: Seleção e avaliação de fontes
+    description: |
+      Receção, avaliação e seleção de propostas face aos critérios publicados.
+  BC-3270.30.10:
+    name: Receção de propostas
+    description: |
+      Receção, registo e salvaguarda de propostas.
+  BC-3270.30.20:
+    name: Avaliação técnica
+    description: |
+      Avaliação técnica de propostas face aos critérios estabelecidos.
+  BC-3270.30.30:
+    name: Análise de preços e custos
+    description: |
+      Análise da razoabilidade de preços e realismo de custos das propostas.
+  BC-3270.30.40:
+    name: Determinação de responsabilidade
+    description: |
+      Determinação da responsabilidade, capacidade financeira e integridade
+      do contratante.
+  BC-3270.40:
+    name: Adjudicação e celebração do contrato
+    description: |
+      Decisão de seleção, notificação de adjudicação, informação de resultados e
+      celebração do contrato incluindo assinatura.
+  BC-3270.40.10:
+    name: Decisão de seleção
+    description: |
+      Decisão de adjudicação e documentação da decisão de seleção de fontes.
+  BC-3270.40.20:
+    name: Aviso de adjudicação e informação de resultados
+    description: |
+      Aviso de adjudicação, notificação a concorrentes não selecionados e
+      informação de resultados.
+  BC-3270.40.30:
+    name: Assinatura e compromisso do contrato
+    description: |
+      Execução de documentos contratuais e compromisso de fundos.
+  BC-3270.50:
+    name: Administração e modificação de contratos
+    description: |
+      Administração diária de contratos incluindo modificações, reclamações e
+      supervisão do gestor do contrato.
+  BC-3270.50.10:
+    name: Aceitação de entregas
+    description: |
+      Inspeção e aceitação de entregas face aos requisitos contratuais.
+  BC-3270.50.20:
+    name: Modificação de contratos
+    description: |
+      Emissão de modificações contratuais, ordens de alteração e exercício de
+      opções.
+  BC-3270.50.30:
+    name: Gestão de reclamações contratuais
+    description: |
+      Receção e julgamento de reclamações do contratante e ajustamentos equitativos.
+  BC-3270.50.40:
+    name: Encerramento de contratos
+    description: |
+      Aceitação final, libertação de compromissos e encerramento físico e
+      administrativo.
+  BC-3270.60:
+    name: Gestão do desempenho de fornecedores
+    description: |
+      Registo do desempenho passado, exclusão e suspensão, e acompanhamento
+      da responsabilidade do contratante.
+  BC-3270.60.10:
+    name: Registo do desempenho passado
+    description: |
+      Registo de avaliações do desempenho passado do contratante em bases de
+      dados governamentais.
+  BC-3270.60.20:
+    name: Administração de suspensão e exclusão
+    description: |
+      Administração de procedimentos de suspensão e exclusão de contratantes.
+  BC-3270.60.30:
+    name: Monitorização da responsabilidade do contratante
+    description: |
+      Monitorização contínua da responsabilidade e capacidade financeira do
+      contratante.
+  BC-3270.70:
+    name: Tratamento de impugnações e litígios
+    description: |
+      Receção e tratamento de impugnações de concursos e litígios contratuais
+      através de vias administrativas e judiciais.
+  BC-3270.70.10:
+    name: Tratamento de impugnações de concursos
+    description: |
+      Tratamento de impugnações pré e pós-adjudicação de concursos.
+  BC-3270.70.20:
+    name: Resolução de litígios contratuais
+    description: |
+      Resolução administrativa e judicial de litígios contratuais.
+  BC-3270.70.30:
+    name: Resolução alternativa de litígios
+    description: |
+      Mediação, arbitragem e RAL para litígios contratuais.
+  BC-3270.80:
+    name: Administração de reservas e programas socioeconómicos
+    description: |
+      Administração de preferências e objetivos de contratação para pequenas
+      empresas, minorias, empresas de mulheres e outros grupos socioeconómicos.
+  BC-3270.80.10:
+    name: Determinação de reservas
+    description: |
+      Determinação da aplicabilidade de reservas a pequenas empresas e grupos
+      socioeconómicos.
+  BC-3270.80.20:
+    name: Supervisão de planos de subcontratação
+    description: |
+      Supervisão de planos e relatórios de subcontratação a pequenas empresas.
+  BC-3270.80.30:
+    name: Reporte de objetivos socioeconómicos
+    description: |
+      Acompanhamento e reporte de objetivos e realizações de contratação
+      socioeconómica.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-public-safety-emergency-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-public-safety-emergency-operations-management.yaml
@@ -1,0 +1,179 @@
+locale: pt
+source: L1-public-safety-emergency-operations-management.yaml
+entries:
+  BC-3310:
+    name: Gestão de segurança pública e operações de emergência
+    description: |
+      Segurança pública e operações de emergência, incluindo comunicações de
+      emergência e despacho, resposta de campo policial, bombeiros e INEM,
+      comando de incidentes alinhado com o NIMS, preparação e recuperação de
+      desastres, investigações de segurança pública e coordenação de ajuda mútua.
+  BC-3310.10:
+    name: Comunicações de emergência e despacho
+    description: |
+      Receção de chamadas de emergência, despacho assistido por computador e
+      comunicações de campo para efetivos de polícia, bombeiros e INEM.
+    in_scope:
+      - Atendimento de chamadas 112/991/999
+      - Despacho assistido por computador
+      - Operações de rádio de segurança pública
+    out_of_scope:
+      - Regimes de obrigação de serviço universal em telecomunicações (cobertos pela Gestão de Conformidade Regulatória de Telecomunicações)
+  BC-3310.10.10:
+    name: Atendimento de chamadas de emergência
+    description: |
+      Receção e triagem de chamadas de emergência e mensagens de texto para
+      emergência.
+  BC-3310.10.20:
+    name: Despacho assistido por computador
+    description: |
+      Despacho via sistema CAD de unidades de polícia, bombeiros e INEM para
+      ocorrências.
+  BC-3310.10.30:
+    name: Operações de rádio de segurança pública
+    description: |
+      Operação de rádio móvel terrestre de segurança pública e banda larga
+      equivalente ao FirstNet.
+  BC-3310.10.40:
+    name: Alertas e avisos públicos
+    description: |
+      Emissão de alertas públicos via WEA, difusão celular, EAS, sirenes e
+      outros canais.
+  BC-3310.20:
+    name: Operações de resposta de campo
+    description: |
+      Operações de campo diárias dos primeiros socorristas de polícia, bombeiros
+      e INEM.
+  BC-3310.20.10:
+    name: Patrulhamento policial
+    description: |
+      Patrulhamento policial de rotina e proativo e resposta a ocorrências.
+  BC-3310.20.20:
+    name: Combate a incêndios e salvamento
+    description: |
+      Operações de combate a incêndios, salvamento e resposta a matérias
+      perigosas.
+  BC-3310.20.30:
+    name: Resposta de emergência médica
+    description: |
+      Avaliação, tratamento e transporte pré-hospitalar de emergência médica.
+  BC-3310.20.40:
+    name: Resposta tática especializada
+    description: |
+      Operações de resposta tática especializada, desativação de engenhos
+      explosivos e matérias perigosas.
+  BC-3310.30:
+    name: Comando e coordenação de incidentes
+    description: |
+      Comando de incidentes alinhado com NIMS/ICS, coordenação multiagência e
+      operações de centros de operações de emergência.
+  BC-3310.30.10:
+    name: Criação do comando de incidente
+    description: |
+      Criação do comando de incidente, comando unificado e estruturas ICS.
+  BC-3310.30.20:
+    name: Coordenação multiagência
+    description: |
+      Coordenação entre organismos e jurisdições durante ocorrências.
+  BC-3310.30.30:
+    name: Operações do centro de operações de emergência
+    description: |
+      Operação de COEs a nível local, regional e nacional durante emergências.
+  BC-3310.30.40:
+    name: Manutenção do quadro de situação comum
+    description: |
+      Manutenção de um quadro de situação comum partilhado entre organismos.
+  BC-3310.40:
+    name: Preparação e mitigação de desastres
+    description: |
+      Análise de riscos, planeamento, exercícios, formação e atividades de
+      mitigação para preparação face a desastres ao abrigo do Quadro de Sendai.
+  BC-3310.40.10:
+    name: Análise de riscos e perigos
+    description: |
+      Identificação e avaliação de perigos e riscos de origem natural e humana.
+  BC-3310.40.20:
+    name: Planeamento de emergência
+    description: |
+      Elaboração de planos de operações de emergência, planos específicos por
+      perigo e disposições de continuidade.
+  BC-3310.40.30:
+    name: Exercícios e formação
+    description: |
+      Exercícios de gabinete, funcionais e de grande escala e programas de
+      formação de intervenientes.
+  BC-3310.40.40:
+    name: Administração de programas de mitigação
+    description: |
+      Administração de programas de mitigação estrutural e não estrutural de
+      desastres.
+  BC-3310.50:
+    name: Resposta e recuperação de desastres
+    description: |
+      Declaração de catástrofe, operações de resposta, assistência individual e
+      pública e coordenação da recuperação a longo prazo.
+  BC-3310.50.10:
+    name: Declaração de catástrofe e ativação
+    description: |
+      Declaração de estados de emergência e ativação de autoridades de resposta.
+  BC-3310.50.20:
+    name: Administração de assistência individual
+    description: |
+      Administração de assistência de catástrofe a indivíduos e famílias
+      afetados.
+  BC-3310.50.30:
+    name: Administração de assistência pública
+    description: |
+      Administração de subvenções de assistência pública para remoção de
+      entulho, infraestruturas e obras de emergência.
+  BC-3310.50.40:
+    name: Coordenação da recuperação a longo prazo
+    description: |
+      Coordenação da recuperação a longo prazo e atividade de reconstrução
+      melhorada.
+  BC-3310.60:
+    name: Investigações de segurança pública
+    description: |
+      Investigações criminais e de segurança pública, incluindo gestão de prova,
+      informações policiais e preparação de processos.
+  BC-3310.60.10:
+    name: Investigação de locais de crime
+    description: |
+      Exame de locais de crime e recolha de prova forense.
+  BC-3310.60.20:
+    name: Gestão de processos de investigação
+    description: |
+      Gestão de processos de investigação, acompanhamento de suspeitos e
+      preparação de processos para julgamento.
+  BC-3310.60.30:
+    name: Operações de informações policiais
+    description: |
+      Recolha, análise e difusão de informações policiais no âmbito da policiamento
+      baseado em informações.
+  BC-3310.60.40:
+    name: Gestão de prova e bens apreendidos
+    description: |
+      Custódia, cadeia de custódia e destino de prova e bens apreendidos.
+  BC-3310.70:
+    name: Gestão de recursos de emergência e ajuda mútua
+    description: |
+      Tipificação de recursos de emergência, mobilização e acordos de ajuda
+      mútua entre jurisdições.
+  BC-3310.70.10:
+    name: Tipificação e inventário de recursos
+    description: |
+      Tipificação de recursos alinhada com o NIMS e inventário de recursos de
+      emergência.
+  BC-3310.70.20:
+    name: Administração de acordos de ajuda mútua
+    description: |
+      Administração de acordos de ajuda mútua intra e interjurisdicionais.
+  BC-3310.70.30:
+    name: Mobilização e desmobilização de recursos
+    description: |
+      Mobilização, acompanhamento e desmobilização de recursos de emergência
+      em ocorrências.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-quality-management.yaml
+++ b/catalogue/i18n/pt/L1-quality-management.yaml
@@ -1,0 +1,131 @@
+locale: pt
+source: L1-quality-management.yaml
+entries:
+  BC-720:
+    name: Gestão da qualidade
+    description: |
+      Estratégia, garantia e controlo de qualidade em todos os outputs empresariais.
+  BC-720.10:
+    name: Gestão da estratégia e política de qualidade
+    description: |
+      Política, normas e quadro de qualidade.
+  BC-720.10.10:
+    name: Gestão do manual e política de qualidade
+    description: |
+      Manual e políticas de qualidade alinhados com ISO 9001 e normas sectoriais.
+  BC-720.10.20:
+    name: Definição de objetivos de qualidade
+    description: |
+      Definição de objetivos de qualidade, KPIs e metas.
+  BC-720.10.30:
+    name: Governação do sistema de gestão da qualidade
+    description: |
+      Governação do âmbito, estrutura e responsabilidades do SGQ.
+  BC-720.10.40:
+    name: Gestão do risco de qualidade
+    description: |
+      Identificação, avaliação e tratamento do risco de qualidade.
+  BC-720.20:
+    name: Gestão da garantia de qualidade
+    description: |
+      Sistemas de qualidade, auditorias e certificação (ISO 9001, etc.).
+  BC-720.20.10:
+    name: Auditorias internas de qualidade
+    description: |
+      Planeamento e execução de auditorias internas de qualidade.
+  BC-720.20.20:
+    name: Gestão de certificações externas
+    description: |
+      Gestão de certificações ISO 9001 e outras e de vigilâncias.
+  BC-720.20.30:
+    name: Validação e qualificação de processos
+    description: |
+      Validação e qualificação de processos e equipamentos.
+  BC-720.20.40:
+    name: Controlo de documentos e registos
+    description: |
+      Documentos controlados, registos e arquivo de qualidade.
+  BC-720.30:
+    name: Gestão do controlo de qualidade
+    description: |
+      Inspeções, testes e critérios de aceitação.
+  BC-720.30.10:
+    name: Planeamento de inspeções
+    description: |
+      Planos de inspeção, amostragem e critérios de aceitação.
+  BC-720.30.20:
+    name: Controlo de qualidade em processo
+    description: |
+      Controlo em processo, medição e controlo estatístico de processos.
+  BC-720.30.30:
+    name: Inspeção final e libertação
+    description: |
+      Inspeção final, libertação de lote e emissão de certificado.
+  BC-720.30.40:
+    name: Gestão de calibração
+    description: |
+      Calibração de equipamentos de medição e ensaio.
+  BC-720.40:
+    name: Gestão de não conformidades
+    description: |
+      NCR, desvios e CAPA.
+  BC-720.40.10:
+    name: Reporte de não conformidades
+    description: |
+      Captura e classificação de não conformidades e desvios.
+  BC-720.40.20:
+    name: Disposição e contenção
+    description: |
+      Disposição de material não conforme e ações de contenção.
+  BC-720.40.30:
+    name: Ação corretiva e preventiva
+    description: |
+      Processo de CAPA incluindo análise de causa raiz e verificações de eficácia.
+  BC-720.40.40:
+    name: Controlo de alterações
+    description: |
+      Controlo de alterações com impacto na qualidade.
+  BC-720.50:
+    name: Gestão da melhoria contínua
+    description: |
+      Lean, Six Sigma, Kaizen e programas de melhoria.
+  BC-720.50.10:
+    name: Gestão de ideias de melhoria
+    description: |
+      Captura, avaliação e priorização de ideias de melhoria.
+  BC-720.50.20:
+    name: Entrega de projetos Lean e Six Sigma
+    description: |
+      Metodologia e entrega de projetos Lean e Six Sigma.
+  BC-720.50.30:
+    name: Coaching de melhoria contínua
+    description: |
+      Coaching e desenvolvimento de capacidades em métodos de melhoria contínua.
+  BC-720.50.40:
+    name: Acompanhamento da realização de benefícios
+    description: |
+      Acompanhamento e verificação dos benefícios de projetos de melhoria contínua.
+  BC-720.60:
+    name: Gestão da qualidade para o cliente
+    description: |
+      Reclamações de clientes sobre qualidade, devoluções e qualidade de campo.
+  BC-720.60.10:
+    name: Tratamento de reclamações de qualidade de clientes
+    description: |
+      Captura, investigação e resposta a reclamações de qualidade de clientes.
+  BC-720.60.20:
+    name: Análise de falhas de campo
+    description: |
+      Análise de falhas de campo e devoluções em garantia.
+  BC-720.60.30:
+    name: Recolha e notificação de clientes
+    description: |
+      Coordenação de recolhas de produtos e notificações a clientes.
+  BC-720.60.40:
+    name: Reporte de qualidade para clientes
+    description: |
+      Reporte de qualidade e scorecards orientados ao cliente.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-real-estate-acquisition-disposition-management.yaml
+++ b/catalogue/i18n/pt/L1-real-estate-acquisition-disposition-management.yaml
@@ -1,0 +1,167 @@
+locale: pt
+source: L1-real-estate-acquisition-disposition-management.yaml
+entries:
+  BC-4930:
+    name: Gestão de aquisição e alienação imobiliária
+    description: |
+      Disciplina de transação que cobre a obtenção, análise de viabilidade, due
+      diligence, estruturação, negociação, encerramento e integração pós-encerramento
+      para aquisições e alienações imobiliárias em negócios diretos, de carteira e ao nível de entidade.
+    in_scope:
+      - Obtenção de leads de aquisição e gestão de mediadores
+      - Análise de viabilidade (DCF, comparáveis, sensibilidade, cenário)
+      - Due diligence física, ambiental, de título, de arrendamento e financeira
+      - Estratégia de oferta, LOI, PSA e estruturação fiscal/veicular
+      - Depósito, encerramento, declaração de liquidação e registo
+      - Estratégia de alienação, marketing de vendas, seleção de comprador
+      - Integração de dados e contratos pós-aquisição
+    out_of_scope:
+      - Governação do comité de investimento e mandatos de fundo (BC-4910)
+      - Planos de negócio de ativos consolidados (BC-4920)
+      - Liberações de construção e monitorização de cláusulas de financiador (BC-4980)
+      - Mediação como linha de serviço (BC-4960)
+  BC-4930.10:
+    name: Obtenção e triagem de aquisições
+    description: |
+      Obtenção de oportunidades de aquisição através de mediadores, clientes diretos
+      e canais proprietários e triagem inicial face a critérios.
+  BC-4930.10.10:
+    name: Obtenção de leads de aquisição
+    description: |
+      Obtenção de leads de aquisição em canais diretos, de mediador e off-market.
+  BC-4930.10.20:
+    name: Gestão de mediadores e intermediários
+    description: |
+      Gestão de relações com mediadores e intermediários que fornecem oportunidades de aquisição.
+  BC-4930.10.30:
+    name: Triagem inicial e decisões de oferta
+    description: |
+      Triagem inicial de oportunidades e decisões de oferta ou desistência.
+  BC-4930.20:
+    name: Análise de viabilidade de aquisição
+    description: |
+      Análise de viabilidade financeira, de mercado e de risco de ativos-alvo
+      para definir o preço de oferta e as expectativas de rendibilidade.
+  BC-4930.20.10:
+    name: Análise de cash flow e DCF
+    description: |
+      Construção de modelos de cash flow do ativo e de análise de viabilidade
+      por fluxo de caixa descontado.
+  BC-4930.20.20:
+    name: Análise de vendas comparáveis e yield
+    description: |
+      Análise de vendas comparáveis e yields vigentes para calibrar o valor.
+  BC-4930.20.30:
+    name: Modelação de sensibilidade e cenário
+    description: |
+      Modelação de sensibilidade e cenário de rendibilidades sob variações de
+      renda, vacância e pressupostos de saída.
+  BC-4930.30:
+    name: Gestão da due diligence
+    description: |
+      Coordenação e execução de due diligence multidisciplinar em aquisições-alvo,
+      incluindo workstreams físicas, ambientais, legais, de arrendamento e financeiras.
+  BC-4930.30.10:
+    name: Due diligence física e de engenharia
+    description: |
+      Avaliações de condição física e due diligence de engenharia em ativos-alvo.
+  BC-4930.30.20:
+    name: Due diligence ambiental (Fase I / II)
+    description: |
+      Due diligence ambiental, incluindo avaliações ASTM Fase I e Fase II.
+  BC-4930.30.30:
+    name: Due diligence de título, levantamento e zonamento
+    description: |
+      Due diligence sobre título, levantamento, servidões e conformidade de zonamento.
+  BC-4930.30.40:
+    name: Due diligence de arrendamento e inquilinos
+    description: |
+      Revisão de abstrações de arrendamento, recolha de certificados de estoppel
+      e entrevistas a inquilinos.
+  BC-4930.30.50:
+    name: Due diligence financeira e fiscal
+    description: |
+      Due diligence financeira e fiscal sobre demonstrações de resultados operacionais,
+      OpEx e avaliações fiscais históricas.
+  BC-4930.40:
+    name: Estruturação e negociação de transações
+    description: |
+      Estratégia de oferta, estruturação de negócio e negociação de documentos
+      vinculativos de transação.
+  BC-4930.40.10:
+    name: Estratégia de oferta
+    description: |
+      Definição de estratégia de oferta, incluindo posicionamento de preço e condições do negócio.
+  BC-4930.40.20:
+    name: Negociação da carta de intenções
+    description: |
+      Negociação de cartas de intenções e períodos de exclusividade.
+  BC-4930.40.30:
+    name: Negociação do contrato de compra e venda
+    description: |
+      Negociação e execução de contratos de compra e venda, incluindo declarações e garantias.
+  BC-4930.40.40:
+    name: Estruturação fiscal e veicular
+    description: |
+      Estruturação de veículos de aquisição para eficiência fiscal, incluindo
+      permutas 1031 e invólucros societários.
+  BC-4930.50:
+    name: Gestão do encerramento e liquidação
+    description: |
+      Gestão de depósito, condições de encerramento, financiamento de liquidação
+      e registo para transações encerradas.
+  BC-4930.50.10:
+    name: Depósito e condições de encerramento
+    description: |
+      Gestão de contas de depósito e monitorização das condições de encerramento até à satisfação.
+  BC-4930.50.20:
+    name: Fundos de encerramento e declaração de liquidação
+    description: |
+      Coordenação dos fundos de encerramento e reconciliação face à declaração de liquidação.
+  BC-4930.50.30:
+    name: Seguro de título e registo
+    description: |
+      Emissão de seguro de título e registo de escrituras e hipotecas.
+  BC-4930.60:
+    name: Gestão da alienação e saída
+    description: |
+      Disciplina do lado do vendedor cobrindo preços de alienação, marketing,
+      seleção de comprador e obrigações pós-encerramento.
+  BC-4930.60.10:
+    name: Estratégia e preços de alienação
+    description: |
+      Definição de estratégia de alienação, preços e pools de compradores-alvo.
+  BC-4930.60.20:
+    name: Marketing de vendas e visitas de compradores
+    description: |
+      Marketing do lado do vendedor, incluindo memorando de oferta, data room e visitas de compradores.
+  BC-4930.60.30:
+    name: Seleção de comprador e processo de oferta
+    description: |
+      Seleção de comprador através de processos de call-for-offer, melhor-e-final
+      ou leilão estruturado.
+  BC-4930.60.40:
+    name: Obrigações pós-encerramento
+    description: |
+      Monitorização de obrigações pós-encerramento, incluindo retenções, earnouts e reclamações de indemnização.
+  BC-4930.70:
+    name: Integração pós-aquisição
+    description: |
+      Transferência de ativos recém-adquiridos da equipa de transação para gestão
+      de ativos e de propriedades, incluindo integração de dados e contratos.
+  BC-4930.70.10:
+    name: Migração de dados do ativo
+    description: |
+      Migração de dados do ativo, desenhos e registos operacionais para os sistemas do proprietário.
+  BC-4930.70.20:
+    name: Integração de dados de arrendamento e inquilinos
+    description: |
+      Integração de abstrações de arrendamento e dados de inquilinos nos sistemas do senhorio.
+  BC-4930.70.30:
+    name: Novação de contratos de fornecedores
+    description: |
+      Novação ou substituição de contratos de fornecedores e serviços em vigor para o novo proprietário.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-real-estate-asset-management.yaml
+++ b/catalogue/i18n/pt/L1-real-estate-asset-management.yaml
@@ -1,0 +1,184 @@
+locale: pt
+source: L1-real-estate-asset-management.yaml
+entries:
+  BC-4920:
+    name: Gestão de ativos imobiliários
+    description: |
+      Gestão de ativos imobiliários consolidados pelo dono durante o período de
+      detenção — execução do plano de negócio, monitorização do desempenho,
+      priorização de capex, reposicionamento, percurso de sustentabilidade, risco
+      do ativo e otimização de impostos sobre propriedade/OpEx. Faz a ponte entre
+      a perspetiva do investidor (BC-4910) e as operações de propriedade no terreno (BC-4940).
+    in_scope:
+      - Plano de negócio por ativo e decisões de detenção/venda
+      - Monitorização do desempenho financeiro, de arrendamento e operacional do ativo
+      - Planeamento, priorização e supervisão de execução do programa de capex
+      - Execução de reposicionamento, conversão e value-add
+      - Percurso de descarbonização ao nível do ativo e certificação ESG
+      - Monitorização de risco do ativo (físico, climático, de mercado, de crédito de inquilino)
+      - Recursos a avaliações de impostos sobre propriedade, revisão de OpEx e auditoria de recuperação de CAM
+    out_of_scope:
+      - Construção de carteira de fundo/investidor (BC-4910)
+      - Operações de propriedade do dia a dia e ordens de trabalho (BC-4940)
+      - Transações de aquisição ou alienação (BC-4930)
+      - Abstração de arrendamentos e escalada de renda (BC-4950)
+  BC-4920.10:
+    name: Gestão do plano de negócio do ativo
+    description: |
+      Definição e atualização de planos de negócio por ativo alinhados com o
+      mandato do fundo, horizonte de detenção e tese de criação de valor.
+  BC-4920.10.10:
+    name: Definição do plano de negócio do ativo
+    description: |
+      Definição de planos de negócio por ativo cobrindo tese, fatores de valor
+      e horizonte de detenção.
+  BC-4920.10.20:
+    name: Análise de detenção/venda
+    description: |
+      Análise da economia de detenção versus venda e recomendação ao comité de investimento.
+  BC-4920.10.30:
+    name: Atualização anual do plano
+    description: |
+      Atualização anual dos planos de negócio do ativo face a valores reais e
+      perspetiva de mercado revista.
+  BC-4920.20:
+    name: Monitorização do desempenho do ativo
+    description: |
+      Monitorização do desempenho financeiro, de arrendamento e operacional ao
+      nível do ativo face ao plano de negócio.
+  BC-4920.20.10:
+    name: Monitorização do desempenho financeiro do ativo
+    description: |
+      Monitorização de NOI, cash flow e yield face ao orçamento e ao plano de negócio.
+  BC-4920.20.20:
+    name: Monitorização do desempenho de arrendamento e ocupação
+    description: |
+      Monitorização de ocupação, percentagem arrendada, prazo médio ponderado de
+      arrendamento e renda versus mercado.
+  BC-4920.20.30:
+    name: Monitorização de KPI operacionais
+    description: |
+      Monitorização de KPI operacionais cobrindo disponibilidade, reclamações,
+      intensidade energética e contagens de visitantes.
+  BC-4920.20.40:
+    name: Análise de variâncias e atualização da previsão
+    description: |
+      Análise de variâncias dos valores reais face ao plano e atualização da previsão
+      e pressupostos de saída.
+  BC-4920.30:
+    name: Gestão do programa de despesas de capital
+    description: |
+      Planeamento, priorização e supervisão de execução de programas de capex de
+      ativo e de carteira.
+  BC-4920.30.10:
+    name: Planeamento do programa de capex
+    description: |
+      Planeamento plurianual do programa de capex por ativo e carteira.
+  BC-4920.30.20:
+    name: Priorização e aprovação de capex
+    description: |
+      Priorização e aprovação de projetos de capex face a critérios de ROI e risco.
+  BC-4920.30.30:
+    name: Supervisão da execução de capex
+    description: |
+      Supervisão da execução de projetos de capex, incluindo liberações e entrega de marcos.
+  BC-4920.30.40:
+    name: Reconciliação do desempenho de capex
+    description: |
+      Reconciliação do desempenho de capex face à valorização e melhoria de NOI subscritas.
+  BC-4920.40:
+    name: Gestão de reposicionamento e value-add do ativo
+    description: |
+      Definição e execução de estratégias de reposicionamento, conversão e
+      composição de inquilinos que alteram o uso ou o perfil de rendimentos de um ativo.
+  BC-4920.40.10:
+    name: Definição da estratégia de reposicionamento
+    description: |
+      Definição da estratégia de reposicionamento, incluindo mercado-alvo e proposta.
+  BC-4920.40.20:
+    name: Programas de conversão e reconversão
+    description: |
+      Programas de conversão de ativos entre usos (escritórios para residencial,
+      retalho para uso misto).
+  BC-4920.40.30:
+    name: Estratégia de composição de inquilinos e merchandising
+    description: |
+      Definição e execução de estratégia de composição de inquilinos e merchandising
+      para ativos de retalho e uso misto.
+  BC-4920.50:
+    name: Gestão de sustentabilidade e ESG ao nível do ativo
+    description: |
+      Percurso de descarbonização ao nível do ativo, gestão da intensidade energética,
+      certificações e submissão ao GRESB.
+  BC-4920.50.10:
+    name: Percurso de descarbonização do ativo
+    description: |
+      Definição do percurso de descarbonização do ativo alinhado com as orientações
+      CRREM e SBTi para edifícios.
+  BC-4920.50.20:
+    name: Gestão da intensidade energética e hídrica
+    description: |
+      Gestão da intensidade energética e hídrica do ativo face a metas.
+  BC-4920.50.30:
+    name: Certificação ESG do ativo (LEED / BREEAM / WELL)
+    description: |
+      Obtenção e manutenção de certificações ao nível do ativo, incluindo LEED,
+      BREEAM, WELL e Fitwel.
+  BC-4920.50.40:
+    name: Submissão do ativo ao GRESB
+    description: |
+      Preparação e submissão de dados ao nível do ativo para a avaliação GRESB.
+  BC-4920.60:
+    name: Gestão do risco do ativo
+    description: |
+      Monitorização ao nível do ativo de riscos físicos, climáticos, de mercado
+      e de crédito de inquilino, e adequação do seguro.
+  BC-4920.60.10:
+    name: Avaliação do risco físico e climático
+    description: |
+      Avaliação de riscos físicos e climáticos no ativo, incluindo exposição a
+      cheias, incêndios florestais e calor.
+  BC-4920.60.20:
+    name: Monitorização do risco de crédito de inquilino
+    description: |
+      Monitorização do risco de crédito de inquilino e de cobrança de rendas
+      por ativo e carteira.
+  BC-4920.60.30:
+    name: Monitorização do risco de mercado
+    description: |
+      Monitorização de fatores de risco de mercado, incluindo movimentos de yield,
+      pipeline de oferta e tendências de renda.
+  BC-4920.60.40:
+    name: Revisão da adequação do seguro
+    description: |
+      Revisão periódica da adequação do seguro de propriedade e responsabilidade
+      civil face ao valor do ativo e exposição.
+  BC-4920.70:
+    name: Otimização de impostos sobre propriedade e despesas operacionais
+    description: |
+      Gestão de avaliações de impostos sobre propriedade, revisões de despesas
+      operacionais, auditorias de recuperação de CAM e otimização de tarifas de
+      utilidade específicas de ativos imobiliários.
+  BC-4920.70.10:
+    name: Avaliação e recurso de impostos sobre propriedade
+    description: |
+      Revisão e recurso de avaliações de impostos sobre propriedade face a
+      evidência comparável.
+  BC-4920.70.20:
+    name: Revisão de despesas operacionais
+    description: |
+      Revisão periódica de despesas operacionais para comparação de referência e
+      oportunidades de poupança.
+  BC-4920.70.30:
+    name: Auditoria de recuperação de CAM
+    description: |
+      Auditoria de recuperação de CAM e encargos de serviço de inquilinos face
+      a direitos de arrendamento.
+  BC-4920.70.40:
+    name: Otimização de tarifas de utilidade
+    description: |
+      Otimização da aquisição de utilidades, tarifas e encargos de ponta na carteira.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-real-estate-brokerage-management.yaml
+++ b/catalogue/i18n/pt/L1-real-estate-brokerage-management.yaml
@@ -1,0 +1,192 @@
+locale: pt
+source: L1-real-estate-brokerage-management.yaml
+entries:
+  BC-4960:
+    name: Gestão de mediação imobiliária
+    description: |
+      Mediação e intermediação de agência como linha de serviço para imobiliário
+      comercial e residencial — obtenção de mandatos de listagem, representação de
+      compradores/inquilinos, gestão de dados MLS, análise comparativa, operações de
+      visitas, negociação de ofertas, coordenação de encerramento de transações, liquidação
+      de comissões e de mediadores cooperantes, e gestão de produtividade e carteira de agentes.
+    in_scope:
+      - Obtenção e representação de mandatos de listagem de vendedor/senhorio
+      - Envolvimento e representação de comprador/inquilino
+      - Captação, sindicalização e conformidade de listagem MLS
+      - Análise comparativa de mercado e opinião de valor do mediador
+      - Operações de visita, dia aberto e acesso por cofre/digital
+      - Redação de oferta, contra-oferta e tratamento de múltiplas ofertas
+      - Coordenação de encerramento e monitorização de contingências
+      - Liquidação de comissão, mediador cooperante e honorários de referência
+      - Licenciamento, patrocínio, desempenho e planos de comissão de agentes
+    out_of_scope:
+      - Operações de arrendamento do lado do senhorio em ativos próprios (BC-4950)
+      - Execução de aquisição/alienação por clientes diretos (BC-4930)
+      - Compromissos de avaliação imobiliária (BC-4970)
+      - Postura regulatória de licenciamento de mediador/agente (BC-4990)
+  BC-4960.10:
+    name: Obtenção e representação de mandatos de listagem
+    description: |
+      Obtenção e conversão de mandatos de listagem de vendedor/senhorio e execução
+      do plano de marketing assumido no contrato de listagem.
+  BC-4960.10.10:
+    name: Proposta e obtenção de mandato de listagem
+    description: |
+      Apresentação de propostas para mandatos de listagem, incluindo CMA, proposta
+      de marketing e apresentação.
+  BC-4960.10.20:
+    name: Gestão de contratos de listagem
+    description: |
+      Gestão de contratos de listagem, incluindo exclusividade, prazo e condições de comissão.
+  BC-4960.10.30:
+    name: Plano de marketing de listagem
+    description: |
+      Definição e execução do plano de marketing assumido no contrato de listagem.
+  BC-4960.20:
+    name: Representação de compradores e inquilinos
+    description: |
+      Envolvimento e execução de mandatos de representação do lado do comprador
+      e do inquilino, incluindo pesquisa e seleção de imóveis.
+  BC-4960.20.10:
+    name: Envolvimento de compradores/inquilinos
+    description: |
+      Envolvimento de clientes compradores e inquilinos, incluindo contratos de agência e divulgações.
+  BC-4960.20.20:
+    name: Definição de requisitos e caderno de encargos
+    description: |
+      Definição do caderno de encargos do cliente cobrindo uso, dimensão, localização e orçamento.
+  BC-4960.20.30:
+    name: Pesquisa e seleção de imóveis
+    description: |
+      Pesquisa, seleção e apresentação de imóveis candidatos ao cliente.
+  BC-4960.30:
+    name: Gestão de dados de listagem e MLS
+    description: |
+      Gestão de dados de listagem MLS e portal, incluindo captação, multimédia,
+      sindicalização e conformidade com as normas de dados RESO.
+  BC-4960.30.10:
+    name: Captação de listagem MLS
+    description: |
+      Captação de listagens MLS face aos campos e regras do dicionário de dados RESO.
+  BC-4960.30.20:
+    name: Multimédia e fotografia de listagem
+    description: |
+      Produção e gestão de multimédia de listagem, incluindo fotografia, vídeo e visitas 3D.
+  BC-4960.30.30:
+    name: Sindicalização e distribuição em portais
+    description: |
+      Distribuição de listagens a portais, sites parceiros e agregadores.
+  BC-4960.30.40:
+    name: Conformidade de listagem e retirada
+    description: |
+      Gestão de conformidade de exatidão de listagem, alterações de estado e retiradas.
+  BC-4960.40:
+    name: Análise comparativa de mercado
+    description: |
+      Produção de análises comparativas de mercado, opiniões de valor do mediador
+      e posicionamento de preços para envolvimentos de listagem e comprador.
+  BC-4960.40.10:
+    name: Curadoria de vendas comparáveis
+    description: |
+      Curadoria de evidência de vendas comparáveis a partir de MLS e registos públicos.
+  BC-4960.40.20:
+    name: Produção de relatórios de CMA
+    description: |
+      Produção de relatórios de análise comparativa de mercado para apresentação ao cliente.
+  BC-4960.40.30:
+    name: Opinião de valor do mediador
+    description: |
+      Emissão de opiniões de valor do mediador para clientes e clientes institucionais.
+  BC-4960.50:
+    name: Operações de visitas e dias abertos
+    description: |
+      Operação de marcações de visitas, dias abertos e acesso físico e digital
+      para candidatos e agentes cooperantes.
+  BC-4960.50.10:
+    name: Gestão de marcações de visitas
+    description: |
+      Gestão de marcações de visitas e pedidos de acesso de agentes cooperantes.
+  BC-4960.50.20:
+    name: Operações de dias abertos
+    description: |
+      Operação de eventos de dia aberto, incluindo registo e acompanhamento.
+  BC-4960.50.30:
+    name: Cofre e controlo de acesso
+    description: |
+      Gestão de cofres e credenciais de acesso digital para imóveis listados.
+  BC-4960.60:
+    name: Gestão de ofertas e negociação
+    description: |
+      Redação e negociação de ofertas, contra-ofertas e cenários de múltiplas
+      ofertas em nome da parte representada.
+  BC-4960.60.10:
+    name: Redação de ofertas
+    description: |
+      Redação de ofertas e adendas de suporte em nome da parte representada.
+  BC-4960.60.20:
+    name: Gestão de contra-ofertas e múltiplas ofertas
+    description: |
+      Gestão de contra-ofertas e processos de múltiplas ofertas, incluindo chamadas de melhor-e-final.
+  BC-4960.60.30:
+    name: Confirmação de aceitação e vinculação
+    description: |
+      Confirmação de aceitação de oferta e formação de contrato vinculativo.
+  BC-4960.70:
+    name: Coordenação de encerramento de transações de mediação
+    description: |
+      Coordenação de contingências, depósito e conveyancing até ao encerramento
+      de transações intermediadas.
+  BC-4960.70.10:
+    name: Monitorização de contingências
+    description: |
+      Monitorização de contingências de inspeção, financiamento e outras até à sua satisfação ou renúncia.
+  BC-4960.70.20:
+    name: Coordenação de depósito/conveyancing
+    description: |
+      Coordenação com partes de depósito e conveyancing sobre documentos de encerramento e fundos.
+  BC-4960.70.30:
+    name: Coordenação do dia de encerramento
+    description: |
+      Coordenação de assinatura, entrega de chaves e logística do dia de encerramento.
+  BC-4960.80:
+    name: Gestão de comissões e mediadores cooperantes
+    description: |
+      Captação de condições de comissão e liquidação de comissões de mediadores
+      cooperantes e honorários de referência.
+  BC-4960.80.10:
+    name: Captação de acordos de comissão
+    description: |
+      Captação de acordos de comissão, incluindo divisões e condições.
+  BC-4960.80.20:
+    name: Liquidação de mediadores cooperantes
+    description: |
+      Liquidação de comissões devidas a mediadores cooperantes em transações encerradas.
+  BC-4960.80.30:
+    name: Desembolso de comissões
+    description: |
+      Desembolso de comissões à mediadora e aos agentes, líquido de deduções.
+  BC-4960.80.40:
+    name: Gestão de honorários de referência
+    description: |
+      Gestão de acordos de honorários de referência com mediadores e parceiros referenciadores.
+  BC-4960.90:
+    name: Gestão de produtividade e carteira de agentes
+    description: |
+      Gestão de patrocínio de licenciamento de agentes, desempenho e administração
+      de planos de comissão na carteira da mediadora.
+  BC-4960.90.10:
+    name: Monitorização de licenciamento e patrocínio de agentes
+    description: |
+      Monitorização do estado de licenciamento de agentes e acordos de patrocínio da mediadora.
+  BC-4960.90.20:
+    name: Gestão do desempenho de agentes
+    description: |
+      Gestão do desempenho de agentes face a metas de produção e normas.
+  BC-4960.90.30:
+    name: Administração do plano de comissão de agentes
+    description: |
+      Administração de planos de comissão de agentes, divisões e tetos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-real-estate-capital-markets-management.yaml
+++ b/catalogue/i18n/pt/L1-real-estate-capital-markets-management.yaml
@@ -1,0 +1,194 @@
+locale: pt
+source: L1-real-estate-capital-markets-management.yaml
+entries:
+  BC-4980:
+    name: Gestão de mercados de capitais imobiliários
+    description: |
+      Disciplina de mercados de capitais de dívida e capital próprio específica
+      para o imobiliário — originação de dívida sénior, mezanino, construção e
+      bridge; serviço de crédito e gestão de ativos; estruturação de CMBS e CRE
+      CLO; programas de capital próprio em joint venture; captação de capital
+      público por REIT; refinanciamento e recapitalização; e gestão do risco de
+      carteiras de crédito imobiliário. Distinto do crédito bancário genérico
+      (BC-1320) e da tesouraria corporativa (BC-210) — ancorado em convenções
+      de colateral imobiliário, reporte IRP e covenants DSCR/LTV.
+    in_scope:
+      - Originação de empréstimos sénior, mezanino, construção e bridge
+      - Integração, monitorização de covenants, modificação e serviço especial de crédito
+      - Agregação, estruturação e reporte IRP de CMBS e CRE CLO
+      - Obtenção de capital próprio em JV, estruturação de promote e waterfall, reporte a parceiros
+      - Capital próprio público/privado, dívida, programas ATM e política de dividendos de REIT
+      - Execução de refinanciamento e recapitalização
+      - Concentração, stress testing e constituição de provisões de carteiras de crédito imobiliário
+    out_of_scope:
+      - Crédito e financiamento bancário genérico (BC-1320)
+      - Negociação genérica em mercados de capitais (BC-1370)
+      - Formação de fundos e captação de capital LP (BC-4910)
+      - Execução de transações de aquisição (BC-4930)
+  BC-4980.10:
+    name: Originação de dívida imobiliária
+    description: |
+      Originação de dívida imobiliária sénior, mezanino, construção e bridge
+      com base na avaliação do ativo e do promotor.
+  BC-4980.10.10:
+    name: Originação de hipoteca sénior
+    description: |
+      Originação de empréstimos hipotecários sénior sobre ativos estabilizados.
+  BC-4980.10.20:
+    name: Originação de empréstimos de construção e bridge
+    description: |
+      Originação de empréstimos de construção e bridge para ativos em
+      desenvolvimento e em transição.
+  BC-4980.10.30:
+    name: Originação de mezanino e capital próprio preferencial
+    description: |
+      Originação de dívida mezanino e capital próprio preferencial na
+      estrutura de capital.
+  BC-4980.10.40:
+    name: Negociação de term sheet e carta de compromisso
+    description: |
+      Negociação de term sheets e cartas de compromisso com mutuários e
+      promotores.
+  BC-4980.20:
+    name: Serviço de crédito e gestão de ativos imobiliários
+    description: |
+      Integração e serviço de créditos imobiliários e monitorização proativa,
+      modificação e reestruturação quando necessário.
+  BC-4980.20.10:
+    name: Integração e configuração do serviço de crédito
+    description: |
+      Integração de novos créditos imobiliários na plataforma de serviço e
+      configuração de fluxos de pagamento e reporte.
+  BC-4980.20.20:
+    name: Monitorização de covenants e DSCR
+    description: |
+      Monitorização contínua de covenants de empréstimo, DSCR e LTV face
+      aos acionadores do contrato de crédito.
+  BC-4980.20.30:
+    name: Modificação e reestruturação de empréstimos
+    description: |
+      Negociação de modificações e reestruturações de empréstimos em
+      ativos sob pressão.
+  BC-4980.20.40:
+    name: Coordenação do serviço especial
+    description: |
+      Coordenação com servicers especiais em empréstimos em incumprimento
+      e próximos do incumprimento em titularizações.
+  BC-4980.30:
+    name: Gestão de CMBS e titularização
+    description: |
+      Agregação de carteiras de crédito, estruturação de transações CMBS e
+      CRE CLO e reporte IRP contínuo a investidores.
+  BC-4980.30.10:
+    name: Agregação de carteiras de crédito
+    description: |
+      Agregação de carteiras de crédito elegíveis para titularização.
+  BC-4980.30.20:
+    name: Estruturação de titularização
+    description: |
+      Estruturação de transações CMBS e CRE CLO, incluindo
+      tranching e notações.
+  BC-4980.30.30:
+    name: Reporte IRP a investidores
+    description: |
+      Reporte a investidores ao abrigo do pacote de reporte a investidores
+      da CREFC.
+  BC-4980.30.40:
+    name: Coordenação com trustee e servicer
+    description: |
+      Coordenação com trustees, servicers master e agências de notação em
+      operações em vigor.
+  BC-4980.40:
+    name: Gestão de joint ventures e parceiros de capital próprio
+    description: |
+      Obtenção de capital próprio em JV, estruturação de promote e waterfall
+      e reporte e distribuições contínuos a parceiros.
+  BC-4980.40.10:
+    name: Obtenção de capital próprio em JV
+    description: |
+      Obtenção de capital próprio em joint venture junto de parceiros
+      institucionais e de elevado património.
+  BC-4980.40.20:
+    name: Estruturação de promote e waterfall
+    description: |
+      Estruturação de promote, hurdles e waterfalls em acordos de
+      parceria em JV.
+  BC-4980.40.30:
+    name: Reporte e distribuições a parceiros de JV
+    description: |
+      Reporte a parceiros de JV e execução de distribuições contratuais.
+  BC-4980.50:
+    name: Gestão de mercados de capitais de REIT
+    description: |
+      Emissão pública e privada de capital próprio e dívida de REIT,
+      programas ATM e gestão da política de dividendos.
+  BC-4980.50.10:
+    name: Emissão de capital próprio de REIT público
+    description: |
+      Emissão de capital próprio de REIT através de ofertas subsequentes
+      e colocações privadas.
+  BC-4980.50.20:
+    name: Emissão de dívida e obrigações de REIT
+    description: |
+      Emissão de dívida não garantida, obrigações e notas permutáveis
+      de REIT.
+  BC-4980.50.30:
+    name: Gestão do programa ATM
+    description: |
+      Gestão de programas de capital próprio at-the-market, incluindo
+      cadenciamento e divulgação.
+  BC-4980.50.40:
+    name: Gestão da política de dividendos
+    description: |
+      Gestão da política de dividendos do REIT alinhada com os requisitos
+      de distribuição e o AFFO.
+  BC-4980.60:
+    name: Gestão de refinanciamento e recapitalização
+    description: |
+      Refinanciamento e recapitalização proativos das estruturas de capital
+      de ativos estabilizados ao longo do período de detenção.
+  BC-4980.60.10:
+    name: Estratégia e cadenciamento de refinanciamento
+    description: |
+      Definição da estratégia de refinanciamento e cadenciamento de
+      maturidades na carteira.
+  BC-4980.60.20:
+    name: Execução de refinanciamento
+    description: |
+      Execução de transações de refinanciamento em ativos e carteiras
+      individuais.
+  BC-4980.60.30:
+    name: Reestruturação de recapitalização
+    description: |
+      Reestruturação de estruturas de capital através de recapitalização
+      de parceiros ou injeções de capital próprio.
+  BC-4980.70:
+    name: Gestão do risco de carteiras de crédito imobiliário
+    description: |
+      Monitorização de concentração, stress testing, constituição de
+      provisões para perdas e gestão de watchlist para carteiras de
+      crédito imobiliário.
+  BC-4980.70.10:
+    name: Monitorização de concentração de LTV/DSCR
+    description: |
+      Monitorização da concentração de LTV e DSCR na carteira de
+      crédito imobiliário.
+  BC-4980.70.20:
+    name: Stress testing de carteiras de crédito imobiliário
+    description: |
+      Stress testing da carteira de crédito imobiliário face a choques
+      de taxa, vacância e valor.
+  BC-4980.70.30:
+    name: Constituição de provisões para perdas CECL/IFRS 9 (imobiliário)
+    description: |
+      Constituição de provisões para perdas da carteira imobiliária ao
+      abrigo dos frameworks de perdas de crédito esperadas CECL e IFRS 9.
+  BC-4980.70.40:
+    name: Monitorização de watchlist e incumprimentos
+    description: |
+      Manutenção da watchlist e monitorização de empréstimos em
+      incumprimento na carteira.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-real-estate-compliance-regulatory-management.yaml
+++ b/catalogue/i18n/pt/L1-real-estate-compliance-regulatory-management.yaml
@@ -1,0 +1,234 @@
+locale: pt
+source: L1-real-estate-compliance-regulatory-management.yaml
+entries:
+  BC-4990:
+    name: Gestão de conformidade regulatória imobiliária
+    description: |
+      Disciplina de conformidade para os regimes regulatórios específicos do
+      imobiliário que se sobrepõem à conformidade empresarial genérica —
+      licenciamento de mediadores/agentes, habitação justa e
+      antidiscriminação, AML imobiliário e titularidade efetiva, divulgação
+      de liquidação e hipoteca (RESPA/TRID), desempenho energético de
+      edifícios, regulação de arrendamento e rendas, regulação de
+      condomínios/HOA/strata e regulação de fundos/assessores.
+    in_scope:
+      - Manutenção de licenças de empresa mediadora e agente
+      - Conformidade com a Fair Housing Act, Equality Act e ECOA
+      - AML imobiliário, titularidade efetiva, sanções e reporte de SAR
+      - Divulgação RESPA, TRID e de negócios associados ao abrigo da Secção 8
+      - Divulgação de desempenho energético de edifícios e conformidade MEES
+      - Estabilização de rendas, aviso de despejo, depósito e registo de arrendamento de curta duração
+      - Divulgações de promotor e fundo de reserva de condomínio/HOA/strata
+      - Conformidade de fundos/assessores ao abrigo da AIFMD, ELTIF e Investment Advisers Act
+    out_of_scope:
+      - Gestão de conformidade empresarial (BC-130)
+      - Regimes de cibersegurança e privacidade (BC-620)
+      - AML genérico de crime financeiro em empresas não imobiliárias (BC-1400)
+      - Administração fiscal (BC-220)
+  BC-4990.10:
+    name: Conformidade de licenciamento de mediadores e agentes
+    description: |
+      Conformidade com os regimes de licenciamento de mediadores e agentes,
+      incluindo manutenção de licença da empresa, formação contínua e
+      supervisão do mediador designado.
+  BC-4990.10.10:
+    name: Manutenção de licença da empresa
+    description: |
+      Manutenção de licenças da empresa mediadora nas regiões de operação.
+  BC-4990.10.20:
+    name: Licenciamento de agentes e formação contínua
+    description: |
+      Monitorização de licenças individuais de agentes e requisitos de
+      formação contínua.
+  BC-4990.10.30:
+    name: Supervisão do mediador designado
+    description: |
+      Supervisão do mediador designado sobre a atividade regulada da empresa.
+  BC-4990.10.40:
+    name: Renovação de licenças e resposta a auditorias
+    description: |
+      Renovação de licenças e resposta a auditorias e inspeções regulatórias.
+  BC-4990.20:
+    name: Conformidade de habitação justa e antidiscriminação
+    description: |
+      Conformidade com a Fair Housing Act, Equality Act, ECOA e regimes
+      antidiscriminação equivalentes nos pontos de contacto de arrendamento,
+      vendas e financiamento.
+  BC-4990.20.10:
+    name: Manutenção da política de habitação justa
+    description: |
+      Manutenção de políticas de habitação justa e procedimentos
+      operacionais padrão.
+  BC-4990.20.20:
+    name: Triagem de publicidade e origem de fundos
+    description: |
+      Triagem de conteúdo publicitário e regras de origem de fundos para
+      conformidade com restrições de classes protegidas.
+  BC-4990.20.30:
+    name: Tratamento de reclamações de discriminação
+    description: |
+      Tratamento de reclamações de discriminação habitacional e pedidos
+      de reguladores.
+  BC-4990.20.40:
+    name: Formação e atestação em habitação justa
+    description: |
+      Formação e atestação de agentes e pessoal sobre obrigações de
+      habitação justa.
+  BC-4990.30:
+    name: Conformidade de AML e sanções imobiliárias
+    description: |
+      Conformidade com as regras AML específicas do imobiliário, incluindo
+      as GTOs da FinCEN, a Regra de Imóveis Residenciais da FinCEN,
+      obrigações DNFBP ao abrigo da AMLD 5/6 e reporte de titularidade
+      efetiva.
+  BC-4990.30.10:
+    name: Captura de titularidade efetiva
+    description: |
+      Captura e verificação da titularidade efetiva das partes em
+      transações imobiliárias.
+  BC-4990.30.20:
+    name: Triagem de sanções e PEP (imobiliário)
+    description: |
+      Triagem de partes em transações face a listas de sanções, PEP e
+      media adversa.
+  BC-4990.30.30:
+    name: Reporte de atividade suspeita (imobiliário)
+    description: |
+      Apresentação de relatórios de atividade suspeita em transações
+      imobiliárias em âmbito.
+  BC-4990.30.40:
+    name: Auditoria AML e inspeção regulatória
+    description: |
+      Resposta a auditorias AML e inspeções regulatórias sobre programas
+      AML imobiliários.
+  BC-4990.40:
+    name: Conformidade de divulgação de liquidação e hipoteca
+    description: |
+      Conformidade com as regras de divulgação de liquidação e hipoteca
+      RESPA e TRID dos EUA e regimes regionais equivalentes.
+  BC-4990.40.10:
+    name: Produção de estimativa de empréstimo e divulgação de encerramento
+    description: |
+      Produção de documentos TRID de estimativa de empréstimo e divulgação
+      de encerramento dentro dos prazos regulamentares.
+  BC-4990.40.20:
+    name: Divulgação de negócios com empresas associadas
+    description: |
+      Divulgação de negócios com empresas associadas nos pontos obrigatórios
+      da transação.
+  BC-4990.40.30:
+    name: Conformidade de prestadores de serviços de liquidação
+    description: |
+      Conformidade com as regras sobre referências de prestadores de serviços
+      de liquidação e proibições da Secção 8.
+  BC-4990.40.40:
+    name: Resposta a auditorias RESPA
+    description: |
+      Resposta a inspeções do CFPB e reguladores estaduais sobre conformidade
+      RESPA.
+  BC-4990.50:
+    name: Conformidade de desempenho energético de edifícios
+    description: |
+      Conformidade com EPC, MEES, normas de desempenho de edifícios e leis
+      de benchmarking (ex.: Local Law 97, recasts da EPBD).
+  BC-4990.50.10:
+    name: Conformidade de certificação energética de edifícios
+    description: |
+      Obtenção e registo de certificados de desempenho energético e
+      equivalentes.
+  BC-4990.50.20:
+    name: Conformidade com eficiência energética mínima (MEES)
+    description: |
+      Conformidade com normas mínimas de eficiência energética em imóveis
+      arrendados e vendidos.
+  BC-4990.50.30:
+    name: Divulgação de benchmarking energético (LL97/BPS)
+    description: |
+      Divulgação ao abrigo de portarias municipais de benchmarking energético
+      e normas de desempenho de edifícios.
+  BC-4990.50.40:
+    name: Conformidade de reporte EPBD da UE
+    description: |
+      Conformidade com o reporte e certificação da Diretiva de Desempenho
+      Energético dos Edifícios da UE.
+  BC-4990.60:
+    name: Conformidade de arrendamento e regulação de rendas
+    description: |
+      Conformidade com o controlo/estabilização de rendas, aviso de despejo,
+      gestão estatutária de depósito de segurança e regimes de registo de
+      arrendamento de curta duração.
+  BC-4990.60.10:
+    name: Conformidade com controlo e estabilização de rendas
+    description: |
+      Conformidade com regimes de controlo e estabilização de rendas em
+      unidades reguladas.
+  BC-4990.60.20:
+    name: Conformidade com aviso e processo de despejo
+    description: |
+      Conformidade com os requisitos estatutários de aviso e processo de
+      despejo.
+  BC-4990.60.30:
+    name: Gestão estatutária de depósito de segurança
+    description: |
+      Gestão estatutária de depósitos de segurança, incluindo regras de
+      custódia, juros e devolução.
+  BC-4990.60.40:
+    name: Conformidade de registo de arrendamento de curta duração
+    description: |
+      Conformidade com o registo de arrendamento de curta duração e
+      regras de exploração em cidades reguladas.
+  BC-4990.70:
+    name: Conformidade regulatória de condomínios, HOA e strata
+    description: |
+      Conformidade com os regimes regulatórios de condomínios, HOA,
+      corporate bodies e strata, incluindo divulgações de promotor e
+      regras de fundo de reserva.
+  BC-4990.70.10:
+    name: Divulgação de promotor de condomínio/strata
+    description: |
+      Obrigações de divulgação do promotor ao abrigo da regulação de
+      condomínios e strata.
+  BC-4990.70.20:
+    name: Registo de HOA e corporate body
+    description: |
+      Registo e comunicações periódicas de entidades HOA e corporate body.
+  BC-4990.70.30:
+    name: Conformidade de divulgação do fundo de reserva
+    description: |
+      Conformidade com os requisitos de estudo e divulgação do fundo
+      de reserva.
+  BC-4990.70.40:
+    name: Conformidade do certificado de revenda
+    description: |
+      Emissão de certificados de revenda e divulgações relacionadas em
+      vendas de unidades de condomínio e HOA.
+  BC-4990.80:
+    name: Conformidade de fundos e assessores imobiliários
+    description: |
+      Conformidade com a AIFMD, ELTIF, a Investment Advisers Act dos EUA
+      e regimes equivalentes de fundos e assessores que regulam os
+      gestores de fundos imobiliários.
+  BC-4990.80.10:
+    name: Registo de assessor de fundos
+    description: |
+      Manutenção de registos e autorizações de assessores e gestores de
+      fundos.
+  BC-4990.80.20:
+    name: Conformidade de reporte AIFMD/ELTIF
+    description: |
+      Conformidade com as obrigações de reporte do Anexo IV da AIFMD
+      e da ELTIF.
+  BC-4990.80.30:
+    name: Marketing e notificação transfronteiriça
+    description: |
+      Conformidade com os regimes de notificação de marketing transfronteiriço
+      para fundos.
+  BC-4990.80.40:
+    name: Resposta a auditorias e inspeções de fundos
+    description: |
+      Resposta a auditorias e inspeções de reguladores de fundos em
+      várias jurisdições.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-real-estate-development-management.yaml
+++ b/catalogue/i18n/pt/L1-real-estate-development-management.yaml
@@ -1,0 +1,229 @@
+locale: pt
+source: L1-real-estate-development-management.yaml
+entries:
+  BC-4900:
+    name: Gestão de promoção imobiliária
+    description: |
+      Originação, viabilidade, licenciamento, financiamento e supervisão da
+      execução de projetos imobiliários de nova construção e grande reabilitação
+      em setores comercial e residencial. Disciplina do lado do promotor que
+      enquadra a execução de construção genérica (BC-1150) com o trabalho
+      a montante (terreno, licenciamento, programa, financiamento de promoção)
+      e a jusante (pré-arrendamento, estabilização) específico da promoção imobiliária.
+    in_scope:
+      - Obtenção de terrenos, análise de mercado e monitorização de pipeline
+      - Análise de melhor e maior uso e viabilidade pro forma
+      - Zonamento, licenciamentos, aprovação de planeamento, licenças de construção
+      - Supervisão de planeamento urbano e conceção de conceito
+      - Estruturação de financiamento de promoção, incluindo capital de JV e dívida de construção
+      - Monitorização de construção pelo dono de obra, ordens de alteração e supervisão de execução
+      - Pré-arrendamento, abertura e ocupação até estabilização
+    out_of_scope:
+      - Execução de construção pelo empreiteiro geral e especialidades (BC-1150)
+      - Aquisição de ativos consolidados (BC-4930)
+      - Planos de negócio e capex de ativos consolidados (BC-4920)
+      - Promoção por ocupante corporativo para uso próprio (BC-710)
+  BC-4900.10:
+    name: Pipeline de promoção e obtenção de terrenos
+    description: |
+      Originação de oportunidades de promoção através de prospeções de mercado,
+      obtenção direta de terrenos, geração de leads off-market e monitorização
+      de pipeline face a critérios de investimento.
+  BC-4900.10.10:
+    name: Análise de mercado e submercado
+    description: |
+      Análise da dinâmica metropolitana, de submercado e de microlocalização para
+      orientar a atividade de promoção.
+  BC-4900.10.20:
+    name: Identificação e obtenção de terrenos
+    description: |
+      Identificação de terrenos candidatos a promoção através de canais de listagem,
+      redes de mediadores e prospeção de dados de parcelas.
+  BC-4900.10.30:
+    name: Originação off-market
+    description: |
+      Cultivo de oportunidades off-market através de contacto com proprietários
+      de terrenos e redes proprietárias.
+  BC-4900.10.40:
+    name: Monitorização do pipeline
+    description: |
+      Monitorização de oportunidades de promoção nas fases de processo de decisão
+      e filtros de critérios de investimento.
+  BC-4900.20:
+    name: Análise de viabilidade de promoção
+    description: |
+      Avaliação de viabilidade de oportunidades candidatas a promoção nas dimensões
+      de terreno, programa e financeira.
+  BC-4900.20.10:
+    name: Análise de melhor e maior uso
+    description: |
+      Análise de usos legalmente permitidos, fisicamente possíveis e financeiramente
+      viáveis para um terreno candidato.
+  BC-4900.20.20:
+    name: Estudos de programa e volumetria
+    description: |
+      Estudos de composição de programa e volumetria para testar o envelope e
+      o rendimento da promoção.
+  BC-4900.20.30:
+    name: Modelação do pro forma de promoção
+    description: |
+      Construção do pro forma de promoção cobrindo custos, receitas e rendibilidades
+      não alavancadas e alavancadas.
+  BC-4900.20.40:
+    name: Análise de viabilidade da aquisição de terreno
+    description: |
+      Análise de viabilidade do preço e estrutura de aquisição de terreno face
+      aos resultados de viabilidade.
+  BC-4900.30:
+    name: Licenciamentos de uso do solo e alvarás
+    description: |
+      Obtenção de direitos de uso do solo, aprovação de planeamento, aprovações
+      ambientais e licenças de construção necessárias para construir.
+  BC-4900.30.10:
+    name: Estratégia de zonamento e uso do solo
+    description: |
+      Estratégia e execução para alterações de zonamento, alterações à carta de
+      uso do solo e bónus de densidade.
+  BC-4900.30.20:
+    name: Aprovação de planeamento e variantes
+    description: |
+      Obtenção de aprovação de planeamento, variantes e licenças de uso especial
+      perante autoridades de planeamento.
+  BC-4900.30.30:
+    name: Revisão ambiental (NEPA / AIA)
+    description: |
+      Revisão ambiental ao abrigo de NEPA, AIA ou regimes regionais equivalentes,
+      incluindo avaliação de impacto e mitigação.
+  BC-4900.30.40:
+    name: Licenças de construção e aprovações
+    description: |
+      Submissão e obtenção de licenças de construção e aprovações de especialidades
+      necessárias para iniciar a construção.
+  BC-4900.30.50:
+    name: Envolvimento da comunidade e partes interessadas
+    description: |
+      Envolvimento com juntas de freguesia, vizinhos e partes interessadas políticas
+      em apoio ao licenciamento.
+  BC-4900.40:
+    name: Gestão do programa de promoção
+    description: |
+      Governação ao nível do programa do planeamento, orçamento, risco e reporte
+      a partes interessadas ao longo do ciclo de vida da promoção.
+  BC-4900.40.10:
+    name: Gestão do planeamento da promoção
+    description: |
+      Definição e monitorização do planeamento-mestre da promoção, desde o encerramento
+      do terreno até à estabilização.
+  BC-4900.40.20:
+    name: Controlo do orçamento de promoção
+    description: |
+      Controlo do orçamento total de custo de promoção, incluindo componentes de
+      construção, soft costs, financiamento e contingências.
+  BC-4900.40.30:
+    name: Gestão de riscos e contingências de promoção
+    description: |
+      Identificação, quantificação e gestão de riscos de programa e consumo de contingências.
+  BC-4900.40.40:
+    name: Reporte a partes interessadas
+    description: |
+      Reporte do progresso da promoção a investidores, financiadores e órgãos de
+      governação interna.
+  BC-4900.50:
+    name: Gestão do planeamento urbano e conceção de conceito
+    description: |
+      Definição de planos urbanos de longo prazo e supervisão das fases de conceção
+      de conceito e esquemática face à intenção do promotor.
+  BC-4900.50.10:
+    name: Definição do plano urbano
+    description: |
+      Definição de planos urbanos para promoções de múltiplas fases ou parcelas,
+      incluindo faseamento.
+  BC-4900.50.20:
+    name: Supervisão da conceção de conceito e esquemática
+    description: |
+      Supervisão pelo dono de obra dos entregáveis de conceção de conceito e
+      esquemática do arquiteto face ao caderno de encargos.
+  BC-4900.50.30:
+    name: Gestão de normas de conceção
+    description: |
+      Gestão das normas de conceção e de marca do promotor junto das equipas de consultores.
+  BC-4900.50.40:
+    name: Definição do caderno de encargos de sustentabilidade
+    description: |
+      Definição de cadernos de encargos de sustentabilidade e certificação (LEED,
+      BREEAM, WELL, NABERS) para a promoção.
+  BC-4900.60:
+    name: Estruturação do financiamento de promoção
+    description: |
+      Estruturação de capital próprio, dívida e incentivos de capital necessários
+      para financiar a promoção até à conclusão.
+  BC-4900.60.10:
+    name: Capitalização de capital próprio
+    description: |
+      Obtenção e encerramento de capital próprio de sponsor e de limited partners
+      para o projeto de promoção.
+  BC-4900.60.20:
+    name: Originação de empréstimo de construção
+    description: |
+      Originação de empréstimos de construção e bridge face ao pro forma de promoção.
+  BC-4900.60.30:
+    name: Incentivos públicos e créditos fiscais
+    description: |
+      Obtenção de incentivos públicos como TIF, PILOT, LIHTC e programas de crédito
+      fiscal histórico.
+  BC-4900.60.40:
+    name: Estruturação de joint venture
+    description: |
+      Estruturação de veículos de joint venture, promote e condições de waterfall
+      para parceiros de promoção.
+  BC-4900.70:
+    name: Supervisão da execução da construção
+    description: |
+      Supervisão pelo dono de obra da execução da construção pelos empreiteiros
+      gerais e especialidades, deixando a execução para a capacidade de construção (BC-1150).
+  BC-4900.70.10:
+    name: Seleção e adjudicação de empreiteiro
+    description: |
+      Seleção e adjudicação de empreiteiros gerais e contratos de especialidades
+      chave para a promoção.
+  BC-4900.70.20:
+    name: Monitorização de construção pelo dono de obra
+    description: |
+      Monitorização pelo dono de obra do progresso, liberações e qualidade da
+      construção durante a execução.
+  BC-4900.70.30:
+    name: Governação de ordens de alteração
+    description: |
+      Governação de ordens de alteração, alterações de âmbito e consumo de contingências face ao orçamento.
+  BC-4900.70.40:
+    name: Supervisão de qualidade e segurança
+    description: |
+      Supervisão do desempenho de qualidade e segurança da construção face às
+      expectativas do promotor e regulamentos.
+  BC-4900.80:
+    name: Gestão de ocupação e estabilização
+    description: |
+      Pré-arrendamento, coordenação da abertura e crescimento do ativo concluído
+      até à ocupação e desempenho estabilizados.
+  BC-4900.80.10:
+    name: Coordenação do pré-arrendamento
+    description: |
+      Coordenação de campanhas de pré-arrendamento antes da conclusão do edifício.
+  BC-4900.80.20:
+    name: Coordenação da abertura e mudanças
+    description: |
+      Coordenação da abertura do edifício, primeiras mudanças e entrega operacional.
+  BC-4900.80.30:
+    name: Monitorização do desempenho de estabilização
+    description: |
+      Monitorização da velocidade de ocupação e desempenho operacional face ao
+      pro forma de estabilização.
+  BC-4900.80.40:
+    name: Encerramento de lista de defeitos e anomalias
+    description: |
+      Encerramento de itens da lista de defeitos, anomalias latentes e reclamações
+      de garantia de empreiteiro após a entrega.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-real-estate-investment-management.yaml
+++ b/catalogue/i18n/pt/L1-real-estate-investment-management.yaml
@@ -1,0 +1,182 @@
+locale: pt
+source: L1-real-estate-investment-management.yaml
+entries:
+  BC-4910:
+    name: Gestão de investimento imobiliário
+    description: |
+      Disciplina do lado da gestora de investimentos e do fundo de estratégia,
+      angariação de capital, pipeline, governação de decisões, construção de
+      carteira, relações com investidores e desempenho ao nível do fundo para
+      veículos de investimento imobiliário, incluindo REITs, fundos não cotados,
+      contas segregadas e programas de joint venture.
+    in_scope:
+      - Definição de fundo/mandato e política de investimento
+      - Angariação de capital, constituição de fundos e subscrição
+      - Pipeline de investimento e obtenção de negócios em canais diretos e indiretos
+      - Governação do comité de investimento e condições de aprovação
+      - Construção de carteira, alocação e reequilíbrio
+      - Reporte a LP, chamadas de capital, distribuições e submissão INREV/NCREIF/EPRA
+      - Cálculo de NAV, atribuição de desempenho e cálculos de waterfall
+    out_of_scope:
+      - Planos de negócio e capex por ativo (BC-4920)
+      - Execução de transações de aquisição e alienação (BC-4930)
+      - Execução de mercados de capitais de dívida e capital (BC-4980)
+      - Tesouraria empresarial genérica e Relações com Investidores (BC-210, BC-240)
+  BC-4910.10:
+    name: Gestão de estratégia de investimento e mandato
+    description: |
+      Definição e gestão da estratégia de investimento, mandatos de fundos,
+      orientação setorial/geográfica e objetivos de risco-rendibilidade para
+      veículos sob gestão.
+  BC-4910.10.10:
+    name: Definição de fundo/mandato
+    description: |
+      Definição de mandatos de fundos ou contas segregadas, incluindo setor,
+      geografia, estilo e restrições.
+  BC-4910.10.20:
+    name: Alocação setorial e geográfica
+    description: |
+      Definição e revisão de metas de alocação setorial e geográfica nos veículos.
+  BC-4910.10.30:
+    name: Definição de objetivos de risco-rendibilidade
+    description: |
+      Definição de perfis de risco-rendibilidade por estilo (core, core-plus,
+      value-add, oportunístico) e benchmark.
+  BC-4910.10.40:
+    name: Manutenção da política de investimento
+    description: |
+      Manutenção de declarações de política de investimento, exceções e
+      consentimentos de investidores.
+  BC-4910.20:
+    name: Angariação de capital e constituição de fundos
+    description: |
+      Constituição de veículos de investimento e angariação de capital de
+      investidores, incluindo estruturação, comercialização e encerramento.
+  BC-4910.20.10:
+    name: Estruturação e criação de veículos de fundo
+    description: |
+      Estruturação e criação de veículos de fundo, feeders, blockers e estruturas
+      de detenção fiscalmente eficientes.
+  BC-4910.20.20:
+    name: Orientação de investidores e subscrição
+    description: |
+      Orientação de segmentos de investidores, resposta a due diligence e
+      processamento de subscrições.
+  BC-4910.20.30:
+    name: Gestão do encerramento do fundo
+    description: |
+      Gestão dos primeiros, intermédios e finais encerramentos, incluindo
+      equalização de investidores tardios.
+  BC-4910.20.40:
+    name: Gestão de co-investimento e veículos satélite
+    description: |
+      Originação e gestão de ofertas de co-investimento e veículos satélite.
+  BC-4910.30:
+    name: Pipeline de investimento e obtenção de negócios
+    description: |
+      Originação e triagem de oportunidades de investimento em aquisições diretas,
+      participações indiretas e canais de JV para os fundos.
+  BC-4910.30.10:
+    name: Originação de negócios diretos
+    description: |
+      Originação de oportunidades de investimento em ativos diretos e carteiras
+      alinhadas com os mandatos.
+  BC-4910.30.20:
+    name: Obtenção de oportunidades indiretas e co-investimento
+    description: |
+      Obtenção de participações indiretas, incluindo secundários, participações
+      em fundos e co-investimentos.
+  BC-4910.30.30:
+    name: Ritmo e alocação do pipeline
+    description: |
+      Ritmo do pipeline face aos planos de implementação do fundo e alocação
+      entre veículos.
+  BC-4910.40:
+    name: Gestão de decisões e aprovações de investimento
+    description: |
+      Governação do comité de investimento, fluxos de trabalho de aprovação e
+      monitorização de condições de aprovação para novos investimentos.
+  BC-4910.40.10:
+    name: Preparação de memorandos de investimento
+    description: |
+      Preparação de memorandos de investimento para revisão pelo comité,
+      cobrindo tese, condições e risco.
+  BC-4910.40.20:
+    name: Governação do comité de investimento
+    description: |
+      Governação do processo do comité de investimento, quórum e registo de decisões.
+  BC-4910.40.30:
+    name: Monitorização de condições de aprovação
+    description: |
+      Monitorização de condições precedentes e condições subsequentes associadas
+      às aprovações de investimento.
+  BC-4910.50:
+    name: Construção e alocação de carteira
+    description: |
+      Construção e reequilíbrio contínuo de carteiras de fundos face a mandato,
+      alavancagem e metas de risco.
+  BC-4910.50.10:
+    name: Modelação de carteira
+    description: |
+      Modelação da composição da carteira, diversificação de vintage e desempenho projetado.
+  BC-4910.50.20:
+    name: Reequilíbrio setorial e geográfico
+    description: |
+      Reequilíbrio da composição setorial e geográfica da carteira através de
+      aquisições e alienações.
+  BC-4910.50.30:
+    name: Definição de metas de alavancagem e cobertura
+    description: |
+      Definição e monitorização de políticas de alavancagem de carteira e de
+      cobertura de FX/taxa de juro.
+  BC-4910.60:
+    name: Relações com investidores e reporte
+    description: |
+      Comunicação com limited partners e investidores cotados, execução de
+      chamadas de capital e distribuições, e submissão a índices da indústria.
+  BC-4910.60.10:
+    name: Chamadas de capital e distribuições
+    description: |
+      Emissão de chamadas de capital e execução de distribuições, incluindo
+      devolução de capital.
+  BC-4910.60.20:
+    name: Reporte e divulgações a LP
+    description: |
+      Reporte trimestral e anual a limited partners, cobrindo desempenho, NAV e divulgações.
+  BC-4910.60.30:
+    name: Submissão a índices e benchmarks
+    description: |
+      Submissão a NCREIF, INREV, EPRA e benchmarks regionais para comparabilidade
+      de desempenho.
+  BC-4910.60.40:
+    name: Reuniões anuais de investidores
+    description: |
+      Organização de reuniões anuais de investidores, conselhos consultivos e
+      dias do investidor.
+  BC-4910.70:
+    name: Gestão do desempenho e NAV do fundo
+    description: |
+      Cálculo do NAV do fundo, atribuição de desempenho e waterfalls de comissões
+      de gestão/desempenho, incluindo cristalização de carry.
+  BC-4910.70.10:
+    name: NAV e preço unitário
+    description: |
+      Cálculo do NAV do fundo e preço unitário no ciclo de avaliação periódico.
+  BC-4910.70.20:
+    name: Atribuição de desempenho
+    description: |
+      Atribuição do desempenho do fundo por ativo, setor, geografia e contribuições cambiais.
+  BC-4910.70.30:
+    name: Cálculo de comissões e carry
+    description: |
+      Cálculo de comissões de gestão e carried interest alinhados com os termos
+      económicos do LPA.
+  BC-4910.70.40:
+    name: Cálculo de hurdle e waterfall
+    description: |
+      Cálculo de hurdles de rendibilidade preferencial e waterfalls de distribuição
+      para cada veículo.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-real-estate-leasing-management.yaml
+++ b/catalogue/i18n/pt/L1-real-estate-leasing-management.yaml
@@ -1,0 +1,184 @@
+locale: pt
+source: L1-real-estate-leasing-management.yaml
+entries:
+  BC-4950:
+    name: Gestão de arrendamento imobiliário
+    description: |
+      Arrendamento do lado do senhorio de espaços comerciais, de retalho e residenciais
+      ao longo do ciclo de vida do arrendamento — preços, marketing, gestão de
+      candidatos, triagem de candidaturas, negociação e execução, administração de
+      arrendamentos, renovação e retenção, e fim de arrendamento. Distinto do
+      arrendamento de ocupante corporativo (BC-710) e da mediação como linha de serviço (BC-4960).
+    in_scope:
+      - Estratégia de renda pedida e concessões
+      - Marketing de vacância, listagens e visitas
+      - Gestão e qualificação de candidatos de entrada
+      - Receção, triagem e tratamento de decisões adversas conforme habitação justa
+      - Minuta de arrendamento, redação, assinatura e gestão de depósito de segurança
+      - Abstração de arrendamento pelo senhorio, indexação e monitorização de opções
+      - Negociação de renovações e programas de retenção
+      - Mudança de saída, danos e contabilidade de fim de arrendamento
+    out_of_scope:
+      - Administração de arrendamento de ocupante corporativo do lado do inquilino (BC-710)
+      - Representação de mediação como linha de serviço (BC-4960)
+      - Operações de propriedade durante a ocupação (BC-4940)
+      - Regulação de rendas e postura de conformidade de arrendamento (BC-4990)
+  BC-4950.10:
+    name: Estratégia de arrendamento e preços
+    description: |
+      Definição da estratégia de renda pedida, pacotes de concessões, composição
+      de inquilinos-alvo e comparação de referência da renda do ativo com o mercado.
+  BC-4950.10.10:
+    name: Estratégia de renda pedida e concessões
+    description: |
+      Definição de níveis de renda pedida e pacotes de concessões por tipo de ativo e unidade.
+  BC-4950.10.20:
+    name: Estratégia de composição de inquilinos-alvo
+    description: |
+      Definição da composição de inquilinos-alvo e qualidade de crédito para o ativo.
+  BC-4950.10.30:
+    name: Comparação de referência de renda de mercado
+    description: |
+      Comparação de referência periódica de rendas em vigor e pedidas face a evidência de mercado.
+  BC-4950.20:
+    name: Marketing de vacância e listagem
+    description: |
+      Marketing de espaço disponível através de conteúdo de listagem, sindicalização
+      de canais e visitas ao local.
+  BC-4950.20.10:
+    name: Produção de conteúdo de listagem
+    description: |
+      Produção de conteúdo de listagem, incluindo fotografia, plantas e visitas virtuais.
+  BC-4950.20.20:
+    name: Gestão de canal de listagem e sindicalização
+    description: |
+      Gestão da distribuição de listagens a portais, MLS e canais parceiros.
+  BC-4950.20.30:
+    name: Operações de visitas a unidades vagas
+    description: |
+      Operação de visitas a unidades vagas e visitas autónomas na propriedade.
+  BC-4950.30:
+    name: Gestão de candidatos e consultas
+    description: |
+      Captação, qualificação e acompanhamento de consultas de arrendamento e
+      candidatos de entrada.
+  BC-4950.30.10:
+    name: Captação e encaminhamento de consultas
+    description: |
+      Captação de consultas de arrendamento em múltiplos canais e encaminhamento
+      para a equipa certa do ativo.
+  BC-4950.30.20:
+    name: Qualificação de candidatos
+    description: |
+      Qualificação de candidatos face ao uso-alvo, crédito e adequação da unidade.
+  BC-4950.30.30:
+    name: Agendamento de visitas e acompanhamento
+    description: |
+      Agendamento de visitas e acompanhamento pós-visita com candidatos.
+  BC-4950.40:
+    name: Candidatura e triagem de inquilinos
+    description: |
+      Receção de candidaturas de inquilinos e execução de verificações de crédito,
+      identidade e referências em conformidade com as regras de habitação justa.
+  BC-4950.40.10:
+    name: Receção de candidaturas
+    description: |
+      Receção de candidaturas de inquilinos e documentação de suporte.
+  BC-4950.40.20:
+    name: Verificações de crédito e referências
+    description: |
+      Execução de verificações de crédito e referências de senhorio/empregador a candidatos.
+  BC-4950.40.30:
+    name: Verificação de identidade e direito a arrendar
+    description: |
+      Verificação de identidade e direito a arrendar/ocupar conforme exigido pela jurisdição.
+  BC-4950.40.40:
+    name: Tratamento de decisão adversa por habitação justa
+    description: |
+      Tratamento de decisões adversas de candidatura em conformidade com as regras de habitação justa e aviso de decisão adversa.
+  BC-4950.50:
+    name: Negociação e execução de arrendamento
+    description: |
+      Negociação de minutas de arrendamento, redação, gestão de revisões, execução
+      e captação de depósitos de segurança e garantias.
+  BC-4950.50.10:
+    name: Negociação de minuta de arrendamento
+    description: |
+      Negociação de minutas de arrendamento cobrindo renda, prazo, opções e incentivos.
+  BC-4950.50.20:
+    name: Redação de arrendamento e gestão de revisões
+    description: |
+      Redação de documentos de arrendamento e gestão de ciclos de revisão com advogados do inquilino.
+  BC-4950.50.30:
+    name: Assinatura e execução do arrendamento
+    description: |
+      Assinatura e execução do arrendamento e documentos acessórios.
+  BC-4950.50.40:
+    name: Captação de depósito de segurança e garantia
+    description: |
+      Captação de depósitos de segurança, cartas de crédito e garantias pessoais ou corporativas.
+  BC-4950.60:
+    name: Administração de arrendamentos (lado do senhorio)
+    description: |
+      Administração pelo senhorio de abstrações de arrendamento, indexação de rendas,
+      monitorização de opções e monitorização de conformidade de arrendamento durante o prazo.
+  BC-4950.60.10:
+    name: Abstração de arrendamentos
+    description: |
+      Abstração de arrendamentos executados em registos de termos-chave estruturados.
+  BC-4950.60.20:
+    name: Monitorização de indexação e escalada de rendas
+    description: |
+      Monitorização e acionamento de escaladas de renda, incluindo cláusulas indexadas e em degrau.
+  BC-4950.60.30:
+    name: Monitorização de opções, quebras e renovações
+    description: |
+      Monitorização de opções de inquilino e senhorio, datas de quebra e janelas de renovação.
+  BC-4950.60.40:
+    name: Monitorização de conformidade de arrendamento
+    description: |
+      Monitorização da conformidade do inquilino com cláusulas do arrendamento,
+      incluindo uso, alterações e reporte.
+  BC-4950.70:
+    name: Gestão de renovação e retenção
+    description: |
+      Gestão proativa do pipeline de renovação, negociação de condições e programas
+      de retenção dirigidos a inquilinos em vigor.
+  BC-4950.70.10:
+    name: Gestão do pipeline de renovação
+    description: |
+      Gestão do pipeline de renovação face ao calendário de expiração e metas de retenção.
+  BC-4950.70.20:
+    name: Negociação de condições de renovação
+    description: |
+      Negociação de condições de renovação, incluindo renda, prazo e incentivos.
+  BC-4950.70.30:
+    name: Operações de programas de retenção
+    description: |
+      Operação de programas de retenção, incluindo contacto com inquilinos e ofertas de incentivo.
+  BC-4950.80:
+    name: Gestão de mudança de saída e rescisão de arrendamento
+    description: |
+      Gestão de aviso de inquilino, entrega, danos, reposição, devolução de depósito
+      e contabilidade final no fim do arrendamento.
+  BC-4950.80.10:
+    name: Processamento de aviso e entrega
+    description: |
+      Processamento de avisos de rescisão e entrega das instalações.
+  BC-4950.80.20:
+    name: Avaliação de danos e obrigações de reposição
+    description: |
+      Avaliação de danos e obrigações de reposição do inquilino face ao arrendamento.
+  BC-4950.80.30:
+    name: Devolução do depósito de segurança
+    description: |
+      Devolução de depósitos de segurança sujeita a deduções em conformidade com
+      a lei e o arrendamento.
+  BC-4950.80.40:
+    name: Contabilidade final de fim de arrendamento
+    description: |
+      Contabilidade final de rendas, recuperações e créditos no fim do arrendamento.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-real-estate-valuation-appraisal-management.yaml
+++ b/catalogue/i18n/pt/L1-real-estate-valuation-appraisal-management.yaml
@@ -1,0 +1,151 @@
+locale: pt
+source: L1-real-estate-valuation-appraisal-management.yaml
+entries:
+  BC-4970:
+    name: Gestão de avaliação e peritagem imobiliária
+    description: |
+      Disciplina de peritagem e avaliação de ativos e carteiras imobiliárias —
+      receção de mandatos, inspeção do imóvel-objeto, curadoria de dados comparáveis,
+      aplicação de abordagens de vendas/rendimento/custo, redação e aprovação de
+      relatórios, reavaliação periódica de carteiras e garantia de qualidade em
+      conformidade com USPAP, Red Book RICS e IVS.
+    in_scope:
+      - Receção de mandatos, âmbito, verificação de conflitos e cartas de mandato
+      - Inspeção do imóvel-objeto e medição conforme IPMS
+      - Curadoria de transações comparáveis e benchmarks de yield
+      - Abordagens de comparação de vendas, capitalização de rendimento, DCF e custo
+      - Redação e aprovação de relatórios conformes com Red Book/USPAP
+      - Reavaliação periódica de carteiras e reavaliação de colateral de mutuante
+      - Amostragem de garantia de qualidade interna, revisão de pares e resposta a auditorias
+    out_of_scope:
+      - Análise de viabilidade de aquisição por clientes diretos (BC-4930)
+      - Cálculo de NAV ao nível do fundo (BC-4910)
+      - Recursos a avaliações de impostos sobre propriedade (BC-4920)
+      - Opinião de valor do mediador como produto de mediação (BC-4960)
+  BC-4970.10:
+    name: Gestão de mandatos de avaliação
+    description: |
+      Receção, âmbito, verificação de conflitos e cartas de mandato para mandatos
+      de avaliação de clientes e mutuantes.
+  BC-4970.10.10:
+    name: Receção e âmbito de mandatos
+    description: |
+      Receção de mandatos de avaliação e definição do âmbito e propósito da avaliação.
+  BC-4970.10.20:
+    name: Verificação de conflitos e independência do mandato
+    description: |
+      Verificações de conflitos de interesse e independência do avaliador em novos mandatos.
+  BC-4970.10.30:
+    name: Emissão de honorários e carta de mandato
+    description: |
+      Definição e emissão de honorários e cartas de mandato a clientes.
+  BC-4970.20:
+    name: Inspeção do imóvel-objeto e captura de dados
+    description: |
+      Visitas de inspeção, medição do edifício conforme IPMS e captura de dados
+      de condição e anomalias nos imóveis-objeto.
+  BC-4970.20.10:
+    name: Operações de inspeção de imóvel
+    description: |
+      Operação de inspeções de imóveis-objeto por avaliadores qualificados.
+  BC-4970.20.20:
+    name: Medição de edifício (IPMS)
+    description: |
+      Medição de edifícios e arrendamentos em conformidade com IPMS e normas locais de medição.
+  BC-4970.20.30:
+    name: Captura de condição e anomalias
+    description: |
+      Captura de condição do edifício e anomalias observadas durante a inspeção.
+  BC-4970.30:
+    name: Dados de mercado e curadoria de comparáveis
+    description: |
+      Obtenção e curadoria de transações comparáveis, índices de mercado e benchmarks
+      de yield que suportam as conclusões de avaliação.
+  BC-4970.30.10:
+    name: Captação de transações comparáveis
+    description: |
+      Captação de transações comparáveis a partir de fontes de mercado e bases de dados internas.
+  BC-4970.30.20:
+    name: Índices de mercado e benchmarks de yield
+    description: |
+      Manutenção de índices de mercado e benchmarks de yield por setor e geografia.
+  BC-4970.30.30:
+    name: Gestão de ajustamentos de comparáveis
+    description: |
+      Gestão de ajustamentos de comparáveis para diferenças de tempo, localização, condição e qualidade.
+  BC-4970.40:
+    name: Aplicação de abordagens de avaliação
+    description: |
+      Aplicação das abordagens de avaliação reconhecidas — comparação de vendas,
+      capitalização de rendimento, DCF e custo — ao imóvel-objeto.
+  BC-4970.40.10:
+    name: Abordagem por comparação de vendas
+    description: |
+      Aplicação da abordagem por comparação de vendas utilizando evidência de transações comparáveis.
+  BC-4970.40.20:
+    name: Abordagem por capitalização de rendimento
+    description: |
+      Aplicação da abordagem por capitalização de rendimento utilizando NOI e evidência de yield.
+  BC-4970.40.30:
+    name: Abordagem por fluxo de caixa descontado
+    description: |
+      Aplicação da abordagem por fluxo de caixa descontado para imóveis de rendimento com projeções plurianuais.
+  BC-4970.40.40:
+    name: Abordagem por custo
+    description: |
+      Aplicação da abordagem por custo utilizando custo de reposição e análise de depreciação.
+  BC-4970.50:
+    name: Redação e aprovação de relatórios de avaliação
+    description: |
+      Redação, revisão interna e aprovação de relatórios de avaliação em conformidade
+      com USPAP, Red Book e normas IVS.
+  BC-4970.50.10:
+    name: Redação de relatórios de avaliação
+    description: |
+      Redação de relatórios de avaliação face ao âmbito e propósito do mandato.
+  BC-4970.50.20:
+    name: Aprovação do revisor e controlo de qualidade
+    description: |
+      Aprovação do revisor e controlo de qualidade de relatórios de avaliação antes da emissão.
+  BC-4970.50.30:
+    name: Gestão de emissão e reemissão de relatórios
+    description: |
+      Emissão de relatórios de avaliação e gestão de reemissões e adendas.
+  BC-4970.60:
+    name: Reavaliação periódica de carteiras e avaliação de índice
+    description: |
+      Reavaliação periódica de carteiras para fundos e mutuantes e submissão de
+      dados de avaliação a índices e benchmarks.
+  BC-4970.60.10:
+    name: Reavaliação periódica de carteiras
+    description: |
+      Reavaliação periódica de carteiras de fundos e proprietários no ciclo contratado.
+  BC-4970.60.20:
+    name: Reavaliação de colateral de mutuante
+    description: |
+      Reavaliação de colateral de mutuante, incluindo acionadores de covenant e stress test.
+  BC-4970.60.30:
+    name: Reporte a índices e benchmarks
+    description: |
+      Reporte de dados de avaliação à NCREIF, MSCI e outros índices de desempenho.
+  BC-4970.70:
+    name: Garantia de qualidade e auditoria de avaliação
+    description: |
+      Amostragem interna de garantia de qualidade, revisão de pares e resposta a
+      auditorias de clientes e reguladores de avaliações emitidas.
+  BC-4970.70.10:
+    name: Amostragem interna de garantia de qualidade
+    description: |
+      Amostragem de avaliações emitidas para revisão interna de garantia de qualidade.
+  BC-4970.70.20:
+    name: Operações de revisão de pares
+    description: |
+      Operação de revisão de pares para avaliações complexas ou de elevado valor.
+  BC-4970.70.30:
+    name: Resposta a auditorias regulatórias e de clientes
+    description: |
+      Resposta a pedidos de auditoria de reguladores e clientes sobre avaliações emitidas.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-refining-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-refining-operations-management.yaml
@@ -1,0 +1,146 @@
+locale: pt
+source: L1-refining-operations-management.yaml
+entries:
+  BC-3080:
+    name: Gestão de operações de refinação
+    description: |
+      Operação de refinarias de crude — destilação, conversão, tratamento, mistura,
+      economia da refinaria, gestão de catalisadores e coordenação de paragens
+      programadas.
+  BC-3080.10:
+    name: Operações de destilação de crude
+    description: |
+      Operação de unidades de destilação atmosférica e de vácuo de crude e
+      transições de dieta de crude.
+  BC-3080.10.10:
+    name: Operações de destilação atmosférica
+    description: |
+      Operação de colunas de destilação atmosférica de crude e trens de
+      pré-flash.
+  BC-3080.10.20:
+    name: Operações de destilação de vácuo
+    description: |
+      Operação de colunas de destilação de vácuo e sistemas de topo.
+  BC-3080.10.30:
+    name: Mudança de dieta de crude
+    description: |
+      Gestão operacional de mudanças de dieta de crude e transições de mistura.
+  BC-3080.20:
+    name: Operações de unidades de conversão
+    description: |
+      Operação de unidades de conversão de cracking catalítico, hydrocracking,
+      coking e reforming.
+  BC-3080.20.10:
+    name: Operações de cracking catalítico fluido
+    description: |
+      Operação de unidades de cracking catalítico fluido e regeneradores.
+  BC-3080.20.20:
+    name: Operações de hydrocracking
+    description: |
+      Operação de hydrocrackers de simples e duas etapas.
+  BC-3080.20.30:
+    name: Operações de coking
+    description: |
+      Operação de unidades de delayed coker, fluid coker e flexicoker.
+  BC-3080.20.40:
+    name: Operações de reforming
+    description: |
+      Operação de reformers catalíticos para produção de octano e aromáticos.
+  BC-3080.30:
+    name: Operações de tratamento e hidroprocessamento
+    description: |
+      Operação de hydrotreaters, recuperação de enxofre e unidades de
+      adoçamento de produtos.
+  BC-3080.30.10:
+    name: Operações de hydrotreating
+    description: |
+      Operação de hydrotreaters de nafta, destilados e gasóleo.
+  BC-3080.30.20:
+    name: Operações de recuperação de enxofre e gás de cauda
+    description: |
+      Operação de unidades de recuperação de enxofre e tratamento de gás de cauda.
+  BC-3080.30.30:
+    name: Operações de adoçamento
+    description: |
+      Operação de adoçamento de produtos à base de cáustica e adsorventes.
+  BC-3080.40:
+    name: Operações de mistura de produtos
+    description: |
+      Mistura em linha e em tanque de produtos acabados para especificação.
+  BC-3080.40.10:
+    name: Mistura de gasolina
+    description: |
+      Mistura multicomponente de gasolina para especificações de grau.
+  BC-3080.40.20:
+    name: Mistura de destilados
+    description: |
+      Mistura de gasóleo e querosene, incluindo incorporação de biocombustível.
+  BC-3080.40.30:
+    name: Mistura de combustível para navios
+    description: |
+      Mistura de combustível marítimo para especificações ISO 8217.
+  BC-3080.40.40:
+    name: Mistura de conformidade com especificações
+    description: |
+      Optimização de especificações em tempo real e emissão de certificado de
+      qualidade.
+  BC-3080.50:
+    name: Planeamento e economia da refinaria
+    description: |
+      Selecção de crude baseada em programação linear, optimização de margem e
+      reporte de rendimentos da refinaria.
+  BC-3080.50.10:
+    name: Modelação por programação linear
+    description: |
+      Manutenção e execução de modelos LP de refinaria para plano e economia.
+  BC-3080.50.20:
+    name: Economia de selecção de crude
+    description: |
+      Avaliação económica de compras candidatas de crude e opções de dieta.
+  BC-3080.50.30:
+    name: Optimização de margem
+    description: |
+      Optimização da margem de operação a curto prazo e replaneamento.
+  BC-3080.50.40:
+    name: Reporte de rendimentos da refinaria
+    description: |
+      Reporte de rendimentos reais face ao plano e ao benchmark.
+  BC-3080.60:
+    name: Gestão de catalisadores e químicos da refinaria
+    description: |
+      Gestão do ciclo de vida de catalisadores de processo e inventário de químicos
+      da refinaria.
+  BC-3080.60.10:
+    name: Gestão do ciclo de vida de catalisadores
+    description: |
+      Planeamento de carga, vigilância em serviço e substituição de catalisadores.
+  BC-3080.60.20:
+    name: Coordenação de regeneração de catalisadores
+    description: |
+      Coordenação de campanhas de regeneração de catalisadores in-situ e ex-situ.
+  BC-3080.60.30:
+    name: Gestão do inventário de químicos da refinaria
+    description: |
+      Gestão de inventário e consumo de químicos de processo.
+  BC-3080.70:
+    name: Coordenação de paragens programadas e manutenção major
+    description: |
+      Coordenação de âmbito, programa e execução de paragens programadas major de
+      refinaria.
+  BC-3080.70.10:
+    name: Gestão do âmbito da paragem programada
+    description: |
+      Definição e congelamento do âmbito da paragem programada, incluindo processo
+      de desafio.
+  BC-3080.70.20:
+    name: Gestão do programa da paragem programada
+    description: |
+      Programação detalhada e controlo de progresso da paragem programada.
+  BC-3080.70.30:
+    name: Coordenação de paragem e arranque
+    description: |
+      Coordenação sequenciada de paragem de unidades, descontaminação e arranque.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-refrigerant-lifecycle-management.yaml
+++ b/catalogue/i18n/pt/L1-refrigerant-lifecycle-management.yaml
@@ -1,0 +1,186 @@
+locale: pt
+source: L1-refrigerant-lifecycle-management.yaml
+entries:
+  BC-2040:
+    name: Gestão do ciclo de vida do refrigerante
+    description: |
+      Ciclo de vida operacional dos refrigerantes na base instalada — aprovisionamento e inventário,
+      contabilidade de carga, recuperação e reclamação, gestão de fugas, relatórios regulatórios ao abrigo
+      de F-Gas/EPA Secção 608/Emenda de Kigali, certificação de técnicos, transições de eliminação gradual
+      e disposição no fim de vida.
+  BC-2040.10:
+    name: Gestão de aprovisionamento e inventário de refrigerante
+    description: |
+      Aprovisionamento, alocação, armazenamento e reconciliação de stocks de refrigerante nas operações.
+  BC-2040.10.10:
+    name: Aprovisionamento de refrigerante
+    description: |
+      Aprovisionamento de refrigerantes junto de fornecedores aprovados.
+  BC-2040.10.20:
+    name: Gestão de alocação de quota
+    description: |
+      Alocação de quotas regulatórias por unidade de negócio e mercado.
+  BC-2040.10.30:
+    name: Armazenamento e manuseamento de refrigerante
+    description: |
+      Armazenamento e manuseamento de cilindros de refrigerante segundo regras de segurança e ambientais.
+  BC-2040.10.40:
+    name: Reconciliação do inventário de refrigerante
+    description: |
+      Reconciliação periódica do inventário de refrigerante nos locais e stocks em campo.
+  BC-2040.20:
+    name: Contabilidade de carga de refrigerante
+    description: |
+      Contabilidade ao nível do ativo da carga de refrigerante, recargas e balanço de auditoria.
+  BC-2040.20.10:
+    name: Registos de carga por ativo
+    description: |
+      Registos da carga de refrigerante instalada por ativo de equipamento.
+  BC-2040.20.20:
+    name: Registo de recargas
+    description: |
+      Registo de recargas face a eventos de assistência de equipamento.
+  BC-2040.20.30:
+    name: Auditoria de exatidão de carga
+    description: |
+      Auditoria da exatidão da contabilidade de carga na base instalada.
+  BC-2040.20.40:
+    name: Reconciliação de balanço de massa
+    description: |
+      Reconciliação de balanço de massa do refrigerante adquirido, utilizado, recuperado e eliminado.
+  BC-2040.30:
+    name: Operações de recuperação e reclamação de refrigerante
+    description: |
+      Recuperação em campo e reclamação a jusante do refrigerante recuperado para reutilização.
+  BC-2040.30.10:
+    name: Operações de recuperação em campo
+    description: |
+      Recuperação no local de refrigerante de equipamentos em assistência.
+  BC-2040.30.20:
+    name: Reclamação de refrigerante
+    description: |
+      Processamento de reclamação do refrigerante recuperado para especificações equivalentes ao virgem.
+  BC-2040.30.30:
+    name: Verificação da qualidade do refrigerante reciclado
+    description: |
+      Verificação da qualidade do refrigerante reciclado antes da reutilização.
+  BC-2040.30.40:
+    name: Gestão do banco de refrigerante recuperado
+    description: |
+      Gestão de bancos de refrigerante que detêm produto reclamado para reutilização.
+  BC-2040.40:
+    name: Gestão de fugas de refrigerante
+    description: |
+      Deteção, reparação e relatório de fugas de refrigerante na base instalada.
+  BC-2040.40.10:
+    name: Monitorização de deteção de fugas
+    description: |
+      Monitorização contínua e periódica de deteção de fugas no equipamento.
+  BC-2040.40.20:
+    name: Fluxo de trabalho de reparação de fugas
+    description: |
+      Fluxo de trabalho para diagnóstico e reparação de fugas identificadas.
+  BC-2040.40.30:
+    name: Relatório de taxa de fuga
+    description: |
+      Relatório de taxas de fuga face a limiares regulatórios.
+  BC-2040.40.40:
+    name: Análise de pontos quentes de fugas
+    description: |
+      Análise de pontos quentes de fugas recorrentes para impulsionar alterações de equipamento ou processo.
+  BC-2040.50:
+    name: Relatório regulatório de refrigerante
+    description: |
+      Relatório regulatório de utilização de refrigerante, fugas, recuperação e divulgações de substâncias.
+  BC-2040.50.10:
+    name: Relatório anual F-Gas
+    description: |
+      Relatório anual ao abrigo dos regulamentos F-Gas da UE.
+  BC-2040.50.20:
+    name: Relatório nacional de refrigerante
+    description: |
+      Relatório ao abrigo de programas nacionais de refrigerante (ex.: relatório EPA nos EUA).
+  BC-2040.50.30:
+    name: Relatório de Kigali e Montreal
+    description: |
+      Relatório ao abrigo das obrigações da Emenda de Kigali e do Protocolo de Montreal.
+  BC-2040.50.40:
+    name: Divulgação do inventário de substâncias
+    description: |
+      Divulgação do inventário de substâncias a reguladores e partes interessadas.
+  BC-2040.60:
+    name: Gestão de certificação de técnicos de refrigeração
+    description: |
+      Gestão de certificações, licenças e competências de técnicos para manuseamento de refrigerante.
+  BC-2040.60.10:
+    name: Registos de certificação de técnicos
+    description: |
+      Registos de certificações de refrigerante de técnicos.
+  BC-2040.60.20:
+    name: Acompanhamento de renovação de certificação
+    description: |
+      Acompanhamento de renovações de certificação próximas.
+  BC-2040.60.30:
+    name: Licenças nacionais de manuseamento de refrigerante
+    description: |
+      Gestão de licenças nacionais de manuseamento de refrigerante (EPA Secção 608, categorias F-Gas).
+  BC-2040.60.40:
+    name: Verificação de competência
+    description: |
+      Verificação periódica de competência dos técnicos que manuseiam refrigerantes.
+  BC-2040.70:
+    name: Gestão de eliminação gradual e transição de refrigerante
+    description: |
+      Gestão estratégica da eliminação gradual de refrigerantes e roteiros de transição do cliente.
+  BC-2040.70.10:
+    name: Roteiro de substituição de refrigerante
+    description: |
+      Roteiro para substituição de refrigerantes em eliminação gradual por alternativas de menor PGA.
+  BC-2040.70.20:
+    name: Planeamento de conversão por retrofit
+    description: |
+      Planeamento de conversões por retrofit para refrigerantes alternativos na base instalada.
+  BC-2040.70.30:
+    name: Comunicações de transição ao cliente
+    description: |
+      Comunicações aos clientes sobre transições de refrigerante e calendários.
+  BC-2040.70.40:
+    name: Gestão do risco de eliminação gradual
+    description: |
+      Gestão de riscos de abastecimento, regulatórios e reputacionais nas janelas de eliminação gradual.
+  BC-2040.80:
+    name: Fim de vida e eliminação de refrigerante
+    description: |
+      Destruição no fim de vida e eliminação certificada de refrigerantes que não podem ser reutilizados.
+  BC-2040.80.10:
+    name: Coordenação de destruição
+    description: |
+      Coordenação com instalações de destruição aprovadas.
+  BC-2040.80.20:
+    name: Trilha de auditoria de eliminação certificada
+    description: |
+      Manutenção de trilha de auditoria que evidencia a eliminação certificada.
+  BC-2040.80.30:
+    name: Reclamação de ativos no fim de vida
+    description: |
+      Reclamação de refrigerante de ativos no fim de vida antes da eliminação.
+  BC-2040.80.40:
+    name: Gestão de fornecedores de eliminação
+    description: |
+      Gestão de fornecedores de eliminação aprovados e programa de auditoria.
+  in_scope:
+    - Aprovisionamento, alocação e armazenamento de refrigerantes
+    - Contabilidade de carga ao nível do ativo e reconciliação de balanço de massa
+    - Recuperação em campo, reclamação e controlo de qualidade de refrigerante reciclado
+    - Deteção de fugas, reparação e relatório de taxa regulatório
+    - Certificação de manuseamento por técnicos e acompanhamento de competências
+    - Roteiros de transição e eliminação gradual de refrigerante
+    - Destruição no fim de vida e eliminação certificada
+  out_of_scope:
+    - Aprovações de refrigerante ao nível do produto durante a certificação (BC-2030)
+    - Ciclo e seleção de refrigerante durante o projeto do equipamento (BC-2000)
+    - Conformidade ambiental geral não específica de refrigerantes (BC-740)
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-refrigerant-lifecycle-management.yaml
+++ b/catalogue/i18n/pt/L1-refrigerant-lifecycle-management.yaml
@@ -8,6 +8,18 @@ entries:
       contabilidade de carga, recuperação e reclamação, gestão de fugas, relatórios regulatórios ao abrigo
       de F-Gas/EPA Secção 608/Emenda de Kigali, certificação de técnicos, transições de eliminação gradual
       e disposição no fim de vida.
+    in_scope:
+      - Aprovisionamento, alocação e armazenamento de refrigerantes
+      - Contabilidade de carga ao nível do ativo e reconciliação de balanço de massa
+      - Recuperação em campo, reclamação e controlo de qualidade de refrigerante reciclado
+      - Deteção de fugas, reparação e relatório de taxa regulatório
+      - Certificação de manuseamento por técnicos e acompanhamento de competências
+      - Roteiros de transição e eliminação gradual de refrigerante
+      - Destruição no fim de vida e eliminação certificada
+    out_of_scope:
+      - Aprovações de refrigerante ao nível do produto durante a certificação (BC-2030)
+      - Ciclo e seleção de refrigerante durante o projeto do equipamento (BC-2000)
+      - Conformidade ambiental geral não específica de refrigerantes (BC-740)
   BC-2040.10:
     name: Gestão de aprovisionamento e inventário de refrigerante
     description: |
@@ -168,18 +180,6 @@ entries:
     name: Gestão de fornecedores de eliminação
     description: |
       Gestão de fornecedores de eliminação aprovados e programa de auditoria.
-  in_scope:
-    - Aprovisionamento, alocação e armazenamento de refrigerantes
-    - Contabilidade de carga ao nível do ativo e reconciliação de balanço de massa
-    - Recuperação em campo, reclamação e controlo de qualidade de refrigerante reciclado
-    - Deteção de fugas, reparação e relatório de taxa regulatório
-    - Certificação de manuseamento por técnicos e acompanhamento de competências
-    - Roteiros de transição e eliminação gradual de refrigerante
-    - Destruição no fim de vida e eliminação certificada
-  out_of_scope:
-    - Aprovações de refrigerante ao nível do produto durante a certificação (BC-2030)
-    - Ciclo e seleção de refrigerante durante o projeto do equipamento (BC-2000)
-    - Conformidade ambiental geral não específica de refrigerantes (BC-740)
 metadata:
   status: draft
   translator: claude-ai

--- a/catalogue/i18n/pt/L1-regulatory-affairs-management.yaml
+++ b/catalogue/i18n/pt/L1-regulatory-affairs-management.yaml
@@ -1,0 +1,119 @@
+locale: pt
+source: L1-regulatory-affairs-management.yaml
+entries:
+  BC-1530:
+    name: Gestão de assuntos regulamentares
+    description: |
+      Submissões, aprovações e interações com reguladores ao longo do ciclo de vida.
+  BC-1530.10:
+    name: Gestão da estratégia regulamentar
+    description: |
+      Estratégia regulamentar e avaliação do risco regulamentar.
+  BC-1530.10.10:
+    name: Estratégia regulamentar global
+    description: |
+      Estratégia regulamentar multirregional e seleção de vias de aprovação.
+  BC-1530.10.20:
+    name: Avaliação do risco regulamentar
+    description: |
+      Avaliação dos riscos regulamentares e contingências.
+  BC-1530.10.30:
+    name: Gestão do perfil do produto-alvo
+    description: |
+      Definição e manutenção do perfil do produto-alvo.
+  BC-1530.20:
+    name: Gestão de submissões regulamentares
+    description: |
+      Preparação e submissão de INDs, NDAs, MAAs e BLAs.
+  BC-1530.20.10:
+    name: Planeamento de submissões
+    description: |
+      Planeamento e agendamento de conteúdos de submissões.
+  BC-1530.20.20:
+    name: Compilação de eCTD
+    description: |
+      Compilação de submissões eCTD.
+  BC-1530.20.30:
+    name: Redação e revisão de submissões
+    description: |
+      Redação e revisão de documentos de submissões regulamentares.
+  BC-1530.20.40:
+    name: Arquivo e acompanhamento de submissões
+    description: |
+      Arquivo e acompanhamento de submissões durante a revisão das agências.
+  BC-1530.30:
+    name: Gestão de inteligência regulamentar
+    description: |
+      Inteligência regulamentar e monitorização de orientações.
+  BC-1530.30.10:
+    name: Monitorização de orientações regulamentares
+    description: |
+      Monitorização de documentos de orientação e alterações regulamentares.
+  BC-1530.30.20:
+    name: Inteligência regulamentar competitiva
+    description: |
+      Inteligência sobre a atividade regulamentar de concorrentes.
+  BC-1530.30.30:
+    name: Repositório de conhecimento regulamentar
+    description: |
+      Manutenção do repositório de conhecimento regulamentar.
+  BC-1530.40:
+    name: Gestão da manutenção do ciclo de vida regulamentar
+    description: |
+      Variações, renovações e alterações pós-aprovação.
+  BC-1530.40.10:
+    name: Submissões de variação
+    description: |
+      Submissão de variações do Tipo IA, IB e II.
+  BC-1530.40.20:
+    name: Submissões de renovação
+    description: |
+      Submissões de renovação de autorização de introdução no mercado.
+  BC-1530.40.30:
+    name: Gestão de alterações pós-aprovação
+    description: |
+      Gestão de alterações CMC e de rotulagem pós-aprovação.
+  BC-1530.40.40:
+    name: Planeamento de submissões ao longo do ciclo de vida
+    description: |
+      Planeamento da atividade de submissão ao longo do ciclo de vida por produto.
+  BC-1530.50:
+    name: Gestão da interação com agências regulamentares
+    description: |
+      Reuniões com FDA/EMA/PMDA e aconselhamento científico.
+  BC-1530.50.10:
+    name: Pedidos de aconselhamento científico
+    description: |
+      Pedidos de aconselhamento científico junto de autoridades de saúde.
+  BC-1530.50.20:
+    name: Gestão de reuniões com autoridades de saúde
+    description: |
+      Preparação e condução de reuniões com agências.
+  BC-1530.50.30:
+    name: Resposta a pedidos de autoridades de saúde
+    description: |
+      Resposta a pedidos de informação de autoridades de saúde.
+  BC-1530.60:
+    name: Gestão de rotulagem
+    description: |
+      SmPC/USPI, folhetos informativos e alterações de rotulagem.
+  BC-1530.60.10:
+    name: Gestão da rotulagem-base
+    description: |
+      Gestão da ficha técnica e rotulagem-base.
+  BC-1530.60.20:
+    name: Adaptação local da rotulagem
+    description: |
+      Adaptação e tradução local de SmPC/USPI.
+  BC-1530.60.30:
+    name: Implementação de alterações de rotulagem
+    description: |
+      Implementação de alterações de rotulagem nos mercados.
+  BC-1530.60.40:
+    name: Gestão de artwork
+    description: |
+      Gestão de artwork de embalagem e proofreading.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-reinsurance-management.yaml
+++ b/catalogue/i18n/pt/L1-reinsurance-management.yaml
@@ -1,0 +1,125 @@
+locale: pt
+source: L1-reinsurance-management.yaml
+entries:
+  BC-2170:
+    name: Gestão de resseguro
+    description: |
+      Resseguro cedido e assumido — conceção de tratado, colocações facultativas,
+      bordereau, recuperações de sinistros, contabilidade e gestão
+      de exposição a contrapartes de resseguro.
+  BC-2170.10:
+    name: Conceção do programa de resseguro cedido
+    description: |
+      Análise das necessidades de resseguro, estruturação do programa e coordenação com o mediador de resseguro.
+  BC-2170.10.10:
+    name: Análise das necessidades de resseguro
+    description: |
+      Análise das necessidades de resseguro com base no portefólio, apetite de risco e restrições de capital.
+  BC-2170.10.20:
+    name: Estratégia de tratado e facultativo
+    description: |
+      Estratégia sobre cessões em tratado vs facultativo e estruturas proporcionais vs não proporcionais.
+  BC-2170.10.30:
+    name: Estruturação do programa
+    description: |
+      Estruturação de programas de resseguro, camadas e retenções.
+  BC-2170.10.40:
+    name: Coordenação com o mediador de resseguro
+    description: |
+      Coordenação com mediadores de resseguro em colocação e renovação.
+  BC-2170.20:
+    name: Administração de resseguro em tratado
+    description: |
+      Integração de tratado, cedência de prémio, produção de bordereau e recuperação de sinistros de tratado.
+  BC-2170.20.10:
+    name: Integração e renovação de tratado
+    description: |
+      Integração e renovação de tratados de resseguro e colocação de slip.
+  BC-2170.20.20:
+    name: Cálculo e cedência do prémio de tratado
+    description: |
+      Cálculo de prémios de tratado e cedência aos resseguradores participantes.
+  BC-2170.20.30:
+    name: Produção de bordereau de tratado
+    description: |
+      Produção de bordereaux de prémio e sinistros de tratado segundo a prática de mercado.
+  BC-2170.20.40:
+    name: Recuperação de sinistros de tratado
+    description: |
+      Recuperação de pagamentos de sinistros de tratado junto dos resseguradores.
+  BC-2170.30:
+    name: Administração de resseguro facultativo
+    description: |
+      Submissão facultativa, acompanhamento da colocação e liquidação de prémio e sinistros.
+  BC-2170.30.10:
+    name: Submissão de risco facultativo
+    description: |
+      Submissão de riscos individuais para colocação facultativa.
+  BC-2170.30.20:
+    name: Acompanhamento de colocação facultativa
+    description: |
+      Acompanhamento das assinaturas e quotas de colocação facultativa junto dos resseguradores.
+  BC-2170.30.30:
+    name: Liquidação de prémio e sinistros facultativos
+    description: |
+      Liquidação de prémio facultativo e recuperações de sinistros.
+  BC-2170.40:
+    name: Gestão de resseguro assumido
+    description: |
+      Subscrição de entrada, lançamento de prémio, adjudicação de sinistros e coordenação de retrocessão.
+  BC-2170.40.10:
+    name: Subscrição de submissões de entrada
+    description: |
+      Subscrição de submissões de resseguro de entrada e aceitação de risco.
+  BC-2170.40.20:
+    name: Lançamento de prémio de entrada
+    description: |
+      Lançamento de prémio de resseguro de entrada e ajustamentos.
+  BC-2170.40.30:
+    name: Adjudicação de sinistros de entrada
+    description: |
+      Adjudicação de sinistros de resseguro de entrada e recuperações.
+  BC-2170.40.40:
+    name: Coordenação de retrocessão
+    description: |
+      Coordenação de retrocessão para resseguradores de segundo nível.
+  BC-2170.50:
+    name: Contabilidade e liquidação de resseguro
+    description: |
+      Contabilidade de cedências, acompanhamento de recuperáveis, reconciliação de extratos e colateral de contraparte.
+  BC-2170.50.10:
+    name: Contabilidade de cedência e prémio
+    description: |
+      Contabilidade de prémio cedido, comissões e ajustamentos.
+  BC-2170.50.20:
+    name: Acompanhamento de recuperáveis de resseguro
+    description: |
+      Acompanhamento de recuperáveis de resseguro sobre sinistros pagos e pendentes.
+  BC-2170.50.30:
+    name: Reconciliação de extratos de ressegurador
+    description: |
+      Reconciliação de extratos de ressegurador e resolução de litígios.
+  BC-2170.50.40:
+    name: Gestão de colateral de contraparte
+    description: |
+      Gestão de cartas de crédito, fundos fiduciários e colateral de resseguradores.
+  BC-2170.60:
+    name: Gestão do risco de contraparte de resseguro
+    description: |
+      Avaliação de crédito de ressegurador, monitorização de limites de contraparte e mitigação de incumprimento.
+  BC-2170.60.10:
+    name: Avaliação de crédito do ressegurador
+    description: |
+      Avaliação de crédito e solidez financeira das contrapartes de resseguro.
+  BC-2170.60.20:
+    name: Monitorização de concentração e limites de contraparte
+    description: |
+      Monitorização de limites de concentração e exposição a contrapartes.
+  BC-2170.60.30:
+    name: Mitigação de incumprimento do ressegurador
+    description: |
+      Ações de mitigação em cenários de rebaixamento ou incumprimento do ressegurador.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-research-development-management.yaml
+++ b/catalogue/i18n/pt/L1-research-development-management.yaml
@@ -1,0 +1,107 @@
+locale: pt
+source: L1-research-development-management.yaml
+entries:
+  BC-810:
+    name: Gestão de investigação e desenvolvimento
+    description: |
+      Investigação, desenvolvimento aplicado e experimentação.
+  BC-810.10:
+    name: Gestão da investigação
+    description: |
+      Investigação fundamental e exploratória.
+  BC-810.10.10:
+    name: Definição do programa de investigação
+    description: |
+      Definição de programas e temas de investigação.
+  BC-810.10.20:
+    name: Revisão de literatura e patentes
+    description: |
+      Revisão sistemática de literatura científica e panoramas de patentes.
+  BC-810.10.30:
+    name: Execução de projetos de investigação
+    description: |
+      Execução de projetos de investigação com marcos e revisões.
+  BC-810.10.40:
+    name: Publicação de resultados de investigação
+    description: |
+      Publicação, conferências e disseminação de resultados de investigação.
+  BC-810.20:
+    name: Gestão do desenvolvimento aplicado
+    description: |
+      Desenvolvimento aplicado e desenvolvimento tecnológico.
+  BC-810.20.10:
+    name: Entrega de projetos de desenvolvimento aplicado
+    description: |
+      Entrega de projetos de desenvolvimento aplicado em marcos de TRL.
+  BC-810.20.20:
+    name: Maturação tecnológica
+    description: |
+      Maturação da prontidão tecnológica desde o conceito até à implementação.
+  BC-810.20.30:
+    name: Ferramentas e métodos de desenvolvimento
+    description: |
+      Ferramentas, métodos e toolchains de desenvolvimento padronizados.
+  BC-810.30:
+    name: Gestão de experimentação e prototipagem
+    description: |
+      Trabalho laboratorial, protótipos e provas de conceito.
+  BC-810.30.10:
+    name: Operações laboratoriais
+    description: |
+      Operação de laboratórios de investigação e desenvolvimento.
+  BC-810.30.20:
+    name: Construção de protótipos
+    description: |
+      Construção e montagem de protótipos físicos e digitais.
+  BC-810.30.30:
+    name: Execução de prova de conceito
+    description: |
+      Execução de prova de conceito e piloto orientada por hipóteses.
+  BC-810.30.40:
+    name: Teste e validação
+    description: |
+      Planos de teste, recolha de dados e validação face a critérios de aceitação.
+  BC-810.40:
+    name: Gestão do portefólio de I&D
+    description: |
+      Portefólio de projetos de I&D, financiamento e priorização.
+  BC-810.40.10:
+    name: Seleção de projetos de I&D
+    description: |
+      Seleção e priorização de projetos de I&D.
+  BC-810.40.20:
+    name: Alocação de recursos de I&D
+    description: |
+      Alocação de investigadores, laboratórios e capital entre projetos.
+  BC-810.40.30:
+    name: Monitorização do desempenho de I&D
+    description: |
+      Monitorização do desempenho do portefólio de I&D e decisões por fases.
+  BC-810.40.40:
+    name: Gestão de créditos fiscais e subsídios de I&D
+    description: |
+      Captura e substantiação de créditos fiscais e subsídios de I&D.
+  BC-810.50:
+    name: Gestão do roadmap tecnológico
+    description: |
+      Scouting tecnológico, roadmaps e estratégia tecnológica.
+  BC-810.50.10:
+    name: Scouting tecnológico
+    description: |
+      Scouting contínuo de tecnologias emergentes e disruptivas.
+  BC-810.50.20:
+    name: Desenvolvimento do roadmap tecnológico
+    description: |
+      Roadmaps plurianuais que ligam tecnologias a produtos e mercados.
+  BC-810.50.30:
+    name: Definição da estratégia tecnológica
+    description: |
+      Estratégia tecnológica e decisões de plataforma.
+  BC-810.50.40:
+    name: Decisões de make-or-buy tecnológico
+    description: |
+      Decisões de construir, parceria ou adquirir para tecnologia.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-research-scholarship-management.yaml
+++ b/catalogue/i18n/pt/L1-research-scholarship-management.yaml
@@ -1,0 +1,151 @@
+locale: pt
+source: L1-research-scholarship-management.yaml
+entries:
+  BC-4780:
+    name: Gestão de investigação e bolsas de estudo
+    description: |
+      Gestão da missão de investigação do ensino superior, cobrindo estratégia de
+      carteira, ciclo de vida de bolsas, supervisão de ética e integridade, produção
+      científica, colaboração em investigação e avaliação do impacto.
+  BC-4780.10:
+    name: Carteira e estratégia de investigação
+    description: |
+      Definição estratégica da carteira de investigação da instituição por temas,
+      centros e investimentos em capacidades.
+    in_scope:
+      - Estratégia de temas e centros de investigação
+      - Planeamento de investimentos em capacidades de investigação
+      - Reporte do desempenho em investigação
+    out_of_scope:
+      - Gestão genérica de carteira de projetos (abrangida em Gestão de Carteira de Projetos transversal)
+  BC-4780.10.10:
+    name: Estratégia de temas e centros de investigação
+    description: |
+      Estratégia para temas, centros e institutos de investigação.
+  BC-4780.10.20:
+    name: Planeamento de investimentos em capacidades de investigação
+    description: |
+      Planeamento de investimentos em capacidades de investigação, incluindo infraestrutura e pessoal.
+  BC-4780.10.30:
+    name: Reporte do desempenho em investigação
+    description: |
+      Reporte interno e externo do desempenho em investigação.
+  BC-4780.20:
+    name: Gestão de bolsas de investigação
+    description: |
+      Gestão de ponta a ponta de bolsas e contratos de investigação, desde a
+      identificação de oportunidades até à administração pós-atribuição.
+    in_scope:
+      - Identificação de oportunidades de bolsa
+      - Desenvolvimento de candidatura pré-atribuição
+      - Administração de bolsa pós-atribuição
+    out_of_scope:
+      - Gestão financeira genérica (abrangida em Gestão Financeira transversal)
+  BC-4780.20.10:
+    name: Identificação de oportunidades de bolsa
+    description: |
+      Identificação de oportunidades de bolsa e financiamento para investigadores.
+  BC-4780.20.20:
+    name: Desenvolvimento de candidatura pré-atribuição
+    description: |
+      Desenvolvimento de candidaturas a bolsas, orçamentação e pacotes de submissão.
+  BC-4780.20.30:
+    name: Administração de bolsa pós-atribuição
+    description: |
+      Administração pós-atribuição de bolsas obtidas, incluindo reporte e conformidade.
+  BC-4780.30:
+    name: Supervisão de ética e integridade em investigação
+    description: |
+      Supervisão independente da ética e integridade em investigação, incluindo revisão
+      de investigação em humanos e animais e investigação de má conduta.
+    in_scope:
+      - Revisão de investigação com sujeitos humanos (IRB/REC)
+      - Supervisão de investigação animal (IACUC/AWERB)
+      - Investigação de má conduta em investigação
+    out_of_scope:
+      - Casos de má conduta académica (de avaliação) (abrangidos em Gestão de Avaliação e Exames)
+  BC-4780.30.10:
+    name: Revisão de investigação com sujeitos humanos
+    description: |
+      Revisão independente de investigação envolvendo sujeitos humanos.
+  BC-4780.30.20:
+    name: Supervisão de investigação animal
+    description: |
+      Supervisão de investigação envolvendo sujeitos animais.
+  BC-4780.30.30:
+    name: Investigação de má conduta em investigação
+    description: |
+      Investigação de alegações de má conduta em investigação.
+  BC-4780.40:
+    name: Gestão de produção científica e publicações
+    description: |
+      Monitorização e gestão da produção científica, incluindo publicações,
+      acesso aberto e identificadores persistentes.
+    in_scope:
+      - Monitorização de publicações
+      - Gestão de acesso aberto e repositório
+      - Gestão de identificadores persistentes (ORCID, DOI)
+    out_of_scope:
+      - Comercialização de propriedade intelectual (abrangida em Gestão de Propriedade Intelectual transversal)
+  BC-4780.40.10:
+    name: Monitorização de publicações
+    description: |
+      Monitorização de publicações e produções de investigadores.
+  BC-4780.40.20:
+    name: Gestão de acesso aberto e repositório
+    description: |
+      Gestão de publicação em acesso aberto e repositórios institucionais.
+  BC-4780.40.30:
+    name: Gestão de identificadores persistentes
+    description: |
+      Gestão de identificadores persistentes de investigadores e produções.
+  BC-4780.50:
+    name: Gestão de colaboração e parcerias em investigação
+    description: |
+      Estabelecimento e operação de parcerias de investigação na academia,
+      indústria e colaboradores internacionais.
+    in_scope:
+      - Acordos de investigação inter-institucionais
+      - Parcerias de investigação com a indústria
+      - Colaboração internacional em investigação
+    out_of_scope:
+      - Relações comerciais com fornecedores (abrangidas em Gestão de Fornecedores transversal)
+  BC-4780.50.10:
+    name: Gestão de acordos de investigação inter-institucionais
+    description: |
+      Gestão de acordos de investigação com instituições pares.
+  BC-4780.50.20:
+    name: Gestão de parcerias de investigação com a indústria
+    description: |
+      Gestão de parcerias de investigação com a indústria e investigação patrocinada.
+  BC-4780.50.30:
+    name: Colaboração internacional em investigação
+    description: |
+      Estabelecimento e operação de colaborações internacionais em investigação.
+  BC-4780.60:
+    name: Avaliação e impacto da investigação
+    description: |
+      Avaliação do impacto da investigação através de estudos de caso, bibliometria e
+      participação em exercícios nacionais de avaliação da investigação.
+    in_scope:
+      - Estudos de caso de impacto da investigação
+      - Análise bibliométrica e altmétrica
+      - Submissão para avaliação nacional da investigação (p. ex. REF)
+    out_of_scope:
+      - Revisões de acreditação académica (abrangidas em Gestão de Qualidade Académica e Acreditação)
+  BC-4780.60.10:
+    name: Estudos de caso de impacto da investigação
+    description: |
+      Desenvolvimento de estudos de caso de impacto da investigação.
+  BC-4780.60.20:
+    name: Análise bibliométrica e altmétrica
+    description: |
+      Análise bibliométrica e altmétrica da produção e alcance da investigação.
+  BC-4780.60.30:
+    name: Submissão para avaliação nacional da investigação
+    description: |
+      Submissão para exercícios nacionais de avaliação da investigação.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-reservation-booking-management.yaml
+++ b/catalogue/i18n/pt/L1-reservation-booking-management.yaml
@@ -1,0 +1,190 @@
+locale: pt
+source: L1-reservation-booking-management.yaml
+entries:
+  BC-4020:
+    name: Gestão de reservas e reserva
+    description: |
+      Ciclo de vida da reserva, PNR e ficha de hotel — captura, alteração,
+      cancelamento, blocos de grupo, confirmações, pagamentos e nova reserva
+      por perturbação — independentemente do canal que originou a reserva.
+  BC-4020.10:
+    name: Captura de reserva
+    description: |
+      Captura de reservas em itinerários de viagem simples e complexos
+      provenientes de qualquer canal ou agente originador.
+  BC-4020.10.10:
+    name: Captura de reserva de itinerário único
+    description: |
+      Captura de reservas de itinerário único, como uma estadia numa
+      única propriedade ou reserva de um único voo.
+  BC-4020.10.20:
+    name: Captura de reserva multi-passageiro
+    description: |
+      Captura de reservas com múltiplos passageiros ou hóspedes que
+      partilham segmentos de itinerário comuns.
+  BC-4020.10.30:
+    name: Captura de reserva multi-componente
+    description: |
+      Captura de reservas multi-componente que combinam voos, hotéis,
+      serviços adicionais e serviços terrestres.
+  BC-4020.10.40:
+    name: Captura de reserva de agente de viagens
+    description: |
+      Captura de reservas feitas por agentes de viagens a retalho e
+      corporativos em nome de viajantes.
+  BC-4020.20:
+    name: Alteração e cancelamento de reserva
+    description: |
+      Alteração e cancelamento voluntários de reservas, incluindo taxas
+      de alteração, elegibilidade de reembolso e operações de reemissão.
+  BC-4020.20.10:
+    name: Gestão de alteração de reserva
+    description: |
+      Gestão de alterações voluntárias de reserva que abrangem datas,
+      produtos e dados do viajante.
+  BC-4020.20.20:
+    name: Gestão de cancelamento de reserva
+    description: |
+      Gestão de cancelamentos voluntários e libertação de inventário
+      de volta ao pool.
+  BC-4020.20.30:
+    name: Elegibilidade e cálculo de reembolso
+    description: |
+      Determinação da elegibilidade de reembolso e cálculo dos montantes
+      reembolsáveis, incluindo penalidades.
+  BC-4020.20.40:
+    name: Operações de reemissão voluntária
+    description: |
+      Operação de reemissão voluntária, incluindo cobrança de diferença
+      de tarifa e reemissão de documento.
+  BC-4020.30:
+    name: Gestão de blocos de grupo
+    description: |
+      Gestão de blocos de grupo contra inventário contratado — criação
+      de bloco, listas de quartos, data de corte e rastreio de ocupação.
+  BC-4020.30.10:
+    name: Criação de bloco de grupo
+    description: |
+      Criação de blocos de grupo que refletem compromissos de inventário
+      e tarifa contratados.
+  BC-4020.30.20:
+    name: Gestão de lista de quartos
+    description: |
+      Gestão de listas de quartos que associam viajantes individuais
+      a inventário de bloco.
+  BC-4020.30.30:
+    name: Gestão de data de corte de grupo
+    description: |
+      Gestão de datas de corte de grupo e libertação do inventário de
+      bloco não utilizado de volta à venda geral.
+  BC-4020.30.40:
+    name: Rastreio de ocupação de grupo
+    description: |
+      Rastreio da ocupação de grupo contra o contrato para reconhecimento
+      de receita e previsão.
+  BC-4020.40:
+    name: Confirmação e documentação de reserva
+    description: |
+      Emissão de confirmações de reserva, vouchers, bilhetes eletrónicos
+      e documentos de itinerário para viajantes e agentes.
+  BC-4020.40.10:
+    name: Geração de confirmação de reserva
+    description: |
+      Geração e envio de confirmações de reserva através de canais
+      de notificação.
+  BC-4020.40.20:
+    name: Emissão de vouchers e documentos
+    description: |
+      Emissão de vouchers e documentos de serviço para componentes
+      de hotel, excursão e atividade.
+  BC-4020.40.30:
+    name: Emissão e reemissão de bilhetes eletrónicos
+    description: |
+      Emissão e reemissão de bilhetes eletrónicos de companhia aérea,
+      incluindo atualizações do estado de cupão.
+  BC-4020.40.40:
+    name: Distribuição de itinerário de reserva
+    description: |
+      Distribuição de documentos de itinerário a viajantes, agentes de
+      viagens e sistemas integrados de gestão de viajantes.
+  BC-4020.50:
+    name: Gestão de reservas provisórias e lista de espera
+    description: |
+      Gestão de reservas provisórias, listas de espera e conversões quando
+      a disponibilidade em tempo real é limitada ou os termos exigem tempo
+      para pagamento.
+  BC-4020.50.10:
+    name: Gestão de reserva provisória
+    description: |
+      Gestão de reservas provisórias com janelas de tempo para pagamento
+      controladas.
+  BC-4020.50.20:
+    name: Captura e priorização de lista de espera
+    description: |
+      Captura de pedidos de lista de espera e regras de priorização
+      para quando o inventário fique disponível.
+  BC-4020.50.30:
+    name: Operações de conversão de lista de espera
+    description: |
+      Operações para converter pedidos de lista de espera em reservas
+      confirmadas à medida que o inventário liberta.
+  BC-4020.50.40:
+    name: Gestão de expiração de reserva provisória
+    description: |
+      Gestão de expirações de reservas provisórias e libertação automática
+      de inventário em espera.
+  BC-4020.60:
+    name: Pagamento e liquidação de reserva
+    description: |
+      Pagamento ao nível de reserva, depósito, captura de encargo e
+      liquidação com parceiros, incluindo BSP e ARC.
+  BC-4020.60.10:
+    name: Depósito e pré-autorização de reserva
+    description: |
+      Captura de depósitos de reserva e pré-autorizações de cartão
+      contra políticas de depósito e garantia.
+  BC-4020.60.20:
+    name: Captura de encargo de reserva
+    description: |
+      Captura de encargos contra instrumentos de pagamento ao nível
+      de reserva nos pontos de elegibilidade.
+  BC-4020.60.30:
+    name: Operações de liquidação BSP e ARC
+    description: |
+      Operações para liquidar reservas emitidas por agentes através
+      do BSP, ARC e planos de liquidação equivalentes.
+  BC-4020.60.40:
+    name: Cálculo e pagamento de comissões
+    description: |
+      Cálculo e pagamento de comissões a agentes de viagens e parceiros
+      de distribuição.
+  BC-4020.70:
+    name: Perturbações e operações de nova reserva
+    description: |
+      Realocação de reservas afetadas por alterações de horário,
+      cancelamentos e perturbações em massa, incluindo comunicações e
+      elegibilidade de compensação.
+  BC-4020.70.10:
+    name: Realocação por alteração de horário
+    description: |
+      Realocação de reservas afetadas por alterações de horário publicadas,
+      incluindo opções oferecidas aos viajantes.
+  BC-4020.70.20:
+    name: Realocação em perturbação em massa
+    description: |
+      Realocação de grandes números de reservas durante eventos de mau
+      tempo, IROPS ou força maior.
+  BC-4020.70.30:
+    name: Determinação de elegibilidade de compensação
+    description: |
+      Determinação da elegibilidade de compensação ao abrigo da política
+      da transportadora e das regras de direitos dos passageiros aplicáveis.
+  BC-4020.70.40:
+    name: Comunicações de realocação
+    description: |
+      Comunicações de saída para viajantes e agentes afetados ao longo
+      de eventos de realocação.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-retail-loss-prevention-management.yaml
+++ b/catalogue/i18n/pt/L1-retail-loss-prevention-management.yaml
@@ -1,0 +1,114 @@
+locale: pt
+source: L1-retail-loss-prevention-management.yaml
+entries:
+  BC-2340:
+    name: Gestão de prevenção de perdas no retalho
+    description: |
+      Prevenção, deteção, investigação e redução de perdas de stock e fraude
+      em toda a rede de retalho — desde furto em loja e crime organizado de
+      retalho a furto interno e abuso no ponto de venda.
+  BC-2340.10:
+    name: Gestão de análise de quebra
+    description: |
+      Medição, análise de causa-raiz e reporte de quebra de stock em lojas,
+      canais e categorias.
+    in_scope:
+      - Medição de perda de stock face ao inventário contabilístico
+      - Reporte de quebra por loja, categoria e causa
+      - Análise de causa-raiz de perda desconhecida
+  BC-2340.10.10:
+    name: Medição de quebra
+    description: |
+      Medição de quebra face ao inventário contabilístico e às contagens físicas.
+  BC-2340.10.20:
+    name: Análise de causa-raiz de quebra
+    description: |
+      Análise de causa-raiz de quebra em perdas conhecidas e desconhecidas.
+  BC-2340.10.30:
+    name: Reporte e objetivos de quebra
+    description: |
+      Reporte de quebra e definição de objetivos de redução por loja e categoria.
+  BC-2340.20:
+    name: Gestão de investigação de furto interno
+    description: |
+      Deteção, investigação e resolução de desonestidade de colaboradores,
+      incluindo ações disciplinares e de recuperação.
+  BC-2340.20.10:
+    name: Deteção de desonestidade de colaboradores
+    description: |
+      Deteção de desonestidade de colaboradores através de linhas de denúncia,
+      análise e auditorias.
+  BC-2340.20.20:
+    name: Instrução de processos de investigação interna
+    description: |
+      Instrução de processos de investigação interna, incluindo gestão de provas.
+  BC-2340.20.30:
+    name: Coordenação de recuperação e ação disciplinar
+    description: |
+      Coordenação de recuperação, ação disciplinar e seguimento de RH.
+  BC-2340.30:
+    name: Gestão de furto externo e crime organizado de retalho
+    description: |
+      Prevenção e investigação de furto em loja e crime organizado de retalho,
+      incluindo ligação com as forças de segurança e associações do setor.
+  BC-2340.30.10:
+    name: Prevenção de furto em loja
+    description: |
+      Prevenção do furto em loja através de dissuasão, layout e intervenção.
+  BC-2340.30.20:
+    name: Investigação de crime organizado de retalho
+    description: |
+      Investigação de redes e padrões de crime organizado de retalho.
+  BC-2340.30.30:
+    name: Ligação com as forças de segurança
+    description: |
+      Ligação com a polícia e fóruns do setor em casos de crime de retalho.
+  BC-2340.40:
+    name: Gestão de prevenção de fraude no ponto de venda
+    description: |
+      Deteção e prevenção de fraude no ponto de venda, incluindo fraude em
+      devoluções, sweethearting e reporte baseado em exceções.
+    in_scope:
+      - Deteção de fraude em devoluções e trocas
+      - Deteção de sweethearting e abuso de descontos
+      - Reporte baseado em exceções do ponto de venda
+  BC-2340.40.10:
+    name: Deteção de fraude em devoluções e trocas
+    description: |
+      Deteção de padrões de fraude em devoluções e trocas.
+  BC-2340.40.20:
+    name: Deteção de sweethearting e abuso de descontos
+    description: |
+      Deteção de sweethearting e aplicação não autorizada de descontos.
+  BC-2340.40.30:
+    name: Reporte baseado em exceções do ponto de venda
+    description: |
+      Reporte baseado em exceções de transações no ponto de venda para identificar
+      anomalias.
+  BC-2340.50:
+    name: Gestão de segurança física e vigilância
+    description: |
+      Segurança física ao nível da loja, incluindo CCTV, EAS, controlos de acesso
+      e serviços de vigilância.
+  BC-2340.50.10:
+    name: Operações de CCTV em loja
+    description: |
+      Operação, monitorização e gestão de evidências do CCTV em loja.
+  BC-2340.50.20:
+    name: Operações de vigilância eletrónica de artigos
+    description: |
+      Operação de portais e etiquetagem EAS, incluindo resposta a alarmes.
+  BC-2340.50.30:
+    name: Controlo de acesso à loja
+    description: |
+      Controlo de acesso físico a armazéns, gabinetes de caixa e zona de
+      retaguarda.
+  BC-2340.50.40:
+    name: Gestão de serviço de vigilância
+    description: |
+      Implementação e gestão de serviços de vigilância próprios e contratados
+      em loja.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-retail-site-network-planning-management.yaml
+++ b/catalogue/i18n/pt/L1-retail-site-network-planning-management.yaml
@@ -1,0 +1,122 @@
+locale: pt
+source: L1-retail-site-network-planning-management.yaml
+entries:
+  BC-2350:
+    name: Gestão de planeamento de rede e localização de retalho
+    description: |
+      Seleção, dimensionamento e ciclo de vida da rede de retalho físico —
+      análise de área de influência, escolha de formato, identificação de espaço
+      em branco e decisões de ciclo de vida por loja.
+  BC-2350.10:
+    name: Análise de área comercial e área de influência
+    description: |
+      Definição de área de influência, microanálise de fluxo e demografia, e
+      avaliação da densidade competitiva para localizações prospetivas e
+      existentes.
+  BC-2350.10.10:
+    name: Definição de área de influência
+    description: |
+      Definição de áreas de influência utilizando tempo de condução, densidade e
+      barreiras.
+  BC-2350.10.20:
+    name: Microanálise demográfica
+    description: |
+      Análise demográfica e de estilo de vida ao nível micro das áreas de
+      influência.
+  BC-2350.10.30:
+    name: Análise de fluxo e mobilidade
+    description: |
+      Análise de padrões de fluxo, dados de mobilidade e fluxo de peões.
+  BC-2350.10.40:
+    name: Análise de densidade competitiva
+    description: |
+      Análise da densidade de concorrentes e quota de área comercial.
+  BC-2350.20:
+    name: Gestão de seleção de formato de loja
+    description: |
+      Seleção do formato de loja adequado — hiper, super, conveniência, especializado,
+      dark store — para uma determinada área de influência e estratégia.
+    in_scope:
+      - Escolha de formato por área de influência e missão do comprador
+      - Portefólio de mix de formatos na rede
+      - Dimensionamento e espaço por formato
+    out_of_scope:
+      - Conceção detalhada do interior da loja (BC-2310.60)
+  BC-2350.20.10:
+    name: Escolha de formato por área de influência
+    description: |
+      Seleção do formato de loja por área de influência com base na missão do
+      comprador.
+  BC-2350.20.20:
+    name: Dimensionamento e espaço do formato
+    description: |
+      Dimensionamento do espaço de vendas, zona de retaguarda e espaço total por
+      formato.
+  BC-2350.20.30:
+    name: Planeamento do portefólio de mix de formatos
+    description: |
+      Planeamento do mix de formatos da rede e migração entre formatos.
+  BC-2350.30:
+    name: Otimização da presença da rede
+    description: |
+      Otimização da presença da rede através da identificação de espaço em branco,
+      canibalização e cobertura global.
+  BC-2350.30.10:
+    name: Identificação de espaço em branco
+    description: |
+      Identificação de áreas comerciais subservidas e oportunidades de espaço em
+      branco.
+  BC-2350.30.20:
+    name: Modelação de canibalização
+    description: |
+      Modelação do impacto de canibalização de novas lojas nas lojas existentes.
+  BC-2350.30.30:
+    name: Otimização de cobertura e alcance
+    description: |
+      Otimização de cobertura e alcance no mercado-alvo.
+  BC-2350.40:
+    name: Gestão do ciclo de vida do desempenho da loja
+    description: |
+      Decisões de ciclo de vida de cada loja — relocalização, renovação,
+      redução de formato ou encerramento, com base no desempenho e em alterações
+      da área comercial.
+  BC-2350.40.10:
+    name: Diagnóstico de desempenho da loja
+    description: |
+      Diagnóstico de lojas com desempenho abaixo do esperado, incluindo alterações
+      na área de influência.
+  BC-2350.40.20:
+    name: Decisões de relocalização e renovação de loja
+    description: |
+      Decisões sobre relocalização ou renovação de lojas face a alternativas.
+  BC-2350.40.30:
+    name: Decisão de encerramento de loja
+    description: |
+      Decisão de encerramento de loja, incluindo impacto para partes interessadas
+      e stock.
+  BC-2350.50:
+    name: Gestão de briefing imobiliário de retalho
+    description: |
+      Briefings imobiliários específicos de retalho entregues às equipas de
+      imóveis corporativos para aquisição de localização, negociação de
+      arrendamento e saídas.
+    in_scope:
+      - Briefings de localização específicos de retalho
+      - Entrega à equipa de aquisição imobiliária corporativa (BC-710.20)
+      - Briefings de saída específicos de retalho (ex. restrições comerciais)
+    out_of_scope:
+      - Negociação e administração de arrendamento (BC-710.20, BC-710.30)
+  BC-2350.50.10:
+    name: Elaboração de briefing de localização de retalho
+    description: |
+      Elaboração de briefings de localização específicos de retalho, incluindo
+      requisitos de formato e adjacência.
+  BC-2350.50.20:
+    name: Elaboração de briefing de saída de retalho
+    description: |
+      Elaboração de briefings de saída específicos de retalho, incluindo posição
+      face a restrições comerciais.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-retail-store-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-retail-store-operations-management.yaml
@@ -1,0 +1,138 @@
+locale: pt
+source: L1-retail-store-operations-management.yaml
+entries:
+  BC-2310:
+    name: Gestão de operações de loja de retalho
+    description: |
+      Operação quotidiana de lojas de retalho físicas — rotinas de abertura e fecho,
+      execução na loja, força de trabalho ao nível da loja, auditorias, cuidado
+      com mobiliário e entrega consistente da experiência do formato de loja.
+  BC-2310.10:
+    name: Operações de abertura e fecho de loja
+    description: |
+      Rotinas diárias de abertura e fecho de loja, incluindo preparação da gaveta de
+      caixa, reconciliação de fim de dia e entrega de turno.
+  BC-2310.10.10:
+    name: Execução da rotina de abertura de loja
+    description: |
+      Execução dos procedimentos de abertura de loja, incluindo verificações de
+      prontidão.
+  BC-2310.10.20:
+    name: Execução da rotina de fecho de loja
+    description: |
+      Rotinas de fecho de fim de dia, incluindo reconciliação e segurança das
+      instalações.
+  BC-2310.10.30:
+    name: Gestão de entrega de turno
+    description: |
+      Entrega de turno entre equipas com passagem de tarefas e incidentes.
+  BC-2310.20:
+    name: Gestão de execução na loja
+    description: |
+      Execução de tarefas de merchandising, promoção, sinalética e reposição ao nível
+      da loja, de modo a que a loja reflita o plano da sede.
+    in_scope:
+      - Gestão de tarefas para colaboradores de loja
+      - Execução de planograma e sinalética
+      - Reposição na loja a partir do stock da zona de retaguarda
+    out_of_scope:
+      - Conceção de planograma (BC-2300.30.10)
+  BC-2310.20.10:
+    name: Gestão de tarefas de loja
+    description: |
+      Distribuição e acompanhamento de tarefas operacionais às equipas de loja.
+  BC-2310.20.20:
+    name: Execução de planograma e sinalética
+    description: |
+      Execução na loja de planogramas, sinalética e montagem promocional.
+  BC-2310.20.30:
+    name: Reposição na loja
+    description: |
+      Reposição de prateleiras a partir do stock da zona de retaguarda e do armazém.
+  BC-2310.20.40:
+    name: Operações de armazém e zona de retaguarda
+    description: |
+      Receção, organização e gestão do inventário do armazém e da zona de retaguarda.
+  BC-2310.30:
+    name: Gestão da força de trabalho da loja
+    description: |
+      Planeamento de horários de trabalho ao nível da loja, planeamento de efetivo
+      por hora e gestão do desempenho dos colaboradores.
+    in_scope:
+      - Previsões de mão-de-obra horária baseadas em tráfego e vendas
+      - Agendamento de turnos e controlo de assiduidade
+      - Desempenho e formação de colaboradores ao nível da loja
+    out_of_scope:
+      - Gestão de capital humano empresarial (BC-300)
+  BC-2310.30.10:
+    name: Previsão da procura de mão-de-obra
+    description: |
+      Previsão da procura de mão-de-obra horária por loja e departamento.
+  BC-2310.30.20:
+    name: Agendamento de turnos de loja
+    description: |
+      Agendamento de turnos de loja respeitando a equidade e as regras laborais.
+  BC-2310.30.30:
+    name: Gestão de assiduidade e pontualidade
+    description: |
+      Registo de entradas, saídas e gestão de exceções.
+  BC-2310.30.40:
+    name: Formação e desempenho de colaboradores
+    description: |
+      Formação, reconhecimento e gestão do desempenho de colaboradores de loja.
+  BC-2310.40:
+    name: Gestão de auditoria e conformidade de loja
+    description: |
+      Auditorias operacionais, visitas de conformidade, cliente mistério e
+      conformidade da loja com as normas de marca e operacionais.
+  BC-2310.40.10:
+    name: Programa de auditoria operacional
+    description: |
+      Programa de auditorias operacionais e visitas de verificação face às normas
+      da loja.
+  BC-2310.40.20:
+    name: Programa de cliente mistério
+    description: |
+      Programa de cliente mistério para avaliar a experiência do cliente.
+  BC-2310.40.30:
+    name: Conformidade com as normas de loja
+    description: |
+      Conformidade com as normas de marca, segurança e operacionais por loja.
+  BC-2310.50:
+    name: Gestão de conservação de ativos da loja
+    description: |
+      Conservação ao nível da loja de mobiliário, equipamentos, refrigeração e
+      higiene para manter a loja em condições de venda.
+  BC-2310.50.10:
+    name: Manutenção de mobiliário e equipamento
+    description: |
+      Manutenção do mobiliário, expositores e equipamentos da loja.
+  BC-2310.50.20:
+    name: Gestão do funcionamento da refrigeração
+    description: |
+      Monitorização e gestão do funcionamento da refrigeração em lojas alimentares.
+  BC-2310.50.30:
+    name: Higiene e limpeza da loja
+    description: |
+      Rotinas de limpeza, higiene e housekeeping do espaço de venda.
+  BC-2310.60:
+    name: Gestão do formato e experiência de loja
+    description: |
+      Definição e salvaguarda das normas de experiência do formato de loja,
+      incluindo o modelo de serviço, a aparência e a jornada do cliente.
+  BC-2310.60.10:
+    name: Normas de formato de loja
+    description: |
+      Normas para cada formato de loja relativas a disposição, serviço e ambiente.
+  BC-2310.60.20:
+    name: Conceção da experiência do cliente na loja
+    description: |
+      Conceção da jornada do cliente na loja e das interações de serviço.
+  BC-2310.60.30:
+    name: Planeamento de renovação do conceito de loja
+    description: |
+      Planeamento de renovações do conceito de loja e implementações piloto.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-route-charges-management.yaml
+++ b/catalogue/i18n/pt/L1-route-charges-management.yaml
@@ -1,0 +1,91 @@
+locale: pt
+source: L1-route-charges-management.yaml
+entries:
+  BC-1270:
+    name: Gestão das tarifas de rota
+    description: |
+      Cálculo, faturação e cobrança de taxas de navegação aérea aos utilizadores do espaço aéreo.
+  BC-1270.10:
+    name: Gestão de zonas de tarifação
+    description: |
+      Definições de zonas de tarifação, regras de faturação e definição de taxas unitárias.
+  BC-1270.10.10:
+    name: Definição de zonas de tarifação
+    description: |
+      Definição de zonas de tarifação de rota e terminais.
+  BC-1270.10.20:
+    name: Cálculo da taxa unitária
+    description: |
+      Cálculo e aprovação de taxas unitárias por zona de tarifação.
+  BC-1270.10.30:
+    name: Gestão das regras de tarifação
+    description: |
+      Manutenção da fórmula de tarifação e regras de isenção.
+  BC-1270.20:
+    name: Gestão do cálculo de tarifas de rota
+    description: |
+      Cálculo de tarifas de rota por voo.
+  BC-1270.20.10:
+    name: Captura de dados de voo para tarifação
+    description: |
+      Captura de dados de voo como inputs para o motor de tarifação.
+  BC-1270.20.20:
+    name: Cálculo de distância e peso
+    description: |
+      Cálculo da distância e fatores de peso tarifáveis.
+  BC-1270.20.30:
+    name: Cálculo de tarifas
+    description: |
+      Aplicação da taxa unitária para derivar as tarifas de rota por voo.
+  BC-1270.30:
+    name: Gestão da cobrança de tarifas
+    description: |
+      Faturação, cobrança, processamento de pagamentos e cobrança coerciva.
+  BC-1270.30.10:
+    name: Faturação de tarifas
+    description: |
+      Geração de faturas mensais de tarifas de rota.
+  BC-1270.30.20:
+    name: Processamento de pagamentos
+    description: |
+      Receção e processamento de pagamentos dos utilizadores do espaço aéreo.
+  BC-1270.30.30:
+    name: Cobrança coerciva
+    description: |
+      Cobrança coerciva e aplicação de medidas sobre tarifas em atraso.
+  BC-1270.40:
+    name: Gestão de contas de companhias aéreas
+    description: |
+      Contas de utilizadores do espaço aéreo, extratos e tratamento de litígios.
+  BC-1270.40.10:
+    name: Manutenção de contas de utilizadores do espaço aéreo
+    description: |
+      Manutenção dos dados mestre da conta do utilizador do espaço aéreo.
+  BC-1270.40.20:
+    name: Prestação de extratos e relatórios
+    description: |
+      Prestação de extratos e relatórios de conta aos utilizadores.
+  BC-1270.40.30:
+    name: Tratamento de litígios de tarifas
+    description: |
+      Tratamento de litígios e reclamações de ajustamento.
+  BC-1270.50:
+    name: Gestão de relatórios e reconciliação de tarifas
+    description: |
+      Relatórios a reguladores e reconciliações ao estilo Eurocontrol.
+  BC-1270.50.10:
+    name: Relatório ao regulador e gestor de rede
+    description: |
+      Relatório a reguladores e gestores de rede equivalentes ao Eurocontrol.
+  BC-1270.50.20:
+    name: Reconciliação de tarifas
+    description: |
+      Reconciliação entre dados de voo e cálculos de tarifas.
+  BC-1270.50.30:
+    name: Monitorização da recuperação de custos
+    description: |
+      Monitorização da recuperação de custos face à base de custos aprovada.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-saas-platform-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-saas-platform-operations-management.yaml
@@ -1,0 +1,141 @@
+locale: pt
+source: L1-saas-platform-operations-management.yaml
+entries:
+  BC-4220:
+    name: Gestão de operações da plataforma SaaS
+    description: |
+      Fiabilidade do serviço, observabilidade, resposta a incidentes, capacidade,
+      desempenho e operações de recuperação de desastres do serviço SaaS
+      multi-tenant.
+  BC-4220.10:
+    name: Engenharia de fiabilidade de serviço
+    description: |
+      Definição e gestão de indicadores de nível de serviço, objetivos e
+      orçamentos de erro para o serviço SaaS.
+    in_scope:
+      - Disciplina de SLI / SLO / orçamento de erro para o produto em execução
+    out_of_scope:
+      - Compromissos de SLA orientados ao cliente (abrangidos pela Gestão de Confiança e Conformidade de Serviço SaaS)
+      - Níveis de serviço de TI internos (abrangidos pela Gestão de Tecnologia de Informação)
+  BC-4220.10.10:
+    name: Definição de indicadores de nível de serviço
+    description: |
+      Definição de indicadores de nível de serviço que medem a experiência
+      do cliente em serviços em execução.
+  BC-4220.10.20:
+    name: Gestão de objetivos de nível de serviço
+    description: |
+      Definição, revisão e revisão de objetivos de nível de serviço
+      em todos os serviços.
+  BC-4220.10.30:
+    name: Gestão de orçamentos de erro
+    description: |
+      Gestão de orçamentos de erro e da política que governa o seu consumo.
+  BC-4220.20:
+    name: Gestão de observabilidade
+    description: |
+      Registos, métricas, rastreios e monitorização sintética que tornam o
+      serviço em execução compreensível em produção.
+  BC-4220.20.10:
+    name: Gestão de registo de aplicações
+    description: |
+      Gestão das convenções de registo de aplicações, pipelines e retenção.
+  BC-4220.20.20:
+    name: Gestão de pipeline de métricas
+    description: |
+      Operação de pipelines de ingestão, armazenamento e consulta de métricas.
+  BC-4220.20.30:
+    name: Rastreio distribuído
+    description: |
+      Rastreio distribuído de ponta a ponta entre serviços para investigação
+      em produção.
+  BC-4220.20.40:
+    name: Monitorização sintética
+    description: |
+      Sondas sintéticas que exercitam percursos críticos do utilizador a
+      partir do exterior do serviço.
+  BC-4220.30:
+    name: Gestão de resposta a incidentes
+    description: |
+      Resposta de plantão, deteção de incidentes, coordenação e comunicação
+      com clientes durante incidentes em produção.
+  BC-4220.30.10:
+    name: Gestão de rotação de plantão
+    description: |
+      Definição e operação de rotações de plantão em todas as equipas
+      de produto.
+  BC-4220.30.20:
+    name: Deteção de incidentes
+    description: |
+      Deteção de incidentes em produção a partir de telemetria e sinais
+      externos.
+  BC-4220.30.30:
+    name: Coordenação de incidentes
+    description: |
+      Coordenação da resposta a incidentes, incluindo papéis, comunicações
+      e decisões durante o incidente.
+  BC-4220.30.40:
+    name: Comunicação de incidentes a clientes
+    description: |
+      Comunicação aos clientes afetados durante e após os incidentes.
+  BC-4220.40:
+    name: Análise pós-incidente e melhoria de fiabilidade
+    description: |
+      Elaboração de análises pós-incidente e acompanhamento de itens de ação
+      de fiabilidade para que as lições se acumulem ao longo do tempo.
+  BC-4220.40.10:
+    name: Elaboração de análise pós-incidente
+    description: |
+      Elaboração sem atribuição de culpa de análises pós-incidente após
+      incidentes e quase-acidentes significativos.
+  BC-4220.40.20:
+    name: Acompanhamento de ações de fiabilidade
+    description: |
+      Acompanhamento de itens de ação de fiabilidade até ao encerramento
+      em todas as equipas.
+  BC-4220.40.30:
+    name: Análise de tendências de fiabilidade
+    description: |
+      Análise de tendências de fiabilidade em todos os serviços e horizontes
+      temporais.
+  BC-4220.50:
+    name: Gestão de capacidade e desempenho
+    description: |
+      Previsão de capacidade, políticas de escalamento automático e testes
+      de desempenho do serviço SaaS.
+  BC-4220.50.10:
+    name: Previsão de capacidade
+    description: |
+      Previsão da procura de capacidade em todos os serviços e regiões.
+  BC-4220.50.20:
+    name: Gestão de políticas de escalamento automático
+    description: |
+      Definição e ajuste de políticas de escalamento automático para serviços
+      do produto.
+  BC-4220.50.30:
+    name: Testes de desempenho
+    description: |
+      Testes de carga, stress e resistência do serviço em execução.
+  BC-4220.60:
+    name: Recuperação de desastres e resiliência
+    description: |
+      Backup e restauro, orquestração de failover e exercícios de recuperação
+      de desastres para o serviço SaaS.
+  BC-4220.60.10:
+    name: Gestão de backup e restauro
+    description: |
+      Política de backup, execução e validação de restauro para repositórios
+      de dados do serviço.
+  BC-4220.60.20:
+    name: Orquestração de failover
+    description: |
+      Orquestração de failover entre zonas de disponibilidade e regiões.
+  BC-4220.60.30:
+    name: Gestão de exercícios de recuperação de desastres
+    description: |
+      Planeamento e execução de exercícios de recuperação de desastres e
+      dias de simulação.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-saas-tenant-management.yaml
+++ b/catalogue/i18n/pt/L1-saas-tenant-management.yaml
@@ -1,0 +1,126 @@
+locale: pt
+source: L1-saas-tenant-management.yaml
+entries:
+  BC-4230:
+    name: Gestão de tenants SaaS
+    description: |
+      Provisionamento, configuração, isolamento, colocação regional, federação
+      de identidade e exportação de dados por tenant no serviço multi-tenant.
+  BC-4230.10:
+    name: Provisionamento e ciclo de vida de tenants
+    description: |
+      Criação, suspensão, desativação e migração de tenants no parque
+      multi-tenant.
+  BC-4230.10.10:
+    name: Provisionamento de tenants
+    description: |
+      Criação de novos tenants e alocação dos recursos associados.
+  BC-4230.10.20:
+    name: Suspensão de tenants
+    description: |
+      Suspensão de tenants por falta de pagamento, abuso ou razões contratuais.
+  BC-4230.10.30:
+    name: Desativação de tenants
+    description: |
+      Desativação de tenants, incluindo eliminação de dados ou entrega conforme
+      o contrato.
+  BC-4230.10.40:
+    name: Migração de tenants
+    description: |
+      Migração de tenants entre clusters, shards ou regiões.
+  BC-4230.20:
+    name: Gestão de configuração de tenants
+    description: |
+      Configuração de funcionalidades por tenant, marca e limites aplicados
+      acima da linha de base do produto partilhado.
+  BC-4230.20.10:
+    name: Configuração de funcionalidades por tenant
+    description: |
+      Configuração de opções de funcionalidades ao nível do tenant.
+  BC-4230.20.20:
+    name: Gestão de marca do tenant
+    description: |
+      Marca ao nível do tenant, como logótipos, cores e domínios personalizados.
+  BC-4230.20.30:
+    name: Gestão de limites do tenant
+    description: |
+      Configuração de limites ao nível do tenant, como quotas e tetos de taxa.
+  BC-4230.30:
+    name: Gestão de isolamento de tenants
+    description: |
+      Mecanismos que mantêm o isolamento lógico e físico entre tenants
+      em dados, computação e caminhos de acesso.
+  BC-4230.30.10:
+    name: Isolamento de dados do tenant
+    description: |
+      Isolamento dos dados do tenant através de particionamento, encriptação
+      e âmbito de acesso.
+  BC-4230.30.20:
+    name: Isolamento de computação do tenant
+    description: |
+      Isolamento das cargas de trabalho do tenant através de limites de
+      computação dedicados ou restritos.
+  BC-4230.30.30:
+    name: Prevenção de acesso entre tenants
+    description: |
+      Controlos e monitorização que impedem a contaminação cruzada de dados
+      e identidade entre tenants.
+  BC-4230.40:
+    name: Residência de dados e colocação regional
+    description: |
+      Atribuição de tenants a regiões, aplicação de compromissos de residência
+      de dados e gestão da política de replicação entre regiões.
+  BC-4230.40.10:
+    name: Atribuição de região a tenants
+    description: |
+      Atribuição de tenants a regiões consistente com o contrato e a regulação.
+  BC-4230.40.20:
+    name: Aplicação de residência de dados
+    description: |
+      Aplicação de limites de residência de dados em tempo de execução.
+  BC-4230.40.30:
+    name: Política de replicação entre regiões
+    description: |
+      Política que governa a replicação entre regiões para resiliência e acesso.
+  BC-4230.50:
+    name: Federação de identidade de tenants
+    description: |
+      Federação de fornecedores de identidade do tenant e ciclo de vida de
+      contas de utilizadores do tenant através de início de sessão único e SCIM.
+  BC-4230.50.10:
+    name: Configuração de SSO do tenant
+    description: |
+      Configuração do início de sessão único entre os fornecedores de identidade
+      do tenant e o serviço.
+  BC-4230.50.20:
+    name: Provisionamento de utilizadores baseado em SCIM
+    description: |
+      Ciclo de vida das contas de utilizadores do tenant conduzido por SCIM
+      ou protocolos de provisionamento equivalentes.
+  BC-4230.50.30:
+    name: Integração de fornecedores de identidade do tenant
+    description: |
+      Integração e validação de fornecedores de identidade do tenant.
+  BC-4230.60:
+    name: Gestão de backup e exportação do tenant
+    description: |
+      Capacidades de exportação, eliminação e restauro de dados por tenant
+      expostas a tenants e administradores.
+  BC-4230.60.10:
+    name: Exportação de dados do tenant
+    description: |
+      Exportação de dados do tenant em formato legível por máquina mediante
+      pedido ou por contrato.
+  BC-4230.60.20:
+    name: Eliminação de dados do tenant
+    description: |
+      Eliminação verificável de dados do tenant no cancelamento ou por pedido.
+  BC-4230.60.30:
+    name: Restauro de backup do tenant
+    description: |
+      Restauro de dados do tenant a partir de backup mediante pedido do tenant
+      ou do operador.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-saas-trust-service-compliance-management.yaml
+++ b/catalogue/i18n/pt/L1-saas-trust-service-compliance-management.yaml
@@ -1,0 +1,132 @@
+locale: pt
+source: L1-saas-trust-service-compliance-management.yaml
+entries:
+  BC-4290:
+    name: Gestão de confiança e conformidade de serviço SaaS
+    description: |
+      Atestações ao nível do serviço, questionários de segurança de clientes,
+      divulgações públicas de confiança, gestão de subprocessadores, compromissos
+      de privacidade do serviço e compromissos de resiliência do serviço
+      orientados ao cliente para a oferta SaaS.
+  BC-4290.10:
+    name: Gestão de atestações de serviço
+    description: |
+      Coordenação de atestações ao nível do serviço como SOC 2, ISO 27001
+      e FedRAMP para a oferta SaaS.
+    in_scope:
+      - Prontidão para auditoria do serviço
+      - Envolvimento de auditores e produção de relatórios
+    out_of_scope:
+      - Programa de conformidade empresarial (abrangido pela Gestão de Conformidade)
+  BC-4290.10.10:
+    name: Coordenação da prontidão para auditoria
+    description: |
+      Coordenação da prontidão para auditoria junto dos responsáveis pelos
+      controlos do serviço.
+  BC-4290.10.20:
+    name: Envolvimento de auditores
+    description: |
+      Envolvimento de auditores externos e gestão do trabalho de auditoria.
+  BC-4290.10.30:
+    name: Gestão de renovação de atestações
+    description: |
+      Gestão dos ciclos de renovação de atestações e de acordos de auditoria
+      contínua.
+  BC-4290.20:
+    name: Gestão de questionários de segurança de clientes
+    description: |
+      Gestão do repositório de questionários, elaboração de respostas e base
+      de conhecimento utilizados para responder a avaliações de risco de
+      fornecedores de clientes.
+  BC-4290.20.10:
+    name: Gestão do repositório de questionários
+    description: |
+      Manutenção do repositório de questionários recebidos e encaminhamento.
+  BC-4290.20.20:
+    name: Elaboração de respostas a questionários
+    description: |
+      Elaboração de respostas a questionários de segurança de clientes.
+  BC-4290.20.30:
+    name: Manutenção da base de conhecimento de questionários
+    description: |
+      Manutenção de uma base de conhecimento selecionada de respostas
+      aprovadas e evidências.
+  BC-4290.30:
+    name: Portal de confiança e divulgação pública
+    description: |
+      Operação do portal de confiança do cliente, divulgações públicas de
+      estado e fluxos de trabalho de distribuição de documentos.
+  BC-4290.30.10:
+    name: Gestão de conteúdos do portal de confiança
+    description: |
+      Curadoria de conteúdos publicados no portal de confiança do cliente.
+  BC-4290.30.20:
+    name: Divulgação pública de estado
+    description: |
+      Divulgação pública do estado de incidentes e do histórico de estado
+      do serviço.
+  BC-4290.30.30:
+    name: Fluxo de trabalho de distribuição de documentos
+    description: |
+      Distribuição controlada de relatórios de auditoria e documentos de
+      confiança a clientes.
+  BC-4290.40:
+    name: Gestão de subprocessadores
+    description: |
+      Inventário, divulgação e notificação de alterações de subprocessadores
+      que tratam dados de clientes.
+  BC-4290.40.10:
+    name: Inventário de subprocessadores
+    description: |
+      Inventário de subprocessadores e das categorias de dados de clientes
+      que tratam.
+  BC-4290.40.20:
+    name: Divulgação de subprocessadores
+    description: |
+      Divulgação orientada ao cliente da lista atual de subprocessadores.
+  BC-4290.40.30:
+    name: Notificação de alterações de subprocessadores
+    description: |
+      Notificação antecipada de adições e remoções de subprocessadores por
+      contrato.
+  BC-4290.50:
+    name: Gestão de compromissos de privacidade do serviço
+    description: |
+      Gestão de adendas de processamento de dados, divulgações de fluxos de
+      dados de clientes e encaminhamento de pedidos de titulares de dados.
+  BC-4290.50.10:
+    name: Gestão de adendas de processamento de dados
+    description: |
+      Manutenção e execução de adendas de processamento de dados com clientes.
+  BC-4290.50.20:
+    name: Mapeamento de fluxos de dados de clientes
+    description: |
+      Mapeamento dos fluxos de dados de clientes para divulgação e avaliação.
+  BC-4290.50.30:
+    name: Encaminhamento de pedidos de titulares de dados
+    description: |
+      Encaminhamento de pedidos de titulares de dados recebidos através de
+      clientes para os responsáveis adequados.
+  BC-4290.60:
+    name: Gestão de compromissos de resiliência do serviço
+    description: |
+      Compromissos de nível de serviço orientados ao cliente, divulgação
+      de disponibilidade e administração de créditos de serviço.
+  BC-4290.60.10:
+    name: Gestão de compromissos de nível de serviço
+    description: |
+      Definição e gestão de compromissos de nível de serviço orientados
+      ao cliente.
+  BC-4290.60.20:
+    name: Divulgação de disponibilidade
+    description: |
+      Divulgação da disponibilidade histórica face aos níveis comprometidos.
+  BC-4290.60.30:
+    name: Administração de créditos de serviço
+    description: |
+      Administração de créditos de serviço resultantes de compromissos
+      não cumpridos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-sales-management.yaml
+++ b/catalogue/i18n/pt/L1-sales-management.yaml
@@ -1,0 +1,151 @@
+locale: pt
+source: L1-sales-management.yaml
+entries:
+  BC-410:
+    name: Gestão de vendas
+    description: |
+      Atividades de lead-to-order — contas, pipeline, negócios e cotações.
+  BC-410.10:
+    name: Gestão da estratégia de vendas
+    description: |
+      Modelo de cobertura, segmentação e planeamento de vendas.
+  BC-410.10.10:
+    name: Design do modelo de cobertura de vendas
+    description: |
+      Definição de segmentos de vendas, territórios e modelos de cobertura.
+  BC-410.10.20:
+    name: Atribuição de território e conta
+    description: |
+      Design de território, atribuição de contas e reequilíbrio.
+  BC-410.10.30:
+    name: Definição de metas de vendas
+    description: |
+      Definição de metas e quotas de vendas descendentes e ascendentes.
+  BC-410.10.40:
+    name: Planeamento da capacidade de vendas
+    description: |
+      Planeamento de capacidade de vendas, ramp e headcount.
+  BC-410.20:
+    name: Gestão de contas
+    description: |
+      Gestão de contas estratégicas e principais.
+  BC-410.20.10:
+    name: Planeamento de contas
+    description: |
+      Planos de contas estratégicos e análise de white-space.
+  BC-410.20.20:
+    name: Governação de contas principais
+    description: |
+      Governação e patrocínio executivo de contas principais.
+  BC-410.20.30:
+    name: Desenvolvimento de relação com contas
+    description: |
+      Mapeamento de relações e relacionamento com partes interessadas nas contas.
+  BC-410.20.40:
+    name: Monitorização da saúde das contas
+    description: |
+      Métricas de saúde das contas, scorecards e monitorização do risco de renovação.
+  BC-410.30:
+    name: Gestão de oportunidades e pipeline
+    description: |
+      Ciclo de vida de lead, oportunidade e negócio.
+  BC-410.30.10:
+    name: Qualificação e entrega de leads
+    description: |
+      Qualificação, pontuação e entrega de leads pelo marketing.
+  BC-410.30.20:
+    name: Gestão de oportunidades
+    description: |
+      Criação, qualificação e progressão de fases de oportunidades.
+  BC-410.30.30:
+    name: Estratégia e perseguição de negócios
+    description: |
+      Perseguição estratégica de negócios, win plans e revisões de negócios.
+  BC-410.30.40:
+    name: Previsão de pipeline
+    description: |
+      Cobertura do pipeline, previsão ponderada e commit calls.
+  BC-410.40:
+    name: Gestão de cotações e configuração
+    description: |
+      CPQ — configurar, definir preço, cotar.
+  BC-410.40.10:
+    name: Configuração de produtos
+    description: |
+      Configuração de produtos e soluções com regras e restrições.
+  BC-410.40.20:
+    name: Geração de cotações
+    description: |
+      Geração de cotações e propostas prontas para o cliente.
+  BC-410.40.30:
+    name: Fluxo de aprovação de cotações
+    description: |
+      Fluxos de aprovação de descontos e termos não standard.
+  BC-410.40.40:
+    name: Conversão de contrato e encomenda
+    description: |
+      Conversão de cotações aceites em encomendas e contratos.
+  BC-410.50:
+    name: Gestão de operações de vendas
+    description: |
+      Processo, ferramentas e capacitação de vendas.
+  BC-410.50.10:
+    name: Governação do processo e metodologia de vendas
+    description: |
+      Definição e gestão do processo e metodologia de vendas.
+  BC-410.50.20:
+    name: Tecnologia e ferramentas de vendas
+    description: |
+      Administração e integração de CRM e ferramentas de vendas.
+  BC-410.50.30:
+    name: Capacitação de vendas
+    description: |
+      Playbooks de vendas, conteúdo de capacitação e certificação.
+  BC-410.50.40:
+    name: Dados e higiene de vendas
+    description: |
+      Qualidade, governação e programas de higiene de dados de CRM.
+  BC-410.60:
+    name: Gestão de vendas por canal
+    description: |
+      Canais indiretos, distribuidores e revendedores.
+  BC-410.60.10:
+    name: Recrutamento de parceiros de canal
+    description: |
+      Recrutamento e integração de distribuidores, revendedores e agentes.
+  BC-410.60.20:
+    name: Capacitação de parceiros de canal
+    description: |
+      Formação, certificação e capacitação de parceiros de canal.
+  BC-410.60.30:
+    name: Gestão do programa de canal
+    description: |
+      Níveis do programa de canal, incentivos e regras de relacionamento.
+  BC-410.60.40:
+    name: Gestão do desempenho de parceiros
+    description: |
+      Acompanhamento do sell-through, sell-out e métricas de desempenho de parceiros.
+  BC-410.70:
+    name: Gestão do desempenho de vendas
+    description: |
+      Planos de comissionamento, gestão de quotas e análise de vendas.
+  BC-410.70.10:
+    name: Design do plano de comissionamento de vendas
+    description: |
+      Design de planos de remuneração variável, aceleradores e SPIFs.
+  BC-410.70.20:
+    name: Gestão de quotas e creditação
+    description: |
+      Alocação de quotas, regras de creditação e rollover.
+  BC-410.70.30:
+    name: Cálculo de comissões de vendas
+    description: |
+      Cálculo, validação e pagamento de comissões de vendas.
+  BC-410.70.40:
+    name: Análise do desempenho de vendas
+    description: |
+      Análise de win/loss, produtividade e desempenho dos vendedores.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-search-rescue-coordination-management.yaml
+++ b/catalogue/i18n/pt/L1-search-rescue-coordination-management.yaml
@@ -1,0 +1,71 @@
+locale: pt
+source: L1-search-rescue-coordination-management.yaml
+entries:
+  BC-1260:
+    name: Gestão da coordenação de busca e salvamento
+    description: |
+      Alerta SAR, coordenação com centros de salvamento e tratamento de balizas de emergência.
+  BC-1260.10:
+    name: Gestão do alerta SAR
+    description: |
+      Fases de alerta - incerteza, alerta e angústia.
+  BC-1260.10.10:
+    name: Tratamento da fase de incerteza
+    description: |
+      Deteção e tratamento da fase de incerteza INCERFA.
+  BC-1260.10.20:
+    name: Tratamento da fase de alerta
+    description: |
+      Tratamento da fase de alerta ALERFA e escalada.
+  BC-1260.10.30:
+    name: Tratamento da fase de angústia
+    description: |
+      Tratamento da fase de angústia DETRESFA e iniciação SAR.
+  BC-1260.20:
+    name: Gestão da coordenação SAR
+    description: |
+      Coordenação com centros de coordenação de salvamento (RCC).
+  BC-1260.20.10:
+    name: Ligação com RCC
+    description: |
+      Ligação com centros de coordenação de salvamento nacionais e regionais.
+  BC-1260.20.20:
+    name: Coordenação de missões SAR
+    description: |
+      Coordenação dos recursos e ativos de missões SAR.
+  BC-1260.20.30:
+    name: Coordenação transfronteiriça SAR
+    description: |
+      Coordenação transfronteiriça de operações SAR.
+  BC-1260.30:
+    name: Gestão das comunicações SAR
+    description: |
+      Redes de comunicações SAR e canais de coordenação.
+  BC-1260.30.10:
+    name: Operações de comunicações de voz SAR
+    description: |
+      Operação de canais e frequências de voz SAR.
+  BC-1260.30.20:
+    name: Operações de comunicações de dados SAR
+    description: |
+      Operação de redes de dados e mensagens SAR.
+  BC-1260.40:
+    name: Gestão de balizas de localização de emergência
+    description: |
+      Tratamento de ativações ELT/EPIRB/PLB e interface COSPAS-SARSAT.
+  BC-1260.40.10:
+    name: Tratamento de ativações ELT
+    description: |
+      Deteção e tratamento de ativações de ELT.
+  BC-1260.40.20:
+    name: Operações de interface COSPAS-SARSAT
+    description: |
+      Interface com centros de controlo de missão COSPAS-SARSAT.
+  BC-1260.40.30:
+    name: Coordenação do registo de balizas
+    description: |
+      Coordenação com registos nacionais de balizas.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-shipment-visibility-tracking-management.yaml
+++ b/catalogue/i18n/pt/L1-shipment-visibility-tracking-management.yaml
@@ -1,0 +1,102 @@
+locale: pt
+source: L1-shipment-visibility-tracking-management.yaml
+entries:
+  BC-2510:
+    name: Gestão de visibilidade e rastreio de envio
+    description: |
+      Visibilidade de ponta a ponta de envios através de captura de eventos,
+      resolução de estado, previsão de ETA, alertas de exceções e operações de
+      torre de controlo.
+  BC-2510.10:
+    name: Gestão de captura de eventos e estado
+    description: |
+      Captura de eventos de envio de transportadoras, IoT e sistemas operacionais,
+      e tradução em estados canónicos.
+    in_scope:
+      - Ingestão de eventos EDI 214, IFTSTA e EPCIS
+      - Captura de eventos IoT e telemetria
+    out_of_scope:
+      - Telemetria para condição de ativos (BC-2430.40)
+  BC-2510.10.10:
+    name: Ingestão de eventos de transportadora
+    description: |
+      Ingestão de eventos de marcos do lado da transportadora via EDI e APIs.
+  BC-2510.10.20:
+    name: Captura de eventos IoT e telemetria
+    description: |
+      Captura de eventos IoT e de telemetria ao nível da carga.
+  BC-2510.10.30:
+    name: Captura de atualizações de estado manuais
+    description: |
+      Captura de atualizações de estado manuais de condutores, agentes e parceiros.
+  BC-2510.20:
+    name: Gestão de rastreio de envio
+    description: |
+      Resolução do estado de envio em etapas, modos e parceiros, e entrega em
+      superfícies de rastreio internas e voltadas para o cliente.
+  BC-2510.20.10:
+    name: Resolução do estado de envio
+    description: |
+      Resolução do estado canónico de envio a partir de eventos brutos.
+  BC-2510.20.20:
+    name: Ligação de rastreio multi-etapa
+    description: |
+      Ligação de viagens multi-etapa e multi-transportadora num único rastreio.
+  BC-2510.20.30:
+    name: Operações do portal de rastreio público
+    description: |
+      Operação de portais de rastreio públicos e APIs de clientes.
+  BC-2510.30:
+    name: Gestão de previsão de ETA
+    description: |
+      Cálculo e refinamento contínuo do tempo estimado de chegada.
+  BC-2510.30.10:
+    name: Cálculo de ETA
+    description: |
+      Cálculo determinístico de ETA a partir de horários e marcos.
+  BC-2510.30.20:
+    name: Modelação preditiva de ETA
+    description: |
+      Modelação preditiva de ETA utilizando dados históricos e contextuais.
+  BC-2510.30.30:
+    name: Alertas de variância de ETA
+    description: |
+      Alertas sobre variâncias materiais de ETA face ao compromisso.
+  BC-2510.40:
+    name: Gestão de exceções e alertas
+    description: |
+      Deteção de exceções operacionais, notificação de partes interessadas e
+      acompanhamento da resolução de exceções.
+  BC-2510.40.10:
+    name: Deteção de exceções
+    description: |
+      Deteção de exceções operacionais baseada em regras e modelos.
+  BC-2510.40.20:
+    name: Notificação de partes interessadas
+    description: |
+      Notificação de clientes, equipas de operações e parceiros.
+  BC-2510.40.30:
+    name: Acompanhamento da resolução de exceções
+    description: |
+      Acompanhamento da triagem, propriedade e encerramento de exceções.
+  BC-2510.50:
+    name: Gestão de operações da torre de controlo
+    description: |
+      Visibilidade de ponta a ponta, monitorização do desempenho e coordenação
+      de intervenções proativas em transportadoras e parceiros.
+  BC-2510.50.10:
+    name: Dashboards de visibilidade de ponta a ponta
+    description: |
+      Operação de dashboards de visibilidade de ponta a ponta em toda a rede.
+  BC-2510.50.20:
+    name: Monitorização de desempenho entre transportadoras
+    description: |
+      Monitorização do desempenho em transportadoras e parceiros.
+  BC-2510.50.30:
+    name: Coordenação de intervenções proativas
+    description: |
+      Coordenação de intervenções proativas para proteger os compromissos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-smelting-refining-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-smelting-refining-operations-management.yaml
@@ -1,0 +1,162 @@
+locale: pt
+source: L1-smelting-refining-operations-management.yaml
+entries:
+  BC-4450:
+    name: Gestão de operações de fundição e refinação
+    description: |
+      Refinação pirometalúrgica e eletroquímica de concentrados e intermédios
+      em metal entregável na LME ou de especificação, incluindo recuperação
+      de subprodutos, tratamento de gases de fundição e contabilidade
+      metalúrgica.
+  BC-4450.10:
+    name: Receção e mistura de concentrado
+    description: |
+      Amostragem na receção, mistura de alimentação e gestão de inventário de
+      concentrados que entram no complexo de fundição.
+    in_scope:
+      - Amostragem e ensaio na receção
+      - Mistura de alimentação da fundição
+      - Inventário do parque de concentrado
+    out_of_scope:
+      - Liquidação de vendas de concentrado (BC-4480.40)
+  BC-4450.10.10:
+    name: Amostragem de concentrado na receção
+    description: |
+      Amostragem e ensaio de concentrados recebidos de minas de terceiros e
+      próprias.
+  BC-4450.10.20:
+    name: Mistura de alimentação da fundição
+    description: |
+      Mistura de concentrados para atingir o teor de alimentação da fundição
+      e os objetivos de impurezas.
+  BC-4450.10.30:
+    name: Gestão do inventário de concentrado
+    description: |
+      Gestão de inventário de concentrado em parque, armazém e silo.
+  BC-4450.20:
+    name: Operações pirometalúrgicas
+    description: |
+      Tostagem, fundição, conversão e manuseio de escória de concentrados de
+      sulfuretos e óxidos.
+  BC-4450.20.10:
+    name: Operações de tostagem
+    description: |
+      Operação de tostadores de leito fluidizado e de múltiplas soleiras para
+      oxidação de sulfuretos.
+  BC-4450.20.20:
+    name: Operações de forno de fundição
+    description: |
+      Operação de fornos de fundição flash, elétricos e de banho.
+  BC-4450.20.30:
+    name: Operações de conversor
+    description: |
+      Operação de conversores Peirce-Smith, rotativos de sopro pelo topo e
+      contínuos.
+  BC-4450.20.40:
+    name: Manuseio de escória
+    description: |
+      Sangria, granulação, limpeza e disposição de escória de forno e conversor.
+  BC-4450.30:
+    name: Operações de refinação eletrolítica
+    description: |
+      Operações de eletrodeposição e eletrorefinação em cubas de eletrólise que
+      produzem metal catódico.
+  BC-4450.30.10:
+    name: Operações de eletrodeposição
+    description: |
+      Operação de células de eletrodeposição que produzem cátodo a partir de
+      eletrólito de lixiviação.
+  BC-4450.30.20:
+    name: Operações de cuba de eletrorefinação
+    description: |
+      Operação de células de eletrorefinação que produzem cátodo de alta pureza
+      a partir de ânodos.
+  BC-4450.30.30:
+    name: Desmoldagem e manuseio de cátodo
+    description: |
+      Desmoldagem, lavagem, pesagem e enfardamento de cátodo para venda ou
+      fundição a jusante.
+  BC-4450.40:
+    name: Recuperação de metais subprodutos
+    description: |
+      Recuperação de metais preciosos e menores de lamas anódicas, poeiras e
+      fluxos de subprodutos.
+  BC-4450.40.10:
+    name: Tratamento de lamas anódicas
+    description: |
+      Tratamento de lamas anódicas de eletrorefinação para recuperação de
+      metais preciosos.
+  BC-4450.40.20:
+    name: Refinação de metais preciosos
+    description: |
+      Refinação de ouro, prata e metais do grupo da platina em lingotes ou
+      esponja.
+  BC-4450.40.30:
+    name: Recuperação de fluxos de subprodutos
+    description: |
+      Recuperação de selénio, telúrio, ácido sulfúrico e outros fluxos de
+      subprodutos.
+  BC-4450.50:
+    name: Acabamento de produtos na fundição
+    description: |
+      Fundição, marcação e inspeção de qualidade de produtos metálicos acabados
+      de acordo com a especificação comercial.
+  BC-4450.50.10:
+    name: Operações de fundição
+    description: |
+      Fundição de barras, lingotes, biletes, placas e formas a partir de metal
+      fundido.
+  BC-4450.50.20:
+    name: Marcação e branding de produtos
+    description: |
+      Marcação, estampagem e aplicação de marca em produtos fundidos para
+      rastreabilidade e aceitação em bolsa.
+  BC-4450.50.30:
+    name: Inspeção de qualidade de metal acabado
+    description: |
+      Inspeção e certificação de metal acabado face à especificação e aos
+      requisitos de registo em bolsa.
+  BC-4450.60:
+    name: Operações de gases de fundição e instalação de ácido
+    description: |
+      Limpeza dos gases de fundição, operações da instalação de ácido sulfúrico
+      e monitorização de emissões da chaminé.
+  BC-4450.60.10:
+    name: Limpeza de gases de fundição
+    description: |
+      Operação de precipitadores eletrostáticos, lavadores e arrefecimento
+      para gases de fundição.
+  BC-4450.60.20:
+    name: Operações da instalação de ácido sulfúrico
+    description: |
+      Operação de instalações de ácido sulfúrico de duplo contacto e dupla
+      absorção nos gases de fundição.
+  BC-4450.60.30:
+    name: Monitorização de emissões da chaminé
+    description: |
+      Monitorização contínua da chaminé de dióxido de enxofre, partículas
+      e emissões de metais.
+  BC-4450.70:
+    name: Contabilidade metalúrgica da fundição
+    description: |
+      Balanço de metal, ensaios de liquidação e contabilidade de tratamento
+      por conta no complexo de fundição.
+  BC-4450.70.10:
+    name: Balanço de metal e ensaios de liquidação
+    description: |
+      Reconciliação periódica do balanço de metal e ensaios de teor de
+      liquidação para produtos expedidos.
+  BC-4450.70.20:
+    name: Reporte de recuperação e perdas
+    description: |
+      Reporte de recuperação metalúrgica e perdas de fluxo em toda a fundição
+      e refinaria.
+  BC-4450.70.30:
+    name: Contabilidade de tratamento por conta
+    description: |
+      Contabilidade de concentrados de terceiros tratados por conta e metal
+      de propriedade do cliente.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-software-product-engineering-management.yaml
+++ b/catalogue/i18n/pt/L1-software-product-engineering-management.yaml
@@ -1,0 +1,183 @@
+locale: pt
+source: L1-software-product-engineering-management.yaml
+entries:
+  BC-4200:
+    name: Gestão de engenharia de produto de software
+    description: |
+      Descoberta, especificação, design, implementação, revisão de código e
+      engenharia de qualidade de produtos SaaS, desde a ideia até à versão
+      pronta para lançamento.
+  BC-4200.10:
+    name: Descoberta de produto e gestão de backlog
+    description: |
+      Investigação de oportunidades, ideação, validação e gestão do backlog que
+      traduzem os sinais do mercado e dos clientes num conjunto de trabalho
+      priorizado.
+    in_scope:
+      - Investigação de utilizadores e de mercado
+      - Refinamento e priorização do backlog
+      - Definição e atualização do roteiro de produto
+    out_of_scope:
+      - Análise quantitativa de produto (abrangida pela Gestão de Telemetria e Experimentação de Produto)
+      - Geração de procura de marketing
+  BC-4200.10.10:
+    name: Investigação de utilizadores
+    description: |
+      Investigação geradora e avaliativa com utilizadores para identificar
+      necessidades, pontos de fricção e disponibilidade de pagamento.
+  BC-4200.10.20:
+    name: Refinamento do backlog
+    description: |
+      Refinamento contínuo do backlog de produto, incluindo estimativa,
+      decomposição e repriorização.
+  BC-4200.10.30:
+    name: Definição do roteiro
+    description: |
+      Definição e atualização periódica do roteiro de produto e das áreas
+      temáticas de investimento.
+  BC-4200.10.40:
+    name: Síntese do feedback de clientes
+    description: |
+      Síntese do feedback recebido de suporte, sucesso, vendas e comunidade
+      em sinais de produto acionáveis.
+  BC-4200.20:
+    name: Gestão da especificação de produto
+    description: |
+      Captura do comportamento pretendido, restrições e critérios de aceitação
+      para que o trabalho de engenharia possa ser executado de forma previsível.
+    in_scope:
+      - Especificações funcionais e não funcionais
+      - Critérios de aceitação
+    out_of_scope:
+      - Design visual e de interação (abrangido pela Gestão de Design de Software)
+  BC-4200.20.10:
+    name: Especificação funcional
+    description: |
+      Especificação do comportamento pretendido e dos resultados visíveis
+      para o utilizador em funcionalidades e capacidades.
+  BC-4200.20.20:
+    name: Especificação não funcional
+    description: |
+      Especificação de requisitos não funcionais como disponibilidade,
+      latência, débito e postura de segurança.
+  BC-4200.20.30:
+    name: Definição de critérios de aceitação
+    description: |
+      Definição de critérios de aceitação testáveis que ancoram o conceito
+      de "concluído" para funcionalidades e histórias.
+  BC-4200.30:
+    name: Gestão de design de software
+    description: |
+      Design de experiência do utilizador, de sistema e de acessibilidade
+      para produtos de software, ancorado em sistemas de design partilhados.
+  BC-4200.30.10:
+    name: Design de experiência do utilizador
+    description: |
+      Design de interação, arquitetura de informação e design visual das
+      superfícies do produto.
+  BC-4200.30.20:
+    name: Design de sistema
+    description: |
+      Design arquitetural de componentes de software, serviços, fluxos de dados
+      e interfaces externas.
+  BC-4200.30.30:
+    name: Gestão do sistema de design
+    description: |
+      Gestão do sistema de design partilhado, incluindo componentes,
+      tokens e orientações de utilização.
+  BC-4200.30.40:
+    name: Design de acessibilidade
+    description: |
+      Conformidade do design com as normas de acessibilidade em todas as
+      superfícies do produto.
+  BC-4200.40:
+    name: Gestão de construção de software
+    description: |
+      Práticas de implementação, incluindo controlo de código-fonte, revisão
+      de código e disciplinas de programação colaborativa.
+  BC-4200.40.10:
+    name: Gestão de código-fonte
+    description: |
+      Gestão de repositórios de código-fonte, política de ramificação e
+      titularidade do código.
+  BC-4200.40.20:
+    name: Prática de revisão de código
+    description: |
+      Revisão por pares de alterações de código face às normas de engenharia
+      e segurança.
+  BC-4200.40.30:
+    name: Prática de programação em par e em grupo
+    description: |
+      Práticas de programação colaborativa utilizadas para partilhar
+      conhecimento e elevar a qualidade em trabalhos selecionados.
+  BC-4200.50:
+    name: Engenharia de qualidade de software
+    description: |
+      Estratégia de testes, gestão de suites de testes automatizados e gestão
+      de defeitos para produtos de software.
+    in_scope:
+      - Testes automatizados unitários, de integração e de ponta a ponta do produto
+      - Triagem e resolução de defeitos
+    out_of_scope:
+      - Sistema de gestão de qualidade empresarial (abrangido pela Gestão de Qualidade)
+      - Testes de desempenho e resiliência do serviço em execução (abrangidos pela Gestão de Operações da Plataforma SaaS)
+  BC-4200.50.10:
+    name: Definição de estratégia de testes
+    description: |
+      Definição da estratégia de testes nas camadas unitária, de integração,
+      de ponta a ponta e exploratória.
+  BC-4200.50.20:
+    name: Gestão de suites de testes automatizados
+    description: |
+      Gestão de suites de testes automatizados, incluindo cobertura,
+      instabilidade e tempo de execução.
+  BC-4200.50.30:
+    name: Triagem e resolução de defeitos
+    description: |
+      Triagem e resolução de defeitos reportados contra o produto.
+  BC-4200.50.40:
+    name: Gestão de cobertura de regressão
+    description: |
+      Gestão da cobertura de regressão à medida que a superfície do produto evolui.
+  BC-4200.60:
+    name: Gestão de código aberto
+    description: |
+      Utilização de entrada, contribuição de saída e artefactos da cadeia de
+      fornecimento de software de código aberto incorporado no produto.
+  BC-4200.60.10:
+    name: Conformidade com código aberto de entrada
+    description: |
+      Conformidade com licenças de código aberto de entrada e obrigações de aviso.
+  BC-4200.60.20:
+    name: Contribuição de código aberto de saída
+    description: |
+      Governação das contribuições de saída e gestão de projetos de código aberto.
+  BC-4200.60.30:
+    name: Gestão de software bill of materials
+    description: |
+      Geração, distribuição e manutenção de software bills of materials
+      em formatos normalizados.
+  BC-4200.70:
+    name: Gestão de produtividade de engenharia
+    description: |
+      Plataformas internas para desenvolvedores, ferramentas e medição do
+      desempenho de engenharia que aumentam o débito de entrega sustentado.
+  BC-4200.70.10:
+    name: Gestão da cadeia de ferramentas do desenvolvedor
+    description: |
+      Seleção e gestão de cadeias de ferramentas de desenvolvimento em toda
+      a organização de engenharia.
+  BC-4200.70.20:
+    name: Gestão da plataforma interna do desenvolvedor
+    description: |
+      Operação de plataformas internas que abstraem a infraestrutura e os
+      fluxos de trabalho padronizados para engenheiros.
+  BC-4200.70.30:
+    name: Métricas de desempenho de engenharia
+    description: |
+      Medição do desempenho de engenharia utilizando métricas de entrega e
+      de experiência do desenvolvedor.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-software-release-deployment-management.yaml
+++ b/catalogue/i18n/pt/L1-software-release-deployment-management.yaml
@@ -1,0 +1,155 @@
+locale: pt
+source: L1-software-release-deployment-management.yaml
+entries:
+  BC-4210:
+    name: Gestão de lançamento e implementação de software
+    description: |
+      Integração contínua, gestão de ambientes, engenharia de lançamento,
+      sinalizadores de funcionalidades e implementação progressiva de produtos
+      SaaS em produção.
+  BC-4210.10:
+    name: Gestão de integração contínua
+    description: |
+      Pipelines de construção, produção de artefactos e aplicação de políticas
+      de pipeline que mantêm o produto integrado continuamente construível.
+  BC-4210.10.10:
+    name: Gestão de pipeline de construção
+    description: |
+      Definição e operação de pipelines de construção automatizados para
+      componentes do produto.
+  BC-4210.10.20:
+    name: Gestão de repositório de artefactos
+    description: |
+      Armazenamento, retenção e acesso a artefactos de construção e pacotes
+      de dependências.
+  BC-4210.10.30:
+    name: Aplicação de políticas de pipeline
+    description: |
+      Aplicação de portais obrigatórios de qualidade, segurança e proveniência
+      em todos os pipelines.
+  BC-4210.20:
+    name: Gestão de ambientes
+    description: |
+      Provisionamento e gestão de ambientes de não-produção utilizados para
+      desenvolvimento, integração e validação de pré-produção.
+  BC-4210.20.10:
+    name: Provisionamento de ambientes
+    description: |
+      Provisionamento de ambientes de não-produção alinhados às necessidades
+      de engenharia e validação.
+  BC-4210.20.20:
+    name: Configuração de ambientes
+    description: |
+      Configuração de ambientes de não-produção para manter paridade com
+      a produção onde necessário.
+  BC-4210.20.30:
+    name: Gestão de dados de ambientes
+    description: |
+      Provisionamento, mascaramento e atualização de dados em ambientes
+      de não-produção.
+  BC-4210.30:
+    name: Gestão de engenharia de lançamento
+    description: |
+      Cadência, versionamento, ramificação e disciplina de notas de lançamento
+      para versões de software.
+  BC-4210.30.10:
+    name: Gestão de cadência de lançamento
+    description: |
+      Definição e gestão da cadência de lançamento em todas as áreas do produto.
+  BC-4210.30.20:
+    name: Versionamento e ramificação
+    description: |
+      Esquema de versionamento e estratégia de ramificação aplicados às
+      versões do produto.
+  BC-4210.30.30:
+    name: Elaboração de notas de lançamento
+    description: |
+      Elaboração de notas de lançamento dirigidas a clientes e operadores
+      para cada versão.
+  BC-4210.40:
+    name: Orquestração de implementação
+    description: |
+      Estratégias para entregar alterações de software em produção de forma
+      segura e com raio de impacto controlado.
+  BC-4210.40.10:
+    name: Lançamento progressivo
+    description: |
+      Lançamento gradual de versões para coortes crescentes de tenants ou
+      utilizadores.
+  BC-4210.40.20:
+    name: Implementação canário
+    description: |
+      Implementação de versões numa pequena população canário com avaliação
+      automatizada de saúde.
+  BC-4210.40.30:
+    name: Implementação azul-verde
+    description: |
+      Implementação em ambiente paralelo com transferência de tráfego para
+      mudanças com tempo de inatividade próximo de zero.
+  BC-4210.40.40:
+    name: Coordenação de reversão
+    description: |
+      Reversão coordenada de versões mediante sinais adversos.
+  BC-4210.50:
+    name: Gestão de sinalizadores de funcionalidades
+    description: |
+      Ciclo de vida e controlo em tempo de execução de sinalizadores de
+      funcionalidades utilizados para desacoplar implementação de lançamento
+      e direcionar funcionalidades a coortes.
+    in_scope:
+      - Criação, retirada e auditoria de sinalizadores de funcionalidades
+      - Regras de direcionamento
+    out_of_scope:
+      - Metodologia de experimentação e adjudicação (abrangida pela Gestão de Telemetria e Experimentação de Produto)
+  BC-4210.50.10:
+    name: Ciclo de vida de sinalizadores de funcionalidades
+    description: |
+      Ciclo de vida dos sinalizadores de funcionalidades desde a criação
+      até à retirada.
+  BC-4210.50.20:
+    name: Gestão de regras de direcionamento
+    description: |
+      Definição de regras de direcionamento que determinam quais os sujeitos
+      que recebem uma variante de sinalizador.
+  BC-4210.50.30:
+    name: Gestão de higiene de sinalizadores
+    description: |
+      Prática de higiene que retira sinalizadores obsoletos e impede a
+      acumulação de código condicional morto.
+  BC-4210.60:
+    name: Gestão de configuração e segredos
+    description: |
+      Gestão de valores de configuração em tempo de execução e segredos
+      consumidos pelos serviços do produto.
+  BC-4210.60.10:
+    name: Gestão de configuração em tempo de execução
+    description: |
+      Armazenamento, distribuição e auditoria de valores de configuração
+      em tempo de execução.
+  BC-4210.60.20:
+    name: Gestão do ciclo de vida de segredos
+    description: |
+      Emissão, rotação e revogação de segredos utilizados pelos serviços
+      do produto.
+  BC-4210.70:
+    name: Autorização de mudanças em produção
+    description: |
+      Revisão pré-implementação, governação de janelas de implementação e
+      autorização de acesso humano à produção.
+  BC-4210.70.10:
+    name: Revisão pré-implementação
+    description: |
+      Revisão e aprovação de alterações antes da implementação em produção.
+  BC-4210.70.20:
+    name: Governação de janelas de implementação
+    description: |
+      Governação das janelas de implementação permitidas e congelamentos.
+  BC-4210.70.30:
+    name: Autorização de acesso à produção
+    description: |
+      Autorização, concessão just-in-time e auditoria do acesso humano aos
+      sistemas de produção.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-spare-parts-aftermarket-management.yaml
+++ b/catalogue/i18n/pt/L1-spare-parts-aftermarket-management.yaml
@@ -1,0 +1,127 @@
+locale: pt
+source: L1-spare-parts-aftermarket-management.yaml
+entries:
+  BC-1060:
+    name: Gestão de peças sobresselentes e pós-venda
+    description: |
+      Fornecimento de peças sobresselentes, vendas e serviços pós-venda para a base instalada.
+  BC-1060.10:
+    name: Gestão do catálogo de peças sobresselentes
+    description: |
+      Catálogo, identificação e substituição de peças.
+  BC-1060.10.10:
+    name: Identificação de peças sobresselentes
+    description: |
+      Identificação de peças incluindo catálogos ilustrados de peças.
+  BC-1060.10.20:
+    name: Gestão de substituições de peças
+    description: |
+      Gestão de substituições e equivalências de peças.
+  BC-1060.10.30:
+    name: Publicação do catálogo
+    description: |
+      Publicação e distribuição de catálogos de peças sobresselentes.
+  BC-1060.20:
+    name: Gestão de preços de peças sobresselentes
+    description: |
+      Estratégia de preços, preços de tabela e preços específicos por cliente.
+  BC-1060.20.10:
+    name: Estratégia de preços de peças
+    description: |
+      Estratégia de preços e segmentação para peças sobresselentes.
+  BC-1060.20.20:
+    name: Definição de preços de peças
+    description: |
+      Definição de preços de tabela e preços baseados em valor para peças.
+  BC-1060.20.30:
+    name: Preços de peças específicos por cliente
+    description: |
+      Preços específicos por cliente e preços contratuais para peças.
+  BC-1060.30:
+    name: Previsão da procura de peças sobresselentes
+    description: |
+      Previsão da procura de peças (artigos de movimento lento, procura intermitente).
+  BC-1060.30.10:
+    name: Previsão de procura intermitente
+    description: |
+      Previsão da procura de peças de movimento lento e intermitente.
+  BC-1060.30.20:
+    name: Previsão impulsionada pela base instalada
+    description: |
+      Previsão da procura impulsionada por dados da base instalada.
+  BC-1060.30.30:
+    name: Plano de stockagem de peças
+    description: |
+      Planos de stockagem em centros de distribuição para peças.
+  BC-1060.40:
+    name: Gestão de vendas pós-venda
+    description: |
+      Vendas comerciais pós-venda, renovações e upselling.
+  BC-1060.40.10:
+    name: Geração de leads pós-venda
+    description: |
+      Geração de leads pós-venda a partir de dados da base instalada.
+  BC-1060.40.20:
+    name: Gestão de encomendas pós-venda
+    description: |
+      Captura e processamento de encomendas pós-venda.
+  BC-1060.40.30:
+    name: Venda cruzada e upselling pós-venda
+    description: |
+      Venda cruzada e upselling de produtos e serviços pós-venda.
+  BC-1060.50:
+    name: Gestão de serviço e reparação
+    description: |
+      Reparações, unidades de troca e recondicionamento.
+  BC-1060.50.10:
+    name: Operações da oficina de reparação
+    description: |
+      Operação de oficinas de reparação centrais.
+  BC-1060.50.20:
+    name: Gestão do pool de unidades de troca
+    description: |
+      Gestão do pool de unidades de troca e componentes rotativos.
+  BC-1060.50.30:
+    name: Operações de recondicionamento
+    description: |
+      Recondicionamento, revisão geral e recertificação de peças devolvidas.
+  BC-1060.60:
+    name: Gestão de garantia
+    description: |
+      Direito de garantia, reclamações e recuperação.
+  BC-1060.60.10:
+    name: Gestão da política de garantia
+    description: |
+      Definição de condições, períodos e exclusões de garantia.
+  BC-1060.60.20:
+    name: Processamento de reclamações de garantia
+    description: |
+      Captura e adjudicação de reclamações de garantia de clientes.
+  BC-1060.60.30:
+    name: Recuperação de garantia junto de fornecedores
+    description: |
+      Recuperação de custos de garantia junto de fornecedores.
+  BC-1060.60.40:
+    name: Gestão da reserva de garantia
+    description: |
+      Estimativa e contabilização da reserva de garantia.
+  BC-1060.70:
+    name: Gestão da base instalada
+    description: |
+      Dados da base instalada, conectividade de ativos e informação do ciclo de vida.
+  BC-1060.70.10:
+    name: Gestão de dados da base instalada
+    description: |
+      Captura e gestão de dados da base instalada.
+  BC-1060.70.20:
+    name: Operações de ativos conectados
+    description: |
+      Operação de ativos conectados e telemetria IoT.
+  BC-1060.70.30:
+    name: Análise da base instalada
+    description: |
+      Análise da utilização, condição e ciclo de vida da base instalada.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-specialty-formulation-blending-management.yaml
+++ b/catalogue/i18n/pt/L1-specialty-formulation-blending-management.yaml
@@ -1,0 +1,126 @@
+locale: pt
+source: L1-specialty-formulation-blending-management.yaml
+entries:
+  BC-4630:
+    name: Gestão de formulação e mistura de especialidade
+    description: |
+      Formulação, mistura, compoundagem, enchimento e acabamento de produtos
+      químicos de especialidade, incluindo revestimentos, adesivos, agro-formulações,
+      lubrificantes, surfactantes e produtos químicos finos.
+  BC-4630.10:
+    name: Conceção e desenvolvimento de formulações
+    description: |
+      Especificação, seleção de matérias-primas, ensaios à escala laboratorial
+      e otimização de custos de formulações de especialidade.
+  BC-4630.10.10:
+    name: Desenvolvimento de especificações de formulação
+    description: |
+      Desenvolvimento de especificações de formulação em função dos objetivos de aplicação.
+  BC-4630.10.20:
+    name: Seleção de matérias-primas
+    description: |
+      Seleção de matérias-primas com base no desempenho, custo e HSE.
+  BC-4630.10.30:
+    name: Ensaios de formulação à escala laboratorial
+    description: |
+      Preparação e caracterização à escala laboratorial de formulações candidatas.
+  BC-4630.10.40:
+    name: Otimização de custos de formulação
+    description: |
+      Otimização de custos de formulações sob restrições de especificação.
+  BC-4630.20:
+    name: Operações de mistura
+    description: |
+      Operação de ativos de mistura de líquidos, sólidos, emulsões e dispersões.
+  BC-4630.20.10:
+    name: Operações de mistura de líquidos
+    description: |
+      Mistura em tanque e em linha de produtos químicos líquidos.
+  BC-4630.20.20:
+    name: Operações de mistura de sólidos
+    description: |
+      Mistura em fita, em cone em V e por tombamento de formulações sólidas.
+  BC-4630.20.30:
+    name: Operações de emulsificação
+    description: |
+      Produção de emulsões com recurso a homogeneizadores rotor-estator e de alta pressão.
+  BC-4630.20.40:
+    name: Operações de dispersão e moagem
+    description: |
+      Operação de moinhos de pérolas, moinhos de três rolos e dispersores.
+  BC-4630.30:
+    name: Operações de compoundagem e extrusão
+    description: |
+      Compoundagem de polímeros, produção de masterbatch e extrusão de
+      intermediários de especialidade.
+  BC-4630.30.10:
+    name: Compoundagem de polímeros
+    description: |
+      Compoundagem de polímeros com cargas, estabilizadores e aditivos.
+  BC-4630.30.20:
+    name: Produção de masterbatch
+    description: |
+      Produção de masterbatches de cor, aditivos e funcionais.
+  BC-4630.30.30:
+    name: Operações de extrusão
+    description: |
+      Operação de linhas de extrusão mono e birrosca.
+  BC-4630.40:
+    name: Operações de enchimento e embalagem
+    description: |
+      Enchimento de produtos de especialidade em contentores a granel, barris, GRG,
+      embalagens pequenas e contentores pressurizados.
+  BC-4630.40.10:
+    name: Enchimento de contentores a granel
+    description: |
+      Enchimento de contentores rodoviários, ferroviários e ISO a granel.
+  BC-4630.40.20:
+    name: Enchimento de barris e GRG
+    description: |
+      Enchimento de barris de aço e plástico e de grandes recipientes para granéis.
+  BC-4630.40.30:
+    name: Enchimento em embalagem pequena
+    description: |
+      Enchimento de alta velocidade de garrafas, galões e embalagens de consumidor.
+  BC-4630.40.40:
+    name: Enchimento de aerossóis e embalagens pressurizadas
+    description: |
+      Enchimento e cravação de latas de aerossol e contentores pressurizados.
+  BC-4630.50:
+    name: Ensaios de desempenho de formulações
+    description: |
+      Ensaios de desempenho de aplicação, estabilidade e comparação de referência
+      de formulações de especialidade.
+  BC-4630.50.10:
+    name: Ensaios de desempenho de aplicação
+    description: |
+      Ensaios de formulações em condições simuladas de utilização final.
+  BC-4630.50.20:
+    name: Ensaios de estabilidade e prazo de validade
+    description: |
+      Ensaios de estabilidade e prazo de validade em tempo real e acelerados.
+  BC-4630.50.30:
+    name: Comparação de referência comparativa
+    description: |
+      Comparação lado a lado de formulações com produtos concorrentes.
+  BC-4630.60:
+    name: Gestão de receitas de especialidade
+    description: |
+      Autoria de receitas-mestre, controlo de versões e localização para produção
+      de formulações em múltiplos locais.
+  BC-4630.60.10:
+    name: Manutenção de receitas-mestre
+    description: |
+      Autoria e manutenção de receitas-mestre segundo as convenções ISA-88.
+  BC-4630.60.20:
+    name: Controlo de versões de receitas
+    description: |
+      Controlo de versões de receitas ao longo dos ciclos de aprovação e revisão.
+  BC-4630.60.30:
+    name: Localização de receitas
+    description: |
+      Localização de receitas-mestre para equipamentos específicos de cada local.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-spectrum-frequency-management.yaml
+++ b/catalogue/i18n/pt/L1-spectrum-frequency-management.yaml
@@ -1,0 +1,107 @@
+locale: pt
+source: L1-spectrum-frequency-management.yaml
+entries:
+  BC-2670:
+    name: Gestão de espectro e frequências
+    description: |
+      Gestão do portefólio de espectro do operador — aquisição e renovação de
+      licenças, planeamento e coordenação de frequências, gestão de interferência
+      e operações de espectro de acesso partilhado.
+  BC-2670.10:
+    name: Gestão do portefólio de espectro
+    description: |
+      Manutenção do registo de participações em espectro e supervisão de decisões
+      estratégicas de espectro.
+  BC-2670.10.10:
+    name: Registo de participações em espectro
+    description: |
+      Manutenção do registo autoritativo de participações em espectro do operador
+      por banda, geografia e licença.
+  BC-2670.10.20:
+    name: Avaliação do espectro
+    description: |
+      Avaliação das participações em espectro para decisões financeiras, de M&A
+      e de leilão.
+  BC-2670.10.30:
+    name: Negociação de espectro
+    description: |
+      Aquisição, alienação e arrendamento de direitos de espectro com outros
+      operadores onde os reguladores o permitam.
+  BC-2670.20:
+    name: Gestão de licenças de espectro
+    description: |
+      Gestão de ponta a ponta de licenças de espectro desde a participação em
+      leilão até à renovação e reporte de conformidade.
+  BC-2670.20.10:
+    name: Aquisição de licença de espectro
+    description: |
+      Participação em leilões de espectro, concursos de beleza e alocações
+      bilaterais.
+  BC-2670.20.20:
+    name: Renovação de licença de espectro
+    description: |
+      Gestão de renovação de licenças de espectro face a calendários de expiração.
+  BC-2670.20.30:
+    name: Reporte de conformidade de licença
+    description: |
+      Reporte face às condições de licença de espectro, incluindo obrigações de
+      cobertura e implementação.
+  BC-2670.30:
+    name: Planeamento e coordenação de frequências
+    description: |
+      Alocação de canais e frequências a elementos de rede e coordenação com
+      utilizadores vizinhos.
+  BC-2670.30.10:
+    name: Atribuição de frequências a células
+    description: |
+      Atribuição de frequências e PCIs a células de rádio individuais.
+  BC-2670.30.20:
+    name: Planeamento de canais
+    description: |
+      Planeamento de atribuições de canais em rádio acesso e ligações de
+      microondas.
+  BC-2670.30.30:
+    name: Planeamento de células vizinhas
+    description: |
+      Definição de relações de vizinhança para gerir handovers e interferência.
+  BC-2670.40:
+    name: Gestão de interferência de espectro
+    description: |
+      Deteção, investigação e resolução de interferência prejudicial de espectro,
+      em coordenação com reguladores.
+  BC-2670.40.10:
+    name: Deteção de interferência
+    description: |
+      Deteção de interferência prejudicial de fontes internas e externas.
+  BC-2670.40.20:
+    name: Resolução de interferência
+    description: |
+      Investigação e resolução de casos de interferência identificados.
+  BC-2670.40.30:
+    name: Coordenação com reguladores
+    description: |
+      Coordenação com reguladores nacionais sobre interferência entre licenciados
+      e aplicação.
+  BC-2670.50:
+    name: Gestão de partilha de espectro
+    description: |
+      Operação de regimes de partilha dinâmica de espectro e de acesso partilhado
+      como CBRS.
+  BC-2670.50.10:
+    name: Partilha dinâmica de espectro
+    description: |
+      Operação de partilha ao estilo DSS em tecnologias de rádio na mesma banda.
+  BC-2670.50.20:
+    name: Coordenação de acesso partilhado
+    description: |
+      Coordenação com plataformas de acesso partilhado como SAS e AFC para
+      obtenção de concessões de canal.
+  BC-2670.50.30:
+    name: Coordenação de utilização secundária
+    description: |
+      Coordenação com licenciados primários e incumbentes em regimes de utilização
+      secundária.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-strategic-management.yaml
+++ b/catalogue/i18n/pt/L1-strategic-management.yaml
@@ -1,0 +1,111 @@
+locale: pt
+source: L1-strategic-management.yaml
+entries:
+  BC-100:
+    name: Gestão estratégica
+    description: |
+      Definição da direção, visão, missão e objetivos de longo prazo da empresa.
+  BC-100.10:
+    name: Planeamento estratégico
+    description: |
+      Visão, missão, objetivos estratégicos e formulação do plano de longo prazo.
+  BC-100.10.10:
+    name: Definição de visão e missão
+    description: |
+      Articulação da visão, missão e valores fundamentais da empresa.
+  BC-100.10.20:
+    name: Análise ambiental
+    description: |
+      Análise externa e interna (PESTLE, SWOT, inteligência competitiva).
+  BC-100.10.30:
+    name: Formulação de escolhas estratégicas
+    description: |
+      Avaliação de opções estratégicas e seleção da direção estratégica.
+  BC-100.10.40:
+    name: Desenvolvimento do plano de longo prazo
+    description: |
+      Plano plurianual com objetivos estratégicos, metas e alocação de capital.
+  BC-100.10.50:
+    name: Planeamento de cenários
+    description: |
+      Cenários futuros plausíveis e estratégias de contingência.
+  BC-100.20:
+    name: Gestão da execução da estratégia
+    description: |
+      Tradução da estratégia em objetivos, OKRs e scorecards equilibrados.
+  BC-100.20.10:
+    name: Cascata de objetivos estratégicos
+    description: |
+      Tradução da estratégia empresarial em objetivos por unidade de negócio e funcionais.
+  BC-100.20.20:
+    name: Gestão do scorecard de desempenho
+    description: |
+      Balanced scorecard, OKRs, definição e acompanhamento de KPIs.
+  BC-100.20.30:
+    name: Revisão e realinhamento da estratégia
+    description: |
+      Ciclos periódicos de revisão estratégica e correção de rumo.
+  BC-100.20.40:
+    name: Governação de iniciativas estratégicas
+    description: |
+      Governação por fases sobre iniciativas estratégicas.
+  BC-100.30:
+    name: Gestão do desenvolvimento corporativo
+    description: |
+      Fusões e aquisições, desinvestimentos, joint ventures e parcerias.
+  BC-100.30.10:
+    name: Execução de fusões e aquisições
+    description: |
+      Triagem de alvos, due diligence, estruturação de negócios e fecho.
+  BC-100.30.20:
+    name: Gestão de desinvestimentos
+    description: |
+      Separações, cisões e alienações de ativos e entidades.
+  BC-100.30.30:
+    name: Gestão de joint ventures e alianças
+    description: |
+      Formação e gestão de joint ventures, alianças e parcerias estratégicas.
+  BC-100.30.40:
+    name: Integração pós-fusão
+    description: |
+      Planeamento de integração e realização de sinergias após fusões e aquisições.
+  BC-100.40:
+    name: Gestão do portefólio estratégico
+    description: |
+      Portefólio de iniciativas estratégicas em toda a empresa.
+  BC-100.40.10:
+    name: Definição do portefólio de iniciativas
+    description: |
+      Inventário e categorização de iniciativas estratégicas.
+  BC-100.40.20:
+    name: Priorização do portefólio
+    description: |
+      Pontuação, seleção e priorização de iniciativas face à estratégia.
+  BC-100.40.30:
+    name: Alocação de investimento
+    description: |
+      Alocação de capital, pessoas e capacidade em todo o portefólio.
+  BC-100.40.40:
+    name: Monitorização do desempenho do portefólio
+    description: |
+      Acompanhamento da realização de benefícios e da saúde do portefólio.
+  BC-100.50:
+    name: Gestão do modelo de negócio
+    description: |
+      Definição, evolução e inovação do modelo de negócio.
+  BC-100.50.10:
+    name: Design do modelo de negócio
+    description: |
+      Articulação da proposta de valor, segmentos de clientes e modelo de receita.
+  BC-100.50.20:
+    name: Inovação do modelo de negócio
+    description: |
+      Exploração e prototipagem de modelos de negócio novos ou adjacentes.
+  BC-100.50.30:
+    name: Avaliação do desempenho do modelo de negócio
+    description: |
+      Avaliação da economia unitária, escalabilidade e adequação do modelo.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-student-enrolment-records-management.yaml
+++ b/catalogue/i18n/pt/L1-student-enrolment-records-management.yaml
@@ -1,0 +1,151 @@
+locale: pt
+source: L1-student-enrolment-records-management.yaml
+entries:
+  BC-4720:
+    name: Gestão de matrículas e registos de estudantes
+    description: |
+      Administração do ciclo de vida ativo do estudante desde a matrícula e
+      registo até aos registos académicos, certificados, transferência de créditos
+      e graduação, bem como gestão de registos de identificação do estudante.
+  BC-4720.10:
+    name: Matrícula e registo
+    description: |
+      Matrícula e registo em cursos de estudantes admitidos por período letivo,
+      incluindo ajustes de horário e continuação entre períodos.
+    in_scope:
+      - Registo em cursos
+      - Adição/abandono e ajuste de horário
+      - Rematrícula e continuação
+    out_of_scope:
+      - Decisões iniciais de admissão (abrangidas em Gestão de Recrutamento e Admissões de Estudantes)
+  BC-4720.10.10:
+    name: Registo em cursos
+    description: |
+      Registo de estudantes em cursos, turmas e unidades de aprendizagem.
+  BC-4720.10.20:
+    name: Adição/abandono e ajuste de horário
+    description: |
+      Processamento de adição/abandono e ajuste de horário dentro dos prazos publicados.
+  BC-4720.10.30:
+    name: Rematrícula e continuação
+    description: |
+      Rematrícula e continuação ao longo de períodos e anos académicos.
+  BC-4720.20:
+    name: Gestão de registos académicos
+    description: |
+      Manutenção de registos académicos autoritativos de estudantes, incluindo
+      notas, certificados de habilitações e determinações de situação académica.
+    in_scope:
+      - Registo de notas e classificações
+      - Produção de certificados de habilitações
+      - Determinação da situação académica
+    out_of_scope:
+      - Fluxo de trabalho de avaliação em si (abrangido em Gestão de Avaliação e Exames)
+  BC-4720.20.10:
+    name: Registo de notas e classificações
+    description: |
+      Registo autoritativo de notas e classificações nos registos de estudantes.
+  BC-4720.20.20:
+    name: Produção de certificados de habilitações
+    description: |
+      Produção e emissão de certificados de habilitações oficiais e não oficiais.
+  BC-4720.20.30:
+    name: Determinação da situação académica
+    description: |
+      Determinação da situação académica, distinções, período probatório e exclusão.
+  BC-4720.30:
+    name: Horários de cursos e registos de calendário
+    description: |
+      Registos autoritativos de horários de turmas, alocação de salas e decisões
+      de resolução de conflitos utilizados a jusante pela matrícula.
+    in_scope:
+      - Registos de horários de turmas e coortes
+      - Registos de alocação de salas e instalações
+      - Registos de resolução de conflitos de horário
+    out_of_scope:
+      - Lecionação diária em sala de aula (abrangida em Gestão de Operações de Ensino e Aprendizagem)
+  BC-4720.30.10:
+    name: Registos de horários de turmas e coortes
+    description: |
+      Registos autoritativos de horários por turma e coorte.
+  BC-4720.30.20:
+    name: Registos de alocação de salas e instalações
+    description: |
+      Registos de alocação de salas de ensino e instalações por sessão do horário.
+  BC-4720.30.30:
+    name: Registos de resolução de conflitos de horário
+    description: |
+      Registos de conflitos de horário identificados e resolvidos.
+  BC-4720.40:
+    name: Transferência de créditos e reconhecimento
+    description: |
+      Avaliação e registo de créditos transferidos de outras instituições, reconhecimento
+      de aprendizagem prévia e aplicação de acordos de articulação.
+    in_scope:
+      - Avaliação de créditos de transferência
+      - Reconhecimento de aprendizagem prévia (RAP)
+      - Aplicação de acordos de articulação
+    out_of_scope:
+      - Avaliação de credenciais internacionais na admissão (abrangida em Gestão de Recrutamento e Admissões de Estudantes)
+  BC-4720.40.10:
+    name: Avaliação de créditos de transferência
+    description: |
+      Avaliação de créditos obtidos noutras instituições face a programas da instituição de destino.
+  BC-4720.40.20:
+    name: Reconhecimento de aprendizagem prévia
+    description: |
+      Reconhecimento de aprendizagem experiencial e informal prévia para crédito.
+  BC-4720.40.30:
+    name: Aplicação de acordos de articulação
+    description: |
+      Aplicação de acordos de articulação inter-institucionais aos registos de estudantes.
+  BC-4720.50:
+    name: Graduação e credenciação
+    description: |
+      Auditoria de elegibilidade para graduação, conferência de graus e emissão de
+      credenciais verificáveis, diplomas e certificados.
+    in_scope:
+      - Auditoria de elegibilidade para graduação
+      - Conferência de graus
+      - Emissão de credenciais e verificação a jusante
+    out_of_scope:
+      - Processamento de resultados de exames (abrangido em Gestão de Avaliação e Exames)
+  BC-4720.50.10:
+    name: Auditoria de elegibilidade para graduação
+    description: |
+      Auditoria dos registos de estudantes face aos requisitos de graduação.
+  BC-4720.50.20:
+    name: Conferência de graus
+    description: |
+      Conferência formal de graus e qualificações.
+  BC-4720.50.30:
+    name: Emissão e verificação de credenciais
+    description: |
+      Emissão e verificação de credenciais em papel e digitais, incluindo credenciais verificáveis.
+  BC-4720.60:
+    name: Registos de identificação e ciclo de vida do estudante
+    description: |
+      Manutenção de identificadores de estudantes, indicadores de estado de matrícula
+      e registos de desistência/licença que fundamentam ações administrativas a jusante.
+    in_scope:
+      - Gestão do ciclo de vida do identificador do estudante
+      - Manutenção do estado de matrícula
+      - Registos de desistência e licença de ausência
+    out_of_scope:
+      - Autenticação de identidade e acesso (abrangida em Gestão de Cibersegurança transversal)
+  BC-4720.60.10:
+    name: Ciclo de vida da identidade do estudante
+    description: |
+      Ciclo de vida de identificadores únicos de estudantes desde a emissão até ao encerramento.
+  BC-4720.60.20:
+    name: Manutenção do estado de matrícula
+    description: |
+      Manutenção dos indicadores autoritativos de estado de matrícula (ativo, licença, desistência).
+  BC-4720.60.30:
+    name: Registos de desistência e licença de ausência
+    description: |
+      Registos de desistências, licenças e readmissões de estudantes.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-student-recruitment-admissions-management.yaml
+++ b/catalogue/i18n/pt/L1-student-recruitment-admissions-management.yaml
@@ -1,0 +1,151 @@
+locale: pt
+source: L1-student-recruitment-admissions-management.yaml
+entries:
+  BC-4710:
+    name: Gestão de recrutamento e admissões de estudantes
+    description: |
+      Atração, candidatura, decisão e conversão de ponta a ponta de estudantes
+      potenciais em estudantes matriculados, incluindo propostas de apoio financeiro
+      e tratamento de admissões internacionais.
+  BC-4710.10:
+    name: Alcance e recrutamento de candidatos
+    description: |
+      Recrutamento de estudantes potenciais através de campanhas, eventos e
+      atividades de geração de leads.
+    in_scope:
+      - Campanhas de recrutamento e atendimento de consultas de entrada
+      - Dias abertos, feiras e visitas ao campus
+      - Captação e nutrição de leads de candidatos
+    out_of_scope:
+      - Marketing institucional genérico de marca (abrangido em Gestão de Marketing transversal)
+  BC-4710.10.10:
+    name: Operações de campanhas de recrutamento
+    description: |
+      Planeamento e execução de campanhas de recrutamento de estudantes em múltiplos canais.
+  BC-4710.10.20:
+    name: Operações de dias abertos e visitas ao campus
+    description: |
+      Operação de dias abertos, sessões de degustação e visitas de estudantes potenciais.
+  BC-4710.10.30:
+    name: Gestão de leads de candidatos
+    description: |
+      Captação, nutrição e qualificação de leads de estudantes potenciais.
+  BC-4710.20:
+    name: Gestão de candidaturas
+    description: |
+      Receção e processamento de candidaturas de estudantes potenciais, incluindo
+      documentação de suporte e comunicações com candidatos.
+    in_scope:
+      - Receção e validação de candidaturas
+      - Verificação de documentos e referências
+      - Comunicação do estado da candidatura
+    out_of_scope:
+      - Decisão de admissão (abrangida em Tomada de Decisão de Admissões)
+  BC-4710.20.10:
+    name: Receção e validação de candidaturas
+    description: |
+      Receção e validação da completude de candidaturas em múltiplos canais.
+  BC-4710.20.20:
+    name: Verificação de documentação de suporte
+    description: |
+      Verificação de certificados de habilitações, referências e documentação de suporte.
+  BC-4710.20.30:
+    name: Comunicação do estado da candidatura
+    description: |
+      Comunicação do progresso da candidatura aos candidatos.
+  BC-4710.30:
+    name: Tomada de decisão de admissões
+    description: |
+      Avaliação, pontuação, revisão em comissão e emissão de decisões de admissão
+      face aos critérios de entrada publicados.
+    in_scope:
+      - Avaliação e pontuação de admissões
+      - Revisão em comissão de admissões
+      - Emissão de decisões de admissão
+    out_of_scope:
+      - Atribuição de apoio financeiro (abrangida em Gestão de Apoio Financeiro e Bolsas)
+  BC-4710.30.10:
+    name: Avaliação e pontuação de admissões
+    description: |
+      Avaliação e pontuação de candidatos face aos critérios de entrada.
+  BC-4710.30.20:
+    name: Revisão em comissão de admissões
+    description: |
+      Revisão em comissão ou painel de candidaturas limítrofes e competitivas.
+  BC-4710.30.30:
+    name: Emissão de decisões
+    description: |
+      Emissão de ofertas, ofertas condicionais, listas de espera e rejeições.
+  BC-4710.40:
+    name: Gestão de apoio financeiro e bolsas de estudo
+    description: |
+      Determinação, atribuição e desembolso de apoio financeiro, bolsas de estudo,
+      subsídios e subsídios de apoio ao acesso e acessibilidade.
+    in_scope:
+      - Avaliação de elegibilidade para apoio financeiro
+      - Administração de atribuição de bolsas de estudo
+      - Desembolso de subsídios e bolsas
+    out_of_scope:
+      - Conformidade com financiamento público/Title IV (abrangida em Gestão de Conformidade e Reporte Regulatório em Educação)
+  BC-4710.40.10:
+    name: Avaliação de elegibilidade para apoio financeiro
+    description: |
+      Avaliação da elegibilidade para apoio financeiro por necessidade e por mérito.
+  BC-4710.40.20:
+    name: Administração de atribuição de bolsas de estudo
+    description: |
+      Administração de atribuições de bolsas de estudo de fontes internas e externas.
+  BC-4710.40.30:
+    name: Desembolso de subsídios e bolsas
+    description: |
+      Desembolso de subsídios, bolsas e pagamentos de apoio a propinas.
+  BC-4710.50:
+    name: Conversão de oferta e matrícula
+    description: |
+      Conversão de ofertas de admissão em matrículas confirmadas, incluindo
+      gestão de aceitação, integração pré-matrícula e análise de conversão.
+    in_scope:
+      - Monitorização da aceitação de ofertas
+      - Atividade de integração pré-matrícula
+      - Análise de rendimento e conversão
+    out_of_scope:
+      - Matrícula e registo ativos (abrangidos em Gestão de Matrículas e Registos de Estudantes)
+  BC-4710.50.10:
+    name: Emissão de ofertas e monitorização de aceitações
+    description: |
+      Emissão de ofertas e monitorização de aceitação, recusa e adiamento.
+  BC-4710.50.20:
+    name: Integração pré-matrícula
+    description: |
+      Tarefas de integração concluídas por estudantes admitidos antes da matrícula formal.
+  BC-4710.50.30:
+    name: Gestão do rendimento e análise de conversão
+    description: |
+      Análise do rendimento, desistências e desempenho de conversão de ofertas.
+  BC-4710.60:
+    name: Gestão de admissões internacionais
+    description: |
+      Tratamento especializado de candidatos internacionais, incluindo avaliação de
+      credenciais, proficiência linguística e documentação de apoio ao visto.
+    in_scope:
+      - Avaliação de credenciais internacionais
+      - Avaliação de proficiência em língua inglesa
+      - Geração de documentação de apoio ao visto
+    out_of_scope:
+      - Conformidade de visto em curso para estudantes matriculados (abrangida em Gestão de Conformidade e Reporte Regulatório em Educação)
+  BC-4710.60.10:
+    name: Avaliação de credenciais internacionais
+    description: |
+      Avaliação de credenciais académicas estrangeiras face à equivalência nacional.
+  BC-4710.60.20:
+    name: Avaliação de proficiência em língua inglesa
+    description: |
+      Avaliação da proficiência em língua inglesa de candidatos não nativos.
+  BC-4710.60.30:
+    name: Documentação de apoio ao visto
+    description: |
+      Emissão de documentos de apoio ao visto (p. ex. I-20, CAS) a estudantes admitidos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-student-support-wellbeing-management.yaml
+++ b/catalogue/i18n/pt/L1-student-support-wellbeing-management.yaml
@@ -1,0 +1,153 @@
+locale: pt
+source: L1-student-support-wellbeing-management.yaml
+entries:
+  BC-4770:
+    name: Gestão de apoio ao estudante e bem-estar
+    description: |
+      Serviços não letivos que apoiam o sucesso e o bem-estar dos estudantes,
+      incluindo aconselhamento académico, serviços de saúde mental, acomodações
+      de acessibilidade e educação especial, serviços de carreira e acompanhamento pastoral.
+  BC-4770.10:
+    name: Aconselhamento académico
+    description: |
+      Aconselhamento de estudantes sobre planeamento de programa, seleção de cursos
+      e progressão académica, incluindo apoio a estudantes em risco.
+    in_scope:
+      - Aconselhamento sobre planeamento de programa
+      - Aconselhamento a estudantes em risco
+      - Apoio em período probatório académico
+    out_of_scope:
+      - Aconselhamento de carreira (abrangido em Serviços de Carreira e Colocação)
+      - Aconselhamento de saúde mental (abrangido em Serviços de Aconselhamento e Saúde Mental)
+  BC-4770.10.10:
+    name: Aconselhamento sobre planeamento de programa
+    description: |
+      Aconselhamento sobre estrutura de programa, seleção de cursos e percursos de graduação.
+  BC-4770.10.20:
+    name: Aconselhamento a estudantes em risco
+    description: |
+      Aconselhamento direcionado a estudantes identificados como em risco académico.
+  BC-4770.10.30:
+    name: Apoio em período probatório académico
+    description: |
+      Apoio estruturado a estudantes em período probatório académico.
+  BC-4770.20:
+    name: Serviços de aconselhamento e saúde mental
+    description: |
+      Prestação de serviços de avaliação de saúde mental, aconselhamento e resposta
+      a crises a estudantes.
+    in_scope:
+      - Avaliação e triagem de saúde mental
+      - Lecionação de sessões de aconselhamento
+      - Coordenação da resposta a crises
+    out_of_scope:
+      - Cuidados médicos clínicos além do aconselhamento (abrangidos em capacidades de Prestador de Cuidados de Saúde ou encaminhamentos)
+  BC-4770.20.10:
+    name: Avaliação e triagem de saúde mental
+    description: |
+      Avaliação inicial e triagem das necessidades de saúde mental dos estudantes.
+  BC-4770.20.20:
+    name: Lecionação de sessões de aconselhamento
+    description: |
+      Lecionação de sessões de aconselhamento individuais e de grupo.
+  BC-4770.20.30:
+    name: Coordenação da resposta a crises
+    description: |
+      Coordenação da resposta a crises e encaminhamentos externos.
+  BC-4770.30:
+    name: Serviços de incapacidade e acomodações
+    description: |
+      Determinação e prestação de acomodações razoáveis para estudantes com
+      incapacidades e disponibilização de tecnologia de apoio.
+    in_scope:
+      - Revisão de documentação de incapacidade
+      - Prestação de acomodações razoáveis
+      - Apoio em tecnologia de apoio
+    out_of_scope:
+      - Programas estatutários de educação especial para K-12 (abrangidos em Serviços de Educação Especial)
+      - Reporte de conformidade com direitos civis (abrangido em Gestão de Conformidade e Reporte Regulatório em Educação)
+  BC-4770.30.10:
+    name: Revisão de documentação de incapacidade
+    description: |
+      Revisão de documentação de incapacidade que suporta pedidos de acomodação.
+  BC-4770.30.20:
+    name: Prestação de acomodações razoáveis
+    description: |
+      Prestação de acomodações académicas e de avaliação.
+  BC-4770.30.30:
+    name: Apoio em tecnologia de apoio
+    description: |
+      Prestação e apoio de tecnologia de apoio a estudantes.
+  BC-4770.40:
+    name: Serviços de educação especial
+    description: |
+      Serviços de educação especial estatutários prestados principalmente em
+      contextos K-12, incluindo planos de educação individualizados e serviços relacionados.
+    in_scope:
+      - Desenvolvimento de programa de educação individualizado (PEI)
+      - Lecionação de instrução especializada
+      - Coordenação de serviços relacionados (p. ex. fala, terapia ocupacional, fisioterapia)
+    out_of_scope:
+      - Acomodações no ensino superior (abrangidas em Serviços de Incapacidade e Acomodações)
+  BC-4770.40.10:
+    name: Desenvolvimento do programa de educação individualizado
+    description: |
+      Desenvolvimento de PEI e planos individualizados equivalentes.
+  BC-4770.40.20:
+    name: Lecionação de instrução especializada
+    description: |
+      Lecionação de instrução especializada a estudantes com necessidades identificadas.
+  BC-4770.40.30:
+    name: Coordenação de serviços relacionados
+    description: |
+      Coordenação de serviços relacionados como fala, terapia ocupacional e fisioterapia.
+  BC-4770.50:
+    name: Serviços de carreira e colocação
+    description: |
+      Aconselhamento de carreira, mediação de estágios e colocações, e gestão de
+      relações com empregadores que apoiam a transição dos estudantes para o mercado de trabalho.
+    in_scope:
+      - Aconselhamento de carreira
+      - Mediação de estágios e colocações
+      - Relações com empregadores e recrutamento no campus
+    out_of_scope:
+      - Supervisão de colocação com crédito académico (abrangida em Gestão de Operações de Ensino e Aprendizagem)
+  BC-4770.50.10:
+    name: Aconselhamento de carreira
+    description: |
+      Aconselhamento de carreira e planeamento para estudantes e recém-graduados.
+  BC-4770.50.20:
+    name: Mediação de estágios e colocações
+    description: |
+      Mediação de estágios e oportunidades de experiência profissional.
+  BC-4770.50.30:
+    name: Relações com empregadores e recrutamento no campus
+    description: |
+      Gestão de relações com empregadores e eventos de recrutamento no campus.
+  BC-4770.60:
+    name: Bem-estar dos estudantes e acompanhamento pastoral
+    description: |
+      Acompanhamento pastoral, mentoria, apoio em conduta e programas de bem-estar
+      operados pela instituição.
+    in_scope:
+      - Acompanhamento pastoral e mentoria
+      - Apoio em conduta e disciplina de estudantes
+      - Operações de programas de bem-estar
+    out_of_scope:
+      - Ações de aplicação de direitos civis (abrangidas em Gestão de Conformidade e Reporte Regulatório em Educação)
+  BC-4770.60.10:
+    name: Acompanhamento pastoral e mentoria
+    description: |
+      Acompanhamento pastoral e mentoria de estudantes por tutores e pessoal dedicado.
+  BC-4770.60.20:
+    name: Apoio em conduta e disciplina de estudantes
+    description: |
+      Apoio em processos de conduta e disciplinares de estudantes.
+  BC-4770.60.30:
+    name: Operações de programas de bem-estar
+    description: |
+      Operação de programas e campanhas de bem-estar institucionais.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-subscription-billing-revenue-management.yaml
+++ b/catalogue/i18n/pt/L1-subscription-billing-revenue-management.yaml
@@ -1,0 +1,156 @@
+locale: pt
+source: L1-subscription-billing-revenue-management.yaml
+entries:
+  BC-4250:
+    name: Gestão de faturação e receita de subscrições
+    description: |
+      Medição de utilização, tarifação, faturação, cobrança de dívidas,
+      reconhecimento de receita de subscrições, gestão de impostos e análise
+      de receita recorrente para o modelo comercial SaaS.
+  BC-4250.10:
+    name: Medição de utilização
+    description: |
+      Ingestão e agregação de eventos de utilização que alimentam a tarifação
+      e análise a jusante.
+  BC-4250.10.10:
+    name: Ingestão de eventos de utilização
+    description: |
+      Ingestão de eventos de utilização dos serviços do produto para o
+      pipeline de medição.
+  BC-4250.10.20:
+    name: Agregação de utilização
+    description: |
+      Agregação de eventos de utilização em quantidades faturáveis por tenant
+      e medidor.
+  BC-4250.10.30:
+    name: Reconciliação de quantidades medidas
+    description: |
+      Reconciliação de quantidades medidas face à fonte de verdade e contadores
+      visíveis ao cliente.
+  BC-4250.20:
+    name: Tarifação e cobrança
+    description: |
+      Aplicação de tarifas de subscrição, tarifas de utilização, prorateamentos
+      e descontos para calcular encargos.
+  BC-4250.20.10:
+    name: Tarifação de subscrição
+    description: |
+      Cálculo dos encargos recorrentes de subscrição por ciclo.
+  BC-4250.20.20:
+    name: Tarifação de utilização
+    description: |
+      Cálculo dos encargos de utilização a partir de quantidades tarifadas
+      e tarifas.
+  BC-4250.20.30:
+    name: Cálculo de prorateamento
+    description: |
+      Cálculo de encargos pro-rata resultantes de alterações a meio do ciclo.
+  BC-4250.20.40:
+    name: Aplicação de descontos
+    description: |
+      Aplicação de descontos e créditos negociados aos encargos calculados.
+  BC-4250.30:
+    name: Gestão de faturas e extratos
+    description: |
+      Geração, entrega e ajuste de faturas e gestão de disputas de faturação
+      de clientes.
+  BC-4250.30.10:
+    name: Geração de faturas
+    description: |
+      Geração de faturas a partir de encargos tarifados e termos do contrato.
+  BC-4250.30.20:
+    name: Entrega de faturas
+    description: |
+      Entrega de faturas aos clientes através do portal, email e canais
+      de parceiros.
+  BC-4250.30.30:
+    name: Ajuste de faturas
+    description: |
+      Ajuste de faturas para créditos, erros e variações contratuais.
+  BC-4250.30.40:
+    name: Tratamento de disputas de faturação de clientes
+    description: |
+      Triagem e resolução de disputas de faturação de clientes.
+  BC-4250.40:
+    name: Cobrança de pagamentos e gestão de dívidas
+    description: |
+      Gestão de métodos de pagamento, autorização de pagamento, cobrança de
+      dívidas e recuperação de churn involuntário.
+  BC-4250.40.10:
+    name: Gestão de métodos de pagamento
+    description: |
+      Captura e gestão de métodos de pagamento e tokens dos clientes.
+  BC-4250.40.20:
+    name: Autorização de pagamento
+    description: |
+      Autorização e captura de pagamentos recorrentes através de processadores
+      de pagamento.
+  BC-4250.40.30:
+    name: Fluxo de cobrança de dívidas
+    description: |
+      Sequências automatizadas de cobrança de dívidas para pagamentos falhados
+      e saldos em atraso.
+  BC-4250.40.40:
+    name: Recuperação de churn involuntário
+    description: |
+      Recuperação de subscrições perdidas por cartões expirados, recusas
+      definitivas e falhas de pagamento semelhantes.
+  BC-4250.50:
+    name: Reconhecimento de receita de subscrições
+    description: |
+      Identificação de obrigações de desempenho e gestão de calendários de
+      receita em linha com ASC 606 / IFRS 15.
+  BC-4250.50.10:
+    name: Identificação de obrigações de desempenho
+    description: |
+      Identificação de obrigações de desempenho distintas a partir de
+      contratos de subscrição.
+  BC-4250.50.20:
+    name: Gestão de calendários de receita
+    description: |
+      Geração e manutenção de calendários de reconhecimento de receita ao
+      longo da vida do contrato.
+  BC-4250.50.30:
+    name: Reconciliação de receita diferida
+    description: |
+      Reconciliação de saldos de receita diferida face a valores faturados
+      e reconhecidos.
+  BC-4250.60:
+    name: Gestão de impostos sobre subscrições
+    description: |
+      Determinação de jurisdição fiscal, cálculo e gestão de isenções em
+      encargos recorrentes e baseados em utilização.
+  BC-4250.60.10:
+    name: Determinação de jurisdição fiscal
+    description: |
+      Determinação das jurisdições fiscais aplicáveis por cliente e encargo.
+  BC-4250.60.20:
+    name: Cálculo de imposto sobre subscrições
+    description: |
+      Cálculo do imposto indireto sobre encargos de subscrição e utilização.
+  BC-4250.60.30:
+    name: Gestão de isenções fiscais
+    description: |
+      Captura e aplicação de certificados de isenção fiscal de clientes.
+  BC-4250.70:
+    name: Análise de receita de subscrições
+    description: |
+      Cálculo e análise de métricas de saúde da receita recorrente,
+      incluindo ARR, MRR, NRR, GRR e vistas de coorte.
+  BC-4250.70.10:
+    name: Cálculo de ARR e MRR
+    description: |
+      Cálculo da receita recorrente anual e mensal a partir do estado das
+      subscrições.
+  BC-4250.70.20:
+    name: Análise de retenção líquida e bruta
+    description: |
+      Análise da retenção de receita líquida e bruta em coortes de clientes.
+  BC-4250.70.30:
+    name: Análise de receita por coorte
+    description: |
+      Análise baseada em coortes da evolução da receita e dinâmicas de retenção.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-subscription-lifecycle-management.yaml
+++ b/catalogue/i18n/pt/L1-subscription-lifecycle-management.yaml
@@ -1,0 +1,152 @@
+locale: pt
+source: L1-subscription-lifecycle-management.yaml
+entries:
+  BC-4240:
+    name: Gestão do ciclo de vida da subscrição
+    description: |
+      Design de planos e direitos, contratação de subscrições, provisionamento,
+      modificação, renovação, cancelamento e aplicação de direitos em tempo de
+      execução ao longo do ciclo de vida comercial SaaS.
+  BC-4240.10:
+    name: Design de planos e direitos
+    description: |
+      Definição de planos, direitos de funcionalidades e regras que determinam
+      quais os clientes elegíveis para cada plano.
+    in_scope:
+      - Catálogo de planos e controlo de acesso a funcionalidades
+      - Regras de elegibilidade de planos
+    out_of_scope:
+      - Estratégia de preços e governação da lista de preços (abrangida pela Gestão de Preços)
+  BC-4240.10.10:
+    name: Definição do catálogo de planos
+    description: |
+      Definição do catálogo de planos, incluindo níveis de plano e respetivo
+      conteúdo.
+  BC-4240.10.20:
+    name: Definição de direitos de funcionalidades
+    description: |
+      Definição de direitos de funcionalidades associados a planos, extras
+      e contratos personalizados.
+  BC-4240.10.30:
+    name: Regras de elegibilidade de planos
+    description: |
+      Regras que determinam quais os clientes e casos de uso elegíveis
+      para cada plano.
+  BC-4240.20:
+    name: Contratação de subscrições
+    description: |
+      Gestão de propostas, geração de formulários de encomenda e captura de
+      artefactos de contratos de subscrição.
+  BC-4240.20.10:
+    name: Gestão de propostas de subscrição
+    description: |
+      Geração e gestão de propostas de subscrição ao longo do processo
+      de vendas.
+  BC-4240.20.20:
+    name: Geração de formulários de encomenda
+    description: |
+      Geração de formulários de encomenda refletindo os termos acordados para
+      clientes novos e existentes.
+  BC-4240.20.30:
+    name: Captura de contratos de subscrição
+    description: |
+      Captura e armazenamento de artefactos de contratos de subscrição
+      executados e termos-chave.
+  BC-4240.30:
+    name: Provisionamento de subscrições
+    description: |
+      Ativação do serviço para novas subscrições, incluindo conversão de
+      trial para pago e provisionamento em massa de lugares.
+  BC-4240.30.10:
+    name: Provisionamento inicial
+    description: |
+      Provisionamento inicial dos direitos de serviço no início da subscrição.
+  BC-4240.30.20:
+    name: Conversão de trial
+    description: |
+      Conversão de contas de trial em subscrições pagas.
+  BC-4240.30.30:
+    name: Provisionamento em massa de lugares
+    description: |
+      Provisionamento em massa de lugares para subscrições empresariais.
+  BC-4240.40:
+    name: Modificação de subscrições
+    description: |
+      Alterações em subscrições ativas, incluindo atualizações, reduções de
+      plano, ajustes de lugares e ativação de extras.
+  BC-4240.40.10:
+    name: Gestão de atualização de plano
+    description: |
+      Gestão de atualizações de plano iniciadas pelo cliente e pelo sistema.
+  BC-4240.40.20:
+    name: Gestão de redução de plano
+    description: |
+      Gestão de reduções de plano, incluindo o efeito nos direitos e dados.
+  BC-4240.40.30:
+    name: Ajuste de lugares
+    description: |
+      Ajuste de contagens de lugares em subscrições ativas.
+  BC-4240.40.40:
+    name: Ativação de extras
+    description: |
+      Ativação de direitos de extras opcionais em subscrições ativas.
+  BC-4240.50:
+    name: Gestão de renovações
+    description: |
+      Previsão, processamento e negociação de renovações de subscrições,
+      sejam automáticas ou manuais.
+  BC-4240.50.10:
+    name: Previsão de renovações
+    description: |
+      Previsão de renovações iminentes e resultados esperados.
+  BC-4240.50.20:
+    name: Processamento de renovação automática
+    description: |
+      Processamento de renovações automáticas de subscrições de acordo com
+      os termos do contrato.
+  BC-4240.50.30:
+    name: Apoio à negociação de renovações
+    description: |
+      Apoio às negociações de renovação, incluindo dados, preços e pacotes
+      de alteração de termos.
+  BC-4240.60:
+    name: Cancelamento e rescisão
+    description: |
+      Cancelamento voluntário, rescisão involuntária e encerramento gradual
+      do serviço para clientes que saem.
+  BC-4240.60.10:
+    name: Processamento de cancelamento
+    description: |
+      Processamento de cancelamentos iniciados pelo cliente.
+  BC-4240.60.20:
+    name: Rescisão involuntária
+    description: |
+      Rescisão do serviço por falta de pagamento, incumprimento ou termo
+      contratual.
+  BC-4240.60.30:
+    name: Coordenação de encerramento gradual do serviço
+    description: |
+      Encerramento coordenado do serviço, incluindo exportação de dados e
+      entrega de eliminação.
+  BC-4240.70:
+    name: Aplicação de direitos
+    description: |
+      Resolução e aplicação em tempo de execução dos direitos de subscrição
+      com registo de auditoria das decisões de acesso.
+  BC-4240.70.10:
+    name: Resolução de direitos
+    description: |
+      Resolução de direitos efetivos por subscrição, conta e utilizador.
+  BC-4240.70.20:
+    name: Aplicação de portais de direitos
+    description: |
+      Controlo em tempo de execução de funcionalidades e quotas face aos
+      direitos resolvidos.
+  BC-4240.70.30:
+    name: Registo de auditoria de direitos
+    description: |
+      Registo de auditoria de alterações de direitos e decisões de portal.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-subsurface-reservoir-management.yaml
+++ b/catalogue/i18n/pt/L1-subsurface-reservoir-management.yaml
@@ -1,0 +1,153 @@
+locale: pt
+source: L1-subsurface-reservoir-management.yaml
+entries:
+  BC-3010:
+    name: Gestão de subsuperfície e reservatório
+    description: |
+      Geociências e engenharia de reservatório ao longo do ciclo de vida do activo
+      produtor — caracterização, simulação, classificação de reservas e recursos,
+      estratégia de depleção e concepção de recuperação melhorada.
+  BC-3010.10:
+    name: Gestão de geociências de subsuperfície
+    description: |
+      Descrição estática da subsuperfície através de modelação geológica,
+      petrofísica e interpretação estrutural em activos produtores.
+  BC-3010.10.10:
+    name: Modelação geológica
+    description: |
+      Construção e actualização de modelos geológicos e de fácies estáticos.
+  BC-3010.10.20:
+    name: Análise petrofísica
+    description: |
+      Análise de perfis, integração de testemunhos e avaliação petrofísica de
+      reservatórios.
+  BC-3010.10.30:
+    name: Interpretação estrutural
+    description: |
+      Interpretação estrutural e da rede de falhas para activos produtores.
+  BC-3010.10.40:
+    name: Actualização de geomodelos
+    description: |
+      Actualização de geomodelos com novos dados de poços, sísmicos e de produção.
+  BC-3010.20:
+    name: Engenharia de reservatório
+    description: |
+      Análise do comportamento dinâmico do reservatório através de simulação, PVT,
+      balanço de materiais e métodos de análise transitória de pressão.
+    in_scope:
+      - Simulação de reservatório e ajuste histórico
+      - Análise de PVT e propriedades de fluidos
+      - Análise transitória de pressão e análise de testes de poços
+    out_of_scope:
+      - Análise de curvas de declínio e previsão de produção (BC-3010.50)
+  BC-3010.20.10:
+    name: Caracterização do reservatório
+    description: |
+      Caracterização integrada estática e dinâmica de reservatórios.
+  BC-3010.20.20:
+    name: Simulação de reservatório
+    description: |
+      Simulação numérica de reservatório, ajuste histórico e geração de previsões.
+  BC-3010.20.30:
+    name: Análise de PVT e fluidos
+    description: |
+      Amostragem de PVT, análise laboratorial e modelação de propriedades de
+      fluidos.
+  BC-3010.20.40:
+    name: Análise de balanço de materiais
+    description: |
+      Análise de balanço de materiais para estimar volumes in-situ e mecanismos
+      de accionamento.
+  BC-3010.20.50:
+    name: Análise transitória de pressão
+    description: |
+      Análise de testes de poços e interpretação transitória de pressão.
+  BC-3010.30:
+    name: Gestão de reservas e recursos
+    description: |
+      Estimativa, classificação e registo externo de reservas de petróleo e
+      recursos contingentes segundo os requisitos SPE-PRMS e SEC.
+  BC-3010.30.10:
+    name: Estimativa de reservas
+    description: |
+      Estimativa determinística e probabilística de reservas de petróleo.
+  BC-3010.30.20:
+    name: Classificação de reservas
+    description: |
+      Classificação de reservas e recursos segundo as categorias SPE-PRMS.
+  BC-3010.30.30:
+    name: Registo de reservas
+    description: |
+      Registo de reservas de final de ano para divulgações regulatórias SEC e
+      equivalentes.
+  BC-3010.30.40:
+    name: Coordenação de auditoria de reservas
+    description: |
+      Coordenação de auditorias internas e de terceiros de reservas.
+  BC-3010.40:
+    name: Planeamento de desenvolvimento de campo
+    description: |
+      Selecção de conceito, estratégia de depleção e redacção do plano de
+      desenvolvimento de campo desde a descoberta até à sanção do desenvolvimento.
+  BC-3010.40.10:
+    name: Selecção de conceito
+    description: |
+      Selecção e triagem de conceitos liderados pela subsuperfície para novos
+      desenvolvimentos de campo.
+  BC-3010.40.20:
+    name: Redacção do plano de desenvolvimento de campo
+    description: |
+      Redacção de planos de desenvolvimento de campo para aprovação regulatória e
+      de parceiros.
+  BC-3010.40.30:
+    name: Definição da estratégia de depleção
+    description: |
+      Definição da estratégia de depleção do reservatório, incluindo drenagem e
+      número de poços.
+  BC-3010.40.40:
+    name: Avaliação de risco de subsuperfície
+    description: |
+      Avaliação da incerteza de subsuperfície e o seu impacto comercial nas
+      decisões de desenvolvimento.
+  BC-3010.50:
+    name: Previsão de produção
+    description: |
+      Geração e reconciliação de previsões de produção para planeamento de activos,
+      negócio e reservas.
+  BC-3010.50.10:
+    name: Análise de curvas de declínio
+    description: |
+      Análise de curvas de declínio para previsão da produção de poços e campo.
+  BC-3010.50.20:
+    name: Geração de previsão de produção
+    description: |
+      Geração de previsões de produção integrando restrições de poços, reservatório
+      e instalações.
+  BC-3010.50.30:
+    name: Reconciliação de previsões
+    description: |
+      Reconciliação de previsões de subsuperfície com os valores reais da
+      contabilidade de produção.
+  BC-3010.60:
+    name: Gestão de recuperação melhorada e aumentada
+    description: |
+      Concepção e vigilância de esquemas de recuperação secundária e terciária,
+      incluindo injecção de água e gás e processos EOR.
+  BC-3010.60.10:
+    name: Concepção de recuperação secundária
+    description: |
+      Concepção de esquemas de recuperação secundária por inundação com água e
+      injecção de gás.
+  BC-3010.60.20:
+    name: Concepção de recuperação terciária
+    description: |
+      Concepção de esquemas de recuperação melhorada de petróleo químicos, térmicos
+      e miscíveis.
+  BC-3010.60.30:
+    name: Vigilância da estratégia de injecção
+    description: |
+      Vigilância e optimização de padrões de injecção e substituição de voidage.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-supplier-management.yaml
+++ b/catalogue/i18n/pt/L1-supplier-management.yaml
@@ -1,0 +1,107 @@
+locale: pt
+source: L1-supplier-management.yaml
+entries:
+  BC-510:
+    name: Gestão de fornecedores
+    description: |
+      Qualificação, desempenho, risco e gestão do relacionamento com fornecedores.
+  BC-510.10:
+    name: Gestão da integração de fornecedores
+    description: |
+      Qualificação, registo e due diligence.
+  BC-510.10.10:
+    name: Registo de fornecedores
+    description: |
+      Captura de identificação, dados bancários e informação fiscal de fornecedores.
+  BC-510.10.20:
+    name: Qualificação e pré-triagem de fornecedores
+    description: |
+      Qualificação de capacidade, financeira e de conformidade de novos fornecedores.
+  BC-510.10.30:
+    name: Due diligence de fornecedores
+    description: |
+      Due diligence de sanções, ABC, ESG e integridade sobre fornecedores.
+  BC-510.10.40:
+    name: Gestão de dados mestre de fornecedores
+    description: |
+      Manutenção de dados mestre de fornecedores e alterações do ciclo de vida.
+  BC-510.20:
+    name: Gestão do desempenho de fornecedores
+    description: |
+      Scorecards de desempenho e gestão de SLAs.
+  BC-510.20.10:
+    name: Scorecards e KPIs de fornecedores
+    description: |
+      Definição e acompanhamento de scorecards de desempenho de fornecedores.
+  BC-510.20.20:
+    name: Gestão de acordos de nível de serviço
+    description: |
+      Definição, monitorização e aplicação de remédios dos SLAs.
+  BC-510.20.30:
+    name: Auditoria e inspeção de fornecedores
+    description: |
+      Auditorias e inspeções presenciais a fornecedores sobre capacidades e qualidade.
+  BC-510.20.40:
+    name: Gestão de problemas e CAPA de fornecedores
+    description: |
+      Registo de problemas, ações corretivas e preventivas com fornecedores.
+  BC-510.30:
+    name: Gestão do risco de fornecedores
+    description: |
+      Risco financeiro, ESG, geopolítico e cibernético nos fornecedores.
+  BC-510.30.10:
+    name: Monitorização do risco financeiro de fornecedores
+    description: |
+      Monitorização da saúde financeira e risco de crédito dos fornecedores.
+  BC-510.30.20:
+    name: Risco ESG e de sustentabilidade de fornecedores
+    description: |
+      Risco de ESG, direitos humanos e escravidão moderna na base de fornecedores.
+  BC-510.30.30:
+    name: Risco cibernético e de TI de fornecedores
+    description: |
+      Avaliação e monitorização do risco cibernético e de TI de terceiros.
+  BC-510.30.40:
+    name: Risco geopolítico e de concentração de fornecedores
+    description: |
+      Risco geopolítico, de país e de concentração na base de fornecedores.
+  BC-510.40:
+    name: Gestão do desenvolvimento de fornecedores
+    description: |
+      Desenvolvimento de capacidades e programas de melhoria de fornecedores.
+  BC-510.40.10:
+    name: Desenvolvimento de capacidades de fornecedores
+    description: |
+      Desenvolvimento conjunto de capacidades, formação e transferência de tecnologia.
+  BC-510.40.20:
+    name: Programa de diversidade de fornecedores
+    description: |
+      Identificação e desenvolvimento de fornecedores diversos e de pequena dimensão.
+  BC-510.40.30:
+    name: Programa de inovação de fornecedores
+    description: |
+      Programas para sourcing de inovação liderada por fornecedores e co-desenvolvimento.
+  BC-510.50:
+    name: Gestão do relacionamento com fornecedores
+    description: |
+      Relações estratégicas com fornecedores e fóruns de governação.
+  BC-510.50.10:
+    name: Segmentação estratégica de fornecedores
+    description: |
+      Segmentação de fornecedores por criticidade e valor.
+  BC-510.50.20:
+    name: Relacionamento executivo com fornecedores
+    description: |
+      Patrocínio executivo e steering com fornecedores estratégicos.
+  BC-510.50.30:
+    name: Planeamento conjunto de negócio
+    description: |
+      Planeamento conjunto de negócio e criação de valor com fornecedores estratégicos.
+  BC-510.50.40:
+    name: Portal de fornecedores e colaboração
+    description: |
+      Portal de fornecedores, self-service e plataformas de colaboração.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-supply-chain-management.yaml
+++ b/catalogue/i18n/pt/L1-supply-chain-management.yaml
@@ -1,0 +1,135 @@
+locale: pt
+source: L1-supply-chain-management.yaml
+entries:
+  BC-520:
+    name: Gestão da cadeia de abastecimento
+    description: |
+      Planeamento, orquestração e execução da cadeia de abastecimento ponta a ponta.
+  BC-520.10:
+    name: Gestão do planeamento da procura
+    description: |
+      Previsão de procura, planeamento estatístico e por consenso.
+  BC-520.10.10:
+    name: Previsão estatística da procura
+    description: |
+      Previsões de procura baseadas em estatística e aprendizagem automática.
+  BC-520.10.20:
+    name: Planeamento da procura por consenso
+    description: |
+      Consenso interfuncional sobre a procura incluindo overlay de vendas.
+  BC-520.10.30:
+    name: Planeamento da procura de novos produtos
+    description: |
+      Planeamento da procura para introduções e descontinuações de novos produtos.
+  BC-520.10.40:
+    name: Sensing e shaping da procura
+    description: |
+      Sensing de procura de curto prazo e iniciativas de shaping de procura.
+  BC-520.20:
+    name: Gestão do planeamento de abastecimento
+    description: |
+      Planeamento da rede de abastecimento e equilíbrio de sourcing.
+  BC-520.20.10:
+    name: Planeamento da rede de abastecimento
+    description: |
+      Planeamento multi-echelon da rede de abastecimento em fábricas e centros de distribuição.
+  BC-520.20.20:
+    name: Geração do plano de produção
+    description: |
+      Geração de planos de produção mestre em locais de abastecimento.
+  BC-520.20.30:
+    name: Alocação de abastecimento
+    description: |
+      Alocação de abastecimento condicionado entre regiões e clientes.
+  BC-520.20.40:
+    name: Equilíbrio de sourcing
+    description: |
+      Equilíbrio entre múltiplas fontes de abastecimento e dual sourcing.
+  BC-520.30:
+    name: Gestão de vendas e planeamento de operações
+    description: |
+      S&OP/IBP e alinhamento interfuncional.
+  BC-520.30.10:
+    name: Gestão do ciclo S&OP
+    description: |
+      Orquestração do ciclo mensal S&OP/IBP e cadência de reuniões.
+  BC-520.30.20:
+    name: Revisão da procura
+    description: |
+      Revisão interfuncional do plano de procura não condicionada.
+  BC-520.30.30:
+    name: Revisão do abastecimento
+    description: |
+      Revisão da viabilidade e restrições de abastecimento no ciclo S&OP.
+  BC-520.30.40:
+    name: Reconciliação integrada e S&OP executivo
+    description: |
+      Reconciliação integrada e reuniões de decisão executiva.
+  BC-520.40:
+    name: Gestão do cumprimento de encomendas
+    description: |
+      Comprometimento de encomendas, alocação e orquestração do cumprimento.
+  BC-520.40.10:
+    name: Comprometimento de encomendas e available-to-promise
+    description: |
+      Comprometimento de encomendas ATP/CTP baseado no abastecimento e capacidade.
+  BC-520.40.20:
+    name: Orquestração de encomendas
+    description: |
+      Orquestração do cumprimento de encomendas em nós e canais.
+  BC-520.40.30:
+    name: Acompanhamento e visibilidade de encomendas
+    description: |
+      Visibilidade do estado de encomendas e envios ponta a ponta.
+  BC-520.40.40:
+    name: Devoluções e cumprimento inverso
+    description: |
+      Autorização de devoluções, logística inversa e encaminhamento de recondicionamento.
+  BC-520.50:
+    name: Gestão de operações logísticas
+    description: |
+      Transporte e operações de armazenagem na cadeia de abastecimento.
+  BC-520.50.10:
+    name: Planeamento de transporte
+    description: |
+      Seleção de modo, encaminhamento e planeamento de carga.
+  BC-520.50.20:
+    name: Gestão de transportadores
+    description: |
+      Seleção, contratos e desempenho de transportadores.
+  BC-520.50.30:
+    name: Operações de armazém
+    description: |
+      Operações de receção, arrumação, picking, embalagem e expedição.
+  BC-520.50.40:
+    name: Operações transfronteiriças e aduaneiras
+    description: |
+      Movimentos transfronteiriços, desalfandegamento e conformidade comercial.
+  BC-520.50.50:
+    name: Operações de entrega de última milha
+    description: |
+      Encaminhamento de entrega de última milha, gestão de slots e prova de entrega.
+  BC-520.60:
+    name: Gestão do risco da cadeia de abastecimento
+    description: |
+      Disrupção da cadeia de abastecimento, visibilidade e resiliência.
+  BC-520.60.10:
+    name: Visibilidade ponta a ponta da cadeia de abastecimento
+    description: |
+      Visibilidade multi-tier sobre fornecedores, inventário e envios.
+  BC-520.60.20:
+    name: Deteção e resposta a disrupções
+    description: |
+      Deteção de disrupções e ações de resposta orquestradas.
+  BC-520.60.30:
+    name: Design de resiliência da cadeia de abastecimento
+    description: |
+      Design de rede para resiliência incluindo dual sourcing e buffers.
+  BC-520.60.40:
+    name: Conformidade da cadeia de abastecimento
+    description: |
+      Conformidade com due diligence da cadeia de abastecimento e regulamentos comerciais.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-sustainability-management.yaml
+++ b/catalogue/i18n/pt/L1-sustainability-management.yaml
@@ -1,0 +1,115 @@
+locale: pt
+source: L1-sustainability-management.yaml
+entries:
+  BC-740:
+    name: Gestão da sustentabilidade
+    description: |
+      Estratégia ESG, clima, circularidade e reporte de sustentabilidade.
+  BC-740.10:
+    name: Gestão da estratégia e reporte ESG
+    description: |
+      Estratégia ESG, materialidade e relatórios de sustentabilidade.
+  BC-740.10.10:
+    name: Desenvolvimento da estratégia ESG
+    description: |
+      Estratégia ESG, ambições e integração com a estratégia de negócio.
+  BC-740.10.20:
+    name: Avaliação de materialidade
+    description: |
+      Avaliações de materialidade simples e dupla de acordo com ESRS/GRI.
+  BC-740.10.30:
+    name: Reporte e divulgação de sustentabilidade
+    description: |
+      Produção de relatórios e divulgações de sustentabilidade (CSRD, IFRS S1/S2, GRI).
+  BC-740.10.40:
+    name: Gestão e garantia de dados ESG
+    description: |
+      Recolha de dados ESG, controlos e garantia externa.
+  BC-740.20:
+    name: Gestão de clima e carbono
+    description: |
+      Pegada de carbono, descarbonização e divulgações climáticas.
+  BC-740.20.10:
+    name: Gestão do inventário de GEE
+    description: |
+      Inventário de gases com efeito de estufa dos âmbitos 1, 2 e 3 segundo o GHG Protocol.
+  BC-740.20.20:
+    name: Gestão do roteiro de descarbonização
+    description: |
+      Metas baseadas na ciência e planeamento do roteiro de descarbonização.
+  BC-740.20.30:
+    name: Análise de risco climático e cenários
+    description: |
+      Risco climático físico e de transição e cenários alinhados com TCFD.
+  BC-740.20.40:
+    name: Gestão de créditos de carbono e compensações
+    description: |
+      Aprovisionamento e utilização de créditos de carbono e compensações.
+  BC-740.20.50:
+    name: Aprovisionamento de energia renovável
+    description: |
+      PPAs, RECs e sourcing de energia renovável.
+  BC-740.30:
+    name: Gestão da economia circular
+    description: |
+      Circularidade, redução de resíduos e programas de retoma.
+  BC-740.30.10:
+    name: Design circular de produtos
+    description: |
+      Design para reparação, reutilização, reciclagem e redução de uso de materiais.
+  BC-740.30.20:
+    name: Programas de retoma e reutilização
+    description: |
+      Programas de retoma, recondicionamento e revenda pelo cliente.
+  BC-740.30.30:
+    name: Reciclagem e recuperação de materiais
+    description: |
+      Programas de reciclagem e reutilização de materiais recuperados.
+  BC-740.30.40:
+    name: Sustentabilidade das embalagens
+    description: |
+      Design de embalagens sustentáveis e conformidade com REP.
+  BC-740.40:
+    name: Gestão de sourcing sustentável
+    description: |
+      Cadeia de abastecimento sustentável e sourcing ético.
+  BC-740.40.10:
+    name: Normas de fornecedores sustentáveis
+    description: |
+      Código de conduta e normas de sustentabilidade para fornecedores.
+  BC-740.40.20:
+    name: Avaliação ESG de fornecedores
+    description: |
+      Ratings, auditorias e avaliações ESG de fornecedores.
+  BC-740.40.30:
+    name: Due diligence de direitos humanos
+    description: |
+      Due diligence de direitos humanos e escravidão moderna nas cadeias de abastecimento.
+  BC-740.40.40:
+    name: Sourcing responsável de matérias-primas
+    description: |
+      Sourcing responsável de minerais de conflito, madeira e commodities.
+  BC-740.50:
+    name: Relacionamento com partes interessadas em sustentabilidade
+    description: |
+      Relacionamento com ONG, comunidade e avaliadores ESG.
+  BC-740.50.10:
+    name: Relacionamento com ONG e sociedade civil
+    description: |
+      Relacionamento com ONG e sociedade civil sobre temas de sustentabilidade.
+  BC-740.50.20:
+    name: Investimento comunitário
+    description: |
+      Investimento comunitário, filantropia e programas de impacto social.
+  BC-740.50.30:
+    name: Relacionamento com avaliadores e índices ESG
+    description: |
+      Relacionamento com agências de rating ESG e índices de sustentabilidade.
+  BC-740.50.40:
+    name: Política pública e advocacia
+    description: |
+      Advocacia de política pública sobre temas de sustentabilidade.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-tailings-mine-waste-management.yaml
+++ b/catalogue/i18n/pt/L1-tailings-mine-waste-management.yaml
@@ -1,0 +1,157 @@
+locale: pt
+source: L1-tailings-mine-waste-management.yaml
+entries:
+  BC-4460:
+    name: Gestão de resíduos de mineração e de mina
+    description: |
+      Gestão do ciclo de vida de instalações de armazenamento de resíduos de
+      mineração, depósitos de resíduos rochosos, águas de mina e resíduos
+      mineiros perigosos ao abrigo da Norma Global da Indústria sobre Gestão
+      de Resíduos de Mineração e de regimes regulatórios equivalentes.
+  BC-4460.10:
+    name: Engenharia de instalações de armazenamento de resíduos
+    description: |
+      Design de engenharia e planeamento do ciclo de vida das instalações de
+      armazenamento de resíduos de mineração, incluindo seleção do local,
+      construção da barragem e design alinhado com o encerramento.
+    in_scope:
+      - Seleção do local e design conceptual
+      - Engenharia de alteamento e construção de barragem
+      - Planeamento de deposição e modelação de praia
+    out_of_scope:
+      - Deposição operacional de resíduos (BC-4460.20)
+      - Monitorização por instrumentação dos resíduos (BC-4460.30)
+  BC-4460.10.10:
+    name: Seleção do local da instalação de armazenamento de resíduos
+    description: |
+      Seleção de local por multicritérios e análise de alternativas para
+      instalações de resíduos novas e ampliadas.
+  BC-4460.10.20:
+    name: Engenharia de construção de barragem
+    description: |
+      Design de engenharia e garantia de qualidade de construção de aterros
+      de barragem de resíduos.
+  BC-4460.10.30:
+    name: Planeamento de deposição de resíduos
+    description: |
+      Planeamento de sequências de deposição, desenvolvimento de praia e
+      localização de lagoa.
+  BC-4460.10.40:
+    name: Design de instalação alinhado com encerramento
+    description: |
+      Design de instalações de resíduos alinhado com o encerramento a longo
+      prazo e a forma final do terreno segura.
+  BC-4460.20:
+    name: Operações de resíduos de mineração
+    description: |
+      Colocação operacional de resíduos nas instalações de armazenamento,
+      incluindo manuseio de polpa, pasta e resíduos filtrados e recuperação
+      de água.
+  BC-4460.20.10:
+    name: Transporte de polpa de resíduos
+    description: |
+      Operação de condutas de resíduos, estações de bombagem e sistemas de
+      distribuição.
+  BC-4460.20.20:
+    name: Operações de deposição de resíduos
+    description: |
+      Deposição operacional de resíduos na instalação de armazenamento de
+      acordo com o plano de deposição.
+  BC-4460.20.30:
+    name: Recuperação de água dos resíduos
+    description: |
+      Recuperação de água de decantação e de percolação das instalações de
+      resíduos para reutilização.
+  BC-4460.20.40:
+    name: Operações de resíduos filtrados e em pilha seca
+    description: |
+      Operação de instalações de filtração de resíduos e colocação em pilha
+      seca.
+  BC-4460.30:
+    name: Vigilância de resíduos e segurança de barragens
+    description: |
+      Vigilância, governação e preparação para emergências das instalações de
+      resíduos ao abrigo da GISTM e de regimes equivalentes de segurança de
+      barragens.
+  BC-4460.30.10:
+    name: Monitorização por instrumentação geotécnica
+    description: |
+      Monitorização de piezómetros, inclinómetros e prismas de levantamento
+      nas instalações de resíduos.
+  BC-4460.30.20:
+    name: Coordenação de revisão independente de resíduos
+    description: |
+      Envolvimento e coordenação de painéis de revisão independentes e
+      engenheiros de registo para resíduos.
+  BC-4460.30.30:
+    name: Preparação para emergências de resíduos
+    description: |
+      Planeamento de preparação e resposta a emergências para cenários de
+      rotura de barragem de resíduos.
+  BC-4460.30.40:
+    name: Reporte de conformidade com normas de resíduos
+    description: |
+      Reporte de conformidade com a Norma Global da Indústria sobre Gestão de
+      Resíduos de Mineração e reguladores equivalentes.
+  BC-4460.40:
+    name: Gestão de resíduos rochosos
+    description: |
+      Caracterização e gestão operacional de depósitos de resíduos rochosos,
+      incluindo controlos de drenagem ácida e metálica.
+  BC-4460.40.10:
+    name: Caracterização de resíduos rochosos
+    description: |
+      Caracterização geoquímica dos resíduos rochosos para potencial de
+      drenagem ácida e metálica.
+  BC-4460.40.20:
+    name: Operações de depósito de resíduos rochosos
+    description: |
+      Colocação operacional de resíduos rochosos em depósitos e áreas de
+      enchimento projetadas.
+  BC-4460.40.30:
+    name: Gestão de drenagem ácida e metálica
+    description: |
+      Prevenção, captura e tratamento de drenagem ácida e metálica proveniente
+      de resíduos rochosos e pilhas de minério.
+  BC-4460.50:
+    name: Gestão das águas de mina
+    description: |
+      Balanço hídrico de toda a mina, tratamento e conformidade de descarga.
+  BC-4460.50.10:
+    name: Operações de balanço hídrico da mina
+    description: |
+      Gestão operacional dos balanços hídricos do sítio em sistemas de água
+      de cava, subterrânea e de processo.
+  BC-4460.50.20:
+    name: Tratamento de águas de mina
+    description: |
+      Operação de instalações de tratamento de águas de mina com cal, osmose
+      inversa e biológicas.
+  BC-4460.50.30:
+    name: Monitorização da conformidade de descarga de água
+    description: |
+      Monitorização e reporte de descarga de água face às condições da licença
+      ambiental.
+  BC-4460.60:
+    name: Gestão de resíduos mineiros perigosos
+    description: |
+      Gestão de resíduos de reagentes de processo, resíduos com cianeto e
+      resíduos com teor de metais pesados.
+  BC-4460.60.10:
+    name: Eliminação de resíduos de reagentes
+    description: |
+      Eliminação de reagentes de processo usados e contentores contaminados.
+  BC-4460.60.20:
+    name: Gestão de resíduos de cianeto
+    description: |
+      Destoxificação e gestão de resíduos de mineração com cianeto e resíduos
+      de processo.
+  BC-4460.60.30:
+    name: Gestão de resíduos de mercúrio e metais pesados
+    description: |
+      Gestão de resíduos com mercúrio, arsénio e outros metais pesados
+      provenientes do processamento e refinação.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-talent-creative-workforce-management.yaml
+++ b/catalogue/i18n/pt/L1-talent-creative-workforce-management.yaml
@@ -1,0 +1,114 @@
+locale: pt
+source: L1-talent-creative-workforce-management.yaml
+entries:
+  BC-3790:
+    name: Gestão de talento criativo e força de trabalho
+    description: |
+      Sourcing e casting de talento em ecrã e criativo, contratação e
+      envolvimento de talento, distribuição de residuais e royalties,
+      conformidade com guildas e sindicatos, e relações de longo prazo
+      com talento criativo.
+  BC-3790.10:
+    name: Sourcing e casting de talento
+    description: |
+      Criação de briefings de casting e pesquisa, audição e seleção de
+      talento em ecrã e de voz para produções.
+  BC-3790.10.10:
+    name: Gestão de briefings de casting
+    description: |
+      Criação de briefings de casting e breakdowns enviados a diretores
+      e agentes de casting.
+  BC-3790.10.20:
+    name: Pesquisa e audição de talento
+    description: |
+      Pesquisa de talento, coordenação de auto-gravações e audições ao vivo,
+      e fluxos de trabalho de pré-seleção.
+  BC-3790.10.30:
+    name: Decisão de seleção de casting
+    description: |
+      Decisões de seleção e aprovação de casting contra critérios criativos
+      e comerciais.
+  BC-3790.20:
+    name: Contratação e envolvimento de talento
+    description: |
+      Negociação e contratação de envolvimentos de talento, incluindo
+      estruturas de loan-out e de empresa de serviços.
+  BC-3790.20.10:
+    name: Apoio à negociação de acordos de talento
+    description: |
+      Apoio à negociação de acordos de talento, incluindo benchmarking de
+      acordos comparáveis e preparação de term sheets.
+  BC-3790.20.20:
+    name: Contratação por loan-out e empresa de serviços
+    description: |
+      Contratação através de estruturas de loan-out e empresa de serviços
+      com considerações fiscais e de indemnização.
+  BC-3790.20.30:
+    name: Gestão de cartas de envolvimento
+    description: |
+      Criação e ciclo de vida de cartas de envolvimento e memos de negócio
+      abreviados para talento e equipas.
+  BC-3790.30:
+    name: Distribuição de residuais e royalties
+    description: |
+      Cálculo e pagamento de residuais, royalties e participações devidos
+      a talento e colaboradores criativos.
+  BC-3790.30.10:
+    name: Cálculo de residuais
+    description: |
+      Cálculo de residuais em fórmulas de guilda, tipos de mercado e
+      janelas de reutilização.
+  BC-3790.30.20:
+    name: Produção de declarações de distribuição de royalties
+    description: |
+      Produção de declarações de distribuição de royalties para talento e
+      detentores de direitos.
+  BC-3790.30.30:
+    name: Rastreio de participações subjacentes
+    description: |
+      Rastreio de participações subjacentes, incluindo definições de lucro
+      e níveis de contabilização.
+  BC-3790.40:
+    name: Conformidade com guildas e sindicatos
+    description: |
+      Aplicação de acordos de negociação coletiva, apoio a relatórios e
+      auditorias de guildas, e contribuições para fundos de pensão e saúde.
+  BC-3790.40.10:
+    name: Aplicação de acordo de negociação coletiva
+    description: |
+      Aplicação de mínimos dos acordos de negociação coletiva, regras de
+      trabalho e estruturas de horas extra em produções.
+  BC-3790.40.20:
+    name: Relatórios de guilda e apoio a auditorias
+    description: |
+      Produção de relatórios de guilda e apoio a auditorias de guildas
+      em produções.
+  BC-3790.40.30:
+    name: Gestão de contribuições para pensão e saúde
+    description: |
+      Cálculo e remessa de contribuições para planos de pensão e saúde
+      de guildas.
+  BC-3790.50:
+    name: Gestão de relações com talento criativo
+    description: |
+      Gestão de relações de longo prazo com talento criativo e os programas
+      que sustentam o envolvimento e desenvolvimento do talento.
+  BC-3790.50.10:
+    name: Gestão de relações de longo prazo com talento
+    description: |
+      Gestão de acordos de exclusividade, acordos globais e acordos de pod
+      de longo prazo com talento criativo.
+  BC-3790.50.20:
+    name: Rastreio de desempenho do talento
+    description: |
+      Rastreio da contribuição do talento e desempenho criativo em projetos
+      e seleções.
+  BC-3790.50.30:
+    name: Programas de envolvimento de talento
+    description: |
+      Programas de envolvimento, incluindo salas de escritores, residências
+      e fundos de desenvolvimento para talento criativo.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-tax-management.yaml
+++ b/catalogue/i18n/pt/L1-tax-management.yaml
@@ -1,0 +1,111 @@
+locale: pt
+source: L1-tax-management.yaml
+entries:
+  BC-220:
+    name: Gestão fiscal
+    description: |
+      Planeamento, conformidade e reporte fiscal direto e indireto.
+  BC-220.10:
+    name: Gestão de impostos diretos
+    description: |
+      Planeamento, conformidade e declarações de imposto sobre o rendimento das pessoas coletivas.
+  BC-220.10.10:
+    name: Provisão de imposto sobre o rendimento das pessoas coletivas
+    description: |
+      Cálculos de imposto corrente e diferido e provisão fiscal.
+  BC-220.10.20:
+    name: Declarações de imposto sobre o rendimento das pessoas coletivas
+    description: |
+      Preparação e submissão de declarações de imposto sobre o rendimento.
+  BC-220.10.30:
+    name: Gestão de retenção na fonte
+    description: |
+      Determinação, pagamento e certificação da retenção na fonte.
+  BC-220.10.40:
+    name: Gestão de prejuízos e créditos fiscais
+    description: |
+      Utilização, monitorização e previsão de prejuízos e créditos fiscais.
+  BC-220.20:
+    name: Gestão de impostos indiretos
+    description: |
+      IVA, GST, imposto sobre vendas e direitos aduaneiros.
+  BC-220.20.10:
+    name: Determinação de IVA e GST
+    description: |
+      Mapeamento de códigos fiscais, lugar de tributação e determinação de impostos indiretos.
+  BC-220.20.20:
+    name: Declarações e entregas de impostos indiretos
+    description: |
+      Preparação e submissão de declarações de IVA, GST e imposto sobre vendas.
+  BC-220.20.30:
+    name: Faturação eletrónica e reporte em tempo real
+    description: |
+      Faturação eletrónica e reporte em tempo real às autoridades fiscais.
+  BC-220.20.40:
+    name: Gestão de direitos aduaneiros e especiais de consumo
+    description: |
+      Valoração aduaneira, classificação e administração de impostos especiais de consumo.
+  BC-220.30:
+    name: Gestão de preços de transferência
+    description: |
+      Política, documentação e defesa de preços de transferência.
+  BC-220.30.10:
+    name: Definição da política de preços de transferência
+    description: |
+      Definição de políticas de preços de transferência alinhadas com as diretrizes da OCDE.
+  BC-220.30.20:
+    name: Documentação de preços de transferência
+    description: |
+      Ficheiro mestre, ficheiro local e reporte país a país.
+  BC-220.30.30:
+    name: Operações de cobranças intercompanhia
+    description: |
+      Cálculo, faturação e liquidação de cobranças intercompanhia.
+  BC-220.30.40:
+    name: Defesa em preços de transferência
+    description: |
+      Defesa em auditorias, APAs e procedimentos de acordo mútuo.
+  BC-220.40:
+    name: Reporte e conformidade fiscal
+    description: |
+      Declarações fiscais e divulgações fiscais estatutárias.
+  BC-220.40.10:
+    name: Contabilidade e divulgação fiscal
+    description: |
+      Divulgações fiscais nas demonstrações financeiras e análise da taxa efetiva de imposto.
+  BC-220.40.20:
+    name: Calendário de conformidade fiscal
+    description: |
+      Calendário global de entregas fiscais e acompanhamento de obrigações.
+  BC-220.40.30:
+    name: Reporte país a país
+    description: |
+      Submissões de reporte país a país ao abrigo do BEPS da OCDE.
+  BC-220.40.40:
+    name: Dados fiscais e reconciliação
+    description: |
+      Extração de dados fiscais, reconciliação e conciliação do balancete com a declaração.
+  BC-220.50:
+    name: Planeamento e consultoria fiscal
+    description: |
+      Estruturação fiscal, consultoria e contencioso.
+  BC-220.50.10:
+    name: Planeamento fiscal estratégico
+    description: |
+      Estruturação fiscal eficiente das operações, financiamento e cadeias de abastecimento.
+  BC-220.50.20:
+    name: Consultoria fiscal em transações
+    description: |
+      Due diligence fiscal e estruturação para fusões, aquisições e reorganizações.
+  BC-220.50.30:
+    name: Gestão de contencioso fiscal
+    description: |
+      Auditorias fiscais, contencioso e resolução de disputas.
+  BC-220.50.40:
+    name: Risco e governação fiscal
+    description: |
+      Quadro de risco fiscal, controlos e divulgações da estratégia fiscal.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-tax-revenue-administration-management.yaml
+++ b/catalogue/i18n/pt/L1-tax-revenue-administration-management.yaml
@@ -1,0 +1,169 @@
+locale: pt
+source: L1-tax-revenue-administration-management.yaml
+entries:
+  BC-3250:
+    name: Gestão da administração fiscal e de receitas
+    description: |
+      Administração governamental de receitas fiscais e não fiscais, incluindo
+      registo de contribuintes, processamento de declarações, avaliação, cobrança,
+      auditoria, execução e administração de reembolsos.
+  BC-3250.10:
+    name: Registo e identidade de contribuintes
+    description: |
+      Registo de contribuintes, gestão da identidade de contribuintes e manutenção
+      dos dados mestre de contribuintes.
+    in_scope:
+      - Registo de contribuintes e emissão de NIF
+      - Manutenção do perfil do contribuinte
+      - Registos de beneficiários efectivos
+    out_of_scope:
+      - Registo de identidade civil (abrangido pela Gestão de Registo Civil e de Identidade)
+  BC-3250.10.10:
+    name: Registo de contribuintes
+    description: |
+      Registo de contribuintes individuais e colectivos e emissão de números de
+      identificação fiscal.
+  BC-3250.10.20:
+    name: Manutenção do perfil do contribuinte
+    description: |
+      Manutenção de dados mestre, contactos e registo de obrigações fiscais do
+      contribuinte.
+  BC-3250.10.30:
+    name: Registo de beneficiários efectivos
+    description: |
+      Captura de estruturas de beneficiários efectivos e de grupo de entidades.
+  BC-3250.20:
+    name: Processamento de declarações e avaliação
+    description: |
+      Recepção, validação e avaliação de declarações fiscais e declarações em
+      impostos directos, indirectos e de retenção na fonte.
+  BC-3250.20.10:
+    name: Entrega de declarações
+    description: |
+      Recepção e entrega de declarações fiscais e declarações de informação por
+      múltiplos canais.
+  BC-3250.20.20:
+    name: Validação de declarações
+    description: |
+      Validação automatizada e manual de declarações, incluindo aritmética,
+      completude e consistência.
+  BC-3250.20.30:
+    name: Processamento de autoliquidação
+    description: |
+      Processamento de declarações de autoliquidação e registo de passivos
+      declarados.
+  BC-3250.20.40:
+    name: Emissão de avaliações por omissão
+    description: |
+      Emissão de avaliações por omissão e de melhor julgamento para
+      não-declarantes.
+  BC-3250.30:
+    name: Operações de cobrança de receitas
+    description: |
+      Cobrança de pagamentos fiscais voluntários por canais electrónicos, de
+      retenção na fonte, de prestações e de balcão.
+  BC-3250.30.10:
+    name: Operações de canais de pagamento
+    description: |
+      Operação de canais de pagamento, incluindo transferência bancária, cartão,
+      carteira electrónica e balcão.
+  BC-3250.30.20:
+    name: Retenção na fonte e deduções
+    description: |
+      Administração de impostos de retenção na fonte e regimes de dedução na fonte
+      por agentes pagadores.
+  BC-3250.30.30:
+    name: Administração de planos prestacionais
+    description: |
+      Configuração e acompanhamento de planos prestacionais de contribuintes e
+      acordos de pagamento faseado.
+  BC-3250.30.40:
+    name: Reconciliação de receitas
+    description: |
+      Reconciliação de receitas com contas de contribuintes e tesouraria.
+  BC-3250.40:
+    name: Auditoria e inspecção fiscal
+    description: |
+      Auditoria, inspecção e reavaliação baseadas em risco da conformidade dos
+      contribuintes.
+  BC-3250.40.10:
+    name: Selecção de casos de auditoria
+    description: |
+      Selecção baseada em risco de casos de auditoria através de análise e
+      informações.
+  BC-3250.40.20:
+    name: Trabalho de campo de auditoria
+    description: |
+      Realização de trabalho de campo de auditoria, exame de documentos e
+      entrevistas a contribuintes.
+  BC-3250.40.30:
+    name: Emissão de reavaliações
+    description: |
+      Emissão de reavaliações, ajustamentos e cartas de decisão de auditoria.
+  BC-3250.40.40:
+    name: Exame de preços de transferência
+    description: |
+      Exame de preços de partes relacionadas transfronteiriças ao abrigo dos
+      princípios de preços de transferência da OCDE.
+  BC-3250.50:
+    name: Gestão de dívida fiscal e execução
+    description: |
+      Recuperação de dívidas fiscais através de poderes de execução estatutários,
+      incluindo penhora, privilégios, apreensão e referenciação para processo
+      judicial.
+  BC-3250.50.10:
+    name: Gestão do portefólio de dívida fiscal
+    description: |
+      Segmentação, envelhecimento e priorização do portefólio de dívida fiscal.
+  BC-3250.50.20:
+    name: Acção de execução estatutária
+    description: |
+      Execução de poderes de execução estatutários, incluindo penhora, privilégios
+      e apreensão.
+  BC-3250.50.30:
+    name: Referenciação de crime fiscal
+    description: |
+      Investigação e referenciação de suspeita de evasão fiscal e crime fiscal para
+      o Ministério Público.
+  BC-3250.60:
+    name: Administração de reembolsos e créditos
+    description: |
+      Processamento de reembolsos fiscais, compensações de crédito e retenções de
+      montantes em litígio.
+  BC-3250.60.10:
+    name: Validação de reembolsos
+    description: |
+      Validação de pedidos de reembolso face a declarações, pagamentos e perfis de
+      risco.
+  BC-3250.60.20:
+    name: Emissão de reembolsos
+    description: |
+      Emissão de reembolsos e compensação face a passivos em aberto.
+  BC-3250.60.30:
+    name: Rastreio de fraude em reembolsos
+    description: |
+      Rastreio de pedidos de reembolso para indicadores de roubo de identidade e
+      fraude em reembolsos.
+  BC-3250.70:
+    name: Administração de receitas não fiscais
+    description: |
+      Administração de receitas governamentais não fiscais, incluindo taxas, coimas,
+      royalties e taxas.
+  BC-3250.70.10:
+    name: Administração de taxas e encargos
+    description: |
+      Administração de taxas estatutárias, encargos e pagamentos de utilizadores ao
+      governo.
+  BC-3250.70.20:
+    name: Cobrança de coimas e penalidades
+    description: |
+      Cobrança de coimas e penalidades judiciais e administrativas.
+  BC-3250.70.30:
+    name: Administração de royalties e taxas
+    description: |
+      Administração de royalties de recursos naturais, taxas ambientais e encargos
+      consignados.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-teaching-learning-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-teaching-learning-operations-management.yaml
@@ -1,0 +1,150 @@
+locale: pt
+source: L1-teaching-learning-operations-management.yaml
+entries:
+  BC-4730:
+    name: Gestão de operações de ensino e aprendizagem
+    description: |
+      Lecionação diária de ensino e aprendizagem, cobrindo instrução presencial e
+      online, plataformas de ambiente de aprendizagem, operações de estágio e
+      colocação, instrução suplementar e monitorização do envolvimento.
+  BC-4730.10:
+    name: Lecionação de aulas e lições
+    description: |
+      Lecionação presencial em formatos de aula, seminário, laboratório, estúdio,
+      workshop e tutorial.
+    in_scope:
+      - Lecionação de aulas e seminários
+      - Lecionação em laboratório e estúdio
+      - Lecionação em workshop e tutorial
+    out_of_scope:
+      - Lecionação online e à distância (abrangida em Operações de Aprendizagem Online e à Distância)
+  BC-4730.10.10:
+    name: Lecionação de aulas e seminários
+    description: |
+      Lecionação de grandes grupos em aulas e ensino em formato de seminário.
+  BC-4730.10.20:
+    name: Lecionação em laboratório e estúdio
+    description: |
+      Lecionação em laboratório e estúdio com atividade prática.
+  BC-4730.10.30:
+    name: Lecionação em workshop e tutorial
+    description: |
+      Lecionação em pequenos grupos em workshops e tutoriais.
+  BC-4730.20:
+    name: Operações de aprendizagem online e à distância
+    description: |
+      Lecionação síncrona, assíncrona e mista através de modalidades online e à distância.
+    in_scope:
+      - Lecionação síncrona de aulas online
+      - Lecionação assíncrona de cursos
+      - Operações de aprendizagem mista
+    out_of_scope:
+      - Autoria de materiais de aprendizagem online (abrangida em Gestão de Conteúdo Educativo e Recursos de Aprendizagem)
+  BC-4730.20.10:
+    name: Lecionação síncrona de aulas online
+    description: |
+      Aulas e tutoriais online ao vivo com instrutor.
+  BC-4730.20.20:
+    name: Lecionação assíncrona de cursos
+    description: |
+      Lecionação assíncrona de cursos ao ritmo próprio com progressão estruturada.
+  BC-4730.20.30:
+    name: Operações de aprendizagem mista
+    description: |
+      Lecionação de cursos que combinam modalidades presencial e online.
+  BC-4730.30:
+    name: Gestão do ambiente de aprendizagem
+    description: |
+      Operação de sistemas de gestão da aprendizagem, plataformas de sala de aula
+      virtual e integração com ferramentas e análises de aprendizagem a jusante.
+    in_scope:
+      - Operações do Sistema de Gestão da Aprendizagem (SGA)
+      - Operações de plataformas de sala de aula virtual
+      - Integração de ferramentas de aprendizagem LTI
+    out_of_scope:
+      - Infraestrutura de TI genérica (abrangida em Gestão de Tecnologias de Informação transversal)
+  BC-4730.30.10:
+    name: Operações do sistema de gestão da aprendizagem
+    description: |
+      Operações do Sistema de Gestão da Aprendizagem institucional.
+  BC-4730.30.20:
+    name: Operações de plataformas de sala de aula virtual
+    description: |
+      Operações de plataformas de sala de aula virtual e videoconferência utilizadas no ensino.
+  BC-4730.30.30:
+    name: Integração de ferramentas de aprendizagem
+    description: |
+      Integração de ferramentas de aprendizagem de terceiros através de LTI e normas equivalentes.
+  BC-4730.40:
+    name: Operações de estágio, clínico e colocação em contexto
+    description: |
+      Operação de aprendizagem integrada no trabalho, incluindo coordenação de
+      colocação, supervisão e monitorização das horas de estágio obrigatórias.
+    in_scope:
+      - Coordenação de locais de colocação
+      - Supervisão clínica e de estágio
+      - Monitorização de horas de colocação e caderneta
+    out_of_scope:
+      - Colocação profissional após a graduação (abrangida em Gestão de Apoio ao Estudante e Bem-Estar)
+  BC-4730.40.10:
+    name: Coordenação de locais de colocação
+    description: |
+      Coordenação com locais de colocação externos e organizações de acolhimento.
+  BC-4730.40.20:
+    name: Supervisão clínica e de estágio
+    description: |
+      Supervisão de estudantes durante colocações clínicas, profissionais e de estágio.
+  BC-4730.40.30:
+    name: Monitorização de horas de colocação e caderneta
+    description: |
+      Monitorização das horas de colocação, competências e entradas de caderneta.
+  BC-4730.50:
+    name: Tutoria e instrução suplementar
+    description: |
+      Tutoria, aprendizagem entre pares e instrução suplementar de competências
+      académicas que complementam o ensino primário.
+    in_scope:
+      - Operações de tutoria entre pares
+      - Lecionação de workshops de competências académicas
+      - Operações de tutoria específica por disciplina
+    out_of_scope:
+      - Aconselhamento académico sobre planeamento de programa (abrangido em Gestão de Apoio ao Estudante e Bem-Estar)
+  BC-4730.50.10:
+    name: Operações de tutoria entre pares
+    description: |
+      Operação de esquemas de tutoria e apoio à aprendizagem entre pares.
+  BC-4730.50.20:
+    name: Lecionação de workshops de competências académicas
+    description: |
+      Lecionação de workshops de competências académicas interdisciplinares.
+  BC-4730.50.30:
+    name: Operações de tutoria específica por disciplina
+    description: |
+      Tutoria específica por disciplina oferecida por docentes, departamentos ou serviços especializados.
+  BC-4730.60:
+    name: Monitorização da presença e envolvimento
+    description: |
+      Registo e monitorização da presença de estudantes e do envolvimento dos estudantes
+      com acionadores de intervenção para estudantes em risco.
+    in_scope:
+      - Registo de presenças
+      - Monitorização do envolvimento dos estudantes
+      - Acionamento de alerta precoce e intervenção
+    out_of_scope:
+      - Intervenção pastoral e de aconselhamento (abrangida em Gestão de Apoio ao Estudante e Bem-Estar)
+  BC-4730.60.10:
+    name: Registo de presenças
+    description: |
+      Registo da presença de estudantes nas atividades de ensino.
+  BC-4730.60.20:
+    name: Monitorização do envolvimento dos estudantes
+    description: |
+      Monitorização de sinais de envolvimento digital e comportamental.
+  BC-4730.60.30:
+    name: Alerta precoce e intervenção
+    description: |
+      Acionamento de alertas precoces e encaminhamento para serviços de apoio.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-telecom-billing-revenue-management.yaml
+++ b/catalogue/i18n/pt/L1-telecom-billing-revenue-management.yaml
@@ -1,0 +1,161 @@
+locale: pt
+source: L1-telecom-billing-revenue-management.yaml
+entries:
+  BC-2660:
+    name: Gestão de faturação e receita de telecomunicações
+    description: |
+      Mediação, cobrança, tarifação, faturação, apresentação, cobranças, garantia
+      de receita e processamento de impostos e sobretaxas específicos de
+      telecomunicações em serviços pré-pago, pós-pago e convergentes.
+  BC-2660.10:
+    name: Gestão de mediação de utilização
+    description: |
+      Recolha, normalização e encaminhamento de registos de utilização de elementos
+      de rede para sistemas de cobrança e faturação.
+  BC-2660.10.10:
+    name: Recolha de CDR
+    description: |
+      Recolha de registos de detalhe de chamada, sessão e evento de elementos de
+      rede e fontes IPDR.
+  BC-2660.10.20:
+    name: Enriquecimento de CDR
+    description: |
+      Enriquecimento de CDRs com dados de assinante, tarifa e referência
+      necessários a jusante.
+  BC-2660.10.30:
+    name: Desduplicação de CDR
+    description: |
+      Deteção e remoção de registos de utilização duplicados.
+  BC-2660.10.40:
+    name: Conversão de formato de CDR
+    description: |
+      Conversão de formatos de CDR entre fontes de recolha e consumidores a
+      jusante.
+  BC-2660.20:
+    name: Gestão de cobrança e tarifação
+    description: |
+      Cobrança online e offline, tarifação, gestão de saldo e recarregamento em
+      modelos pré-pago e pós-pago.
+  BC-2660.20.10:
+    name: Gestão de cobrança online
+    description: |
+      Cobrança em tempo real de sessões e eventos face ao saldo e política do
+      assinante.
+  BC-2660.20.20:
+    name: Gestão de cobrança offline
+    description: |
+      Tarifação offline de registos de utilização e eventos para faturação
+      pós-pago.
+  BC-2660.20.30:
+    name: Gestão de saldo
+    description: |
+      Gestão de saldos principais e dedicados, acumuladores e quotas do assinante.
+  BC-2660.20.40:
+    name: Gestão de vales e recarregamentos
+    description: |
+      Emissão, distribuição e resgate de vales e recarregamentos eletrónicos.
+  BC-2660.30:
+    name: Gestão de operações de faturação
+    description: |
+      Execução de ciclos de faturação, cálculo de faturas e gestão de ajustamentos
+      e correções.
+  BC-2660.30.10:
+    name: Execução do ciclo de faturação
+    description: |
+      Execução de ciclos de faturação programados e emissões de fatura ad-hoc.
+  BC-2660.30.20:
+    name: Cálculo de fatura
+    description: |
+      Cálculo de encargos, impostos e ajustamentos em todos os componentes da
+      conta.
+  BC-2660.30.30:
+    name: Ajustamento de fatura
+    description: |
+      Aplicação de ajustamentos aprovados a faturas, incluindo créditos e
+      isenções.
+  BC-2660.30.40:
+    name: Correção de fatura
+    description: |
+      Correção de faturas incorretas via refaturação ou ajustamentos
+      compensatórios.
+  BC-2660.40:
+    name: Gestão de apresentação e consulta de fatura
+    description: |
+      Apresentação multiformat de faturas e resolução de consultas e litígios de
+      clientes.
+  BC-2660.40.10:
+    name: Apresentação de fatura
+    description: |
+      Produção e distribuição de faturas em formatos papel, PDF e digital.
+  BC-2660.40.20:
+    name: Consulta de fatura detalhada
+    description: |
+      Tratamento de consultas detalhadas e iniciação de litígios por clientes.
+  BC-2660.40.30:
+    name: Explicação de fatura
+    description: |
+      Explicação e visualização dos componentes da fatura para clientes e agentes
+      de apoio.
+  BC-2660.50:
+    name: Gestão de cobranças de telecomunicações
+    description: |
+      Fluxos de dunning, suspensão, desconexão e cobrança de dívida específicos
+      de telecomunicações.
+  BC-2660.50.10:
+    name: Fluxo de trabalho de dunning
+    description: |
+      Fluxo de trabalho de dunning em múltiplas etapas para contas pós-pago em
+      atraso.
+  BC-2660.50.20:
+    name: Suspensão e desconexão de serviço
+    description: |
+      Suspensão suave, desconexão total e reativação de serviços por saldos não
+      pagos.
+  BC-2660.50.30:
+    name: Coordenação de cobrança de dívida
+    description: |
+      Coordenação com agências de cobrança de dívida internas e de terceiros.
+  BC-2660.60:
+    name: Gestão de garantia de receita
+    description: |
+      Deteção, quantificação e remediação de fuga de receita ao longo da cadeia
+      de receita.
+  BC-2660.60.10:
+    name: Deteção de fuga de receita
+    description: |
+      Deteção de fuga entre utilização de rede, mediação, cobrança, faturação e
+      contabilidade.
+  BC-2660.60.20:
+    name: Verificação da precisão da faturação
+    description: |
+      Verificação por amostragem e exaustiva da precisão da fatura face a eventos
+      de origem.
+  BC-2660.60.30:
+    name: Reconciliação rede-faturação
+    description: |
+      Reconciliação de ponta a ponta de eventos registados na rede com a receita
+      faturada.
+  BC-2660.70:
+    name: Gestão de impostos e sobretaxas de telecomunicações
+    description: |
+      Cálculo e remessa de impostos, sobretaxas e taxas regulatórias específicos
+      de telecomunicações.
+  BC-2660.70.10:
+    name: Sobretaxa de fundo de serviço universal
+    description: |
+      Cálculo, faturação e remessa de contribuições para o fundo de serviço
+      universal.
+  BC-2660.70.20:
+    name: Imposto especial de telecomunicações
+    description: |
+      Cálculo e remessa de impostos especiais de consumo e impostos específicos
+      de comunicações.
+  BC-2660.70.30:
+    name: Acréscimo de taxas regulatórias
+    description: |
+      Acréscimo e remessa de taxas regulatórias recorrentes ligadas a contagens
+      de assinantes e receita.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-telecom-fraud-management.yaml
+++ b/catalogue/i18n/pt/L1-telecom-fraud-management.yaml
@@ -1,0 +1,126 @@
+locale: pt
+source: L1-telecom-fraud-management.yaml
+entries:
+  BC-2690:
+    name: Gestão de fraude de telecomunicações
+    description: |
+      Deteção, investigação, prevenção, recuperação e reporte entre operadores de
+      fraude específica de telecomunicações — fraude de subscrição, IRSF, Wangiri,
+      SIM-swap, bypass e esquemas de partilha de receita — ancorada nas
+      orientações de fraude da GSMA.
+  BC-2690.10:
+    name: Deteção de fraude de telecomunicações
+    description: |
+      Deteção em tempo real e quase em tempo real de padrões de fraude específicos
+      de telecomunicações em tráfego de voz, dados e sinalização.
+  BC-2690.10.10:
+    name: Deteção de fraude de subscrição
+    description: |
+      Deteção de aquisição fraudulenta de serviços utilizando identidades roubadas
+      ou fabricadas.
+  BC-2690.10.20:
+    name: Deteção de fraude de partilha de receita internacional
+    description: |
+      Deteção de padrões de tráfego IRSF que inflacionam a liquidação para
+      destinos premium.
+  BC-2690.10.30:
+    name: Deteção de Wangiri
+    description: |
+      Deteção de padrões de fraude de callback Wangiri e intervalos de números
+      associados.
+  BC-2690.10.40:
+    name: Deteção de SIM-swap
+    description: |
+      Deteção de tentativas fraudulentas de troca de SIM e eSIM e apropriação
+      de conta a jusante.
+  BC-2690.10.50:
+    name: Deteção de fraude de bypass
+    description: |
+      Deteção de esquemas de SIM-box e outros esquemas de bypass que defraudam
+      as receitas de interligação.
+  BC-2690.20:
+    name: Investigação de fraude de telecomunicações
+    description: |
+      Instrução de processos sobre fraude detetada, preservação de evidências e
+      ligação com as autoridades.
+  BC-2690.20.10:
+    name: Investigação de casos de fraude
+    description: |
+      Investigação estruturada de casos de fraude detetados até ao resultado.
+  BC-2690.20.20:
+    name: Recolha de evidências
+    description: |
+      Recolha forense e preservação de evidências de suporte a investigações de
+      fraude.
+  BC-2690.20.30:
+    name: Ligação com as autoridades
+    description: |
+      Ligação com as autoridades de aplicação da lei em casos de fraude
+      referenciados.
+  BC-2690.30:
+    name: Controlos de prevenção de fraude de telecomunicações
+    description: |
+      Controlos preventivos — regras, limites de velocidade, reforço de
+      autenticação e listas negras — operados sobre o tráfego em tempo real.
+  BC-2690.30.10:
+    name: Gestão de regras de fraude em tempo real
+    description: |
+      Elaboração e ajuste de conjuntos de regras em tempo real utilizados por
+      plataformas de gestão de fraude.
+  BC-2690.30.20:
+    name: Gestão de controlos de velocidade
+    description: |
+      Controlos baseados em velocidade sobre utilização, recarregamentos e
+      alterações para limitar a exposição à fraude.
+  BC-2690.30.30:
+    name: Reforço de autenticação
+    description: |
+      Autenticação step-up de transações de alto risco e ações de autoatendimento.
+  BC-2690.30.40:
+    name: Gestão de listas negras de fraude
+    description: |
+      Manutenção de listas negras relacionadas com fraude para números, intervalos,
+      dispositivos e identidades.
+  BC-2690.40:
+    name: Recuperação de perdas de fraude de telecomunicações
+    description: |
+      Recuperação de encargos fraudulentos, dívidas incobráveis e ativos onde a
+      fraude é confirmada.
+  BC-2690.40.10:
+    name: Recuperação de encargos fraudulentos
+    description: |
+      Recuperação de encargos gerados por atividade fraudulenta confirmada.
+  BC-2690.40.20:
+    name: Recuperação de dívida incobrável
+    description: |
+      Recuperação de dívidas incobráveis associadas a fraude de subscrição e
+      apropriação de conta.
+  BC-2690.40.30:
+    name: Recuperação de ativos
+    description: |
+      Recuperação de dispositivos, SIMs e outros ativos ligados a ordens
+      fraudulentas.
+  BC-2690.50:
+    name: Reporte de fraude entre operadores
+    description: |
+      Partilha de informações de fraude com a indústria e reporte a reguladores
+      quando exigido.
+  BC-2690.50.10:
+    name: Partilha de informações de fraude da indústria
+    description: |
+      Contribuição e consumo de canais de informações de fraude da indústria
+      como o fórum de fraude da GSMA.
+  BC-2690.50.20:
+    name: Reporte de fraude a reguladores
+    description: |
+      Reporte de incidentes de fraude e exposição agregada a reguladores quando
+      obrigatório.
+  BC-2690.50.30:
+    name: Referenciação de fraude entre operadores
+    description: |
+      Referenciação de atividade fraudulenta suspeita a operadores de origem ou
+      destino para ação conjunta.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-telecom-network-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-telecom-network-operations-management.yaml
@@ -1,0 +1,207 @@
+locale: pt
+source: L1-telecom-network-operations-management.yaml
+entries:
+  BC-2600:
+    name: Gestão de operações de rede de telecomunicações
+    description: |
+      Operação quotidiana de redes fixas, móveis e IP em rádio acesso, núcleo,
+      transporte e edge — cobrindo falhas, configuração, desempenho, inventário,
+      alterações, operações de segurança e coordenação de campo, ancorada em
+      TMN FCAPS e eTOM Gestão de Recursos e Operações.
+  BC-2600.10:
+    name: Gestão de falhas de rede
+    description: |
+      Deteção, correlação, ticketing, restauro e análise de causa-raiz de falhas
+      de rede nos domínios de acesso, núcleo e transporte.
+  BC-2600.10.10:
+    name: Correlação de alarmes
+    description: |
+      Correlação em tempo real e desduplicação de alarmes de rede em eventos
+      acionáveis.
+  BC-2600.10.20:
+    name: Gestão de tickets de avaria
+    description: |
+      Gestão do ciclo de vida de tickets de avaria de rede, desde a criação até
+      ao encerramento.
+  BC-2600.10.30:
+    name: Gestão de interrupções de rede
+    description: |
+      Coordenação da resposta a interrupções major de rede, comunicações e ações
+      de recuperação.
+  BC-2600.10.40:
+    name: Análise de causa-raiz
+    description: |
+      Investigação estruturada de falhas recorrentes ou graves para identificar
+      e eliminar causas subjacentes.
+  BC-2600.20:
+    name: Gestão de configuração de rede
+    description: |
+      Definição e aplicação de normas de configuração de elementos de rede e
+      implementação controlada de alterações de configuração.
+  BC-2600.20.10:
+    name: Gestão de configuração de referência
+    description: |
+      Definição e manutenção de configurações de referência aprovadas por tipo
+      e função de elemento de rede.
+  BC-2600.20.20:
+    name: Gestão de parâmetros de rede
+    description: |
+      Gestão do ciclo de vida de parâmetros de rede ajustáveis e os seus
+      intervalos autorizados.
+  BC-2600.20.30:
+    name: Gestão de imagens de software
+    description: |
+      Custódia e controlo de versões aprovadas de imagens de software e firmware
+      de elementos de rede.
+  BC-2600.20.40:
+    name: Implementação automatizada de configuração
+    description: |
+      Implementação por ferramentas de alterações de configuração aprovadas em
+      escala, com verificação e rollback.
+  BC-2600.30:
+    name: Gestão do desempenho de rede
+    description: |
+      Captura e análise contínua de contadores de desempenho e KPIs de rede para
+      detetar e prevenir degradação.
+  BC-2600.30.10:
+    name: Captura de KPIs de rede
+    description: |
+      Recolha e armazenamento de contadores de desempenho e KPIs ao nível de
+      elemento e de rede.
+  BC-2600.30.20:
+    name: Monitorização de limiares
+    description: |
+      Monitorização de KPIs de desempenho face a limiares de engenharia e SLA.
+  BC-2600.30.30:
+    name: Monitorização da utilização de capacidade
+    description: |
+      Acompanhamento da utilização de recursos face à capacidade dimensionada
+      para sinalizar condições próximas da saturação.
+  BC-2600.30.40:
+    name: Correlação com impacto no cliente
+    description: |
+      Correlação de sinais de desempenho de rede com indicadores de experiência
+      do cliente para identificar condições com impacto no serviço.
+  BC-2600.40:
+    name: Gestão de inventário de rede
+    description: |
+      Registo autoritativo de recursos de rede lógicos e físicos e as suas
+      relações, mantido em sincronização com a realidade através de reconciliação.
+  BC-2600.40.10:
+    name: Inventário de rede lógico
+    description: |
+      Registo autoritativo de recursos lógicos como serviços, circuitos,
+      atribuições IP/VLAN e caminhos de portador.
+  BC-2600.40.20:
+    name: Inventário de rede físico
+    description: |
+      Registo autoritativo de ativos físicos como nós, placas, portas, fibra,
+      condutas e antenas.
+  BC-2600.40.30:
+    name: Reconciliação de inventário
+    description: |
+      Reconciliação de registos de inventário com descoberta, conceção e
+      levantamentos de campo.
+  BC-2600.40.40:
+    name: Descoberta de recursos de rede
+    description: |
+      Descoberta automatizada de elementos de rede implementados e o seu estado.
+  BC-2600.50:
+    name: Gestão de alterações e lançamentos de rede
+    description: |
+      Planeamento, aprovação, execução, verificação e rollback de alterações a
+      elementos e serviços de rede em produção.
+  BC-2600.50.10:
+    name: Planeamento de alterações de rede
+    description: |
+      Planeamento e avaliação de risco de alterações de rede, incluindo janelas
+      de impacto.
+  BC-2600.50.20:
+    name: Implementação de alterações de rede
+    description: |
+      Execução controlada de alterações de rede aprovadas nas janelas planeadas.
+  BC-2600.50.30:
+    name: Verificação de alterações
+    description: |
+      Verificação pós-alteração de que a rede está no estado esperado e a operar
+      dentro da tolerância.
+  BC-2600.50.40:
+    name: Rollback de alterações
+    description: |
+      Reversão de alterações que falham a verificação ou desencadeiam impacto
+      inaceitável.
+  BC-2600.60:
+    name: Operações de segurança de rede
+    description: |
+      Monitorização e resposta de segurança específica para rede de
+      telecomunicações, cobrindo os domínios de sinalização, transporte e rede
+      central, complementando a cibersegurança empresarial.
+  BC-2600.60.10:
+    name: Monitorização de ameaças à rede
+    description: |
+      Monitorização de redes de sinalização, transporte e núcleo para atividade
+      anómala e maliciosa.
+  BC-2600.60.20:
+    name: Proteção contra DDoS
+    description: |
+      Deteção e mitigação de ataques de negação de serviço volumétricos e
+      baseados em protocolo contra pontos de rede e de clientes.
+  BC-2600.60.30:
+    name: Controlo de acesso à rede
+    description: |
+      Aplicação de controlos de acesso administrativo e de máquina a elementos
+      de rede.
+  BC-2600.60.40:
+    name: Resposta a incidentes de segurança de rede
+    description: |
+      Contenção, erradicação e recuperação de incidentes de segurança de rede
+      confirmados.
+  BC-2600.70:
+    name: Coordenação de operações de campo
+    description: |
+      Despacho, controlo de execução e coordenação de acesso a locais para
+      atividades de campo de rede.
+  BC-2600.70.10:
+    name: Despacho de ordens de trabalho de campo
+    description: |
+      Atribuição de ordens de trabalho de rede a equipas de campo internas e
+      de empreiteiros.
+  BC-2600.70.20:
+    name: Execução de procedimentos de operação
+    description: |
+      Controlo de execução de procedimentos de operação aprovados em elementos
+      de rede em produção.
+  BC-2600.70.30:
+    name: Coordenação de acesso a locais
+    description: |
+      Coordenação de acesso físico a locais de rede, incluindo escolta, licenças
+      e controlos de segurança.
+  BC-2600.80:
+    name: Gestão de otimização de rede
+    description: |
+      Ajuste contínuo de elementos e caminhos de tráfego de rede para maximizar
+      o desempenho, a capacidade e a experiência do cliente.
+  BC-2600.80.10:
+    name: Otimização de rádio acesso
+    description: |
+      Ajuste de parâmetros de rádio acesso, relações de vizinhança e configuração
+      de antenas.
+  BC-2600.80.20:
+    name: Otimização de transporte
+    description: |
+      Ajuste de caminhos de rede de transporte, alocação de capacidade e qualidade
+      de serviço.
+  BC-2600.80.30:
+    name: Engenharia de tráfego
+    description: |
+      Encaminhamento de tráfego IP e de transporte na rede para objetivos de
+      desempenho, custo e resiliência.
+  BC-2600.80.40:
+    name: Automação de ciclo fechado
+    description: |
+      Ciclos automatizados de detetar-decidir-agir que otimizam continuamente
+      a rede sem intervenção manual.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-telecom-network-planning-management.yaml
+++ b/catalogue/i18n/pt/L1-telecom-network-planning-management.yaml
@@ -1,0 +1,144 @@
+locale: pt
+source: L1-telecom-network-planning-management.yaml
+entries:
+  BC-2610:
+    name: Gestão de planeamento de rede de telecomunicações
+    description: |
+      Conceção e dimensionamento a longo prazo de redes fixas, móveis e IP —
+      previsão de procura, planeamento de cobertura e capacidade, definição da
+      evolução tecnológica, calendarização de implementação de locais e
+      coordenação do fim de vida de redes legadas.
+  BC-2610.10:
+    name: Previsão de procura de rede
+    description: |
+      Previsão de procura a longo prazo de assinantes, tráfego e serviços para
+      orientar decisões de cobertura e capacidade.
+  BC-2610.10.10:
+    name: Previsão de crescimento de assinantes
+    description: |
+      Previsão da população de assinantes por segmento, tecnologia e geografia.
+  BC-2610.10.20:
+    name: Previsão de procura de tráfego
+    description: |
+      Previsão de volumes de tráfego de voz, dados, vídeo e sinalização por
+      domínio e célula.
+  BC-2610.10.30:
+    name: Modelação de procura de serviços
+    description: |
+      Modelação da procura de serviços novos e em evolução para ancorar roteiros
+      de capacidade e funcionalidades.
+  BC-2610.20:
+    name: Planeamento de cobertura de rede
+    description: |
+      Planeamento de objetivos de cobertura geográfica e resiliência para redes
+      de rádio, fibra e transporte.
+  BC-2610.20.10:
+    name: Planeamento de cobertura de rádio
+    description: |
+      Definição de objetivos de cobertura de rádio e modelação de propagação por
+      banda e tecnologia.
+  BC-2610.20.20:
+    name: Planeamento de cobertura de fibra
+    description: |
+      Planeamento da pegada de fibra, casas passadas e posicionamento de nós de
+      acesso.
+  BC-2610.20.30:
+    name: Planeamento de redundância e resiliência
+    description: |
+      Conceção de diversidade de rotas, redundância geográfica e objetivos de
+      resiliência.
+  BC-2610.30:
+    name: Planeamento de capacidade de rede
+    description: |
+      Dimensionamento de capacidade nos domínios de rádio acesso, núcleo e
+      transporte para satisfazer a procura prevista dentro dos objetivos de
+      desempenho.
+  BC-2610.30.10:
+    name: Planeamento de capacidade de rádio acesso
+    description: |
+      Dimensionamento de capacidade de células, setores e portadoras na rede de
+      rádio acesso.
+  BC-2610.30.20:
+    name: Planeamento de capacidade do núcleo
+    description: |
+      Dimensionamento de capacidade das funções do núcleo de rede móvel e fixo
+      e repositórios de dados de assinantes.
+  BC-2610.30.30:
+    name: Planeamento de capacidade de transporte
+    description: |
+      Dimensionamento de capacidade de fronthaul, backhaul, metro e transporte
+      de agregação.
+  BC-2610.30.40:
+    name: Planeamento de capacidade do backbone IP
+    description: |
+      Dimensionamento de capacidade do backbone IP, peering e ligações de
+      trânsito.
+  BC-2610.40:
+    name: Planeamento de evolução tecnológica de rede
+    description: |
+      Definição do roteiro tecnológico de rede plurianual e evolução da
+      arquitetura.
+  BC-2610.40.10:
+    name: Definição do roteiro tecnológico
+    description: |
+      Definição do roteiro de evolução plurianual em tecnologias de rádio,
+      transporte e núcleo.
+  BC-2610.40.20:
+    name: Evolução da arquitetura de rede
+    description: |
+      Transformação arquitetural para arquiteturas de referência alvo como núcleo
+      cloud-native e Open RAN.
+  BC-2610.40.30:
+    name: Seleção de tecnologia de fornecedor
+    description: |
+      Avaliação e seleção de tecnologias de fornecedores para novos domínios de
+      rede e ciclos de renovação.
+  BC-2610.50:
+    name: Planeamento de locais de rede
+    description: |
+      Identificação, levantamento, aprovação e calendarização de implementação
+      de novos locais de rede.
+  BC-2610.50.10:
+    name: Identificação de locais
+    description: |
+      Identificação de locais candidatos face a critérios de cobertura, capacidade
+      e backhaul.
+  BC-2610.50.20:
+    name: Levantamento de radiofrequência no local
+    description: |
+      Levantamento de locais candidatos quanto a desempenho RF, viabilidade
+      estrutural e interferência.
+  BC-2610.50.30:
+    name: Coordenação de aprovações de construção
+    description: |
+      Coordenação de aprovações internas, licenças de planeamento e zonamento
+      para novos locais.
+  BC-2610.50.40:
+    name: Calendarização de implementação
+    description: |
+      Calendarização e sequenciamento de construção de locais face a compromissos
+      de capex, fornecedor e cobertura.
+  BC-2610.60:
+    name: Planeamento do fim de vida de rede
+    description: |
+      Planeamento do desmantelamento de redes legadas, migração de clientes e
+      abate de ativos.
+  BC-2610.60.10:
+    name: Planeamento de desmantelamento de rede legada
+    description: |
+      Planeamento do desmantelamento ordenado de elementos de rede legados e
+      ativos associados.
+  BC-2610.60.20:
+    name: Planeamento de migração de clientes
+    description: |
+      Planeamento da migração de clientes de tecnologias a retirar para
+      plataformas alvo.
+  BC-2610.60.30:
+    name: Planeamento de encerramento de tecnologia
+    description: |
+      Definição de marcos de encerramento de tecnologia, notificações regulatórias
+      e eventos de desativação final.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-telecom-product-catalogue-management.yaml
+++ b/catalogue/i18n/pt/L1-telecom-product-catalogue-management.yaml
@@ -1,0 +1,112 @@
+locale: pt
+source: L1-telecom-product-catalogue-management.yaml
+entries:
+  BC-2650:
+    name: Gestão de catálogo de produtos de telecomunicações
+    description: |
+      Conceção, configuração, ciclo de vida e publicação em canal de produtos,
+      tarifas, planos, bundles e promoções de telecomunicações para consumidor,
+      empresa e grossista.
+  BC-2650.10:
+    name: Conceção de oferta de produto
+    description: |
+      Conceção de novas ofertas comerciais, incluindo funcionalidades,
+      elegibilidade e estruturas de preços.
+  BC-2650.10.10:
+    name: Especificação de oferta
+    description: |
+      Especificação da composição da oferta, funcionalidades e termos voltados
+      para o cliente.
+  BC-2650.10.20:
+    name: Viabilidade técnica do produto
+    description: |
+      Validação de que a oferta proposta é tecnicamente entregável nas redes e
+      plataformas alvo.
+  BC-2650.10.30:
+    name: Conceção de escalões de preço
+    description: |
+      Conceção de escalões de preço, regras de elegibilidade e estruturas de
+      contrato para a oferta.
+  BC-2650.20:
+    name: Gestão de tarifas e planos
+    description: |
+      Definição e ciclo de vida de tarifas, encargos recorrentes e políticas de
+      utilização razoável que sustentam as ofertas.
+  BC-2650.20.10:
+    name: Definição de tarifa de utilização
+    description: |
+      Definição de tarifas de utilização por evento e por unidade por tipo de
+      serviço e jurisdição.
+  BC-2650.20.20:
+    name: Definição de encargo recorrente
+    description: |
+      Definição de encargos recorrentes, mensalidades e encargos relacionados
+      com o contrato.
+  BC-2650.20.30:
+    name: Gestão de política de utilização razoável
+    description: |
+      Definição e ciclo de vida de políticas de utilização razoável e utilização
+      aceitável em planos ilimitados e de elevada utilização.
+  BC-2650.30:
+    name: Gestão de bundles e promoções
+    description: |
+      Composição e regras de bundles de múltiplos produtos e promoções com
+      duração limitada.
+  BC-2650.30.10:
+    name: Composição de bundle
+    description: |
+      Composição de bundles multi-serviço abrangendo móvel, fixo, conteúdo e
+      dispositivo.
+  BC-2650.30.20:
+    name: Regras de elegibilidade para promoções
+    description: |
+      Definição de regras de elegibilidade ao nível de cliente e oferta para
+      promoções.
+  BC-2650.30.30:
+    name: Regras de acumulação de descontos
+    description: |
+      Regras que regem a forma como múltiplos descontos e promoções se combinam
+      numa única conta.
+  BC-2650.40:
+    name: Publicação do catálogo de produtos
+    description: |
+      Publicação de versões do catálogo em canais e parceiros com controlo de
+      versões e variantes regionais.
+  BC-2650.40.10:
+    name: Publicação do catálogo multicanal
+    description: |
+      Publicação de conteúdo do catálogo em canais de retalho, digital, contact
+      center e parceiro.
+  BC-2650.40.20:
+    name: Controlo de versões do catálogo
+    description: |
+      Controlo de versões do conteúdo do catálogo, incluindo datas de vigência
+      e rollback.
+  BC-2650.40.30:
+    name: Gestão de variantes regionais do catálogo
+    description: |
+      Gestão de variantes regionais e de marca do catálogo a partir de um mestre
+      partilhado.
+  BC-2650.50:
+    name: Gestão do ciclo de vida de produto de telecomunicações
+    description: |
+      Gestão do ciclo de vida de ofertas desde o lançamento até à modificação,
+      encerramento e grandfathering.
+  BC-2650.50.10:
+    name: Lançamento de oferta
+    description: |
+      Coordenação de lançamentos de novas ofertas em sistemas, canais e regiões.
+  BC-2650.50.20:
+    name: Modificação de oferta
+    description: |
+      Modificação controlada de ofertas em mercado e migração de assinantes
+      existentes quando aplicável.
+  BC-2650.50.30:
+    name: Retirada e grandfathering de oferta
+    description: |
+      Retirada de ofertas da venda e grandfathering de assinantes existentes nos
+      termos legados.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-telecom-regulatory-compliance-management.yaml
+++ b/catalogue/i18n/pt/L1-telecom-regulatory-compliance-management.yaml
@@ -1,0 +1,152 @@
+locale: pt
+source: L1-telecom-regulatory-compliance-management.yaml
+entries:
+  BC-2700:
+    name: Gestão de conformidade regulatória em telecomunicações
+    description: |
+      Obrigações regulatórias específicas das telecomunicações — serviço universal,
+      intercepção legal, retenção de dados, serviços de emergência, acessibilidade,
+      neutralidade da rede e relatório de condições de licença — ancoradas nos
+      reguladores nacionais de telecomunicações e nas normas ETSI / 3GPP LI.
+  BC-2700.10:
+    name: Gestão da obrigação de serviço universal
+    description: |
+      Cumprimento e reporte das obrigações de serviço universal e dos subsídios
+      associados.
+  BC-2700.10.10:
+    name: Planeamento de áreas OSU
+    description: |
+      Planeamento da cobertura do serviço universal e dos compromissos de qualidade
+      por área.
+  BC-2700.10.20:
+    name: Relatório de subsídios OSU
+    description: |
+      Relatório do número de clientes subsidiados e da prestação de serviços aos
+      fundos OSU.
+  BC-2700.10.30:
+    name: Prestação do serviço OSU
+    description: |
+      Prestação dos serviços OSU obrigatórios, incluindo tarifas subsidiadas e
+      níveis mínimos de serviço.
+  BC-2700.20:
+    name: Gestão de intercepção legal
+    description: |
+      Provisionamento e entrega de capacidade de intercepção legal ao abrigo de
+      mandados autorizados.
+  BC-2700.20.10:
+    name: Provisionamento de intercepção legal
+    description: |
+      Provisionamento de alvos de intercepção legal em elementos de rede ao abrigo
+      de mandados autorizados.
+  BC-2700.20.20:
+    name: Entrega de intercepção legal
+    description: |
+      Entrega de conteúdo interceptado e metadados às instalações de monitorização
+      das autoridades de aplicação da lei.
+  BC-2700.20.30:
+    name: Auditoria e controlo de acesso de intercepção legal
+    description: |
+      Controlo de acesso e auditoria da actividade de intercepção legal para
+      prevenir utilizações não autorizadas.
+  BC-2700.30:
+    name: Gestão de retenção de dados de telecomunicações
+    description: |
+      Captura, armazenamento seguro e divulgação autorizada de dados de comunicações
+      retidos ao abrigo dos regimes nacionais de retenção de dados.
+  BC-2700.30.10:
+    name: Captura de dados retidos
+    description: |
+      Captura de dados de comunicações sujeitos a obrigações de retenção.
+  BC-2700.30.20:
+    name: Fluxo de trabalho de acesso a dados retidos
+    description: |
+      Fluxo de trabalho de pedidos autorizados de acesso a dados retidos por
+      autoridades competentes.
+  BC-2700.30.30:
+    name: Eliminação de dados retidos
+    description: |
+      Eliminação de dados retidos após o termo dos períodos de retenção.
+  BC-2700.40:
+    name: Gestão de serviços de emergência
+    description: |
+      Encaminhamento de chamadas de emergência, entrega de localização e capacidades
+      de aviso público obrigatórias pelos reguladores.
+  BC-2700.40.10:
+    name: Encaminhamento de chamadas de emergência
+    description: |
+      Encaminhamento de chamadas de emergência para os centros de atendimento de
+      segurança pública adequados.
+  BC-2700.40.20:
+    name: Entrega de localização do chamador
+    description: |
+      Entrega de informação de localização do chamador aos serviços de emergência
+      segundo as normas E911, eCall e AML.
+  BC-2700.40.30:
+    name: Difusão de avisos públicos
+    description: |
+      Difusão de mensagens de aviso público por cell-broadcast e SMS mediante
+      activação autorizada.
+  BC-2700.50:
+    name: Gestão de acessibilidade em telecomunicações
+    description: |
+      Prestação de funcionalidades de acessibilidade e resolução de reclamações
+      relacionadas com acessibilidade ao abrigo das obrigações específicas de
+      telecomunicações.
+  BC-2700.50.10:
+    name: Suporte a texto em tempo real e TTY
+    description: |
+      Suporte a serviços de texto em tempo real e TTY para utilizadores surdos e
+      com dificuldades auditivas.
+  BC-2700.50.20:
+    name: Prestação de funcionalidades de acessibilidade
+    description: |
+      Prestação de funcionalidades de acessibilidade específicas de telecomunicações,
+      como serviços de retransmissão e facturas acessíveis.
+  BC-2700.50.30:
+    name: Gestão de reclamações de acessibilidade
+    description: |
+      Gestão de reclamações relacionadas com acessibilidade e relatórios exigidos
+      pelo regulador.
+  BC-2700.60:
+    name: Neutralidade da rede e divulgação de gestão de tráfego
+    description: |
+      Divulgação das práticas de gestão de tráfego e conformidade com os regimes
+      de neutralidade da rede.
+  BC-2700.60.10:
+    name: Divulgação da política de gestão de tráfego
+    description: |
+      Divulgação das práticas de gestão de tráfego a clientes e reguladores.
+  BC-2700.60.20:
+    name: Transparência do estrangulamento
+    description: |
+      Reporte transparente das práticas de estrangulamento, priorização e
+      tarifação zero.
+  BC-2700.60.30:
+    name: Comunicação regulatória de neutralidade da rede
+    description: |
+      Comunicações aos reguladores sobre práticas e reclamações de neutralidade
+      da rede.
+  BC-2700.70:
+    name: Relatório regulatório de telecomunicações
+    description: |
+      Submissões recorrentes de KPIs, dados de mercado e conformidade com condições
+      de licença aos reguladores de telecomunicações.
+  BC-2700.70.10:
+    name: Submissões de KPI de telecomunicações
+    description: |
+      Submissão de KPIs obrigatórios sobre cobertura, qualidade e desempenho do
+      serviço.
+  BC-2700.70.20:
+    name: Comunicações de dados de mercado de telecomunicações
+    description: |
+      Submissão de comunicações de dados de mercado sobre assinantes, receitas e
+      tráfego.
+  BC-2700.70.30:
+    name: Relatório de condições de licença
+    description: |
+      Reporte relativo às condições da licença de operação, incluindo obrigações de
+      cobertura, implantação e qualidade.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-telecom-service-assurance-management.yaml
+++ b/catalogue/i18n/pt/L1-telecom-service-assurance-management.yaml
@@ -1,0 +1,142 @@
+locale: pt
+source: L1-telecom-service-assurance-management.yaml
+entries:
+  BC-2630:
+    name: Gestão de garantia de serviço de telecomunicações
+    description: |
+      Gestão do desempenho ao nível de serviço, qualidade, incidentes e
+      experiência do cliente face a objetivos comprometidos — ancorada em eTOM
+      Garantia de Serviço, ITU-T E.800 qualidade de serviço e TM Forum SLA
+      Open API.
+  BC-2630.10:
+    name: Gestão do nível de serviço
+    description: |
+      Definição, monitorização, reporte e gestão de violações de acordos de nível
+      de serviço com clientes e parceiros.
+  BC-2630.10.10:
+    name: Definição do nível de serviço
+    description: |
+      Definição de objetivos de SLA, métricas e métodos de medição por oferta
+      de serviço.
+  BC-2630.10.20:
+    name: Monitorização do nível de serviço
+    description: |
+      Monitorização do desempenho de serviço medido face a compromissos de SLA.
+  BC-2630.10.30:
+    name: Reporte do nível de serviço
+    description: |
+      Reporte de resultados de SLA a clientes, parceiros e partes interessadas
+      internas.
+  BC-2630.10.40:
+    name: Gestão de violações do nível de serviço
+    description: |
+      Gestão de violações de SLA, incluindo cálculo de créditos e remediação
+      de clientes.
+  BC-2630.20:
+    name: Monitorização do desempenho de serviço
+    description: |
+      Monitorização contínua de KPIs de serviço de ponta a ponta e indicadores
+      de experiência do cliente para detetar degradação.
+  BC-2630.20.10:
+    name: Monitorização de KPIs de serviço de ponta a ponta
+    description: |
+      Monitorização de KPIs de serviço de ponta a ponta agregados nos domínios
+      de rede subjacentes.
+  BC-2630.20.20:
+    name: Monitorização de indicadores de experiência do cliente
+    description: |
+      Monitorização de indicadores de estilo QoE que refletem a qualidade de
+      serviço percecionada pelo cliente.
+  BC-2630.20.30:
+    name: Deteção de degradação de serviço
+    description: |
+      Deteção precoce de padrões de degradação de serviço antes do impacto no
+      cliente.
+  BC-2630.30:
+    name: Gestão de incidentes com impacto no cliente
+    description: |
+      Gestão de ponta a ponta de incidentes que afetam clientes — deteção,
+      notificação, escalada e revisão.
+  BC-2630.30.10:
+    name: Deteção de incidentes com impacto no cliente
+    description: |
+      Deteção de incidentes que afetam um ou mais clientes, com base em sinais
+      de rede e de clientes.
+  BC-2630.30.20:
+    name: Notificação de incidentes ao cliente
+    description: |
+      Notificação a clientes e canais afetados com informação de estado, ETA e
+      soluções alternativas.
+  BC-2630.30.30:
+    name: Escalada de incidentes
+    description: |
+      Escalada de incidentes com impacto no cliente de acordo com políticas de
+      gravidade e duração.
+  BC-2630.30.40:
+    name: Revisão pós-incidente
+    description: |
+      Revisão estruturada de incidentes significativos com impacto no cliente
+      para orientar ações corretivas.
+  BC-2630.40:
+    name: Gestão da qualidade de serviço
+    description: |
+      Medição, modelação e reporte da qualidade de serviço e experiência do
+      cliente, incluindo reporte para reguladores.
+  BC-2630.40.10:
+    name: Medição da qualidade de serviço
+    description: |
+      Medição de parâmetros de QoS como latência, perda, jitter e throughput
+      por serviço.
+  BC-2630.40.20:
+    name: Modelação da qualidade de experiência
+    description: |
+      Modelação da qualidade de experiência percecionada pelo cliente a partir
+      de sinais de rede e comportamentais.
+  BC-2630.40.30:
+    name: Reporte da qualidade de serviço
+    description: |
+      Reporte de métricas de qualidade de serviço a partes interessadas internas
+      e reguladores.
+  BC-2630.50:
+    name: Coordenação do restauro de serviço
+    description: |
+      Coordenação de atividades de restauro, soluções alternativas e validação
+      de recuperação de serviços com falhas.
+  BC-2630.50.10:
+    name: Fluxo de trabalho de restauro de serviço
+    description: |
+      Orquestração de tarefas de restauro em equipas de rede e de campo.
+  BC-2630.50.20:
+    name: Coordenação de soluções alternativas
+    description: |
+      Coordenação de soluções alternativas temporárias e rotas de bypass durante
+      falhas prolongadas.
+  BC-2630.50.30:
+    name: Validação da recuperação de serviço
+    description: |
+      Validação de que o serviço foi restaurado à linha de base e que os clientes
+      já não são afetados.
+  BC-2630.60:
+    name: Gestão da experiência do cliente
+    description: |
+      Medição da experiência do cliente em torno de eventos de serviço e contacto
+      proativo para mitigar insatisfação.
+  BC-2630.60.10:
+    name: Medição de NPS de evento de serviço
+    description: |
+      Medição da satisfação do cliente e NPS no contexto de eventos com impacto
+      no serviço.
+  BC-2630.60.20:
+    name: Sinalização de risco de churn
+    description: |
+      Identificação de clientes com risco elevado de churn após incidentes de
+      serviço.
+  BC-2630.60.30:
+    name: Contacto proativo com clientes
+    description: |
+      Contacto proativo com clientes afetados com pedidos de desculpa, créditos
+      e ofertas de retenção.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-telecom-service-fulfilment-management.yaml
+++ b/catalogue/i18n/pt/L1-telecom-service-fulfilment-management.yaml
@@ -1,0 +1,139 @@
+locale: pt
+source: L1-telecom-service-fulfilment-management.yaml
+entries:
+  BC-2620:
+    name: Gestão de provisionamento de serviço de telecomunicações
+    description: |
+      Captura, decomposição, provisionamento, ativação, aceitação e instalação
+      nas instalações do cliente de ordens de serviço em serviços de consumidor,
+      empresa e grossista — ancorada em eTOM Provisionamento de Serviço e TM
+      Forum Open APIs.
+  BC-2620.10:
+    name: Captura de ordem de serviço
+    description: |
+      Captura multicanal de ordens de serviço com verificações de viabilidade e
+      crédito antes da submissão.
+  BC-2620.10.10:
+    name: Captura de ordens omnicanal
+    description: |
+      Captura de ordens de serviço em canais de retalho, digital, contact center
+      e parceiro.
+  BC-2620.10.20:
+    name: Verificação de viabilidade de serviço
+    description: |
+      Verificações de viabilidade ao nível de morada, cobertura e recursos para
+      os serviços solicitados.
+  BC-2620.10.30:
+    name: Avaliação de crédito e risco
+    description: |
+      Avaliação de crédito e filtragem de risco de fraude antes da aceitação da
+      ordem.
+  BC-2620.10.40:
+    name: Submissão de ordem
+    description: |
+      Validação, persistência e submissão a jusante de ordens de serviço aceites.
+  BC-2620.20:
+    name: Decomposição de ordem de serviço
+    description: |
+      Decomposição de ordens voltadas para o cliente em trabalho voltado para
+      recursos e sequenciamento de dependências.
+  BC-2620.20.10:
+    name: Decomposição serviço-para-recurso
+    description: |
+      Decomposição de serviços voltados para o cliente em serviços e elementos
+      voltados para recursos.
+  BC-2620.20.20:
+    name: Geração de ordens de trabalho
+    description: |
+      Geração de ordens de trabalho de rede e de campo a partir de ordens de
+      serviço decompostas.
+  BC-2620.20.30:
+    name: Sequenciamento de dependências
+    description: |
+      Sequenciamento de trabalho dependente em domínios de rede para entregar
+      um serviço de ponta a ponta.
+  BC-2620.30:
+    name: Provisionamento de serviço
+    description: |
+      Alocação de recursos de rede e orquestração de alterações de configuração
+      para instanciar serviços.
+  BC-2620.30.10:
+    name: Alocação de recursos de rede
+    description: |
+      Alocação de largura de banda, portas, endereços IP e outros recursos a uma
+      instância de serviço específica.
+  BC-2620.30.20:
+    name: Orquestração de serviço
+    description: |
+      Execução orquestrada de passos de provisionamento em funções de rede físicas
+      e virtualizadas.
+  BC-2620.30.30:
+    name: Aplicação de configuração
+    description: |
+      Aplicação de configuração específica de serviço a elementos de rede alvo.
+  BC-2620.40:
+    name: Ativação de serviço
+    description: |
+      Ativação final de serviços provisionados e notificação ao cliente e sistemas
+      a jusante.
+  BC-2620.40.10:
+    name: Ativação de serviço
+    description: |
+      Colocação em produção de serviços provisionados.
+  BC-2620.40.20:
+    name: Registo de assinante
+    description: |
+      Registo de assinantes em sistemas de autenticação, autorização e política
+      para o novo serviço.
+  BC-2620.40.30:
+    name: Ativação de faturação
+    description: |
+      Comunicação de eventos de ativação para faturação para início de encargos
+      e início do relógio contratual.
+  BC-2620.40.40:
+    name: Notificação de ativação ao cliente
+    description: |
+      Notificação a clientes e canais de que o serviço está disponível e pronto
+      a utilizar.
+  BC-2620.50:
+    name: Testes de aceitação de serviço
+    description: |
+      Testes de ponta a ponta e captura de linha de base antes da entrega formal
+      de novos serviços.
+  BC-2620.50.10:
+    name: Testes de serviço de ponta a ponta
+    description: |
+      Execução de testes funcionais e de desempenho de ponta a ponta em serviços
+      recentemente provisionados.
+  BC-2620.50.20:
+    name: Captura de linha de base de serviço
+    description: |
+      Captura de linhas de base de desempenho de serviço para monitorização de
+      SLA a jusante.
+  BC-2620.50.30:
+    name: Aprovação de aceitação
+    description: |
+      Aceitação e entrega formal de serviços para operações e para o cliente.
+  BC-2620.60:
+    name: Coordenação de instalação nas instalações do cliente
+    description: |
+      Coordenação da instalação no local de equipamento nas instalações do cliente
+      e atividades associadas.
+  BC-2620.60.10:
+    name: Agendamento de marcação de instalação
+    description: |
+      Agendamento de marcações de clientes para instalações no local.
+  BC-2620.60.20:
+    name: Coordenação de instalação no local
+    description: |
+      Coordenação de atividades do instalador, materiais e acesso nas instalações
+      do cliente.
+  BC-2620.60.30:
+    name: Registo de equipamento do cliente
+    description: |
+      Registo do equipamento instalado nas instalações do cliente e associação
+      à instância de serviço.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-telecom-subscriber-management.yaml
+++ b/catalogue/i18n/pt/L1-telecom-subscriber-management.yaml
@@ -1,0 +1,130 @@
+locale: pt
+source: L1-telecom-subscriber-management.yaml
+entries:
+  BC-2640:
+    name: Gestão de assinantes de telecomunicações
+    description: |
+      Identidade do assinante, ciclo de vida de SIM e eSIM, numeração,
+      portabilidade, identidade de dispositivo e autenticação e autorização em
+      redes móveis e fixas.
+  BC-2640.10:
+    name: Gestão de identidade do assinante
+    description: |
+      Gestão do ciclo de vida de identificadores e perfis de assinantes na
+      camada de dados de assinantes.
+  BC-2640.10.10:
+    name: Provisionamento de IMSI
+    description: |
+      Alocação e provisionamento de IMSI e identificadores equivalentes em
+      repositórios de dados de assinantes.
+  BC-2640.10.20:
+    name: Gestão de perfil de assinante
+    description: |
+      Gestão de registos de perfil de assinantes em HLR, HSS, UDM e sistemas
+      equivalentes.
+  BC-2640.10.30:
+    name: Revogação de identidade do assinante
+    description: |
+      Revogação de identidades de assinantes em caso de cancelamento, fraude ou
+      pedido regulatório.
+  BC-2640.20:
+    name: Gestão do ciclo de vida de SIM e eSIM
+    description: |
+      Gestão do ciclo de vida de cartões SIM físicos e perfis eSIM, incluindo
+      personalização, distribuição, troca e substituição.
+  BC-2640.20.10:
+    name: Provisionamento de SIM físico
+    description: |
+      Personalização e distribuição de cartões SIM físicos.
+  BC-2640.20.20:
+    name: Gestão de perfis eSIM
+    description: |
+      Gestão de perfis eSIM via SM-DP+, SM-SR e plataformas equivalentes.
+  BC-2640.20.30:
+    name: Troca e substituição de perfil
+    description: |
+      Troca e substituição de perfis SIM e eSIM de assinantes, incluindo fluxos
+      com consciência de fraude.
+  BC-2640.30:
+    name: Gestão de recursos de numeração
+    description: |
+      Gestão dos recursos de numeração telefónica concedidos por reguladores e
+      a sua atribuição a serviços.
+  BC-2640.30.10:
+    name: Alocação de blocos de números
+    description: |
+      Aquisição e alocação de blocos de números do regulador para inventário
+      interno.
+  BC-2640.30.20:
+    name: Gestão do inventário de números
+    description: |
+      Gestão do inventário de números disponíveis, reservados, atribuídos e em
+      quarentena.
+  BC-2640.30.30:
+    name: Reserva e devolução de números
+    description: |
+      Reserva de números para ordens e devolução de números não utilizados ao
+      conjunto ou ao regulador.
+  BC-2640.40:
+    name: Gestão de portabilidade de números
+    description: |
+      Portabilidade de números móveis e fixos de entrada e saída e manutenção
+      de dados de referência de encaminhamento.
+  BC-2640.40.10:
+    name: Gestão de portabilidade de entrada
+    description: |
+      Processamento de pedidos de portabilidade de números de entrada de outros
+      operadores.
+  BC-2640.40.20:
+    name: Gestão de portabilidade de saída
+    description: |
+      Processamento de pedidos de portabilidade de números de saída para outros
+      operadores.
+  BC-2640.40.30:
+    name: Manutenção de referências de encaminhamento de portabilidade
+    description: |
+      Manutenção de dados de encaminhamento de portabilidade, incluindo ENUM e
+      bases de dados de referência centrais.
+  BC-2640.50:
+    name: Gestão de identidade de dispositivo
+    description: |
+      Registo e controlo de identificadores de dispositivos para elegibilidade
+      de serviço e lista negra de dispositivos roubados.
+  BC-2640.50.10:
+    name: Registo de IMEI
+    description: |
+      Registo de IMEIs de dispositivos face a assinantes e verificações de
+      elegibilidade de serviço.
+  BC-2640.50.20:
+    name: Manutenção do registo de identidade de equipamento
+    description: |
+      Manutenção de dados EIR para dispositivos em lista branca, cinza e negra.
+  BC-2640.50.30:
+    name: Lista negra de dispositivos roubados
+    description: |
+      Inclusão em lista negra de dispositivos roubados e perdidos em cooperação
+      com registos da indústria e das autoridades.
+  BC-2640.60:
+    name: Autenticação e autorização de assinantes
+    description: |
+      Autenticação, autorização e contabilização de assinantes e dispositivos
+      em tecnologias de acesso.
+  BC-2640.60.10:
+    name: Autenticação de assinantes
+    description: |
+      Autenticação de assinantes em acesso móvel, fixo e Wi-Fi usando protocolos
+      AAA.
+  BC-2640.60.20:
+    name: Gestão de política de autorização
+    description: |
+      Gestão de regras de autorização de serviço e política por assinante e
+      dispositivo.
+  BC-2640.60.30:
+    name: Gestão de registos de contabilização
+    description: |
+      Geração e gestão de registos de contabilização AAA para cobrança e análise
+      a jusante.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-terminal-yard-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-terminal-yard-operations-management.yaml
@@ -1,0 +1,120 @@
+locale: pt
+source: L1-terminal-yard-operations-management.yaml
+entries:
+  BC-2470:
+    name: Gestão de operações de terminal e pátio
+    description: |
+      Operação de terminais portuários, intermodais, ferroviários e de carga aérea,
+      incluindo manuseamento de navios e aeronaves, gestão de pátio, portão e
+      operações de equipamento de terminal.
+  BC-2470.10:
+    name: Gestão de manuseamento de navios e aeronaves
+    description: |
+      Atracação, manuseamento em rampa e carga ou descarga de navios e aeronaves
+      em terminais.
+    in_scope:
+      - Operações de carga no cais e na rampa
+      - Planeamento de estiva na interface com o terminal
+    out_of_scope:
+      - Operações a bordo durante o longo curso (BC-2420.20)
+  BC-2470.10.10:
+    name: Atracação e estiva de navios
+    description: |
+      Atracação, amarração e planeamento de estiva de navios no porto.
+  BC-2470.10.20:
+    name: Manuseamento em rampa de aeronaves
+    description: |
+      Manuseamento em rampa e carga ou descarga de aeronaves.
+  BC-2470.10.30:
+    name: Operações de carga e descarga
+    description: |
+      Carga e descarga de contentores, ULDs e carga a granel.
+  BC-2470.20:
+    name: Gestão de pátio e pilhas
+    description: |
+      Alocação e movimentação de contentores, reboques e vagões ferroviários nos
+      pátios e pilhas do terminal.
+  BC-2470.20.10:
+    name: Alocação de slots de pátio
+    description: |
+      Alocação de slots de pátio a unidades de entrada e saída.
+  BC-2470.20.20:
+    name: Planeamento de pilhas de contentores
+    description: |
+      Planeamento de pilhas para otimizar o remanuseamento e a preparação de
+      carga.
+  BC-2470.20.30:
+    name: Gestão de pilhas de reefer e mercadorias perigosas
+    description: |
+      Gestão especializada de pilhas para ligações de reefer e unidades perigosas.
+  BC-2470.30:
+    name: Gestão de operações de portão
+    description: |
+      Operações de portão para camiões e comboios, incluindo marcação de hora
+      pré-portão, entrada e saída pelo portão.
+  BC-2470.30.10:
+    name: Operações de entrada no portão
+    description: |
+      Receção de camiões e vagões ferroviários na entrada do terminal.
+  BC-2470.30.20:
+    name: Operações de saída pelo portão
+    description: |
+      Saída de camiões e vagões ferroviários pela entrada do terminal.
+  BC-2470.30.30:
+    name: Gestão de pré-portão e marcações
+    description: |
+      Gestão de identidade, documentação e janela de marcação no pré-portão.
+  BC-2470.40:
+    name: Gestão de operações de equipamento de terminal
+    description: |
+      Operação e manutenção de equipamento de manuseamento do terminal, como
+      gruas, RTGs, reach stackers e equipamento de apoio em terra.
+  BC-2470.40.10:
+    name: Operações de grua e RTG
+    description: |
+      Operação de gruas ship-to-shore, RTGs e gruas pórtico.
+  BC-2470.40.20:
+    name: Operações de equipamento de apoio em terra
+    description: |
+      Operação de GSE como rebocadores, dollies e carregadores.
+  BC-2470.40.30:
+    name: Manutenção de equipamento de terminal
+    description: |
+      Manutenção e revisão de equipamento de manuseamento do terminal.
+  BC-2470.50:
+    name: Gestão de transferência intermodal
+    description: |
+      Transferência de carga e unidades entre modos em pontos intermodais, como
+      pátios ferrovia-estrada e estações de interligação de carga aérea.
+  BC-2470.50.10:
+    name: Intercâmbio de pátio ferroviário
+    description: |
+      Intercâmbio de vagões e unidades intermodais entre operadores ferroviários.
+  BC-2470.50.20:
+    name: Operações de transferência camião-comboio
+    description: |
+      Transferência de contentores e reboques entre camião e comboio.
+  BC-2470.50.30:
+    name: Interligação de carga aérea
+    description: |
+      Interligação de carga entre transportadoras aéreas em aeroportos hub.
+  BC-2470.60:
+    name: Gestão de capacidade e desempenho do terminal
+    description: |
+      Medição e melhoria da produtividade, dwell e throughput do terminal.
+  BC-2470.60.10:
+    name: Produtividade de cais e posição
+    description: |
+      Medição de produtividade em cais de navios e posições de aeronaves.
+  BC-2470.60.20:
+    name: Gestão de dwell de contentores
+    description: |
+      Gestão dos tempos de permanência de contentores e exposição a demurrage.
+  BC-2470.60.30:
+    name: Reporte de throughput do terminal
+    description: |
+      Reporte do throughput do terminal por modo e tipo de unidade.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-time-and-engagement-billing-management.yaml
+++ b/catalogue/i18n/pt/L1-time-and-engagement-billing-management.yaml
@@ -1,0 +1,171 @@
+locale: pt
+source: L1-time-and-engagement-billing-management.yaml
+entries:
+  BC-4330:
+    name: Gestão de tempo e faturação de projetos
+    description: |
+      Captura de tempo, trabalho em curso, acordos de honorários, faturação,
+      realização e controlo de imparidades para projetos faturáveis, além da
+      gestão de fundos fiduciários de clientes e fundos de retenção específicos
+      da prática jurídica.
+  BC-4330.10:
+    name: Gestão de registo de tempo
+    description: |
+      Captura, validação e submissão de registos de tempo de profissionais com
+      detalhe narrativo ao nível do projeto e tarefa.
+  BC-4330.10.10:
+    name: Captura de registos de tempo
+    description: |
+      Registo diário de tempo faturável e não faturável ao nível do projeto,
+      tarefa e atividade.
+  BC-4330.10.20:
+    name: Gestão da qualidade narrativa do tempo
+    description: |
+      Controlo de qualidade das narrativas de tempo para cumprir as diretrizes
+      de faturação do cliente e requisitos de faturação eletrónica.
+  BC-4330.10.30:
+    name: Submissão e aprovação do tempo
+    description: |
+      Submissão, aprovação pelo supervisor e bloqueio dos registos de tempo.
+  BC-4330.20:
+    name: Gestão de despesas do projeto
+    description: |
+      Captura e alocação de despesas relacionadas com o projeto, como taxas
+      judiciais, honorários de peritos, deslocações e impressão para faturação
+      ao cliente.
+  BC-4330.20.10:
+    name: Captura de despesas
+    description: |
+      Captura de despesas no ficheiro do projeto para recuperação posterior.
+  BC-4330.20.20:
+    name: Revisão de recuperabilidade de despesas
+    description: |
+      Revisão da recuperabilidade das despesas face à carta de missão e às
+      diretrizes de faturação do cliente.
+  BC-4330.20.30:
+    name: Imputação de despesas ao projeto
+    description: |
+      Alocação das despesas aprovadas ao trabalho em curso do projeto para
+      faturação posterior.
+  BC-4330.30:
+    name: Gestão de trabalho em curso
+    description: |
+      Acompanhamento de saldos de trabalho em curso não faturado, antiguidade
+      e decisões de ajuste em alta ou em baixa antes da faturação.
+  BC-4330.30.10:
+    name: Acompanhamento do trabalho em curso
+    description: |
+      Acompanhamento em tempo real do trabalho em curso não faturado por
+      projeto, sócio e prática.
+  BC-4330.30.20:
+    name: Análise de antiguidade do trabalho em curso
+    description: |
+      Análise de antiguidade do trabalho em curso não faturado e escalamento
+      de saldos obsoletos.
+  BC-4330.30.30:
+    name: Decisão de ajuste em alta e em baixa do trabalho em curso
+    description: |
+      Decisão ao nível do sócio sobre ajustes em alta, em baixa e diferimentos
+      do trabalho em curso antes da faturação.
+  BC-4330.40:
+    name: Gestão de acordos de honorários
+    description: |
+      Manutenção de estruturas de honorários ao nível do projeto, incluindo
+      tabelas de honorários por hora, acordos de honorários alternativos,
+      honorários fixos, honorários de sucesso e retenções.
+  BC-4330.40.10:
+    name: Manutenção de tabelas de honorários
+    description: |
+      Manutenção de tabelas de honorários padrão, específicas do cliente e
+      específicas do projeto por hora.
+  BC-4330.40.20:
+    name: Configuração de acordos de honorários alternativos
+    description: |
+      Configuração de acordos de honorários fixos, com teto, de sucesso,
+      contingentes e de retenção por projeto.
+  BC-4330.40.30:
+    name: Gestão de descontos de honorários e preços por volume
+    description: |
+      Aplicação de descontos de honorários acordados e preços por volume no
+      portefólio de projetos do cliente.
+  BC-4330.50:
+    name: Gestão de geração de faturas
+    description: |
+      Produção de faturas de projetos, formatação narrativa e conformidade
+      com os requisitos de formato de faturação eletrónica do cliente.
+  BC-4330.50.10:
+    name: Preparação de faturas pro forma
+    description: |
+      Preparação e revisão pelo sócio de faturas pro forma antes da emissão
+      final.
+  BC-4330.50.20:
+    name: Emissão de faturas finais
+    description: |
+      Emissão de faturas finais de projetos, incluindo narrativa, despesas
+      e imposto.
+  BC-4330.50.30:
+    name: Conformidade com o formato de faturação eletrónica do cliente
+    description: |
+      Conformidade com os requisitos de faturação eletrónica do cliente,
+      incluindo LEDES, códigos de tarefa UTBMS e submissão no portal do cliente.
+  BC-4330.50.40:
+    name: Cumprimento das diretrizes de faturação do cliente
+    description: |
+      Aplicação das diretrizes de faturação de advogados externos do cliente
+      sobre tempo, honorários e despesas.
+  BC-4330.60:
+    name: Gestão de realização do projeto
+    description: |
+      Acompanhamento dos rácios de realização faturado-cobrado e padrão-faturado,
+      imparidades e rentabilidade do projeto.
+  BC-4330.60.10:
+    name: Acompanhamento da realização padrão-faturado
+    description: |
+      Acompanhamento do trabalho em curso à taxa padrão face ao valor faturado
+      para identificar fugas de receita.
+  BC-4330.60.20:
+    name: Acompanhamento da realização faturado-cobrado
+    description: |
+      Acompanhamento do valor faturado face ao numerário cobrado, incluindo
+      provisão para créditos de cobrança duvidosa.
+  BC-4330.60.30:
+    name: Relatório de rentabilidade do projeto
+    description: |
+      Reporte da rentabilidade por projeto, sócio e prática utilizando receita
+      realizada e custo direto.
+  BC-4330.60.40:
+    name: Aprovação e análise de imparidades
+    description: |
+      Fluxo de trabalho de aprovação e análise de causa raiz de imparidades
+      em trabalho em curso e contas a receber.
+  BC-4330.70:
+    name: Gestão de fundos fiduciários e de retenção de clientes
+    description: |
+      Gestão de fundos de clientes detidos em fideicomisso, contas do tipo
+      IOLTA e saldos de retenção, com requisitos específicos de segregação e
+      reconciliação aplicáveis à prática jurídica.
+    in_scope:
+      - Operações de conta fiduciária de clientes
+      - Acompanhamento de saldos de retenção
+      - Reconciliação e reporte de conta fiduciária
+    out_of_scope:
+      - Tesouraria geral da firma (BC-180)
+  BC-4330.70.10:
+    name: Operações de conta fiduciária de clientes
+    description: |
+      Operação de contas fiduciárias segregadas de clientes, incluindo
+      recebimentos e pagamentos em nome do cliente.
+  BC-4330.70.20:
+    name: Gestão de saldos de retenção
+    description: |
+      Acompanhamento de saldos de retenção de clientes e gatilhos de
+      reposição.
+  BC-4330.70.30:
+    name: Reconciliação e reporte fiduciário
+    description: |
+      Reconciliação a três vias dos razões fiduciários e reporte estatutário
+      ou do organismo profissional sobre saldos fiduciários.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-tour-itinerary-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-tour-itinerary-operations-management.yaml
@@ -1,0 +1,193 @@
+locale: pt
+source: L1-tour-itinerary-operations-management.yaml
+entries:
+  BC-4100:
+    name: Gestão de operações de excursão e itinerário
+    description: |
+      Operação de atividades de operador turístico e gestão de destino
+      — montagem de produto e contratação de fornecedores, decisão de
+      partida, entrega por guia e acompanhante, logística no destino,
+      coordenação de fornecedores, recuperação de itinerário e documentação
+      do viajante.
+  BC-4100.10:
+    name: Montagem e contratação de produto de excursão
+    description: |
+      Montagem de produtos de excursão, contratação de fornecedores,
+      custeio, encaminhamento e estado do ciclo de vida do produto
+      nas marcas de excursão.
+  BC-4100.10.10:
+    name: Contratação de fornecedores e negociação de atribuições
+    description: |
+      Contratação de fornecedores de alojamento, transporte e atividades,
+      incluindo negociação de atribuições.
+  BC-4100.10.20:
+    name: Custeio e construção de margem de excursão
+    description: |
+      Custeio de produtos de excursão e construção de margem contra
+      preços de venda alvo.
+  BC-4100.10.30:
+    name: Composição e encaminhamento de itinerário
+    description: |
+      Composição de itinerários e encaminhamento entre destinos e
+      componentes de fornecedores.
+  BC-4100.10.40:
+    name: Estado do ciclo de vida do produto de excursão
+    description: |
+      Estado do ciclo de vida dos produtos de excursão, desde o conceito
+      e piloto ao retirado.
+  BC-4100.20:
+    name: Gestão de partidas de excursão
+    description: |
+      Decisão sobre partidas de excursão que abrange limiares mínimos de
+      passageiros, alocação, consolidação de marca e cancelamento ou
+      substituição.
+  BC-4100.20.10:
+    name: Limiar de partida e decisão de avançar/não avançar
+    description: |
+      Decisão sobre se as partidas programadas serão operadas contra os
+      limiares mínimos de passageiros.
+  BC-4100.20.20:
+    name: Alocação de partida e libertação de inventário
+    description: |
+      Alocação de lugares e decisões de libertação de inventário entre
+      partidas.
+  BC-4100.20.30:
+    name: Consolidação de partidas entre marcas
+    description: |
+      Consolidação de partidas marginais entre marcas irmãs ou operadores
+      parceiros.
+  BC-4100.20.40:
+    name: Cancelamento e substituição de partidas
+    description: |
+      Cancelamento de partidas inviáveis e substituição para datas de
+      partida alternativas.
+  BC-4100.30:
+    name: Operações de guia e acompanhante de excursão
+    description: |
+      Atribuição, briefing, gestão de desempenho e coordenação de guia
+      local para a entrega de excursões.
+  BC-4100.30.10:
+    name: Atribuição de guia e diretor de excursão
+    description: |
+      Atribuição de guias e diretores de excursão a partidas, de acordo
+      com requisitos de idioma e itinerário.
+  BC-4100.30.20:
+    name: Briefing pré-excursão e gestão de script
+    description: |
+      Briefing pré-excursão das equipas de acompanhamento e gestão de
+      scripts e conteúdos de itinerário.
+  BC-4100.30.30:
+    name: Monitorização do desempenho do guia durante a excursão
+    description: |
+      Monitorização do desempenho do guia durante a entrega da excursão
+      usando feedback dos hóspedes e relatórios de acompanhante.
+  BC-4100.30.40:
+    name: Coordenação do guia local
+    description: |
+      Coordenação de guias locais nos destinos, de acordo com os requisitos
+      específicos de cidade e local.
+  BC-4100.40:
+    name: Logística e transfers no destino
+    description: |
+      Logística no destino que abrange serviços de autocarro e veículo,
+      transfers de aeroporto e hotel, execução de excursões de um dia
+      e venda de bilhetes de atividade.
+  BC-4100.40.10:
+    name: Logística de autocarro e veículo
+    description: |
+      Logística para serviços de autocarro e veículo ao longo do itinerário.
+  BC-4100.40.20:
+    name: Transfers de aeroporto e hotel
+    description: |
+      Operação de transfers de aeroporto e hotel para viajantes de excursão.
+  BC-4100.40.30:
+    name: Operações de execução de excursões de um dia
+    description: |
+      Execução de excursões de um dia e de visita dentro de itinerários
+      de vários dias.
+  BC-4100.40.40:
+    name: Operações de venda de bilhetes de atividades e atrações
+    description: |
+      Operações de venda de bilhetes de atividades e atrações, incluindo
+      alocação de horários.
+  BC-4100.50:
+    name: Coordenação de fornecedores de excursão
+    description: |
+      Coordenação com empresas de gestão de destino, alojamento e
+      fornecedores de atividade ao longo da entrega operacional.
+  BC-4100.50.10:
+    name: Coordenação com empresa de gestão de destino e operador local
+    description: |
+      Coordenação com empresas de gestão de destino e operadores locais
+      que prestam serviços de excursão.
+  BC-4100.50.20:
+    name: Coordenação com fornecedores de alojamento
+    description: |
+      Coordenação com fornecedores de alojamento em listas de quartos,
+      horas de chegada e pedidos especiais.
+  BC-4100.50.30:
+    name: Coordenação com fornecedores de atrações e atividades
+    description: |
+      Coordenação com fornecedores de atrações e atividades, abrangendo
+      acesso, capacidade e arranjos especiais.
+  BC-4100.50.40:
+    name: Operações de desempenho de fornecedores
+    description: |
+      Gestão do desempenho operacional dos fornecedores de excursão com
+      base no feedback do acompanhante e na experiência do viajante.
+  BC-4100.60:
+    name: Modificação e recuperação de itinerário
+    description: |
+      Modificação em tempo real de itinerários de excursão e recuperação
+      de eventos de perturbação, incluindo força maior e alteração
+      iniciada pelo viajante.
+  BC-4100.60.10:
+    name: Operações de modificação de itinerário em tempo real
+    description: |
+      Modificação em tempo real de itinerários enquanto uma excursão
+      está em andamento, devido a fatores de operação.
+  BC-4100.60.20:
+    name: Recuperação de itinerário por força maior
+    description: |
+      Recuperação de itinerários durante eventos de força maior, como
+      mau tempo, greves e instabilidade política.
+  BC-4100.60.30:
+    name: Alteração de itinerário iniciada pelo viajante
+    description: |
+      Tratamento de alterações iniciadas pelo viajante que afetam reservas
+      de fornecedores a jusante.
+  BC-4100.60.40:
+    name: Determinação de compensação de recuperação
+    description: |
+      Determinação de compensação após modificações de itinerário,
+      incluindo reembolso e gesto de boa vontade.
+  BC-4100.70:
+    name: Documentação do cliente de excursão
+    description: |
+      Emissão e reemissão de documentos de viagem finais, vouchers,
+      informações pré-partida e comunicações de viajante específicas
+      de excursão.
+  BC-4100.70.10:
+    name: Emissão de documentos de viagem finais
+    description: |
+      Emissão de documentos de viagem finais, incluindo itinerário final
+      e contactos de emergência.
+  BC-4100.70.20:
+    name: Emissão de vouchers e documentos de serviço
+    description: |
+      Emissão de vouchers e documentos de serviço a apresentar em
+      fornecedores de excursão.
+  BC-4100.70.30:
+    name: Pacote de informações pré-partida
+    description: |
+      Compilação de pacotes de informações pré-partida, incluindo orientações
+      sobre saúde, visto e bagagem.
+  BC-4100.70.40:
+    name: Operações de reemissão de documentos de viagem
+    description: |
+      Reemissão de documentos após modificações de itinerário e alterações
+      de dados do viajante.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-trade-finance-management.yaml
+++ b/catalogue/i18n/pt/L1-trade-finance-management.yaml
@@ -1,0 +1,99 @@
+locale: pt
+source: L1-trade-finance-management.yaml
+entries:
+  BC-1350:
+    name: Gestão de financiamento de comércio
+    description: |
+      Créditos documentários, garantias, financiamento da cadeia de abastecimento e empréstimos comerciais.
+  BC-1350.10:
+    name: Gestão de crédito documentário
+    description: |
+      Cartas de crédito, LCs de importação/exportação.
+  BC-1350.10.10:
+    name: Emissão de carta de crédito
+    description: |
+      Emissão de cartas de crédito de importação ao abrigo das UCP 600.
+  BC-1350.10.20:
+    name: Notificação e confirmação de carta de crédito
+    description: |
+      Notificação e confirmação de cartas de crédito de exportação.
+  BC-1350.10.30:
+    name: Exame de documentos e conformidade
+    description: |
+      Exame de documentos quanto à conformidade com as UCP e ISBP.
+  BC-1350.10.40:
+    name: Liquidação e reembolso de LC
+    description: |
+      Liquidação e reembolso ao abrigo de créditos documentários.
+  BC-1350.20:
+    name: Gestão de garantias e cartas de crédito standby
+    description: |
+      Garantias bancárias, LCs standby e cauções de boa execução.
+  BC-1350.20.10:
+    name: Emissão de garantia bancária
+    description: |
+      Emissão de garantias bancárias e cauções de boa execução.
+  BC-1350.20.20:
+    name: Emissão de carta de crédito standby
+    description: |
+      Emissão de cartas de crédito standby ao abrigo das ISP98.
+  BC-1350.20.30:
+    name: Tratamento de reclamações de garantias
+    description: |
+      Tratamento de exigências e reclamações ao abrigo de garantias.
+  BC-1350.20.40:
+    name: Alterações e cancelamento de garantias
+    description: |
+      Alterações, prorrogações e cancelamento de garantias.
+  BC-1350.30:
+    name: Gestão de cobranças documentárias
+    description: |
+      Cobranças documentárias D/P e D/A.
+  BC-1350.30.10:
+    name: Operações de documentos contra pagamento
+    description: |
+      Operações de cobrança D/P ao abrigo das URC 522.
+  BC-1350.30.20:
+    name: Operações de documentos contra aceite
+    description: |
+      Operações de cobrança D/A incluindo letras.
+  BC-1350.30.30:
+    name: Liquidação de cobranças
+    description: |
+      Liquidação e remessa ao abrigo de cobranças documentárias.
+  BC-1350.40:
+    name: Gestão do financiamento da cadeia de abastecimento
+    description: |
+      Factoring inverso, financiamento de pagáveis e desconto dinâmico.
+  BC-1350.40.10:
+    name: Financiamento de pagáveis liderado pelo comprador
+    description: |
+      Programas de factoring inverso e financiamento de pagáveis liderados pelo comprador.
+  BC-1350.40.20:
+    name: Programas de financiamento de recebíveis
+    description: |
+      Financiamento de recebíveis e factoring para vendedores.
+  BC-1350.40.30:
+    name: Operações de desconto dinâmico
+    description: |
+      Plataformas de desconto dinâmico e cálculo de desconto.
+  BC-1350.50:
+    name: Gestão de empréstimos comerciais
+    description: |
+      Financiamento comercial pré-exportação e pós-exportação.
+  BC-1350.50.10:
+    name: Financiamento comercial pré-exportação
+    description: |
+      Financiamento pré-exportação de fundo de maneio e produção.
+  BC-1350.50.20:
+    name: Financiamento comercial pós-exportação
+    description: |
+      Desconto pós-exportação e operações de forfaiting.
+  BC-1350.50.30:
+    name: Financiamento comercial de importação
+    description: |
+      Financiamento de importação incluindo créditos-ponte e recibos de fidúcia.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-trade-promotion-management.yaml
+++ b/catalogue/i18n/pt/L1-trade-promotion-management.yaml
@@ -1,0 +1,122 @@
+locale: pt
+source: L1-trade-promotion-management.yaml
+entries:
+  BC-2360:
+    name: Gestão de promoção comercial
+    description: |
+      Disciplina de bens de consumo relativa ao investimento comercial junto de
+      clientes retalhistas — planos de negócio conjuntos, orçamentação do investimento
+      comercial, execução de eventos em loja, gestão de deduções e medição do
+      incremento pós-evento.
+  BC-2360.10:
+    name: Estratégia e planeamento de promoção comercial
+    description: |
+      Estratégia anual de promoção comercial, planeamento de investimento por
+      cliente e planos de negócio conjuntos negociados com clientes retalhistas.
+    in_scope:
+      - Calendário anual de promoção comercial
+      - Planos de negócio conjuntos por cliente
+      - Estratégia de taxas de posicionamento e listagem
+  BC-2360.10.10:
+    name: Desenvolvimento do plano comercial anual
+    description: |
+      Desenvolvimento do plano anual de promoção comercial e calendário de eventos.
+  BC-2360.10.20:
+    name: Planeamento de negócio conjunto com clientes
+    description: |
+      Planeamento de negócio conjunto com clientes retalhistas estratégicos.
+  BC-2360.10.30:
+    name: Estratégia de taxas de posicionamento e listagem
+    description: |
+      Estratégia e negociação de taxas de posicionamento e listagem para novos
+      artigos.
+  BC-2360.20:
+    name: Gestão do orçamento de investimento comercial
+    description: |
+      Orçamentação do investimento comercial, acréscimos, alocação por cliente e
+      controlo financeiro dos investimentos comerciais.
+  BC-2360.20.10:
+    name: Orçamentação do investimento comercial
+    description: |
+      Orçamentação do investimento comercial por cliente, marca e evento.
+  BC-2360.20.20:
+    name: Gestão de acréscimos de investimento comercial
+    description: |
+      Acréscimo de passivos de investimento comercial por cliente e evento.
+  BC-2360.20.30:
+    name: Alocação de investimento comercial
+    description: |
+      Alocação de dotações de investimento comercial por clientes, regiões e
+      eventos.
+  BC-2360.20.40:
+    name: Controlo financeiro do investimento comercial
+    description: |
+      Controlo financeiro do investimento comercial, incluindo limiares de
+      aprovação.
+  BC-2360.30:
+    name: Gestão de execução de eventos promocionais
+    description: |
+      Execução de eventos promocionais em loja e online, incluindo auditorias de
+      loja perfeita e ativação por equipas de campo.
+  BC-2360.30.10:
+    name: Preparação do evento com o cliente
+    description: |
+      Preparação de eventos promocionais com o cliente retalhista, incluindo
+      artes finais e previsões.
+  BC-2360.30.20:
+    name: Ativação em loja e displays
+    description: |
+      Ativação de displays em loja, gôndolas e posicionamentos secundários.
+  BC-2360.30.30:
+    name: Execução de auditoria de loja perfeita
+    description: |
+      Execução de campo de auditorias de loja perfeita e verificações por
+      reconhecimento de imagem.
+  BC-2360.30.40:
+    name: Ativação da equipa de vendas de campo
+    description: |
+      Ativação de equipas de vendas de campo para impulsionar a execução de eventos.
+  BC-2360.40:
+    name: Gestão de deduções e reclamações
+    description: |
+      Validação, contestação e resolução de deduções de clientes e reclamações
+      promocionais aplicadas contra faturas.
+    in_scope:
+      - Receção de deduções e correspondência com eventos
+      - Validação face a termos acordados
+      - Resolução de litígios e recuperação
+    out_of_scope:
+      - Cobranças genéricas de contas a receber (BC-200)
+  BC-2360.40.10:
+    name: Receção e correspondência de deduções
+    description: |
+      Receção de deduções de clientes e correspondência com eventos promocionais.
+  BC-2360.40.20:
+    name: Validação de deduções
+    description: |
+      Validação de deduções face a termos, volumes e preços acordados.
+  BC-2360.40.30:
+    name: Resolução de litígios e recuperação
+    description: |
+      Resolução de litígios com o cliente e recuperação de deduções inválidas.
+  BC-2360.50:
+    name: Medição da eficácia da promoção comercial
+    description: |
+      Medição pós-evento do incremento promocional, análise de base vs. incremental
+      e ROI por evento, cliente e marca.
+  BC-2360.50.10:
+    name: Medição de base e incremento
+    description: |
+      Medição das vendas de base e do incremento gerado por eventos promocionais.
+  BC-2360.50.20:
+    name: Análise de ROI de promoções
+    description: |
+      Análise de ROI de promoções comerciais por evento, cliente e marca.
+  BC-2360.50.30:
+    name: Análise de canibalização e antecipação de procura
+    description: |
+      Análise dos efeitos de canibalização e antecipação de procura.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-transformation-management.yaml
+++ b/catalogue/i18n/pt/L1-transformation-management.yaml
@@ -1,0 +1,87 @@
+locale: pt
+source: L1-transformation-management.yaml
+entries:
+  BC-920:
+    name: Gestão da transformação
+    description: |
+      Programas de transformação empresarial de larga escala.
+  BC-920.10:
+    name: Gestão do programa de transformação
+    description: |
+      Entrega do programa de transformação de ponta a ponta.
+  BC-920.10.10:
+    name: Visão e design da transformação
+    description: |
+      Definição da visão de transformação, estado-alvo e design.
+  BC-920.10.20:
+    name: Definição do roteiro de transformação
+    description: |
+      Roteiro de transformação plurianual e vagas.
+  BC-920.10.30:
+    name: Entrega de fluxos de trabalho da transformação
+    description: |
+      Entrega dos fluxos de trabalho e dependências da transformação.
+  BC-920.10.40:
+    name: Gestão de riscos da transformação
+    description: |
+      Identificação e gestão de riscos ao nível da transformação.
+  BC-920.20:
+    name: Gestão da governação da transformação
+    description: |
+      Direção da transformação, direitos de decisão e escalada.
+  BC-920.20.10:
+    name: Operações do órgão de direção da transformação
+    description: |
+      Operações do comité de direção e da autoridade de design.
+  BC-920.20.20:
+    name: Gestão de decisões da transformação
+    description: |
+      Quadro de tomada de decisões, registo e percursos de escalada.
+  BC-920.20.30:
+    name: Garantia da transformação
+    description: |
+      Garantia independente da saúde e qualidade da transformação.
+  BC-920.30:
+    name: Gestão da realização de benefícios
+    description: |
+      Identificação, acompanhamento e realização de benefícios.
+  BC-920.30.10:
+    name: Identificação e mapeamento de benefícios
+    description: |
+      Identificação e mapa de benefícios ligados a resultados.
+  BC-920.30.20:
+    name: Linha de base e definição de metas de benefícios
+    description: |
+      Medição da linha de base e definição de benefícios alvo.
+  BC-920.30.30:
+    name: Acompanhamento e relatório de benefícios
+    description: |
+      Acompanhamento de benefícios, relatório de realização e validação.
+  BC-920.30.40:
+    name: Otimização da captura de valor
+    description: |
+      Identificação de oportunidades adicionais de captura de valor.
+  BC-920.40:
+    name: Gestão das operações do gabinete de transformação
+    description: |
+      Serviços e operações do gabinete de transformação.
+  BC-920.40.10:
+    name: Criação do gabinete de transformação
+    description: |
+      Constituição do gabinete de transformação, papéis e modelo operativo.
+  BC-920.40.20:
+    name: Relatório de transformação
+    description: |
+      Relatório e dashboards sobre o progresso da transformação.
+  BC-920.40.30:
+    name: Gestão de ferramentas de transformação
+    description: |
+      Ferramentas para acompanhamento da transformação, dependências e benefícios.
+  BC-920.40.40:
+    name: Desenvolvimento de capacidades de transformação
+    description: |
+      Desenvolvimento de capacidades e orientação para líderes de transformação.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-transport-network-planning-management.yaml
+++ b/catalogue/i18n/pt/L1-transport-network-planning-management.yaml
@@ -1,0 +1,105 @@
+locale: pt
+source: L1-transport-network-planning-management.yaml
+entries:
+  BC-2410:
+    name: Gestão de planeamento de rede de transporte
+    description: |
+      Conceção de redes de transporte, rotas, hubs, horários e mix modal que
+      determinam o portefólio de serviços da transportadora ou 3PL.
+  BC-2410.10:
+    name: Gestão da conceção de rede
+    description: |
+      Conceção a longo prazo de hubs, gateways, rotas e mix modal de suporte ao
+      portefólio de serviços.
+    in_scope:
+      - Decisões de estrutura hub-and-spoke e ponto-a-ponto
+      - Conceção do mix modal em estrada, ferrovia, oceano e ar
+    out_of_scope:
+      - Conceção de rede pelo lado da procura por expedidores (BC-520)
+  BC-2410.10.10:
+    name: Conceção de hubs e gateways
+    description: |
+      Seleção e dimensionamento de hubs, gateways e pontos de consolidação.
+  BC-2410.10.20:
+    name: Conceção de rotas e serviços
+    description: |
+      Definição de rotas origem-destino e os serviços que nelas operam.
+  BC-2410.10.30:
+    name: Conceção do mix modal
+    description: |
+      Escolha de modo e mix intermodal para cada rota e nível de serviço.
+  BC-2410.20:
+    name: Gestão de planeamento de horários
+    description: |
+      Construção de horários mestre, slots e janelas de serviço para viagens,
+      voos, caminhos ferroviários e partidas de camião.
+  BC-2410.20.10:
+    name: Conceção do horário mestre
+    description: |
+      Conceção de horários recorrentes de viagem, voo, comboio e camião.
+  BC-2410.20.20:
+    name: Planeamento de slots e janelas
+    description: |
+      Alocação de janelas de cais, pista e porta a serviços programados.
+  BC-2410.20.30:
+    name: Publicação de horários
+    description: |
+      Publicação de horários para clientes, parceiros e canais de reserva.
+  BC-2410.30:
+    name: Gestão de padrões de serviço
+    description: |
+      Definição de produtos de serviço, níveis de tempo de trânsito e o catálogo
+      de serviços oferecidos aos clientes.
+  BC-2410.30.10:
+    name: Definição de nível de serviço
+    description: |
+      Definição de níveis de serviço expresso, normal, diferido e intermodal com
+      os respetivos compromissos.
+  BC-2410.30.20:
+    name: Engenharia de tempo de trânsito
+    description: |
+      Engenharia dos tempos de trânsito de ponta a ponta em escalas e ligações.
+  BC-2410.30.30:
+    name: Gestão do catálogo de serviços
+    description: |
+      Manutenção do catálogo publicado de serviços de transporte.
+  BC-2410.40:
+    name: Gestão de equilíbrio capacidade-procura
+    description: |
+      Reconciliação da capacidade planeada com a procura prevista, incluindo
+      reposicionamento de equipamento vazio.
+  BC-2410.40.10:
+    name: Integração de previsão de procura
+    description: |
+      Integração de previsões de procura de clientes e de mercado nos planos de
+      rede.
+  BC-2410.40.20:
+    name: Reconciliação do plano de capacidade
+    description: |
+      Reconciliação da capacidade planeada face à procura e restrições.
+  BC-2410.40.30:
+    name: Planeamento de reposicionamento de equipamento vazio
+    description: |
+      Planeamento do reposicionamento de contentores, reboques e ULDs vazios.
+  BC-2410.50:
+    name: Otimização e simulação de rede
+    description: |
+      Modelação, simulação e benchmarking de opções de rede e cenários de
+      perturbação.
+  BC-2410.50.10:
+    name: Modelação de rede
+    description: |
+      Construção de modelos analíticos da rede de transporte.
+  BC-2410.50.20:
+    name: Simulação de cenários
+    description: |
+      Simulação de alternativas de procura, perturbação e conceção.
+  BC-2410.50.30:
+    name: Benchmarking do desempenho da rede
+    description: |
+      Benchmarking do custo e serviço da rede face a concorrentes e configurações
+      anteriores.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-transport-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-transport-operations-management.yaml
@@ -1,0 +1,131 @@
+locale: pt
+source: L1-transport-operations-management.yaml
+entries:
+  BC-2420:
+    name: Gestão de operações de transporte
+    description: |
+      Execução multimodal de movimentos de transporte desde a recolha até ao
+      longo curso, drayage e entrega de última milha, incluindo resposta a
+      perturbações operacionais.
+  BC-2420.10:
+    name: Gestão de despacho
+    description: |
+      Atribuição de cargas, condutores, tripulações e equipamento a movimentos
+      de transporte programados e ad-hoc.
+    in_scope:
+      - Atribuição de carga a condutor e carga a veículo
+      - Instruções de posicionamento de equipamento
+    out_of_scope:
+      - Escalonamento de condutores antes do despacho (BC-2440)
+      - Alocação de capacidade por contrato (BC-2400.20)
+  BC-2420.10.10:
+    name: Atribuição de carga
+    description: |
+      Atribuição de cargas a veículos, navios, voos ou caminhos ferroviários.
+  BC-2420.10.20:
+    name: Despacho de condutor e tripulação
+    description: |
+      Despacho de condutores e tripulações qualificados para as cargas atribuídas.
+  BC-2420.10.30:
+    name: Despacho de equipamento
+    description: |
+      Posicionamento de contentores, reboques e ULDs para movimentos atribuídos.
+  BC-2420.20:
+    name: Gestão de operações de longo curso
+    description: |
+      Movimento de longa distância de carga entre hubs, terminais e gateways em
+      vários modos.
+  BC-2420.20.10:
+    name: Operações de longo curso rodoviário
+    description: |
+      Transporte de longa distância por camião entre hubs e terminais.
+  BC-2420.20.20:
+    name: Operações de longo curso ferroviário
+    description: |
+      Operação de comboios de mercadorias e serviços de comboio por blocos.
+  BC-2420.20.30:
+    name: Operações de longo curso marítimo
+    description: |
+      Operações de viagem entre portos, incluindo escalas de transhipment.
+  BC-2420.20.40:
+    name: Operações de longo curso aéreo
+    description: |
+      Operação de voos de carga e serviços freighter entre aeroportos.
+  BC-2420.30:
+    name: Gestão de operações de recolha e drayage
+    description: |
+      Recolhas de primeira milha junto de expedidores e drayage de curta distância
+      entre terminais, pátios e pontos interiores.
+  BC-2420.30.10:
+    name: Operações de recolha
+    description: |
+      Recolha de carga junto de expedidores e consolidadores.
+  BC-2420.30.20:
+    name: Operações de drayage de contentores
+    description: |
+      Drayage de contentores entre terminais portuários, rampas ferroviárias e
+      depósitos interiores.
+  BC-2420.30.30:
+    name: Movimento de equipamento vazio
+    description: |
+      Movimento de contentores, reboques e ULDs vazios entre depósitos.
+  BC-2420.40:
+    name: Gestão de operações de entrega de última milha
+    description: |
+      Entrega na última etapa ao destinatário, incluindo encaminhamento, execução
+      e prova de entrega.
+  BC-2420.40.10:
+    name: Encaminhamento de última milha
+    description: |
+      Encaminhamento e sequenciamento de paragens de entrega e janelas horárias.
+  BC-2420.40.20:
+    name: Execução de entrega ao cliente
+    description: |
+      Entrega no local, captura de assinatura e entrega ao destinatário.
+  BC-2420.40.30:
+    name: Prova de entrega
+    description: |
+      Captura e armazenamento de registos de prova de entrega.
+  BC-2420.40.40:
+    name: Gestão de exceções de entrega
+    description: |
+      Gestão de recusas, entregas falhadas e novas tentativas.
+  BC-2420.50:
+    name: Gestão de perturbações operacionais
+    description: |
+      Deteção de perturbações operacionais em curso e orquestração de ações de
+      recuperação.
+  BC-2420.50.10:
+    name: Deteção de incidentes operacionais
+    description: |
+      Deteção de avarias, condições meteorológicas, atrasos portuários e outras
+      perturbações.
+  BC-2420.50.20:
+    name: Redirecionamento e recuperação
+    description: |
+      Redirecionamento de carga e recuperação de serviços perturbados.
+  BC-2420.50.30:
+    name: Reposição do serviço
+    description: |
+      Reposição dos horários normais e dos compromissos com os clientes.
+  BC-2420.60:
+    name: Gestão do desempenho operacional
+    description: |
+      Medição operacional do desempenho de pontualidade, tempos de trânsito e
+      cumprimento do nível de serviço.
+  BC-2420.60.10:
+    name: Acompanhamento de pontualidade
+    description: |
+      Acompanhamento da pontualidade de recolha, partida, chegada e entrega.
+  BC-2420.60.20:
+    name: Monitorização do tempo de trânsito
+    description: |
+      Monitorização dos tempos de trânsito reais vs. comprometidos.
+  BC-2420.60.30:
+    name: Reporte de KPIs operacionais
+    description: |
+      Reporte de KPIs operacionais para partes interessadas internas e externas.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-travel-distribution-channel-management.yaml
+++ b/catalogue/i18n/pt/L1-travel-distribution-channel-management.yaml
@@ -1,0 +1,191 @@
+locale: pt
+source: L1-travel-distribution-channel-management.yaml
+entries:
+  BC-4010:
+    name: Gestão de distribuição e canais de viagem
+    description: |
+      Gestão da forma como os produtos de viagem são distribuídos e
+      promovidos em canais diretos, GDS, OTA, grossistas e de metapesquisa
+      — incluindo conectividade de canal, sindicação de conteúdo e paridade
+      de tarifa e disponibilidade.
+  BC-4010.10:
+    name: Gestão de distribuição em canal direto
+    description: |
+      Distribuição de produtos de viagem através de canais diretos
+      pertencentes à empresa, incluindo web, aplicação móvel, telefone
+      e quiosques de self-service.
+  BC-4010.10.10:
+    name: Gestão de distribuição no sítio web da marca
+    description: |
+      Operação do sítio web da marca como superfície de pesquisa e reserva
+      direta de produtos de viagem.
+  BC-4010.10.20:
+    name: Gestão de distribuição em aplicação móvel
+    description: |
+      Operação de aplicações móveis nativas como superfície de distribuição
+      e serviço direta.
+  BC-4010.10.30:
+    name: Distribuição por voz e centro de atendimento
+    description: |
+      Distribuição por voz e centro de atendimento, incluindo pesquisa e
+      reserva assistida por agente.
+  BC-4010.10.40:
+    name: Distribuição por quiosque e self-service
+    description: |
+      Distribuição em self-service através de quiosques em aeroportos,
+      hotéis e instalações de parceiros.
+  BC-4010.20:
+    name: Gestão de distribuição em GDS
+    description: |
+      Distribuição através de sistemas de distribuição global, incluindo
+      sincronização de conteúdo, mapeamento de classe de reserva e gestão
+      de custos.
+  BC-4010.20.10:
+    name: Operações de conectividade com GDS
+    description: |
+      Operação de conectividade com fornecedores de GDS em fluxos de
+      pesquisa, reserva e emissão de bilhetes.
+  BC-4010.20.20:
+    name: Envio e sincronização de conteúdo para GDS
+    description: |
+      Envio e sincronização de conteúdo, tarifas e disponibilidade para
+      fornecedores de GDS.
+  BC-4010.20.30:
+    name: Mapeamento de classe de reserva em GDS
+    description: |
+      Mapeamento de classes de produto internas para classes de reserva
+      e códigos de tarifa do GDS.
+  BC-4010.20.40:
+    name: Gestão de custos e sobretaxas do GDS
+    description: |
+      Gestão de taxas de reserva, sobretaxas e alocação de custo de venda
+      do GDS.
+  BC-4010.30:
+    name: Gestão de distribuição em OTA e grossistas
+    description: |
+      Distribuição através de agências de viagem em linha, bedbanks e
+      grossistas B2B, incluindo condições comerciais e substituições
+      de conteúdo.
+  BC-4010.30.10:
+    name: Operações de conectividade com OTA
+    description: |
+      Operação de conectividade com OTAs, abrangendo fluxos de pesquisa,
+      reserva e eventos pós-reserva.
+  BC-4010.30.20:
+    name: Conectividade com grossistas e bedbanks
+    description: |
+      Operação de conectividade com grossistas e bedbanks para redistribuição
+      B2B.
+  BC-4010.30.30:
+    name: Gestão de condições comerciais com OTA
+    description: |
+      Gestão de condições comerciais com OTA, incluindo modelos de comissão,
+      mark-up e tarifa líquida.
+  BC-4010.30.40:
+    name: Gestão de substituições de conteúdo em OTA
+    description: |
+      Gestão de substituições de conteúdo específicas por canal para OTAs,
+      mantendo a consistência da marca.
+  BC-4010.40:
+    name: Gestão de distribuição em metapesquisa
+    description: |
+      Distribuição e licitação em plataformas de metapesquisa, incluindo
+      operações de feed e rastreio de conversão.
+  BC-4010.40.10:
+    name: Operações de feed de metapesquisa
+    description: |
+      Operação de feeds de preço e disponibilidade para fornecedores
+      de metapesquisa.
+  BC-4010.40.20:
+    name: Operações de licitação em metapesquisa
+    description: |
+      Operação de estratégias de licitação em posicionamentos de metapesquisa
+      em mercados e dispositivos.
+  BC-4010.40.30:
+    name: Rastreio de conversão em metapesquisa
+    description: |
+      Rastreio da atribuição de conversão e eficácia de licitação no
+      tráfego de metapesquisa.
+  BC-4010.40.40:
+    name: Gestão de conflitos de licitação de marca
+    description: |
+      Gestão de conflitos de licitação entre a própria marca e licitações
+      de OTA em metapesquisa e pesquisa paga.
+  BC-4010.50:
+    name: Operações do gestor de canais
+    description: |
+      Operação do hub de gestor de canais que sincroniza inventário,
+      tarifas e restrições entre canais de distribuição.
+  BC-4010.50.10:
+    name: Configuração de mapeamento de canais
+    description: |
+      Configuração de mapeamentos entre produtos internos e catálogos
+      específicos por canal.
+  BC-4010.50.20:
+    name: Operações de envio de inventário
+    description: |
+      Operação de atualizações de inventário enviadas do pool central
+      para todos os canais ligados.
+  BC-4010.50.30:
+    name: Operações de envio de tarifas
+    description: |
+      Operação de atualizações de tarifas enviadas dos motores de preços
+      para todos os canais ligados.
+  BC-4010.50.40:
+    name: Operações de envio de restrições
+    description: |
+      Operação de atualizações de restrições, como estadia mínima,
+      fechado à chegada e stop-sell entre canais.
+  BC-4010.60:
+    name: Gestão de paridade de tarifa e disponibilidade
+    description: |
+      Definição, monitorização e aplicação da paridade de tarifa e
+      disponibilidade nos canais diretos e indiretos.
+  BC-4010.60.10:
+    name: Definição de política de paridade
+    description: |
+      Definição de política de paridade de tarifa e disponibilidade entre
+      tipos de canal e segmentos de parceiro.
+  BC-4010.60.20:
+    name: Monitorização e auditoria de paridade
+    description: |
+      Monitorização de canais para violações de paridade e auditoria de
+      rotina no mix de canais.
+  BC-4010.60.30:
+    name: Resolução de violações de paridade
+    description: |
+      Resolução de violações de paridade identificadas com canais e parceiros.
+  BC-4010.60.40:
+    name: Gestão de disponibilidade do último quarto
+    description: |
+      Gestão de compromissos de disponibilidade do último quarto para
+      parceiros corporativos e de canal.
+  BC-4010.70:
+    name: Sindicação de conteúdo de distribuição
+    description: |
+      Sindicação de conteúdo de produto para parceiros de distribuição
+      com controlos de formato, atualização e fallback.
+  BC-4010.70.10:
+    name: Gestão de formato de feed de conteúdo
+    description: |
+      Gestão de formatos e esquemas de feed de conteúdo específicos
+      por canal.
+  BC-4010.70.20:
+    name: Monitorização da atualização de conteúdo
+    description: |
+      Monitorização da atualização de conteúdo nas superfícies de parceiros
+      de distribuição contra SLAs de publicação.
+  BC-4010.70.30:
+    name: Regras de fallback de conteúdo de canal
+    description: |
+      Regras de fallback utilizadas quando o conteúdo específico do parceiro
+      está em falta ou desatualizado.
+  BC-4010.70.40:
+    name: Reconciliação de substituições de conteúdo
+    description: |
+      Reconciliação de substituições de conteúdo de parceiros contra o
+      registo de conteúdo principal.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-travel-loyalty-programme-management.yaml
+++ b/catalogue/i18n/pt/L1-travel-loyalty-programme-management.yaml
@@ -1,0 +1,165 @@
+locale: pt
+source: L1-travel-loyalty-programme-management.yaml
+entries:
+  BC-4050:
+    name: Gestão do programa de fidelização de viagem
+    description: |
+      Conceção e operação de programas de fidelização de viajantes —
+      arquitetura de níveis, motores de acumulação e resgate, acumulações
+      de parceiros, gestão de estado e comunicações a membros —
+      independentemente do registo subjacente de hóspede e das plataformas
+      de canal.
+  BC-4050.10:
+    name: Conceção do programa de fidelização
+    description: |
+      Conceção da arquitetura do programa, incluindo estrutura de níveis,
+      catálogo de benefícios, parâmetros de taxa de acumulação e regras
+      do programa.
+  BC-4050.10.10:
+    name: Arquitetura de níveis do programa
+    description: |
+      Arquitetura de níveis de fidelização, incluindo limiares, benefícios
+      e regras de progressão.
+  BC-4050.10.20:
+    name: Catálogo de benefícios de membro
+    description: |
+      Catálogo de benefícios de membro nas superfícies de produto e parceiro.
+  BC-4050.10.30:
+    name: Definição de taxa de acumulação e multiplicador
+    description: |
+      Definição de taxas de acumulação base e multiplicadores de nível
+      e produto.
+  BC-4050.10.40:
+    name: Gestão de termos e condições do programa
+    description: |
+      Gestão dos termos e condições do programa, incluindo variantes
+      jurisdicionais.
+  BC-4050.20:
+    name: Operações do motor de acumulação de fidelização
+    description: |
+      Operação do motor de acumulação em estadias, voos, gastos com
+      parceiros, bónus promocionais e reclamações de atividade em falta.
+  BC-4050.20.10:
+    name: Processamento de acumulação de estadia e voo
+    description: |
+      Processamento de eventos de acumulação de estadias, voos e conclusões
+      de excursões.
+  BC-4050.20.20:
+    name: Processamento de acumulação de gastos com parceiros
+    description: |
+      Processamento de eventos de acumulação de gastos em cartão co-marcado
+      e retalho de parceiros.
+  BC-4050.20.30:
+    name: Acumulação de bónus promocional
+    description: |
+      Acumulação de bónus promocionais vinculados a regras de campanha.
+  BC-4050.20.40:
+    name: Tratamento de reclamações de atividade em falta
+    description: |
+      Tratamento de reclamações de atividade em falta e ajustamentos
+      de acumulação retroativos.
+  BC-4050.30:
+    name: Operações de resgate e queima de fidelização
+    description: |
+      Operação de fluxos de resgate, incluindo disponibilidade de prémio,
+      combinação de dinheiro e pontos e liquidação de inventário.
+  BC-4050.30.10:
+    name: Cálculo de disponibilidade de prémio
+    description: |
+      Cálculo da disponibilidade de prémio contra o inventário de receita
+      e as regras de proteção.
+  BC-4050.30.20:
+    name: Reserva de resgate de prémio
+    description: |
+      Reserva de resgates de prémio no inventário da própria marca e de
+      parceiros.
+  BC-4050.30.30:
+    name: Resgate misto de dinheiro e pontos
+    description: |
+      Fluxos de resgate que combinam pagamento em dinheiro e pontos
+      para a mesma reserva.
+  BC-4050.30.40:
+    name: Liquidação de inventário de resgate
+    description: |
+      Liquidação do consumo de inventário de resgate entre o livro de
+      contas da marca e do parceiro.
+  BC-4050.40:
+    name: Gestão do estado de nível
+    description: |
+      Operação de qualificação de nível, promoção, despromoção, programas
+      de correspondência de estado e regras de aterragem suave.
+  BC-4050.40.10:
+    name: Rastreio de qualificação de nível
+    description: |
+      Rastreio da atividade qualificante contra os limiares de nível ao
+      longo do ano do programa.
+  BC-4050.40.20:
+    name: Operações de promoção e despromoção de nível
+    description: |
+      Operações para promover, despromover e requalificar membros nos
+      limites do período.
+  BC-4050.40.30:
+    name: Programas de correspondência de estado e desafio
+    description: |
+      Operação de programas de correspondência de estado e desafio de
+      nível para aquisição segmentada.
+  BC-4050.40.40:
+    name: Regras de retenção de aterragem suave
+    description: |
+      Regras de retenção que suavizam a perda de nível para membros de
+      elevado valor entre períodos de qualificação.
+  BC-4050.50:
+    name: Gestão do programa de parceiros de fidelização
+    description: |
+      Gestão de parceiros de fidelização, incluindo cartão de crédito,
+      retalho e parceiros companhia aérea-hotel, na integração, configuração
+      e liquidação.
+  BC-4050.50.10:
+    name: Integração e contratação de parceiros
+    description: |
+      Integração e contratação de novos parceiros de fidelização, incluindo
+      devida diligência e integração.
+  BC-4050.50.20:
+    name: Configuração da taxa de acumulação de parceiros
+    description: |
+      Configuração de taxas de acumulação e estruturas de bónus para
+      cada parceiro de fidelização.
+  BC-4050.50.30:
+    name: Liquidação e reconciliação de parceiros
+    description: |
+      Liquidação e reconciliação de pontos emitidos por parceiros e
+      taxas de acumulação.
+  BC-4050.50.40:
+    name: Gestão do desempenho de parceiros
+    description: |
+      Gestão do desempenho dos parceiros de fidelização contra KPIs
+      contratuais.
+  BC-4050.60:
+    name: Operações de comunicação e reconhecimento de fidelização
+    description: |
+      Operação de comunicações a membros, reconhecimento de marcos e
+      gestos de surpresa e prazer ao longo do ciclo de vida de fidelização.
+  BC-4050.60.10:
+    name: Comunicações do ciclo de vida do membro
+    description: |
+      Comunicações do ciclo de vida a membros nas fases de integração,
+      ativo e reativação.
+  BC-4050.60.20:
+    name: Reconhecimento de marcos e aniversários
+    description: |
+      Reconhecimento de marcos de membros, aniversários de antiguidade e
+      promoções de nível.
+  BC-4050.60.30:
+    name: Operações de surpresa e prazer
+    description: |
+      Operação de gestos de surpresa e prazer acionados pelo comportamento
+      do membro ou eventos de serviço.
+  BC-4050.60.40:
+    name: Geração de extrato de membro
+    description: |
+      Geração de extratos de membro que abrangem saldo, atividade e
+      progressão de nível.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-travel-product-inventory-management.yaml
+++ b/catalogue/i18n/pt/L1-travel-product-inventory-management.yaml
@@ -1,0 +1,192 @@
+locale: pt
+source: L1-travel-product-inventory-management.yaml
+entries:
+  BC-4000:
+    name: Gestão de produto e inventário de viagem
+    description: |
+      Definição principal, estrutura e controlo de inventário de produtos
+      de viagem reserváveis — quartos, tarifas, pacotes, serviços adicionais,
+      atrações e a taxonomia e conteúdo que os descreve — independentemente
+      dos canais através dos quais são vendidos.
+  BC-4000.10:
+    name: Gestão de produto de alojamento
+    description: |
+      Definição de produtos de alojamento, incluindo tipos de quarto, planos
+      de tarifa, códigos de pacote e taxonomia de alojamento utilizados
+      em toda a empresa.
+  BC-4000.10.10:
+    name: Definição de tipo de quarto e classe de inventário
+    description: |
+      Definição de tipos de quarto, categorias de suite e classes de inventário
+      que formam a base do produto de alojamento.
+  BC-4000.10.20:
+    name: Definição de plano de tarifa e código de tarifa
+    description: |
+      Definição de planos de tarifa, códigos de tarifa e atributos de plano
+      de tarifa que abrangem regras de reembolsabilidade, pré-pagamento
+      e inclusão.
+  BC-4000.10.30:
+    name: Estado do ciclo de vida do produto de alojamento
+    description: |
+      Gestão do estado do ciclo de vida dos produtos de alojamento, desde
+      proposto a ativo, suspenso e retirado.
+  BC-4000.10.40:
+    name: Agrupamento de produtos de alojamento
+    description: |
+      Construção de pacotes de alojamento que combinam acomodação com
+      pequeno-almoço, estacionamento e outras inclusões.
+  BC-4000.20:
+    name: Gestão de produto aéreo
+    description: |
+      Definição de famílias de tarifas de companhia aérea, atributos de
+      tarifas de marca, regras de tarifa e mapeamentos de produtos de
+      codeshare/interline.
+  BC-4000.20.10:
+    name: Definição de família de tarifas
+    description: |
+      Definição de famílias de tarifas, cabines e classes de tarifa
+      utilizadas para pesquisa e controlo de inventário.
+  BC-4000.20.20:
+    name: Gestão de atributos de tarifas de marca
+    description: |
+      Gestão de atributos de tarifas de marca, como franquia de bagagem,
+      seleção de assento e acesso a sala VIP.
+  BC-4000.20.30:
+    name: Criação de regras de tarifa
+    description: |
+      Criação de regras de tarifa que abrangem compra antecipada, estadia
+      mínima, combinabilidade e penalidades de alteração.
+  BC-4000.20.40:
+    name: Mapeamento de produtos de codeshare e interline
+    description: |
+      Mapeamento de produtos de transportadoras parceiras para as famílias
+      de tarifas próprias para distribuição de codeshare e interline.
+  BC-4000.30:
+    name: Gestão de produtos de excursão e pacote
+    description: |
+      Definição de itinerários empacotados, produtos de viagem multi-percurso
+      e mapeamentos de componentes de pacote dinâmico.
+  BC-4000.30.10:
+    name: Definição de produto de pacote estático
+    description: |
+      Definição de pacotes fixos que combinam componentes fixos num único
+      produto vendável.
+  BC-4000.30.20:
+    name: Mapeamento de componentes de pacote dinâmico
+    description: |
+      Mapeamento de componentes para pacotes dinâmicos onde o viajante
+      monta voo, hotel e serviços adicionais no momento da pesquisa.
+  BC-4000.30.30:
+    name: Versionamento de produtos de pacote
+    description: |
+      Versionamento de produtos de pacote entre épocas, ciclos de brochura
+      e lançamentos de funcionalidades.
+  BC-4000.30.40:
+    name: Calendário de partidas de pacote
+    description: |
+      Definição de calendários de partidas de pacote, datas bloqueadas e
+      janelas de época.
+  BC-4000.40:
+    name: Gestão de produtos adicionais e complementares
+    description: |
+      Definição de produtos adicionais e complementares, como refeições,
+      bagagem, transfers, atrações, spa e serviços terrestres.
+  BC-4000.40.10:
+    name: Definição do catálogo de serviços adicionais
+    description: |
+      Definição do catálogo de serviços adicionais, incluindo categorias,
+      variantes e condições de aplicabilidade.
+  BC-4000.40.20:
+    name: Regras de agrupamento de serviços adicionais
+    description: |
+      Regras para agrupar serviços adicionais com produtos de viagem
+      principais e com outros serviços adicionais.
+  BC-4000.40.30:
+    name: Regras de elegibilidade de venda cruzada
+    description: |
+      Regras de elegibilidade que regem quais os serviços adicionais que
+      podem ser vendidos em conjunto com quais os produtos principais em
+      quais os canais.
+  BC-4000.40.40:
+    name: Gestão do ciclo de vida de serviços adicionais
+    description: |
+      Gestão do ciclo de vida de serviços adicionais desde o lançamento
+      até à retirada, incluindo ofertas por tempo limitado.
+  BC-4000.50:
+    name: Alocação de inventário de viagem
+    description: |
+      Definição e controlo de reservas de inventário, blocos, atribuições
+      e regras de retenção em produtos de viagem.
+  BC-4000.50.10:
+    name: Definição de reserva de inventário
+    description: |
+      Definição de reservas de inventário ao nível de propriedade, frota
+      ou produto utilizado como base para alocação.
+  BC-4000.50.20:
+    name: Alocação de atribuições e blocos
+    description: |
+      Alocação de atribuições e blocos a canais, parceiros e operadores
+      de excursões.
+  BC-4000.50.30:
+    name: Regras de retenção e proteção de classe
+    description: |
+      Regras para proteger inventário para segmentos, canais ou membros
+      de programa de fidelização específicos.
+  BC-4000.50.40:
+    name: Configuração de tampão de overbooking
+    description: |
+      Configuração de tampões de overbooking que refletem as taxas esperadas
+      de não comparência e cancelamento.
+  BC-4000.60:
+    name: Governação de dados mestre de produto de viagem
+    description: |
+      Custódia de taxonomia de produto, classificações, normas de atributos
+      e integridade de identificadores no mestre de produto de viagem.
+  BC-4000.60.10:
+    name: Normas de atributos de produto
+    description: |
+      Normas para atributos de produto que garantem semântica consistente
+      entre sistemas e canais.
+  BC-4000.60.20:
+    name: Classificação e marcação de produtos
+    description: |
+      Classificação e marcação de produtos contra taxonomias utilizadas
+      para pesquisa, merchandising e relatórios.
+  BC-4000.60.30:
+    name: Estado do ciclo de vida do mestre de produto
+    description: |
+      Estado do ciclo de vida principal para produtos que abrangem subtipos
+      de produto e alinham alterações de estado filho.
+  BC-4000.60.40:
+    name: Custódia de identificadores de produto
+    description: |
+      Custódia de identificadores canónicos de produto e resolução de
+      colisões e duplicados de identificadores.
+  BC-4000.70:
+    name: Gestão de conteúdo e imagens de viagem
+    description: |
+      Criação e gestão de conteúdo descritivo, imagens, ativos multimédia
+      e registos de classificação/certificação que descrevem produtos
+      de viagem.
+  BC-4000.70.10:
+    name: Criação de conteúdo descritivo
+    description: |
+      Criação de conteúdo descritivo longo e curto para produtos de viagem.
+  BC-4000.70.20:
+    name: Gestão de ativos de imagens e multimédia
+    description: |
+      Gestão de ativos multimédia de fotografia, vídeo e 360 graus
+      associados a produtos de viagem.
+  BC-4000.70.30:
+    name: Registos de classificação de estrelas e certificação
+    description: |
+      Manutenção de classificações de estrelas, certificações de terceiros
+      e selos de qualidade associados a produtos de viagem.
+  BC-4000.70.40:
+    name: Localização de conteúdo
+    description: |
+      Localização de conteúdo de produto nos mercados e idiomas suportados.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-travel-revenue-yield-management.yaml
+++ b/catalogue/i18n/pt/L1-travel-revenue-yield-management.yaml
@@ -1,0 +1,165 @@
+locale: pt
+source: L1-travel-revenue-yield-management.yaml
+entries:
+  BC-4030:
+    name: Gestão de receita e yield de viagem
+    description: |
+      Previsão de procura, preços dinâmicos, controlos de inventário e
+      decisões de yield que maximizam a receita em produtos de viagem
+      — distinto do mestre de produto, da ligação de distribuição e
+      do ciclo de vida de reservas.
+  BC-4030.10:
+    name: Previsão de procura de viagem
+    description: |
+      Previsão de procura não restrita, ritmo de reserva, procura de
+      grupo e comportamento de não comparência ou cancelamento para
+      produtos de viagem.
+  BC-4030.10.10:
+    name: Previsão de procura não restrita
+    description: |
+      Previsão de procura na ausência de restrições de capacidade
+      e preço.
+  BC-4030.10.20:
+    name: Previsão de ritmo e ocupação de reservas
+    description: |
+      Previsão de curvas de ritmo e ocupação contra padrões históricos
+      e em carteira.
+  BC-4030.10.30:
+    name: Previsão de procura de grupo
+    description: |
+      Previsão de procura de grupo, incluindo efeitos de deslocamento
+      no inventário transitório.
+  BC-4030.10.40:
+    name: Previsão de não comparência e cancelamento
+    description: |
+      Previsão de comportamento de não comparência e cancelamento como
+      entradas para controlos de overbooking e inventário.
+  BC-4030.20:
+    name: Gestão de preços e estratégia de tarifa
+    description: |
+      Definição e ajustamento da estratégia de tarifa em níveis de BAR,
+      classes de tarifa, janelas de época e preços de pacote.
+  BC-4030.20.10:
+    name: Definição da melhor tarifa disponível
+    description: |
+      Definição de escadas de melhor tarifa disponível por data e segmento.
+  BC-4030.20.20:
+    name: Estratégia de classe de tarifa e classe de inventário
+    description: |
+      Estratégia para classes de tarifa e classes de inventário, incluindo
+      aberturas, encerramentos e reajustamentos.
+  BC-4030.20.30:
+    name: Preços sazonais e por tipo de dia
+    description: |
+      Variação de preços entre épocas, padrões de dia da semana e janelas
+      de evento.
+  BC-4030.20.40:
+    name: Preços de pacote e pacote agrupado
+    description: |
+      Preços para produtos empacotados e pacotes agrupados, incluindo
+      alocação de componentes.
+  BC-4030.30:
+    name: Controlos de inventário e capacidade
+    description: |
+      Controlos de inventário, incluindo limites de reserva, restrições
+      de duração da estadia, estratégia de overbooking e aninhamento
+      de preço de licitação.
+  BC-4030.30.10:
+    name: Definição de limite de reserva e autorização
+    description: |
+      Definição de limites de reserva e níveis de autorização por classe,
+      canal e segmento.
+  BC-4030.30.20:
+    name: Gestão de restrições de duração da estadia
+    description: |
+      Gestão de restrições de duração da estadia, incluindo mínimos,
+      máximos e regras de dia de chegada.
+  BC-4030.30.30:
+    name: Gestão da estratégia de overbooking
+    description: |
+      Gestão estratégica dos níveis de overbooking por data e segmento,
+      calibrada contra os custos de recusa de serviço.
+  BC-4030.30.40:
+    name: Gestão de aninhamento e preço de licitação
+    description: |
+      Gestão de aninhamento de inventário e limiares de preço de licitação
+      em modelos de otimização de receita.
+  BC-4030.40:
+    name: Inteligência de tarifas da concorrência
+    description: |
+      Pesquisa de tarifas da concorrência, análise de quota de mercado e
+      recomendações de posicionamento de tarifa.
+  BC-4030.40.10:
+    name: Pesquisa de tarifas da concorrência
+    description: |
+      Pesquisa de rotina das tarifas dos concorrentes em canais e datas
+      de chegada selecionados.
+  BC-4030.40.20:
+    name: Análise de quota de mercado e penetração
+    description: |
+      Análise de quota de mercado, índice de ocupação e índice de tarifa
+      contra o conjunto competitivo.
+  BC-4030.40.30:
+    name: Recomendações de posicionamento de tarifa
+    description: |
+      Geração de recomendações de posicionamento de tarifa contra o
+      conjunto competitivo e o estado da procura.
+  BC-4030.40.40:
+    name: Definição e manutenção do conjunto competitivo
+    description: |
+      Definição e manutenção contínua de conjuntos competitivos utilizados
+      para benchmarking.
+  BC-4030.50:
+    name: Gestão de promoções e descontos
+    description: |
+      Definição e operação de promoções, códigos de desconto, preços opacos
+      e de grupo de utilizadores fechado em produtos de viagem.
+  BC-4030.50.10:
+    name: Gestão do calendário de promoções
+    description: |
+      Gestão de calendário de promoções entre épocas e janelas de reserva
+      principais.
+  BC-4030.50.20:
+    name: Regras de elegibilidade de promoção
+    description: |
+      Regras de elegibilidade que regem o resgate de promoções por segmento,
+      canal e janela de estadia.
+  BC-4030.50.30:
+    name: Gestão de código de desconto e voucher
+    description: |
+      Gestão de códigos de desconto, vouchers e tokens de uso promocional
+      semelhantes a cartões de oferta.
+  BC-4030.50.40:
+    name: Preços opacos e de grupo de utilizadores fechado
+    description: |
+      Operação de mecanismos de preços em canal opaco e grupo de utilizadores
+      fechado que protegem a visibilidade da tarifa pública.
+  BC-4030.60:
+    name: Análise do desempenho de receita
+    description: |
+      Relatórios e análise do desempenho de receita, incluindo RevPAR,
+      RevPAX, ADR, yield e variância de previsão.
+  BC-4030.60.10:
+    name: Relatórios de KPI de receita
+    description: |
+      Relatórios de KPIs de receita principais contra orçamento e período
+      anterior.
+  BC-4030.60.20:
+    name: Análise de variância de yield
+    description: |
+      Análise de variância de yield que atribui a mudança a efeitos de
+      mix, tarifa e ocupação.
+  BC-4030.60.30:
+    name: Análise de contribuição de receita por canal
+    description: |
+      Análise da contribuição de receita por canal, segmento e código
+      de tarifa.
+  BC-4030.60.40:
+    name: Análise de previsão vs. real de receita
+    description: |
+      Análise da receita prevista versus real, com atribuição a fontes
+      de erro de previsão.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-treasury-asset-liability-management.yaml
+++ b/catalogue/i18n/pt/L1-treasury-asset-liability-management.yaml
@@ -1,0 +1,103 @@
+locale: pt
+source: L1-treasury-asset-liability-management.yaml
+entries:
+  BC-1360:
+    name: Gestão de tesouraria e ativo e passivo
+    description: |
+      Tesouraria bancária, ALM, FTP, liquidez e risco de taxa de juro do livro bancário.
+  BC-1360.10:
+    name: Gestão de liquidez bancária
+    description: |
+      Liquidez bancária, liquidez intradiária, LCR/NSFR.
+  BC-1360.10.10:
+    name: Gestão do rácio de cobertura de liquidez
+    description: |
+      Cálculo, monitorização e reporte do LCR ao abrigo de Basileia III.
+  BC-1360.10.20:
+    name: Gestão do rácio de financiamento estável líquido
+    description: |
+      Cálculo do NSFR e gestão do financiamento estrutural.
+  BC-1360.10.30:
+    name: Gestão da liquidez intradiária
+    description: |
+      Monitorização da liquidez intradiária em sistemas de pagamento.
+  BC-1360.10.40:
+    name: Gestão de ativos de elevada qualidade de liquidez
+    description: |
+      Manutenção e gestão do portefólio de HQLA.
+  BC-1360.20:
+    name: Gestão de ativo e passivo
+    description: |
+      ALM, gestão do balanço e análise de gaps.
+  BC-1360.20.10:
+    name: Gestão do balanço
+    description: |
+      Gestão estratégica e otimização do balanço.
+  BC-1360.20.20:
+    name: Análise de gaps
+    description: |
+      Análise de gaps de repricing e liquidez ao longo do balanço.
+  BC-1360.20.30:
+    name: Modelação comportamental
+    description: |
+      Modelação comportamental de depósitos sem prazo definido e pré-pagamentos.
+  BC-1360.20.40:
+    name: Testes de esforço de ALM
+    description: |
+      Testes de esforço de desfasamentos de ativo e passivo.
+  BC-1360.30:
+    name: Gestão de preços de transferência de fundos
+    description: |
+      FTP e preços de fundos internos.
+  BC-1360.30.10:
+    name: Gestão da metodologia de FTP
+    description: |
+      Manutenção da metodologia FTP e construção de curvas.
+  BC-1360.30.20:
+    name: Aplicação de taxas de FTP
+    description: |
+      Aplicação de taxas de FTP a produtos e contratos.
+  BC-1360.30.30:
+    name: Reporte e análise de FTP
+    description: |
+      Reporte FTP e análise de impacto na rentabilidade.
+  BC-1360.40:
+    name: Gestão do financiamento bancário
+    description: |
+      Financiamento por grosso, captação de depósitos e financiamento nos mercados de capitais.
+  BC-1360.40.10:
+    name: Gestão do financiamento por grosso
+    description: |
+      Gestão de financiamento por grosso não garantido e garantido.
+  BC-1360.40.20:
+    name: Financiamento nos mercados de capitais
+    description: |
+      Emissão de obrigações, MTN, obrigações hipotecárias e titularização.
+  BC-1360.40.30:
+    name: Operações de facilidades do banco central
+    description: |
+      Utilização de facilidades do banco central e gestão de colateral.
+  BC-1360.40.40:
+    name: Gestão do plano de financiamento
+    description: |
+      Plano anual de financiamento e execução face ao plano.
+  BC-1360.50:
+    name: Gestão do risco de taxa de juro do livro bancário
+    description: |
+      IRRBB e exposição a taxa de juro do livro bancário.
+  BC-1360.50.10:
+    name: Medição do IRRBB
+    description: |
+      Medição das sensibilidades EVE e NII para o IRRBB.
+  BC-1360.50.20:
+    name: Cobertura do IRRBB
+    description: |
+      Cobertura do risco de taxa de juro do livro bancário.
+  BC-1360.50.30:
+    name: Reporte do IRRBB
+    description: |
+      Reporte regulatório e de gestão do IRRBB.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-treasury-management.yaml
+++ b/catalogue/i18n/pt/L1-treasury-management.yaml
@@ -1,0 +1,127 @@
+locale: pt
+source: L1-treasury-management.yaml
+entries:
+  BC-210:
+    name: Gestão de tesouraria
+    description: |
+      Gestão de caixa, liquidez, financiamento e exposições aos mercados financeiros.
+  BC-210.10:
+    name: Gestão de caixa
+    description: |
+      Posicionamento de caixa, pooling e financiamento intercompanhia.
+  BC-210.10.10:
+    name: Monitorização da posição de caixa
+    description: |
+      Monitorização diária de posições de caixa em entidades e moedas.
+  BC-210.10.20:
+    name: Operações de pooling de caixa
+    description: |
+      Pooling de caixa nocional e físico em todo o grupo.
+  BC-210.10.30:
+    name: Financiamento intercompanhia
+    description: |
+      Empréstimos intercompanhia, banco interno e liquidação intercompanhia.
+  BC-210.10.40:
+    name: Gestão de investimentos de curto prazo
+    description: |
+      Atividades de investimento de caixa em mercado monetário e curto prazo.
+  BC-210.20:
+    name: Gestão de liquidez
+    description: |
+      Previsão de liquidez, stress testing e planos de financiamento.
+  BC-210.20.10:
+    name: Previsão de fluxos de caixa
+    description: |
+      Previsões de fluxos de caixa de curto, médio e longo prazo.
+  BC-210.20.20:
+    name: Monitorização do risco de liquidez
+    description: |
+      Rácios de liquidez, buffers e indicadores de alerta precoce.
+  BC-210.20.30:
+    name: Stress testing de liquidez
+    description: |
+      Testes de stress para adequação da liquidez em cenários adversos.
+  BC-210.20.40:
+    name: Planeamento de financiamento de contingência
+    description: |
+      Planos de financiamento de contingência e facilidades de liquidez comprometidas.
+  BC-210.30:
+    name: Gestão de financiamento e dívida
+    description: |
+      Emissão de dívida, gestão de facilidades e covenants.
+  BC-210.30.10:
+    name: Emissão de dívida
+    description: |
+      Emissão de obrigações, papel comercial e colocações privadas.
+  BC-210.30.20:
+    name: Gestão de empréstimos e facilidades bancárias
+    description: |
+      Negociação e administração de facilidades de crédito e empréstimos bilaterais.
+  BC-210.30.30:
+    name: Serviço da dívida
+    description: |
+      Agendamento e execução de pagamentos de juros, capital e comissões.
+  BC-210.30.40:
+    name: Gestão de covenants e rating
+    description: |
+      Monitorização de covenants e relações com agências de rating de crédito.
+  BC-210.40:
+    name: Gestão de câmbio
+    description: |
+      Exposição cambial, cobertura e liquidação.
+  BC-210.40.10:
+    name: Identificação de exposição cambial
+    description: |
+      Identificação e quantificação de exposições cambiais em todas as entidades.
+  BC-210.40.20:
+    name: Execução de cobertura cambial
+    description: |
+      Execução de forwards, swaps e opções cambiais.
+  BC-210.40.30:
+    name: Liquidação e confirmação cambial
+    description: |
+      Liquidação, confirmação e reconciliação de operações cambiais.
+  BC-210.40.40:
+    name: Gestão da exposição de conversão
+    description: |
+      Cobertura de exposições de investimento líquido e conversão.
+  BC-210.50:
+    name: Gestão do risco de taxa de juro
+    description: |
+      Exposição a taxas de juro e estratégias de cobertura.
+  BC-210.50.10:
+    name: Medição da exposição à taxa de juro
+    description: |
+      Medição da sensibilidade à taxa de juro em todo o balanço.
+  BC-210.50.20:
+    name: Cobertura de taxa de juro
+    description: |
+      Execução de swaps de taxa de juro, caps e outros derivados.
+  BC-210.50.30:
+    name: Contabilidade de cobertura
+    description: |
+      Designação de cobertura, teste de eficácia e contabilização segundo IFRS 9.
+  BC-210.60:
+    name: Gestão do relacionamento bancário
+    description: |
+      Estrutura de contas bancárias e gestão de parceiros bancários.
+  BC-210.60.10:
+    name: Gestão do ciclo de vida de contas bancárias
+    description: |
+      Abertura, alteração e encerramento de contas bancárias.
+  BC-210.60.20:
+    name: Gestão de mandatos e signatários bancários
+    description: |
+      Listas de signatários bancários, mandatos e alterações de autoridade.
+  BC-210.60.30:
+    name: Aprovisionamento de serviços bancários
+    description: |
+      Seleção e contratação de parceiros e serviços bancários.
+  BC-210.60.40:
+    name: Gestão de taxas e qualidade de serviço bancário
+    description: |
+      Monitorização de taxas bancárias, qualidade de serviço e análise.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-utility-customer-metering-management.yaml
+++ b/catalogue/i18n/pt/L1-utility-customer-metering-management.yaml
@@ -1,0 +1,157 @@
+locale: pt
+source: L1-utility-customer-metering-management.yaml
+entries:
+  BC-3910:
+    name: Gestão de clientes e medição de serviço público
+    description: |
+      Operações específicas de clientes e medição do serviço público
+      desde o ponto de abastecimento até às entradas de faturação — contas
+      de clientes do serviço público, inventário de contadores, aquisição
+      de dados AMI / contador inteligente, leitura e validação de contadores,
+      entradas de contagem para faturação, ligação e desligação do serviço,
+      e proteção de clientes vulneráveis.
+  BC-3910.10:
+    name: Gestão de contas de clientes do serviço público
+    description: |
+      Ciclo de vida da conta de cliente específico do serviço público,
+      abrangendo identificadores de pontos de abastecimento, alterações
+      de ocupação e atribuição de tarifas.
+  BC-3910.10.10:
+    name: Registo de pontos de abastecimento
+    description: |
+      Registo e manutenção de identificadores de pontos de abastecimento
+      (MPAN, MPRN, SPID).
+  BC-3910.10.20:
+    name: Operações de alteração de ocupação
+    description: |
+      Processamento de entradas, saídas e alterações de inquilino para
+      pontos de abastecimento do serviço público.
+  BC-3910.10.30:
+    name: Atribuição de tarifa ao cliente
+    description: |
+      Atribuição de clientes a calendários de tarifas aplicáveis e
+      opções de produto.
+  BC-3910.20:
+    name: Gestão de ativos de contadores
+    description: |
+      Gestão do ciclo de vida de ativos físicos de contadores e comunicação,
+      incluindo stock, instalação, troca e recuperação.
+  BC-3910.20.10:
+    name: Operações de stock de contadores
+    description: |
+      Gestão de stock, comissionamento e descomissionamento de ativos
+      de contadores.
+  BC-3910.20.20:
+    name: Operações de instalação de contadores
+    description: |
+      Instalação no campo de contadores novos e de substituição.
+  BC-3910.20.30:
+    name: Recuperação e eliminação de contadores
+    description: |
+      Recuperação, recondicionamento e eliminação de fim de vida de
+      ativos de contadores.
+  BC-3910.30:
+    name: Operações de aquisição de dados AMI
+    description: |
+      Aquisição de dados de infraestrutura de medição avançada através
+      de sistemas de head-end, redes de comunicação e gestão de dados
+      de contadores.
+  BC-3910.30.10:
+    name: Operações do sistema de head-end
+    description: |
+      Operação de sistemas de head-end de contadores inteligentes e
+      emissão de comandos a contadores.
+  BC-3910.30.20:
+    name: Operações da rede de comunicação AMI
+    description: |
+      Operação de redes de comunicação AMI por RF, PLC e celular e
+      concentradores.
+  BC-3910.30.30:
+    name: Ingestão de gestão de dados de contadores
+    description: |
+      Ingestão de leituras de intervalo e de registo no sistema de
+      gestão de dados de contadores.
+  BC-3910.40:
+    name: Leitura e validação de contadores
+    description: |
+      Leitura cíclica e baseada em eventos de contadores e validação,
+      estimação e edição de dados de consumo.
+  BC-3910.40.10:
+    name: Operações de leitura manual e por passagem
+    description: |
+      Operações de leitura por percurso a pé, por passagem e AMR para
+      contadores sem AMI.
+  BC-3910.40.20:
+    name: Validação, estimação e edição
+    description: |
+      Processamento de VEE de leituras de registo e intervalo para
+      produzir dados de qualidade de faturação.
+  BC-3910.40.30:
+    name: Agregação de consumo
+    description: |
+      Agregação de consumo para períodos de faturação e para perfis
+      de liquidação.
+  BC-3910.50:
+    name: Operações de contagem para faturação
+    description: |
+      Operações específicas do serviço público que preparam dados de
+      utilização para faturação e proteção de receita, incluindo tratamento
+      de exceções de faturas e deteção de fuga de receita.
+  BC-3910.50.10:
+    name: Preparação de determinantes de fatura
+    description: |
+      Preparação de determinantes de fatura — utilização, procura e
+      reativa — para sistemas de faturação.
+  BC-3910.50.20:
+    name: Tratamento de exceções de faturas
+    description: |
+      Investigação e resolução de exceções de faturas e anomalias de
+      dados de contadores.
+  BC-3910.50.30:
+    name: Operações de proteção de receita
+    description: |
+      Deteção e investigação no campo de adulteração de contadores e
+      furto de energia ou água.
+  BC-3910.60:
+    name: Operações de ligação e desligação do serviço
+    description: |
+      Ativação, desativação e operação em modo de pré-pagamento de
+      abastecimentos do serviço público na interface do cliente.
+  BC-3910.60.10:
+    name: Operações de ativação do abastecimento
+    description: |
+      Ativação de abastecimentos novos e reativados, incluindo energização
+      remota.
+  BC-3910.60.20:
+    name: Desligação por falta de pagamento
+    description: |
+      Processos de desligação contra proteções estatutárias e regulatórias.
+  BC-3910.60.30:
+    name: Operações em modo de pré-pagamento
+    description: |
+      Operação de contadores de pré-pagamento e canais de recarga.
+  BC-3910.70:
+    name: Gestão de clientes vulneráveis
+    description: |
+      Identificação e proteção de clientes em circunstâncias vulneráveis,
+      incluindo registos de serviços prioritários e esquemas de acessibilidade
+      financeira.
+  BC-3910.70.10:
+    name: Operações do registo de serviços prioritários
+    description: |
+      Manutenção do registo de serviços prioritários e sinalizadores de
+      apoio personalizado.
+  BC-3910.70.20:
+    name: Operações de esquemas de dificuldades e acessibilidade financeira
+    description: |
+      Administração de esquemas de tarifa social e fundo de apoio a
+      dificuldades para clientes do serviço público.
+  BC-3910.70.30:
+    name: Gestão de clientes com equipamentos médicos
+    description: |
+      Gestão de clientes dependentes de equipamentos médicos ou de diálise
+      para planeamento de interrupções.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-utility-network-asset-management.yaml
+++ b/catalogue/i18n/pt/L1-utility-network-asset-management.yaml
@@ -1,0 +1,153 @@
+locale: pt
+source: L1-utility-network-asset-management.yaml
+entries:
+  BC-3900:
+    name: Gestão de ativos da rede de serviço público
+    description: |
+      Gestão do ciclo de vida completo de infraestrutura de rede de
+      serviço público de longa duração — ativos de eletricidade, gás,
+      água e águas residuais — abrangendo integridade do registo de ativos,
+      vigilância de condição e saúde, pontuação de risco e criticidade,
+      planeamento de investimento com consciência da base de ativos
+      regulada, programas de renovação, relatórios de desempenho e
+      registos geoespaciais de rede.
+  BC-3900.10:
+    name: Gestão do registo de ativos
+    description: |
+      Manutenção do registo de ativos do serviço público como fonte
+      única de verdade para ativos de rede e as suas relações hierárquicas.
+  BC-3900.10.10:
+    name: Custódia de dados mestre de ativos
+    description: |
+      Custódia de atributos de dados mestre de ativos e classificação.
+  BC-3900.10.20:
+    name: Manutenção da hierarquia de ativos
+    description: |
+      Manutenção de hierarquias de ativos funcionais e físicos para
+      ativos de rede.
+  BC-3900.10.30:
+    name: Reconciliação do registo de ativos
+    description: |
+      Reconciliação entre o registo de ativos, SIG e sistemas operacionais.
+  BC-3900.20:
+    name: Monitorização da condição e saúde de ativos
+    description: |
+      Inspeção, ensaio e vigilância em linha da condição de ativos que
+      alimenta a pontuação de saúde e priorização de ativos.
+  BC-3900.20.10:
+    name: Operações do programa de inspeção
+    description: |
+      Programas de inspeção cíclica de instalações primárias e ativos
+      de rede.
+  BC-3900.20.20:
+    name: Monitorização de condição em linha
+    description: |
+      Monitorização de condição em linha de transformadores, cabos e
+      instalações rotativas.
+  BC-3900.20.30:
+    name: Pontuação de saúde de ativos
+    description: |
+      Cálculo de índices de saúde de ativos a partir de dados de inspeção,
+      ensaio e operação.
+  BC-3900.30:
+    name: Avaliação do risco e criticidade de ativos
+    description: |
+      Avaliação quantificada do risco de ativos combinando probabilidade,
+      consequência e criticidade para priorizar intervenções.
+  BC-3900.30.10:
+    name: Pontuação de criticidade de ativos
+    description: |
+      Pontuação de criticidade de rede e impacto social de ativos do
+      serviço público.
+  BC-3900.30.20:
+    name: Modelação da probabilidade de falha
+    description: |
+      Modelação estatística e baseada em condição da probabilidade de falha.
+  BC-3900.30.30:
+    name: Cálculo de risco monetarizado
+    description: |
+      Cálculo de risco monetarizado alinhado com enquadramentos regulatórios
+      de análise custo-benefício.
+  BC-3900.40:
+    name: Planeamento de investimento em ativos
+    description: |
+      Planeamento de investimento de longo prazo e alinhado com o controlo
+      de preços nas categorias de rede para programas regulados e não
+      regulados.
+  BC-3900.40.10:
+    name: Planeamento de investimento de capital
+    description: |
+      Planeamento de programa de capital de rede plurianual por classe
+      de ativo.
+  BC-3900.40.20:
+    name: Avaliação custo-benefício
+    description: |
+      Avaliação custo-benefício de opções de investimento contra as
+      regras de ensaio regulatório.
+  BC-3900.40.30:
+    name: Priorização do portfólio de investimento
+    description: |
+      Priorização do portfólio entre categorias sob restrições de capital
+      e recursos.
+  BC-3900.50:
+    name: Planeamento de renovação e substituição de ativos
+    description: |
+      Planeamento de programa para renovações, substituições e
+      descomissionamento de fim de vida de ativos na rede.
+  BC-3900.50.10:
+    name: Previsão de fim de vida
+    description: |
+      Previsão de fim de vida de ativos por classe e coorte.
+  BC-3900.50.20:
+    name: Conceção de programa de renovação
+    description: |
+      Conceção de programas de renovação plurianuais por categoria de
+      ativo e geografia.
+  BC-3900.50.30:
+    name: Planeamento do descomissionamento de rede
+    description: |
+      Planeamento de trabalhos de descomissionamento, abandono e
+      reinstalação.
+  BC-3900.60:
+    name: Relatórios de desempenho de ativos
+    description: |
+      Relatórios de desempenho de ativos e utilização de totex contra
+      compromissos de desempenho regulatórios e internos.
+  BC-3900.60.10:
+    name: Relatórios de KPI de desempenho de rede
+    description: |
+      Relatórios de SAIDI, SAIFI, perdas e KPIs equivalentes de rede.
+  BC-3900.60.20:
+    name: Relatórios de desempenho de totex
+    description: |
+      Relatórios de despesa de totex vs. dotação ao abrigo de regimes
+      de controlo de preços.
+  BC-3900.60.30:
+    name: Análise de tendências de falha de ativos
+    description: |
+      Análise de tendências de falhas de ativos e eficácia das intervenções.
+  BC-3900.70:
+    name: Gestão de SIG e registos de rede
+    description: |
+      Registos geoespaciais de ativos de rede — circuitos, condutas,
+      coletores e pontos de ligação — e a sua integração com sistemas
+      operacionais.
+  BC-3900.70.10:
+    name: Manutenção dos registos de rede em SIG
+    description: |
+      Manutenção dos registos SIG da conectividade da rede e localização
+      de ativos.
+  BC-3900.70.20:
+    name: Captura de registos conforme construído
+    description: |
+      Captura de alterações conforme construído de projetos de construção
+      e renovação no SIG.
+  BC-3900.70.30:
+    name: Operações de pesquisa de ativos subterrâneos
+    description: |
+      Respostas de pesquisa de registos de utilidades subterrâneas a
+      terceiros que realizam escavações.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-utility-regulatory-price-control-management.yaml
+++ b/catalogue/i18n/pt/L1-utility-regulatory-price-control-management.yaml
@@ -1,0 +1,155 @@
+locale: pt
+source: L1-utility-regulatory-price-control-management.yaml
+entries:
+  BC-3920:
+    name: Gestão regulatória e de controlo de preços do serviço público
+    description: |
+      Envolvimento com reguladores do setor dos serviços públicos e
+      administração de regimes de controlo de preços — interações com
+      reguladores, submissões de controlo de preços, conceção da estrutura
+      tarifária, relatórios regulatórios, compromissos de desempenho de
+      serviço, alocação de custos regulatórios e obrigações de serviço
+      universal e acessibilidade financeira.
+  BC-3920.10:
+    name: Envolvimento com o regulador do serviço público
+    description: |
+      Gestão diária do relacionamento e do fluxo de informação com
+      reguladores setoriais e organismos de proteção do consumidor.
+  BC-3920.10.10:
+    name: Gestão de correspondência com o regulador
+    description: |
+      Tratamento de correspondência de entrada e saída e pedidos de
+      informação com reguladores.
+  BC-3920.10.20:
+    name: Resposta a consultas regulatórias
+    description: |
+      Preparação e submissão de respostas a consultas regulatórias.
+  BC-3920.10.30:
+    name: Participação em audiências regulatórias
+    description: |
+      Participação em audiências regulatórias, conferências técnicas e
+      fóruns de partes interessadas.
+  BC-3920.20:
+    name: Gestão de submissões de controlo de preços
+    description: |
+      Preparação, submissão e negociação ponta-a-ponta de planos de
+      negócio plurianuais de controlo de preços ou de processo tarifário.
+  BC-3920.20.10:
+    name: Preparação do plano de negócio
+    description: |
+      Preparação de planos de negócio de controlo de preços (RIIO, PR,
+      equivalentes de processo tarifário).
+  BC-3920.20.20:
+    name: Benchmarking de custos e modelação de totex
+    description: |
+      Benchmarking de custos e modelação de totex contra conjuntos de
+      dados do regulador e de pares.
+  BC-3920.20.30:
+    name: Negociação de receita autorizada
+    description: |
+      Negociação de receita autorizada, resultados e parâmetros de
+      incentivo com o regulador.
+  BC-3920.30:
+    name: Conceção da estrutura tarifária
+    description: |
+      Conceção de estruturas tarifárias reguladas — encargos de energia,
+      encargos de rede e encargos fixos — para clientes residenciais,
+      comerciais e industriais.
+  BC-3920.30.10:
+    name: Conceção de tarifa de utilização da rede
+    description: |
+      Conceção de tarifas de utilização da rede de distribuição e transporte.
+  BC-3920.30.20:
+    name: Conceção de calendário de tarifas a retalho
+    description: |
+      Conceção de calendários de tarifas a retalho, incluindo estruturas
+      de uso no tempo e sazonais.
+  BC-3920.30.30:
+    name: Metodologia de tarifação de ligações
+    description: |
+      Metodologia de tarifação de ligações e gestão da fronteira
+      contestável / não contestável.
+  BC-3920.40:
+    name: Operações de relatórios regulatórios
+    description: |
+      Relatórios estatutários periódicos a reguladores de serviços públicos,
+      incluindo relatórios de desempenho anuais, contas regulatórias e
+      submissões intercalares.
+  BC-3920.40.10:
+    name: Relatórios de desempenho anuais
+    description: |
+      Compilação e submissão de relatórios de desempenho anuais a
+      reguladores.
+  BC-3920.40.20:
+    name: Preparação de contas regulatórias
+    description: |
+      Preparação de contas regulatórias ao abrigo de diretrizes contabilísticas
+      definidas pelo regulador.
+  BC-3920.40.30:
+    name: Submissões regulatórias ad hoc
+    description: |
+      Submissões de dados ad hoc a portais do regulador e pedidos de
+      informação.
+  BC-3920.50:
+    name: Gestão de compromissos de desempenho de serviço
+    description: |
+      Rastreio e administração de incentivos de incentivos de entrega de
+      resultados e compromissos de nível de serviço definidos pelo regulador.
+  BC-3920.50.10:
+    name: Rastreio de incentivos de entrega de resultados
+    description: |
+      Rastreio de ODIs, compromissos de desempenho e ganhos de incentivo.
+  BC-3920.50.20:
+    name: Administração de normas garantidas
+    description: |
+      Administração de pagamentos de normas garantidas de serviço
+      a clientes.
+  BC-3920.50.30:
+    name: Cálculo de penalidades de desempenho
+    description: |
+      Cálculo de penalidades e recompensas regulatórias de desempenho.
+  BC-3920.60:
+    name: Alocação de custos regulatórios
+    description: |
+      Alocação de custos entre unidades de negócio reguladas e não reguladas
+      e entre categorias de controlo de preços ao abrigo da metodologia
+      de alocação de custos.
+  BC-3920.60.10:
+    name: Manutenção da metodologia de alocação de custos
+    description: |
+      Manutenção de metodologias de alocação de custos aprovadas pelo
+      regulador.
+  BC-3920.60.20:
+    name: Divisão de custos regulados vs não regulados
+    description: |
+      Aplicação periódica de divisões de custos entre atividades reguladas
+      e não reguladas.
+  BC-3920.60.30:
+    name: Classificação de capex / opex
+    description: |
+      Classificação de despesa entre capex e opex de acordo com as
+      definições do regulador.
+  BC-3920.70:
+    name: Gestão de serviço universal e acessibilidade financeira
+    description: |
+      Entrega de programas para obrigações de serviço universal e esquemas
+      de acessibilidade financeira e de combate à pobreza energética/hídrica
+      impostos pelo regulador.
+  BC-3920.70.10:
+    name: Entrega de obrigações de serviço universal
+    description: |
+      Entrega de requisitos de obrigações de serviço universal a clientes
+      a retalho.
+  BC-3920.70.20:
+    name: Operações de programas de pobreza energética e hídrica
+    description: |
+      Operação de programas de alívio da pobreza energética e hídrica.
+  BC-3920.70.30:
+    name: Relatórios de esquemas de acessibilidade financeira
+    description: |
+      Relatórios de entrega de esquemas de acessibilidade financeira ao
+      regulador e ao governo.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-vehicle-aftersales-warranty-management.yaml
+++ b/catalogue/i18n/pt/L1-vehicle-aftersales-warranty-management.yaml
@@ -1,0 +1,178 @@
+locale: pt
+source: L1-vehicle-aftersales-warranty-management.yaml
+entries:
+  BC-3450:
+    name: Gestão de pós-venda e garantia de veículos
+    description: |
+      Pós-venda do OEM — operações e apreciação de garantias, gestão de
+      campanhas de recall e serviço, informação técnica de serviço, assistência
+      ao cliente e ciclo de feedback de engenharia, ancorado na Magnuson-Moss,
+      regras europeias de venda ao consumidor e regimes de recall NHTSA/UE.
+  BC-3450.10:
+    name: Gestão de política de garantia e reclamações
+    description: |
+      Definição de políticas de garantia e apreciação de reclamações de garantia
+      dos concessionários, incluindo recuperação junto de fornecedores.
+  BC-3450.10.10:
+    name: Definição de política de garantia
+    description: |
+      Definição de termos, durações, coberturas e exclusões de garantia nos
+      vários mercados e linhas de produtos.
+  BC-3450.10.20:
+    name: Apreciação de reclamações de garantia
+    description: |
+      Apreciação de reclamações de garantia dos concessionários, incluindo normas
+      de tempo de mão de obra e validação de peças.
+  BC-3450.10.30:
+    name: Gestão de boa vontade e concessões
+    description: |
+      Gestão de reparações de boa vontade, concessões e extensões de garantia
+      por fidelização de clientes.
+  BC-3450.10.40:
+    name: Gestão de recuperação junto de fornecedores
+    description: |
+      Recuperação de custos de garantia junto de fornecedores responsáveis ao
+      abrigo de acordos de partilha de custos de garantia.
+  BC-3450.20:
+    name: Gestão de campanhas de serviço e recall
+    description: |
+      Gestão de ponta a ponta de recalls de segurança e campanhas de serviço
+      não relacionadas com segurança, incluindo notificação e acompanhamento
+      de conclusão.
+  BC-3450.20.10:
+    name: Decisão e notificação de recall
+    description: |
+      Tomada de decisão e notificação estatutária de recalls de segurança às
+      autoridades e proprietários.
+  BC-3450.20.20:
+    name: Planeamento de campanhas de serviço
+    description: |
+      Planeamento de campanhas de serviço, incluindo definição de medidas
+      corretivas, aprovisionamento de peças e instruções aos concessionários.
+  BC-3450.20.30:
+    name: Gestão da notificação a proprietários
+    description: |
+      Identificação e notificação dos proprietários de veículos afetados por
+      correio, e-mail e canais do veículo.
+  BC-3450.20.40:
+    name: Acompanhamento da taxa de conclusão de campanhas
+    description: |
+      Acompanhamento das taxas de conclusão de recall e campanha e obrigações
+      de reporte regulatório.
+  BC-3450.30:
+    name: Gestão de informação técnica de serviço
+    description: |
+      Elaboração e distribuição de procedimentos de reparação, boletins técnicos
+      e informação de diagnóstico para a rede de serviço dos concessionários.
+  BC-3450.30.10:
+    name: Elaboração de procedimentos de reparação
+    description: |
+      Elaboração de procedimentos de reparação de veículos, vistas explodidas e
+      dados de apertos/fixação.
+  BC-3450.30.20:
+    name: Gestão de boletins técnicos de serviço
+    description: |
+      Elaboração, emissão e gestão do ciclo de vida de boletins técnicos de
+      serviço.
+  BC-3450.30.30:
+    name: Gestão da biblioteca de códigos de diagnóstico
+    description: |
+      Manutenção de bibliotecas de DTC, árvores de diagnóstico e conteúdo de
+      diagnóstico guiado relacionado.
+  BC-3450.30.40:
+    name: Especificação de ferramentas de serviço
+    description: |
+      Especificação de ferramentas especiais e equipamento de serviço dos
+      concessionários para operações de serviço de veículos.
+  BC-3450.40:
+    name: Operações de diagnóstico e telemática de veículos
+    description: |
+      Operações do OEM de suporte a diagnóstico conectado, dados de diagnóstico
+      remoto e ecossistemas de ferramentas de diagnóstico dos concessionários.
+  BC-3450.40.10:
+    name: Operações de diagnóstico remoto de veículos
+    description: |
+      Operação de serviços de saúde e diagnóstico remoto de veículos em apoio
+      ao serviço dos concessionários.
+  BC-3450.40.20:
+    name: Gestão de atualizações de ferramentas de diagnóstico
+    description: |
+      Gestão de software de ferramentas de diagnóstico dos concessionários,
+      dados de calibração e acesso de segurança.
+  BC-3450.40.30:
+    name: Agregação de dados de serviço
+    description: |
+      Agregação e análise de dados de eventos de serviço de concessionários e
+      veículos conectados.
+  BC-3450.50:
+    name: Operações de assistência ao cliente e apoio em estrada
+    description: |
+      Serviços de assistência ao cliente com marca do OEM, incluindo apoio em
+      estrada, substituição de mobilidade e repatriamento de veículos.
+  BC-3450.50.10:
+    name: Operações de assistência em estrada
+    description: |
+      Operação de assistência em estrada com marca do OEM para resposta a avarias
+      e incidentes.
+  BC-3450.50.20:
+    name: Coordenação de substituição de mobilidade
+    description: |
+      Coordenação de transporte de substituição para clientes durante reparação
+      ou avaria.
+  BC-3450.50.30:
+    name: Coordenação de repatriamento de veículos
+    description: |
+      Coordenação do repatriamento de veículos após incidentes no estrangeiro ou
+      avaria a longa distância.
+  BC-3450.60:
+    name: Coordenação de logística de peças de pós-venda
+    description: |
+      Coordenação com a cadeia de fornecimento de peças do mercado secundário
+      para suportar a procura de serviço dos concessionários e medidas corretivas
+      de recall.
+    in_scope:
+      - Coordenação de procura e fornecimento de peças com concessionários
+      - Expedição de peças críticas para eventos de veículo imobilizado
+      - Alocação de peças de recall na rede de concessionários
+    out_of_scope:
+      - Catálogo e preçário de peças sobresselentes (BC-1060 Gestão de Peças Sobresselentes e Mercado Secundário)
+      - Operações de armazenagem e distribuição física de peças (BC-1060)
+  BC-3450.60.10:
+    name: Coordenação da procura de peças com concessionários
+    description: |
+      Coordenação da visibilidade da procura de peças dos concessionários e
+      sinais de reabastecimento para a cadeia de fornecimento de peças.
+  BC-3450.60.20:
+    name: Gestão de expedição de peças críticas
+    description: |
+      Expedição de peças críticas para veículos imobilizados e casos de cliente
+      de elevada gravidade.
+  BC-3450.60.30:
+    name: Alocação de peças de recall
+    description: |
+      Alocação de peças de recall restringidas a concessionários e mercados com
+      base nas prioridades da população afetada.
+  BC-3450.70:
+    name: Desempenho de pós-venda e feedback de qualidade
+    description: |
+      Análise de tendências de falhas em campo e feedback de clientes e
+      encaminhamento de problemas de volta para engenharia e produção.
+  BC-3450.70.10:
+    name: Análise de tendências de falhas em campo
+    description: |
+      Análise de dados de garantia e eventos de serviço para identificar
+      tendências de falhas em campo e problemas emergentes.
+  BC-3450.70.20:
+    name: Gestão da voz do cliente de pós-venda
+    description: |
+      Captura e análise da voz do cliente de pós-venda, incluindo inquéritos e
+      feedback registado pelos concessionários.
+  BC-3450.70.30:
+    name: Gestão do ciclo de feedback de engenharia
+    description: |
+      Encaminhamento de problemas de qualidade em campo para engenharia para
+      contenção, correção e lições aprendidas.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-vehicle-connected-services-management.yaml
+++ b/catalogue/i18n/pt/L1-vehicle-connected-services-management.yaml
@@ -1,0 +1,161 @@
+locale: pt
+source: L1-vehicle-connected-services-management.yaml
+entries:
+  BC-3460:
+    name: Gestão de serviços conectados do veículo
+    description: |
+      Operação de serviços conectados do veículo — plataforma de conectividade
+      do veículo, atualizações de software OTA, aplicações e subscrições do
+      veículo, plataforma de dados do veículo, serviços V2X, operações de
+      segurança do veículo e suporte ao cliente de serviços conectados.
+  BC-3460.10:
+    name: Operações da plataforma de conectividade do veículo
+    description: |
+      Operação da conectividade do veículo, provisionamento de SIM e plataforma
+      de telemetria veículo-para-nuvem.
+  BC-3460.10.10:
+    name: Provisionamento de SIM e conectividade do veículo
+    description: |
+      Provisionamento de conectividade de SIM embebido e roaming de operadora
+      para veículos conectados.
+  BC-3460.10.20:
+    name: Operações da rede de conectividade
+    description: |
+      Operação da infraestrutura de conectividade que suporta os serviços do
+      veículo, incluindo failover e qualidade de serviço.
+  BC-3460.10.30:
+    name: Operações de telemetria veículo-para-nuvem
+    description: |
+      Operação de pipelines de telemetria do veículo desde agentes no veículo
+      até às plataformas na nuvem.
+  BC-3460.20:
+    name: Operações de atualização de software OTA
+    description: |
+      Operação de campanhas de atualização de software OTA alinhadas com o UN R156
+      e o sistema de gestão de atualizações de software.
+  BC-3460.20.10:
+    name: Planeamento de campanhas OTA
+    description: |
+      Planeamento de campanhas de atualização de software OTA, incluindo âmbito,
+      elegibilidade e estratégia de implementação.
+  BC-3460.20.20:
+    name: Distribuição de pacotes OTA
+    description: |
+      Distribuição de pacotes OTA assinados para veículos e orquestração da
+      instalação entre UCEs.
+  BC-3460.20.30:
+    name: Gestão de rollback e recuperação OTA
+    description: |
+      Gestão de rollback, recuperação e resposta a incidentes em campo quando
+      as atualizações falham.
+  BC-3460.30:
+    name: Gestão de aplicações e subscrições do veículo
+    description: |
+      Operação da loja de aplicações do veículo, ciclo de vida das subscrições
+      e serviços de pagamento no veículo.
+  BC-3460.30.10:
+    name: Gestão do catálogo de serviços conectados
+    description: |
+      Manutenção do catálogo de serviços conectados e aplicações do veículo
+      oferecidas aos clientes.
+  BC-3460.30.20:
+    name: Gestão do ciclo de vida das subscrições
+    description: |
+      Gestão do ciclo de vida das subscrições de clientes a serviços conectados
+      e funções por ativação.
+  BC-3460.30.30:
+    name: Operações de pagamento no veículo
+    description: |
+      Operação de pagamento no veículo, tokenização e liquidação de transações.
+  BC-3460.40:
+    name: Operações da plataforma de dados do veículo
+    description: |
+      Operação da plataforma de dados do veículo — ingestão, armazenamento,
+      partilha e gestão de consentimento — suportando casos de uso de primeira e
+      terceira partes.
+    in_scope:
+      - Ingestão e armazenamento de dados do veículo
+      - APIs de partilha de dados do veículo para consumidores internos e parceiros
+      - Gestão de privacidade e consentimento para dados do veículo
+    out_of_scope:
+      - Gestão genérica de dados empresariais (coberta pela gestão de dados empresariais e TI)
+      - Elaboração do caso de segurança funcional (BC-3400.80)
+  BC-3460.40.10:
+    name: Ingestão e armazenamento de dados do veículo
+    description: |
+      Ingestão, normalização e armazenamento de telemetria do veículo e dados de
+      eventos à escala de frota.
+  BC-3460.40.20:
+    name: Partilha de dados do veículo e gestão de APIs
+    description: |
+      Prestação de APIs de dados do veículo a equipas internas, concessionários
+      e parceiros externos ao abrigo de acordos de partilha de dados.
+  BC-3460.40.30:
+    name: Gestão de privacidade e consentimento de dados do veículo
+    description: |
+      Gestão do consentimento, preferências e controlos de privacidade do cliente
+      para dados gerados pelo veículo.
+  BC-3460.50:
+    name: Serviços V2X e de mobilidade cooperativa
+    description: |
+      Operação de serviços de mensagens V2X e serviços de mobilidade cooperativa
+      com infraestrutura e outros veículos.
+  BC-3460.50.10:
+    name: Operações de serviços V2I
+    description: |
+      Operação de serviços veículo-para-infraestrutura, como fase e temporização
+      de semáforos, avisos de obras e portagens.
+  BC-3460.50.20:
+    name: Operações de mensagens V2V
+    description: |
+      Operação de serviços de mensagens veículo-para-veículo e canais de difusão
+      segundo o SAE J2735 e equivalentes.
+  BC-3460.50.30:
+    name: Operações de serviços de consciência cooperativa
+    description: |
+      Operação de serviços de consciência cooperativa, aviso de perigos e
+      platooning em frotas mistas.
+  BC-3460.60:
+    name: Operações de segurança do veículo
+    description: |
+      Monitorização de segurança operacional da frota de veículos conectados e
+      resposta a incidentes cibernéticos do veículo.
+  BC-3460.60.10:
+    name: Deteção de ameaças ao veículo
+    description: |
+      Deteção de ameaças cibernéticas e comportamento anómalo na frota de
+      veículos conectados.
+  BC-3460.60.20:
+    name: Resposta a incidentes de segurança do veículo
+    description: |
+      Resposta a incidentes de cibersegurança do veículo, incluindo contenção,
+      remediação e notificação ao cliente.
+  BC-3460.60.30:
+    name: Operações do SOC do veículo
+    description: |
+      Operação do centro de operações de segurança do veículo e pipelines de
+      telemetria de suporte.
+  BC-3460.70:
+    name: Operações de clientes de serviços conectados
+    description: |
+      Operações orientadas para o cliente de serviços conectados, incluindo apoio
+      à ativação, resolução de problemas e gestão de contas.
+  BC-3460.70.10:
+    name: Apoio à ativação de serviços conectados
+    description: |
+      Apoio à ativação, transferência e desativação de serviços conectados pelo
+      cliente.
+  BC-3460.70.20:
+    name: Resolução de problemas de serviços conectados
+    description: |
+      Resolução de problemas de serviços conectados comunicados por clientes nos
+      canais de centro de contacto, concessionário e self-service.
+  BC-3460.70.30:
+    name: Gestão de contas de serviços conectados
+    description: |
+      Gestão de contas de clientes de serviços conectados, identidade e
+      ligação de direitos a veículos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-vehicle-engineering-management.yaml
+++ b/catalogue/i18n/pt/L1-vehicle-engineering-management.yaml
@@ -1,0 +1,267 @@
+locale: pt
+source: L1-vehicle-engineering-management.yaml
+entries:
+  BC-3400:
+    name: Gestão de engenharia de veículos
+    description: |
+      Engenharia integral de veículos em carroçaria, chassis, trem de força
+      (motor de combustão interna, elétrico, pilha de combustível), arquitetura
+      elétrica/eletrónica, software embebido, segurança funcional, cibersegurança
+      e SOTIF, ancorada na IATF 16949, ISO 26262, ISO/SAE 21434, ISO 21448,
+      Automotive SPICE e AUTOSAR.
+  BC-3400.10:
+    name: Gestão da arquitetura do veículo
+    description: |
+      Arquitetura integral do veículo, embalagem, definição de metas de atributos
+      e decomposição de plataforma/variantes que enquadram toda a engenharia
+      subsequente.
+    in_scope:
+      - Metas de atributos do veículo e resolução de compromissos
+      - Embalagem, disposição e definição zonal do veículo
+      - Escolhas de arquitetura de plataforma e módulo
+    out_of_scope:
+      - Governação de fase-gate do programa (BC-3410)
+      - Engenharia detalhada ao nível do componente (coberta nos L2 específicos por disciplina)
+  BC-3400.10.10:
+    name: Definição de metas de atributos do veículo
+    description: |
+      Definição de metas de desempenho, conforto, segurança, eficiência e atributos
+      de marca ao nível do veículo e respetiva resolução de compromissos.
+  BC-3400.10.20:
+    name: Embalagem e disposição do veículo
+    description: |
+      Embalagem integral do veículo, disposição de ocupantes e bagagem, definição
+      de pontos fixos e alocação zonal.
+  BC-3400.10.30:
+    name: Definição da arquitetura da plataforma
+    description: |
+      Definição de plataformas partilhadas de veículos, módulos comuns e
+      estratégias de transferência entre programas.
+  BC-3400.10.40:
+    name: Arquitetura de módulos e variantes
+    description: |
+      Estratégia modular e de variantes que permite derivados de carroçaria,
+      trens de força e níveis de equipamento a partir de uma arquitetura comum.
+  BC-3400.20:
+    name: Engenharia de trem de força
+    description: |
+      Engenharia de sistemas de propulsão de combustão interna, elétrica e de pilha
+      de combustível, incluindo transmissões, linha de transmissão e sistemas de
+      armazenamento de energia.
+  BC-3400.20.10:
+    name: Engenharia de trem de força de combustão interna
+    description: |
+      Engenharia de motores de combustão interna, sistemas de combustível, pós-
+      tratamento de escape e calibração associada.
+  BC-3400.20.20:
+    name: Engenharia de trem de força elétrico
+    description: |
+      Engenharia de unidades de tração elétrica, inversores, eletrónica de
+      carregamento e integração com o sistema de alta tensão.
+  BC-3400.20.30:
+    name: Engenharia de sistema de bateria
+    description: |
+      Engenharia de células, módulos, pacotes de bateria de tração, BMS e
+      subsistemas de gestão térmica.
+  BC-3400.20.40:
+    name: Engenharia de sistema de pilha de combustível
+    description: |
+      Engenharia de armazenamento de hidrogénio, stack de pilha de combustível,
+      balanço de planta e integração no veículo.
+  BC-3400.20.50:
+    name: Engenharia de transmissão e linha de transmissão
+    description: |
+      Engenharia de transmissões, eixos, árvores de transmissão e componentes
+      de linha de transmissão com vectorização de binário.
+  BC-3400.30:
+    name: Engenharia de chassis e dinâmica do veículo
+    description: |
+      Engenharia de sistemas de suspensão, direção, travagem, rodas e pneus e
+      respetivo comportamento dinâmico integrado.
+  BC-3400.30.10:
+    name: Engenharia de suspensão e direção
+    description: |
+      Engenharia de geometria de suspensão, amortecedores, molas e sistemas de
+      direção, incluindo direção por fio.
+  BC-3400.30.20:
+    name: Engenharia de sistema de travagem
+    description: |
+      Engenharia de travões de serviço, recuperação regenerativa e sistemas de
+      controlo de travagem.
+  BC-3400.30.30:
+    name: Afinação da dinâmica do veículo
+    description: |
+      Afinação de conforto, manobrabilidade, estabilidade e controlo de tração
+      para cumprir os atributos dinâmicos pretendidos.
+  BC-3400.30.40:
+    name: Engenharia de rodas e pneus
+    description: |
+      Engenharia e seleção de rodas e pneus, incluindo TPMS e compromissos
+      desempenho/eficiência.
+  BC-3400.40:
+    name: Engenharia de carroçaria e exterior
+    description: |
+      Engenharia de carroçaria em branco, fechos, vidros, acabamentos exteriores,
+      iluminação e superfícies aerodinâmicas.
+  BC-3400.40.10:
+    name: Engenharia de carroçaria em branco
+    description: |
+      Engenharia da estrutura da carroçaria, estratégia de ligação e caminhos de
+      carga de resistência ao choque.
+  BC-3400.40.20:
+    name: Engenharia de fechos e vidros
+    description: |
+      Engenharia de portas, capots, portas traseiras, fechos deslizantes e
+      sistemas de envidraçamento.
+  BC-3400.40.30:
+    name: Engenharia de acabamentos exteriores e iluminação
+    description: |
+      Engenharia de acabamentos exteriores, emblemas e sistemas de iluminação
+      exterior, incluindo arquiteturas de faróis e sinalização.
+  BC-3400.40.40:
+    name: Engenharia aerodinâmica
+    description: |
+      Desenvolvimento de forma aerodinâmica, equilíbrio de resistência e
+      sustentação e gestão de fluxo sob o veículo.
+  BC-3400.50:
+    name: Engenharia de interior e conforto
+    description: |
+      Engenharia de assentos, sistemas de retenção, acabamentos interiores,
+      superfícies de IHM, climatização e desempenho acústico/NVH.
+  BC-3400.50.10:
+    name: Engenharia de assentos e sistemas de retenção
+    description: |
+      Engenharia de assentos, cintos de segurança, airbags e outros sistemas de
+      retenção de ocupantes.
+  BC-3400.50.20:
+    name: Engenharia de acabamentos interiores e IHM
+    description: |
+      Engenharia de painel de instrumentos, consola, revestimento de tecto e
+      superfícies físicas/digitais de IHM.
+  BC-3400.50.30:
+    name: Engenharia de climatização
+    description: |
+      Engenharia de AVAC, fluido refrigerante, bomba de calor e sistemas de
+      gestão térmica de bateria e habitáculo.
+  BC-3400.50.40:
+    name: Engenharia acústica e NVH
+    description: |
+      Engenharia e afinação acústica, de vibração e de dureza em todo o veículo.
+  BC-3400.60:
+    name: Engenharia de arquitetura elétrica e eletrónica
+    description: |
+      Engenharia da topologia elétrica/eletrónica do veículo, redes internas,
+      distribuição de energia e hardware de UCE.
+  BC-3400.60.10:
+    name: Definição de topologia E/E
+    description: |
+      Definição da topologia E/E do veículo, incluindo arquiteturas de computação
+      por domínio, zonal e centralizada.
+  BC-3400.60.20:
+    name: Engenharia de redes internas do veículo
+    description: |
+      Engenharia de CAN, CAN-FD, LIN, FlexRay, Ethernet Automóvel e redes de
+      comunicação internas relacionadas.
+  BC-3400.60.30:
+    name: Engenharia de cablagem e distribuição de energia
+    description: |
+      Engenharia de arneses de cablagem, conectores e distribuição de energia em
+      alta e baixa tensão.
+  BC-3400.60.40:
+    name: Engenharia de hardware de UCE
+    description: |
+      Engenharia de hardware de unidades de controlo eletrónico, semicondutores e
+      designs de PCB segundo as normas AEC-Q.
+  BC-3400.70:
+    name: Engenharia de software de veículo
+    description: |
+      Engenharia de software embebido, plataformas de software automóvel e sistemas
+      operativos de veículo alinhados com AUTOSAR e Automotive SPICE.
+  BC-3400.70.10:
+    name: Engenharia de software embebido
+    description: |
+      Engenharia de software embebido ao nível de UCE, incluindo controladores de
+      dispositivo e componentes de software básico.
+  BC-3400.70.20:
+    name: Engenharia de plataforma AUTOSAR
+    description: |
+      Engenharia de configurações e integração das plataformas AUTOSAR Classic e
+      Adaptive.
+  BC-3400.70.30:
+    name: Engenharia de sistema operativo do veículo
+    description: |
+      Engenharia de sistemas operativos de alto desempenho, hipervisores e
+      middleware para veículos definidos por software.
+  BC-3400.70.40:
+    name: Gestão de integração e build de software
+    description: |
+      Integração de software do veículo, gestão de build e comboio de releases
+      entre UCEs e domínios.
+  BC-3400.80:
+    name: Engenharia de segurança funcional e cibersegurança
+    description: |
+      Disciplinas de engenharia que asseguram o comportamento de segurança dos
+      sistemas críticos e do veículo conectado, ancoradas na ISO 26262,
+      ISO/SAE 21434 e ISO 21448.
+    in_scope:
+      - Elaboração do caso de segurança funcional (ISO 26262)
+      - Engenharia de cibersegurança (ISO/SAE 21434)
+      - Análise e validação SOTIF (ISO 21448)
+      - HARA, FMEA-MSR e TARA
+    out_of_scope:
+      - SOC operacional do veículo e resposta a incidentes (BC-3460.60)
+      - Submissões de aprovação de tipo para UN R155/R156 (BC-3420.50)
+  BC-3400.80.10:
+    name: Gestão do caso de segurança funcional
+    description: |
+      Elaboração e manutenção de casos de segurança ISO 26262, alocação ASIL e
+      evidências de argumentação de segurança.
+  BC-3400.80.20:
+    name: Engenharia de cibersegurança automóvel
+    description: |
+      Atividades de engenharia de cibersegurança alinhadas com a ISO/SAE 21434,
+      incluindo TARA, design seguro e ciclo de vida de desenvolvimento seguro.
+  BC-3400.80.30:
+    name: Engenharia SOTIF
+    description: |
+      Análise e validação da segurança da funcionalidade pretendida para funções
+      ADAS e de condução automatizada segundo a ISO 21448.
+  BC-3400.80.40:
+    name: Análise de riscos e perigos
+    description: |
+      HARA, FMEA-MSR e outras análises sistemáticas de perigos que orientam
+      requisitos de segurança e proteção.
+  BC-3400.90:
+    name: Gestão de verificação e validação do veículo
+    description: |
+      Verificação e validação de designs de veículo, subsistema e componente
+      através de campanhas de teste virtual, em bancada e físico.
+  BC-3400.90.10:
+    name: Validação virtual
+    description: |
+      Verificação virtual de comportamento de veículo e subsistema baseada em
+      CAE, MIL/SIL/HIL e gémeo digital.
+  BC-3400.90.20:
+    name: Teste de componentes e subsistemas
+    description: |
+      Teste em bancada e em plataforma de componentes e subsistemas face a
+      especificações de engenharia.
+  BC-3400.90.30:
+    name: Teste de integração do veículo
+    description: |
+      Teste de integração do veículo completo em pistas de ensaio e vias
+      públicas em condições controladas.
+  BC-3400.90.40:
+    name: Teste de durabilidade e fiabilidade
+    description: |
+      Teste acelerado e correlacionado com o cliente de durabilidade e
+      fiabilidade de componentes e do veículo completo.
+  BC-3400.90.50:
+    name: Teste de colisão e proteção de ocupantes
+    description: |
+      Testes de colisão e proteção de ocupantes de engenharia em apoio a
+      requisitos regulatórios e de classificação do consumidor.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-vehicle-homologation-type-approval-management.yaml
+++ b/catalogue/i18n/pt/L1-vehicle-homologation-type-approval-management.yaml
@@ -1,0 +1,184 @@
+locale: pt
+source: L1-vehicle-homologation-type-approval-management.yaml
+entries:
+  BC-3420:
+    name: Gestão de homologação e aprovação de tipo de veículo
+    description: |
+      Certificação regulatória de veículos e componentes principais em vários
+      mercados — aprovação de tipo UNECE WP.29, autocertificação FMVSS,
+      aprovações regionais (CCC, KS, MLIT), homologação de emissões e energia,
+      programas de colisão e classificação do consumidor e auditorias de
+      conformidade da produção.
+  BC-3420.10:
+    name: Estratégia e planeamento de aprovação de tipo
+    description: |
+      Estratégia de homologação multimercado e planeamento, incluindo envolvimento
+      com autoridades de aprovação e execução do plano de homologação.
+  BC-3420.10.10:
+    name: Estratégia de aprovação por mercado
+    description: |
+      Estratégia de aprovação de tipo e certificação em mercados-alvo e regimes
+      regulatórios.
+  BC-3420.10.20:
+    name: Gestão do plano de homologação
+    description: |
+      Gestão dos planos de homologação ao nível do programa, entregas e marcos.
+  BC-3420.10.30:
+    name: Envolvimento com autoridades de aprovação
+    description: |
+      Envolvimento com autoridades de aprovação e serviços técnicos em várias
+      jurisdições.
+  BC-3420.20:
+    name: Submissões de aprovação de tipo do veículo
+    description: |
+      Preparação e submissão de dossiês de aprovação de tipo e autocertificação
+      nos regimes UNECE, FMVSS e regionais.
+  BC-3420.20.10:
+    name: Gestão do dossiê de aprovação de tipo UNECE
+    description: |
+      Preparação, submissão e manutenção de dossiês de aprovação de tipo integral
+      do veículo UNECE WP.29.
+  BC-3420.20.20:
+    name: Gestão de autocertificação FMVSS
+    description: |
+      Gestão de evidências de autocertificação para FMVSS/49 CFR 571 nos
+      Estados Unidos.
+  BC-3420.20.30:
+    name: Gestão de submissões regionais
+    description: |
+      Gestão de submissões para CCC, KS, MLIT, CCG e outros regimes regionais
+      de aprovação de automóveis.
+  BC-3420.20.40:
+    name: Gestão de variações e extensões de aprovação
+    description: |
+      Gestão de variações, extensões e revisões de aprovação ao longo do ciclo
+      de vida do veículo.
+  BC-3420.30:
+    name: Homologação de emissões e energia
+    description: |
+      Homologação de emissões de veículos, consumo de energia e autonomia de VE
+      face aos regimes WLTP, RDE, EPA, CARB, China e equivalentes.
+  BC-3420.30.10:
+    name: Execução de ciclos de teste de emissões
+    description: |
+      Execução de ciclos de teste de emissões e consumo de combustível WLTP,
+      FTP-75, China e outros regulatórios.
+  BC-3420.30.20:
+    name: Conformidade de emissões em condições reais de condução
+    description: |
+      Campanhas de teste de emissões em condições reais de condução e demonstração
+      de conformidade para conformidade em serviço.
+  BC-3420.30.30:
+    name: Reporte de CO2 e consumo de combustível
+    description: |
+      Reporte regulatório de CO2 e consumo de combustível ao abrigo das regras
+      de frota de CO2 da UE, CAFE e equivalentes.
+  BC-3420.30.40:
+    name: Homologação de autonomia e eficiência de VE
+    description: |
+      Homologação de autonomia de veículo elétrico, consumo de energia e métricas
+      de carregamento em vários mercados.
+  BC-3420.40:
+    name: Homologação de segurança em colisão e proteção de ocupantes
+    description: |
+      Homologação regulatória de colisão, proteção de ocupantes e proteção de
+      peões, juntamente com programas de classificação do consumidor.
+  BC-3420.40.10:
+    name: Gestão do programa de testes de colisão
+    description: |
+      Planeamento e execução de campanhas regulatórias de teste de colisão para
+      homologação.
+  BC-3420.40.20:
+    name: Aprovação do sistema de retenção
+    description: |
+      Aprovação de cintos de segurança, airbags e ancoragens para sistemas de
+      retenção de crianças em vários regimes regulatórios.
+  BC-3420.40.30:
+    name: Aprovação de proteção de peões
+    description: |
+      Homologação de proteção de peões e utilizadores vulneráveis da via ao abrigo
+      do GTR 9 UNECE e equivalentes.
+  BC-3420.40.40:
+    name: Gestão do programa NCAP
+    description: |
+      Gestão de programas de classificação de colisão do consumidor, incluindo
+      Euro NCAP, IIHS, NHTSA NCAP e NCAPs regionais.
+  BC-3420.50:
+    name: Aprovação funcional e cibernética
+    description: |
+      Atividades de aprovação de tipo específicas de cibersegurança UN R155,
+      atualizações de software UN R156 e ALKS/ADS UN R157, complementando as
+      atividades de engenharia da Gestão de Engenharia de Veículos.
+    in_scope:
+      - Auditorias e aprovação de tipo do CSMS
+      - Auditorias e aprovação de tipo do SUMS
+      - Submissões regulatórias para ALKS/ADS
+    out_of_scope:
+      - Atividades de engenharia de cibersegurança (BC-3400.80)
+      - Operações de SOC do veículo (BC-3460.60)
+  BC-3420.50.10:
+    name: Gestão da aprovação de tipo do CSMS
+    description: |
+      Aprovação de tipo do sistema de gestão de cibersegurança ao abrigo do
+      UN R155, incluindo preparação de auditoria e vigilância.
+  BC-3420.50.20:
+    name: Gestão da aprovação de tipo do SUMS
+    description: |
+      Aprovação de tipo do sistema de gestão de atualizações de software ao
+      abrigo do UN R156, incluindo preparação de auditoria e vigilância.
+  BC-3420.50.30:
+    name: Gestão de aprovação de ALKS e ADS
+    description: |
+      Submissões de aprovação para manutenção automática de faixa e sistemas de
+      condução automatizada mais amplos ao abrigo do UN R157 e regulamentação
+      emergente.
+  BC-3420.60:
+    name: Aprovação de tipo de componentes e sistemas
+    description: |
+      Aprovações de tipo ao nível do componente para sistemas como iluminação,
+      CEM, pneus e travagem necessários para suportar a aprovação do veículo
+      completo.
+  BC-3420.60.10:
+    name: Aprovação de iluminação e sinalização
+    description: |
+      Aprovação de faróis, dispositivos de sinalização e sistemas de iluminação
+      adaptativa.
+  BC-3420.60.20:
+    name: Aprovação CEM
+    description: |
+      Aprovação de compatibilidade eletromagnética do veículo e subconjuntos
+      eletrónicos ao abrigo do UN R10.
+  BC-3420.60.30:
+    name: Aprovação de pneus e rodas
+    description: |
+      Aprovação e rotulagem de pneus e rodas ao abrigo dos regimes UNECE e
+      regionais.
+  BC-3420.60.40:
+    name: Aprovação de componentes de travagem e direção
+    description: |
+      Aprovação de componentes de travagem e direção ao abrigo do UN R13/R13H,
+      R79 e equivalentes.
+  BC-3420.70:
+    name: Gestão da conformidade da produção
+    description: |
+      Auditorias de conformidade da produção e verificação contínua de amostras
+      de produção face às especificações aprovadas.
+  BC-3420.70.10:
+    name: Gestão de auditorias CoP
+    description: |
+      Gestão de auditorias de conformidade da produção por autoridades de
+      aprovação e serviços técnicos.
+  BC-3420.70.20:
+    name: Verificação de amostras de produção
+    description: |
+      Verificação de amostras de produção face às especificações e tolerâncias
+      aprovadas.
+  BC-3420.70.30:
+    name: Vigilância de conformidade em serviço
+    description: |
+      Testes e vigilância de conformidade em serviço para confirmar a continuidade
+      do cumprimento após o lançamento.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-vehicle-programme-management.yaml
+++ b/catalogue/i18n/pt/L1-vehicle-programme-management.yaml
@@ -1,0 +1,174 @@
+locale: pt
+source: L1-vehicle-programme-management.yaml
+entries:
+  BC-3410:
+    name: Gestão de programa de veículo
+    description: |
+      Governação de programas de veículos plurianuais, cobrindo conceito, marcos
+      de fase-gate, estratégia de plataforma e variantes e custo, peso e
+      calendarização do programa até ao início e fim de produção.
+  BC-3410.10:
+    name: Definição e iniciação do programa
+    description: |
+      Definição de conceito, caso de negócio, carta de programa e aprovação para
+      prosseguir em programas de veículos novos e derivados.
+    in_scope:
+      - Carta de programa e aprovação do caso de negócio
+      - Definição do conceito e posicionamento do veículo
+      - Alinhamento da estratégia de plataforma e transferência
+    out_of_scope:
+      - Engenharia detalhada de subsistemas do veículo (BC-3400)
+      - Governação de portfólio de projetos empresarial (BC-900)
+  BC-3410.10.10:
+    name: Carta de programa e caso de negócio
+    description: |
+      Carta de programa com grau de aprovação, caso de negócio financeiro e
+      autorização de investimento.
+  BC-3410.10.20:
+    name: Definição do conceito do veículo
+    description: |
+      Conceito do veículo, posicionamento, definição de pacote de cliente e metas
+      de atributos de alto nível.
+  BC-3410.10.30:
+    name: Alinhamento da estratégia de plataforma
+    description: |
+      Alinhamento dos programas com roteiros de plataforma, decisões de
+      transferência e estratégias de módulos partilhados.
+  BC-3410.10.40:
+    name: Fase-gate de aprovação do programa
+    description: |
+      Fases-gate iniciais de aprovação do programa, incluindo orçamento,
+      calendarização e compromissos de recursos.
+  BC-3410.20:
+    name: Governação de fase-gate do programa
+    description: |
+      Operação do modelo de fase-gate do programa de veículo com revisões de
+      marcos, garantia de entregas e controlo de riscos e problemas.
+  BC-3410.20.10:
+    name: Planeamento de marcos
+    description: |
+      Planeamento de marcos do programa desde PT e PVS até SOP e fim de
+      produção.
+  BC-3410.20.20:
+    name: Execução de revisões de fase-gate
+    description: |
+      Execução de revisões de fase-gate incluindo avaliação de entregas e
+      decisões de aprovação/suspensão.
+  BC-3410.20.30:
+    name: Gestão de riscos e problemas do programa
+    description: |
+      Identificação, escalada e mitigação de riscos e problemas críticos do
+      programa.
+  BC-3410.20.40:
+    name: Avaliação da maturidade do programa
+    description: |
+      Avaliação da maturidade do programa face a critérios de prontidão de
+      engenharia, fabrico e fornecedores.
+  BC-3410.30:
+    name: Gestão de custos do programa
+    description: |
+      Definição e acompanhamento de metas de custo do programa em lista de
+      materiais, ferramental, investimento e provisões de garantia.
+  BC-3410.30.10:
+    name: Definição de metas de custo do programa
+    description: |
+      Definição de metas de custo do programa, incluindo envelopes de BoM,
+      conversão e investimento.
+  BC-3410.30.20:
+    name: Acompanhamento de custo da lista de materiais
+    description: |
+      Acompanhamento do custo da BoM do veículo, cotações de fornecedores e
+      decisões de conteúdo.
+  BC-3410.30.30:
+    name: Previsão de custos variáveis e fixos
+    description: |
+      Previsão de custos variáveis e fixos do programa nas fases de lançamento
+      e estado estacionário.
+  BC-3410.30.40:
+    name: Acompanhamento de iniciativas de redução de custos
+    description: |
+      Acompanhamento de iniciativas de redução de custos, engenharia de valor e
+      respetiva realização face a metas.
+  BC-3410.40:
+    name: Acompanhamento de peso e atributos do programa
+    description: |
+      Acompanhamento do peso, desempenho e outros atributos do veículo face a
+      metas do programa e resolução de compromissos ao nível do programa.
+  BC-3410.40.10:
+    name: Acompanhamento do peso do veículo
+    description: |
+      Acompanhamento da acumulação de massa por sistema e reservas face a metas
+      de peso do programa.
+  BC-3410.40.20:
+    name: Acompanhamento do desempenho de atributos
+    description: |
+      Acompanhamento do desempenho de atributos ao nível do programa e reservas
+      face a metas.
+  BC-3410.40.30:
+    name: Reporte de conformidade face a metas
+    description: |
+      Reporte do estado de conformidade face a metas à liderança do programa e
+      comités de direção.
+  BC-3410.50:
+    name: Planeamento de variantes e derivados
+    description: |
+      Planeamento de variantes de equipamento, regionais e de séries especiais
+      ao longo do ciclo de vida do programa.
+  BC-3410.50.10:
+    name: Planeamento de variantes de equipamento
+    description: |
+      Planeamento de níveis de equipamento, opções e conteúdo de série por
+      mercado e segmento.
+  BC-3410.50.20:
+    name: Planeamento de derivados regionais
+    description: |
+      Planeamento de derivados regionais incluindo carroçarias, trens de força e
+      conteúdo de funções específicos do mercado.
+  BC-3410.50.30:
+    name: Planeamento de séries especiais e edições limitadas
+    description: |
+      Planeamento de séries especiais, edições limitadas e derivados de
+      competição.
+  BC-3410.60:
+    name: Coordenação de início e fim de produção
+    description: |
+      Coordenação da prontidão para o SOP, rampa de produção e planeamento de
+      fim de produção entre fábricas e redes de fornecedores.
+  BC-3410.60.10:
+    name: Coordenação da prontidão para SOP
+    description: |
+      Coordenação dos critérios de prontidão de engenharia, fornecedores, fábrica
+      e pós-venda para o SOP.
+  BC-3410.60.20:
+    name: Planeamento da rampa de produção
+    description: |
+      Planeamento de curvas de rampa de produção, construção de pré-série e
+      cadência de volumes de arranque.
+  BC-3410.60.30:
+    name: Coordenação do planeamento de fim de produção
+    description: |
+      Coordenação da calendarização de fim de produção, últimas encomendas e
+      planos de escoamento.
+  BC-3410.70:
+    name: Reporte de desempenho do programa
+    description: |
+      Reporte do estado do programa, decisões e desempenho pós-lançamento a
+      comités de direção e liderança executiva.
+  BC-3410.70.10:
+    name: Reporte do estado do programa
+    description: |
+      Reporte periódico do estado do programa em custo, calendarização, qualidade
+      e risco.
+  BC-3410.70.20:
+    name: Apoio ao comité de direção do programa
+    description: |
+      Preparação e apoio a comités de direção do programa e revisões executivas.
+  BC-3410.70.30:
+    name: Revisão pós-lançamento do programa
+    description: |
+      Revisões pós-lançamento que capturam lições aprendidas e alimentam a
+      iniciação de programas subsequentes.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-vehicle-sales-distribution-management.yaml
+++ b/catalogue/i18n/pt/L1-vehicle-sales-distribution-management.yaml
@@ -1,0 +1,168 @@
+locale: pt
+source: L1-vehicle-sales-distribution-management.yaml
+entries:
+  BC-3440:
+    name: Gestão de vendas e distribuição de veículos
+    description: |
+      Vendas operacionais e distribuição de veículos novos — planeamento de
+      grossistas, alocação de vagas de fabrico, bancos de encomendas, inventário
+      de demonstração e veículos usados certificados, vendas de frota e B2B e a
+      interface de entrega e matrícula ao cliente de retalho.
+  BC-3440.10:
+    name: Planeamento e alocação de vendas de veículos
+    description: |
+      Planeamento de volumes de veículos grossistas por mercado e concessionário
+      e alocação de vagas de fabrico em conformidade.
+  BC-3440.10.10:
+    name: Planeamento de volumes grossistas
+    description: |
+      Planeamento periódico de volumes de veículos grossistas por mercado, modelo
+      e segmento.
+  BC-3440.10.20:
+    name: Alocação de produção por mercado
+    description: |
+      Alocação de capacidade finita da fábrica a mercados e canais em linha com
+      a procura e prioridades estratégicas.
+  BC-3440.10.30:
+    name: Gestão de vagas de fabrico
+    description: |
+      Alocação, troca e liberação de vagas de fabrico a concessionários e clientes
+      de frota.
+  BC-3440.20:
+    name: Gestão do banco de encomendas de veículos
+    description: |
+      Captura, validação de configuração e gestão do ciclo de vida de encomendas
+      de veículos em stock e de clientes.
+  BC-3440.20.10:
+    name: Gestão de encomendas de stock
+    description: |
+      Gestão de encomendas de stock de concessionários face a alocações e metas
+      de stock.
+  BC-3440.20.20:
+    name: Captura de encomendas de clientes
+    description: |
+      Captura de encomendas de veículos de clientes de retalho e frota, incluindo
+      configuração e preçário.
+  BC-3440.20.30:
+    name: Validação de configuração de encomendas
+    description: |
+      Validação de configurações de encomendas face a regras de viabilidade,
+      regulatórias e de preçário.
+  BC-3440.20.40:
+    name: Acompanhamento do estado de encomendas
+    description: |
+      Acompanhamento de ponta a ponta do estado de encomendas desde a receção
+      até ao fabrico, expedição e chegada ao concessionário.
+  BC-3440.30:
+    name: Operações de fabrico e distribuição
+    description: |
+      Coordenação da execução de produção por encomenda e logística de veículos
+      à saída da fábrica até ao concessionário.
+  BC-3440.30.10:
+    name: Coordenação da produção por encomenda
+    description: |
+      Coordenação da execução de produção por encomenda com operações de fabrico
+      e chamadas de fornecedores.
+  BC-3440.30.20:
+    name: Coordenação da logística de veículos
+    description: |
+      Coordenação da logística de veículos à saída da fábrica por camião,
+      comboio, navio e movimentos internos de parque.
+  BC-3440.30.30:
+    name: Coordenação de operações portuárias e de parque
+    description: |
+      Coordenação de operações portuárias, centros de processamento e parque,
+      incluindo acessorização pré-entrega.
+  BC-3440.40:
+    name: Gestão de inventário e veículos de demonstração
+    description: |
+      Gestão de inventários de veículos de stock, demonstração, imprensa e
+      empréstimo dos concessionários.
+  BC-3440.40.10:
+    name: Gestão de inventário de stock dos concessionários
+    description: |
+      Visibilidade e gestão do inventário de veículos nos concessionários e em
+      trânsito.
+  BC-3440.40.20:
+    name: Gestão de veículos de demonstração
+    description: |
+      Gestão de pools de veículos de demonstração utilizados por concessionários
+      e vendas de campo do OEM.
+  BC-3440.40.30:
+    name: Gestão de frota de imprensa e empréstimo
+    description: |
+      Gestão de frotas de imprensa, marketing e empréstimo, incluindo configurações
+      e rotação.
+  BC-3440.50:
+    name: Gestão do programa de usados certificados
+    description: |
+      Gestão dos programas de veículos usados certificados do OEM, cobrindo
+      inspeção, elegibilidade, marca e garantia.
+    in_scope:
+      - Inspeção e critérios de elegibilidade de usados certificados
+      - Inventário e preçário de usados certificados
+      - Programas de garantia específicos de usados certificados
+    out_of_scope:
+      - Comercialização de veículos usados de inventário de final de leasing fora do programa de usados certificados
+  BC-3440.50.10:
+    name: Elegibilidade e inspeção de veículos usados certificados
+    description: |
+      Definição e execução de critérios de elegibilidade e normas de inspeção
+      de usados certificados.
+  BC-3440.50.20:
+    name: Gestão de inventário de usados certificados
+    description: |
+      Gestão do inventário de usados certificados nos concessionários e pools
+      centrais.
+  BC-3440.50.30:
+    name: Garantia e marca de usados certificados
+    description: |
+      Conceção do programa de garantia de usados certificados com marca e
+      comercialização.
+  BC-3440.60:
+    name: Gestão de vendas de frota e B2B
+    description: |
+      Operações de vendas para clientes de frota, leasing, aluguer e outros
+      compradores de veículos B2B, incluindo tratamento de concursos e propostas.
+  BC-3440.60.10:
+    name: Gestão de contas de frota
+    description: |
+      Gestão de grandes contas de frota e relações com clientes empresariais.
+  BC-3440.60.20:
+    name: Gestão de concursos e propostas de frota
+    description: |
+      Resposta a concursos de frota, RFPs e processos estruturados de proposta
+      para grandes negócios de veículos.
+  BC-3440.60.30:
+    name: Gestão de especificações de veículos de frota
+    description: |
+      Gestão de especificações de veículos de frota, opções e transformações.
+  BC-3440.60.40:
+    name: Gestão do canal de aluguer e leasing
+    description: |
+      Gestão das relações do OEM com empresas de aluguer e leasing, incluindo
+      acordos de recompra.
+  BC-3440.70:
+    name: Apoio à entrega e matrícula de veículos
+    description: |
+      Apoio a concessionários para entrega de veículos, matrícula e entrada na
+      fase de experiência do cliente.
+  BC-3440.70.10:
+    name: Coordenação da inspeção pré-entrega
+    description: |
+      Coordenação das normas e aprovações de inspeção pré-entrega nos
+      concessionários e centros de processamento.
+  BC-3440.70.20:
+    name: Ligação com autoridades de registo de veículos
+    description: |
+      Ligação com autoridades de matrícula de veículos e prestação de dados de
+      primeira matrícula.
+  BC-3440.70.30:
+    name: Experiência de entrega ao cliente
+    description: |
+      Definição e garantia da experiência de entrega ao cliente na entrega do
+      veículo.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-warehousing-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-warehousing-operations-management.yaml
@@ -1,0 +1,142 @@
+locale: pt
+source: L1-warehousing-operations-management.yaml
+entries:
+  BC-2460:
+    name: Gestão de operações de armazenagem
+    description: |
+      Operação de armazéns e centros de distribuição de terceiros, incluindo
+      receção, armazenamento, expedição, serviços de valor acrescentado e
+      logística inversa.
+  BC-2460.10:
+    name: Gestão de operações de receção
+    description: |
+      Receção, inspeção e arrumação de mercadorias que entram no armazém.
+    in_scope:
+      - Aviso prévio de receção e processamento de ASN
+      - Inspeção de mercadorias recebidas e arrumação
+    out_of_scope:
+      - Expedição de saída (BC-2460.30)
+      - Propriedade do inventário ao nível do expedidor (BC-530)
+  BC-2460.10.10:
+    name: Planeamento pré-receção
+    description: |
+      Ingestão de ASN, agendamento de cais e planeamento de recursos para
+      receções.
+  BC-2460.10.20:
+    name: Receção e inspeção de mercadorias
+    description: |
+      Receção física e inspeção de mercadorias recebidas.
+  BC-2460.10.30:
+    name: Arrumação e alocação de armazenamento
+    description: |
+      Arrumação de mercadorias recebidas e alocação a localizações de armazenamento.
+  BC-2460.20:
+    name: Gestão de operações de armazenamento e inventário
+    description: |
+      Operações de armazenamento interno, incluindo slotting, contagens cíclicas
+      e armazenamento condicionado.
+  BC-2460.20.10:
+    name: Slotting e gestão de localizações
+    description: |
+      Decisões de slotting e manutenção de localizações de armazenamento.
+  BC-2460.20.20:
+    name: Contagens cíclicas e reconciliação
+    description: |
+      Contagens cíclicas, reconciliação de stock e ajustamento de inventário.
+  BC-2460.20.30:
+    name: Rastreio de lote, série e batch
+    description: |
+      Rastreio de atributos de lote, série e batch para mercadorias armazenadas.
+  BC-2460.20.40:
+    name: Armazenamento em cadeia de frio e condicionado
+    description: |
+      Operação de armazenamento em temperatura controlada, perigoso e aduaneiro.
+  BC-2460.30:
+    name: Gestão de operações de expedição
+    description: |
+      Picking, embalagem, etiquetagem e expedição de envios de saída.
+  BC-2460.30.10:
+    name: Operações de picking
+    description: |
+      Picking de encomendas usando estratégias de batch, wave e zona.
+  BC-2460.30.20:
+    name: Embalagem e etiquetagem
+    description: |
+      Embalagem, etiquetagem e preparação de documentos de envio.
+  BC-2460.30.30:
+    name: Expedição e carregamento
+    description: |
+      Carregamento de veículos de saída e confirmação de expedição.
+  BC-2460.40:
+    name: Gestão de serviços de valor acrescentado
+    description: |
+      Serviços de valor acrescentado em armazém como kitting, co-packing,
+      etiquetagem e configuração.
+  BC-2460.40.10:
+    name: Serviços de kitting e montagem
+    description: |
+      Kitting, sub-montagem e montagem de bundles no armazém.
+  BC-2460.40.20:
+    name: Co-packing e reetiquetagem
+    description: |
+      Serviços de co-packing, reembalagem e reetiquetagem.
+  BC-2460.40.30:
+    name: Postponement e configuração
+    description: |
+      Configuração de produto em fase tardia e postponement.
+  BC-2460.50:
+    name: Gestão de operações de devoluções e logística inversa
+    description: |
+      Receção, triagem e disposição de mercadorias devolvidas e fluxos de
+      logística inversa.
+  BC-2460.50.10:
+    name: Receção e triagem de devoluções
+    description: |
+      Receção e triagem de mercadorias devolvidas.
+  BC-2460.50.20:
+    name: Recondicionamento e disposição
+    description: |
+      Recondicionamento, reembalagem e decisões de disposição.
+  BC-2460.50.30:
+    name: Eliminação em logística inversa
+    description: |
+      Eliminação, reciclagem e destruição de devoluções sem valor de recuperação.
+  BC-2460.60:
+    name: Gestão de recursos do armazém
+    description: |
+      Gestão de mão-de-obra, equipamento de movimentação de materiais e capacidade
+      de cais e slot no armazém.
+  BC-2460.60.10:
+    name: Planeamento de mão-de-obra e produtividade
+    description: |
+      Planeamento de turnos, atribuição de tarefas e acompanhamento da
+      produtividade.
+  BC-2460.60.20:
+    name: Operações de equipamento de movimentação de materiais
+    description: |
+      Operação, alocação e manutenção de empilhadoras, tapetes rolantes e AGVs.
+  BC-2460.60.30:
+    name: Agendamento de cais e slots
+    description: |
+      Agendamento de slots de cais de entrada e saída.
+  BC-2460.70:
+    name: Gestão do desempenho do armazém
+    description: |
+      Medição de KPIs de serviço, precisão e throughput do armazém.
+  BC-2460.70.10:
+    name: Acompanhamento de KPIs do ciclo de encomenda
+    description: |
+      Acompanhamento de KPIs de ciclo de encomenda, taxa de preenchimento e
+      precisão.
+  BC-2460.70.20:
+    name: Reporte de precisão do inventário
+    description: |
+      Reporte da precisão do inventário e quebra.
+  BC-2460.70.30:
+    name: Reporte de throughput e produtividade
+    description: |
+      Reporte de throughput, unidades por hora e benchmarks de produtividade.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-wastewater-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-wastewater-operations-management.yaml
@@ -1,0 +1,170 @@
+locale: pt
+source: L1-wastewater-operations-management.yaml
+entries:
+  BC-3890:
+    name: Gestão de operações de águas residuais
+    description: |
+      Recolha, tratamento e eliminação de águas residuais municipais e
+      industriais — operação da rede de esgotos, operação do processo
+      de estações de tratamento de águas residuais, resposta a bloqueios
+      e inundações, gestão de lamas e biossólidos, operações de
+      extravasamentos de tempestade e conformidade com a qualidade
+      do efluente final.
+  BC-3890.10:
+    name: Operações da rede de esgotos
+    description: |
+      Operação de redes de esgotos domésticos, pluviais e unitários,
+      incluindo estações de bombagem e condutas elevatórias.
+  BC-3890.10.10:
+    name: Operações de estações de bombagem de esgotos
+    description: |
+      Operação e vigilância de estações de bombagem de esgotos e
+      condutas elevatórias.
+  BC-3890.10.20:
+    name: Vigilância da rede de esgotos
+    description: |
+      Vigilância por telemetria de níveis de esgotos e alarmes de
+      estações de bombagem.
+  BC-3890.10.30:
+    name: Limpeza da rede de esgotos
+    description: |
+      Limpeza planeada e reativa, desentupimento por jacto e
+      desassorização de esgotos.
+  BC-3890.20:
+    name: Operações de estação de tratamento de águas residuais
+    description: |
+      Operação diária de estações de tratamento de águas residuais,
+      incluindo processos preliminares, primários, secundários e terciários.
+  BC-3890.20.10:
+    name: Operações de tratamento preliminar e primário
+    description: |
+      Operação de etapas de gradagem, remoção de areias e decantação primária.
+  BC-3890.20.20:
+    name: Operações de tratamento biológico secundário
+    description: |
+      Operação de processos secundários de lamas ativadas, leitos percoladores
+      e MBR.
+  BC-3890.20.30:
+    name: Operações de tratamento terciário
+    description: |
+      Operação de etapas terciárias de remoção de nutrientes, filtração
+      e desinfeção.
+  BC-3890.20.40:
+    name: Controlo e otimização de processo
+    description: |
+      Controlo de processo e otimização energética de etapas biológicas
+      e de arejamento.
+  BC-3890.30:
+    name: Resposta a bloqueios e inundações de esgotos
+    description: |
+      Resposta reativa a bloqueios de esgotos, inundações internas e
+      externas por esgotos e incidentes de poluição.
+  BC-3890.30.10:
+    name: Operações de resposta a bloqueios
+    description: |
+      Resposta de campo a bloqueios de esgotos com desentupimento
+      por jacto.
+  BC-3890.30.20:
+    name: Resposta a inundação interna por esgotos
+    description: |
+      Resposta orientada ao cliente a incidentes de inundação interna
+      por esgotos.
+  BC-3890.30.30:
+    name: Resposta a inundação externa por esgotos
+    description: |
+      Resposta a inundação externa por esgotos e eventos de impacto
+      em vias públicas.
+  BC-3890.30.40:
+    name: Contenção de incidentes de poluição
+    description: |
+      Contenção e remediação de incidentes de poluição por esgotos
+      em linhas de água.
+  BC-3890.40:
+    name: Gestão de efluentes industriais
+    description: |
+      Autorização, monitorização e tarifação de descargas de efluentes
+      industriais na rede de esgotos pública.
+  BC-3890.40.10:
+    name: Administração de consentimentos de efluentes industriais
+    description: |
+      Emissão e variação de consentimentos de efluentes industriais
+      a descarregadores industriais.
+  BC-3890.40.20:
+    name: Operações de amostragem de efluentes industriais
+    description: |
+      Amostragem e análise de descargas de efluentes industriais contra
+      as condições de consentimento.
+  BC-3890.40.30:
+    name: Tarifação de efluentes industriais
+    description: |
+      Cálculo de encargos de efluentes industriais usando a fórmula
+      Mogden ou equivalente.
+  BC-3890.50:
+    name: Gestão de lamas e biossólidos
+    description: |
+      Tratamento, uso benéfico e eliminação de lamas de águas residuais,
+      incluindo digestão anaeróbia e reciclagem de biossólidos para o solo.
+  BC-3890.50.10:
+    name: Operações de espessamento e desidratação de lamas
+    description: |
+      Operação de sistemas de espessamento, desidratação e centrifugação
+      de lamas.
+  BC-3890.50.20:
+    name: Operações de digestão anaeróbia
+    description: |
+      Operação de digestores anaeróbios mesofílicos e termofílicos e
+      sistemas de biogás.
+  BC-3890.50.30:
+    name: Reciclagem de biossólidos para o solo
+    description: |
+      Aplicação de biossólidos em solos agrícolas ao abrigo de regimes
+      de lamas seguras.
+  BC-3890.50.40:
+    name: Operações de incineração e eliminação de lamas
+    description: |
+      Operação de incineração de lamas e vias alternativas de eliminação.
+  BC-3890.60:
+    name: Operações de extravasamentos de tempestade
+    description: |
+      Operação, monitorização e comunicação de extravasamentos de esgotos
+      unitários e de emergência, incluindo monitorização da duração de
+      eventos.
+  BC-3890.60.10:
+    name: Monitorização da duração de eventos
+    description: |
+      Operação de telemetria de monitorização da duração de eventos em
+      extravasamentos de tempestade e de emergência.
+  BC-3890.60.20:
+    name: Relatórios de extravasamento de tempestade
+    description: |
+      Relatórios de volumes e durações de extravasamentos a reguladores
+      e ao público.
+  BC-3890.60.30:
+    name: Operações de tanque de tempestade
+    description: |
+      Operação de tanques de tempestade e instalações de regularização
+      nas entradas de estações de tratamento de águas residuais.
+  BC-3890.70:
+    name: Operações de qualidade do efluente final
+    description: |
+      Amostragem, análise e relatórios regulatórios da qualidade do
+      efluente final contra consentimentos de licença de descarga.
+  BC-3890.70.10:
+    name: Amostragem de conformidade com a licença de descarga
+    description: |
+      Amostragem de automonitorização do operador contra consentimentos
+      numéricos de descarga.
+  BC-3890.70.20:
+    name: Vigilância da qualidade do efluente
+    description: |
+      Vigilância em linha e laboratorial de CBO, azoto amoniacal e
+      parâmetros de nutrientes do efluente final.
+  BC-3890.70.30:
+    name: Relatórios de licença de descarga
+    description: |
+      Relatórios estatutários de conformidade com a descarga a reguladores
+      ambientais.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-water-distribution-network-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-water-distribution-network-operations-management.yaml
@@ -1,0 +1,157 @@
+locale: pt
+source: L1-water-distribution-network-operations-management.yaml
+entries:
+  BC-3880:
+    name: Gestão de operações da rede de distribuição de água
+    description: |
+      Operação de condutas principais e de distribuição que fornecem água
+      tratada aos clientes — gestão hidráulica e de pressão, controlo de
+      perdas, qualidade da água na rede, reparação e renovação de condutas,
+      e entrega de novas ligações.
+  BC-3880.10:
+    name: Controlo da rede de distribuição
+    description: |
+      Operação 24/7 da sala de controlo do sistema de distribuição de
+      água usando telemetria, modelos hidráulicos e SCADA.
+  BC-3880.10.10:
+    name: Operações de SCADA de distribuição
+    description: |
+      Controlo supervisório em tempo real de ativos de bombagem e pressão
+      na rede.
+  BC-3880.10.20:
+    name: Operações de modelo hidráulico
+    description: |
+      Operação de modelos hidráulicos em linha e fora de linha para
+      decisões de rede.
+  BC-3880.10.30:
+    name: Vigilância de telemetria da rede
+    description: |
+      Vigilância de telemetria em ZMC, válvulas e pontos de pressão.
+  BC-3880.20:
+    name: Operações de conduta principal e bombagem
+    description: |
+      Operação de condutas principais, estações de bombagem e transferências
+      inter-zonais, incluindo sobrepressão e gestão de golpe de aríete.
+  BC-3880.20.10:
+    name: Operações de estações de bombagem
+    description: |
+      Operação e otimização energética de estações de bombagem de distribuição.
+  BC-3880.20.20:
+    name: Operações de conduta principal
+    description: |
+      Operação, manobra de válvulas e gestão de golpe de aríete em condutas
+      principais de transporte.
+  BC-3880.20.30:
+    name: Operações de transferência inter-zonal
+    description: |
+      Operação de transferências inter-zonais e ligações de abastecimento
+      a granel entre zonas de recurso.
+  BC-3880.30:
+    name: Gestão de perdas de água
+    description: |
+      Controlo ativo e passivo de perdas em zonas de medição e controlo
+      usando análise de caudal de entrada, deteção acústica e trabalho
+      de campo.
+  BC-3880.30.10:
+    name: Análise de zona de medição e controlo
+    description: |
+      Análise de caudal de entrada e dados de caudal noturno mínimo de
+      ZMC para localizar perdas.
+  BC-3880.30.20:
+    name: Deteção acústica de perdas
+    description: |
+      Sondagem acústica, correlação e varrimentos de registadores de ruído
+      para localização de perdas.
+  BC-3880.30.30:
+    name: Operações de localização e reparação de perdas
+    description: |
+      Operações de localização e reparação no campo de perdas detetadas
+      contra alvos de tempo de reparação.
+  BC-3880.30.40:
+    name: Relatórios de desempenho de perdas
+    description: |
+      Relatórios de desempenho de perdas contra métricas de balanço hídrico
+      regulatórias e da IWA.
+  BC-3880.40:
+    name: Gestão de pressão
+    description: |
+      Otimização da pressão de distribuição em zonas de pressão gerida
+      para redução de perdas e controlo da taxa de rebentamentos.
+  BC-3880.40.10:
+    name: Configuração de zona de pressão
+    description: |
+      Configuração de zonas de pressão gerida e pontos de ajuste de
+      válvulas redutoras de pressão.
+  BC-3880.40.20:
+    name: Controlo avançado de pressão
+    description: |
+      Operação de válvulas redutoras de pressão telecomandadas e com
+      modulação temporal.
+  BC-3880.40.30:
+    name: Gestão de pressão transitória
+    description: |
+      Análise de golpe de aríete e mitigação de transitórios em redes
+      de distribuição.
+  BC-3880.50:
+    name: Operações de qualidade de água na rede
+    description: |
+      Vigilância de qualidade da água na rede — resíduo de cloro, água
+      descolorada, sabor e odor — e operações de remediação.
+  BC-3880.50.10:
+    name: Vigilância de resíduo de cloro na rede
+    description: |
+      Vigilância de resíduos de cloro na rede e doseamento de recloração.
+  BC-3880.50.20:
+    name: Controlo de descoloração e sedimentos
+    description: |
+      Operações de lavagem e pig de gelo para gerir reclamações de água
+      descolorada.
+  BC-3880.50.30:
+    name: Operações de amostragem da rede
+    description: |
+      Amostragem estatutária nas torneiras e pontos de abastecimento
+      dos clientes.
+  BC-3880.60:
+    name: Operações de reparação e renovação de condutas
+    description: |
+      Reparação reativa de rebentamentos e falhas de juntas, e entrega
+      operacional de programas de renovação de condutas.
+  BC-3880.60.10:
+    name: Resposta a rebentamento de condutas
+    description: |
+      Resposta, isolamento e reparação de rebentamentos de condutas contra
+      alvos de minutos de cliente perdidos.
+  BC-3880.60.20:
+    name: Operações de reparação de ramal de serviço
+    description: |
+      Reparação de ramais de comunicação e de serviço entre a conduta
+      principal e a torneira de passeio.
+  BC-3880.60.30:
+    name: Operações de campo de renovação de condutas
+    description: |
+      Execução no campo de programas de renovação e reabilitação de
+      condutas, incluindo métodos sem abertura de vala.
+  BC-3880.70:
+    name: Operações de novas ligações de água
+    description: |
+      Entrega de novas ligações de abastecimento de água para clientes
+      domésticos, comerciais e promotores.
+  BC-3880.70.10:
+    name: Avaliação de candidaturas a nova ligação de água
+    description: |
+      Avaliação técnica de candidaturas a nova ligação de água e prestação
+      de serviços ao promotor.
+  BC-3880.70.20:
+    name: Operações de instalação de ligação
+    description: |
+      Instalação de ramais de comunicação, abraçadeiras e contadores
+      de clientes.
+  BC-3880.70.30:
+    name: Comissionamento de ligações
+    description: |
+      Comissionamento, limpeza por bola e desinfeção de novas ligações
+      antes da utilização.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-water-resource-management.yaml
+++ b/catalogue/i18n/pt/L1-water-resource-management.yaml
@@ -1,0 +1,156 @@
+locale: pt
+source: L1-water-resource-management.yaml
+entries:
+  BC-3860:
+    name: Gestão de recursos hídricos
+    description: |
+      Gestão sustentável de fontes de água bruta — proteção de bacias
+      hidrográficas e fontes, captação e armazenamento de água bruta,
+      planeamento de recursos a longo prazo, gestão de secas e restrições,
+      conformidade com licenças de captação, e redes de monitorização de
+      águas superficiais e subterrâneas.
+  BC-3860.10:
+    name: Proteção de bacias hidrográficas e fontes
+    description: |
+      Proteção de bacias hidrográficas de captação através do envolvimento
+      de partes interessadas, medidas de uso do solo e avaliação do risco
+      de fontes de água.
+  BC-3860.10.10:
+    name: Avaliação do risco de bacia hidrográfica
+    description: |
+      Avaliação do risco de bacia hidrográfica para fontes de água potável
+      ao abrigo dos princípios do Plano de Segurança da Água da OMS.
+  BC-3860.10.20:
+    name: Gestão de zonas de proteção de fontes
+    description: |
+      Designação e gestão de zonas de proteção de fontes de águas
+      subterrâneas e superficiais.
+  BC-3860.10.30:
+    name: Envolvimento de partes interessadas da bacia hidrográfica
+    description: |
+      Envolvimento com proprietários de terras, reguladores e agricultores
+      sobre medidas na bacia hidrográfica.
+  BC-3860.20:
+    name: Operações de captação de água bruta
+    description: |
+      Operação diária de captações, derivações fluviais e furos de águas
+      subterrâneas que alimentam o parque de tratamento.
+  BC-3860.20.10:
+    name: Operações de captação de águas superficiais
+    description: |
+      Operação de captações fluviais e de albufeiras, incluindo filtragem
+      e bombagem.
+  BC-3860.20.20:
+    name: Operações de furos de água subterrânea
+    description: |
+      Operação e gestão do rendimento de furos de água subterrânea e
+      campos de poços.
+  BC-3860.20.30:
+    name: Operações de bombagem de água bruta
+    description: |
+      Bombagem de água bruta para estações de tratamento e sistemas
+      de aqueduto.
+  BC-3860.30:
+    name: Operações de armazenamento de água bruta
+    description: |
+      Operação de albufeiras de retenção e de regularização, barragens
+      e armazenamento pré-tratamento, incluindo vigilância da segurança
+      de barragens.
+  BC-3860.30.10:
+    name: Operações de nível de albufeira
+    description: |
+      Gestão por curva operacional de albufeiras de retenção e de
+      regularização.
+  BC-3860.30.20:
+    name: Vigilância da segurança de barragens
+    description: |
+      Vigilância e inspeção de barragens ao abrigo dos regimes estatutários
+      de segurança de barragens.
+  BC-3860.30.30:
+    name: Operações de qualidade da água em albufeiras
+    description: |
+      Vigilância e gestão da qualidade da água bruta, incluindo proliferações
+      de algas.
+  BC-3860.40:
+    name: Planeamento dos recursos hídricos
+    description: |
+      Planeamento de longo prazo dos recursos hídricos e da procura,
+      incluindo equilíbrio oferta-procura, ajustamento para alterações
+      climáticas e avaliação de opções.
+  BC-3860.40.10:
+    name: Previsão do equilíbrio oferta-procura
+    description: |
+      Previsão de longo prazo da oferta e procura por zona de recurso.
+  BC-3860.40.20:
+    name: Avaliação de opções de recurso
+    description: |
+      Avaliação de opções de novas fontes, transferências e medidas de
+      gestão da procura.
+  BC-3860.40.30:
+    name: Ajustamento de recursos para alterações climáticas
+    description: |
+      Ajustamento de rendimentos de recursos e da procura para cenários
+      de alterações climáticas.
+  BC-3860.50:
+    name: Gestão de secas e restrições
+    description: |
+      Ativação de planos de seca e restrições de abastecimento através de
+      gatilhos de seca, restrições de utilização pelos clientes e candidaturas
+      a licenças de seca de emergência.
+  BC-3860.50.10:
+    name: Monitorização de gatilhos de seca
+    description: |
+      Monitorização de gatilhos de seca de albufeiras, rios e águas
+      subterrâneas.
+  BC-3860.50.20:
+    name: Operações de restrição em seca
+    description: |
+      Implementação e levantamento de restrições de utilização de água
+      pelos clientes.
+  BC-3860.50.30:
+    name: Gestão de licenças e ordens de seca
+    description: |
+      Candidatura e operação de licenças e ordens de seca autorizadas
+      pelos reguladores.
+  BC-3860.60:
+    name: Conformidade com licenças de captação
+    description: |
+      Administração de licenças de captação e relatórios de conformidade
+      contra condições de quantidade, calendário e ambientais.
+  BC-3860.60.10:
+    name: Administração de licenças de captação
+    description: |
+      Manutenção do portfólio de licenças de captação e registo de condições.
+  BC-3860.60.20:
+    name: Relatórios de volumes de captação
+    description: |
+      Relatórios de volumes captados e adesão às condições de licença.
+  BC-3860.60.30:
+    name: Conformidade de caudal mínimo
+    description: |
+      Monitorização do caudal mínimo e das condições de caudal ecológico
+      nas captações.
+  BC-3860.70:
+    name: Monitorização hidrométrica
+    description: |
+      Operação de redes de monitorização de águas superficiais e
+      subterrâneas que fornecem dados para o planeamento de recursos e
+      decisões operacionais.
+  BC-3860.70.10:
+    name: Monitorização de águas superficiais
+    description: |
+      Operação de redes de monitorização de caudal, nível e precipitação
+      em rios.
+  BC-3860.70.20:
+    name: Monitorização do nível de águas subterrâneas
+    description: |
+      Operação de redes de furos de observação de águas subterrâneas.
+  BC-3860.70.30:
+    name: Gestão da qualidade de dados hidrométricos
+    description: |
+      Controlo de qualidade e gestão de curvas de vazão para dados
+      hidrométricos.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-water-treatment-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-water-treatment-operations-management.yaml
@@ -1,0 +1,144 @@
+locale: pt
+source: L1-water-treatment-operations-management.yaml
+entries:
+  BC-3870:
+    name: Gestão de operações de tratamento de água
+    description: |
+      Produção de água potável em estações de tratamento — operação de
+      processo, garantia da qualidade da água potável, gestão de reagentes
+      de tratamento, armazenamento de água tratada, e gestão de resíduos
+      de tratamento ao abrigo dos regulamentos de água potável e dos
+      princípios do Plano de Segurança da Água da OMS.
+  BC-3870.10:
+    name: Operações de estação de tratamento
+    description: |
+      Operação diária de estações de tratamento de água potável a fornecer
+      produção conforme a especificação e à procura.
+  BC-3870.10.10:
+    name: Operações de turno em estação de tratamento
+    description: |
+      Operação de turno de estações de tratamento convencionais e de
+      membrana.
+  BC-3870.10.20:
+    name: Calendarização da produção de tratamento
+    description: |
+      Calendarização da produção de tratamento contra a procura de
+      distribuição e o estado do armazenamento.
+  BC-3870.10.30:
+    name: Relatórios de desempenho da estação de tratamento
+    description: |
+      Relatórios de produção, consumo energético e métricas de desempenho
+      da estação de tratamento.
+  BC-3870.20:
+    name: Controlo do processo de tratamento
+    description: |
+      Controlo de processo de operações de tratamento unitário — coagulação,
+      filtração, desinfeção e tratamento avançado — contra monitorização
+      de qualidade em linha.
+  BC-3870.20.10:
+    name: Controlo de coagulação e clarificação
+    description: |
+      Controlo de doseamento de coagulante, floculação e desempenho
+      do clarificador.
+  BC-3870.20.20:
+    name: Controlo do processo de filtração
+    description: |
+      Controlo de etapas de filtração rápida por gravidade, lenta em areia
+      e por membrana.
+  BC-3870.20.30:
+    name: Controlo do processo de desinfeção
+    description: |
+      Controlo de processos de cloração, UV, ozono e desinfeção avançada.
+  BC-3870.20.40:
+    name: Controlo do processo de tratamento avançado
+    description: |
+      Controlo de etapas de carvão ativado granulado, permuta iónica e
+      oxidação avançada.
+  BC-3870.30:
+    name: Operações de qualidade de água potável
+    description: |
+      Amostragem, análise laboratorial, vigilância em linha e relatórios
+      regulatórios de conformidade da qualidade de água potável.
+  BC-3870.30.10:
+    name: Programa de amostragem estatutária
+    description: |
+      Operação de programas de amostragem estatutária de água potável em
+      estações de tratamento e pontos de abastecimento.
+  BC-3870.30.20:
+    name: Monitorização em linha de água tratada
+    description: |
+      Monitorização em linha de turbidez, resíduo de cloro e outros
+      parâmetros da água tratada.
+  BC-3870.30.30:
+    name: Resposta a incidentes de qualidade de água potável
+    description: |
+      Investigação e remediação de incidentes de qualidade de água potável
+      e excedências.
+  BC-3870.30.40:
+    name: Relatórios de qualidade de água potável
+    description: |
+      Relatórios estatutários a reguladores de água potável (IRAR, EPA,
+      equivalentes).
+  BC-3870.40:
+    name: Gestão de reagentes de tratamento
+    description: |
+      Gestão operacional com consciência de aprovisionamento de reagentes
+      de tratamento, incluindo stocks, doseamento e segurança no manuseio
+      de produtos químicos.
+  BC-3870.40.10:
+    name: Operações de stock de reagentes
+    description: |
+      Gestão do nível de stock de reagentes de tratamento nas instalações.
+  BC-3870.40.20:
+    name: Operações de doseamento de reagentes
+    description: |
+      Operação e calibração de sistemas de doseamento de reagentes
+      de tratamento.
+  BC-3870.40.30:
+    name: Segurança no manuseio de produtos químicos
+    description: |
+      Manuseio seguro e controlos de substâncias perigosas para reagentes
+      de tratamento no local.
+  BC-3870.50:
+    name: Operações de armazenamento de água tratada
+    description: |
+      Operação de reservatórios de serviço, câmaras de contacto e torres
+      de água a fornecer água tratada para a rede de distribuição.
+  BC-3870.50.10:
+    name: Operações de reservatório de serviço
+    description: |
+      Operação, controlo de nível e gestão de renovação de reservatórios
+      de serviço.
+  BC-3870.50.20:
+    name: Operações de câmara de contacto
+    description: |
+      Operação de câmaras de contacto de desinfeção para os valores de CT
+      necessários.
+  BC-3870.50.30:
+    name: Inspeção de reservatório de serviço
+    description: |
+      Inspeção interna e limpeza de ativos de armazenamento de água tratada.
+  BC-3870.60:
+    name: Gestão de resíduos de tratamento
+    description: |
+      Operação de fluxos de resíduos resultantes do tratamento — lamas de
+      clarificador, lavagem de filtros e meios gastos — e respetivas vias
+      de eliminação.
+  BC-3870.60.10:
+    name: Operações de lamas de clarificador
+    description: |
+      Operação de espessamento e desidratação de lamas em estações de
+      tratamento de água.
+  BC-3870.60.20:
+    name: Recuperação de água de lavagem de filtros
+    description: |
+      Recuperação e reciclagem ou eliminação da água de lavagem de filtros.
+  BC-3870.60.30:
+    name: Eliminação de meios gastos
+    description: |
+      Substituição e eliminação de meios filtrantes gastos e resinas de
+      permuta iónica.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.

--- a/catalogue/i18n/pt/L1-wealth-management-operations-management.yaml
+++ b/catalogue/i18n/pt/L1-wealth-management-operations-management.yaml
@@ -1,0 +1,99 @@
+locale: pt
+source: L1-wealth-management-operations-management.yaml
+entries:
+  BC-1390:
+    name: Gestão de operações de gestão de patrimónios
+    description: |
+      Consultoria de investimento, gestão discricionária de portefólios, reporte a clientes e adequação.
+  BC-1390.10:
+    name: Gestão de consultoria de investimento
+    description: |
+      Mandatos de consultoria e geração de recomendações.
+  BC-1390.10.10:
+    name: Integração de mandatos de consultoria
+    description: |
+      Integração de mandatos de consultoria e acordos com clientes.
+  BC-1390.10.20:
+    name: Geração de recomendações de investimento
+    description: |
+      Geração de recomendações de investimento personalizadas.
+  BC-1390.10.30:
+    name: Gestão de propostas de investimento
+    description: |
+      Produção e aprovação de propostas de investimento.
+  BC-1390.20:
+    name: Gestão discricionária de portefólios
+    description: |
+      Mandatos discricionários e construção de portefólios.
+  BC-1390.20.10:
+    name: Configuração de mandato discricionário
+    description: |
+      Configuração de mandatos discricionários e documentação IPS.
+  BC-1390.20.20:
+    name: Construção de portefólio
+    description: |
+      Construção de portefólio e alocação de ativos.
+  BC-1390.20.30:
+    name: Rebalanceamento de portefólio
+    description: |
+      Rebalanceamento de portefólios discricionários face ao modelo.
+  BC-1390.20.40:
+    name: Execução de operações para mandatos
+    description: |
+      Execução de operações em nome de mandatos discricionários.
+  BC-1390.30:
+    name: Gestão de reporte a clientes
+    description: |
+      Extratos de clientes e relatórios de desempenho.
+  BC-1390.30.10:
+    name: Extratos periódicos de clientes
+    description: |
+      Produção de extratos periódicos e valorizações de clientes.
+  BC-1390.30.20:
+    name: Relatórios de desempenho e atividade
+    description: |
+      Relatórios de desempenho, atividade e fiscais para clientes.
+  BC-1390.30.30:
+    name: Divulgações regulatórias a clientes
+    description: |
+      Divulgações de custos e encargos MiFID II e outras divulgações regulatórias.
+  BC-1390.40:
+    name: Gestão de medição de desempenho
+    description: |
+      Atribuição de desempenho e comparação com benchmarks.
+  BC-1390.40.10:
+    name: Cálculo do desempenho do portefólio
+    description: |
+      Cálculo de TWR, MWR e outras rendibilidades de desempenho.
+  BC-1390.40.20:
+    name: Análise de atribuição do desempenho
+    description: |
+      Análise de atribuição por modelo de Brinson e por fatores.
+  BC-1390.40.30:
+    name: Comparação com benchmarks e pares
+    description: |
+      Comparação do desempenho do portefólio com benchmarks e pares.
+  BC-1390.50:
+    name: Gestão de adequação e pertinência
+    description: |
+      Adequação MiFID/equivalente e verificações de pertinência.
+  BC-1390.50.10:
+    name: Perfilagem de risco do cliente
+    description: |
+      Perfilagem da tolerância e capacidade de risco dos clientes.
+  BC-1390.50.20:
+    name: Avaliação de adequação
+    description: |
+      Avaliação de adequação de aconselhamento e portefólios discricionários.
+  BC-1390.50.30:
+    name: Avaliação de pertinência
+    description: |
+      Verificações de pertinência para transações de produto em modo de simples execução.
+  BC-1390.50.40:
+    name: Recolha de preferências de sustentabilidade
+    description: |
+      Recolha e integração das preferências de sustentabilidade dos clientes.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-weapon-systems-management.yaml
+++ b/catalogue/i18n/pt/L1-weapon-systems-management.yaml
@@ -1,0 +1,115 @@
+locale: pt
+source: L1-weapon-systems-management.yaml
+entries:
+  BC-1710:
+    name: Gestão de sistemas de armas
+    description: |
+      Gestão do ciclo de vida de sistemas de armas e plataformas.
+  BC-1710.10:
+    name: Gestão de engenharia de sistemas de armas
+    description: |
+      Engenharia de sistemas de armas, requisitos e arquitetura.
+  BC-1710.10.10:
+    name: Engenharia de requisitos de sistemas de armas
+    description: |
+      Engenharia de requisitos para sistemas de armas.
+  BC-1710.10.20:
+    name: Conceção da arquitetura de sistemas de armas
+    description: |
+      Conceção de arquitetura e análise de trade-off.
+  BC-1710.10.30:
+    name: Modelação e simulação de sistemas de armas
+    description: |
+      Modelação e simulação do desempenho de sistemas de armas.
+  BC-1710.20:
+    name: Gestão da configuração de sistemas de armas
+    description: |
+      Linhas de base de configuração e controlo de configuração.
+  BC-1710.20.10:
+    name: Gestão de linhas de base de configuração
+    description: |
+      Definição e manutenção de linhas de base de configuração do sistema.
+  BC-1710.20.20:
+    name: Controlo de alterações de configuração
+    description: |
+      Controlo de alterações de configuração através de CCBs.
+  BC-1710.20.30:
+    name: Registo do estado de configuração
+    description: |
+      Registo e auditoria do estado de configuração.
+  BC-1710.30:
+    name: Gestão da integração de sistemas de armas
+    description: |
+      Integração de subsistemas e desenvolvimento de sistema integrado.
+  BC-1710.30.10:
+    name: Integração de subsistemas
+    description: |
+      Integração de subsistemas na plataforma de armas.
+  BC-1710.30.20:
+    name: Integração de sistemas de missão
+    description: |
+      Integração de sistemas de missão e sensores.
+  BC-1710.30.30:
+    name: Integração de sistema-de-sistemas
+    description: |
+      Integração com o sistema-de-sistemas alargado e C5ISR.
+  BC-1710.40:
+    name: Gestão de ensaios e qualificação de sistemas de armas
+    description: |
+      Programas de ensaio, qualificação e certificação.
+  BC-1710.40.10:
+    name: Planeamento do programa de ensaios
+    description: |
+      Planeamento do programa de ensaio e avaliação.
+  BC-1710.40.20:
+    name: Execução de ensaios de desenvolvimento
+    description: |
+      Execução de ensaios de desenvolvimento em protótipos.
+  BC-1710.40.30:
+    name: Execução de ensaios operacionais
+    description: |
+      Execução de ensaio e avaliação operacionais.
+  BC-1710.40.40:
+    name: Certificação de tipo
+    description: |
+      Aeronavegabilidade militar e certificação de tipo.
+  BC-1710.50:
+    name: Gestão da sustentação de sistemas de armas
+    description: |
+      Sustentação em serviço, manutenção em depósito e obsolescência.
+  BC-1710.50.10:
+    name: Suporte de engenharia em serviço
+    description: |
+      Suporte de engenharia em serviço a sistemas em operação.
+  BC-1710.50.20:
+    name: Manutenção em depósito
+    description: |
+      Manutenção ao nível de depósito, revisão geral e reset.
+  BC-1710.50.30:
+    name: Gestão de obsolescência e DMSMS
+    description: |
+      Gestão de DMSMS e obsolescência para sistemas em operação.
+  BC-1710.50.40:
+    name: Operações de logística baseada em desempenho
+    description: |
+      Operação de acordos de logística baseada em desempenho.
+  BC-1710.60:
+    name: Gestão de modificações e atualizações de sistemas de armas
+    description: |
+      Atualizações de capacidade, atualizações de meia vida e retrofits.
+  BC-1710.60.10:
+    name: Planeamento de atualizações de capacidade
+    description: |
+      Planeamento de atualizações de capacidade e inserção de capacidade.
+  BC-1710.60.20:
+    name: Gestão do programa de atualização de meia vida
+    description: |
+      Gestão de programas de atualização de meia vida.
+  BC-1710.60.30:
+    name: Execução de retrofits e modificações
+    description: |
+      Execução de retrofits e modificações no terreno.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Tradução automática; requer revisão por falante nativo.

--- a/catalogue/i18n/pt/L1-wholesale-interconnect-roaming-management.yaml
+++ b/catalogue/i18n/pt/L1-wholesale-interconnect-roaming-management.yaml
@@ -1,0 +1,134 @@
+locale: pt
+source: L1-wholesale-interconnect-roaming-management.yaml
+entries:
+  BC-2680:
+    name: Gestão de grossista, interligação e itinerância
+    description: |
+      Serviços de telecomunicações grossistas para outros operadores e parceiros
+      — produto e preços grossistas, parcerias MVNO e MVNE, interligação e
+      peering, relações com parceiros de itinerância, liquidação entre operadores
+      e acordos de capacidade como IRU e fibra escura.
+  BC-2680.10:
+    name: Gestão de produto e preços grossistas
+    description: |
+      Definição, preços e negociação comercial de ofertas grossistas para
+      operadores, MVNOs e grandes parceiros.
+  BC-2680.10.10:
+    name: Conceção de tarifa grossista
+    description: |
+      Conceção de tarifas grossistas em produtos de voz, dados, mensagens e
+      capacidade.
+  BC-2680.10.20:
+    name: Publicação de oferta grossista
+    description: |
+      Publicação de ofertas grossistas em canais voltados para parceiros e ofertas
+      de referência exigidas por reguladores.
+  BC-2680.10.30:
+    name: Negociação comercial grossista
+    description: |
+      Negociação comercial bilateral de acordos grossistas e termos à medida.
+  BC-2680.20:
+    name: Gestão de parcerias MVNO e MVNE
+    description: |
+      Integração e gestão contínua de parceiros MVNO e MVNE, incluindo integração
+      BSS e governação comercial.
+  BC-2680.20.10:
+    name: Integração de MVNO
+    description: |
+      Integração de novos parceiros MVNO e MVNE face a critérios de prontidão
+      comercial, regulatória e técnica.
+  BC-2680.20.20:
+    name: Integração BSS de MVNO
+    description: |
+      Integração de parceiros MVNO com o BSS do anfitrião para provisionamento,
+      tarifação e reporte.
+  BC-2680.20.30:
+    name: Gestão comercial de MVNO
+    description: |
+      Governação comercial contínua, revisões de desempenho e gestão de saída
+      de parceiros MVNO.
+  BC-2680.30:
+    name: Gestão de acordos de interligação
+    description: |
+      Gestão de acordos de interligação de voz e IP, incluindo peering e trânsito.
+  BC-2680.30.10:
+    name: Gestão de acordos de peering
+    description: |
+      Gestão de acordos de peering IP e termos comerciais e operacionais
+      associados.
+  BC-2680.30.20:
+    name: Gestão de acordos de trânsito
+    description: |
+      Gestão de acordos de trânsito de voz e IP com fornecedores upstream.
+  BC-2680.30.30:
+    name: Medição de troca de tráfego
+    description: |
+      Medição de volumes de tráfego trocados com peers e fornecedores de trânsito
+      para liquidação e engenharia.
+  BC-2680.40:
+    name: Gestão de parceiros de itinerância
+    description: |
+      Estabelecimento e operação de relações de itinerância com redes parceiras
+      internacionais.
+  BC-2680.40.10:
+    name: Gestão de acordos de itinerância
+    description: |
+      Negociação e gestão do ciclo de vida de acordos de itinerância bilaterais.
+  BC-2680.40.20:
+    name: Troca de ficheiros TAP
+    description: |
+      Troca de ficheiros TAP com parceiros de itinerância para liquidação de
+      utilização.
+  BC-2680.40.30:
+    name: Integração de parceiros de itinerância
+    description: |
+      Integração técnica e comercial de novos parceiros de itinerância, incluindo
+      testes IREG e TADIG.
+  BC-2680.50:
+    name: Gestão de liquidação entre operadores
+    description: |
+      Liquidação de utilização e litígios entre operadores para itinerância e
+      interligação.
+  BC-2680.50.10:
+    name: Liquidação TAP e NRTRDE
+    description: |
+      Liquidação de utilização de itinerância baseada em registos TAP e NRTRDE
+      em tempo quase real.
+  BC-2680.50.20:
+    name: Faturação de interligação
+    description: |
+      Faturação de parceiros de interligação por tráfego de terminação, origem
+      e trânsito.
+  BC-2680.50.30:
+    name: Resolução de litígios de liquidação
+    description: |
+      Resolução de litígios levantados em declarações de liquidação entre
+      operadores.
+  BC-2680.50.40:
+    name: Reconciliação de liquidação
+    description: |
+      Reconciliação de registos de liquidação entre operadores com contabilidade
+      interna e tesouraria.
+  BC-2680.60:
+    name: Gestão de capacidade grossista e IRU
+    description: |
+      Acordos de capacidade grossista de longo prazo, incluindo direito indefensável
+      de utilização e arrendamentos de fibra escura.
+  BC-2680.60.10:
+    name: Gestão de direito indefensável de utilização
+    description: |
+      Venda e compra de direitos indefensáveis de utilização em capacidade de
+      longa distância e submarina.
+  BC-2680.60.20:
+    name: Gestão de fibra escura
+    description: |
+      Arrendamento e gestão de pares de fibra escura de e para parceiros.
+  BC-2680.60.30:
+    name: Gestão de arrendamento de capacidade
+    description: |
+      Gestão de arrendamentos recorrentes de capacidade em rotas metro, longa
+      distância e submarinas.
+metadata:
+  status: draft
+  translator: claude-ai
+  notes: Machine-translated; needs native-speaker review.


### PR DESCRIPTION
## Summary
This PR adds Portuguese language translations for the complete set of Level 1 (L1) business capability management YAML files in the catalogue internationalization (i18n) directory.

## Changes Made
- Added 250+ new Portuguese translation files in `catalogue/i18n/pt/` directory
- Each file corresponds to an English source file with the same name, containing translated:
  - Capability names (e.g., "Gestão de relacionamento com clientes" for "Client Engagement Management")
  - Capability descriptions and detailed explanations
  - Associated business capability codes (BC-XXXX)
- Translations cover all major business domains including:
  - Financial management (BC-200)
  - Human capital management (BC-300)
  - Healthcare and clinical operations
  - Manufacturing and production
  - Energy and utilities
  - Transportation and logistics
  - Technology and digital services
  - And many others

## Implementation Details
- All files follow the standard YAML structure with `locale: pt` and `source` reference to the original English file
- Each entry maintains the same business capability code and hierarchical structure as the source files
- Files are organized alphabetically by capability domain name

https://claude.ai/code/session_011ByuPSB1EsV7GnNKmhH25t