### PR TITLE
Make author photo clickable link to CV

### DIFF
--- a/site/src/pages/about.astro
+++ b/site/src/pages/about.astro
@@ -52,11 +52,13 @@ import { version } from "../data/load.ts";
     <div class="detail-card author-card">
       <h3 style="margin-top:0;">Author</h3>
       <div class="author-block">
-        <img
-          src="https://www.turbo-ea.org/blog/images/vincent-verdet.jpeg"
-          alt="Vincent Verdet"
-          class="author-photo"
-        />
+        <a href="https://cv.verdet.me" target="_blank" rel="noopener">
+          <img
+            src="https://www.turbo-ea.org/blog/images/vincent-verdet.jpeg"
+            alt="Vincent Verdet"
+            class="author-photo"
+          />
+        </a>
         <div class="author-bio">
           <div class="author-name">Vincent Verdet</div>
           <p>


### PR DESCRIPTION
## Summary
Made the author photo on the about page clickable by wrapping it in a link to the author's CV.

## Changes
- Wrapped the author photo `<img>` element in an `<a>` tag linking to https://cv.verdet.me
- Added `target="_blank"` to open the link in a new tab
- Added `rel="noopener"` for security best practices when opening external links in new tabs

## Details
This change improves the about page by providing an easy way for visitors to access the author's CV directly from their photo, enhancing the user experience and making the author's professional information more discoverable.

https://claude.ai/code/session_01Ffq1S9yo3PUAPkuFFzeR9n