### PR TITLE
Replace Ko-fi donation button with GitHub Sponsors

### DIFF
--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -111,24 +111,13 @@ const generatedDate = version.generated_at.slice(0, 10);
             target="_blank"
             rel="noopener">PyPI</a
           >
-          <a
-            href="https://ko-fi.com/vincentmakes"
-            target="_blank"
-            rel="noopener"
-            class="kofi-button"
-            aria-label="Support on Ko-fi"
-          >
-            <svg
-              viewBox="0 0 24 24"
-              width="20"
-              height="20"
-              fill="currentColor"
-              aria-hidden="true"
-            >
-              <path d="M20 3H6a2 2 0 0 0-2 2v9a4 4 0 0 0 4 4h6a4 4 0 0 0 4-4h2a3 3 0 0 0 3-3V6a3 3 0 0 0-3-3Zm0 8h-2V5h2a1 1 0 0 1 1 1v4a1 1 0 0 1-1 1ZM4 20h16v2H4z"/>
-            </svg>
-            <span>Support on Ko-fi</span>
-          </a>
+          <iframe
+            src="https://github.com/sponsors/vincentmakes/button"
+            title="Sponsor vincentmakes"
+            height="32"
+            width="114"
+            style="border: 0; border-radius: 6px;"
+          ></iframe>
         </div>
         <div class="footer-copy">
           Catalog {version.catalogue_version} · schema v{version.schema_version} ·

--- a/site/src/pages/about.astro
+++ b/site/src/pages/about.astro
@@ -92,24 +92,13 @@ import { version } from "../data/load.ts";
         This catalogue is free and open-source. If it's useful to you or your
         team, you can support continued development with a small contribution.
       </p>
-      <a
-        href="https://ko-fi.com/vincentmakes"
-        target="_blank"
-        rel="noopener"
-        class="kofi-button"
-        aria-label="Support Vincent on Ko-fi"
-      >
-        <svg
-          viewBox="0 0 24 24"
-          width="20"
-          height="20"
-          fill="currentColor"
-          aria-hidden="true"
-        >
-          <path d="M20 3H6a2 2 0 0 0-2 2v9a4 4 0 0 0 4 4h6a4 4 0 0 0 4-4h2a3 3 0 0 0 3-3V6a3 3 0 0 0-3-3Zm0 8h-2V5h2a1 1 0 0 1 1 1v4a1 1 0 0 1-1 1ZM4 20h16v2H4z"/>
-        </svg>
-        <span>Support on Ko-fi</span>
-      </a>
+      <iframe
+        src="https://github.com/sponsors/vincentmakes/button"
+        title="Sponsor vincentmakes"
+        height="32"
+        width="114"
+        style="border: 0; border-radius: 6px; margin-top: 12px;"
+      ></iframe>
     </div>
 
     <div class="detail-card">
@@ -169,8 +158,5 @@ import { version } from "../data/load.ts";
       align-items: center;
       text-align: center;
     }
-  }
-  .kofi-button {
-    margin-top: 12px;
   }
 </style>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -362,7 +362,6 @@ body {
   color: var(--color-white);
 }
 
-.kofi-button,
 .github-button,
 .linkedin-button {
   display: inline-flex;
@@ -381,17 +380,10 @@ body {
     box-shadow var(--transition-fast);
 }
 
-.kofi-button:hover,
 .github-button:hover,
 .linkedin-button:hover {
   color: #fff;
   transform: translateY(-1px);
-}
-
-.kofi-button { background: #d6336c; }
-.kofi-button:hover {
-  background: #b8255a;
-  box-shadow: 0 4px 12px rgba(214, 51, 108, 0.35);
 }
 
 .github-button { background: #126EF8; }
@@ -406,7 +398,6 @@ body {
   box-shadow: 0 4px 12px rgba(10, 102, 194, 0.35);
 }
 
-.kofi-button svg,
 .github-button svg,
 .linkedin-button svg {
   display: block;
@@ -414,7 +405,6 @@ body {
 }
 
 /* Compact pill buttons inside the top nav */
-.nav-links .kofi-button,
 .nav-links .github-button,
 .nav-links .linkedin-button {
   padding: 6px 12px;
@@ -423,7 +413,6 @@ body {
   font-weight: 600;
 }
 
-.nav-links .kofi-button svg,
 .nav-links .github-button svg,
 .nav-links .linkedin-button svg {
   width: 14px;
@@ -431,7 +420,6 @@ body {
 }
 
 /* Suppress nav underline indicator on pill buttons */
-.nav-links .kofi-button::after,
 .nav-links .github-button::after,
 .nav-links .linkedin-button::after {
   display: none;


### PR DESCRIPTION
## Summary
This PR replaces the Ko-fi donation button with GitHub Sponsors across the site, using an embedded iframe instead of a custom SVG button implementation.

## Key Changes
- **about.astro**: Replaced custom Ko-fi link and SVG icon with GitHub Sponsors iframe embed
- **Base.astro**: Updated footer donation button from Ko-fi to GitHub Sponsors iframe
- **global.css**: Removed all Ko-fi button styling (`.kofi-button` class and related hover/responsive styles)

## Implementation Details
- The GitHub Sponsors button is embedded via iframe (`https://github.com/sponsors/vincentmakes/button`) with dimensions 114x32px
- Removed custom SVG icon and associated markup in favor of GitHub's native button embed
- Cleaned up CSS by removing Ko-fi-specific styling while preserving GitHub and LinkedIn button styles
- The iframe approach is simpler and maintains consistency with GitHub's official sponsorship UI

https://claude.ai/code/session_01BeDzKy2rprPgvrCysYyyVF