### PR TITLE
Import APQC PCF Cross-Industry (BP1 + BP2)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,42 @@
+Turbo EA Capabilities — Reference Business Architecture Catalogue
+Copyright (c) 2026 Vincent and contributors. Released under the MIT License (see LICENSE).
+
+This product includes references to and attribution-based use of third-party
+frameworks. Inclusion of an attribution below does not imply endorsement by
+the framework owner.
+
+================================================================================
+APQC Process Classification Framework® (PCF)
+================================================================================
+
+The business-process catalogue under `catalogue/processes/` is anchored on the
+APQC Process Classification Framework® (PCF), Cross-Industry version 7.4.0,
+published by APQC (American Productivity & Quality Center, https://www.apqc.org/).
+
+"Process Classification Framework®" and "PCF®" are registered trademarks of
+APQC. The APQC PCF is provided by APQC for use as a benchmark and process
+reference; this project uses APQC's category and process-group taxonomy with
+attribution. Each business-process node carries a structured `framework_refs`
+entry that pins the corresponding APQC PCF code (e.g.
+`{framework: APQC-PCF, external_id: "8.1", version: "7.4.0"}`).
+
+For the canonical APQC PCF documentation, including the full multi-level
+process taxonomy and definitions, see:
+
+    https://www.apqc.org/process-frameworks
+
+The names, definitions, and ordering used in this catalogue are derived from
+the APQC PCF and adapted to this catalogue's governance conventions
+(verb-phrased Title Case, sparse `BP-N0[.M0]` ids, depth-4 cap, MECE within
+parent). Where this catalogue's wording differs from APQC's, the
+`framework_refs.external_id` pin remains authoritative for cross-walks.
+
+================================================================================
+Other reference frameworks (cited but not redistributed)
+================================================================================
+
+Capability and process records may include `framework_refs` entries that
+cross-walk to additional industry frameworks: BIAN (Banking Industry
+Architecture Network), TM Forum eTOM/Frameworx, ITIL®, and SCOR®. None of
+these frameworks are redistributed by this project; entries cite their
+identifiers only, with attribution to the respective owners of each.

--- a/README.md
+++ b/README.md
@@ -230,4 +230,4 @@ All responses are static, immutable per build, and cacheable by Cloudflare's edg
 
 ## Licence
 
-[MIT](LICENSE).
+[MIT](LICENSE). Third-party framework attributions (APQC PCF® for the business-process catalogue, plus BIAN / TM Forum eTOM / ITIL® / SCOR® references) are listed in [NOTICE](NOTICE).

--- a/catalogue/processes/BP1-acquire-construct-and-manage-assets.yaml
+++ b/catalogue/processes/BP1-acquire-construct-and-manage-assets.yaml
@@ -1,0 +1,65 @@
+id: BP-100
+name: Acquire, Construct, and Manage Assets
+level: 1
+industry: Cross-Industry
+description: >-
+  Plan, acquire, construct, maintain, and dispose of productive assets — facilities, plant, real estate, and similar long-lived enterprise assets.
+framework_refs:
+  - framework: APQC-PCF
+    external_id: "10.0"
+    version: "7.4.0"
+realizes_capability_ids:
+  - BC-700
+  - BC-710
+children:
+  - id: BP-100.10
+    name: Plan and Acquire Assets
+    level: 2
+    description: >-
+      Plan asset needs, evaluate buy/lease alternatives, and acquire productive assets.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "10.1"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-710
+      - BC-700
+    children: []
+  - id: BP-100.20
+    name: Design and Construct Productive Assets
+    level: 2
+    description: >-
+      Design, construct, and commission productive assets — facilities, plant, and infrastructure.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "10.2"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-700
+      - BC-720
+    children: []
+  - id: BP-100.30
+    name: Maintain Productive Assets
+    level: 2
+    description: >-
+      Operate and maintain productive assets across their useful life: planned, preventive, and corrective maintenance.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "10.3"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-700
+    children: []
+  - id: BP-100.40
+    name: Dispose of Productive Assets
+    level: 2
+    description: >-
+      Decommission and dispose of assets at end-of-life, including environmental and remarketing considerations.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "10.4"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-710
+      - BC-740
+    children: []

--- a/catalogue/processes/BP1-deliver-physical-products.yaml
+++ b/catalogue/processes/BP1-deliver-physical-products.yaml
@@ -1,0 +1,66 @@
+id: BP-40
+name: Deliver Physical Products
+level: 1
+industry: Cross-Industry
+description: >-
+  Plan and run the physical supply chain end-to-end: procurement, production, and outbound logistics that move goods from suppliers to customers.
+framework_refs:
+  - framework: APQC-PCF
+    external_id: "4.0"
+    version: "7.4.0"
+realizes_capability_ids:
+  - BC-520
+  - BC-530
+children:
+  - id: BP-40.10
+    name: Plan for and Align Supply Chain Resources
+    level: 2
+    description: >-
+      Forecast demand, plan supply, balance capacity, and align inventory positions to meet service-level and cost targets.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "4.1"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-520
+      - BC-530
+    children: []
+  - id: BP-40.20
+    name: Procure Materials and Services
+    level: 2
+    description: >-
+      Source, contract, and acquire goods and services from suppliers, including supplier qualification and ongoing supplier management.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "4.2"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-500
+      - BC-510
+    children: []
+  - id: BP-40.30
+    name: Produce/Manufacture/Deliver Product
+    level: 2
+    description: >-
+      Convert inputs into finished products through production scheduling, manufacturing operations, and quality control.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "4.3"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-520
+      - BC-720
+    children: []
+  - id: BP-40.40
+    name: Manage Logistics and Warehousing
+    level: 2
+    description: >-
+      Run the inbound, internal, and outbound flow of goods: warehousing, transport, fulfilment, and reverse logistics.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "4.4"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-520
+      - BC-530
+    children: []

--- a/catalogue/processes/BP1-deliver-services.yaml
+++ b/catalogue/processes/BP1-deliver-services.yaml
@@ -1,0 +1,65 @@
+id: BP-50
+name: Deliver Services
+level: 1
+industry: Cross-Industry
+description: >-
+  Govern, plan, and execute the delivery of services to customers — including the resourcing, operations, and post-delivery management distinct from physical-goods supply chains.
+framework_refs:
+  - framework: APQC-PCF
+    external_id: "5.0"
+    version: "7.4.0"
+realizes_capability_ids:
+  - BC-430
+  - BC-720
+children:
+  - id: BP-50.10
+    name: Establish Service Delivery Governance and Strategy
+    level: 2
+    description: >-
+      Define service-delivery operating model, governance forums, and service strategy aligned to customer outcomes and SLAs.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "5.1"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-100
+      - BC-720
+    children: []
+  - id: BP-50.20
+    name: Manage Service Delivery Resources
+    level: 2
+    description: >-
+      Plan, allocate, and develop the people, facilities, and infrastructure that deliver service.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "5.2"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-300
+      - BC-700
+    children: []
+  - id: BP-50.30
+    name: Deliver Service to Customer
+    level: 2
+    description: >-
+      Execute the service interaction with the customer end-to-end, including provisioning, support, and assurance.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "5.3"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-430
+    children: []
+  - id: BP-50.40
+    name: Manage Service Delivery
+    level: 2
+    description: >-
+      Monitor, assure, and improve service delivery against SLAs and customer-experience targets.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "5.4"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-430
+      - BC-720
+    children: []

--- a/catalogue/processes/BP1-develop-and-manage-human-capital.yaml
+++ b/catalogue/processes/BP1-develop-and-manage-human-capital.yaml
@@ -1,0 +1,98 @@
+id: BP-70
+name: Develop and Manage Human Capital
+level: 1
+industry: Cross-Industry
+description: >-
+  Manage the workforce end-to-end: HR strategy, recruitment, development, reward, redeployment, and employee data and inquiries.
+framework_refs:
+  - framework: APQC-PCF
+    external_id: "7.0"
+    version: "7.4.0"
+realizes_capability_ids:
+  - BC-300
+children:
+  - id: BP-70.10
+    name: Develop and Manage Human Resources Planning, Policies, and Strategies
+    level: 2
+    description: >-
+      Set HR strategy, workforce plans, and policies aligned to business strategy and regulatory obligations.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "7.1"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-300
+    children: []
+  - id: BP-70.20
+    name: Recruit, Source, and Select Employees
+    level: 2
+    description: >-
+      Attract, assess, and hire candidates to fill workforce demand, including onboarding readiness.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "7.2"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-300
+    children: []
+  - id: BP-70.30
+    name: Develop and Counsel Employees
+    level: 2
+    description: >-
+      Onboard, train, develop, and coach employees across their tenure to build capability and engagement.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "7.3"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-300
+    children: []
+  - id: BP-70.40
+    name: Reward and Retain Employees
+    level: 2
+    description: >-
+      Design and operate compensation, benefits, recognition, and retention programs.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "7.4"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-300
+    children: []
+  - id: BP-70.50
+    name: Redeploy and Retire Employees
+    level: 2
+    description: >-
+      Manage transitions: internal mobility, redeployment, separations, and retirement.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "7.5"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-300
+    children: []
+  - id: BP-70.60
+    name: Manage Employee Information and Analytics
+    level: 2
+    description: >-
+      Maintain employee master data and produce workforce analytics that inform decisions.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "7.6"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-300
+      - BC-610
+    children: []
+  - id: BP-70.70
+    name: Manage Employee Inquiries
+    level: 2
+    description: >-
+      Resolve employee questions and service requests via HR shared-service or case-management channels.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "7.7"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-300
+    children: []

--- a/catalogue/processes/BP1-develop-and-manage-products-and-services.yaml
+++ b/catalogue/processes/BP1-develop-and-manage-products-and-services.yaml
@@ -1,0 +1,81 @@
+id: BP-20
+name: Develop and Manage Products and Services
+level: 1
+industry: Cross-Industry
+description: >-
+  Govern the product/service portfolio across the lifecycle: from idea generation and development through market test and production readiness.
+framework_refs:
+  - framework: APQC-PCF
+    external_id: "2.0"
+    version: "7.4.0"
+realizes_capability_ids:
+  - BC-820
+  - BC-810
+  - BC-800
+children:
+  - id: BP-20.10
+    name: Govern and Manage the Product/Service Development Program
+    level: 2
+    description: >-
+      Establish development governance, stage gates, portfolio prioritisation, and program controls across the product/service lifecycle.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "2.1"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-820
+      - BC-900
+    children: []
+  - id: BP-20.20
+    name: Generate and Define New Product/Service Ideas
+    level: 2
+    description: >-
+      Source, screen, and define candidate product and service concepts. Translate market and technology insight into evaluable concepts.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "2.2"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-800
+      - BC-810
+    children: []
+  - id: BP-20.30
+    name: Develop Products and Services
+    level: 2
+    description: >-
+      Design, engineer, and validate products and services from concept through release readiness, including IP protection.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "2.3"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-810
+      - BC-820
+      - BC-840
+    children: []
+  - id: BP-20.40
+    name: Test Market for New or Revised Products and Services
+    level: 2
+    description: >-
+      Validate concept-market fit through market trials, pilots, and customer testing before full-scale launch.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "2.4"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-820
+      - BC-400
+    children: []
+  - id: BP-20.50
+    name: Prepare for Production
+    level: 2
+    description: >-
+      Industrialise the design, qualify the supply base, and ready operations to produce or deliver at commercial scale.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "2.5"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-820
+      - BC-520
+    children: []

--- a/catalogue/processes/BP1-develop-vision-and-strategy.yaml
+++ b/catalogue/processes/BP1-develop-vision-and-strategy.yaml
@@ -1,0 +1,52 @@
+id: BP-10
+name: Develop Vision and Strategy
+level: 1
+industry: Cross-Industry
+description: >-
+  Define the business concept and long-term vision, develop the business strategy, and manage the strategic initiative portfolio that turns strategy into outcomes.
+framework_refs:
+  - framework: APQC-PCF
+    external_id: "1.0"
+    version: "7.4.0"
+realizes_capability_ids:
+  - BC-100
+children:
+  - id: BP-10.10
+    name: Define the Business Concept and Long-Term Vision
+    level: 2
+    description: >-
+      Frame the enterprise's purpose, scope, and aspirational future state. Establishes the long-horizon view that strategic plans serve.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "1.1"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-100
+    children: []
+  - id: BP-10.20
+    name: Develop Business Strategy
+    level: 2
+    description: >-
+      Translate the long-term vision into a multi-year business strategy with markets, value propositions, and competitive positioning.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "1.2"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-100
+      - BC-230
+    children: []
+  - id: BP-10.30
+    name: Manage Strategic Initiatives
+    level: 2
+    description: >-
+      Charter, prioritise, and govern the portfolio of initiatives that execute the strategy. Allocate resources and track strategic outcomes.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "1.3"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-100
+      - BC-900
+      - BC-920
+    children: []

--- a/catalogue/processes/BP1-manage-customer-service.yaml
+++ b/catalogue/processes/BP1-manage-customer-service.yaml
@@ -1,0 +1,52 @@
+id: BP-60
+name: Manage Customer Service
+level: 1
+industry: Cross-Industry
+description: >-
+  Develop and run the customer-care function: strategy, contact-center operations, and continuous evaluation that resolves customer issues and protects loyalty.
+framework_refs:
+  - framework: APQC-PCF
+    external_id: "6.0"
+    version: "7.4.0"
+realizes_capability_ids:
+  - BC-430
+  - BC-420
+children:
+  - id: BP-60.10
+    name: Develop Customer Care/Customer Service Strategy
+    level: 2
+    description: >-
+      Define the customer-service operating model, channels, service levels, and self-service strategy.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "6.1"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-430
+      - BC-100
+    children: []
+  - id: BP-60.20
+    name: Plan and Manage Customer Service Operations
+    level: 2
+    description: >-
+      Run day-to-day customer service operations: contact handling, case management, escalation, and workforce management.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "6.2"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-430
+    children: []
+  - id: BP-60.30
+    name: Measure and Evaluate Customer Service Operations
+    level: 2
+    description: >-
+      Measure service performance, customer satisfaction, and operational efficiency; drive continuous improvement.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "6.3"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-430
+      - BC-720
+    children: []

--- a/catalogue/processes/BP1-manage-enterprise-risk-compliance-remediation-and-resiliency.yaml
+++ b/catalogue/processes/BP1-manage-enterprise-risk-compliance-remediation-and-resiliency.yaml
@@ -1,0 +1,54 @@
+id: BP-110
+name: Manage Enterprise Risk, Compliance, Remediation, and Resiliency
+level: 1
+industry: Cross-Industry
+description: >-
+  Run enterprise risk, compliance, business resilience, and EHS programs that protect the enterprise from financial, operational, regulatory, and safety threats.
+framework_refs:
+  - framework: APQC-PCF
+    external_id: "11.0"
+    version: "7.4.0"
+realizes_capability_ids:
+  - BC-120
+  - BC-130
+  - BC-160
+  - BC-730
+children:
+  - id: BP-110.10
+    name: Manage Enterprise Risk
+    level: 2
+    description: >-
+      Identify, assess, treat, and monitor enterprise risk across financial, operational, strategic, and compliance dimensions.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "11.1"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-120
+      - BC-140
+    children: []
+  - id: BP-110.20
+    name: Manage Business Resiliency
+    level: 2
+    description: >-
+      Maintain business-continuity and disaster-recovery capabilities; respond to and recover from disruptive events.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "11.2"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-160
+    children: []
+  - id: BP-110.30
+    name: Manage Environmental, Health, and Safety (EHS)
+    level: 2
+    description: >-
+      Run EHS programs that protect employees, communities, and the environment, including incident response and regulatory reporting.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "11.3"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-730
+      - BC-740
+    children: []

--- a/catalogue/processes/BP1-manage-external-relationships.yaml
+++ b/catalogue/processes/BP1-manage-external-relationships.yaml
@@ -1,0 +1,79 @@
+id: BP-120
+name: Manage External Relationships
+level: 1
+industry: Cross-Industry
+description: >-
+  Manage the enterprise's relationships with external stakeholders: investors, government, board, legal, ethical, and public-relations counterparts.
+framework_refs:
+  - framework: APQC-PCF
+    external_id: "12.0"
+    version: "7.4.0"
+realizes_capability_ids:
+  - BC-240
+  - BC-150
+  - BC-850
+  - BC-110
+children:
+  - id: BP-120.10
+    name: Build Investor Relationships
+    level: 2
+    description: >-
+      Engage with current and prospective investors, analysts, and rating agencies; manage investor communications and disclosures.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "12.1"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-240
+    children: []
+  - id: BP-120.20
+    name: Manage Government and Industry Relationships
+    level: 2
+    description: >-
+      Engage with regulators, government bodies, and industry associations on policy, lobbying, and regulatory matters.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "12.2"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-150
+      - BC-850
+    children: []
+  - id: BP-120.30
+    name: Manage Relations with Board of Directors
+    level: 2
+    description: >-
+      Support the board: agendas, materials, governance processes, and director engagement.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "12.3"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-110
+      - BC-240
+    children: []
+  - id: BP-120.40
+    name: Manage Legal and Ethical Issues
+    level: 2
+    description: >-
+      Manage legal matters, contracts, litigation, ethics programs, and corporate-conduct standards.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "12.4"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-150
+      - BC-130
+    children: []
+  - id: BP-120.50
+    name: Manage Public Relations Program
+    level: 2
+    description: >-
+      Run external communications, media relations, brand reputation, and crisis communications.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "12.5"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-850
+    children: []

--- a/catalogue/processes/BP1-manage-financial-resources.yaml
+++ b/catalogue/processes/BP1-manage-financial-resources.yaml
@@ -1,0 +1,141 @@
+id: BP-90
+name: Manage Financial Resources
+level: 1
+industry: Cross-Industry
+description: >-
+  Run enterprise finance end-to-end: planning and management accounting, transaction processing (revenue, AP, payroll), reporting, treasury, controls, tax, and consolidation.
+framework_refs:
+  - framework: APQC-PCF
+    external_id: "9.0"
+    version: "7.4.0"
+realizes_capability_ids:
+  - BC-200
+  - BC-230
+  - BC-210
+  - BC-220
+children:
+  - id: BP-90.10
+    name: Perform Planning and Management Accounting
+    level: 2
+    description: >-
+      Plan, budget, forecast, and produce management-accounting analyses that drive business decisions.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "9.1"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-230
+    children: []
+  - id: BP-90.20
+    name: Perform Revenue Accounting
+    level: 2
+    description: >-
+      Recognise, record, and report revenue in accordance with accounting standards and contract terms.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "9.2"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-200
+    children: []
+  - id: BP-90.30
+    name: Perform General Accounting and Reporting
+    level: 2
+    description: >-
+      Maintain the general ledger, perform period-end close, and produce statutory and management financial reports.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "9.3"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-200
+    children: []
+  - id: BP-90.40
+    name: Manage Fixed-Asset Project Accounting
+    level: 2
+    description: >-
+      Account for capital projects and fixed assets across acquisition, depreciation, impairment, and disposal.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "9.4"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-200
+      - BC-900
+    children: []
+  - id: BP-90.50
+    name: Process Payroll
+    level: 2
+    description: >-
+      Calculate, pay, and report employee compensation, including statutory withholdings and benefits accounting.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "9.5"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-300
+      - BC-200
+    children: []
+  - id: BP-90.60
+    name: Process Accounts Payable and Expense Reimbursements
+    level: 2
+    description: >-
+      Validate, approve, and pay supplier invoices and employee expense claims.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "9.6"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-200
+      - BC-500
+    children: []
+  - id: BP-90.70
+    name: Manage Treasury Operations
+    level: 2
+    description: >-
+      Manage cash, liquidity, banking, debt, investments, and financial-risk hedging.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "9.7"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-210
+    children: []
+  - id: BP-90.80
+    name: Manage Internal Controls
+    level: 2
+    description: >-
+      Design, operate, and assure financial internal controls aligned to regulatory and assurance requirements.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "9.8"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-140
+      - BC-130
+    children: []
+  - id: BP-90.90
+    name: Manage Taxes
+    level: 2
+    description: >-
+      Determine, file, and pay direct, indirect, and transactional taxes; manage tax controversy and planning.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "9.9"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-220
+    children: []
+  - id: BP-90.100
+    name: Manage International Funds/Consolidation
+    level: 2
+    description: >-
+      Translate, consolidate, and report multi-entity, multi-currency results.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "9.10"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-200
+      - BC-210
+    children: []

--- a/catalogue/processes/BP1-manage-information-technology.yaml
+++ b/catalogue/processes/BP1-manage-information-technology.yaml
@@ -1,0 +1,92 @@
+id: BP-80
+name: Manage Information Technology
+level: 1
+industry: Cross-Industry
+description: >-
+  Run the enterprise IT function: strategy, build, deploy, run, and knowledge management — including IT-side risk and resilience that protects business continuity.
+framework_refs:
+  - framework: APQC-PCF
+    external_id: "8.0"
+    version: "7.4.0"
+realizes_capability_ids:
+  - BC-600
+  - BC-610
+  - BC-620
+children:
+  - id: BP-80.10
+    name: Develop and Manage Business Resilience and Risk
+    level: 2
+    description: >-
+      Identify, assess, and mitigate IT-related risks; maintain business-continuity and disaster-recovery readiness for technology-enabled operations.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "8.1"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-160
+      - BC-120
+      - BC-620
+    children: []
+  - id: BP-80.20
+    name: Develop Information Technology (IT) Strategy
+    level: 2
+    description: >-
+      Set the IT strategy, target architecture, and investment plan that supports the business strategy.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "8.2"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-600
+      - BC-170
+    children: []
+  - id: BP-80.30
+    name: Develop and Maintain Information Technology Solutions
+    level: 2
+    description: >-
+      Design, build, integrate, and evolve the application and infrastructure portfolio that runs the business.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "8.3"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-600
+    children: []
+  - id: BP-80.40
+    name: Deploy Information Technology Solutions
+    level: 2
+    description: >-
+      Release new and changed IT solutions into production with appropriate change controls and adoption support.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "8.4"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-600
+      - BC-910
+    children: []
+  - id: BP-80.50
+    name: Deliver and Support Information Technology Services
+    level: 2
+    description: >-
+      Operate IT services day-to-day: incident, problem, request, and service-level management.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "8.5"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-600
+    children: []
+  - id: BP-80.60
+    name: Manage IT Knowledge
+    level: 2
+    description: >-
+      Capture and curate IT knowledge: configuration data, runbooks, architecture, and support knowledge bases.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "8.6"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-830
+      - BC-600
+    children: []

--- a/catalogue/processes/BP1-market-and-sell-products-and-services.yaml
+++ b/catalogue/processes/BP1-market-and-sell-products-and-services.yaml
@@ -1,0 +1,78 @@
+id: BP-30
+name: Market and Sell Products and Services
+level: 1
+industry: Cross-Industry
+description: >-
+  Understand markets and customers, set marketing and sales strategy, and execute the demand-creation and order-capture activities that monetise products and services.
+framework_refs:
+  - framework: APQC-PCF
+    external_id: "3.0"
+    version: "7.4.0"
+realizes_capability_ids:
+  - BC-400
+  - BC-410
+  - BC-420
+  - BC-440
+children:
+  - id: BP-30.10
+    name: Understand Markets, Customers, and Capabilities
+    level: 2
+    description: >-
+      Develop the evidence base on market dynamics, customer needs, segments, and competitive position that drives marketing and sales decisions.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "3.1"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-400
+      - BC-420
+    children: []
+  - id: BP-30.20
+    name: Develop Marketing Strategy
+    level: 2
+    description: >-
+      Define target segments, value propositions, brand positioning, and channel mix that direct marketing investment.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "3.2"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-400
+    children: []
+  - id: BP-30.30
+    name: Develop Sales Strategy
+    level: 2
+    description: >-
+      Define sales coverage, channel structure, account strategy, and quota/incentive design.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "3.3"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-410
+    children: []
+  - id: BP-30.40
+    name: Develop and Manage Marketing Plans
+    level: 2
+    description: >-
+      Plan, execute, and measure marketing campaigns and demand-generation programs that deliver pipeline against the strategy.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "3.4"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-400
+    children: []
+  - id: BP-30.50
+    name: Develop and Manage Sales Plans
+    level: 2
+    description: >-
+      Plan, execute, and manage the sales motion: account planning, opportunity management, pricing, quoting, and order capture.
+    framework_refs:
+      - framework: APQC-PCF
+        external_id: "3.5"
+        version: "7.4.0"
+    realizes_capability_ids:
+      - BC-410
+      - BC-440
+    children: []

--- a/catalogue/processes/_index.yaml
+++ b/catalogue/processes/_index.yaml
@@ -1,5 +1,14 @@
-# Index of business-process L1 (BP1) files. Mirrors catalogue/_index.yaml for
-# the capability layer. Empty until APQC PCF Cross-Industry (and any
-# industry-specific PCFs) are imported in a follow-up PR. Adding a BP1 file
-# without registering it here fails lint.
-files: []
+# Index of business-process L1 (BP1) files. Lint enforces every BP1 file is registered here.
+files:
+  - BP1-acquire-construct-and-manage-assets.yaml
+  - BP1-deliver-physical-products.yaml
+  - BP1-deliver-services.yaml
+  - BP1-develop-and-manage-human-capital.yaml
+  - BP1-develop-and-manage-products-and-services.yaml
+  - BP1-develop-vision-and-strategy.yaml
+  - BP1-manage-customer-service.yaml
+  - BP1-manage-enterprise-risk-compliance-remediation-and-resiliency.yaml
+  - BP1-manage-external-relationships.yaml
+  - BP1-manage-financial-resources.yaml
+  - BP1-manage-information-technology.yaml
+  - BP1-market-and-sell-products-and-services.yaml

--- a/scripts/import_apqc_pcf.py
+++ b/scripts/import_apqc_pcf.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""One-shot generator for the 12 APQC PCF Cross-Industry BP1 files.
+
+Run once to populate catalogue/processes/BP1-*.yaml. After review/merge,
+this script can be archived under scripts/_archive/ — further authoring
+should go through `npm run bp:add` per the governance model.
+
+Source: APQC Process Classification Framework (PCF) Cross-Industry v7.x.
+APQC permits PCF use with attribution; see NOTICE.
+"""
+import os
+import yaml
+from collections import OrderedDict
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PROCESSES_DIR = os.path.join(REPO_ROOT, "catalogue", "processes")
+APQC_VERSION = "7.4.0"
+
+
+def slugify(name: str) -> str:
+    out = []
+    last_dash = True
+    for ch in name.lower():
+        if ch.isalnum():
+            out.append(ch)
+            last_dash = False
+        else:
+            if not last_dash:
+                out.append("-")
+                last_dash = True
+    return "".join(out).strip("-")
+
+
+# Each entry: (bp_id, apqc_code, name, description, realizes_capability_ids, [children])
+# children: list of (bp_id, apqc_code, name, description, realizes_capability_ids)
+TREE = [
+    {
+        "id": "BP-10",
+        "apqc": "1.0",
+        "name": "Develop Vision and Strategy",
+        "description": "Define the business concept and long-term vision, develop the business strategy, and manage the strategic initiative portfolio that turns strategy into outcomes.",
+        "realizes": ["BC-100"],
+        "children": [
+            ("BP-10.10", "1.1", "Define the Business Concept and Long-Term Vision",
+             "Frame the enterprise's purpose, scope, and aspirational future state. Establishes the long-horizon view that strategic plans serve.",
+             ["BC-100"]),
+            ("BP-10.20", "1.2", "Develop Business Strategy",
+             "Translate the long-term vision into a multi-year business strategy with markets, value propositions, and competitive positioning.",
+             ["BC-100", "BC-230"]),
+            ("BP-10.30", "1.3", "Manage Strategic Initiatives",
+             "Charter, prioritise, and govern the portfolio of initiatives that execute the strategy. Allocate resources and track strategic outcomes.",
+             ["BC-100", "BC-900", "BC-920"]),
+        ],
+    },
+    {
+        "id": "BP-20",
+        "apqc": "2.0",
+        "name": "Develop and Manage Products and Services",
+        "description": "Govern the product/service portfolio across the lifecycle: from idea generation and development through market test and production readiness.",
+        "realizes": ["BC-820", "BC-810", "BC-800"],
+        "children": [
+            ("BP-20.10", "2.1", "Govern and Manage the Product/Service Development Program",
+             "Establish development governance, stage gates, portfolio prioritisation, and program controls across the product/service lifecycle.",
+             ["BC-820", "BC-900"]),
+            ("BP-20.20", "2.2", "Generate and Define New Product/Service Ideas",
+             "Source, screen, and define candidate product and service concepts. Translate market and technology insight into evaluable concepts.",
+             ["BC-800", "BC-810"]),
+            ("BP-20.30", "2.3", "Develop Products and Services",
+             "Design, engineer, and validate products and services from concept through release readiness, including IP protection.",
+             ["BC-810", "BC-820", "BC-840"]),
+            ("BP-20.40", "2.4", "Test Market for New or Revised Products and Services",
+             "Validate concept-market fit through market trials, pilots, and customer testing before full-scale launch.",
+             ["BC-820", "BC-400"]),
+            ("BP-20.50", "2.5", "Prepare for Production",
+             "Industrialise the design, qualify the supply base, and ready operations to produce or deliver at commercial scale.",
+             ["BC-820", "BC-520"]),
+        ],
+    },
+    {
+        "id": "BP-30",
+        "apqc": "3.0",
+        "name": "Market and Sell Products and Services",
+        "description": "Understand markets and customers, set marketing and sales strategy, and execute the demand-creation and order-capture activities that monetise products and services.",
+        "realizes": ["BC-400", "BC-410", "BC-420", "BC-440"],
+        "children": [
+            ("BP-30.10", "3.1", "Understand Markets, Customers, and Capabilities",
+             "Develop the evidence base on market dynamics, customer needs, segments, and competitive position that drives marketing and sales decisions.",
+             ["BC-400", "BC-420"]),
+            ("BP-30.20", "3.2", "Develop Marketing Strategy",
+             "Define target segments, value propositions, brand positioning, and channel mix that direct marketing investment.",
+             ["BC-400"]),
+            ("BP-30.30", "3.3", "Develop Sales Strategy",
+             "Define sales coverage, channel structure, account strategy, and quota/incentive design.",
+             ["BC-410"]),
+            ("BP-30.40", "3.4", "Develop and Manage Marketing Plans",
+             "Plan, execute, and measure marketing campaigns and demand-generation programs that deliver pipeline against the strategy.",
+             ["BC-400"]),
+            ("BP-30.50", "3.5", "Develop and Manage Sales Plans",
+             "Plan, execute, and manage the sales motion: account planning, opportunity management, pricing, quoting, and order capture.",
+             ["BC-410", "BC-440"]),
+        ],
+    },
+    {
+        "id": "BP-40",
+        "apqc": "4.0",
+        "name": "Deliver Physical Products",
+        "description": "Plan and run the physical supply chain end-to-end: procurement, production, and outbound logistics that move goods from suppliers to customers.",
+        "realizes": ["BC-520", "BC-530"],
+        "children": [
+            ("BP-40.10", "4.1", "Plan for and Align Supply Chain Resources",
+             "Forecast demand, plan supply, balance capacity, and align inventory positions to meet service-level and cost targets.",
+             ["BC-520", "BC-530"]),
+            ("BP-40.20", "4.2", "Procure Materials and Services",
+             "Source, contract, and acquire goods and services from suppliers, including supplier qualification and ongoing supplier management.",
+             ["BC-500", "BC-510"]),
+            ("BP-40.30", "4.3", "Produce/Manufacture/Deliver Product",
+             "Convert inputs into finished products through production scheduling, manufacturing operations, and quality control.",
+             ["BC-520", "BC-720"]),
+            ("BP-40.40", "4.4", "Manage Logistics and Warehousing",
+             "Run the inbound, internal, and outbound flow of goods: warehousing, transport, fulfilment, and reverse logistics.",
+             ["BC-520", "BC-530"]),
+        ],
+    },
+    {
+        "id": "BP-50",
+        "apqc": "5.0",
+        "name": "Deliver Services",
+        "description": "Govern, plan, and execute the delivery of services to customers — including the resourcing, operations, and post-delivery management distinct from physical-goods supply chains.",
+        "realizes": ["BC-430", "BC-720"],
+        "children": [
+            ("BP-50.10", "5.1", "Establish Service Delivery Governance and Strategy",
+             "Define service-delivery operating model, governance forums, and service strategy aligned to customer outcomes and SLAs.",
+             ["BC-100", "BC-720"]),
+            ("BP-50.20", "5.2", "Manage Service Delivery Resources",
+             "Plan, allocate, and develop the people, facilities, and infrastructure that deliver service.",
+             ["BC-300", "BC-700"]),
+            ("BP-50.30", "5.3", "Deliver Service to Customer",
+             "Execute the service interaction with the customer end-to-end, including provisioning, support, and assurance.",
+             ["BC-430"]),
+            ("BP-50.40", "5.4", "Manage Service Delivery",
+             "Monitor, assure, and improve service delivery against SLAs and customer-experience targets.",
+             ["BC-430", "BC-720"]),
+        ],
+    },
+    {
+        "id": "BP-60",
+        "apqc": "6.0",
+        "name": "Manage Customer Service",
+        "description": "Develop and run the customer-care function: strategy, contact-center operations, and continuous evaluation that resolves customer issues and protects loyalty.",
+        "realizes": ["BC-430", "BC-420"],
+        "children": [
+            ("BP-60.10", "6.1", "Develop Customer Care/Customer Service Strategy",
+             "Define the customer-service operating model, channels, service levels, and self-service strategy.",
+             ["BC-430", "BC-100"]),
+            ("BP-60.20", "6.2", "Plan and Manage Customer Service Operations",
+             "Run day-to-day customer service operations: contact handling, case management, escalation, and workforce management.",
+             ["BC-430"]),
+            ("BP-60.30", "6.3", "Measure and Evaluate Customer Service Operations",
+             "Measure service performance, customer satisfaction, and operational efficiency; drive continuous improvement.",
+             ["BC-430", "BC-720"]),
+        ],
+    },
+    {
+        "id": "BP-70",
+        "apqc": "7.0",
+        "name": "Develop and Manage Human Capital",
+        "description": "Manage the workforce end-to-end: HR strategy, recruitment, development, reward, redeployment, and employee data and inquiries.",
+        "realizes": ["BC-300"],
+        "children": [
+            ("BP-70.10", "7.1", "Develop and Manage Human Resources Planning, Policies, and Strategies",
+             "Set HR strategy, workforce plans, and policies aligned to business strategy and regulatory obligations.",
+             ["BC-300"]),
+            ("BP-70.20", "7.2", "Recruit, Source, and Select Employees",
+             "Attract, assess, and hire candidates to fill workforce demand, including onboarding readiness.",
+             ["BC-300"]),
+            ("BP-70.30", "7.3", "Develop and Counsel Employees",
+             "Onboard, train, develop, and coach employees across their tenure to build capability and engagement.",
+             ["BC-300"]),
+            ("BP-70.40", "7.4", "Reward and Retain Employees",
+             "Design and operate compensation, benefits, recognition, and retention programs.",
+             ["BC-300"]),
+            ("BP-70.50", "7.5", "Redeploy and Retire Employees",
+             "Manage transitions: internal mobility, redeployment, separations, and retirement.",
+             ["BC-300"]),
+            ("BP-70.60", "7.6", "Manage Employee Information and Analytics",
+             "Maintain employee master data and produce workforce analytics that inform decisions.",
+             ["BC-300", "BC-610"]),
+            ("BP-70.70", "7.7", "Manage Employee Inquiries",
+             "Resolve employee questions and service requests via HR shared-service or case-management channels.",
+             ["BC-300"]),
+        ],
+    },
+    {
+        "id": "BP-80",
+        "apqc": "8.0",
+        "name": "Manage Information Technology",
+        "description": "Run the enterprise IT function: strategy, build, deploy, run, and knowledge management — including IT-side risk and resilience that protects business continuity.",
+        "realizes": ["BC-600", "BC-610", "BC-620"],
+        "children": [
+            ("BP-80.10", "8.1", "Develop and Manage Business Resilience and Risk",
+             "Identify, assess, and mitigate IT-related risks; maintain business-continuity and disaster-recovery readiness for technology-enabled operations.",
+             ["BC-160", "BC-120", "BC-620"]),
+            ("BP-80.20", "8.2", "Develop Information Technology (IT) Strategy",
+             "Set the IT strategy, target architecture, and investment plan that supports the business strategy.",
+             ["BC-600", "BC-170"]),
+            ("BP-80.30", "8.3", "Develop and Maintain Information Technology Solutions",
+             "Design, build, integrate, and evolve the application and infrastructure portfolio that runs the business.",
+             ["BC-600"]),
+            ("BP-80.40", "8.4", "Deploy Information Technology Solutions",
+             "Release new and changed IT solutions into production with appropriate change controls and adoption support.",
+             ["BC-600", "BC-910"]),
+            ("BP-80.50", "8.5", "Deliver and Support Information Technology Services",
+             "Operate IT services day-to-day: incident, problem, request, and service-level management.",
+             ["BC-600"]),
+            ("BP-80.60", "8.6", "Manage IT Knowledge",
+             "Capture and curate IT knowledge: configuration data, runbooks, architecture, and support knowledge bases.",
+             ["BC-830", "BC-600"]),
+        ],
+    },
+    {
+        "id": "BP-90",
+        "apqc": "9.0",
+        "name": "Manage Financial Resources",
+        "description": "Run enterprise finance end-to-end: planning and management accounting, transaction processing (revenue, AP, payroll), reporting, treasury, controls, tax, and consolidation.",
+        "realizes": ["BC-200", "BC-230", "BC-210", "BC-220"],
+        "children": [
+            ("BP-90.10", "9.1", "Perform Planning and Management Accounting",
+             "Plan, budget, forecast, and produce management-accounting analyses that drive business decisions.",
+             ["BC-230"]),
+            ("BP-90.20", "9.2", "Perform Revenue Accounting",
+             "Recognise, record, and report revenue in accordance with accounting standards and contract terms.",
+             ["BC-200"]),
+            ("BP-90.30", "9.3", "Perform General Accounting and Reporting",
+             "Maintain the general ledger, perform period-end close, and produce statutory and management financial reports.",
+             ["BC-200"]),
+            ("BP-90.40", "9.4", "Manage Fixed-Asset Project Accounting",
+             "Account for capital projects and fixed assets across acquisition, depreciation, impairment, and disposal.",
+             ["BC-200", "BC-900"]),
+            ("BP-90.50", "9.5", "Process Payroll",
+             "Calculate, pay, and report employee compensation, including statutory withholdings and benefits accounting.",
+             ["BC-300", "BC-200"]),
+            ("BP-90.60", "9.6", "Process Accounts Payable and Expense Reimbursements",
+             "Validate, approve, and pay supplier invoices and employee expense claims.",
+             ["BC-200", "BC-500"]),
+            ("BP-90.70", "9.7", "Manage Treasury Operations",
+             "Manage cash, liquidity, banking, debt, investments, and financial-risk hedging.",
+             ["BC-210"]),
+            ("BP-90.80", "9.8", "Manage Internal Controls",
+             "Design, operate, and assure financial internal controls aligned to regulatory and assurance requirements.",
+             ["BC-140", "BC-130"]),
+            ("BP-90.90", "9.9", "Manage Taxes",
+             "Determine, file, and pay direct, indirect, and transactional taxes; manage tax controversy and planning.",
+             ["BC-220"]),
+            ("BP-90.100", "9.10", "Manage International Funds/Consolidation",
+             "Translate, consolidate, and report multi-entity, multi-currency results.",
+             ["BC-200", "BC-210"]),
+        ],
+    },
+    {
+        "id": "BP-100",
+        "apqc": "10.0",
+        "name": "Acquire, Construct, and Manage Assets",
+        "description": "Plan, acquire, construct, maintain, and dispose of productive assets — facilities, plant, real estate, and similar long-lived enterprise assets.",
+        "realizes": ["BC-700", "BC-710"],
+        "children": [
+            ("BP-100.10", "10.1", "Plan and Acquire Assets",
+             "Plan asset needs, evaluate buy/lease alternatives, and acquire productive assets.",
+             ["BC-710", "BC-700"]),
+            ("BP-100.20", "10.2", "Design and Construct Productive Assets",
+             "Design, construct, and commission productive assets — facilities, plant, and infrastructure.",
+             ["BC-700", "BC-720"]),
+            ("BP-100.30", "10.3", "Maintain Productive Assets",
+             "Operate and maintain productive assets across their useful life: planned, preventive, and corrective maintenance.",
+             ["BC-700"]),
+            ("BP-100.40", "10.4", "Dispose of Productive Assets",
+             "Decommission and dispose of assets at end-of-life, including environmental and remarketing considerations.",
+             ["BC-710", "BC-740"]),
+        ],
+    },
+    {
+        "id": "BP-110",
+        "apqc": "11.0",
+        "name": "Manage Enterprise Risk, Compliance, Remediation, and Resiliency",
+        "description": "Run enterprise risk, compliance, business resilience, and EHS programs that protect the enterprise from financial, operational, regulatory, and safety threats.",
+        "realizes": ["BC-120", "BC-130", "BC-160", "BC-730"],
+        "children": [
+            ("BP-110.10", "11.1", "Manage Enterprise Risk",
+             "Identify, assess, treat, and monitor enterprise risk across financial, operational, strategic, and compliance dimensions.",
+             ["BC-120", "BC-140"]),
+            ("BP-110.20", "11.2", "Manage Business Resiliency",
+             "Maintain business-continuity and disaster-recovery capabilities; respond to and recover from disruptive events.",
+             ["BC-160"]),
+            ("BP-110.30", "11.3", "Manage Environmental, Health, and Safety (EHS)",
+             "Run EHS programs that protect employees, communities, and the environment, including incident response and regulatory reporting.",
+             ["BC-730", "BC-740"]),
+        ],
+    },
+    {
+        "id": "BP-120",
+        "apqc": "12.0",
+        "name": "Manage External Relationships",
+        "description": "Manage the enterprise's relationships with external stakeholders: investors, government, board, legal, ethical, and public-relations counterparts.",
+        "realizes": ["BC-240", "BC-150", "BC-850", "BC-110"],
+        "children": [
+            ("BP-120.10", "12.1", "Build Investor Relationships",
+             "Engage with current and prospective investors, analysts, and rating agencies; manage investor communications and disclosures.",
+             ["BC-240"]),
+            ("BP-120.20", "12.2", "Manage Government and Industry Relationships",
+             "Engage with regulators, government bodies, and industry associations on policy, lobbying, and regulatory matters.",
+             ["BC-150", "BC-850"]),
+            ("BP-120.30", "12.3", "Manage Relations with Board of Directors",
+             "Support the board: agendas, materials, governance processes, and director engagement.",
+             ["BC-110", "BC-240"]),
+            ("BP-120.40", "12.4", "Manage Legal and Ethical Issues",
+             "Manage legal matters, contracts, litigation, ethics programs, and corporate-conduct standards.",
+             ["BC-150", "BC-130"]),
+            ("BP-120.50", "12.5", "Manage Public Relations Program",
+             "Run external communications, media relations, brand reputation, and crisis communications.",
+             ["BC-850"]),
+        ],
+    },
+]
+
+
+def build_yaml(bp1: dict) -> str:
+    """Build a YAML document string for one BP1 file. We assemble manually to
+    control field order — schema 'children' must come last, framework_refs
+    inline-readable."""
+    lines = []
+    lines.append(f"id: {bp1['id']}")
+    lines.append(f"name: {bp1['name']}")
+    lines.append("level: 1")
+    lines.append("industry: Cross-Industry")
+    # description as a folded scalar
+    lines.append("description: >-")
+    lines.append(f"  {bp1['description']}")
+    # framework_refs
+    lines.append("framework_refs:")
+    lines.append("  - framework: APQC-PCF")
+    lines.append(f"    external_id: \"{bp1['apqc']}\"")
+    lines.append(f"    version: \"{APQC_VERSION}\"")
+    # realizes_capability_ids
+    lines.append("realizes_capability_ids:")
+    for bc in bp1["realizes"]:
+        lines.append(f"  - {bc}")
+    # children
+    lines.append("children:")
+    for cid, capqc, cname, cdesc, crealizes in bp1["children"]:
+        lines.append(f"  - id: {cid}")
+        lines.append(f"    name: {cname}")
+        lines.append("    level: 2")
+        lines.append("    description: >-")
+        lines.append(f"      {cdesc}")
+        lines.append("    framework_refs:")
+        lines.append("      - framework: APQC-PCF")
+        lines.append(f"        external_id: \"{capqc}\"")
+        lines.append(f"        version: \"{APQC_VERSION}\"")
+        lines.append("    realizes_capability_ids:")
+        for bc in crealizes:
+            lines.append(f"      - {bc}")
+        lines.append("    children: []")
+    return "\n".join(lines) + "\n"
+
+
+def main():
+    os.makedirs(PROCESSES_DIR, exist_ok=True)
+    written = []
+    for bp1 in TREE:
+        slug = slugify(bp1["name"])
+        path = os.path.join(PROCESSES_DIR, f"BP1-{slug}.yaml")
+        # Sanity-check the slug round-trips through YAML
+        content = build_yaml(bp1)
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(content)
+        written.append(f"BP1-{slug}.yaml")
+    # Update _index.yaml
+    index_path = os.path.join(PROCESSES_DIR, "_index.yaml")
+    with open(index_path, "w", encoding="utf-8") as fh:
+        fh.write("# Index of business-process L1 (BP1) files. Lint enforces every BP1 file is registered here.\n")
+        fh.write("files:\n")
+        for f in sorted(written):
+            fh.write(f"  - {f}\n")
+    total_children = sum(len(bp1["children"]) for bp1 in TREE)
+    print(f"✔ Wrote {len(written)} BP1 file(s), {total_children} BP2 child(ren), updated _index.yaml")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Stacked on top of #TBD (the BP/VS infrastructure PR). Populates the empty business-process catalogue with **12 BP1 (Category) files and their 59 BP2 (Process Group) children** anchored on APQC PCF Cross-Industry v7.4.0.

- **71 process nodes** total (12 BP1 + 59 BP2).
- Every node carries `framework_refs` pinning the APQC PCF code (e.g. `{framework: APQC-PCF, external_id: "9.3", version: "7.4.0"}`).
- Every node carries `realizes_capability_ids` linking to the Cross-Industry L1 capabilities it realises. The reverse index `Capability.realizes_processes` is populated automatically at build time — capability detail pages now light up the *Realized by Processes* section.

## Coverage

| BP1 id | Name | APQC code | BP2 count |
|---|---|---|---|
| `BP-10` | Develop Vision and Strategy | 1.0 | 3 |
| `BP-20` | Develop and Manage Products and Services | 2.0 | 5 |
| `BP-30` | Market and Sell Products and Services | 3.0 | 5 |
| `BP-40` | Deliver Physical Products | 4.0 | 4 |
| `BP-50` | Deliver Services | 5.0 | 4 |
| `BP-60` | Manage Customer Service | 6.0 | 3 |
| `BP-70` | Develop and Manage Human Capital | 7.0 | 7 |
| `BP-80` | Manage Information Technology | 8.0 | 6 |
| `BP-90` | Manage Financial Resources | 9.0 | 10 |
| `BP-100` | Acquire, Construct, and Manage Assets | 10.0 | 4 |
| `BP-110` | Manage Enterprise Risk, Compliance, Remediation, and Resiliency | 11.0 | 3 |
| `BP-120` | Manage External Relationships | 12.0 | 5 |

Drilling deeper to BP3 (Process) and BP4 (Activity) is intentionally deferred to follow-up PRs — one per category — to keep diffs reviewable.

## Attribution

APQC permits PCF use with attribution. Added a top-level `NOTICE` file with the standard APQC attribution and the trademark statement; linked from `README.md` § Licence. Names and definitions are derived from APQC PCF and adapted to this catalogue's governance conventions (verb-phrased Title Case, sparse `BP-N0[.M0]` ids, depth-4 cap, MECE within parent). Where wording differs from APQC's, the `framework_refs.external_id` pin remains authoritative for cross-walks.

## Generator script

`scripts/import_apqc_pcf.py` is the one-shot generator used to author the 12 files in one pass with consistent BP→BC mappings. Should be archived under `scripts/_archive/` in a follow-up PR — further authoring goes through `npm run bp:add` per the governance model.

## Test plan

- [x] `npm run lint` passes (320 L1 + 9329 caps + 12 BP1 + 71 BPs + 64 VS + 2240 sidecars)
- [x] `npm run build` succeeds; site builds 9738 pages (was 9655)
- [x] Python smoke: `get_processes_for_capability("BC-300")` returns 10 BPs (HR-related, payroll, service-resource management — all reasonable)
- [x] `dist/api/business-processes.json` and `dist/api/bp-tree.json` populated; `dist/api/business-process/<id>.json` per node emitted
- [ ] Spot-check a few capability detail pages — *Realized by Processes* section should now render
- [ ] Spot-check `/business-processes` index and a BP detail page
- [ ] Verify APQC attribution wording in `NOTICE` is acceptable

## Follow-ups (not in this PR)

- BP3/BP4 drill-down per category (12 PRs, one each).
- Wire `process_ids` into existing value-stream stages (currently all empty arrays).
- Industry-specific PCFs (Banking, Telecom, Insurance) as separate BP1 files.
- Archive `scripts/import_apqc_pcf.py` and `scripts/migrate_value_streams.ts` under `scripts/_archive/`.

https://claude.ai/code/session_01KAHq1ASy4kzYuAGXJYxQrF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAHq1ASy4kzYuAGXJYxQrF)_