### PR TITLE
Auto-publish package on main with unique calver+commit-count versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,5 +40,33 @@ jobs:
           pip install -e ".[dev]"
           pytest -q
 
+      - name: Build wheel and verify bundled data
+        working-directory: packages/py
+        run: |
+          python -m pip install --upgrade build
+          python -m build --wheel
+          python - <<'PY'
+          import pathlib, sys, zipfile
+          wheels = sorted(pathlib.Path("dist").glob("*.whl"))
+          assert wheels, "no wheel produced"
+          names = zipfile.ZipFile(wheels[-1]).namelist()
+          required = [
+              "turbo_ea_capabilities/data/version.json",
+              "turbo_ea_capabilities/data/capabilities.json",
+              "turbo_ea_capabilities/data/tree.json",
+              "turbo_ea_capabilities/data/locales.json",
+          ]
+          missing = [r for r in required if r not in names]
+          if missing:
+              sys.exit(f"missing from wheel: {missing}")
+          locales = sorted(
+              n for n in names
+              if n.startswith("turbo_ea_capabilities/data/i18n/") and n.endswith(".json")
+          )
+          if not locales:
+              sys.exit("wheel ships no i18n locale files")
+          print(f"wheel ok: {len(names)} files, locales={locales}")
+          PY
+
       - name: Build Astro site
         run: npm run build:site

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -2,6 +2,7 @@ name: publish-package
 
 on:
   push:
+    branches: [main]
     tags: ["v*"]
   workflow_dispatch:
 
@@ -43,3 +44,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/py/dist
+          # Belt-and-braces: a re-run of the same SHA produces the same
+          # version, so let PyPI silently no-op rather than fail the job.
+          skip-existing: true

--- a/packages/py/pyproject.toml
+++ b/packages/py/pyproject.toml
@@ -43,6 +43,16 @@ source = "code"
 path = "src/turbo_ea_capabilities/_version.py"
 expression = "VERSION"
 
+[tool.hatch.build]
+# data/ is gitignored (populated at build time by scripts/build_pkg.ts).
+# Hatchling's VCS-aware filter would otherwise drop it from the wheel —
+# `artifacts` overrides that so the bundled JSON catalogue and per-locale
+# i18n maps actually ship.
+artifacts = [
+    "src/turbo_ea_capabilities/data/*.json",
+    "src/turbo_ea_capabilities/data/i18n/*.json",
+]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/turbo_ea_capabilities"]
 

--- a/scripts/build_api.ts
+++ b/scripts/build_api.ts
@@ -30,8 +30,24 @@ const DIST_API = join(REPO_ROOT, "dist", "api");
 
 const SCHEMA_VERSION = 1;
 
-function getCatalogueVersion(): string {
-  // Prefer an exact tag at HEAD; otherwise calver YYYY.MM.DD from build time.
+function getCommitCount(): number | undefined {
+  try {
+    const n = execSync("git rev-list --count HEAD 2>/dev/null", {
+      encoding: "utf8",
+    }).trim();
+    const parsed = Number.parseInt(n, 10);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function getCatalogueVersion(commitCount: number | undefined): string {
+  // Prefer an exact tag at HEAD (clean release). Otherwise emit a PEP 440
+  // 4-segment release `<YYYY>.<M>.<D>.<N>` where N is the total commit count
+  // on this branch — strictly monotonic across rebuilds so PyPI never rejects
+  // a duplicate. Leading zeros are intentionally omitted to match PEP 440
+  // normalization (2026.04.30 → 2026.4.30).
   try {
     const exact = execSync("git describe --tags --exact-match HEAD 2>/dev/null", {
       encoding: "utf8",
@@ -42,9 +58,10 @@ function getCatalogueVersion(): string {
   }
   const d = new Date();
   const yyyy = d.getUTCFullYear();
-  const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
-  const dd = String(d.getUTCDate()).padStart(2, "0");
-  return `${yyyy}.${mm}.${dd}`;
+  const m = d.getUTCMonth() + 1;
+  const day = d.getUTCDate();
+  const base = `${yyyy}.${m}.${day}`;
+  return commitCount !== undefined ? `${base}.${commitCount}` : base;
 }
 
 function getCatalogueCommit(): string | undefined {
@@ -139,12 +156,14 @@ for (const f of flatSorted) {
 
 // version.json
 const commit = getCatalogueCommit();
+const commitCount = getCommitCount();
 const version = {
-  catalogue_version: getCatalogueVersion(),
+  catalogue_version: getCatalogueVersion(commitCount),
   schema_version: SCHEMA_VERSION,
   generated_at: new Date().toISOString(),
   node_count: flatSorted.length,
   ...(commit && { commit }),
+  ...(commitCount !== undefined && { commit_count: commitCount }),
 };
 
 mkdir(DIST_API);


### PR DESCRIPTION
- build_api: untagged builds emit `<YYYY>.<M>.<D>.<N>` (commit count) so
  same-day rebuilds get a strictly monotonic, PEP 440 release version
  PyPI never rejects. Also surface commit_count in version.json.
- publish-package: also trigger on push to main (parity with CF Pages
  auto-deploy). skip-existing on the upload step makes re-runs no-op.
- pyproject: explicit hatch artifacts directive so the gitignored
  data/ tree (capabilities, tree, version, locales, i18n/<lang>.json)
  actually ships in the wheel — the missing piece behind TurboEA not
  seeing the new locales.
- lint workflow: build the wheel and assert data/ + i18n/ contents to
  catch packaging regressions before merge.