### PR TITLE
Wire process_ids into 5 canonical Cross-Industry value streams

### DIFF
--- a/catalogue/_value-streams.yaml
+++ b/catalogue/_value-streams.yaml
@@ -8,8166 +8,8454 @@
 # Each stream declares an `industries` array using the canonical L1 industry
 # vocabulary. `Cross-Industry`, when present, must stand alone.
 value_streams:
-  - id: VS-10
-    name: Acquire-to-Retire
-    industries:
-      - Cross-Industry
-    stages:
-      - id: VS-10.10
-        stage_order: 1
-        stage_name: Asset Need & Justification
-        capability_ids:
-          - BC-1040
-          - BC-230
-        process_ids: []
-        notes: Asset strategy / lifecycle plan; CAPEX business case
-      - id: VS-10.20
-        stage_order: 1
-        stage_name: Asset Need & Justification
-        capability_ids:
-          - BC-3540
-        process_ids: []
-        industry_variant: Agriculture
-        notes: Land acquisition or lease and equipment fleet planning
-      - id: VS-10.30
-        stage_order: 1
-        stage_name: Asset Need & Justification
-        capability_ids:
-          - BC-3480
-        process_ids: []
-        industry_variant: Automotive
-        notes: Charging site selection and business case
-      - id: VS-10.40
-        stage_order: 1
-        stage_name: Asset Need & Justification
-        capability_ids:
-          - BC-3000
-          - BC-3010
-        process_ids: []
-        industry_variant: Oil & Gas
-        notes: License and seismic acquisition decision; Field development plan and FID
-      - id: VS-10.50
-        stage_order: 1
-        stage_name: Asset Need & Justification
-        capability_ids:
-          - BC-2350
-        process_ids: []
-        industry_variant: Retail & Consumer Goods
-        notes: Catchment, format, and network business case
-      - id: VS-10.60
-        stage_order: 1
-        stage_name: Asset Need & Justification
-        capability_ids:
-          - BC-2610
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Site identification and rollout business case
-      - id: VS-10.70
-        stage_order: 1
-        stage_name: Asset Need & Justification
-        capability_ids:
-          - BC-2430
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: Fleet specification and renewal plan
-      - id: VS-10.80
-        stage_order: 1
-        stage_name: Asset Need & Justification
-        capability_ids:
-          - BC-3900
-        process_ids: []
-        industry_variant: Utilities
-        notes: RAB-aligned network investment plan and CBA
-      - id: VS-10.90
-        stage_order: 2
-        stage_name: Acquisition
-        capability_ids:
-          - BC-500
-        process_ids: []
-        notes: Capital procurement
-      - id: VS-10.100
-        stage_order: 2
-        stage_name: Acquisition
-        capability_ids:
-          - BC-3540
-        process_ids: []
-        industry_variant: Agriculture
-        notes: Land lease, equipment purchase, and irrigation infrastructure build
-      - id: VS-10.110
-        stage_order: 2
-        stage_name: Acquisition
-        capability_ids:
-          - BC-3480
-        process_ids: []
-        industry_variant: Automotive
-        notes: Charger installation and grid connection
-      - id: VS-10.120
-        stage_order: 2
-        stage_name: Acquisition
-        capability_ids:
-          - BC-4610
-        process_ids: []
-        industry_variant: Chemicals
-        notes: Chemical plant FEED and basic engineering
-      - id: VS-10.130
-        stage_order: 2
-        stage_name: Acquisition
-        capability_ids:
-          - BC-1110
-        process_ids: []
-        industry_variant: Engineering Services
-        notes: Project engineering for build assets
-      - id: VS-10.140
-        stage_order: 2
-        stage_name: Acquisition
-        capability_ids:
-          - BC-2020
-        process_ids: []
-        industry_variant: HVAC & Building Automation Systems
-        notes: Project-level HVAC integration during build
-      - id: VS-10.150
-        stage_order: 2
-        stage_name: Acquisition
-        capability_ids:
-          - BC-3020
-        process_ids: []
-        industry_variant: Oil & Gas
-        notes: Capex execution to drill and complete wells
-      - id: VS-10.160
-        stage_order: 2
-        stage_name: Acquisition
-        capability_ids:
-          - BC-2610
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Site acquisition, build approval, and rollout scheduling
-      - id: VS-10.170
-        stage_order: 2
-        stage_name: Acquisition
-        capability_ids:
-          - BC-2430
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: Fleet procurement, lease, and charter
-      - id: VS-10.180
-        stage_order: 2
-        stage_name: Acquisition
-        capability_ids:
-          - BC-3900
-        process_ids: []
-        industry_variant: Utilities
-        notes: Network capital procurement and project execution
-      - id: VS-10.190
-        stage_order: 3
-        stage_name: Commissioning & Capitalisation
-        capability_ids:
-          - BC-200
-        process_ids: []
-        notes: Capitalisation / fixed asset register
-      - id: VS-10.200
-        stage_order: 3
-        stage_name: Commissioning & Capitalisation
-        capability_ids:
-          - BC-1960
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: OEM-led FAT / SAT / energisation
-      - id: VS-10.210
-        stage_order: 3
-        stage_name: Commissioning & Capitalisation
-        capability_ids:
-          - BC-1160
-        process_ids: []
-        industry_variant: Engineering Services
-        notes: Commissioning & handover
-      - id: VS-10.220
-        stage_order: 3
-        stage_name: Commissioning & Capitalisation
-        capability_ids:
-          - BC-2050
-        process_ids: []
-        industry_variant: HVAC & Building Automation Systems
-        notes: HVAC/BAS Cx, retro-Cx, MBCx
-      - id: VS-10.230
-        stage_order: 3
-        stage_name: Commissioning & Capitalisation
-        capability_ids:
-          - BC-3030
-        process_ids: []
-        industry_variant: Oil & Gas
-        notes: Field/facility startup and first oil/gas
-      - id: VS-10.240
-        stage_order: 4
-        stage_name: Operate & Maintain
-        capability_ids:
-          - BC-1030
-          - BC-1040
-        process_ids: []
-        notes: Preventive maintenance; Predictive maintenance; Asset performance monitoring
-      - id: VS-10.250
-        stage_order: 4
-        stage_name: Operate & Maintain
-        capability_ids:
-          - BC-3540
-        process_ids: []
-        industry_variant: Agriculture
-        notes: Day-to-day operation of farm assets and ISOBUS telemetry
-      - id: VS-10.260
-        stage_order: 4
-        stage_name: Operate & Maintain
-        capability_ids:
-          - BC-3480
-        process_ids: []
-        industry_variant: Automotive
-        notes: Charge-point operations and uptime
-      - id: VS-10.270
-        stage_order: 4
-        stage_name: Operate & Maintain
-        capability_ids:
-          - BC-4620
-        process_ids: []
-        industry_variant: Chemicals
-        notes: Day-to-day chemical plant operation
-      - id: VS-10.280
-        stage_order: 4
-        stage_name: Operate & Maintain
-        capability_ids:
-          - BC-1960
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Remote condition monitoring services
-      - id: VS-10.290
-        stage_order: 4
-        stage_name: Operate & Maintain
-        capability_ids:
-          - BC-2060
-          - BC-2070
-        process_ids: []
-        industry_variant: HVAC & Building Automation Systems
-        notes: OEM/contractor service on installed HVAC + BAS; Continuous M&V, FDD, performance improvement
-      - id: VS-10.300
-        stage_order: 4
-        stage_name: Operate & Maintain
-        capability_ids:
-          - BC-3030
-          - BC-3060
-          - BC-3070
-          - BC-3080
-        process_ids: []
-        industry_variant: Oil & Gas
-        notes: Producing-asset operations; Pipeline operations and integrity; Gas plant and LNG operations; Refinery operations
-      - id: VS-10.310
-        stage_order: 4
-        stage_name: Operate & Maintain
-        capability_ids:
-          - BC-2600
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Network fault, change, performance, and optimisation
-      - id: VS-10.320
-        stage_order: 4
-        stage_name: Operate & Maintain
-        capability_ids:
-          - BC-2430
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: Fleet utilisation, telematics, and maintenance
-      - id: VS-10.330
-        stage_order: 4
-        stage_name: Operate & Maintain
-        capability_ids:
-          - BC-3800
-          - BC-3810
-          - BC-3820
-          - BC-3870
-          - BC-3880
-          - BC-3890
-        process_ids: []
-        industry_variant: Utilities
-        notes: Generation fleet operations and surveillance; Transmission grid operation, switching, and substation surveillance; Distribution network operation, vegetation, and inspection; Water treatment plant operation and process control; Water distribution network operation and mains repair; Sewer network and wastewater treatment plant operation
-      - id: VS-10.340
-        stage_order: 5
-        stage_name: Risk & Reliability
-        capability_ids:
-          - BC-1030
-          - BC-1040
-        process_ids: []
-        notes: Reliability engineering; Criticality / risk
-      - id: VS-10.350
-        stage_order: 5
-        stage_name: Risk & Reliability
-        capability_ids:
-          - BC-3480
-        process_ids: []
-        industry_variant: Automotive
-        notes: Charger reliability and uptime engineering
-      - id: VS-10.360
-        stage_order: 5
-        stage_name: Risk & Reliability
-        capability_ids:
-          - BC-4640
-        process_ids: []
-        industry_variant: Chemicals
-        notes: Mechanical integrity and SIS reliability assurance
-      - id: VS-10.370
-        stage_order: 5
-        stage_name: Risk & Reliability
-        capability_ids:
-          - BC-1780
-        process_ids: []
-        industry_variant: Defense
-        notes: RAM engineering
-      - id: VS-10.380
-        stage_order: 5
-        stage_name: Risk & Reliability
-        capability_ids:
-          - BC-1970
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Reliability & MTBF on installed base
-      - id: VS-10.390
-        stage_order: 5
-        stage_name: Risk & Reliability
-        capability_ids:
-          - BC-3050
-        process_ids: []
-        industry_variant: Oil & Gas
-        notes: SCE assurance and mechanical integrity
-      - id: VS-10.400
-        stage_order: 5
-        stage_name: Risk & Reliability
-        capability_ids:
-          - BC-2430
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: Mandatory inspection and airworthiness or seaworthiness
-      - id: VS-10.410
-        stage_order: 5
-        stage_name: Risk & Reliability
-        capability_ids:
-          - BC-3900
-        process_ids: []
-        industry_variant: Utilities
-        notes: Asset health scoring, criticality, and monetised risk
-      - id: VS-10.420
-        stage_order: 6
-        stage_name: Asset Information Maintenance
-        capability_ids:
-          - BC-1040
-        process_ids: []
-        notes: Asset master data
-      - id: VS-10.430
-        stage_order: 6
-        stage_name: Asset Information Maintenance
-        capability_ids:
-          - BC-3540
-        process_ids: []
-        industry_variant: Agriculture
-        notes: Field, parcel, and equipment master data
-      - id: VS-10.440
-        stage_order: 6
-        stage_name: Asset Information Maintenance
-        capability_ids:
-          - BC-3710
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Metadata, identifier, and version lineage stewardship
-      - id: VS-10.450
-        stage_order: 6
-        stage_name: Asset Information Maintenance
-        capability_ids:
-          - BC-3900
-        process_ids: []
-        industry_variant: Utilities
-        notes: Network asset register, GIS, and as-built records
-      - id: VS-10.460
-        stage_order: 7
-        stage_name: Decommissioning & Disposal
-        capability_ids:
-          - BC-1040
-          - BC-740
-        process_ids: []
-        notes: Decommissioning / disposal; Circular economy / recycling
-      - id: VS-10.470
-        stage_order: 7
-        stage_name: Decommissioning & Disposal
-        capability_ids:
-          - BC-3540
-        process_ids: []
-        industry_variant: Agriculture
-        notes: Equipment disposal and lease end-of-term
-      - id: VS-10.480
-        stage_order: 7
-        stage_name: Decommissioning & Disposal
-        capability_ids:
-          - BC-1980
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: WEEE take-back, remanufacture, reuse
-      - id: VS-10.490
-        stage_order: 7
-        stage_name: Decommissioning & Disposal
-        capability_ids:
-          - BC-3710
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Archive sunset, master deletion, and rights-driven take-down
-      - id: VS-10.500
-        stage_order: 7
-        stage_name: Decommissioning & Disposal
-        capability_ids:
-          - BC-4470
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Mine site dismantling, asset disposal, clean-up, and post-closure stewardship
-      - id: VS-10.510
-        stage_order: 7
-        stage_name: Decommissioning & Disposal
-        capability_ids:
-          - BC-3120
-        process_ids: []
-        industry_variant: Oil & Gas
-        notes: Well plug and abandonment, facility removal
-      - id: VS-10.520
-        stage_order: 7
-        stage_name: Decommissioning & Disposal
-        capability_ids:
-          - BC-2610
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Legacy network decommissioning and technology sunset
-      - id: VS-10.530
-        stage_order: 7
-        stage_name: Decommissioning & Disposal
-        capability_ids:
-          - BC-2430
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: Fleet end-of-life disposal and resale
-      - id: VS-10.540
-        stage_order: 7
-        stage_name: Decommissioning & Disposal
-        capability_ids:
-          - BC-3900
-        process_ids: []
-        industry_variant: Utilities
-        notes: Network decommissioning, abandonment, and reinstatement planning
-  - id: VS-20
-    name: Adverse-Event-to-Action
-    industries:
-      - Pharmaceuticals & Life Sciences
-    stages:
-      - id: VS-20.10
-        stage_order: 1
-        stage_name: Case Intake
-        capability_ids:
-          - BC-1540
-        process_ids: []
-        industry_variant: Pharma
-        notes: Adverse event capture
-      - id: VS-20.20
-        stage_order: 2
-        stage_name: Case Triage & Coding
-        capability_ids:
-          - BC-1540
-        process_ids: []
-        industry_variant: Pharma
-        notes: MedDRA coding, seriousness assessment
-      - id: VS-20.30
-        stage_order: 3
-        stage_name: Causality & Medical Review
-        capability_ids:
-          - BC-1580
-        process_ids: []
-        industry_variant: Pharma
-        notes: Medical affairs review
-      - id: VS-20.40
-        stage_order: 4
-        stage_name: Signal Detection
-        capability_ids:
-          - BC-1540
-        process_ids: []
-        industry_variant: Pharma
-        notes: Signal detection & evaluation
-      - id: VS-20.50
-        stage_order: 5
-        stage_name: Risk Assessment & RMP Update
-        capability_ids:
-          - BC-1540
-        process_ids: []
-        industry_variant: Pharma
-        notes: Risk management plan
-      - id: VS-20.60
-        stage_order: 6
-        stage_name: Regulatory Reporting
-        capability_ids:
-          - BC-1530
-          - BC-1540
-        process_ids: []
-        industry_variant: Pharma
-        notes: Agency notification; Periodic safety reports
-      - id: VS-20.70
-        stage_order: 7
-        stage_name: Label & Communication Updates
-        capability_ids:
-          - BC-850
-        process_ids: []
-        notes: Stakeholder communications
-      - id: VS-20.80
-        stage_order: 7
-        stage_name: Label & Communication Updates
-        capability_ids:
-          - BC-1530
-        process_ids: []
-        industry_variant: Pharma
-        notes: Labelling change
-      - id: VS-20.90
-        stage_order: 8
-        stage_name: Audit & Inspection Readiness
-        capability_ids:
-          - BC-1540
-        process_ids: []
-        industry_variant: Pharma
-        notes: PV audit
-  - id: VS-30
-    name: Application-to-Benefit
-    industries:
-      - Public Sector & Government
-    stages:
-      - id: VS-30.10
-        stage_order: 1
-        stage_name: Programme Configuration
-        capability_ids:
-          - BC-3230
-        process_ids: []
-        notes: Eligibility rules, benefit formulae, and indexation parameters
-      - id: VS-30.20
-        stage_order: 2
-        stage_name: Application Intake
-        capability_ids:
-          - BC-3230
-          - BC-3220
-        process_ids: []
-        notes: Receipt of benefit applications across channels; Citizen-service channels supporting assisted application
-      - id: VS-30.30
-        stage_order: 3
-        stage_name: Eligibility Determination
-        capability_ids:
-          - BC-3230
-        process_ids: []
-        notes: Means testing, categorical eligibility, decision and notification
-      - id: VS-30.40
-        stage_order: 4
-        stage_name: Award Calculation
-        capability_ids:
-          - BC-3230
-        process_ids: []
-        notes: Contribution-record assessment, award calculation, and issuance
-      - id: VS-30.50
-        stage_order: 5
-        stage_name: Disbursement
-        capability_ids:
-          - BC-3230
-        process_ids: []
-        notes: Payment runs across bank, prepaid card, and in-kind channels
-      - id: VS-30.60
-        stage_order: 6
-        stage_name: Continuing Eligibility
-        capability_ids:
-          - BC-3230
-        process_ids: []
-        notes: Change of circumstances, periodic redetermination, conditionality
-      - id: VS-30.70
-        stage_order: 7
-        stage_name: Overpayment & Recovery
-        capability_ids:
-          - BC-3230
-        process_ids: []
-        notes: Overpayment detection, recovery plans, and debt collection
-      - id: VS-30.80
-        stage_order: 8
-        stage_name: Fraud Investigation
-        capability_ids:
-          - BC-3230
-        process_ids: []
-        notes: Fraud detection, investigation, and sanction
-  - id: VS-40
-    name: Application-to-Funding
-    industries:
-      - Banking & Capital Markets
-      - Real Estate
-    stages:
-      - id: VS-40.10
-        stage_order: 1
-        stage_name: Application Capture
-        capability_ids:
-          - BC-1300
-          - BC-1320
-        process_ids: []
-        industry_variant: Banking
-        notes: Channel intake (digital, branch); Origination intake
-      - id: VS-40.20
-        stage_order: 1
-        stage_name: Application Capture
-        capability_ids:
-          - BC-4980
-        process_ids: []
-        industry_variant: Real Estate
-        notes: CRE debt origination intake — senior, mezz, construction, and bridge loans
-      - id: VS-40.30
-        stage_order: 2
-        stage_name: KYC & Due Diligence
-        capability_ids:
-          - BC-1300
-          - BC-1400
-        process_ids: []
-        industry_variant: Banking
-        notes: KYC / CDD; Sanctions screening
-      - id: VS-40.40
-        stage_order: 3
-        stage_name: Underwriting & Decisioning
-        capability_ids:
-          - BC-1320
-        process_ids: []
-        industry_variant: Banking
-        notes: Credit decisioning; Credit risk model scoring
-      - id: VS-40.50
-        stage_order: 3
-        stage_name: Underwriting & Decisioning
-        capability_ids:
-          - BC-4980
-        process_ids: []
-        industry_variant: Real Estate
-        notes: CRE loan underwriting against asset and sponsor
-      - id: VS-40.60
-        stage_order: 4
-        stage_name: Pricing & Offer
-        capability_ids:
-          - BC-440
-        process_ids: []
-        notes: Discount / promotional pricing
-      - id: VS-40.70
-        stage_order: 4
-        stage_name: Pricing & Offer
-        capability_ids:
-          - BC-1310
-        process_ids: []
-        industry_variant: Banking
-        notes: Banking product configuration
-      - id: VS-40.80
-        stage_order: 5
-        stage_name: Documentation & Booking
-        capability_ids:
-          - BC-150
-        process_ids: []
-        notes: Loan agreement drafting
-      - id: VS-40.90
-        stage_order: 5
-        stage_name: Documentation & Booking
-        capability_ids:
-          - BC-1320
-        process_ids: []
-        industry_variant: Banking
-        notes: Loan booking
-      - id: VS-40.100
-        stage_order: 5
-        stage_name: Documentation & Booking
-        capability_ids:
-          - BC-4980
-        process_ids: []
-        industry_variant: Real Estate
-        notes: CRE loan boarding and servicing setup
-      - id: VS-40.110
-        stage_order: 6
-        stage_name: Disbursement
-        capability_ids:
-          - BC-1340
-        process_ids: []
-        industry_variant: Banking
-        notes: Payment initiation; Payment processing
-      - id: VS-40.120
-        stage_order: 7
-        stage_name: Servicing & Collections
-        capability_ids:
-          - BC-1320
-        process_ids: []
-        industry_variant: Banking
-        notes: Loan servicing; Collections & recoveries
-      - id: VS-40.130
-        stage_order: 7
-        stage_name: Servicing & Collections
-        capability_ids:
-          - BC-4980
-        process_ids: []
-        industry_variant: Real Estate
-        notes: CRE loan servicing and special-servicing coordination
-      - id: VS-40.140
-        stage_order: 8
-        stage_name: Portfolio Monitoring
-        capability_ids:
-          - BC-1320
-          - BC-1410
-        process_ids: []
-        industry_variant: Banking
-        notes: Loan portfolio health; Banking risk overview
-      - id: VS-40.150
-        stage_order: 8
-        stage_name: Portfolio Monitoring
-        capability_ids:
-          - BC-4980
-        process_ids: []
-        industry_variant: Real Estate
-        notes: Covenant, DSCR, and LTV monitoring across CRE loan portfolio
-  - id: VS-50
-    name: Application-to-Licence
-    industries:
-      - Public Sector & Government
-    stages:
-      - id: VS-50.10
-        stage_order: 1
-        stage_name: Application Intake
-        capability_ids:
-          - BC-3240
-          - BC-3220
-        process_ids: []
-        notes: Submission, completeness check, and fee assessment; Citizen-service channels for licence applications
-      - id: VS-50.20
-        stage_order: 2
-        stage_name: Eligibility & Qualification Assessment
-        capability_ids:
-          - BC-3240
-        process_ids: []
-        notes: Fit and proper, qualification, and background checks
-      - id: VS-50.30
-        stage_order: 3
-        stage_name: Licensing Decision
-        capability_ids:
-          - BC-3240
-        process_ids: []
-        notes: Decisioning on grant, refusal, or conditional grant
-      - id: VS-50.40
-        stage_order: 4
-        stage_name: Credential Issuance
-        capability_ids:
-          - BC-3240
-        process_ids: []
-        notes: Production and issuance of physical and digital credentials
-      - id: VS-50.50
-        stage_order: 5
-        stage_name: Inspection & Compliance Monitoring
-        capability_ids:
-          - BC-3240
-        process_ids: []
-        notes: Risk-based inspection and compliance reporting review
-      - id: VS-50.60
-        stage_order: 6
-        stage_name: Enforcement & Sanction
-        capability_ids:
-          - BC-3240
-        process_ids: []
-        notes: Suspension, revocation, civil penalties, and sanctions
-      - id: VS-50.70
-        stage_order: 7
-        stage_name: Renewal
-        capability_ids:
-          - BC-3240
-        process_ids: []
-        notes: Renewal processing and continuing-eligibility checks
-      - id: VS-50.80
-        stage_order: 8
-        stage_name: Register Disclosure
-        capability_ids:
-          - BC-3240
-        process_ids: []
-        notes: Public register search and credential verification services
-  - id: VS-60
-    name: Apply-to-Graduate
-    industries:
-      - Education
-    stages:
-      - id: VS-60.10
-        stage_order: 1
-        stage_name: Outreach & Recruitment
-        capability_ids:
-          - BC-4710
-        process_ids: []
-        notes: Prospect outreach and recruitment campaigns
-      - id: VS-60.20
-        stage_order: 2
-        stage_name: Application & Admissions
-        capability_ids:
-          - BC-4710
-        process_ids: []
-        notes: Application processing and admissions decisioning
-      - id: VS-60.30
-        stage_order: 3
-        stage_name: Enrolment & Registration
-        capability_ids:
-          - BC-4720
-        process_ids: []
-        notes: Enrolment, registration, and course allocation
-      - id: VS-60.40
-        stage_order: 4
-        stage_name: Teaching & Learning Delivery
-        capability_ids:
-          - BC-4730
-          - BC-4790
-        process_ids: []
-        notes: Delivery of teaching across in-person, online, and blended modes; Educational content and learning resources delivered to students
-      - id: VS-60.50
-        stage_order: 5
-        stage_name: Student Support
-        capability_ids:
-          - BC-4770
-        process_ids: []
-        notes: Academic advising, accommodations, and pastoral support during study
-      - id: VS-60.60
-        stage_order: 6
-        stage_name: Assessment & Examination
-        capability_ids:
-          - BC-4740
-        process_ids: []
-        notes: Assessment design, examination delivery, and marking
-      - id: VS-60.70
-        stage_order: 7
-        stage_name: Award & Credentialing
-        capability_ids:
-          - BC-4720
-        process_ids: []
-        notes: Graduation eligibility audit, award conferral, and credential issuance
-  - id: VS-70
-    name: Appoint-to-Operate
-    industries:
-      - Automotive & Mobility
-    stages:
-      - id: VS-70.10
-        stage_order: 1
-        stage_name: Network Strategy & Coverage
-        capability_ids:
-          - BC-3430
-        process_ids: []
-        industry_variant: Automotive
-        notes: Market coverage planning and footprint optimisation
-      - id: VS-70.20
-        stage_order: 2
-        stage_name: Application & Vetting
-        capability_ids:
-          - BC-3430
-        process_ids: []
-        industry_variant: Automotive
-        notes: Dealer application, financial and operational due diligence
-      - id: VS-70.30
-        stage_order: 3
-        stage_name: Agreement Execution
-        capability_ids:
-          - BC-150
-        process_ids: []
-        notes: Legal terms and competition-law review
-      - id: VS-70.40
-        stage_order: 3
-        stage_name: Agreement Execution
-        capability_ids:
-          - BC-3430
-        process_ids: []
-        industry_variant: Automotive
-        notes: Dealer agreement drafting and territory rights
-      - id: VS-70.50
-        stage_order: 4
-        stage_name: Onboarding & Certification
-        capability_ids:
-          - BC-3430
-        process_ids: []
-        industry_variant: Automotive
-        notes: Dealer training, certification, and DMS integration
-      - id: VS-70.60
-        stage_order: 5
-        stage_name: Standards Compliance
-        capability_ids:
-          - BC-3430
-        process_ids: []
-        industry_variant: Automotive
-        notes: Brand and facility standards auditing and corrective action
-      - id: VS-70.70
-        stage_order: 6
-        stage_name: Performance Management
-        capability_ids:
-          - BC-3430
-        process_ids: []
-        industry_variant: Automotive
-        notes: Scorecard, performance reviews, and incentive programmes
-      - id: VS-70.80
-        stage_order: 7
-        stage_name: Termination & Transition
-        capability_ids:
-          - BC-3430
-        process_ids: []
-        industry_variant: Automotive
-        notes: Dealer termination, run-out, and territory reassignment
-  - id: VS-80
-    name: Audit-to-Action
-    industries:
-      - Cross-Industry
-    stages:
-      - id: VS-80.10
-        stage_order: 1
-        stage_name: Audit Universe & Plan
-        capability_ids:
-          - BC-140
-        process_ids: []
-        notes: Risk-based annual plan
-      - id: VS-80.20
-        stage_order: 1
-        stage_name: Audit Universe & Plan
-        capability_ids:
-          - BC-4750
-        process_ids: []
-        industry_variant: Education
-        notes: Programme review and accreditation cycle planning
-      - id: VS-80.30
-        stage_order: 2
-        stage_name: Engagement Scoping
-        capability_ids:
-          - BC-140
-        process_ids: []
-        notes: Scope, criteria, resources
-      - id: VS-80.40
-        stage_order: 3
-        stage_name: Fieldwork
-        capability_ids:
-          - BC-140
-          - BC-4970
-        process_ids: []
-        notes: Testing & evidence; Valuation QA sampling and peer review fieldwork
-      - id: VS-80.50
-        stage_order: 3
-        stage_name: Fieldwork
-        capability_ids:
-          - BC-3590
-        process_ids: []
-        industry_variant: Agriculture
-        notes: Farm assurance and certification audit readiness
-      - id: VS-80.60
-        stage_order: 3
-        stage_name: Fieldwork
-        capability_ids:
-          - BC-4750
-        process_ids: []
-        industry_variant: Education
-        notes: Accreditation site visits and inspection
-      - id: VS-80.70
-        stage_order: 3
-        stage_name: Fieldwork
-        capability_ids:
-          - BC-2840
-        process_ids: []
-        industry_variant: Healthcare Providers
-        notes: Accreditation surveys and tracer methodology
-      - id: VS-80.80
-        stage_order: 3
-        stage_name: Fieldwork
-        capability_ids:
-          - BC-1540
-        process_ids: []
-        industry_variant: Pharma
-        notes: GxP audit & inspection readiness
-      - id: VS-80.90
-        stage_order: 3
-        stage_name: Fieldwork
-        capability_ids:
-          - BC-4340
-        process_ids: []
-        industry_variant: Professional Services
-        notes: External practice-inspection fieldwork response (PCAOB / FRC / ICAEW)
-      - id: VS-80.100
-        stage_order: 3
-        stage_name: Fieldwork
-        capability_ids:
-          - BC-2380
-        process_ids: []
-        industry_variant: Retail & Consumer Goods
-        notes: Food-safety audit & inspection readiness
-      - id: VS-80.110
-        stage_order: 3
-        stage_name: Fieldwork
-        capability_ids:
-          - BC-4290
-        process_ids: []
-        industry_variant: Software & Technology
-        notes: External service-attestation audits (SOC 2, ISO 27001)
-      - id: VS-80.120
-        stage_order: 4
-        stage_name: Findings & Reporting
-        capability_ids:
-          - BC-140
-        process_ids: []
-        notes: Findings, ratings, report
-      - id: VS-80.130
-        stage_order: 4
-        stage_name: Findings & Reporting
-        capability_ids:
-          - BC-4750
-        process_ids: []
-        industry_variant: Education
-        notes: Accreditation outcome and conditions
-      - id: VS-80.140
-        stage_order: 5
-        stage_name: Remediation Tracking
-        capability_ids:
-          - BC-140
-          - BC-4990
-        process_ids: []
-        notes: Action plan follow-up; Remediation tracking of RESPA, AML, and fair-housing audit findings
-      - id: VS-80.150
-        stage_order: 5
-        stage_name: Remediation Tracking
-        capability_ids:
-          - BC-4750
-        process_ids: []
-        industry_variant: Education
-        notes: Quality improvement action tracking
-      - id: VS-80.160
-        stage_order: 5
-        stage_name: Remediation Tracking
-        capability_ids:
-          - BC-4340
-        process_ids: []
-        industry_variant: Professional Services
-        notes: Remediation of inspection findings and deficiency closure
-      - id: VS-80.170
-        stage_order: 5
-        stage_name: Remediation Tracking
-        capability_ids:
-          - BC-4290
-        process_ids: []
-        industry_variant: Software & Technology
-        notes: Remediation of attestation findings
-      - id: VS-80.180
-        stage_order: 6
-        stage_name: Audit Quality Assurance
-        capability_ids:
-          - BC-140
-        process_ids: []
-        notes: QA review & maturation
-  - id: VS-90
-    name: Bill-to-Statute
-    industries:
-      - Public Sector & Government
-    stages:
-      - id: VS-90.10
-        stage_order: 1
-        stage_name: Drafting Instruction
-        capability_ids:
-          - BC-3200
-          - BC-3210
-        process_ids: []
-        notes: Policy decision converted into drafting instructions; Receipt and clarification of drafting instructions by parliamentary counsel
-      - id: VS-90.20
-        stage_order: 2
-        stage_name: Drafting
-        capability_ids:
-          - BC-3210
-        process_ids: []
-        notes: Drafting of bills, regulations, and statutory instruments
-      - id: VS-90.30
-        stage_order: 3
-        stage_name: Legal Vetting
-        capability_ids:
-          - BC-3210
-          - BC-150
-        process_ids: []
-        notes: Constitutional, human-rights, and international-law review; Government legal services advisory review
-      - id: VS-90.40
-        stage_order: 4
-        stage_name: Impact Assessment
-        capability_ids:
-          - BC-3210
-        process_ids: []
-        notes: Regulatory impact assessment and small-business test
-      - id: VS-90.50
-        stage_order: 5
-        stage_name: Legislative Passage
-        capability_ids:
-          - BC-3210
-        process_ids: []
-        notes: Parliamentary liaison, committee evidence, amendment tracking
-      - id: VS-90.60
-        stage_order: 6
-        stage_name: Promulgation
-        capability_ids:
-          - BC-3210
-        process_ids: []
-        notes: Royal assent or executive signature and effective-date setting
-      - id: VS-90.70
-        stage_order: 7
-        stage_name: Codification & Publication
-        capability_ids:
-          - BC-3210
-        process_ids: []
-        notes: Official gazette publication and statutory codification
-  - id: VS-100
-    name: Brief-to-Campaign
-    industries:
-      - Media, Entertainment & Telecom Content
-    stages:
-      - id: VS-100.10
-        stage_order: 1
-        stage_name: Brief Intake
-        capability_ids:
-          - BC-3760
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Advertiser and agency brief capture and qualification
-      - id: VS-100.20
-        stage_order: 2
-        stage_name: Audience & Avail Planning
-        capability_ids:
-          - BC-3760
-          - BC-3770
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Avail forecasting and inventory shaping against the brief; Audience definition and reach modelling informing the plan
-      - id: VS-100.30
-        stage_order: 3
-        stage_name: Media Plan Development
-        capability_ids:
-          - BC-3760
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Multi-surface media plan, packaging, and pricing development
-      - id: VS-100.40
-        stage_order: 4
-        stage_name: Booking & Insertion Order
-        capability_ids:
-          - BC-3760
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Insertion-order capture, deal-ID provisioning, and inventory reservation
-      - id: VS-100.50
-        stage_order: 5
-        stage_name: Creative Onboarding & Trafficking
-        capability_ids:
-          - BC-3760
-          - BC-3780
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Creative ingest, technical QC, decisioning rules, and trafficking; Advertising-code review and creative-classification compliance
-      - id: VS-100.60
-        stage_order: 6
-        stage_name: Campaign Delivery
-        capability_ids:
-          - BC-3760
-          - BC-3740
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Spot scheduling, ad insertion, pacing, and brand-safety enforcement; Server-side and client-side ad delivery on linear, OTT, and IPTV surfaces
-      - id: VS-100.70
-        stage_order: 7
-        stage_name: Measurement & Reconciliation
-        capability_ids:
-          - BC-3760
-          - BC-3770
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Delivery reporting, make-good and credit-memo handling; Currency-grade audience measurement and post-campaign analytics
-      - id: VS-100.80
-        stage_order: 8
-        stage_name: Billing & Settlement
-        capability_ids:
-          - BC-3760
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Advertiser and agency billing, agency-discount and commission settlement
-  - id: VS-110
-    name: Capture-to-Contract
-    industries:
-      - Defense & Aerospace
-    stages:
-      - id: VS-110.10
-        stage_order: 1
-        stage_name: Customer Intelligence
-        capability_ids:
-          - BC-1730
-          - BC-1750
-        process_ids: []
-        industry_variant: Defense
-        notes: Intelligence operations input; Defense customer intel
-      - id: VS-110.20
-        stage_order: 2
-        stage_name: Capture Strategy
-        capability_ids:
-          - BC-1750
-        process_ids: []
-        industry_variant: Defense
-        notes: Capture management
-      - id: VS-110.30
-        stage_order: 3
-        stage_name: Teaming & Subcontracting
-        capability_ids:
-          - BC-1750
-          - BC-1810
-        process_ids: []
-        industry_variant: Defense
-        notes: Teaming strategy; Cleared subcontractor vetting
-      - id: VS-110.40
-        stage_order: 4
-        stage_name: Bid & Proposal
-        capability_ids:
-          - BC-1750
-        process_ids: []
-        industry_variant: Defense
-        notes: Bid management; Proposal development
-      - id: VS-110.50
-        stage_order: 5
-        stage_name: Pricing & Cost Estimation
-        capability_ids:
-          - BC-440
-        process_ids: []
-        notes: Pricing strategy
-      - id: VS-110.60
-        stage_order: 5
-        stage_name: Pricing & Cost Estimation
-        capability_ids:
-          - BC-1140
-        process_ids: []
-        industry_variant: Defense
-        notes: Tendering & estimation
-      - id: VS-110.70
-        stage_order: 6
-        stage_name: Compliance & Export Review
-        capability_ids:
-          - BC-130
-        process_ids: []
-        notes: Regulatory compliance
-      - id: VS-110.80
-        stage_order: 6
-        stage_name: Compliance & Export Review
-        capability_ids:
-          - BC-1790
-        process_ids: []
-        industry_variant: Defense
-        notes: ITAR / EAR / export control
-      - id: VS-110.90
-        stage_order: 7
-        stage_name: Contract Negotiation & Award
-        capability_ids:
-          - BC-150
-        process_ids: []
-        notes: Contract negotiation
-      - id: VS-110.100
-        stage_order: 7
-        stage_name: Contract Negotiation & Award
-        capability_ids:
-          - BC-1760
-        process_ids: []
-        industry_variant: Defense
-        notes: Programme handover
-  - id: VS-120
-    name: Claim-to-Reimbursement
-    industries:
-      - Healthcare Providers
-    stages:
-      - id: VS-120.10
-        stage_order: 1
-        stage_name: Charge Capture
-        capability_ids:
-          - BC-2870
-        process_ids: []
-        notes: Charge capture from clinical documentation and ancillary systems
-      - id: VS-120.20
-        stage_order: 2
-        stage_name: Coding
-        capability_ids:
-          - BC-2870
-        process_ids: []
-        notes: Medical coding, CDI queries, and DRG / APC assignment
-      - id: VS-120.30
-        stage_order: 3
-        stage_name: Claim Production & Submission
-        capability_ids:
-          - BC-2870
-        process_ids: []
-        notes: Claim assembly, edits, and payer submission
-      - id: VS-120.40
-        stage_order: 4
-        stage_name: Adjudication & Denial Management
-        capability_ids:
-          - BC-2870
-        process_ids: []
-        notes: Remittance handling, denial work, and appeals
-      - id: VS-120.50
-        stage_order: 5
-        stage_name: Cash Posting & Reconciliation
-        capability_ids:
-          - BC-2870
-          - BC-200
-        process_ids: []
-        notes: ERA / EOB posting and contract variance analysis; Patient AR accounting and bank reconciliation
-      - id: VS-120.60
-        stage_order: 6
-        stage_name: Patient Billing & Collections
-        capability_ids:
-          - BC-2870
-        process_ids: []
-        notes: Patient statements, payment plans, and collections
-      - id: VS-120.70
-        stage_order: 7
-        stage_name: Underpayment Recovery
-        capability_ids:
-          - BC-2870
-        process_ids: []
-        notes: Underpayment identification and payer recovery actions
-  - id: VS-130
-    name: Concept-to-Manufacture
-    industries:
-      - Manufacturing & Industrial
-      - Engineering Services
-      - Electrical Components & Equipment
-      - HVAC & Building Automation Systems
-      - Defense & Aerospace
-      - Automotive & Mobility
-    stages:
-      - id: VS-130.10
-        stage_order: 1
-        stage_name: Concept Design
-        capability_ids:
-          - BC-3400
-        process_ids: []
-        industry_variant: Automotive
-        notes: Vehicle concept and architecture
-      - id: VS-130.20
-        stage_order: 1
-        stage_name: Concept Design
-        capability_ids:
-          - BC-1900
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Concept-stage circuit & topology design
-      - id: VS-130.30
-        stage_order: 1
-        stage_name: Concept Design
-        capability_ids:
-          - BC-1120
-        process_ids: []
-        industry_variant: Engineering Services
-        notes: Conceptual design
-      - id: VS-130.40
-        stage_order: 1
-        stage_name: Concept Design
-        capability_ids:
-          - BC-2000
-          - BC-2010
-        process_ids: []
-        industry_variant: HVAC & Building Automation Systems
-        notes: HVAC equipment concept-stage cycle & topology; BAS controller & supervisor concept
-      - id: VS-130.50
-        stage_order: 2
-        stage_name: FEED & Specification
-        capability_ids:
-          - BC-820
-        process_ids: []
-        notes: Product specification
-      - id: VS-130.60
-        stage_order: 2
-        stage_name: FEED & Specification
-        capability_ids:
-          - BC-3400
-        process_ids: []
-        industry_variant: Automotive
-        notes: Vehicle attribute and subsystem specification
-      - id: VS-130.70
-        stage_order: 2
-        stage_name: FEED & Specification
-        capability_ids:
-          - BC-1900
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Front-end electrical engineering
-      - id: VS-130.80
-        stage_order: 2
-        stage_name: FEED & Specification
-        capability_ids:
-          - BC-1120
-        process_ids: []
-        industry_variant: Engineering Services
-        notes: Front-end engineering design
-      - id: VS-130.90
-        stage_order: 2
-        stage_name: FEED & Specification
-        capability_ids:
-          - BC-2000
-          - BC-2020
-        process_ids: []
-        industry_variant: HVAC & Building Automation Systems
-        notes: HVAC equipment FEED; Project-level HVAC system spec & sizing
-      - id: VS-130.100
-        stage_order: 3
-        stage_name: Detailed Design
-        capability_ids:
-          - BC-3400
-        process_ids: []
-        industry_variant: Automotive
-        notes: Multi-domain vehicle engineering
-      - id: VS-130.110
-        stage_order: 3
-        stage_name: Detailed Design
-        capability_ids:
-          - BC-1900
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Detailed electrical/electronic design
-      - id: VS-130.120
-        stage_order: 3
-        stage_name: Detailed Design
-        capability_ids:
-          - BC-1100
-          - BC-1120
-        process_ids: []
-        industry_variant: Engineering Services
-        notes: Multi-discipline engineering; Detailed design
-      - id: VS-130.130
-        stage_order: 3
-        stage_name: Detailed Design
-        capability_ids:
-          - BC-2000
-          - BC-2010
-          - BC-2020
-        process_ids: []
-        industry_variant: HVAC & Building Automation Systems
-        notes: Detailed HVAC equipment engineering; Detailed BAS product engineering; Project-level integration design
-      - id: VS-130.140
-        stage_order: 4
-        stage_name: Design Review
-        capability_ids:
-          - BC-3400
-          - BC-3420
-        process_ids: []
-        industry_variant: Automotive
-        notes: ISO 26262 / 21434 / 21448 reviews; Type-approval readiness review
-      - id: VS-130.150
-        stage_order: 4
-        stage_name: Design Review
-        capability_ids:
-          - BC-1770
-        process_ids: []
-        industry_variant: Defense
-        notes: Defense V&V
-      - id: VS-130.160
-        stage_order: 4
-        stage_name: Design Review
-        capability_ids:
-          - BC-1910
-          - BC-1920
-          - BC-1970
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Certification readiness review; Type-test sign-off on first articles; Safety case & FMEA review
-      - id: VS-130.170
-        stage_order: 4
-        stage_name: Design Review
-        capability_ids:
-          - BC-1120
-        process_ids: []
-        industry_variant: Engineering Services
-        notes: Verification & validation
-      - id: VS-130.180
-        stage_order: 4
-        stage_name: Design Review
-        capability_ids:
-          - BC-2000
-          - BC-2010
-          - BC-2030
-        process_ids: []
-        industry_variant: HVAC & Building Automation Systems
-        notes: HVAC equipment design verification; BAS conformance & interoperability review; Performance & safety listing readiness
-      - id: VS-130.190
-        stage_order: 5
-        stage_name: Manufacturing Engineering
-        capability_ids:
-          - BC-820
-        process_ids: []
-        notes: Configuration / variants
-      - id: VS-130.200
-        stage_order: 5
-        stage_name: Manufacturing Engineering
-        capability_ids:
-          - BC-3410
-        process_ids: []
-        industry_variant: Automotive
-        notes: Programme governance over industrialisation
-      - id: VS-130.210
-        stage_order: 5
-        stage_name: Manufacturing Engineering
-        capability_ids:
-          - BC-1930
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Preferred parts feed manufacturing engineering
-      - id: VS-130.220
-        stage_order: 5
-        stage_name: Manufacturing Engineering
-        capability_ids:
-          - BC-1020
-        process_ids: []
-        industry_variant: Manufacturing
-        notes: Process design / industrialisation
-      - id: VS-130.230
-        stage_order: 6
-        stage_name: Production Ramp-Up
-        capability_ids:
-          - BC-3410
-        process_ids: []
-        industry_variant: Automotive
-        notes: SOP readiness and ramp coordination
-      - id: VS-130.240
-        stage_order: 6
-        stage_name: Production Ramp-Up
-        capability_ids:
-          - BC-1000
-          - BC-1010
-        process_ids: []
-        industry_variant: Manufacturing
-        notes: Production planning; Shop floor execution
-      - id: VS-130.250
-        stage_order: 7
-        stage_name: Quality & Yield Stabilisation
-        capability_ids:
-          - BC-720
-        process_ids: []
-        notes: QC ramp-up
-      - id: VS-130.260
-        stage_order: 7
-        stage_name: Quality & Yield Stabilisation
-        capability_ids:
-          - BC-1000
-        process_ids: []
-        industry_variant: Manufacturing
-        notes: Production performance
-      - id: VS-130.270
-        stage_order: 8
-        stage_name: Configuration Baseline
-        capability_ids:
-          - BC-3410
-          - BC-3420
-        process_ids: []
-        industry_variant: Automotive
-        notes: Vehicle programme configuration baseline at SOP; Type-approved configuration baseline
-      - id: VS-130.280
-        stage_order: 8
-        stage_name: Configuration Baseline
-        capability_ids:
-          - BC-1770
-        process_ids: []
-        industry_variant: Defense
-        notes: Configuration management
-      - id: VS-130.290
-        stage_order: 8
-        stage_name: Configuration Baseline
-        capability_ids:
-          - BC-1940
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Saleable variant baseline
-      - id: VS-130.300
-        stage_order: 8
-        stage_name: Configuration Baseline
-        capability_ids:
-          - BC-1130
-        process_ids: []
-        industry_variant: Engineering Services
-        notes: Engineering document control
-  - id: VS-140
-    name: Crisis-to-Recovery
-    industries:
-      - Cross-Industry
-    stages:
-      - id: VS-140.10
-        stage_order: 1
-        stage_name: Continuity Planning
-        capability_ids:
-          - BC-160
-        process_ids: []
-        notes: BIA & continuity plans
-      - id: VS-140.20
-        stage_order: 1
-        stage_name: Continuity Planning
-        capability_ids:
-          - BC-4460
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Tailings emergency preparedness plans
-      - id: VS-140.30
-        stage_order: 1
-        stage_name: Continuity Planning
-        capability_ids:
-          - BC-3310
-        process_ids: []
-        industry_variant: Public Sector
-        notes: Hazard analysis and emergency planning under Sendai Framework
-      - id: VS-140.40
-        stage_order: 1
-        stage_name: Continuity Planning
-        capability_ids:
-          - BC-3830
-        process_ids: []
-        industry_variant: Utilities
-        notes: Black-start contracts and system restoration plans
-      - id: VS-140.50
-        stage_order: 2
-        stage_name: Resilience Testing
-        capability_ids:
-          - BC-160
-          - BC-4220
-        process_ids: []
-        notes: Exercises & drills; Disaster-recovery exercises and game-days for the SaaS service
-      - id: VS-140.60
-        stage_order: 2
-        stage_name: Resilience Testing
-        capability_ids:
-          - BC-1280
-        process_ids: []
-        industry_variant: ATC
-        notes: Aviation safety performance drills
-      - id: VS-140.70
-        stage_order: 2
-        stage_name: Resilience Testing
-        capability_ids:
-          - BC-3310
-        process_ids: []
-        industry_variant: Public Sector
-        notes: Tabletop, functional, and full-scale exercises
-      - id: VS-140.80
-        stage_order: 3
-        stage_name: Detection & Activation
-        capability_ids:
-          - BC-160
-          - BC-620
-        process_ids: []
-        notes: Crisis declaration; Cyber incident trigger
-      - id: VS-140.90
-        stage_order: 3
-        stage_name: Detection & Activation
-        capability_ids:
-          - BC-4460
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Tailings facility instrumentation triggers
-      - id: VS-140.100
-        stage_order: 3
-        stage_name: Detection & Activation
-        capability_ids:
-          - BC-3310
-        process_ids: []
-        industry_variant: Public Sector
-        notes: 911/112 emergency call taking; disaster declaration
-      - id: VS-140.110
-        stage_order: 3
-        stage_name: Detection & Activation
-        capability_ids:
-          - BC-2630
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Major service outage declaration
-      - id: VS-140.120
-        stage_order: 3
-        stage_name: Detection & Activation
-        capability_ids:
-          - BC-3820
-        process_ids: []
-        industry_variant: Utilities
-        notes: Major distribution event activation and storm protocol
-      - id: VS-140.130
-        stage_order: 4
-        stage_name: Crisis Response
-        capability_ids:
-          - BC-160
-          - BC-850
-        process_ids: []
-        notes: Crisis management cell; Crisis communications
-      - id: VS-140.140
-        stage_order: 4
-        stage_name: Crisis Response
-        capability_ids:
-          - BC-4770
-        process_ids: []
-        industry_variant: Education
-        notes: Student mental-health crisis response coordination
-      - id: VS-140.150
-        stage_order: 4
-        stage_name: Crisis Response
-        capability_ids:
-          - BC-2810
-        process_ids: []
-        industry_variant: Healthcare Providers
-        notes: Mass-casualty and surge response activation
-      - id: VS-140.160
-        stage_order: 4
-        stage_name: Crisis Response
-        capability_ids:
-          - BC-4460
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Dam-safety emergency response coordination
-      - id: VS-140.170
-        stage_order: 4
-        stage_name: Crisis Response
-        capability_ids:
-          - BC-3050
-        process_ids: []
-        industry_variant: Oil & Gas
-        notes: Major-accident response (loss of containment, blowout, fire)
-      - id: VS-140.180
-        stage_order: 4
-        stage_name: Crisis Response
-        capability_ids:
-          - BC-3310
-        process_ids: []
-        industry_variant: Public Sector
-        notes: NIMS / ICS incident command; police, fire, EMS field response
-      - id: VS-140.190
-        stage_order: 4
-        stage_name: Crisis Response
-        capability_ids:
-          - BC-2380
-        process_ids: []
-        industry_variant: Retail & Consumer Goods
-        notes: Major food recall response
-      - id: VS-140.200
-        stage_order: 4
-        stage_name: Crisis Response
-        capability_ids:
-          - BC-2700
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Emergency call routing and public-warning broadcast
-      - id: VS-140.210
-        stage_order: 4
-        stage_name: Crisis Response
-        capability_ids:
-          - BC-3820
-          - BC-3890
-        process_ids: []
-        industry_variant: Utilities
-        notes: Storm and major-event distribution response with mutual assistance; Sewage pollution incident containment and remediation
-      - id: VS-140.220
-        stage_order: 5
-        stage_name: Disaster Recovery
-        capability_ids:
-          - BC-160
-          - BC-600
-          - BC-4220
-        process_ids: []
-        notes: IT/site DR; IT operations failover; Failover orchestration and backup restoration for the SaaS service
-      - id: VS-140.230
-        stage_order: 5
-        stage_name: Disaster Recovery
-        capability_ids:
-          - BC-3310
-        process_ids: []
-        industry_variant: Public Sector
-        notes: Individual and public assistance administration
-      - id: VS-140.240
-        stage_order: 6
-        stage_name: Restoration
-        capability_ids:
-          - BC-1030
-        process_ids: []
-        industry_variant: Manufacturing
-        notes: Asset / line restart
-      - id: VS-140.250
-        stage_order: 6
-        stage_name: Restoration
-        capability_ids:
-          - BC-3310
-        process_ids: []
-        industry_variant: Public Sector
-        notes: Long-term recovery coordination
-      - id: VS-140.260
-        stage_order: 6
-        stage_name: Restoration
-        capability_ids:
-          - BC-2600
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Network restoration coordination
-      - id: VS-140.270
-        stage_order: 6
-        stage_name: Restoration
-        capability_ids:
-          - BC-3830
-        process_ids: []
-        industry_variant: Utilities
-        notes: Black start and bulk-system restoration coordination
-      - id: VS-140.280
-        stage_order: 7
-        stage_name: Post-Crisis Review
-        capability_ids:
-          - BC-120
-          - BC-830
-        process_ids: []
-        notes: Risk reassessment; Lessons learned
-      - id: VS-140.290
-        stage_order: 7
-        stage_name: Post-Crisis Review
-        capability_ids:
-          - BC-3310
-        process_ids: []
-        industry_variant: Public Sector
-        notes: After-action review and lessons learned
-  - id: VS-150
-    name: Discover-to-Automate
-    industries:
-      - Cross-Industry
-    stages:
-      - id: VS-150.10
-        stage_order: 1
-        stage_name: Process Discovery
-        capability_ids:
-          - BC-930
-        process_ids: []
-        notes: Process elicitation; BPMN authoring; documentation publication
-      - id: VS-150.20
-        stage_order: 2
-        stage_name: Process Measurement
-        capability_ids:
-          - BC-930
-        process_ids: []
-        notes: KPI definition; performance monitoring
-      - id: VS-150.30
-        stage_order: 3
-        stage_name: Process Mining
-        capability_ids:
-          - BC-930
-        process_ids: []
-        notes: Event log acquisition; discovery analysis; conformance checking
-      - id: VS-150.40
-        stage_order: 4
-        stage_name: Process Redesign
-        capability_ids:
-          - BC-930
-        process_ids: []
-        notes: Bottleneck analysis; simulation; to-be design
-      - id: VS-150.50
-        stage_order: 5
-        stage_name: Process Automation
-        capability_ids:
-          - BC-930
-        process_ids: []
-        notes: Automation portfolio; orchestration governance; RPA programme; control & audit
-  - id: VS-160
-    name: Discovery-to-Approval
-    industries:
-      - Pharmaceuticals & Life Sciences
-    stages:
-      - id: VS-160.10
-        stage_order: 1
-        stage_name: Target Discovery
-        capability_ids:
-          - BC-1500
-        process_ids: []
-        industry_variant: Pharma
-        notes: Target identification & validation
-      - id: VS-160.20
-        stage_order: 2
-        stage_name: Hit & Lead Discovery
-        capability_ids:
-          - BC-1500
-        process_ids: []
-        industry_variant: Pharma
-        notes: Hit discovery; Lead optimisation
-      - id: VS-160.30
-        stage_order: 3
-        stage_name: Pre-Clinical Development
-        capability_ids:
-          - BC-1500
-          - BC-1510
-        process_ids: []
-        industry_variant: Pharma
-        notes: Candidate selection; Pre-clinical studies; CMC development
-      - id: VS-160.40
-        stage_order: 4
-        stage_name: Clinical Trial Design
-        capability_ids:
-          - BC-1520
-          - BC-1530
-        process_ids: []
-        industry_variant: Pharma
-        notes: Protocol design; Regulatory strategy
-      - id: VS-160.50
-        stage_order: 5
-        stage_name: Clinical Trials Execution
-        capability_ids:
-          - BC-1520
-        process_ids: []
-        industry_variant: Pharma
-        notes: Site management; Subject management; Clinical data management; Trial supply
-      - id: VS-160.60
-        stage_order: 6
-        stage_name: Phase Progression
-        capability_ids:
-          - BC-1510
-        process_ids: []
-        industry_variant: Pharma
-        notes: Phase I; Phase II; Phase III
-      - id: VS-160.70
-        stage_order: 7
-        stage_name: Regulatory Submission
-        capability_ids:
-          - BC-1530
-        process_ids: []
-        industry_variant: Pharma
-        notes: NDA / MAA submission; Agency interaction; Labelling
-      - id: VS-160.80
-        stage_order: 8
-        stage_name: Approval & Launch Readiness
-        capability_ids:
-          - BC-1580
-          - BC-1590
-          - BC-1600
-        process_ids: []
-        industry_variant: Pharma
-        notes: Medical affairs preparation; Commercial readiness; Market access & reimbursement
-      - id: VS-160.90
-        stage_order: 9
-        stage_name: Post-Marketing Surveillance
-        capability_ids:
-          - BC-1510
-          - BC-1530
-        process_ids: []
-        industry_variant: Pharma
-        notes: Phase IV; Lifecycle maintenance
-  - id: VS-170
-    name: Disruption-to-Recovery
-    industries:
-      - Travel & Hospitality
-    stages:
-      - id: VS-170.10
-        stage_order: 1
-        stage_name: Disruption Detection
-        capability_ids:
-          - BC-4080
-        process_ids: []
-        industry_variant: Airline
-        notes: OCC detection of weather, mechanical, and ATC events
-      - id: VS-170.20
-        stage_order: 1
-        stage_name: Disruption Detection
-        capability_ids:
-          - BC-4090
-        process_ids: []
-        industry_variant: Cruise
-        notes: Voyage-level detection of weather, medical, and port events
-      - id: VS-170.30
-        stage_order: 1
-        stage_name: Disruption Detection
-        capability_ids:
-          - BC-4100
-        process_ids: []
-        industry_variant: Tour
-        notes: In-destination disruption detection by escort and operator
-      - id: VS-170.40
-        stage_order: 2
-        stage_name: Operational Decision
-        capability_ids:
-          - BC-4080
-        process_ids: []
-        industry_variant: Airline
-        notes: Diversion, cancellation, and fleet and crew recovery decisions
-      - id: VS-170.50
-        stage_order: 2
-        stage_name: Operational Decision
-        capability_ids:
-          - BC-4090
-        process_ids: []
-        industry_variant: Cruise
-        notes: Itinerary substitution and port-call change decisions
-      - id: VS-170.60
-        stage_order: 2
-        stage_name: Operational Decision
-        capability_ids:
-          - BC-4100
-        process_ids: []
-        industry_variant: Tour
-        notes: Force-majeure itinerary recovery decisions
-      - id: VS-170.70
-        stage_order: 3
-        stage_name: Traveller Reaccommodation
-        capability_ids:
-          - BC-4020
-        process_ids: []
-        notes: Schedule-change and mass-disruption reaccommodation
-      - id: VS-170.80
-        stage_order: 4
-        stage_name: Communications
-        capability_ids:
-          - BC-4040
-          - BC-4020
-        process_ids: []
-        notes: Outbound disruption communications using traveller record and consent; Booking-level reaccommodation communications
-      - id: VS-170.90
-        stage_order: 5
-        stage_name: Care of Passengers
-        capability_ids:
-          - BC-4060
-          - BC-4070
-        process_ids: []
-        notes: Hotel rooming and care services for stranded travellers; Meal vouchers and traveller catering during disruption
-      - id: VS-170.100
-        stage_order: 6
-        stage_name: Compensation Closure
-        capability_ids:
-          - BC-4020
-        process_ids: []
-        notes: Compensation eligibility determination and refund or voucher issuance
-      - id: VS-170.110
-        stage_order: 7
-        stage_name: Post-Event Review
-        capability_ids:
-          - BC-4030
-        process_ids: []
-        notes: Revenue impact analysis and forecast adjustment
-      - id: VS-170.120
-        stage_order: 7
-        stage_name: Post-Event Review
-        capability_ids:
-          - BC-4080
-        process_ids: []
-        industry_variant: Airline
-        notes: Operational safety investigation support and lessons
-  - id: VS-180
-    name: Encounter-to-Discharge
-    industries:
-      - Healthcare Providers
-    stages:
-      - id: VS-180.10
-        stage_order: 1
-        stage_name: Pre-Encounter Access
-        capability_ids:
-          - BC-2800
-        process_ids: []
-        notes: Scheduling, eligibility verification, and financial counselling
-      - id: VS-180.20
-        stage_order: 2
-        stage_name: Registration & Admission
-        capability_ids:
-          - BC-2800
-        process_ids: []
-        notes: Patient registration, admission, and bed assignment
-      - id: VS-180.30
-        stage_order: 3
-        stage_name: Clinical Care Delivery
-        capability_ids:
-          - BC-2810
-        process_ids: []
-        notes: Inpatient, outpatient, emergency, and procedural care delivery
-      - id: VS-180.40
-        stage_order: 4
-        stage_name: Diagnostic & Therapeutic Services
-        capability_ids:
-          - BC-2860
-          - BC-2850
-        process_ids: []
-        notes: Laboratory, imaging, and ancillary diagnostic services; Medication ordering, dispensing, and administration
-      - id: VS-180.50
-        stage_order: 5
-        stage_name: Clinical Documentation
-        capability_ids:
-          - BC-2830
-        process_ids: []
-        notes: Notes, orders, results review, and decision support
-      - id: VS-180.60
-        stage_order: 6
-        stage_name: Care Coordination
-        capability_ids:
-          - BC-2820
-        process_ids: []
-        notes: Multidisciplinary coordination, transitions, and case management
-      - id: VS-180.70
-        stage_order: 7
-        stage_name: Discharge & Transition
-        capability_ids:
-          - BC-2810
-          - BC-2820
-        process_ids: []
-        notes: Discharge planning, instructions, and disposition; Post-discharge follow-up and onward care handoff
-  - id: VS-190
-    name: Engagement-to-Realisation
-    industries:
-      - Professional Services
-      - Real Estate
-    stages:
-      - id: VS-190.10
-        stage_order: 1
-        stage_name: Engagement Acceptance
-        capability_ids:
-          - BC-4300
-          - BC-4350
-        process_ids: []
-        notes: Client and engagement acceptance, scoping, and engagement-letter execution; Independence, conflicts, and integrity clearance feeding acceptance
-      - id: VS-190.20
-        stage_order: 1
-        stage_name: Engagement Acceptance
-        capability_ids:
-          - BC-4970
-        process_ids: []
-        industry_variant: Real Estate
-        notes: Valuation engagement intake, scoping, conflict and independence checks
-      - id: VS-190.30
-        stage_order: 2
-        stage_name: Mobilisation
-        capability_ids:
-          - BC-4300
-          - BC-4320
-        process_ids: []
-        notes: Engagement team formation, kickoff, and data-access setup; Engagement staffing and leverage allocation
-      - id: VS-190.40
-        stage_order: 3
-        stage_name: Delivery
-        capability_ids:
-          - BC-4310
-          - BC-4320
-          - BC-4330
-        process_ids: []
-        notes: Fieldwork, advisory analysis, drafting, and working-paper capture; Utilisation tracking and bench redeployment during delivery; Timekeeping and disbursement capture against the engagement
-      - id: VS-190.50
-        stage_order: 3
-        stage_name: Delivery
-        capability_ids:
-          - BC-4970
-        process_ids: []
-        industry_variant: Real Estate
-        notes: Valuation approach application and report drafting
-      - id: VS-190.60
-        stage_order: 4
-        stage_name: Quality Review
-        capability_ids:
-          - BC-4340
-        process_ids: []
-        notes: EQR, file review, and technical consultation before issuance
-      - id: VS-190.70
-        stage_order: 4
-        stage_name: Quality Review
-        capability_ids:
-          - BC-4970
-        process_ids: []
-        industry_variant: Real Estate
-        notes: Reviewer sign-off and quality control
-      - id: VS-190.80
-        stage_order: 5
-        stage_name: Issuance
-        capability_ids:
-          - BC-4310
-          - BC-4300
-        process_ids: []
-        notes: Final report, opinion, or deliverable issuance to the client; Engagement closure communication and post-issuance handover
-      - id: VS-190.90
-        stage_order: 5
-        stage_name: Issuance
-        capability_ids:
-          - BC-4970
-        process_ids: []
-        industry_variant: Real Estate
-        notes: Valuation report issuance to client and lender
-      - id: VS-190.100
-        stage_order: 6
-        stage_name: Billing & Realisation
-        capability_ids:
-          - BC-4330
-        process_ids: []
-        notes: Invoicing, WIP write-up/down, realisation tracking, and write-off control
-      - id: VS-190.110
-        stage_order: 7
-        stage_name: File Lock-Down & Retention
-        capability_ids:
-          - BC-4310
-          - BC-4300
-        process_ids: []
-        notes: Engagement file assembly and post-issuance lock-down; Retention configuration and engagement-file archival
-  - id: VS-200
-    name: ESG-to-Disclosure
-    industries:
-      - Cross-Industry
-    stages:
-      - id: VS-200.10
-        stage_order: 1
-        stage_name: ESG Strategy & Materiality
-        capability_ids:
-          - BC-740
-        process_ids: []
-        notes: ESG strategy & materiality
-      - id: VS-200.20
-        stage_order: 1
-        stage_name: ESG Strategy & Materiality
-        capability_ids:
-          - BC-4500
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Social materiality input to mining ESG strategy
-      - id: VS-200.30
-        stage_order: 2
-        stage_name: Data Collection
-        capability_ids:
-          - BC-510
-          - BC-740
-          - BC-4920
-        process_ids: []
-        notes: Supplier sustainability ratings; Emissions / energy data; Circular economy metrics; Sustainable sourcing data; Asset-level energy, water, waste, and carbon intensity data collection
-      - id: VS-200.40
-        stage_order: 2
-        stage_name: Data Collection
-        capability_ids:
-          - BC-3600
-          - BC-3590
-        process_ids: []
-        industry_variant: Agriculture
-        notes: Soil carbon, water, biodiversity, and farm GHG data; Animal welfare and provenance indicator data
-      - id: VS-200.50
-        stage_order: 2
-        stage_name: Data Collection
-        capability_ids:
-          - BC-1980
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Substance & product footprint data
-      - id: VS-200.60
-        stage_order: 2
-        stage_name: Data Collection
-        capability_ids:
-          - BC-2040
-          - BC-2070
-        process_ids: []
-        industry_variant: HVAC & Building Automation Systems
-        notes: Refrigerant leak rate & charge accounting data; Building energy & operational carbon telemetry
-      - id: VS-200.70
-        stage_order: 2
-        stage_name: Data Collection
-        capability_ids:
-          - BC-2200
-        process_ids: []
-        industry_variant: Insurance
-        notes: Investment portfolio climate data
-      - id: VS-200.80
-        stage_order: 2
-        stage_name: Data Collection
-        capability_ids:
-          - BC-3780
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Accessibility coverage and content-moderation transparency data
-      - id: VS-200.90
-        stage_order: 2
-        stage_name: Data Collection
-        capability_ids:
-          - BC-4460
-          - BC-4450
-          - BC-4500
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Water, tailings, and mine-waste indicator data; Smelter SO2, particulate, and acid-plant emissions data; Community investment, local content, and social KPI data
-      - id: VS-200.100
-        stage_order: 2
-        stage_name: Data Collection
-        capability_ids:
-          - BC-3030
-        process_ids: []
-        industry_variant: Oil & Gas
-        notes: Methane and flare emissions data capture
-      - id: VS-200.110
-        stage_order: 2
-        stage_name: Data Collection
-        capability_ids:
-          - BC-3800
-          - BC-3890
-        process_ids: []
-        industry_variant: Utilities
-        notes: Generation emissions, CO2, and renewables share data; Storm-overflow event-duration monitoring data
-      - id: VS-200.120
-        stage_order: 3
-        stage_name: Data Collection
-        capability_ids:
-          - BC-4650
-        process_ids: []
-        industry_variant: Chemicals
-        notes: Hazard, SVHC, and product carbon footprint data collection
-      - id: VS-200.130
-        stage_order: 3
-        stage_name: Data Quality & Assurance
-        capability_ids:
-          - BC-140
-          - BC-610
-        process_ids: []
-        notes: Internal assurance; Data quality controls
-      - id: VS-200.140
-        stage_order: 4
-        stage_name: Reporting & Disclosure
-        capability_ids:
-          - BC-200
-          - BC-740
-          - BC-4920
-          - BC-4990
-        process_ids: []
-        notes: Statutory ESG filings; Sustainability report; GRESB asset and entity submission; EPC, MEES, LL97, and EPBD building energy disclosure
-      - id: VS-200.150
-        stage_order: 4
-        stage_name: Reporting & Disclosure
-        capability_ids:
-          - BC-3600
-        process_ids: []
-        industry_variant: Agriculture
-        notes: Agri-environmental scheme reporting and soil-carbon credit issuance
-      - id: VS-200.160
-        stage_order: 4
-        stage_name: Reporting & Disclosure
-        capability_ids:
-          - BC-1980
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Environmental product declarations & digital product passport
-      - id: VS-200.170
-        stage_order: 4
-        stage_name: Reporting & Disclosure
-        capability_ids:
-          - BC-2040
-          - BC-2070
-        process_ids: []
-        industry_variant: HVAC & Building Automation Systems
-        notes: F-Gas / EPA / Kigali refrigerant disclosures; Mandatory benchmarking & green certification reporting
-      - id: VS-200.180
-        stage_order: 4
-        stage_name: Reporting & Disclosure
-        capability_ids:
-          - BC-3780
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: DSA transparency and accessibility compliance reporting
-      - id: VS-200.190
-        stage_order: 4
-        stage_name: Reporting & Disclosure
-        capability_ids:
-          - BC-4400
-          - BC-4410
-          - BC-4460
-          - BC-4470
-          - BC-4490
-          - BC-4500
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Public exploration results disclosure under JORC, NI 43-101, and SAMREC; Annual public mineral resources and ore reserves statement; GISTM conformance disclosure; Closure provisions and post-closure stewardship disclosure; Payments-to-governments and EITI disclosure; Social performance, community, and human-rights disclosure
-      - id: VS-200.200
-        stage_order: 4
-        stage_name: Reporting & Disclosure
-        capability_ids:
-          - BC-3120
-        process_ids: []
-        industry_variant: Oil & Gas
-        notes: Decommissioning provisions and post-closure disclosures
-      - id: VS-200.210
-        stage_order: 4
-        stage_name: Reporting & Disclosure
-        capability_ids:
-          - BC-3920
-        process_ids: []
-        industry_variant: Utilities
-        notes: Utility regulator ESG, performance, and price-control disclosures
-      - id: VS-200.220
-        stage_order: 5
-        stage_name: Stakeholder Engagement
-        capability_ids:
-          - BC-240
-          - BC-740
-        process_ids: []
-        notes: Investor relations briefings; Investor / NGO engagement
-      - id: VS-200.230
-        stage_order: 5
-        stage_name: Stakeholder Engagement
-        capability_ids:
-          - BC-4500
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Investor and community engagement on social performance
-      - id: VS-200.240
-        stage_order: 6
-        stage_name: Improvement Targets
-        capability_ids:
-          - BC-100
-        process_ids: []
-        notes: Strategy execution feedback
-  - id: VS-210
-    name: Event-to-Record
-    industries:
-      - Public Sector & Government
-    stages:
-      - id: VS-210.10
-        stage_order: 1
-        stage_name: Event Notification
-        capability_ids:
-          - BC-3290
-        process_ids: []
-        notes: Notification of births, deaths, marriages, business events, and land transactions
-      - id: VS-210.20
-        stage_order: 2
-        stage_name: Registration
-        capability_ids:
-          - BC-3290
-        process_ids: []
-        notes: Authoritative registration and identifier assignment
-      - id: VS-210.30
-        stage_order: 3
-        stage_name: Certification & Issuance
-        capability_ids:
-          - BC-3290
-        process_ids: []
-        notes: Issuance of certificates, credentials, and registry extracts
-      - id: VS-210.40
-        stage_order: 4
-        stage_name: Authentication
-        capability_ids:
-          - BC-3290
-        process_ids: []
-        notes: Document authentication and apostille issuance under the Hague Convention
-      - id: VS-210.50
-        stage_order: 5
-        stage_name: Disclosure & Search
-        capability_ids:
-          - BC-3290
-        process_ids: []
-        notes: Public-facing search services and certified-copy provision
-      - id: VS-210.60
-        stage_order: 6
-        stage_name: Record Maintenance & Privacy
-        capability_ids:
-          - BC-3290
-        process_ids: []
-        notes: Ongoing maintenance, restricted disclosure, and privacy controls
-  - id: VS-220
-    name: Filing-to-Disposition
-    industries:
-      - Public Sector & Government
-    stages:
-      - id: VS-220.10
-        stage_order: 1
-        stage_name: Case Filing
-        capability_ids:
-          - BC-3320
-        process_ids: []
-        notes: Case initiation, e-filing, classification, and fee assessment
-      - id: VS-220.20
-        stage_order: 2
-        stage_name: Docket & Scheduling
-        capability_ids:
-          - BC-3320
-        process_ids: []
-        notes: Docket maintenance, hearing scheduling, and judicial assignment
-      - id: VS-220.30
-        stage_order: 3
-        stage_name: Hearing & Trial
-        capability_ids:
-          - BC-3320
-        process_ids: []
-        notes: Jury management, courtroom operations, and witness support
-      - id: VS-220.40
-        stage_order: 4
-        stage_name: Judgment & Sentencing
-        capability_ids:
-          - BC-3320
-        process_ids: []
-        notes: Recording of judgments, sentences, and dispositional orders
-      - id: VS-220.50
-        stage_order: 5
-        stage_name: Order Enforcement
-        capability_ids:
-          - BC-3320
-        process_ids: []
-        notes: Fines, restitution, civil judgment enforcement, and warrants
-      - id: VS-220.60
-        stage_order: 6
-        stage_name: Custody & Supervision
-        capability_ids:
-          - BC-3320
-        process_ids: []
-        notes: Corrections custody, probation, and parole supervision
-      - id: VS-220.70
-        stage_order: 7
-        stage_name: Records & Public Access
-        capability_ids:
-          - BC-3320
-        process_ids: []
-        notes: Court records maintenance, public access, sealing, and expungement
-  - id: VS-230
-    name: Firmware-to-Field
-    industries:
-      - Electrical Components & Equipment
-    stages:
-      - id: VS-230.10
-        stage_order: 1
-        stage_name: Firmware Build & Sign
-        capability_ids:
-          - BC-1950
-        process_ids: []
-        notes: Firmware build pipelines, code signing, and artefact governance
-      - id: VS-230.20
-        stage_order: 2
-        stage_name: Release Authorisation
-        capability_ids:
-          - BC-1950
-        process_ids: []
-        notes: Release-train governance, change approval, and release-note authoring
-      - id: VS-230.30
-        stage_order: 3
-        stage_name: Staged Rollout & Pilot
-        capability_ids:
-          - BC-1950
-        process_ids: []
-        notes: Canary rings, pilot fleets, and rollback gating
-      - id: VS-230.40
-        stage_order: 4
-        stage_name: OTA Distribution
-        capability_ids:
-          - BC-1950
-        process_ids: []
-        notes: Over-the-air delivery, device-side update orchestration, and verification
-      - id: VS-230.50
-        stage_order: 5
-        stage_name: Field Telemetry & Health
-        capability_ids:
-          - BC-1950
-        process_ids: []
-        notes: Device telemetry ingestion and fleet health monitoring
-      - id: VS-230.60
-        stage_order: 6
-        stage_name: Vulnerability & Incident Response
-        capability_ids:
-          - BC-1950
-          - BC-620
-        process_ids: []
-        notes: Product PSIRT, CVE triage, and emergency patch issuance; Enterprise cybersecurity coordination for product incidents
-      - id: VS-230.70
-        stage_order: 7
-        stage_name: Decommission & Sunset
-        capability_ids:
-          - BC-1950
-        process_ids: []
-        notes: End-of-support declaration, key revocation, and device retirement
-  - id: VS-240
-    name: First-Notice-to-Settlement
-    industries:
-      - Insurance
-    stages:
-      - id: VS-240.10
-        stage_order: 1
-        stage_name: FNOL Intake
-        capability_ids:
-          - BC-2160
-          - BC-2120
-        process_ids: []
-        notes: Multi-channel first notice of loss capture and registration; Policyholder identification and contact verification at FNOL
-      - id: VS-240.20
-        stage_order: 2
-        stage_name: Triage & Coverage
-        capability_ids:
-          - BC-2160
-        process_ids: []
-        notes: Severity triage, coverage verification, and assignment
-      - id: VS-240.30
-        stage_order: 3
-        stage_name: Investigation & Adjustment
-        capability_ids:
-          - BC-2160
-        process_ids: []
-        notes: Investigation, liability assessment, and loss adjustment
-      - id: VS-240.40
-        stage_order: 4
-        stage_name: Reserving
-        capability_ids:
-          - BC-2160
-          - BC-2180
-        process_ids: []
-        notes: Case reserve setting and revision through claim life; IBNR and bulk reserve estimation feeding portfolio reserves
-      - id: VS-240.50
-        stage_order: 5
-        stage_name: Settlement
-        capability_ids:
-          - BC-2160
-        process_ids: []
-        notes: Settlement negotiation, payment, and litigation closure
-      - id: VS-240.60
-        stage_order: 6
-        stage_name: Recovery & Subrogation
-        capability_ids:
-          - BC-2160
-          - BC-2170
-        process_ids: []
-        notes: Salvage, subrogation, and third-party recovery; Reinsurance recoveries against ceded claims
-  - id: VS-250
-    name: Flight-to-Settle
-    industries:
-      - Air Traffic Control
-    stages:
-      - id: VS-250.10
-        stage_order: 1
-        stage_name: Flight Plan Filing
-        capability_ids:
-          - BC-1230
-        process_ids: []
-        industry_variant: ATC
-        notes: Aeronautical information / flight plan
-      - id: VS-250.20
-        stage_order: 2
-        stage_name: Flight Operations
-        capability_ids:
-          - BC-1210
-          - BC-1220
-        process_ids: []
-        industry_variant: ATC
-        notes: En-route control; Flow management
-      - id: VS-250.30
-        stage_order: 3
-        stage_name: Charge Determination
-        capability_ids:
-          - BC-1270
-        process_ids: []
-        industry_variant: ATC
-        notes: Charging zone resolution; Route charge calculation
-      - id: VS-250.40
-        stage_order: 4
-        stage_name: Invoicing
-        capability_ids:
-          - BC-200
-        process_ids: []
-        notes: AR processing
-      - id: VS-250.50
-        stage_order: 4
-        stage_name: Invoicing
-        capability_ids:
-          - BC-1270
-        process_ids: []
-        industry_variant: ATC
-        notes: Airline billing
-      - id: VS-250.60
-        stage_order: 5
-        stage_name: Collection
-        capability_ids:
-          - BC-1270
-        process_ids: []
-        industry_variant: ATC
-        notes: Charges collection
-      - id: VS-250.70
-        stage_order: 6
-        stage_name: Reconciliation & Reporting
-        capability_ids:
-          - BC-200
-        process_ids: []
-        notes: GL posting
-      - id: VS-250.80
-        stage_order: 6
-        stage_name: Reconciliation & Reporting
-        capability_ids:
-          - BC-1270
-        process_ids: []
-        industry_variant: ATC
-        notes: Charges reporting
-  - id: VS-260
-    name: Generate-to-Settle
-    industries:
-      - Power & Water Utilities
-    stages:
-      - id: VS-260.10
-        stage_order: 1
-        stage_name: Generation Scheduling
-        capability_ids:
-          - BC-3800
-          - BC-3850
-        process_ids: []
-        industry_variant: Utilities
-        notes: Unit commitment and economic dispatch against forecast load; Forward and bilateral position pre-scheduling
-      - id: VS-260.20
-        stage_order: 2
-        stage_name: Wholesale Trading & Position Management
-        capability_ids:
-          - BC-3850
-        process_ids: []
-        industry_variant: Utilities
-        notes: Day-ahead, intraday, capacity, and environmental commodity trading
-      - id: VS-260.30
-        stage_order: 3
-        stage_name: Generation Operations
-        capability_ids:
-          - BC-3800
-        process_ids: []
-        industry_variant: Utilities
-        notes: Thermal, hydro, nuclear, renewable, and storage plant operations
-      - id: VS-260.40
-        stage_order: 4
-        stage_name: System Balancing & Dispatch
-        capability_ids:
-          - BC-3830
-        process_ids: []
-        industry_variant: Utilities
-        notes: Real-time system ops, frequency, reserves, and ancillary services
-      - id: VS-260.50
-        stage_order: 5
-        stage_name: Distributed Energy Coordination
-        capability_ids:
-          - BC-3840
-        process_ids: []
-        industry_variant: Utilities
-        notes: VPP, demand response, EV grid integration, and microgrid dispatch
-      - id: VS-260.60
-        stage_order: 6
-        stage_name: Physical Delivery
-        capability_ids:
-          - BC-3810
-          - BC-3820
-        process_ids: []
-        industry_variant: Utilities
-        notes: Transmission grid operation and inter-area flow; Distribution-network delivery to point of use
-      - id: VS-260.70
-        stage_order: 7
-        stage_name: Metering & Imbalance Calculation
-        capability_ids:
-          - BC-3910
-          - BC-3830
-        process_ids: []
-        industry_variant: Utilities
-        notes: AMI data acquisition, validation, and aggregation by BRP; Imbalance volume, price calculation, and BRP notification
-      - id: VS-260.80
-        stage_order: 8
-        stage_name: Trade Settlement & Reporting
-        capability_ids:
-          - BC-3850
-        process_ids: []
-        industry_variant: Utilities
-        notes: Trade confirmation, settlement, and REMIT / EMIR / Dodd-Frank reporting
-  - id: VS-270
-    name: Greenlight-to-Premiere
-    industries:
-      - Media, Entertainment & Telecom Content
-    stages:
-      - id: VS-270.10
-        stage_order: 1
-        stage_name: Concept & Pitch Intake
-        capability_ids:
-          - BC-3700
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Concept evaluation, slate planning, and incoming pitch triage
-      - id: VS-270.20
-        stage_order: 2
-        stage_name: Greenlight Decision
-        capability_ids:
-          - BC-3700
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Greenlight authority, commissioning brief, budget and creative envelope
-      - id: VS-270.30
-        stage_order: 3
-        stage_name: Pre-Production
-        capability_ids:
-          - BC-3700
-          - BC-3790
-          - BC-3720
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Script development, production budgeting, scheduling, and location planning; Casting and talent contracting; Inbound rights and underlying material clearance for production
-      - id: VS-270.40
-        stage_order: 4
-        stage_name: Production
-        capability_ids:
-          - BC-3700
-          - BC-3710
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Principal photography, studio production, live and news production; On-set ingest of source material into the asset platform
-      - id: VS-270.50
-        stage_order: 5
-        stage_name: Post-Production & Mastering
-        capability_ids:
-          - BC-3700
-          - BC-3710
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Picture edit, audio post, colour, conform, and master delivery; Mezzanine generation, distribution renditions, and identifier assignment
-      - id: VS-270.60
-        stage_order: 6
-        stage_name: Rights & Compliance Clearance
-        capability_ids:
-          - BC-3720
-          - BC-3780
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Chain-of-title verification and clearance against territorial rights; Classification submission, editorial review, and accessibility compliance
-      - id: VS-270.70
-        stage_order: 7
-        stage_name: Schedule & Catalogue Placement
-        capability_ids:
-          - BC-3730
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Schedule slot, EPG publication, and on-demand catalogue exposure
-      - id: VS-270.80
-        stage_order: 8
-        stage_name: Distribution & Premiere
-        capability_ids:
-          - BC-3740
-          - BC-3750
-          - BC-3760
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Linear, OTT, IPTV, and syndication delivery for first-window release; Viewer activation and entitlement at premiere; Promotional inventory and sponsorship activation around the launch
-      - id: VS-270.90
-        stage_order: 9
-        stage_name: Performance Feedback
-        capability_ids:
-          - BC-3770
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Title performance, engagement funnel, and recommendation feedback to commissioning
-  - id: VS-280
-    name: Hire-to-Retire
-    industries:
-      - Cross-Industry
-    stages:
-      - id: VS-280.10
-        stage_order: 1
-        stage_name: Workforce Planning
-        capability_ids:
-          - BC-300
-        process_ids: []
-        notes: Demand planning
-      - id: VS-280.20
-        stage_order: 1
-        stage_name: Workforce Planning
-        capability_ids:
-          - BC-4760
-        process_ids: []
-        industry_variant: Education
-        notes: Faculty workforce and teaching-load planning
-      - id: VS-280.30
-        stage_order: 2
-        stage_name: Sourcing & Attraction
-        capability_ids:
-          - BC-300
-          - BC-400
-        process_ids: []
-        notes: Sourcing; Employer brand
-      - id: VS-280.40
-        stage_order: 2
-        stage_name: Sourcing & Attraction
-        capability_ids:
-          - BC-3790
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Talent search and casting briefs
-      - id: VS-280.50
-        stage_order: 3
-        stage_name: Selection & Hire
-        capability_ids:
-          - BC-300
-        process_ids: []
-        notes: Selection
-      - id: VS-280.60
-        stage_order: 3
-        stage_name: Selection & Hire
-        capability_ids:
-          - BC-1810
-        process_ids: []
-        industry_variant: Defense
-        notes: Clearance verification
-      - id: VS-280.70
-        stage_order: 3
-        stage_name: Selection & Hire
-        capability_ids:
-          - BC-4760
-        process_ids: []
-        industry_variant: Education
-        notes: Academic search and credentialed appointment
-      - id: VS-280.80
-        stage_order: 3
-        stage_name: Selection & Hire
-        capability_ids:
-          - BC-2890
-        process_ids: []
-        industry_variant: Healthcare Providers
-        notes: Practitioner credentialing and initial privileging
-      - id: VS-280.90
-        stage_order: 3
-        stage_name: Selection & Hire
-        capability_ids:
-          - BC-3790
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Casting decision, talent contracting, loan-out structures
-      - id: VS-280.100
-        stage_order: 3
-        stage_name: Selection & Hire
-        capability_ids:
-          - BC-4380
-        process_ids: []
-        industry_variant: Professional Services
-        notes: Practising-certificate and bar-admission verification at hire
-      - id: VS-280.110
-        stage_order: 3
-        stage_name: Selection & Hire
-        capability_ids:
-          - BC-4960
-        process_ids: []
-        industry_variant: Real Estate
-        notes: Agent licence and brokerage sponsorship verification at hire
-      - id: VS-280.120
-        stage_order: 3
-        stage_name: Selection & Hire
-        capability_ids:
-          - BC-2440
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: Driver and crew licence and rating verification at hire
-      - id: VS-280.130
-        stage_order: 4
-        stage_name: Onboarding
-        capability_ids:
-          - BC-300
-        process_ids: []
-        notes: Onboarding programme; Records, payroll setup
-      - id: VS-280.140
-        stage_order: 5
-        stage_name: Performance & Development
-        capability_ids:
-          - BC-300
-        process_ids: []
-        notes: Performance reviews; Training
-      - id: VS-280.150
-        stage_order: 5
-        stage_name: Performance & Development
-        capability_ids:
-          - BC-1290
-        process_ids: []
-        industry_variant: ATC
-        notes: ATCO licensing track
-      - id: VS-280.160
-        stage_order: 5
-        stage_name: Performance & Development
-        capability_ids:
-          - BC-4760
-        process_ids: []
-        industry_variant: Education
-        notes: Pedagogy development and teaching peer review
-      - id: VS-280.170
-        stage_order: 5
-        stage_name: Performance & Development
-        capability_ids:
-          - BC-2890
-        process_ids: []
-        industry_variant: Healthcare Providers
-        notes: Ongoing and focused practitioner performance evaluation
-      - id: VS-280.180
-        stage_order: 5
-        stage_name: Performance & Development
-        capability_ids:
-          - BC-1560
-        process_ids: []
-        industry_variant: Pharma
-        notes: GxP training records
-      - id: VS-280.190
-        stage_order: 5
-        stage_name: Performance & Development
-        capability_ids:
-          - BC-4380
-        process_ids: []
-        industry_variant: Professional Services
-        notes: CPD / CPE tracking and shortfall remediation
-      - id: VS-280.200
-        stage_order: 5
-        stage_name: Performance & Development
-        capability_ids:
-          - BC-4990
-        process_ids: []
-        industry_variant: Real Estate
-        notes: Agent continuing education tracking
-      - id: VS-280.210
-        stage_order: 5
-        stage_name: Performance & Development
-        capability_ids:
-          - BC-2440
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: Recurrent training; HOS and fatigue compliance
-      - id: VS-280.220
-        stage_order: 6
-        stage_name: Compensation & Benefits Administration
-        capability_ids:
-          - BC-300
-        process_ids: []
-        notes: Pay design; Payroll execution
-      - id: VS-280.230
-        stage_order: 6
-        stage_name: Compensation & Benefits Administration
-        capability_ids:
-          - BC-3790
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Residuals, royalty distribution, guild pension and health contributions
-      - id: VS-280.240
-        stage_order: 7
-        stage_name: Employee Experience & Engagement
-        capability_ids:
-          - BC-300
-        process_ids: []
-        notes: Engagement; Grievances, works councils
-      - id: VS-280.250
-        stage_order: 8
-        stage_name: Internal Mobility & Career
-        capability_ids:
-          - BC-300
-        process_ids: []
-        notes: Internal moves; Succession
-      - id: VS-280.260
-        stage_order: 8
-        stage_name: Internal Mobility & Career
-        capability_ids:
-          - BC-4760
-        process_ids: []
-        industry_variant: Education
-        notes: Tenure track and academic promotion
-      - id: VS-280.270
-        stage_order: 9
-        stage_name: Offboarding & Alumni
-        capability_ids:
-          - BC-300
-        process_ids: []
-        notes: Separation processing
-  - id: VS-290
-    name: Idea-to-Market
-    industries:
-      - Cross-Industry
-    stages:
-      - id: VS-290.10
-        stage_order: 1
-        stage_name: Idea Capture
-        capability_ids:
-          - BC-800
-        process_ids: []
-        notes: Idea & opportunity intake; Open innovation / external sourcing
-      - id: VS-290.20
-        stage_order: 1
-        stage_name: Idea Capture
-        capability_ids:
-          - BC-4700
-        process_ids: []
-        industry_variant: Education
-        notes: Programme idea intake
-      - id: VS-290.30
-        stage_order: 1
-        stage_name: Idea Capture
-        capability_ids:
-          - BC-3700
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Concept and pitch intake
-      - id: VS-290.40
-        stage_order: 2
-        stage_name: Concept & Feasibility
-        capability_ids:
-          - BC-230
-          - BC-800
-          - BC-820
-          - BC-4200
-        process_ids: []
-        notes: Business case; Incubation / acceleration; Product concept definition; Software product discovery and feasibility
-      - id: VS-290.50
-        stage_order: 2
-        stage_name: Concept & Feasibility
-        capability_ids:
-          - BC-3700
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Greenlight evaluation
-      - id: VS-290.60
-        stage_order: 3
-        stage_name: Research & Prototyping
-        capability_ids:
-          - BC-810
-          - BC-4200
-        process_ids: []
-        notes: Research; Experimentation & prototyping; Software prototyping and validation
-      - id: VS-290.70
-        stage_order: 3
-        stage_name: Research & Prototyping
-        capability_ids:
-          - BC-4600
-        process_ids: []
-        industry_variant: Chemicals
-        notes: Chemical R&D, kinetics, and synthesis route screening
-      - id: VS-290.80
-        stage_order: 3
-        stage_name: Research & Prototyping
-        capability_ids:
-          - BC-1500
-        process_ids: []
-        industry_variant: Pharma
-        notes: Hit discovery
-      - id: VS-290.90
-        stage_order: 4
-        stage_name: Portfolio Selection
-        capability_ids:
-          - BC-800
-          - BC-810
-        process_ids: []
-        notes: Innovation portfolio; R&D portfolio
-      - id: VS-290.100
-        stage_order: 5
-        stage_name: Design & Development
-        capability_ids:
-          - BC-810
-          - BC-820
-          - BC-4200
-        process_ids: []
-        notes: Applied development; Product design; Software product engineering
-      - id: VS-290.110
-        stage_order: 5
-        stage_name: Design & Development
-        capability_ids:
-          - BC-3400
-        process_ids: []
-        industry_variant: Automotive
-        notes: Vehicle product design and development
-      - id: VS-290.120
-        stage_order: 5
-        stage_name: Design & Development
-        capability_ids:
-          - BC-4600
-        process_ids: []
-        industry_variant: Chemicals
-        notes: Pilot scale-up to commercial process definition
-      - id: VS-290.130
-        stage_order: 5
-        stage_name: Design & Development
-        capability_ids:
-          - BC-4700
-          - BC-4790
-        process_ids: []
-        industry_variant: Education
-        notes: Programme structure and curriculum design; Courseware and learning-resource authoring
-      - id: VS-290.140
-        stage_order: 5
-        stage_name: Design & Development
-        capability_ids:
-          - BC-1900
-          - BC-1920
-          - BC-1970
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Electrical/electronic product design; Type-test & qualification on prototypes; Functional-safety & reliability analysis
-      - id: VS-290.150
-        stage_order: 5
-        stage_name: Design & Development
-        capability_ids:
-          - BC-2000
-          - BC-2010
-        process_ids: []
-        industry_variant: HVAC & Building Automation Systems
-        notes: HVAC equipment NPD; BAS product NPD
-      - id: VS-290.160
-        stage_order: 5
-        stage_name: Design & Development
-        capability_ids:
-          - BC-2100
-        process_ids: []
-        industry_variant: Insurance
-        notes: Insurance product design & wording
-      - id: VS-290.170
-        stage_order: 5
-        stage_name: Design & Development
-        capability_ids:
-          - BC-3710
-          - BC-3700
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Mezzanine and master generation; Pre-production, production, post-production
-      - id: VS-290.180
-        stage_order: 5
-        stage_name: Design & Development
-        capability_ids:
-          - BC-1510
-        process_ids: []
-        industry_variant: Pharma
-        notes: Drug development phases
-      - id: VS-290.190
-        stage_order: 5
-        stage_name: Design & Development
-        capability_ids:
-          - BC-2300
-        process_ids: []
-        industry_variant: Retail & Consumer Goods
-        notes: Private-label NPD specification
-      - id: VS-290.200
-        stage_order: 5
-        stage_name: Design & Development
-        capability_ids:
-          - BC-2650
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Tariff, plan, and bundle design
-      - id: VS-290.210
-        stage_order: 6
-        stage_name: IP Protection
-        capability_ids:
-          - BC-840
-        process_ids: []
-        notes: Patents, trademarks
-      - id: VS-290.220
-        stage_order: 6
-        stage_name: IP Protection
-        capability_ids:
-          - BC-3720
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Chain-of-title and rights documentation
-      - id: VS-290.230
-        stage_order: 7
-        stage_name: Launch Readiness
-        capability_ids:
-          - BC-400
-          - BC-820
-          - BC-4210
-          - BC-4270
-        process_ids: []
-        notes: Demand generation; Release & launch; Release engineering and environment readiness; Public API and SDK release readiness
-      - id: VS-290.240
-        stage_order: 7
-        stage_name: Launch Readiness
-        capability_ids:
-          - BC-3410
-        process_ids: []
-        industry_variant: Automotive
-        notes: Vehicle programme launch readiness gating
-      - id: VS-290.250
-        stage_order: 7
-        stage_name: Launch Readiness
-        capability_ids:
-          - BC-4650
-          - BC-4660
-        process_ids: []
-        industry_variant: Chemicals
-        notes: SDS, GHS labels, and exposure scenarios pre-launch; Substance registration ahead of placement on market
-      - id: VS-290.260
-        stage_order: 7
-        stage_name: Launch Readiness
-        capability_ids:
-          - BC-4700
-        process_ids: []
-        industry_variant: Education
-        notes: Programme catalogue publication and approval
-      - id: VS-290.270
-        stage_order: 7
-        stage_name: Launch Readiness
-        capability_ids:
-          - BC-1940
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Saleable catalogue activation
-      - id: VS-290.280
-        stage_order: 7
-        stage_name: Launch Readiness
-        capability_ids:
-          - BC-2100
-        process_ids: []
-        industry_variant: Insurance
-        notes: Filing & channel readiness
-      - id: VS-290.290
-        stage_order: 7
-        stage_name: Launch Readiness
-        capability_ids:
-          - BC-3730
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Schedule slot and EPG readiness
-      - id: VS-290.300
-        stage_order: 7
-        stage_name: Launch Readiness
-        capability_ids:
-          - BC-2370
-        process_ids: []
-        industry_variant: Retail & Consumer Goods
-        notes: Channel content readiness
-      - id: VS-290.310
-        stage_order: 7
-        stage_name: Launch Readiness
-        capability_ids:
-          - BC-2650
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Multi-channel catalogue publication
-      - id: VS-290.320
-        stage_order: 8
-        stage_name: Market Introduction
-        capability_ids:
-          - BC-410
-          - BC-4210
-        process_ids: []
-        notes: Sales strategy / GTM; Progressive production rollout
-      - id: VS-290.330
-        stage_order: 8
-        stage_name: Market Introduction
-        capability_ids:
-          - BC-3420
-        process_ids: []
-        industry_variant: Automotive
-        notes: Type approval as market-entry gate
-      - id: VS-290.340
-        stage_order: 8
-        stage_name: Market Introduction
-        capability_ids:
-          - BC-4700
-        process_ids: []
-        industry_variant: Education
-        notes: Programme launch into student recruitment
-      - id: VS-290.350
-        stage_order: 8
-        stage_name: Market Introduction
-        capability_ids:
-          - BC-1910
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Type approval & agency mark issuance
-      - id: VS-290.360
-        stage_order: 8
-        stage_name: Market Introduction
-        capability_ids:
-          - BC-2030
-        process_ids: []
-        industry_variant: HVAC & Building Automation Systems
-        notes: Performance & safety mark issuance for HVAC equipment
-      - id: VS-290.370
-        stage_order: 8
-        stage_name: Market Introduction
-        capability_ids:
-          - BC-2100
-        process_ids: []
-        industry_variant: Insurance
-        notes: Regulatory rate filing & approval
-      - id: VS-290.380
-        stage_order: 8
-        stage_name: Market Introduction
-        capability_ids:
-          - BC-3740
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: First-window release
-      - id: VS-290.390
-        stage_order: 8
-        stage_name: Market Introduction
-        capability_ids:
-          - BC-1530
-        process_ids: []
-        industry_variant: Pharma
-        notes: Regulatory submission & approval
-      - id: VS-290.400
-        stage_order: 8
-        stage_name: Market Introduction
-        capability_ids:
-          - BC-2360
-        process_ids: []
-        industry_variant: Retail & Consumer Goods
-        notes: Trade-event launch activation
-      - id: VS-290.410
-        stage_order: 8
-        stage_name: Market Introduction
-        capability_ids:
-          - BC-2650
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Telecom offer launch and channel activation
-      - id: VS-290.420
-        stage_order: 9
-        stage_name: Post-Launch Performance
-        capability_ids:
-          - BC-820
-          - BC-4280
-          - BC-4220
-        process_ids: []
-        notes: Performance & feedback; End-of-life planning; Telemetry, A/B tests, and feature engagement reporting; Reliability and performance of the launched service
-      - id: VS-290.430
-        stage_order: 9
-        stage_name: Post-Launch Performance
-        capability_ids:
-          - BC-3450
-        process_ids: []
-        industry_variant: Automotive
-        notes: Field-quality feedback into product
-      - id: VS-290.440
-        stage_order: 9
-        stage_name: Post-Launch Performance
-        capability_ids:
-          - BC-4700
-        process_ids: []
-        industry_variant: Education
-        notes: Periodic curriculum review and improvement
-      - id: VS-290.450
-        stage_order: 9
-        stage_name: Post-Launch Performance
-        capability_ids:
-          - BC-1940
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Phase-in / phase-out, last-buy windows
-      - id: VS-290.460
-        stage_order: 9
-        stage_name: Post-Launch Performance
-        capability_ids:
-          - BC-2100
-        process_ids: []
-        industry_variant: Insurance
-        notes: Product performance review
-      - id: VS-290.470
-        stage_order: 9
-        stage_name: Post-Launch Performance
-        capability_ids:
-          - BC-3770
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Title performance feedback to commissioning
-      - id: VS-290.480
-        stage_order: 9
-        stage_name: Post-Launch Performance
-        capability_ids:
-          - BC-2650
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Offer modification, retirement, and grandfathering
-  - id: VS-300
-    name: Insight-to-Reuse
-    industries:
-      - Professional Services
-    stages:
-      - id: VS-300.10
-        stage_order: 1
-        stage_name: Asset Identification
-        capability_ids:
-          - BC-4310
-          - BC-4370
-        process_ids: []
-        notes: Engagement deliverables and working papers identified as candidate assets; Reusable asset selection from completed engagements
-      - id: VS-300.20
-        stage_order: 2
-        stage_name: Sanitisation & Redaction
-        capability_ids:
-          - BC-4370
-          - BC-4350
-        process_ids: []
-        notes: Removal of client-confidential content before reuse; Information-barrier and confidentiality compliance during redaction
-      - id: VS-300.30
-        stage_order: 3
-        stage_name: Curation & Versioning
-        capability_ids:
-          - BC-4370
-        process_ids: []
-        notes: Precedent curation and methodology versioning
-      - id: VS-300.40
-        stage_order: 4
-        stage_name: Cataloguing
-        capability_ids:
-          - BC-4370
-          - BC-720
-        process_ids: []
-        notes: Asset tagging, metadata enrichment, and library catalogue placement; Enterprise knowledge taxonomy and search alignment
-      - id: VS-300.50
-        stage_order: 5
-        stage_name: Distribution & Community
-        capability_ids:
-          - BC-4370
-        process_ids: []
-        notes: Practice-group, community-of-practice, and knowledge-champion distribution
-      - id: VS-300.60
-        stage_order: 6
-        stage_name: Reuse & Analytics
-        capability_ids:
-          - BC-4370
-        process_ids: []
-        notes: Library usage analytics and reuse-impact tracking
-  - id: VS-310
-    name: Issue-to-Resolution
-    industries:
-      - Cross-Industry
-    stages:
-      - id: VS-310.10
-        stage_order: 1
-        stage_name: Issue Capture (ADS Incident)
-        capability_ids:
-          - BC-3470
-        process_ids: []
-        industry_variant: Automotive
-        notes: ADS disengagement and incident intake
-      - id: VS-310.20
-        stage_order: 1
-        stage_name: Issue Capture (Agri-Food Compliance)
-        capability_ids:
-          - BC-3590
-        process_ids: []
-        industry_variant: Agriculture
-        notes: Farm assurance, organic, welfare, MRL non-conformance intake
-      - id: VS-310.30
-        stage_order: 1
-        stage_name: Issue Capture (Audit)
-        capability_ids:
-          - BC-140
-        process_ids: []
-      - id: VS-310.40
-        stage_order: 1
-        stage_name: Issue Capture (Aviation Safety - Carrier)
-        capability_ids:
-          - BC-4080
-        process_ids: []
-        industry_variant: Travel & Hospitality
-        notes: Air safety reports captured by carrier operations
-      - id: VS-310.50
-        stage_order: 1
-        stage_name: Issue Capture (Aviation Safety)
-        capability_ids:
-          - BC-1280
-        process_ids: []
-        industry_variant: ATC
-      - id: VS-310.60
-        stage_order: 1
-        stage_name: Issue Capture (Banking Fin Crime)
-        capability_ids:
-          - BC-1400
-        process_ids: []
-        industry_variant: Banking
-      - id: VS-310.70
-        stage_order: 1
-        stage_name: Issue Capture (Cargo Claim)
-        capability_ids:
-          - BC-2530
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: Cargo loss and damage claim intake
-      - id: VS-310.80
-        stage_order: 1
-        stage_name: Issue Capture (Chemical Reg)
-        capability_ids:
-          - BC-4660
-        process_ids: []
-        industry_variant: Chemicals
-        notes: Restriction triggers and substance non-compliance intake
-      - id: VS-310.90
-        stage_order: 1
-        stage_name: Issue Capture (Citizen Service)
-        capability_ids:
-          - BC-3220
-        process_ids: []
-        industry_variant: Public Sector
-        notes: Citizen complaint, FOI request, and ombudsman intake
-      - id: VS-310.100
-        stage_order: 1
-        stage_name: Issue Capture (Community Grievance)
-        capability_ids:
-          - BC-4500
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Operational community grievance mechanism intake
-      - id: VS-310.110
-        stage_order: 1
-        stage_name: Issue Capture (Content Compliance)
-        capability_ids:
-          - BC-3780
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Editorial complaints, takedown notices, classification challenges
-      - id: VS-310.120
-        stage_order: 1
-        stage_name: Issue Capture (Cruise Health)
-        capability_ids:
-          - BC-4090
-        process_ids: []
-        industry_variant: Travel & Hospitality
-        notes: Onboard outbreak detection and reporting
-      - id: VS-310.130
-        stage_order: 1
-        stage_name: Issue Capture (Customer)
-        capability_ids:
-          - BC-430
-        process_ids: []
-      - id: VS-310.140
-        stage_order: 1
-        stage_name: Issue Capture (Defense Security)
-        capability_ids:
-          - BC-1810
-        process_ids: []
-        industry_variant: Defense
-      - id: VS-310.150
-        stage_order: 1
-        stage_name: Issue Capture (DG Incident)
-        capability_ids:
-          - BC-2490
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: Dangerous-goods incident, spill, and release intake
-      - id: VS-310.160
-        stage_order: 1
-        stage_name: Issue Capture (Drinking Water Quality)
-        capability_ids:
-          - BC-3870
-        process_ids: []
-        industry_variant: Utilities
-        notes: Drinking-water quality incident and exceedance intake
-      - id: VS-310.170
-        stage_order: 1
-        stage_name: Issue Capture (Engagement Quality)
-        capability_ids:
-          - BC-4340
-        process_ids: []
-        industry_variant: Professional Services
-        notes: Quality deficiencies from EQR, hot review, and cold review
-      - id: VS-310.180
-        stage_order: 1
-        stage_name: Issue Capture (Food Safety)
-        capability_ids:
-          - BC-2380
-        process_ids: []
-        industry_variant: Retail & Consumer Goods
-        notes: Food-safety incident intake
-      - id: VS-310.190
-        stage_order: 1
-        stage_name: Issue Capture (Guest Service)
-        capability_ids:
-          - BC-4040
-        process_ids: []
-        industry_variant: Travel & Hospitality
-        notes: Guest service incident and complaint logging
-      - id: VS-310.200
-        stage_order: 1
-        stage_name: Issue Capture (HSE)
-        capability_ids:
-          - BC-730
-        process_ids: []
-      - id: VS-310.210
-        stage_order: 1
-        stage_name: Issue Capture (HVAC Product Compliance)
-        capability_ids:
-          - BC-2030
-        process_ids: []
-        industry_variant: HVAC & Building Automation Systems
-        notes: Field safety / non-compliance intake
-      - id: VS-310.220
-        stage_order: 1
-        stage_name: Issue Capture (IT/Security)
-        capability_ids:
-          - BC-600
-          - BC-620
-        process_ids: []
-      - id: VS-310.230
-        stage_order: 1
-        stage_name: Issue Capture (Mine Safety)
-        capability_ids:
-          - BC-4430
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Geotechnical TARP, ground-control, and mine atmosphere alarms
-      - id: VS-310.240
-        stage_order: 1
-        stage_name: Issue Capture (Mobility Trust & Safety)
-        capability_ids:
-          - BC-3490
-        process_ids: []
-        industry_variant: Automotive
-        notes: Rider and driver safety incident intake
-      - id: VS-310.250
-        stage_order: 1
-        stage_name: Issue Capture (Patient Safety)
-        capability_ids:
-          - BC-2840
-        process_ids: []
-        industry_variant: Healthcare Providers
-        notes: Patient safety and adverse-event intake
-      - id: VS-310.260
-        stage_order: 1
-        stage_name: Issue Capture (Pharma Reg)
-        capability_ids:
-          - BC-1530
-        process_ids: []
-        industry_variant: Pharma
-      - id: VS-310.270
-        stage_order: 1
-        stage_name: Issue Capture (Pharmacovigilance)
-        capability_ids:
-          - BC-1540
-        process_ids: []
-        industry_variant: Pharma
-      - id: VS-310.280
-        stage_order: 1
-        stage_name: Issue Capture (Process Conformance)
-        capability_ids:
-          - BC-930
-        process_ids: []
-        notes: Process mining and conformance reporting surface execution issues
-      - id: VS-310.290
-        stage_order: 1
-        stage_name: Issue Capture (Process Safety)
-        capability_ids:
-          - BC-4640
-        process_ids: []
-        industry_variant: Chemicals
-        notes: Tier 1 / 2 chemical process safety event capture
-      - id: VS-310.300
-        stage_order: 1
-        stage_name: Issue Capture (Process Safety)
-        capability_ids:
-          - BC-4440
-          - BC-4450
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Cyanide release, reagent leak, and process plant safety events; Smelter and refinery process safety events
-      - id: VS-310.310
-        stage_order: 1
-        stage_name: Issue Capture (Process Safety)
-        capability_ids:
-          - BC-3050
-        process_ids: []
-        industry_variant: Oil & Gas
-        notes: Tier 1/2 process safety event capture
-      - id: VS-310.320
-        stage_order: 1
-        stage_name: Issue Capture (Product Compliance)
-        capability_ids:
-          - BC-1910
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Field non-compliance reports
-      - id: VS-310.330
-        stage_order: 1
-        stage_name: Issue Capture (Professional Conduct)
-        capability_ids:
-          - BC-4380
-        process_ids: []
-        industry_variant: Professional Services
-        notes: Professional conduct breach intake
-      - id: VS-310.340
-        stage_order: 1
-        stage_name: Issue Capture (Property Tenant Service)
-        capability_ids:
-          - BC-4940
-        process_ids: []
-        notes: Tenant service request and complaint capture on commercial and residential properties
-      - id: VS-310.350
-        stage_order: 1
-        stage_name: Issue Capture (Quality)
-        capability_ids:
-          - BC-720
-        process_ids: []
-      - id: VS-310.360
-        stage_order: 1
-        stage_name: Issue Capture (Retail Loss Prevention)
-        capability_ids:
-          - BC-2340
-        process_ids: []
-        industry_variant: Retail & Consumer Goods
-        notes: Shrink, theft, POS fraud intake
-      - id: VS-310.370
-        stage_order: 1
-        stage_name: Issue Capture (SaaS Service)
-        capability_ids:
-          - BC-4220
-        process_ids: []
-        industry_variant: Software & Technology
-        notes: Production incident detection from telemetry and customer reports
-      - id: VS-310.380
-        stage_order: 1
-        stage_name: Issue Capture (Shipment Exception)
-        capability_ids:
-          - BC-2510
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: Shipment exception and disruption alerts
-      - id: VS-310.390
-        stage_order: 1
-        stage_name: Issue Capture (Student Wellbeing)
-        capability_ids:
-          - BC-4770
-        process_ids: []
-        notes: Pastoral, conduct, and grievance intake
-      - id: VS-310.400
-        stage_order: 1
-        stage_name: Issue Capture (Tailings)
-        capability_ids:
-          - BC-4460
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: TSF instrumentation alarm, dam-safety, and water-exceedance events
-      - id: VS-310.410
-        stage_order: 1
-        stage_name: Issue Capture (Telecom Fraud)
-        capability_ids:
-          - BC-2690
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Fraud alert and customer-reported fraud intake
-      - id: VS-310.420
-        stage_order: 1
-        stage_name: Issue Capture (Telecom Service)
-        capability_ids:
-          - BC-2630
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Customer-impacting service incident intake
-      - id: VS-310.430
-        stage_order: 1
-        stage_name: Issue Capture (Title IX)
-        capability_ids:
-          - BC-4810
-        process_ids: []
-        notes: Title IX and education civil-rights complaint intake
-      - id: VS-310.440
-        stage_order: 1
-        stage_name: Issue Capture (Travel F&B Safety)
-        capability_ids:
-          - BC-4070
-        process_ids: []
-        industry_variant: Travel & Hospitality
-        notes: Food-borne illness and allergen incidents
-      - id: VS-310.450
-        stage_order: 1
-        stage_name: Issue Capture (Utility Billing)
-        capability_ids:
-          - BC-3910
-        process_ids: []
-        industry_variant: Utilities
-        notes: Bill exception, dispute, and complaint intake
-      - id: VS-310.460
-        stage_order: 1
-        stage_name: Issue Capture (Vehicle Aftersales)
-        capability_ids:
-          - BC-3450
-        process_ids: []
-        industry_variant: Automotive
-        notes: Warranty claim and field-quality intake
-      - id: VS-310.470
-        stage_order: 1
-        stage_name: Issue Capture (Viewer Service)
-        capability_ids:
-          - BC-3750
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Viewer-reported playback, billing, and entitlement issues
-      - id: VS-310.480
-        stage_order: 1
-        stage_name: Issue Capture (Wastewater Pollution)
-        capability_ids:
-          - BC-3890
-        process_ids: []
-        industry_variant: Utilities
-        notes: Pollution incident and discharge non-compliance intake
-      - id: VS-310.490
-        stage_order: 3
-        stage_name: Investigation (Agri-Food Compliance)
-        capability_ids:
-          - BC-3590
-        process_ids: []
-        industry_variant: Agriculture
-        notes: Compliance and certification non-conformance investigation
-      - id: VS-310.500
-        stage_order: 3
-        stage_name: Investigation (Audit)
-        capability_ids:
-          - BC-140
-        process_ids: []
-      - id: VS-310.510
-        stage_order: 3
-        stage_name: Investigation (Aviation Safety)
-        capability_ids:
-          - BC-1280
-        process_ids: []
-        industry_variant: ATC
-      - id: VS-310.520
-        stage_order: 3
-        stage_name: Investigation (Banking Fin Crime)
-        capability_ids:
-          - BC-1400
-        process_ids: []
-        industry_variant: Banking
-      - id: VS-310.530
-        stage_order: 3
-        stage_name: Investigation (Cargo Claim)
-        capability_ids:
-          - BC-2530
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: Liability assessment under transport conventions
-      - id: VS-310.540
-        stage_order: 3
-        stage_name: Investigation (Chemical Reg)
-        capability_ids:
-          - BC-4660
-        process_ids: []
-        industry_variant: Chemicals
-        notes: Regulatory non-compliance investigation
-      - id: VS-310.550
-        stage_order: 3
-        stage_name: Investigation (Content Compliance)
-        capability_ids:
-          - BC-3780
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Content review and complaint investigation
-      - id: VS-310.560
-        stage_order: 3
-        stage_name: Investigation (Customer)
-        capability_ids:
-          - BC-430
-        process_ids: []
-      - id: VS-310.570
-        stage_order: 3
-        stage_name: Investigation (Defense Security)
-        capability_ids:
-          - BC-1810
-        process_ids: []
-        industry_variant: Defense
-      - id: VS-310.580
-        stage_order: 3
-        stage_name: Investigation (DG Incident)
-        capability_ids:
-          - BC-2490
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: DG incident investigation and authority notification
-      - id: VS-310.590
-        stage_order: 3
-        stage_name: Investigation (Food Safety)
-        capability_ids:
-          - BC-2380
-        process_ids: []
-        industry_variant: Retail & Consumer Goods
-        notes: Lot trace and root-cause analysis
-      - id: VS-310.600
-        stage_order: 3
-        stage_name: Investigation (HSE)
-        capability_ids:
-          - BC-730
-        process_ids: []
-      - id: VS-310.610
-        stage_order: 3
-        stage_name: Investigation (HVAC Product Compliance)
-        capability_ids:
-          - BC-2030
-        process_ids: []
-        industry_variant: HVAC & Building Automation Systems
-        notes: Certifier liaison & root cause for HVAC equipment
-      - id: VS-310.620
-        stage_order: 3
-        stage_name: Investigation (IT/Security)
-        capability_ids:
-          - BC-620
-        process_ids: []
-      - id: VS-310.630
-        stage_order: 3
-        stage_name: Investigation (Patient Safety)
-        capability_ids:
-          - BC-2840
-        process_ids: []
-        industry_variant: Healthcare Providers
-        notes: Root-cause analysis and just-culture review
-      - id: VS-310.640
-        stage_order: 3
-        stage_name: Investigation (Pharma Reg)
-        capability_ids:
-          - BC-1560
-        process_ids: []
-        industry_variant: Pharma
-      - id: VS-310.650
-        stage_order: 3
-        stage_name: Investigation (Pharmacovigilance)
-        capability_ids:
-          - BC-1540
-        process_ids: []
-        industry_variant: Pharma
-      - id: VS-310.660
-        stage_order: 3
-        stage_name: Investigation (Process Safety)
-        capability_ids:
-          - BC-4640
-        process_ids: []
-        industry_variant: Chemicals
-        notes: Root-cause investigation of major chemical incidents
-      - id: VS-310.670
-        stage_order: 3
-        stage_name: Investigation (Process Safety)
-        capability_ids:
-          - BC-3050
-        process_ids: []
-        industry_variant: Oil & Gas
-        notes: Root-cause investigation of major-hazard events
-      - id: VS-310.680
-        stage_order: 3
-        stage_name: Investigation (Product Compliance)
-        capability_ids:
-          - BC-1910
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Root-cause investigation, certifier liaison
-      - id: VS-310.690
-        stage_order: 3
-        stage_name: Investigation (Quality)
-        capability_ids:
-          - BC-720
-        process_ids: []
-        notes: CAPA
-      - id: VS-310.700
-        stage_order: 3
-        stage_name: Investigation (Retail Loss Prevention)
-        capability_ids:
-          - BC-2340
-        process_ids: []
-        industry_variant: Retail & Consumer Goods
-        notes: LP casework, ORC investigation
-      - id: VS-310.710
-        stage_order: 3
-        stage_name: Investigation (SaaS Service)
-        capability_ids:
-          - BC-4220
-        process_ids: []
-        industry_variant: Software & Technology
-        notes: Incident coordination and blameless postmortem authoring
-      - id: VS-310.720
-        stage_order: 3
-        stage_name: Investigation (Telecom Fraud)
-        capability_ids:
-          - BC-2690
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Telecom fraud case investigation
-      - id: VS-310.730
-        stage_order: 3
-        stage_name: Investigation (Telecom Service)
-        capability_ids:
-          - BC-2630
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Root cause analysis and customer-incident investigation
-      - id: VS-310.740
-        stage_order: 3
-        stage_name: Investigation (Title IX)
-        capability_ids:
-          - BC-4810
-        process_ids: []
-        notes: Statutory civil-rights investigation
-      - id: VS-310.750
-        stage_order: 4
-        stage_name: Resolution (Audit)
-        capability_ids:
-          - BC-140
-        process_ids: []
-      - id: VS-310.760
-        stage_order: 4
-        stage_name: Resolution (Aviation Safety)
-        capability_ids:
-          - BC-1280
-        process_ids: []
-        industry_variant: ATC
-      - id: VS-310.770
-        stage_order: 4
-        stage_name: Resolution (Banking Fin Crime)
-        capability_ids:
-          - BC-1400
-        process_ids: []
-        industry_variant: Banking
-      - id: VS-310.780
-        stage_order: 4
-        stage_name: Resolution (Cargo Claim)
-        capability_ids:
-          - BC-2530
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: Claim settlement, recourse, and subrogation
-      - id: VS-310.790
-        stage_order: 4
-        stage_name: Resolution (Chemical Reg)
-        capability_ids:
-          - BC-4660
-        process_ids: []
-        industry_variant: Chemicals
-        notes: Remediation submissions and authority response
-      - id: VS-310.800
-        stage_order: 4
-        stage_name: Resolution (Citizen Service)
-        capability_ids:
-          - BC-3220
-        process_ids: []
-        industry_variant: Public Sector
-        notes: Case resolution, ombudsman determination, appeals outcome
-      - id: VS-310.810
-        stage_order: 4
-        stage_name: Resolution (Content Compliance)
-        capability_ids:
-          - BC-3780
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Edits, takedowns, on-air corrections, counter-notice handling
-      - id: VS-310.820
-        stage_order: 4
-        stage_name: Resolution (Customer)
-        capability_ids:
-          - BC-720
-          - BC-910
-        process_ids: []
-      - id: VS-310.830
-        stage_order: 4
-        stage_name: Resolution (Food Safety)
-        capability_ids:
-          - BC-2380
-        process_ids: []
-        industry_variant: Retail & Consumer Goods
-        notes: Recall execution and effectiveness verification
-      - id: VS-310.840
-        stage_order: 4
-        stage_name: Resolution (HVAC Product Compliance)
-        capability_ids:
-          - BC-2030
-        process_ids: []
-        industry_variant: HVAC & Building Automation Systems
-        notes: Field modification, recall, mark withdrawal
-      - id: VS-310.850
-        stage_order: 4
-        stage_name: Resolution (Patient Safety)
-        capability_ids:
-          - BC-2840
-        process_ids: []
-        industry_variant: Healthcare Providers
-        notes: Corrective action and clinical risk mitigation
-      - id: VS-310.860
-        stage_order: 4
-        stage_name: Resolution (Pharma Reg)
-        capability_ids:
-          - BC-1560
-        process_ids: []
-        industry_variant: Pharma
-      - id: VS-310.870
-        stage_order: 4
-        stage_name: Resolution (Pharmacovigilance)
-        capability_ids:
-          - BC-1540
-        process_ids: []
-        industry_variant: Pharma
-      - id: VS-310.880
-        stage_order: 4
-        stage_name: Resolution (Process Safety)
-        capability_ids:
-          - BC-4640
-        process_ids: []
-        industry_variant: Chemicals
-        notes: Corrective actions and barrier rebuild
-      - id: VS-310.890
-        stage_order: 4
-        stage_name: Resolution (Process Safety)
-        capability_ids:
-          - BC-3050
-        process_ids: []
-        industry_variant: Oil & Gas
-        notes: Corrective actions and barrier rebuild
-      - id: VS-310.900
-        stage_order: 4
-        stage_name: Resolution (Product Compliance)
-        capability_ids:
-          - BC-1910
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Recall / stop-ship coordination
-      - id: VS-310.910
-        stage_order: 4
-        stage_name: Resolution (Property Service Recovery)
-        capability_ids:
-          - BC-4060
-        process_ids: []
-        industry_variant: Travel & Hospitality
-        notes: Service-recovery actions, compensation, and follow-up
-      - id: VS-310.920
-        stage_order: 4
-        stage_name: Resolution (Property Tenant Service)
-        capability_ids:
-          - BC-4940
-        process_ids: []
-        notes: Tenant service recovery and incident closure on commercial and residential properties
-      - id: VS-310.930
-        stage_order: 4
-        stage_name: Resolution (Quality)
-        capability_ids:
-          - BC-720
-        process_ids: []
-      - id: VS-310.940
-        stage_order: 4
-        stage_name: Resolution (Retail Loss Prevention)
-        capability_ids:
-          - BC-2340
-        process_ids: []
-        industry_variant: Retail & Consumer Goods
-        notes: Recovery and disciplinary follow-through
-      - id: VS-310.950
-        stage_order: 4
-        stage_name: Resolution (SaaS Service)
-        capability_ids:
-          - BC-4220
-        process_ids: []
-        industry_variant: Software & Technology
-        notes: Reliability action tracking to closure
-      - id: VS-310.960
-        stage_order: 4
-        stage_name: Resolution (Student Wellbeing)
-        capability_ids:
-          - BC-4770
-        process_ids: []
-        notes: Wellbeing case resolution and remediation
-      - id: VS-310.970
-        stage_order: 4
-        stage_name: Resolution (Telecom Fraud)
-        capability_ids:
-          - BC-2690
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Fraudulent-charge recovery and account remediation
-      - id: VS-310.980
-        stage_order: 4
-        stage_name: Resolution (Telecom Service)
-        capability_ids:
-          - BC-2630
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Service restoration and customer remediation
-      - id: VS-310.990
-        stage_order: 4
-        stage_name: Resolution (Title IX)
-        capability_ids:
-          - BC-4810
-        process_ids: []
-        notes: Sanctioning and statutory closure
-      - id: VS-310.1000
-        stage_order: 4
-        stage_name: Resolution (Viewer Service)
-        capability_ids:
-          - BC-3750
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Entitlement, billing, and playback remediation
-      - id: VS-310.1010
-        stage_order: 6
-        stage_name: Lessons Learned (Aviation Safety)
-        capability_ids:
-          - BC-1280
-        process_ids: []
-        industry_variant: ATC
-      - id: VS-310.1020
-        stage_order: 6
-        stage_name: Lessons Learned (Chemical Reg)
-        capability_ids:
-          - BC-4660
-        process_ids: []
-        industry_variant: Chemicals
-        notes: Surveillance loop into regulatory horizon scanning
-      - id: VS-310.1030
-        stage_order: 6
-        stage_name: Lessons Learned (Generic)
-        capability_ids:
-          - BC-830
-        process_ids: []
-      - id: VS-310.1040
-        stage_order: 6
-        stage_name: Lessons Learned (Patient Safety)
-        capability_ids:
-          - BC-2840
-        process_ids: []
-        industry_variant: Healthcare Providers
-        notes: High-reliability organisational learning
-      - id: VS-310.1050
-        stage_order: 6
-        stage_name: Lessons Learned (Pharma Reg)
-        capability_ids:
-          - BC-1560
-        process_ids: []
-        industry_variant: Pharma
-      - id: VS-310.1060
-        stage_order: 6
-        stage_name: Lessons Learned (Process Safety)
-        capability_ids:
-          - BC-4640
-        process_ids: []
-        industry_variant: Chemicals
-        notes: Industry-wide chemical process-safety lessons sharing
-      - id: VS-310.1070
-        stage_order: 6
-        stage_name: Lessons Learned (Process Safety)
-        capability_ids:
-          - BC-3050
-        process_ids: []
-        industry_variant: Oil & Gas
-        notes: Industry-wide lessons-learned sharing
-      - id: VS-310.1080
-        stage_order: 6
-        stage_name: Lessons Learned (Quality)
-        capability_ids:
-          - BC-830
-        process_ids: []
-  - id: VS-320
-    name: Lead-to-Event
-    industries:
-      - Travel & Hospitality
-    stages:
-      - id: VS-320.10
-        stage_order: 1
-        stage_name: Lead Qualification
-        capability_ids:
-          - BC-4110
-        process_ids: []
-        notes: Inbound group lead qualification
-      - id: VS-320.20
-        stage_order: 2
-        stage_name: Proposal & Contract
-        capability_ids:
-          - BC-4110
-          - BC-4030
-        process_ids: []
-        notes: Group proposal authoring and contract execution; Group pricing and concession against revenue guidance
-      - id: VS-320.30
-        stage_order: 3
-        stage_name: Block & Event Setup
-        capability_ids:
-          - BC-4110
-          - BC-4020
-        process_ids: []
-        notes: BEO authoring and function-space allocation; Group room block contract and rooming list
-      - id: VS-320.40
-        stage_order: 4
-        stage_name: Event Execution
-        capability_ids:
-          - BC-4110
-          - BC-4070
-          - BC-4060
-        process_ids: []
-        notes: Setup, service, AV, and group servicing; Banquet and catering service; Property security, engineering, and concierge support to event
-      - id: VS-320.50
-        stage_order: 5
-        stage_name: Settlement
-        capability_ids:
-          - BC-4110
-        process_ids: []
-        notes: Master account settlement and reconciliation
-      - id: VS-320.60
-        stage_order: 6
-        stage_name: Post-Event
-        capability_ids:
-          - BC-4110
-        process_ids: []
-        notes: Block-vs-pickup, financial, attendee feedback, and renewal tracking
-  - id: VS-330
-    name: Lease-to-Production
-    industries:
-      - Oil & Gas
-      - Mining & Metals
-    stages:
-      - id: VS-330.10
-        stage_order: 1
-        stage_name: Acreage Acquisition
-        capability_ids:
-          - BC-3000
-          - BC-3110
-        process_ids: []
-        notes: License round entry, concession bidding, farm-in; JOA negotiation and AFE setup at entry
-      - id: VS-330.20
-        stage_order: 1
-        stage_name: Acreage Acquisition
-        capability_ids:
-          - BC-4490
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Mineral tenement application, lease, and acquisition due diligence
-      - id: VS-330.30
-        stage_order: 2
-        stage_name: Prospect Maturation
-        capability_ids:
-          - BC-3000
-        process_ids: []
-        notes: Seismic acquisition, prospect evaluation and risking
-      - id: VS-330.40
-        stage_order: 2
-        stage_name: Prospect Maturation
-        capability_ids:
-          - BC-4400
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Geoscientific surveys, target generation, and prospect ranking
-      - id: VS-330.50
-        stage_order: 3
-        stage_name: Exploration Drilling
-        capability_ids:
-          - BC-3020
-          - BC-3000
-        process_ids: []
-        notes: Wildcat and appraisal drilling execution; Post-well evaluation and prospect inventory update
-      - id: VS-330.60
-        stage_order: 3
-        stage_name: Exploration Drilling
-        capability_ids:
-          - BC-4400
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Reverse-circulation and diamond core drilling, sample assay, discovery reporting
-      - id: VS-330.70
-        stage_order: 4
-        stage_name: Reserves Maturation
-        capability_ids:
-          - BC-3010
-        process_ids: []
-        notes: Reservoir characterisation and SPE-PRMS classification
-      - id: VS-330.80
-        stage_order: 4
-        stage_name: Reserves Maturation
-        capability_ids:
-          - BC-4410
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Geological modelling, resource estimation, reserve classification
-      - id: VS-330.90
-        stage_order: 5
-        stage_name: Field Development Sanction
-        capability_ids:
-          - BC-3010
-          - BC-3110
-        process_ids: []
-        notes: Concept selection and field development plan authoring; Partner approvals via OPCOM and host-government FDP submission
-      - id: VS-330.100
-        stage_order: 5
-        stage_name: Field Development Sanction
-        capability_ids:
-          - BC-4420
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Mine design, life-of-mine planning, and capital project sequencing
-      - id: VS-330.110
-        stage_order: 6
-        stage_name: Development Execution
-        capability_ids:
-          - BC-3020
-          - BC-1110
-        process_ids: []
-        notes: Development drilling and completions; Project engineering for surface facility EPC
-      - id: VS-330.120
-        stage_order: 7
-        stage_name: First Production
-        capability_ids:
-          - BC-3030
-          - BC-1160
-        process_ids: []
-        notes: Startup, ramp-up, and first oil/gas; Facility commissioning and handover
-      - id: VS-330.130
-        stage_order: 7
-        stage_name: First Production
-        capability_ids:
-          - BC-4430
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Production ramp-up across open-pit and underground operations
-      - id: VS-330.140
-        stage_order: 8
-        stage_name: Operations Handover
-        capability_ids:
-          - BC-3030
-          - BC-3010
-        process_ids: []
-        notes: Handover to steady-state operate phase; Production forecasting handover and reservoir surveillance
-      - id: VS-330.150
-        stage_order: 8
-        stage_name: Operations Handover
-        capability_ids:
-          - BC-4430
-          - BC-4410
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Handover to steady-state mining operations; Resource and reserve reconciliation handover
-  - id: VS-340
-    name: Listing-to-Closing
-    industries:
-      - Real Estate
-    stages:
-      - id: VS-340.10
-        stage_order: 1
-        stage_name: Listing Pursuit & Win
-        capability_ids:
-          - BC-4960
-        process_ids: []
-        notes: Listing pitch, CMA, and win of the listing mandate
-      - id: VS-340.20
-        stage_order: 2
-        stage_name: Listing Setup & Marketing
-        capability_ids:
-          - BC-4960
-        process_ids: []
-        notes: Listing agreement, MLS capture, media production, and syndication
-      - id: VS-340.30
-        stage_order: 3
-        stage_name: Showing & Engagement
-        capability_ids:
-          - BC-4960
-        process_ids: []
-        notes: Showings, open houses, and prospect engagement
-      - id: VS-340.40
-        stage_order: 4
-        stage_name: Offer & Negotiation
-        capability_ids:
-          - BC-4960
-        process_ids: []
-        notes: Offer drafting, counter-offers, and multiple-offer handling
-      - id: VS-340.50
-        stage_order: 5
-        stage_name: Contingency & Closing Coordination
-        capability_ids:
-          - BC-4960
-        process_ids: []
-        notes: Contingency tracking and coordination with escrow / conveyancing
-      - id: VS-340.60
-        stage_order: 6
-        stage_name: Closing Execution
-        capability_ids:
-          - BC-4960
-        process_ids: []
-        notes: Closing-day coordination and key handover
-      - id: VS-340.70
-        stage_order: 7
-        stage_name: Commission Settlement
-        capability_ids:
-          - BC-4960
-        process_ids: []
-        notes: Cooperating-broker settlement, commission disbursement, and referral fees
-  - id: VS-350
-    name: Maintenance-Request-to-Closure
-    industries:
-      - Manufacturing & Industrial
-      - HVAC & Building Automation Systems
-      - Electrical Components & Equipment
-      - Transportation & Logistics
-      - Oil & Gas
-      - Real Estate
-    stages:
-      - id: VS-350.10
-        stage_order: 1
-        stage_name: Notification / Request
-        capability_ids:
-          - BC-1050
-        process_ids: []
-        notes: Service request (field)
-      - id: VS-350.20
-        stage_order: 1
-        stage_name: Notification / Request
-        capability_ids:
-          - BC-2060
-        process_ids: []
-        industry_variant: HVAC & Building Automation Systems
-        notes: HVAC service request intake
-      - id: VS-350.30
-        stage_order: 1
-        stage_name: Notification / Request
-        capability_ids:
-          - BC-1030
-        process_ids: []
-        industry_variant: Manufacturing
-        notes: Corrective maintenance notification
-      - id: VS-350.40
-        stage_order: 1
-        stage_name: Notification / Request
-        capability_ids:
-          - BC-4940
-        process_ids: []
-        industry_variant: Real Estate
-        notes: Tenant work-order intake on commercial and residential properties
-      - id: VS-350.50
-        stage_order: 1
-        stage_name: Notification / Request
-        capability_ids:
-          - BC-2430
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: Fleet defect notification, mandatory-inspection trigger
-      - id: VS-350.60
-        stage_order: 2
-        stage_name: Triage & Planning
-        capability_ids:
-          - BC-1050
-        process_ids: []
-        notes: Dispatch & scheduling
-      - id: VS-350.70
-        stage_order: 2
-        stage_name: Triage & Planning
-        capability_ids:
-          - BC-1960
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Retrofit & service contract planning
-      - id: VS-350.80
-        stage_order: 2
-        stage_name: Triage & Planning
-        capability_ids:
-          - BC-2060
-        process_ids: []
-        industry_variant: HVAC & Building Automation Systems
-        notes: Reactive triage; remote diagnostic triage
-      - id: VS-350.90
-        stage_order: 2
-        stage_name: Triage & Planning
-        capability_ids:
-          - BC-1030
-        process_ids: []
-        industry_variant: Manufacturing
-        notes: Maintenance work order planning
-      - id: VS-350.100
-        stage_order: 2
-        stage_name: Triage & Planning
-        capability_ids:
-          - BC-4940
-        process_ids: []
-        industry_variant: Real Estate
-        notes: Preventive and reactive maintenance triage
-      - id: VS-350.110
-        stage_order: 2
-        stage_name: Triage & Planning
-        capability_ids:
-          - BC-2430
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: Preventive-maintenance scheduling and defect triage
-      - id: VS-350.120
-        stage_order: 3
-        stage_name: Execution
-        capability_ids:
-          - BC-1050
-        process_ids: []
-        notes: Field service execution
-      - id: VS-350.130
-        stage_order: 3
-        stage_name: Execution
-        capability_ids:
-          - BC-1960
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: OEM service execution on installed base
-      - id: VS-350.140
-        stage_order: 3
-        stage_name: Execution
-        capability_ids:
-          - BC-2060
-        process_ids: []
-        industry_variant: HVAC & Building Automation Systems
-        notes: On-site HVAC repair; BAS reprogramming
-      - id: VS-350.150
-        stage_order: 3
-        stage_name: Execution
-        capability_ids:
-          - BC-1030
-        process_ids: []
-        industry_variant: Manufacturing
-        notes: Corrective maintenance execution
-      - id: VS-350.160
-        stage_order: 3
-        stage_name: Execution
-        capability_ids:
-          - BC-4940
-        process_ids: []
-        industry_variant: Real Estate
-        notes: Maintenance execution including statutory and compliance inspections
-      - id: VS-350.170
-        stage_order: 3
-        stage_name: Execution
-        capability_ids:
-          - BC-2430
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: Fleet maintenance and overhaul execution
-      - id: VS-350.180
-        stage_order: 4
-        stage_name: Parts & Logistics
-        capability_ids:
-          - BC-1050
-        process_ids: []
-        notes: Service parts
-      - id: VS-350.190
-        stage_order: 4
-        stage_name: Parts & Logistics
-        capability_ids:
-          - BC-2060
-        process_ids: []
-        industry_variant: HVAC & Building Automation Systems
-        notes: Refrigerant, filters, sensors, replacement parts
-      - id: VS-350.200
-        stage_order: 4
-        stage_name: Parts & Logistics
-        capability_ids:
-          - BC-1030
-        process_ids: []
-        industry_variant: Manufacturing
-        notes: Maintenance spares
-      - id: VS-350.210
-        stage_order: 4
-        stage_name: Parts & Logistics
-        capability_ids:
-          - BC-2430
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: Spare parts for fleet maintenance
-      - id: VS-350.220
-        stage_order: 5
-        stage_name: Verification & Closure
-        capability_ids:
-          - BC-720
-        process_ids: []
-        notes: Quality control sign-off
-      - id: VS-350.230
-        stage_order: 5
-        stage_name: Verification & Closure
-        capability_ids:
-          - BC-2060
-        process_ids: []
-        industry_variant: HVAC & Building Automation Systems
-        notes: Retrofit validation, post-service tests
-      - id: VS-350.240
-        stage_order: 5
-        stage_name: Verification & Closure
-        capability_ids:
-          - BC-1030
-        process_ids: []
-        industry_variant: Manufacturing
-        notes: Reliability data update
-      - id: VS-350.250
-        stage_order: 5
-        stage_name: Verification & Closure
-        capability_ids:
-          - BC-4940
-        process_ids: []
-        industry_variant: Real Estate
-        notes: Work-order verification and closure with tenant
-      - id: VS-350.260
-        stage_order: 5
-        stage_name: Verification & Closure
-        capability_ids:
-          - BC-2430
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: Roadworthiness, airworthiness, or seaworthiness sign-off
-      - id: VS-350.270
-        stage_order: 6
-        stage_name: Performance & Cost Analysis
-        capability_ids:
-          - BC-1050
-          - BC-200
-        process_ids: []
-        notes: Field service KPIs; Maintenance cost posting
-      - id: VS-350.280
-        stage_order: 6
-        stage_name: Performance & Cost Analysis
-        capability_ids:
-          - BC-2060
-        process_ids: []
-        industry_variant: HVAC & Building Automation Systems
-        notes: Service KPIs, SLA reporting
-  - id: VS-360
-    name: Mandate-to-Distribution
-    industries:
-      - Real Estate
-    stages:
-      - id: VS-360.10
-        stage_order: 1
-        stage_name: Mandate & Strategy Definition
-        capability_ids:
-          - BC-4910
-        process_ids: []
-        notes: Fund / mandate definition and investment strategy
-      - id: VS-360.20
-        stage_order: 2
-        stage_name: Vehicle Formation
-        capability_ids:
-          - BC-4910
-        process_ids: []
-        notes: Fund structuring, vehicle setup, and tax-efficient holding
-      - id: VS-360.30
-        stage_order: 3
-        stage_name: Capital Raising
-        capability_ids:
-          - BC-4910
-        process_ids: []
-        notes: Investor targeting, subscription, and fund closing
-      - id: VS-360.40
-        stage_order: 4
-        stage_name: Capital Deployment
-        capability_ids:
-          - BC-4910
-        process_ids: []
-        notes: Pipeline pacing, allocation across vehicles, and capital calls
-      - id: VS-360.50
-        stage_order: 5
-        stage_name: NAV & Performance Management
-        capability_ids:
-          - BC-4910
-        process_ids: []
-        notes: NAV computation, attribution, and fee / waterfall calculation
-      - id: VS-360.60
-        stage_order: 6
-        stage_name: LP Reporting
-        capability_ids:
-          - BC-4910
-        process_ids: []
-        notes: LP reporting and INREV / NCREIF / EPRA index submission
-      - id: VS-360.70
-        stage_order: 7
-        stage_name: Distribution & Wind-Down
-        capability_ids:
-          - BC-4910
-        process_ids: []
-        notes: Periodic distributions and end-of-life fund wind-down
-  - id: VS-370
-    name: Network-Plan-to-Service
-    industries:
-      - Transportation & Logistics
-    stages:
-      - id: VS-370.10
-        stage_order: 1
-        stage_name: Demand Forecast
-        capability_ids:
-          - BC-2410
-        process_ids: []
-        notes: Lane-level demand forecasting and modal mix analysis
-      - id: VS-370.20
-        stage_order: 2
-        stage_name: Network Design
-        capability_ids:
-          - BC-2410
-        process_ids: []
-        notes: Hub, gateway, lane, and modal-mix design decisions
-      - id: VS-370.30
-        stage_order: 3
-        stage_name: Capacity & Schedule Plan
-        capability_ids:
-          - BC-2410
-          - BC-2400
-        process_ids: []
-        notes: Schedule and slot planning across the service portfolio; Capacity commitments and equipment / vessel allocation
-      - id: VS-370.40
-        stage_order: 4
-        stage_name: Service Publication
-        capability_ids:
-          - BC-2410
-        process_ids: []
-        notes: Service catalogue publication and channel distribution
-      - id: VS-370.50
-        stage_order: 5
-        stage_name: Service Operations
-        capability_ids:
-          - BC-2420
-        process_ids: []
-        notes: Day-to-day execution of the published service
-      - id: VS-370.60
-        stage_order: 6
-        stage_name: Performance Monitoring & Re-plan
-        capability_ids:
-          - BC-2410
-        process_ids: []
-        notes: Service KPIs, gap analysis, and feedback into the next planning cycle
-  - id: VS-380
-    name: Opportunity-to-Order
-    industries:
-      - Cross-Industry
-    stages:
-      - id: VS-380.10
-        stage_order: 1
-        stage_name: Opportunity Qualification
-        capability_ids:
-          - BC-410
-          - BC-420
-        process_ids: []
-        notes: BANT/MEDDIC qualification; Account ownership; Customer record lookup
-      - id: VS-380.20
-        stage_order: 1
-        stage_name: Opportunity Qualification
-        capability_ids:
-          - BC-3440
-        process_ids: []
-        industry_variant: Automotive
-        notes: Fleet and B2B opportunity qualification
-      - id: VS-380.30
-        stage_order: 1
-        stage_name: Opportunity Qualification
-        capability_ids:
-          - BC-3720
-          - BC-3760
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Outbound licence opportunity qualification; Advertiser opportunity qualification
-      - id: VS-380.40
-        stage_order: 1
-        stage_name: Opportunity Qualification
-        capability_ids:
-          - BC-4360
-          - BC-4350
-        process_ids: []
-        industry_variant: Professional Services
-        notes: Pursuit qualification and pre-clearance; Independence and conflicts pre-clearance during pursuit
-      - id: VS-380.50
-        stage_order: 2
-        stage_name: Solution Scoping
-        capability_ids:
-          - BC-410
-        process_ids: []
-        notes: Solution design within opportunity
-      - id: VS-380.60
-        stage_order: 2
-        stage_name: Solution Scoping
-        capability_ids:
-          - BC-3440
-        process_ids: []
-        industry_variant: Automotive
-        notes: Fleet vehicle specification scoping
-      - id: VS-380.70
-        stage_order: 2
-        stage_name: Solution Scoping
-        capability_ids:
-          - BC-1750
-        process_ids: []
-        industry_variant: Defense
-        notes: Capture management
-      - id: VS-380.80
-        stage_order: 2
-        stage_name: Solution Scoping
-        capability_ids:
-          - BC-1110
-          - BC-1140
-        process_ids: []
-        industry_variant: Engineering Services
-        notes: Project engineering scoping; Tendering & estimation
-      - id: VS-380.90
-        stage_order: 2
-        stage_name: Solution Scoping
-        capability_ids:
-          - BC-2020
-        process_ids: []
-        industry_variant: HVAC & Building Automation Systems
-        notes: Project-level HVAC/BAS solution scoping
-      - id: VS-380.100
-        stage_order: 2
-        stage_name: Solution Scoping
-        capability_ids:
-          - BC-2680
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Wholesale solution scoping for carrier and MVNO orders
-      - id: VS-380.110
-        stage_order: 3
-        stage_name: Quote & Configuration
-        capability_ids:
-          - BC-410
-          - BC-440
-          - BC-4240
-        process_ids: []
-        notes: CPQ; Price list application; Subscription quote management
-      - id: VS-380.120
-        stage_order: 3
-        stage_name: Quote & Configuration
-        capability_ids:
-          - BC-1940
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Variant configurator for engineered orders
-      - id: VS-380.130
-        stage_order: 3
-        stage_name: Quote & Configuration
-        capability_ids:
-          - BC-2650
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Catalogue-driven enterprise CPQ
-      - id: VS-380.140
-        stage_order: 4
-        stage_name: Pricing & Approvals
-        capability_ids:
-          - BC-440
-        process_ids: []
-        notes: Pricing strategy / deal desk; Discount & promotional pricing; Price realisation / exception approval
-      - id: VS-380.150
-        stage_order: 5
-        stage_name: Proposal Development
-        capability_ids:
-          - BC-410
-        process_ids: []
-        notes: Proposal authoring
-      - id: VS-380.160
-        stage_order: 5
-        stage_name: Proposal Development
-        capability_ids:
-          - BC-1750
-        process_ids: []
-        industry_variant: Defense
-        notes: Defense proposal
-      - id: VS-380.170
-        stage_order: 5
-        stage_name: Proposal Development
-        capability_ids:
-          - BC-3760
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Media plan and proposal development
-      - id: VS-380.180
-        stage_order: 5
-        stage_name: Proposal Development
-        capability_ids:
-          - BC-4360
-        process_ids: []
-        industry_variant: Professional Services
-        notes: Proposal and pitch authoring
-      - id: VS-380.190
-        stage_order: 6
-        stage_name: Negotiation
-        capability_ids:
-          - BC-150
-          - BC-410
-        process_ids: []
-        notes: Legal terms negotiation; Executive negotiation
-      - id: VS-380.200
-        stage_order: 6
-        stage_name: Negotiation
-        capability_ids:
-          - BC-1750
-        process_ids: []
-        industry_variant: Defense
-        notes: Bid management & negotiation
-      - id: VS-380.210
-        stage_order: 6
-        stage_name: Negotiation
-        capability_ids:
-          - BC-3760
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Upfront and scatter negotiation
-      - id: VS-380.220
-        stage_order: 6
-        stage_name: Negotiation
-        capability_ids:
-          - BC-4360
-        process_ids: []
-        industry_variant: Professional Services
-        notes: Engagement-letter and fee negotiation
-      - id: VS-380.230
-        stage_order: 6
-        stage_name: Negotiation
-        capability_ids:
-          - BC-2680
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Wholesale, interconnect, and roaming agreement negotiation
-      - id: VS-380.240
-        stage_order: 7
-        stage_name: Contract & Order Booking
-        capability_ids:
-          - BC-150
-          - BC-410
-          - BC-4240
-        process_ids: []
-        notes: Master agreement execution; Order entry; Order form generation and subscription contract capture
-      - id: VS-380.250
-        stage_order: 7
-        stage_name: Contract & Order Booking
-        capability_ids:
-          - BC-3720
-          - BC-3760
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Outbound licence deal booking; IO booking against avail plan
-      - id: VS-380.260
-        stage_order: 8
-        stage_name: Handover to Fulfilment
-        capability_ids:
-          - BC-410
-          - BC-420
-          - BC-4230
-        process_ids: []
-        notes: Sales-to-delivery handover; Sales performance / commission booking; Customer lifecycle activation; Tenant provisioning handover
-  - id: VS-390
-    name: Order-to-Cash
-    industries:
-      - Cross-Industry
-    stages:
-      - id: VS-390.10
-        stage_order: 1
-        stage_name: Lead Capture & Qualification
-        capability_ids:
-          - BC-410
-          - BC-420
-        process_ids: []
-        notes: Lead intake, qualification; Customer record creation
-      - id: VS-390.20
-        stage_order: 1
-        stage_name: Lead Capture & Qualification
-        capability_ids:
-          - BC-3760
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Advertiser lead capture
-      - id: VS-390.30
-        stage_order: 1
-        stage_name: Lead Capture & Qualification
-        capability_ids:
-          - BC-3910
-        process_ids: []
-        industry_variant: Utilities
-        notes: Supply-point registration and customer onboarding
-      - id: VS-390.40
-        stage_order: 2
-        stage_name: Quote & Configuration
-        capability_ids:
-          - BC-410
-          - BC-440
-        process_ids: []
-        notes: CPQ; Pricing application
-      - id: VS-390.50
-        stage_order: 2
-        stage_name: Quote & Configuration
-        capability_ids:
-          - BC-3570
-        process_ids: []
-        industry_variant: Agriculture
-        notes: Cash and basis quotes with hedge-aligned pricing
-      - id: VS-390.60
-        stage_order: 2
-        stage_name: Quote & Configuration
-        capability_ids:
-          - BC-3440
-        process_ids: []
-        industry_variant: Automotive
-        notes: Vehicle CPQ and configurator
-      - id: VS-390.70
-        stage_order: 2
-        stage_name: Quote & Configuration
-        capability_ids:
-          - BC-1940
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Configurator-driven CPQ for electrical variants
-      - id: VS-390.80
-        stage_order: 2
-        stage_name: Quote & Configuration
-        capability_ids:
-          - BC-3760
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Campaign quote and avail planning
-      - id: VS-390.90
-        stage_order: 2
-        stage_name: Quote & Configuration
-        capability_ids:
-          - BC-3090
-        process_ids: []
-        industry_variant: Oil & Gas
-        notes: Trade quote and term-contract pricing
-      - id: VS-390.100
-        stage_order: 2
-        stage_name: Quote & Configuration
-        capability_ids:
-          - BC-2520
-          - BC-2450
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: Freight rate quotation; Forwarder quote to shipper
-      - id: VS-390.110
-        stage_order: 3
-        stage_name: Contract & Order Capture
-        capability_ids:
-          - BC-150
-          - BC-410
-          - BC-4240
-        process_ids: []
-        notes: Master agreement, T&Cs; Order entry; Subscription contracting and order forms
-      - id: VS-390.120
-        stage_order: 3
-        stage_name: Contract & Order Capture
-        capability_ids:
-          - BC-3570
-        process_ids: []
-        industry_variant: Agriculture
-        notes: Forward and production contract capture
-      - id: VS-390.130
-        stage_order: 3
-        stage_name: Contract & Order Capture
-        capability_ids:
-          - BC-3440
-        process_ids: []
-        industry_variant: Automotive
-        notes: Customer and dealer vehicle order capture
-      - id: VS-390.140
-        stage_order: 3
-        stage_name: Contract & Order Capture
-        capability_ids:
-          - BC-4690
-        process_ids: []
-        industry_variant: Chemicals
-        notes: Bulk offtake and index-linked chemical contract capture
-      - id: VS-390.150
-        stage_order: 3
-        stage_name: Contract & Order Capture
-        capability_ids:
-          - BC-3720
-          - BC-3750
-          - BC-3760
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Outbound licence deal capture; Subscription enrolment and entitlement grant; IO and linear spot order capture
-      - id: VS-390.160
-        stage_order: 3
-        stage_name: Contract & Order Capture
-        capability_ids:
-          - BC-4480
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Spot and term concentrate and metal sales contracting
-      - id: VS-390.170
-        stage_order: 3
-        stage_name: Contract & Order Capture
-        capability_ids:
-          - BC-3090
-        process_ids: []
-        industry_variant: Oil & Gas
-        notes: Trade capture into ETRM
-      - id: VS-390.180
-        stage_order: 3
-        stage_name: Contract & Order Capture
-        capability_ids:
-          - BC-4300
-        process_ids: []
-        industry_variant: Professional Services
-        notes: Engagement acceptance and engagement-letter execution
-      - id: VS-390.190
-        stage_order: 3
-        stage_name: Contract & Order Capture
-        capability_ids:
-          - BC-2320
-        process_ids: []
-        industry_variant: Retail & Consumer Goods
-        notes: POS basket capture
-      - id: VS-390.200
-        stage_order: 3
-        stage_name: Contract & Order Capture
-        capability_ids:
-          - BC-2620
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Service order capture, feasibility, and credit gating
-      - id: VS-390.210
-        stage_order: 3
-        stage_name: Contract & Order Capture
-        capability_ids:
-          - BC-2400
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: Booking acceptance against capacity
-      - id: VS-390.220
-        stage_order: 4
-        stage_name: Order Promising & Allocation
-        capability_ids:
-          - BC-520
-          - BC-530
-        process_ids: []
-        notes: ATP/CTP, allocation; Stock reservation
-      - id: VS-390.230
-        stage_order: 4
-        stage_name: Order Promising & Allocation
-        capability_ids:
-          - BC-3440
-        process_ids: []
-        industry_variant: Automotive
-        notes: Build-slot allocation and ATP
-      - id: VS-390.240
-        stage_order: 4
-        stage_name: Order Promising & Allocation
-        capability_ids:
-          - BC-4320
-        process_ids: []
-        industry_variant: Professional Services
-        notes: Engagement staffing and leverage allocation
-      - id: VS-390.250
-        stage_order: 4
-        stage_name: Order Promising & Allocation
-        capability_ids:
-          - BC-2330
-        process_ids: []
-        industry_variant: Retail & Consumer Goods
-        notes: Cross-channel order routing
-      - id: VS-390.260
-        stage_order: 4
-        stage_name: Order Promising & Allocation
-        capability_ids:
-          - BC-2620
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Network resource allocation against orders
-      - id: VS-390.270
-        stage_order: 4
-        stage_name: Order Promising & Allocation
-        capability_ids:
-          - BC-2400
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: Capacity allocation and ATP for cargo
-      - id: VS-390.280
-        stage_order: 5
-        stage_name: Production / Service Delivery
-        capability_ids:
-          - BC-4230
-        process_ids: []
-        notes: Tenant provisioning as service-delivery fulfilment
-      - id: VS-390.290
-        stage_order: 5
-        stage_name: Production / Service Delivery
-        capability_ids:
-          - BC-3580
-        process_ids: []
-        industry_variant: Agriculture
-        notes: Food and beverage manufacturing as the service product
-      - id: VS-390.300
-        stage_order: 5
-        stage_name: Production / Service Delivery
-        capability_ids:
-          - BC-3440
-          - BC-3460
-          - BC-3490
-        process_ids: []
-        industry_variant: Automotive
-        notes: Build-to-order coordination; Connected service activation at delivery; Trip dispatch and ride delivery
-      - id: VS-390.310
-        stage_order: 5
-        stage_name: Production / Service Delivery
-        capability_ids:
-          - BC-4620
-          - BC-4630
-        process_ids: []
-        industry_variant: Chemicals
-        notes: Bulk chemical production execution; Specialty formulation and finishing
-      - id: VS-390.320
-        stage_order: 5
-        stage_name: Production / Service Delivery
-        capability_ids:
-          - BC-1960
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: OEM commissioning & energisation
-      - id: VS-390.330
-        stage_order: 5
-        stage_name: Production / Service Delivery
-        capability_ids:
-          - BC-1110
-        process_ids: []
-        industry_variant: Engineering Services
-      - id: VS-390.340
-        stage_order: 5
-        stage_name: Production / Service Delivery
-        capability_ids:
-          - BC-1000
-          - BC-1050
-        process_ids: []
-        industry_variant: Manufacturing
-      - id: VS-390.350
-        stage_order: 5
-        stage_name: Production / Service Delivery
-        capability_ids:
-          - BC-3740
-          - BC-3760
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Syndication, licensee delivery, and OTT playback delivery; Ad decisioning, trafficking, and insertion
-      - id: VS-390.360
-        stage_order: 5
-        stage_name: Production / Service Delivery
-        capability_ids:
-          - BC-1550
-        process_ids: []
-        industry_variant: Pharma
-      - id: VS-390.370
-        stage_order: 5
-        stage_name: Production / Service Delivery
-        capability_ids:
-          - BC-4310
-        process_ids: []
-        industry_variant: Professional Services
-        notes: Engagement execution against work plan
-      - id: VS-390.380
-        stage_order: 5
-        stage_name: Production / Service Delivery
-        capability_ids:
-          - BC-2310
-          - BC-2330
-        process_ids: []
-        industry_variant: Retail & Consumer Goods
-        notes: In-store sale delivery; Omnichannel fulfilment
-      - id: VS-390.390
-        stage_order: 5
-        stage_name: Production / Service Delivery
-        capability_ids:
-          - BC-2620
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Service provisioning, activation, and acceptance testing
-      - id: VS-390.400
-        stage_order: 5
-        stage_name: Production / Service Delivery
-        capability_ids:
-          - BC-2420
-          - BC-2470
-          - BC-2460
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: Multimodal carriage execution; Terminal handling within service delivery; 3PL fulfilment as the service product
-      - id: VS-390.410
-        stage_order: 5
-        stage_name: Production / Service Delivery
-        capability_ids:
-          - BC-3820
-          - BC-3880
-        process_ids: []
-        industry_variant: Utilities
-        notes: Electricity supply at customer point of use; Treated water supply at customer point of use
-      - id: VS-390.420
-        stage_order: 6
-        stage_name: Outbound Logistics
-        capability_ids:
-          - BC-520
-        process_ids: []
-        notes: Shipping
-      - id: VS-390.430
-        stage_order: 6
-        stage_name: Outbound Logistics
-        capability_ids:
-          - BC-3440
-        process_ids: []
-        industry_variant: Automotive
-        notes: Vehicle distribution to dealer or customer
-      - id: VS-390.440
-        stage_order: 6
-        stage_name: Outbound Logistics
-        capability_ids:
-          - BC-4680
-        process_ids: []
-        industry_variant: Chemicals
-        notes: Bulk and hazmat outbound chemical logistics
-      - id: VS-390.450
-        stage_order: 6
-        stage_name: Outbound Logistics
-        capability_ids:
-          - BC-4480
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Bulk shipment nomination and IMSBC Code compliance
-      - id: VS-390.460
-        stage_order: 6
-        stage_name: Outbound Logistics
-        capability_ids:
-          - BC-3100
-        process_ids: []
-        industry_variant: Oil & Gas
-        notes: Marine cargo lifting and terminal load-out
-      - id: VS-390.470
-        stage_order: 6
-        stage_name: Outbound Logistics
-        capability_ids:
-          - BC-1570
-        process_ids: []
-        industry_variant: Pharma
-        notes: Cold-chain variant
-      - id: VS-390.480
-        stage_order: 6
-        stage_name: Outbound Logistics
-        capability_ids:
-          - BC-2330
-        process_ids: []
-        industry_variant: Retail & Consumer Goods
-        notes: BOPIS, kerbside, ship-from-store, last-mile slots
-      - id: VS-390.490
-        stage_order: 6
-        stage_name: Outbound Logistics
-        capability_ids:
-          - BC-2420
-          - BC-2480
-          - BC-2500
-          - BC-2510
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: Last-mile delivery to consignee; Customs clearance during outbound move; Bill of lading and air waybill issuance; Track-and-trace and ETA in transit
-      - id: VS-390.500
-        stage_order: 7
-        stage_name: Customer Invoicing
-        capability_ids:
-          - BC-200
-          - BC-4250
-          - BC-4940
-        process_ids: []
-        notes: Invoice generation; Subscription invoicing; Tenant rent and recoveries billing
-      - id: VS-390.510
-        stage_order: 7
-        stage_name: Customer Invoicing
-        capability_ids:
-          - BC-3570
-        process_ids: []
-        industry_variant: Agriculture
-        notes: Settlement statement with grade-based discounts
-      - id: VS-390.520
-        stage_order: 7
-        stage_name: Customer Invoicing
-        capability_ids:
-          - BC-3480
-          - BC-3490
-        process_ids: []
-        industry_variant: Automotive
-        notes: Charge-session rating and invoicing; Trip fare invoicing and receipt
-      - id: VS-390.530
-        stage_order: 7
-        stage_name: Customer Invoicing
-        capability_ids:
-          - BC-2150
-        process_ids: []
-        industry_variant: Insurance
-        notes: Premium invoicing
-      - id: VS-390.540
-        stage_order: 7
-        stage_name: Customer Invoicing
-        capability_ids:
-          - BC-3720
-          - BC-3750
-          - BC-3760
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Licensee invoicing; Viewer subscription billing; Advertiser and agency billing
-      - id: VS-390.550
-        stage_order: 7
-        stage_name: Customer Invoicing
-        capability_ids:
-          - BC-4480
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Provisional invoicing under quotational-period terms
-      - id: VS-390.560
-        stage_order: 7
-        stage_name: Customer Invoicing
-        capability_ids:
-          - BC-3040
-          - BC-3060
-        process_ids: []
-        industry_variant: Oil & Gas
-        notes: Fiscal-meter-based invoice volumes; Pipeline shipper billing
-      - id: VS-390.570
-        stage_order: 7
-        stage_name: Customer Invoicing
-        capability_ids:
-          - BC-4330
-        process_ids: []
-        industry_variant: Professional Services
-        notes: Pro-forma, narrative, and e-billing-compliant invoicing
-      - id: VS-390.580
-        stage_order: 7
-        stage_name: Customer Invoicing
-        capability_ids:
-          - BC-2320
-        process_ids: []
-        industry_variant: Retail & Consumer Goods
-        notes: POS receipt issuance
-      - id: VS-390.590
-        stage_order: 7
-        stage_name: Customer Invoicing
-        capability_ids:
-          - BC-2660
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Telecom bill cycle, calculation, and presentment
-      - id: VS-390.600
-        stage_order: 7
-        stage_name: Customer Invoicing
-        capability_ids:
-          - BC-2530
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: Freight and accessorial invoice issuance
-      - id: VS-390.610
-        stage_order: 7
-        stage_name: Customer Invoicing
-        capability_ids:
-          - BC-3910
-        process_ids: []
-        industry_variant: Utilities
-        notes: Utility bill calculation, presentment, and prepayment top-up
-      - id: VS-390.620
-        stage_order: 8
-        stage_name: Cash Collection & Application
-        capability_ids:
-          - BC-200
-          - BC-210
-          - BC-4250
-          - BC-4940
-        process_ids: []
-        notes: Collections; Cash positioning; Payment collection, dunning, and involuntary churn recovery; Tenant rent collection and application against AR
-      - id: VS-390.630
-        stage_order: 8
-        stage_name: Cash Collection & Application
-        capability_ids:
-          - BC-3570
-        process_ids: []
-        industry_variant: Agriculture
-        notes: Settlement collection and counterparty position
-      - id: VS-390.640
-        stage_order: 8
-        stage_name: Cash Collection & Application
-        capability_ids:
-          - BC-3480
-          - BC-3490
-        process_ids: []
-        industry_variant: Automotive
-        notes: Charging payment capture and roaming settlement; Rider payment capture and driver payout
-      - id: VS-390.650
-        stage_order: 8
-        stage_name: Cash Collection & Application
-        capability_ids:
-          - BC-2150
-        process_ids: []
-        industry_variant: Insurance
-        notes: Premium collection
-      - id: VS-390.660
-        stage_order: 8
-        stage_name: Cash Collection & Application
-        capability_ids:
-          - BC-3750
-          - BC-3760
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Viewer dunning and suspension; Advertiser collections and make-goods
-      - id: VS-390.670
-        stage_order: 8
-        stage_name: Cash Collection & Application
-        capability_ids:
-          - BC-4330
-        process_ids: []
-        industry_variant: Professional Services
-        notes: Realisation, write-off, and trust-account application
-      - id: VS-390.680
-        stage_order: 8
-        stage_name: Cash Collection & Application
-        capability_ids:
-          - BC-2320
-        process_ids: []
-        industry_variant: Retail & Consumer Goods
-        notes: Tender acceptance & end-of-day reconciliation
-      - id: VS-390.690
-        stage_order: 8
-        stage_name: Cash Collection & Application
-        capability_ids:
-          - BC-2660
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Telecom dunning, suspension, and disconnection
-      - id: VS-390.700
-        stage_order: 8
-        stage_name: Cash Collection & Application
-        capability_ids:
-          - BC-2530
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: Freight collection
-      - id: VS-390.710
-        stage_order: 8
-        stage_name: Cash Collection & Application
-        capability_ids:
-          - BC-3910
-        process_ids: []
-        industry_variant: Utilities
-        notes: Utility collections, dunning, and disconnection-for-non-payment
-      - id: VS-390.720
-        stage_order: 9
-        stage_name: Revenue Recognition
-        capability_ids:
-          - BC-200
-          - BC-4250
-          - BC-4940
-        process_ids: []
-        notes: Revenue posting; Reporting; Subscription revenue recognition under ASC 606 / IFRS 15; Lease revenue recognition under IFRS 16 / ASC 842
-      - id: VS-390.730
-        stage_order: 9
-        stage_name: Revenue Recognition
-        capability_ids:
-          - BC-2150
-        process_ids: []
-        industry_variant: Insurance
-        notes: Earned-premium recognition
-      - id: VS-390.740
-        stage_order: 9
-        stage_name: Revenue Recognition
-        capability_ids:
-          - BC-3720
-          - BC-3760
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Licensing revenue recognition; Ad delivery-based revenue recognition
-      - id: VS-390.750
-        stage_order: 9
-        stage_name: Revenue Recognition
-        capability_ids:
-          - BC-4480
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Final settlement after umpire assay and quotational-period pricing
-      - id: VS-390.760
-        stage_order: 9
-        stage_name: Revenue Recognition
-        capability_ids:
-          - BC-2660
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Usage-based revenue recognition and revenue assurance
-      - id: VS-390.770
-        stage_order: 9
-        stage_name: Revenue Recognition
-        capability_ids:
-          - BC-2530
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: Freight revenue recognition
-      - id: VS-390.780
-        stage_order: 9
-        stage_name: Revenue Recognition
-        capability_ids:
-          - BC-3910
-        process_ids: []
-        industry_variant: Utilities
-        notes: Usage-based and standing-charge revenue recognition
-  - id: VS-400
-    name: Plan-to-Inventory
-    industries:
-      - Cross-Industry
-    stages:
-      - id: VS-400.10
-        stage_order: 1
-        stage_name: Demand Planning
-        capability_ids:
-          - BC-400
-          - BC-520
-        process_ids: []
-        notes: Market intelligence input; Statistical forecast + consensus
-      - id: VS-400.20
-        stage_order: 1
-        stage_name: Demand Planning
-        capability_ids:
-          - BC-3440
-        process_ids: []
-        industry_variant: Automotive
-        notes: Wholesale vehicle volume planning
-      - id: VS-400.30
-        stage_order: 1
-        stage_name: Demand Planning
-        capability_ids:
-          - BC-2300
-        process_ids: []
-        industry_variant: Retail & Consumer Goods
-        notes: Cluster assortment & range demand
-      - id: VS-400.40
-        stage_order: 1
-        stage_name: Demand Planning
-        capability_ids:
-          - BC-2610
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Subscriber growth and traffic demand forecasting
-      - id: VS-400.50
-        stage_order: 2
-        stage_name: Supply Planning
-        capability_ids:
-          - BC-520
-        process_ids: []
-        notes: Capacity / material plan
-      - id: VS-400.60
-        stage_order: 2
-        stage_name: Supply Planning
-        capability_ids:
-          - BC-3500
-          - BC-3510
-          - BC-3520
-          - BC-3580
-        process_ids: []
-        industry_variant: Agriculture
-        notes: Crop production planning; Livestock production planning; Aquaculture production planning; Food and beverage manufacturing planning
-      - id: VS-400.70
-        stage_order: 2
-        stage_name: Supply Planning
-        capability_ids:
-          - BC-3410
-        process_ids: []
-        industry_variant: Automotive
-        notes: Programme volume cadence into supply plan
-      - id: VS-400.80
-        stage_order: 2
-        stage_name: Supply Planning
-        capability_ids:
-          - BC-4620
-        process_ids: []
-        industry_variant: Chemicals
-        notes: Campaign and continuous-mode chemical supply planning
-      - id: VS-400.90
-        stage_order: 2
-        stage_name: Supply Planning
-        capability_ids:
-          - BC-1930
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Semiconductor allocation forecasting
-      - id: VS-400.100
-        stage_order: 2
-        stage_name: Supply Planning
-        capability_ids:
-          - BC-1000
-        process_ids: []
-        industry_variant: Manufacturing
-        notes: Production planning
-      - id: VS-400.110
-        stage_order: 2
-        stage_name: Supply Planning
-        capability_ids:
-          - BC-4420
-          - BC-4430
-          - BC-4440
-          - BC-4450
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Short-term mine schedule defining plant feed supply; Mine production execution against schedule; Concentrator throughput and recovery planning; Smelter and refinery throughput planning
-      - id: VS-400.120
-        stage_order: 3
-        stage_name: S&OP Reconciliation
-        capability_ids:
-          - BC-230
-          - BC-520
-        process_ids: []
-        notes: Financial forecast alignment; Executive S&OP cycle
-      - id: VS-400.130
-        stage_order: 4
-        stage_name: Inventory Positioning
-        capability_ids:
-          - BC-530
-        process_ids: []
-        notes: Stock level targets; Allocation across nodes
-      - id: VS-400.140
-        stage_order: 4
-        stage_name: Inventory Positioning
-        capability_ids:
-          - BC-3560
-        process_ids: []
-        industry_variant: Agriculture
-        notes: On-farm storage and processor receival positioning
-      - id: VS-400.150
-        stage_order: 4
-        stage_name: Inventory Positioning
-        capability_ids:
-          - BC-3440
-        process_ids: []
-        industry_variant: Automotive
-        notes: Dealer stock and CPO inventory positioning
-      - id: VS-400.160
-        stage_order: 4
-        stage_name: Inventory Positioning
-        capability_ids:
-          - BC-4680
-        process_ids: []
-        industry_variant: Chemicals
-        notes: Tank-farm and hazmat warehouse positioning
-      - id: VS-400.170
-        stage_order: 4
-        stage_name: Inventory Positioning
-        capability_ids:
-          - BC-2850
-        process_ids: []
-        industry_variant: Healthcare Providers
-        notes: Drug inventory positioning across pharmacies and automated dispensing cabinets
-      - id: VS-400.180
-        stage_order: 4
-        stage_name: Inventory Positioning
-        capability_ids:
-          - BC-4480
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Concentrate stockpile and exchange-warrant positioning
-      - id: VS-400.190
-        stage_order: 4
-        stage_name: Inventory Positioning
-        capability_ids:
-          - BC-2300
-        process_ids: []
-        industry_variant: Retail & Consumer Goods
-        notes: Allocation across store clusters
-      - id: VS-400.200
-        stage_order: 4
-        stage_name: Inventory Positioning
-        capability_ids:
-          - BC-2600
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Logical and physical network inventory
-      - id: VS-400.210
-        stage_order: 4
-        stage_name: Inventory Positioning
-        capability_ids:
-          - BC-2460
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: 3PL inventory positioning across nodes
-      - id: VS-400.220
-        stage_order: 5
-        stage_name: Replenishment Execution
-        capability_ids:
-          - BC-530
-        process_ids: []
-        notes: Auto-replenishment triggers
-      - id: VS-400.230
-        stage_order: 5
-        stage_name: Replenishment Execution
-        capability_ids:
-          - BC-2460
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: 3PL replenishment picking and dispatch
-      - id: VS-400.240
-        stage_order: 6
-        stage_name: Inventory Health Monitoring
-        capability_ids:
-          - BC-520
-          - BC-530
-        process_ids: []
-        notes: Supply chain risk; Accuracy / cycle counting; Slow-moving / obsolete review
-      - id: VS-400.250
-        stage_order: 6
-        stage_name: Inventory Health Monitoring
-        capability_ids:
-          - BC-1930
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Component lifecycle & obsolescence risk
-      - id: VS-400.260
-        stage_order: 6
-        stage_name: Inventory Health Monitoring
-        capability_ids:
-          - BC-4480
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Warehouse warrant and finished metal stock health monitoring
-      - id: VS-400.270
-        stage_order: 6
-        stage_name: Inventory Health Monitoring
-        capability_ids:
-          - BC-2600
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Inventory reconciliation and network discovery
-      - id: VS-400.280
-        stage_order: 6
-        stage_name: Inventory Health Monitoring
-        capability_ids:
-          - BC-2460
-        process_ids: []
-        industry_variant: Transportation & Logistics
-        notes: Cycle counting and accuracy in 3PL warehouses
-  - id: VS-410
-    name: Population-Health-to-Outcome
-    industries:
-      - Healthcare Providers
-    stages:
-      - id: VS-410.10
-        stage_order: 1
-        stage_name: Population Identification
-        capability_ids:
-          - BC-2880
-        process_ids: []
-        notes: Attribution, empanelment, and population definition
-      - id: VS-410.20
-        stage_order: 2
-        stage_name: Risk Stratification
-        capability_ids:
-          - BC-2880
-        process_ids: []
-        notes: Predictive risk modelling and rising-risk identification
-      - id: VS-410.30
-        stage_order: 3
-        stage_name: Care Gap Identification
-        capability_ids:
-          - BC-2880
-        process_ids: []
-        notes: HEDIS / quality-measure gap detection across the panel
-      - id: VS-410.40
-        stage_order: 4
-        stage_name: Outreach & Intervention
-        capability_ids:
-          - BC-2880
-          - BC-2820
-        process_ids: []
-        notes: Outreach campaigns, preventive care, and chronic-disease programmes; Care management coordination for high-risk cohorts
-      - id: VS-410.50
-        stage_order: 5
-        stage_name: Care Delivery
-        capability_ids:
-          - BC-2810
-        process_ids: []
-        notes: Clinical care delivery aligned to the intervention plan
-      - id: VS-410.60
-        stage_order: 6
-        stage_name: Outcomes Measurement
-        capability_ids:
-          - BC-2880
-        process_ids: []
-        notes: Outcome tracking, value-based-care reporting, and feedback loop
-  - id: VS-420
-    name: Procure-to-Pay
-    industries:
-      - Cross-Industry
-    stages:
-      - id: VS-420.10
-        stage_order: 1
-        stage_name: Need Identification & Requisition
-        capability_ids:
-          - BC-500
-        process_ids: []
-        notes: Requisition intake
-      - id: VS-420.20
-        stage_order: 1
-        stage_name: Need Identification & Requisition
-        capability_ids:
-          - BC-3550
-        process_ids: []
-        industry_variant: Agriculture
-        notes: Seed, fertilizer, crop-protection, and vet-medicine requisition
-      - id: VS-420.30
-        stage_order: 1
-        stage_name: Need Identification & Requisition
-        capability_ids:
-          - BC-4690
-        process_ids: []
-        industry_variant: Chemicals
-        notes: Feedstock and chemical raw material need identification
-      - id: VS-420.40
-        stage_order: 1
-        stage_name: Need Identification & Requisition
-        capability_ids:
-          - BC-2040
-        process_ids: []
-        industry_variant: HVAC & Building Automation Systems
-        notes: Refrigerant requisition by region/quota
-      - id: VS-420.50
-        stage_order: 1
-        stage_name: Need Identification & Requisition
-        capability_ids:
-          - BC-3270
-        process_ids: []
-        industry_variant: Public Sector
-        notes: Acquisition planning; market research; independent government cost estimate
-      - id: VS-420.60
-        stage_order: 2
-        stage_name: Sourcing
-        capability_ids:
-          - BC-500
-        process_ids: []
-        notes: RFx, sourcing events; Category strategy
-      - id: VS-420.70
-        stage_order: 2
-        stage_name: Sourcing
-        capability_ids:
-          - BC-3550
-        process_ids: []
-        industry_variant: Agriculture
-        notes: Sourcing through licensed agri-input channels
-      - id: VS-420.80
-        stage_order: 2
-        stage_name: Sourcing
-        capability_ids:
-          - BC-4690
-        process_ids: []
-        industry_variant: Chemicals
-        notes: Feedstock, aromatic, and bio-feedstock sourcing
-      - id: VS-420.90
-        stage_order: 2
-        stage_name: Sourcing
-        capability_ids:
-          - BC-2040
-        process_ids: []
-        industry_variant: HVAC & Building Automation Systems
-        notes: Refrigerant sourcing & quota management
-      - id: VS-420.100
-        stage_order: 2
-        stage_name: Sourcing
-        capability_ids:
-          - BC-3720
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Rights and content sourcing
-      - id: VS-420.110
-        stage_order: 2
-        stage_name: Sourcing
-        capability_ids:
-          - BC-3270
-        process_ids: []
-        industry_variant: Public Sector
-        notes: Solicitation drafting and publication under FAR / EU procurement directives
-      - id: VS-420.120
-        stage_order: 3
-        stage_name: Supplier Selection & Onboarding
-        capability_ids:
-          - BC-510
-        process_ids: []
-        notes: Qualification; Pre-award risk check
-      - id: VS-420.130
-        stage_order: 3
-        stage_name: Supplier Selection & Onboarding
-        capability_ids:
-          - BC-3550
-        process_ids: []
-        industry_variant: Agriculture
-        notes: Agri-input supplier qualification with stewardship checks
-      - id: VS-420.140
-        stage_order: 3
-        stage_name: Supplier Selection & Onboarding
-        capability_ids:
-          - BC-4670
-        process_ids: []
-        industry_variant: Chemicals
-        notes: Chemical raw material and toller supplier qualification
-      - id: VS-420.150
-        stage_order: 3
-        stage_name: Supplier Selection & Onboarding
-        capability_ids:
-          - BC-1810
-        process_ids: []
-        industry_variant: Defense
-        notes: Cleared subcontractors
-      - id: VS-420.160
-        stage_order: 3
-        stage_name: Supplier Selection & Onboarding
-        capability_ids:
-          - BC-1930
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Distributor & broker onboarding; component qualification
-      - id: VS-420.170
-        stage_order: 3
-        stage_name: Supplier Selection & Onboarding
-        capability_ids:
-          - BC-1560
-        process_ids: []
-        industry_variant: Pharma
-        notes: GxP supplier qualification
-      - id: VS-420.180
-        stage_order: 3
-        stage_name: Supplier Selection & Onboarding
-        capability_ids:
-          - BC-3270
-        process_ids: []
-        industry_variant: Public Sector
-        notes: Source selection, responsibility determination, set-aside compliance
-      - id: VS-420.190
-        stage_order: 4
-        stage_name: Contract & Purchase Order
-        capability_ids:
-          - BC-500
-        process_ids: []
-        notes: Contracting; PO issuance
-      - id: VS-420.200
-        stage_order: 4
-        stage_name: Contract & Purchase Order
-        capability_ids:
-          - BC-1790
-        process_ids: []
-        industry_variant: Defense
-        notes: ITAR/EAR screening
-      - id: VS-420.210
-        stage_order: 4
-        stage_name: Contract & Purchase Order
-        capability_ids:
-          - BC-3720
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Rights acquisition contracting
-      - id: VS-420.220
-        stage_order: 4
-        stage_name: Contract & Purchase Order
-        capability_ids:
-          - BC-3270
-        process_ids: []
-        industry_variant: Public Sector
-        notes: Award, debriefing, contract formation, obligation of funds
-      - id: VS-420.230
-        stage_order: 5
-        stage_name: Goods/Services Receipt
-        capability_ids:
-          - BC-500
-          - BC-4940
-        process_ids: []
-        notes: GR/SR; Property vendor service receipt and verification
-      - id: VS-420.240
-        stage_order: 5
-        stage_name: Goods/Services Receipt
-        capability_ids:
-          - BC-3550
-        process_ids: []
-        industry_variant: Agriculture
-        notes: Input receival with batch and stewardship recording
-      - id: VS-420.250
-        stage_order: 5
-        stage_name: Goods/Services Receipt
-        capability_ids:
-          - BC-1010
-        process_ids: []
-        industry_variant: Manufacturing
-      - id: VS-420.260
-        stage_order: 5
-        stage_name: Goods/Services Receipt
-        capability_ids:
-          - BC-3270
-        process_ids: []
-        industry_variant: Public Sector
-        notes: Deliverable acceptance and contract administration
-      - id: VS-420.270
-        stage_order: 6
-        stage_name: Invoice Receipt & Verification
-        capability_ids:
-          - BC-200
-        process_ids: []
-        notes: 3-way match
-      - id: VS-420.280
-        stage_order: 6
-        stage_name: Invoice Receipt & Verification
-        capability_ids:
-          - BC-3720
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Inbound royalty statement reconciliation
-      - id: VS-420.290
-        stage_order: 7
-        stage_name: Payment Execution
-        capability_ids:
-          - BC-200
-          - BC-210
-          - BC-4940
-        process_ids: []
-        notes: Payment run; Payment funding; Property vendor payment execution
-      - id: VS-420.300
-        stage_order: 8
-        stage_name: Reconciliation
-        capability_ids:
-          - BC-200
-        process_ids: []
-        notes: GL posting; Vendor account
-      - id: VS-420.310
-        stage_order: 9
-        stage_name: Supplier Performance Monitoring
-        capability_ids:
-          - BC-510
-        process_ids: []
-        notes: Post-transaction loop; Strategic suppliers
-      - id: VS-420.320
-        stage_order: 9
-        stage_name: Supplier Performance Monitoring
-        capability_ids:
-          - BC-1930
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Distributor performance, PCN/EOL handling
-      - id: VS-420.330
-        stage_order: 9
-        stage_name: Supplier Performance Monitoring
-        capability_ids:
-          - BC-3270
-        process_ids: []
-        industry_variant: Public Sector
-        notes: Past performance recording; suspension and debarment
-  - id: VS-430
-    name: Proposal-to-Impact
-    industries:
-      - Education
-    stages:
-      - id: VS-430.10
-        stage_order: 1
-        stage_name: Opportunity Identification
-        capability_ids:
-          - BC-4780
-        process_ids: []
-        notes: Grant and funding opportunity scanning and identification
-      - id: VS-430.20
-        stage_order: 2
-        stage_name: Proposal Development
-        capability_ids:
-          - BC-4780
-        process_ids: []
-        notes: Pre-award proposal authoring, costing, and submission
-      - id: VS-430.30
-        stage_order: 3
-        stage_name: Award & Setup
-        capability_ids:
-          - BC-4780
-        process_ids: []
-        notes: Post-award setup, account creation, and compliance onboarding
-      - id: VS-430.40
-        stage_order: 4
-        stage_name: Ethics & Integrity Oversight
-        capability_ids:
-          - BC-4780
-        process_ids: []
-        notes: Independent ethics review and integrity oversight during conduct
-      - id: VS-430.50
-        stage_order: 4
-        stage_name: Research Conduct
-        capability_ids:
-          - BC-4780
-        process_ids: []
-        notes: Research execution against the funded plan
-      - id: VS-430.60
-        stage_order: 5
-        stage_name: Output & Dissemination
-        capability_ids:
-          - BC-4780
-        process_ids: []
-        notes: Publication, open-access, and persistent identifier management
-      - id: VS-430.70
-        stage_order: 6
-        stage_name: Impact Assessment
-        capability_ids:
-          - BC-4780
-        process_ids: []
-        notes: Bibliometric, altmetric, and case-study impact assessment
-  - id: VS-440
-    name: Prospect-to-Customer
-    industries:
-      - Cross-Industry
-    stages:
-      - id: VS-440.10
-        stage_order: 1
-        stage_name: Market & Segment Strategy
-        capability_ids:
-          - BC-400
-          - BC-420
-        process_ids: []
-        notes: Marketing strategy; Customer segmentation
-      - id: VS-440.20
-        stage_order: 2
-        stage_name: Brand & Positioning
-        capability_ids:
-          - BC-400
-          - BC-850
-        process_ids: []
-        notes: Brand management; Corporate communications
-      - id: VS-440.30
-        stage_order: 3
-        stage_name: Demand Generation
-        capability_ids:
-          - BC-400
-          - BC-4950
-          - BC-4960
-        process_ids: []
-        notes: Campaigns, content syndication; Digital marketing; Content marketing; Vacancy listing and marketing for landlord-side leasing; Listing marketing across MLS, portals, and syndication
-      - id: VS-440.40
-        stage_order: 3
-        stage_name: Demand Generation
-        capability_ids:
-          - BC-4710
-        process_ids: []
-        industry_variant: Education
-        notes: Student recruitment campaigns and outreach
-      - id: VS-440.50
-        stage_order: 3
-        stage_name: Demand Generation
-        capability_ids:
-          - BC-2360
-        process_ids: []
-        industry_variant: Retail & Consumer Goods
-        notes: Trade-event-driven sell-through
-      - id: VS-440.60
-        stage_order: 4
-        stage_name: Lead Capture & Nurture
-        capability_ids:
-          - BC-400
-          - BC-410
-          - BC-4950
-          - BC-4960
-        process_ids: []
-        notes: Marketing operations / MarOps; Pipeline handoff; Tenant prospect inquiry capture and qualification; Buyer and tenant engagement on representation mandates
-      - id: VS-440.70
-        stage_order: 4
-        stage_name: Lead Capture & Nurture
-        capability_ids:
-          - BC-4710
-        process_ids: []
-        industry_variant: Education
-        notes: Prospect lead management for education applicants
-      - id: VS-440.80
-        stage_order: 4
-        stage_name: Lead Capture & Nurture
-        capability_ids:
-          - BC-2110
-        process_ids: []
-        industry_variant: Insurance
-        notes: Quote / submission intake via producers
-      - id: VS-440.90
-        stage_order: 4
-        stage_name: Lead Capture & Nurture
-        capability_ids:
-          - BC-3750
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Free-trial and prospect viewer capture
-      - id: VS-440.100
-        stage_order: 5
-        stage_name: Conversion
-        capability_ids:
-          - BC-410
-          - BC-4950
-          - BC-4960
-        process_ids: []
-        notes: Quote / CPQ; Tenant application screening and lease execution; Offer, negotiation, and brokered closing
-      - id: VS-440.110
-        stage_order: 5
-        stage_name: Conversion
-        capability_ids:
-          - BC-1300
-        process_ids: []
-        industry_variant: Banking
-        notes: Customer onboarding
-      - id: VS-440.120
-        stage_order: 5
-        stage_name: Conversion
-        capability_ids:
-          - BC-4710
-        process_ids: []
-        industry_variant: Education
-        notes: Admissions decisioning and offer acceptance
-      - id: VS-440.130
-        stage_order: 5
-        stage_name: Conversion
-        capability_ids:
-          - BC-2120
-        process_ids: []
-        industry_variant: Insurance
-        notes: Policyholder conversion
-      - id: VS-440.140
-        stage_order: 5
-        stage_name: Conversion
-        capability_ids:
-          - BC-3750
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Subscription conversion
-      - id: VS-440.150
-        stage_order: 5
-        stage_name: Conversion
-        capability_ids:
-          - BC-2640
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Subscriber identity creation and SIM/eSIM activation
-      - id: VS-440.160
-        stage_order: 6
-        stage_name: Customer Onboarding
-        capability_ids:
-          - BC-420
-          - BC-4260
-        process_ids: []
-        notes: Customer lifecycle activation; Customer onboarding and activation
-      - id: VS-440.170
-        stage_order: 6
-        stage_name: Customer Onboarding
-        capability_ids:
-          - BC-1300
-        process_ids: []
-        industry_variant: Banking
-        notes: KYC & due diligence
-      - id: VS-440.180
-        stage_order: 6
-        stage_name: Customer Onboarding
-        capability_ids:
-          - BC-4710
-        process_ids: []
-        industry_variant: Education
-        notes: Pre-enrolment onboarding of admitted students
-      - id: VS-440.190
-        stage_order: 6
-        stage_name: Customer Onboarding
-        capability_ids:
-          - BC-2120
-        process_ids: []
-        industry_variant: Insurance
-        notes: Policyholder onboarding & KYC
-      - id: VS-440.200
-        stage_order: 6
-        stage_name: Customer Onboarding
-        capability_ids:
-          - BC-3750
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Viewer activation and onboarding journeys
-      - id: VS-440.210
-        stage_order: 6
-        stage_name: Customer Onboarding
-        capability_ids:
-          - BC-2640
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Subscriber enrolment, AAA, and device binding
-      - id: VS-440.220
-        stage_order: 6
-        stage_name: Customer Onboarding
-        capability_ids:
-          - BC-4040
-          - BC-4050
-        process_ids: []
-        industry_variant: Travel & Hospitality
-        notes: Guest profile creation, preference capture, and consent at first interaction; Loyalty enrolment and welcome programme activation
-      - id: VS-440.230
-        stage_order: 7
-        stage_name: Retention & Advocacy
-        capability_ids:
-          - BC-420
-          - BC-430
-          - BC-4260
-          - BC-4950
-        process_ids: []
-        notes: Loyalty & retention; Customer feedback loop; Retention, NPS, references, and expansion advocacy; Renewal pipeline and retention programmes
-      - id: VS-440.240
-        stage_order: 7
-        stage_name: Retention & Advocacy
-        capability_ids:
-          - BC-4800
-        process_ids: []
-        industry_variant: Education
-        notes: Alumni engagement and giving programmes
-      - id: VS-440.250
-        stage_order: 7
-        stage_name: Retention & Advocacy
-        capability_ids:
-          - BC-2120
-        process_ids: []
-        industry_variant: Insurance
-        notes: Policyholder retention
-      - id: VS-440.260
-        stage_order: 7
-        stage_name: Retention & Advocacy
-        capability_ids:
-          - BC-3750
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Engagement and win-back programmes
-      - id: VS-440.270
-        stage_order: 7
-        stage_name: Retention & Advocacy
-        capability_ids:
-          - BC-2630
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Customer experience following service events
-  - id: VS-450
-    name: Quote-to-Bind
-    industries:
-      - Insurance
-    stages:
-      - id: VS-450.10
-        stage_order: 1
-        stage_name: Submission Intake
-        capability_ids:
-          - BC-2110
-          - BC-2130
-        process_ids: []
-        notes: Producer / broker submission capture and routing; Submission triage and risk data collection
-      - id: VS-450.20
-        stage_order: 2
-        stage_name: Risk Evaluation & Pricing
-        capability_ids:
-          - BC-2130
-          - BC-2180
-        process_ids: []
-        notes: Risk evaluation, exposure rating, and underwriting authority enforcement; Pricing model application and rate adequacy support
-      - id: VS-450.30
-        stage_order: 3
-        stage_name: Quote Production
-        capability_ids:
-          - BC-2130
-        process_ids: []
-        notes: Quote generation, indication letters, and broker negotiation support
-      - id: VS-450.40
-        stage_order: 4
-        stage_name: Reinsurance Check
-        capability_ids:
-          - BC-2170
-        process_ids: []
-        notes: Facultative reinsurance enquiry and treaty capacity check
-      - id: VS-450.50
-        stage_order: 5
-        stage_name: Underwriting Decision
-        capability_ids:
-          - BC-2130
-        process_ids: []
-        notes: Acceptance, declination, or referral with conditions
-      - id: VS-450.60
-        stage_order: 6
-        stage_name: Bind
-        capability_ids:
-          - BC-2130
-          - BC-2110
-        process_ids: []
-        notes: Binding of agreed terms and conditions; Broker / producer bind confirmation and commission setup
-      - id: VS-450.70
-        stage_order: 7
-        stage_name: Policy Issuance
-        capability_ids:
-          - BC-2140
-          - BC-2150
-        process_ids: []
-        notes: Policy document generation, schedule assembly, and activation; Initial premium booking and instalment schedule setup
-      - id: VS-450.80
-        stage_order: 8
-        stage_name: Reinsurance Cession Setup
-        capability_ids:
-          - BC-2170
-        process_ids: []
-        notes: Cession to treaty programme and bordereau preparation
-  - id: VS-460
-    name: Record-to-Report
-    industries:
-      - Cross-Industry
-    stages:
-      - id: VS-460.10
-        stage_order: 1
-        stage_name: Transaction Capture
-        capability_ids:
-          - BC-200
-          - BC-4940
-        process_ids: []
-        notes: GL posting from sub-ledgers; Cost accounting allocations; Property-level GL transaction capture
-      - id: VS-460.20
-        stage_order: 1
-        stage_name: Transaction Capture
-        capability_ids:
-          - BC-3280
-        process_ids: []
-        industry_variant: Public Sector
-        notes: Appropriations execution; commitment, obligation, and outlay posting
-      - id: VS-460.30
-        stage_order: 1
-        stage_name: Transaction Capture
-        capability_ids:
-          - BC-2660
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Telecom billing and usage transactions feeding GL
-      - id: VS-460.40
-        stage_order: 1
-        stage_name: Transaction Capture
-        capability_ids:
-          - BC-3910
-        process_ids: []
-        industry_variant: Utilities
-        notes: Meter-to-cash usage transactions feeding the GL
-      - id: VS-460.50
-        stage_order: 2
-        stage_name: Sub-Ledger Close
-        capability_ids:
-          - BC-200
-        process_ids: []
-        notes: AP cut-off; AR cut-off; Fixed asset depreciation run
-      - id: VS-460.60
-        stage_order: 2
-        stage_name: Sub-Ledger Close
-        capability_ids:
-          - BC-2150
-        process_ids: []
-        industry_variant: Insurance
-        notes: Premium earnings & DAC close
-      - id: VS-460.70
-        stage_order: 2
-        stage_name: Sub-Ledger Close
-        capability_ids:
-          - BC-3280
-        process_ids: []
-        industry_variant: Public Sector
-        notes: Government fund accounting close
-      - id: VS-460.80
-        stage_order: 3
-        stage_name: Reconciliation & Adjustments
-        capability_ids:
-          - BC-200
-          - BC-210
-        process_ids: []
-        notes: Account reconciliations; Bank reconciliation
-      - id: VS-460.90
-        stage_order: 4
-        stage_name: Consolidation
-        capability_ids:
-          - BC-200
-          - BC-220
-          - BC-4910
-        process_ids: []
-        notes: Group consolidation; Transfer pricing adjustments; Fund NAV consolidation across vehicles
-      - id: VS-460.100
-        stage_order: 4
-        stage_name: Consolidation
-        capability_ids:
-          - BC-3280
-        process_ids: []
-        industry_variant: Public Sector
-        notes: Whole-of-government consolidation
-      - id: VS-460.110
-        stage_order: 5
-        stage_name: Management Reporting
-        capability_ids:
-          - BC-230
-          - BC-4910
-          - BC-4940
-        process_ids: []
-        notes: Internal management pack; Variance / performance analysis; LP and investor reporting; Owner reporting pack
-      - id: VS-460.120
-        stage_order: 5
-        stage_name: Management Reporting
-        capability_ids:
-          - BC-4250
-        process_ids: []
-        industry_variant: Software & Technology
-        notes: ARR, MRR, NRR, GRR, and cohort recurring-revenue reporting
-      - id: VS-460.130
-        stage_order: 6
-        stage_name: Statutory & Regulatory Reporting
-        capability_ids:
-          - BC-200
-          - BC-220
-          - BC-240
-          - BC-4910
-          - BC-4980
-        process_ids: []
-        notes: Statutory filings; Tax filings; Investor relations disclosures; INREV, NCREIF, and EPRA index submission; CREFC IRP investor reporting on CMBS pools
-      - id: VS-460.140
-        stage_order: 6
-        stage_name: Statutory & Regulatory Reporting
-        capability_ids:
-          - BC-4810
-        process_ids: []
-        industry_variant: Education
-        notes: IPEDS, HESA, and equivalent statutory education returns
-      - id: VS-460.150
-        stage_order: 6
-        stage_name: Statutory & Regulatory Reporting
-        capability_ids:
-          - BC-2180
-        process_ids: []
-        industry_variant: Insurance
-        notes: IFRS 17 & Solvency II reporting
-      - id: VS-460.160
-        stage_order: 6
-        stage_name: Statutory & Regulatory Reporting
-        capability_ids:
-          - BC-3280
-        process_ids: []
-        industry_variant: Public Sector
-        notes: IPSAS financial statements; GFSM and COFOG statistical reporting
-      - id: VS-460.170
-        stage_order: 6
-        stage_name: Statutory & Regulatory Reporting
-        capability_ids:
-          - BC-3920
-        process_ids: []
-        industry_variant: Utilities
-        notes: Utility regulatory accounts and price-control performance reporting
-      - id: VS-460.180
-        stage_order: 7
-        stage_name: Audit & Sign-Off
-        capability_ids:
-          - BC-130
-          - BC-140
-        process_ids: []
-        notes: Regulatory compliance sign-off; Internal audit review
-  - id: VS-470
-    name: Refrigerant-to-Reclaim
-    industries:
-      - HVAC & Building Automation Systems
-    stages:
-      - id: VS-470.10
-        stage_order: 1
-        stage_name: Procurement & Inventory
-        capability_ids:
-          - BC-2040
-        process_ids: []
-        notes: Refrigerant sourcing, allocation, and storage
-      - id: VS-470.20
-        stage_order: 2
-        stage_name: Charge & Install
-        capability_ids:
-          - BC-2040
-          - BC-2060
-        process_ids: []
-        notes: Asset-level charge accounting on installed equipment; Field charging activity during install and service visits
-      - id: VS-470.30
-        stage_order: 3
-        stage_name: Leak Detection & Repair
-        capability_ids:
-          - BC-2040
-        process_ids: []
-        notes: Leak rate tracking, repair triggers, and rate reporting
-      - id: VS-470.40
-        stage_order: 4
-        stage_name: Recovery & Reclaim
-        capability_ids:
-          - BC-2040
-        process_ids: []
-        notes: Field recovery, reclamation, and recycled-refrigerant quality control
-      - id: VS-470.50
-        stage_order: 5
-        stage_name: Regulatory Reporting
-        capability_ids:
-          - BC-2040
-        process_ids: []
-        notes: F-Gas, EPA Section 608, and Kigali Amendment reporting
-      - id: VS-470.60
-        stage_order: 6
-        stage_name: Phase-Out & Substitution
-        capability_ids:
-          - BC-2040
-        process_ids: []
-        notes: Refrigerant transition planning and low-GWP substitution roadmap
-      - id: VS-470.70
-        stage_order: 7
-        stage_name: End-of-Life Disposition
-        capability_ids:
-          - BC-2040
-        process_ids: []
-        notes: Certified destruction, disposal, and chain-of-custody evidence
-  - id: VS-480
-    name: Registration-to-Certification
-    industries:
-      - Public Sector & Government
-    stages:
-      - id: VS-480.10
-        stage_order: 1
-        stage_name: Voter Registration
-        capability_ids:
-          - BC-3330
-        process_ids: []
-        notes: Voter enrolment, list maintenance, and eligibility verification
-      - id: VS-480.20
-        stage_order: 2
-        stage_name: Boundary & Polling Place Setup
-        capability_ids:
-          - BC-3330
-        process_ids: []
-        notes: Electoral district maintenance and polling-place designation
-      - id: VS-480.30
-        stage_order: 3
-        stage_name: Candidate Nomination
-        capability_ids:
-          - BC-3330
-        process_ids: []
-        notes: Party registration, candidate filing, and ballot access determination
-      - id: VS-480.40
-        stage_order: 4
-        stage_name: Ballot Production
-        capability_ids:
-          - BC-3330
-        process_ids: []
-        notes: Ballot design, translation, accessibility, and secure distribution
-      - id: VS-480.50
-        stage_order: 5
-        stage_name: Polling
-        capability_ids:
-          - BC-3330
-        process_ids: []
-        notes: Poll-worker management, voter check-in, and absentee voting
-      - id: VS-480.60
-        stage_order: 6
-        stage_name: Counting & Tabulation
-        capability_ids:
-          - BC-3330
-        process_ids: []
-        notes: Ballot counting, results aggregation, and post-election audit
-      - id: VS-480.70
-        stage_order: 7
-        stage_name: Certification
-        capability_ids:
-          - BC-3330
-        process_ids: []
-        notes: Statutory certification of election results
-      - id: VS-480.80
-        stage_order: 8
-        stage_name: Campaign Finance Disclosure
-        capability_ids:
-          - BC-3330
-        process_ids: []
-        notes: Political-committee registration, donation reporting, and enforcement
-  - id: VS-490
-    name: Return-to-Collection
-    industries:
-      - Public Sector & Government
-    stages:
-      - id: VS-490.10
-        stage_order: 1
-        stage_name: Taxpayer Registration
-        capability_ids:
-          - BC-3250
-        process_ids: []
-        notes: Registration and TIN issuance; taxpayer master data
-      - id: VS-490.20
-        stage_order: 2
-        stage_name: Return Lodgement
-        capability_ids:
-          - BC-3250
-        process_ids: []
-        notes: Receipt and validation of tax returns
-      - id: VS-490.30
-        stage_order: 3
-        stage_name: Assessment
-        capability_ids:
-          - BC-3250
-        process_ids: []
-        notes: Self-assessment processing and default assessments
-      - id: VS-490.40
-        stage_order: 4
-        stage_name: Payment Collection
-        capability_ids:
-          - BC-3250
-        process_ids: []
-        notes: Payment channel operations, withholding, instalment plans
-      - id: VS-490.50
-        stage_order: 5
-        stage_name: Refund & Credit
-        capability_ids:
-          - BC-3250
-        process_ids: []
-        notes: Refund validation, issuance, and fraud screening
-      - id: VS-490.60
-        stage_order: 6
-        stage_name: Audit & Examination
-        capability_ids:
-          - BC-3250
-        process_ids: []
-        notes: Risk-based audit, fieldwork, and reassessment issuance
-      - id: VS-490.70
-        stage_order: 7
-        stage_name: Debt Enforcement
-        capability_ids:
-          - BC-3250
-        process_ids: []
-        notes: Tax debt portfolio management, statutory enforcement, prosecution referral
-  - id: VS-500
-    name: Risk-to-Mitigation
-    industries:
-      - Cross-Industry
-    stages:
-      - id: VS-500.10
-        stage_order: 1
-        stage_name: Risk Appetite & Framework
-        capability_ids:
-          - BC-120
-        process_ids: []
-        notes: Appetite statements
-      - id: VS-500.20
-        stage_order: 1
-        stage_name: Risk Appetite & Framework
-        capability_ids:
-          - BC-4350
-        process_ids: []
-        industry_variant: Professional Services
-        notes: Independence policy and conflicts framework
-      - id: VS-500.30
-        stage_order: 2
-        stage_name: Risk Identification
-        capability_ids:
-          - BC-120
-          - BC-520
-        process_ids: []
-        notes: Top-down + bottom-up scan; Supply chain risk feed
-      - id: VS-500.40
-        stage_order: 2
-        stage_name: Risk Identification
-        capability_ids:
-          - BC-3590
-        process_ids: []
-        industry_variant: Agriculture
-        notes: Agri-food compliance risk taxonomy (zoonosis, MRL, welfare)
-      - id: VS-500.50
-        stage_order: 2
-        stage_name: Risk Identification
-        capability_ids:
-          - BC-1410
-        process_ids: []
-        industry_variant: Banking
-        notes: Banking risk taxonomy
-      - id: VS-500.60
-        stage_order: 2
-        stage_name: Risk Identification
-        capability_ids:
-          - BC-2840
-        process_ids: []
-        industry_variant: Healthcare Providers
-        notes: Clinical risk taxonomy
-      - id: VS-500.70
-        stage_order: 2
-        stage_name: Risk Identification
-        capability_ids:
-          - BC-2190
-        process_ids: []
-        industry_variant: Insurance
-        notes: Insurance risk taxonomy
-      - id: VS-500.80
-        stage_order: 2
-        stage_name: Risk Identification
-        capability_ids:
-          - BC-3780
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Content risk identification across editorial, legal, and reputational
-      - id: VS-500.90
-        stage_order: 2
-        stage_name: Risk Identification
-        capability_ids:
-          - BC-4460
-          - BC-4500
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Tailings and dam-safety risk identification under GISTM; Human-rights and social risk identification
-      - id: VS-500.100
-        stage_order: 2
-        stage_name: Risk Identification
-        capability_ids:
-          - BC-4350
-        process_ids: []
-        industry_variant: Professional Services
-        notes: Conflict and independence threat identification
-      - id: VS-500.110
-        stage_order: 2
-        stage_name: Risk Identification
-        capability_ids:
-          - BC-2700
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Telecom regulatory and licence-conditions risk taxonomy
-      - id: VS-500.120
-        stage_order: 2
-        stage_name: Risk Identification
-        capability_ids:
-          - BC-3850
-        process_ids: []
-        industry_variant: Utilities
-        notes: Energy market, credit, and operational risk taxonomy for trading
-      - id: VS-500.130
-        stage_order: 3
-        stage_name: Risk Assessment
-        capability_ids:
-          - BC-120
-          - BC-4920
-        process_ids: []
-        notes: Likelihood / impact scoring; Asset physical, climate, market, and tenant credit risk assessment
-      - id: VS-500.140
-        stage_order: 3
-        stage_name: Risk Assessment
-        capability_ids:
-          - BC-3590
-        process_ids: []
-        industry_variant: Agriculture
-        notes: Compliance and food-safety risk assessment
-      - id: VS-500.150
-        stage_order: 3
-        stage_name: Risk Assessment
-        capability_ids:
-          - BC-1280
-        process_ids: []
-        industry_variant: ATC
-        notes: Aviation safety risk assessment
-      - id: VS-500.160
-        stage_order: 3
-        stage_name: Risk Assessment
-        capability_ids:
-          - BC-1970
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Functional-safety risk assessment for products
-      - id: VS-500.170
-        stage_order: 3
-        stage_name: Risk Assessment
-        capability_ids:
-          - BC-2840
-        process_ids: []
-        industry_variant: Healthcare Providers
-        notes: Clinical and patient-safety risk assessment
-      - id: VS-500.180
-        stage_order: 3
-        stage_name: Risk Assessment
-        capability_ids:
-          - BC-2180
-        process_ids: []
-        industry_variant: Insurance
-        notes: Capital & solvency modelling
-      - id: VS-500.190
-        stage_order: 3
-        stage_name: Risk Assessment
-        capability_ids:
-          - BC-3850
-        process_ids: []
-        industry_variant: Utilities
-        notes: VaR, earnings-at-risk, and stress-test analysis
-      - id: VS-500.200
-        stage_order: 4
-        stage_name: Treatment & Control Design
-        capability_ids:
-          - BC-120
-          - BC-4990
-        process_ids: []
-        notes: Controls & mitigations; Insurance transfer; Real-estate compliance controls including fair housing, AML, RESPA, and MEES
-      - id: VS-500.210
-        stage_order: 4
-        stage_name: Treatment & Control Design
-        capability_ids:
-          - BC-2840
-        process_ids: []
-        industry_variant: Healthcare Providers
-        notes: Clinical risk mitigation planning
-      - id: VS-500.220
-        stage_order: 4
-        stage_name: Treatment & Control Design
-        capability_ids:
-          - BC-2170
-        process_ids: []
-        industry_variant: Insurance
-        notes: Reinsurance as risk transfer
-      - id: VS-500.230
-        stage_order: 4
-        stage_name: Treatment & Control Design
-        capability_ids:
-          - BC-3780
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Editorial guidelines and pre-transmission compliance review controls
-      - id: VS-500.240
-        stage_order: 4
-        stage_name: Treatment & Control Design
-        capability_ids:
-          - BC-4350
-        process_ids: []
-        industry_variant: Professional Services
-        notes: Information-barrier design and prohibited-service controls
-      - id: VS-500.250
-        stage_order: 5
-        stage_name: Monitoring
-        capability_ids:
-          - BC-120
-          - BC-4980
-        process_ids: []
-        notes: KRIs / dashboards; CRE loan portfolio LTV / DSCR concentration and stress-test monitoring
-      - id: VS-500.260
-        stage_order: 5
-        stage_name: Monitoring
-        capability_ids:
-          - BC-1320
-        process_ids: []
-        industry_variant: Banking
-        notes: Credit risk modelling
-      - id: VS-500.270
-        stage_order: 5
-        stage_name: Monitoring
-        capability_ids:
-          - BC-2190
-        process_ids: []
-        industry_variant: Insurance
-        notes: ORSA monitoring
-      - id: VS-500.280
-        stage_order: 5
-        stage_name: Monitoring
-        capability_ids:
-          - BC-3780
-        process_ids: []
-        industry_variant: Media & Entertainment
-        notes: Ongoing content compliance monitoring
-      - id: VS-500.290
-        stage_order: 5
-        stage_name: Monitoring
-        capability_ids:
-          - BC-4480
-        process_ids: []
-        industry_variant: Mining & Metals
-        notes: Trading book price and counterparty risk monitoring
-      - id: VS-500.300
-        stage_order: 5
-        stage_name: Monitoring
-        capability_ids:
-          - BC-3850
-        process_ids: []
-        industry_variant: Utilities
-        notes: Position, exposure, and limit-utilisation monitoring
-      - id: VS-500.310
-        stage_order: 6
-        stage_name: Reporting & Escalation
-        capability_ids:
-          - BC-120
-          - BC-130
-        process_ids: []
-        notes: Risk reporting to board; Regulatory disclosure where required
-      - id: VS-500.320
-        stage_order: 6
-        stage_name: Reporting & Escalation
-        capability_ids:
-          - BC-2700
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Telecom regulator filings and licence-conditions reporting
-  - id: VS-510
-    name: Settle-Inter-Operator
-    industries:
-      - Telecommunications
-    stages:
-      - id: VS-510.10
-        stage_order: 1
-        stage_name: Wholesale Agreement
-        capability_ids:
-          - BC-2680
-        process_ids: []
-        notes: Wholesale, interconnect, and roaming agreement negotiation
-      - id: VS-510.20
-        stage_order: 2
-        stage_name: Usage Capture
-        capability_ids:
-          - BC-2680
-          - BC-2600
-        process_ids: []
-        notes: TAP/RAP file exchange and inter-operator usage record collection; Network-side CDR generation and mediation feed
-      - id: VS-510.30
-        stage_order: 3
-        stage_name: Rating & Charging
-        capability_ids:
-          - BC-2680
-        process_ids: []
-        notes: Wholesale rating against contracted tariffs and discount schemes
-      - id: VS-510.40
-        stage_order: 4
-        stage_name: Inter-Operator Settlement
-        capability_ids:
-          - BC-2680
-          - BC-2660
-        process_ids: []
-        notes: Net settlement, invoicing, and clearing-house exchange; Wholesale revenue assurance and accounting integration
-      - id: VS-510.50
-        stage_order: 5
-        stage_name: Dispute & Reconciliation
-        capability_ids:
-          - BC-2680
-        process_ids: []
-        notes: Discrepancy investigation, dispute resolution, and adjustment posting
-  - id: VS-520
-    name: Shop-to-Stay
-    industries:
-      - Travel & Hospitality
-    stages:
-      - id: VS-520.10
-        stage_order: 1
-        stage_name: Inspire & Discover
-        capability_ids:
-          - BC-4010
-          - BC-4030
-        process_ids: []
-        notes: Channel exposure across direct, OTA, and metasearch; Promotion and offer surfacing
-      - id: VS-520.20
-        stage_order: 2
-        stage_name: Shop & Compare
-        capability_ids:
-          - BC-4000
-          - BC-4030
-          - BC-4010
-        process_ids: []
-        notes: Product content, taxonomy, and merchandising; Live pricing and dynamic offer; Channel-specific shopping and parity
-      - id: VS-520.30
-        stage_order: 3
-        stage_name: Book & Confirm
-        capability_ids:
-          - BC-4020
-          - BC-4040
-        process_ids: []
-        notes: Reservation capture, confirmation, and payment; Profile creation; consent and travel-document capture at booking
-      - id: VS-520.40
-        stage_order: 4
-        stage_name: Pre-Arrival
-        capability_ids:
-          - BC-4040
-          - BC-4060
-        process_ids: []
-        notes: Pre-arrival recognition cueing; Pre-arrival room and amenity preparation
-      - id: VS-520.50
-        stage_order: 5
-        stage_name: Travel & Stay
-        capability_ids:
-          - BC-4070
-          - BC-4020
-        process_ids: []
-        notes: Restaurant, in-room dining, and bar service; In-stay rebook and IROPS reaccommodation
-      - id: VS-520.60
-        stage_order: 5
-        stage_name: Travel & Stay
-        capability_ids:
-          - BC-4080
-        process_ids: []
-        industry_variant: Airline
-        notes: On-the-day flight operations including IROPS
-      - id: VS-520.70
-        stage_order: 5
-        stage_name: Travel & Stay
-        capability_ids:
-          - BC-4090
-        process_ids: []
-        industry_variant: Cruise
-        notes: Onboard cruise operations during voyage
-      - id: VS-520.80
-        stage_order: 5
-        stage_name: Travel & Stay
-        capability_ids:
-          - BC-4060
-        process_ids: []
-        industry_variant: Lodging
-        notes: Front office, housekeeping, and concierge during the stay
-      - id: VS-520.90
-        stage_order: 5
-        stage_name: Travel & Stay
-        capability_ids:
-          - BC-4100
-        process_ids: []
-        industry_variant: Tour
-        notes: In-destination tour delivery
-      - id: VS-520.100
-        stage_order: 6
-        stage_name: Settle & Recognise
-        capability_ids:
-          - BC-4020
-          - BC-4060
-          - BC-4050
-        process_ids: []
-        notes: Booking settlement and final charge capture; Folio settlement at check-out; Earn engine accrual on completed activity
-      - id: VS-520.110
-        stage_order: 7
-        stage_name: Post-Stay & Retain
-        capability_ids:
-          - BC-4040
-          - BC-4050
-          - BC-4030
-        process_ids: []
-        notes: Feedback capture, segmentation, and lifetime-value update; Recognition delivery and member communications; Revenue performance analysis and forecast tuning
-  - id: VS-530
-    name: Site-to-Stabilisation
-    industries:
-      - Real Estate
-    stages:
-      - id: VS-530.10
-        stage_order: 1
-        stage_name: Site Sourcing & Origination
-        capability_ids:
-          - BC-4900
-        process_ids: []
-        notes: Site identification, off-market origination, and pipeline tracking
-      - id: VS-530.20
-        stage_order: 2
-        stage_name: Feasibility & Underwriting
-        capability_ids:
-          - BC-4900
-        process_ids: []
-        notes: Highest & best use, programme studies, pro forma, and land underwriting
-      - id: VS-530.30
-        stage_order: 3
-        stage_name: Entitlement & Permitting
-        capability_ids:
-          - BC-4900
-        process_ids: []
-        notes: Zoning, planning consent, environmental review, and building permits
-      - id: VS-530.40
-        stage_order: 4
-        stage_name: Development Capitalisation
-        capability_ids:
-          - BC-4900
-          - BC-4980
-        process_ids: []
-        notes: Equity, construction loans, JV, and public incentives sourcing; Construction and bridge loan origination
-      - id: VS-530.50
-        stage_order: 5
-        stage_name: Design & Construction Execution
-        capability_ids:
-          - BC-4900
-          - BC-1150
-        process_ids: []
-        notes: Design oversight and owner-side construction monitoring; Construction execution by GC and trades
-      - id: VS-530.60
-        stage_order: 6
-        stage_name: Lease-Up & Stabilisation
-        capability_ids:
-          - BC-4900
-          - BC-4950
-        process_ids: []
-        notes: Pre-leasing, opening, and ramp to stabilised performance; Pre-leasing campaigns and initial lease execution
-      - id: VS-530.70
-        stage_order: 7
-        stage_name: Operational Handover
-        capability_ids:
-          - BC-4940
-        process_ids: []
-        notes: Handover into ongoing property management operations
-  - id: VS-540
-    name: Solicitation-to-Closeout
-    industries:
-      - Public Sector & Government
-    stages:
-      - id: VS-540.10
-        stage_order: 1
-        stage_name: Programme Design
-        capability_ids:
-          - BC-3260
-        process_ids: []
-        notes: Objectives, allocation modelling, evaluation criteria
-      - id: VS-540.20
-        stage_order: 2
-        stage_name: Solicitation Publication
-        capability_ids:
-          - BC-3260
-        process_ids: []
-        notes: Funding opportunity publication and applicant outreach
-      - id: VS-540.30
-        stage_order: 3
-        stage_name: Application Review
-        capability_ids:
-          - BC-3260
-        process_ids: []
-        notes: Eligibility screening and merit review with conflict-of-interest controls
-      - id: VS-540.40
-        stage_order: 4
-        stage_name: Award & Agreement
-        capability_ids:
-          - BC-3260
-        process_ids: []
-        notes: Award selection, grant agreement issuance, and obligation
-      - id: VS-540.50
-        stage_order: 5
-        stage_name: Recipient Monitoring
-        capability_ids:
-          - BC-3260
-        process_ids: []
-        notes: Performance, financial, and site monitoring of recipients
-      - id: VS-540.60
-        stage_order: 6
-        stage_name: Closeout & Audit Resolution
-        capability_ids:
-          - BC-3260
-        process_ids: []
-        notes: Final reporting, single-audit resolution, and disallowed-cost recovery
-  - id: VS-550
-    name: Source-to-Tap
-    industries:
-      - Power & Water Utilities
-    stages:
-      - id: VS-550.10
-        stage_order: 1
-        stage_name: Resource Planning & Authorisation
-        capability_ids:
-          - BC-3860
-        process_ids: []
-        industry_variant: Utilities
-        notes: Supply-demand balance, drought planning, abstraction licence administration
-      - id: VS-550.20
-        stage_order: 2
-        stage_name: Catchment Stewardship
-        capability_ids:
-          - BC-3860
-        process_ids: []
-        industry_variant: Utilities
-        notes: Catchment risk assessment, source protection zones, stakeholder engagement
-      - id: VS-550.30
-        stage_order: 3
-        stage_name: Raw Water Abstraction
-        capability_ids:
-          - BC-3860
-        process_ids: []
-        industry_variant: Utilities
-        notes: Surface intake, groundwater borehole, and raw-water pumping operations
-      - id: VS-550.40
-        stage_order: 4
-        stage_name: Treatment
-        capability_ids:
-          - BC-3870
-        process_ids: []
-        industry_variant: Utilities
-        notes: Treatment-works shift operations and unit-process control
-      - id: VS-550.50
-        stage_order: 5
-        stage_name: Drinking Water Quality Assurance
-        capability_ids:
-          - BC-3870
-        process_ids: []
-        industry_variant: Utilities
-        notes: Statutory sampling, online monitoring, incident response, and DWI/EPA reporting
-      - id: VS-550.60
-        stage_order: 6
-        stage_name: Bulk Storage & Transmission
-        capability_ids:
-          - BC-3870
-          - BC-3880
-        process_ids: []
-        industry_variant: Utilities
-        notes: Service reservoir and contact-tank operations; Trunk-main and pumping-station operations between zones
-      - id: VS-550.70
-        stage_order: 7
-        stage_name: Distribution
-        capability_ids:
-          - BC-3880
-        process_ids: []
-        industry_variant: Utilities
-        notes: Distribution control, leakage, pressure, network quality, and mains repair
-      - id: VS-550.80
-        stage_order: 8
-        stage_name: Customer Supply & Metering
-        capability_ids:
-          - BC-3880
-          - BC-3910
-        process_ids: []
-        industry_variant: Utilities
-        notes: New service connection installation and commissioning; Customer account, AMI data acquisition, meter reading, and M2C inputs
-  - id: VS-560
-    name: Sourcing-to-Onboarding
-    industries:
-      - Real Estate
-    stages:
-      - id: VS-560.10
-        stage_order: 1
-        stage_name: Deal Sourcing
-        capability_ids:
-          - BC-4930
-        process_ids: []
-        notes: Acquisition lead sourcing across direct, broker, and off-market channels
-      - id: VS-560.20
-        stage_order: 2
-        stage_name: Underwriting
-        capability_ids:
-          - BC-4930
-        process_ids: []
-        notes: Cash flow, comparables, sensitivity, and scenario underwriting
-      - id: VS-560.30
-        stage_order: 3
-        stage_name: Due Diligence
-        capability_ids:
-          - BC-4930
-        process_ids: []
-        notes: Physical, environmental, title, lease, and financial diligence
-      - id: VS-560.40
-        stage_order: 4
-        stage_name: Structuring & Negotiation
-        capability_ids:
-          - BC-4930
-        process_ids: []
-        notes: Bid strategy, LOI, PSA, and tax / vehicle structuring
-      - id: VS-560.50
-        stage_order: 5
-        stage_name: Closing & Settlement
-        capability_ids:
-          - BC-4930
-        process_ids: []
-        notes: Escrow, settlement statement, and recording
-      - id: VS-560.60
-        stage_order: 6
-        stage_name: Operational Onboarding
-        capability_ids:
-          - BC-4930
-        process_ids: []
-        notes: Asset and lease data migration and vendor contract novation
-      - id: VS-560.70
-        stage_order: 7
-        stage_name: Asset Management Handover
-        capability_ids:
-          - BC-4920
-        process_ids: []
-        notes: Handover to ongoing asset stewardship and business plan execution
-  - id: VS-570
-    name: Spectrum-to-Deployment
-    industries:
-      - Telecommunications
-    stages:
-      - id: VS-570.10
-        stage_order: 1
-        stage_name: Spectrum Strategy
-        capability_ids:
-          - BC-2670
-        process_ids: []
-        notes: Spectrum portfolio strategy and technology-band roadmap
-      - id: VS-570.20
-        stage_order: 2
-        stage_name: Licence Acquisition
-        capability_ids:
-          - BC-2670
-          - BC-2700
-        process_ids: []
-        notes: Auction participation, licence purchase, and trading; Regulatory engagement and licence-condition negotiation
-      - id: VS-570.30
-        stage_order: 3
-        stage_name: Frequency Assignment & Coordination
-        capability_ids:
-          - BC-2670
-        process_ids: []
-        notes: Frequency planning, cell-level assignment, and cross-border coordination
-      - id: VS-570.40
-        stage_order: 4
-        stage_name: Network Deployment
-        capability_ids:
-          - BC-2610
-          - BC-2600
-        process_ids: []
-        notes: RAN and transport build-out aligned to the spectrum plan; Activation, optimisation, and acceptance of new spectrum carriers
-      - id: VS-570.50
-        stage_order: 5
-        stage_name: Interference & Compliance
-        capability_ids:
-          - BC-2670
-          - BC-2700
-        process_ids: []
-        notes: Interference monitoring, mitigation, and shared-access spectrum operations; Licence-condition compliance and regulatory reporting
-      - id: VS-570.60
-        stage_order: 6
-        stage_name: Renewal & Reframing
-        capability_ids:
-          - BC-2670
-        process_ids: []
-        notes: Licence renewal, reframing, and end-of-life return
-  - id: VS-580
-    name: Strategy-to-Execution
-    industries:
-      - Cross-Industry
-    stages:
-      - id: VS-580.10
-        stage_order: 1
-        stage_name: Strategy Formulation
-        capability_ids:
-          - BC-100
-          - BC-170
-          - BC-4910
-        process_ids: []
-        notes: Strategic planning; Business model design; Capability and operating model translate strategy into structure; Real-estate fund mandate and investment strategy formulation
-      - id: VS-580.20
-        stage_order: 1
-        stage_name: Strategy Formulation
-        capability_ids:
-          - BC-3200
-        process_ids: []
-        industry_variant: Public Sector
-        notes: Policy options analysis and decision support
-      - id: VS-580.30
-        stage_order: 2
-        stage_name: Portfolio Definition
-        capability_ids:
-          - BC-100
-          - BC-170
-          - BC-900
-          - BC-4910
-        process_ids: []
-        notes: Strategic portfolio; Capability heatmap and gap analysis drive investment prioritisation; Project portfolio prioritisation; Real-estate portfolio construction, pacing, and allocation
-      - id: VS-580.40
-        stage_order: 3
-        stage_name: Programme & Project Setup
-        capability_ids:
-          - BC-900
-        process_ids: []
-        notes: Programme establishment; Project initiation
-      - id: VS-580.50
-        stage_order: 4
-        stage_name: Delivery & Governance
-        capability_ids:
-          - BC-900
-          - BC-920
-          - BC-930
-          - BC-4920
-        process_ids: []
-        notes: Project governance; PMO operations; Transformation programme execution; Process redesign and conformance during transformation delivery; Asset business plan delivery and governance
-      - id: VS-580.60
-        stage_order: 4
-        stage_name: Delivery & Governance
-        capability_ids:
-          - BC-3200
-        process_ids: []
-        industry_variant: Public Sector
-        notes: Cross-agency policy implementation coordination
-      - id: VS-580.70
-        stage_order: 5
-        stage_name: Change Adoption
-        capability_ids:
-          - BC-910
-        process_ids: []
-        notes: Stakeholder engagement; Communications & training; Adoption & reinforcement
-      - id: VS-580.80
-        stage_order: 6
-        stage_name: Benefits Realisation
-        capability_ids:
-          - BC-100
-          - BC-170
-          - BC-920
-          - BC-4920
-        process_ids: []
-        notes: Strategy execution review; Target-state capability assessment validates strategic outcomes; Benefits tracking; Realisation against asset value-creation thesis
-      - id: VS-580.90
-        stage_order: 6
-        stage_name: Benefits Realisation
-        capability_ids:
-          - BC-3200
-        process_ids: []
-        industry_variant: Public Sector
-        notes: Policy evaluation and ex-post review
-  - id: VS-590
-    name: Sustain-to-Disposition
-    industries:
-      - Defense & Aerospace
-    stages:
-      - id: VS-590.10
-        stage_order: 1
-        stage_name: Sustainment Planning
-        capability_ids:
-          - BC-1780
-        process_ids: []
-        industry_variant: Defense
-        notes: In-service support plan; RAM engineering
-      - id: VS-590.20
-        stage_order: 2
-        stage_name: Operate & Maintain
-        capability_ids:
-          - BC-1720
-          - BC-1780
-        process_ids: []
-        industry_variant: Defense
-        notes: Defense logistics; Depot maintenance
-      - id: VS-590.30
-        stage_order: 3
-        stage_name: Spares & Repairs
-        capability_ids:
-          - BC-1060
-        process_ids: []
-        notes: Aftermarket parts
-      - id: VS-590.40
-        stage_order: 3
-        stage_name: Spares & Repairs
-        capability_ids:
-          - BC-1780
-        process_ids: []
-        industry_variant: Defense
-        notes: Spares & repair pipeline
-      - id: VS-590.50
-        stage_order: 4
-        stage_name: Technical Documentation
-        capability_ids:
-          - BC-1780
-        process_ids: []
-        industry_variant: Defense
-        notes: Technical publications
-      - id: VS-590.60
-        stage_order: 5
-        stage_name: Obsolescence Management
-        capability_ids:
-          - BC-1780
-        process_ids: []
-        industry_variant: Defense
-        notes: DMSMS / obsolescence
-      - id: VS-590.70
-        stage_order: 6
-        stage_name: Capability Upgrades
-        capability_ids:
-          - BC-1770
-          - BC-1800
-        process_ids: []
-        industry_variant: Defense
-        notes: Configuration management; Test & evaluation
-      - id: VS-590.80
-        stage_order: 7
-        stage_name: Disposal & Disposition
-        capability_ids:
-          - BC-1040
-        process_ids: []
-        notes: Decommissioning
-      - id: VS-590.90
-        stage_order: 7
-        stage_name: Disposal & Disposition
-        capability_ids:
-          - BC-1810
-        process_ids: []
-        industry_variant: Defense
-        notes: Classified material destruction
-  - id: VS-600
-    name: Threat-to-Mitigation
-    industries:
-      - Cross-Industry
-    stages:
-      - id: VS-600.10
-        stage_order: 1
-        stage_name: Security Posture Definition
-        capability_ids:
-          - BC-620
-        process_ids: []
-        notes: Strategy & governance; Reference architecture
-      - id: VS-600.20
-        stage_order: 2
-        stage_name: Threat Intelligence
-        capability_ids:
-          - BC-620
-        process_ids: []
-        notes: Threat feeds & intel
-      - id: VS-600.30
-        stage_order: 2
-        stage_name: Threat Intelligence
-        capability_ids:
-          - BC-3460
-        process_ids: []
-        industry_variant: Automotive
-        notes: Vehicle threat intelligence feeds
-      - id: VS-600.40
-        stage_order: 2
-        stage_name: Threat Intelligence
-        capability_ids:
-          - BC-1740
-        process_ids: []
-        industry_variant: Defense
-        notes: Cyber operations intel
-      - id: VS-600.50
-        stage_order: 2
-        stage_name: Threat Intelligence
-        capability_ids:
-          - BC-1950
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Product CVE feeds & supplier advisories
-      - id: VS-600.60
-        stage_order: 3
-        stage_name: Vulnerability Discovery
-        capability_ids:
-          - BC-620
-        process_ids: []
-        notes: Scanning, pen test, bug bounty
-      - id: VS-600.70
-        stage_order: 3
-        stage_name: Vulnerability Discovery
-        capability_ids:
-          - BC-1950
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: Coordinated product vulnerability disclosure
-      - id: VS-600.80
-        stage_order: 3
-        stage_name: Vulnerability Discovery
-        capability_ids:
-          - BC-2010
-        process_ids: []
-        industry_variant: HVAC & Building Automation Systems
-        notes: BAS product vulnerability disclosure
-      - id: VS-600.90
-        stage_order: 4
-        stage_name: Detection
-        capability_ids:
-          - BC-620
-        process_ids: []
-        notes: SIEM / SOC monitoring
-      - id: VS-600.100
-        stage_order: 4
-        stage_name: Detection
-        capability_ids:
-          - BC-3460
-        process_ids: []
-        industry_variant: Automotive
-        notes: Vehicle SOC fleet-wide threat detection
-      - id: VS-600.110
-        stage_order: 4
-        stage_name: Detection
-        capability_ids:
-          - BC-2060
-        process_ids: []
-        industry_variant: HVAC & Building Automation Systems
-        notes: Connected-service anomaly detection on BAS
-      - id: VS-600.120
-        stage_order: 4
-        stage_name: Detection
-        capability_ids:
-          - BC-2600
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Signalling, transport, and core network threat monitoring
-      - id: VS-600.130
-        stage_order: 4
-        stage_name: Detection
-        capability_ids:
-          - BC-3810
-        process_ids: []
-        industry_variant: Utilities
-        notes: NERC CIP and OT-network threat detection on bulk-electric system
-      - id: VS-600.140
-        stage_order: 5
-        stage_name: Incident Response
-        capability_ids:
-          - BC-160
-          - BC-620
-        process_ids: []
-        notes: Disaster recovery activation; Containment & eradication
-      - id: VS-600.150
-        stage_order: 5
-        stage_name: Incident Response
-        capability_ids:
-          - BC-3460
-        process_ids: []
-        industry_variant: Automotive
-        notes: Vehicle incident response and OTA remediation
-      - id: VS-600.160
-        stage_order: 5
-        stage_name: Incident Response
-        capability_ids:
-          - BC-1950
-        process_ids: []
-        industry_variant: Electrical Components & Equipment
-        notes: OTA patch deployment for product CVEs
-      - id: VS-600.170
-        stage_order: 5
-        stage_name: Incident Response
-        capability_ids:
-          - BC-2060
-        process_ids: []
-        industry_variant: HVAC & Building Automation Systems
-        notes: OTA patching of BAS controllers
-      - id: VS-600.180
-        stage_order: 5
-        stage_name: Incident Response
-        capability_ids:
-          - BC-2600
-        process_ids: []
-        industry_variant: Telecommunications
-        notes: Network security incident response and DDoS mitigation
-      - id: VS-600.190
-        stage_order: 5
-        stage_name: Incident Response
-        capability_ids:
-          - BC-3810
-        process_ids: []
-        industry_variant: Utilities
-        notes: Bulk-electric-system cyber incident response and CIP-008 reporting
-      - id: VS-600.200
-        stage_order: 6
-        stage_name: Identity & Access Hardening
-        capability_ids:
-          - BC-620
-        process_ids: []
-        notes: IAM tightening
-      - id: VS-600.210
-        stage_order: 7
-        stage_name: Awareness & Lessons Learned
-        capability_ids:
-          - BC-620
-          - BC-830
-        process_ids: []
-        notes: Awareness campaigns; Best-practice capture
-  - id: VS-610
-    name: Trade-Plan-to-Settle
-    industries:
-      - Retail & Consumer Goods
-    stages:
-      - id: VS-610.10
-        stage_order: 1
-        stage_name: Trade Plan Development
-        capability_ids:
-          - BC-2360
-        process_ids: []
-        notes: Annual trade plan, joint business plans, and customer-level investment strategy
-      - id: VS-610.20
-        stage_order: 2
-        stage_name: Fund Allocation
-        capability_ids:
-          - BC-2360
-        process_ids: []
-        notes: Trade-spend budgeting and accrual setup
-      - id: VS-610.30
-        stage_order: 3
-        stage_name: Promotion Execution
-        capability_ids:
-          - BC-2360
-        process_ids: []
-        notes: In-store event execution, slotting, and feature scheduling
-      - id: VS-610.40
-        stage_order: 4
-        stage_name: Deduction & Claim Handling
-        capability_ids:
-          - BC-2360
-          - BC-200
-        process_ids: []
-        notes: Customer deduction validation, claim resolution, and chargeback management; Trade-spend accruals, deduction accounting, and AR clearing
-      - id: VS-610.50
-        stage_order: 5
-        stage_name: Post-Event Lift Measurement
-        capability_ids:
-          - BC-2360
-        process_ids: []
-        notes: Lift analytics, ROI evaluation, and feedback into next plan
-  - id: VS-620
-    name: Trial-to-Renewal
-    industries:
-      - Software & Technology
-    stages:
-      - id: VS-620.10
-        stage_order: 1
-        stage_name: Trial Initiation
-        capability_ids:
-          - BC-4240
-          - BC-4230
-        process_ids: []
-        notes: Trial sign-up and trial subscription provisioning; Tenant provisioning for trial accounts
-      - id: VS-620.20
-        stage_order: 2
-        stage_name: Trial Activation
-        capability_ids:
-          - BC-4260
-        process_ids: []
-        notes: Onboarding and activation milestone tracking during trial
-      - id: VS-620.30
-        stage_order: 3
-        stage_name: Conversion to Paid
-        capability_ids:
-          - BC-4240
-          - BC-4250
-        process_ids: []
-        notes: Trial-to-paid subscription conversion; Initial invoicing and payment authorisation on conversion
-      - id: VS-620.40
-        stage_order: 4
-        stage_name: Adoption
-        capability_ids:
-          - BC-4260
-          - BC-4280
-        process_ids: []
-        notes: Adoption programmes, power-user enablement; Product telemetry and feature engagement reporting that drive adoption
-      - id: VS-620.50
-        stage_order: 5
-        stage_name: Health & Risk Monitoring
-        capability_ids:
-          - BC-4260
-        process_ids: []
-        notes: Customer health scoring and at-risk account intervention
-      - id: VS-620.60
-        stage_order: 6
-        stage_name: Renewal
-        capability_ids:
-          - BC-4240
-          - BC-4260
-        process_ids: []
-        notes: Auto-renewal processing and renewal negotiation; Renewal advocacy, save motions, renewal forecasting
-      - id: VS-620.70
-        stage_order: 7
-        stage_name: Expansion
-        capability_ids:
-          - BC-4260
-          - BC-4240
-        process_ids: []
-        notes: Expansion opportunity identification and upsell qualification; Plan upgrade, seat adjustment, and add-on activation
-      - id: VS-620.80
-        stage_order: 8
-        stage_name: Churn or Wind-Down
-        capability_ids:
-          - BC-4240
-        process_ids: []
-        notes: Cancellation processing and service wind-down coordination
-  - id: VS-630
-    name: Validate-to-Authorise
-    industries:
-      - Automotive & Mobility
-    stages:
-      - id: VS-630.10
-        stage_order: 1
-        stage_name: ODD Definition
-        capability_ids:
-          - BC-3470
-        process_ids: []
-        industry_variant: Automotive
-        notes: Operational design domain definition
-      - id: VS-630.20
-        stage_order: 2
-        stage_name: Scenario Coverage Build
-        capability_ids:
-          - BC-3470
-        process_ids: []
-        industry_variant: Automotive
-        notes: Scenario library curation and edge-case capture
-      - id: VS-630.30
-        stage_order: 3
-        stage_name: Validation Execution
-        capability_ids:
-          - BC-3470
-        process_ids: []
-        industry_variant: Automotive
-        notes: Simulation, closed-course, and public-road validation
-      - id: VS-630.40
-        stage_order: 4
-        stage_name: Safety Case Authoring
-        capability_ids:
-          - BC-3470
-        process_ids: []
-        industry_variant: Automotive
-        notes: Authoring and assurance of the ADS safety case
-      - id: VS-630.50
-        stage_order: 5
-        stage_name: Regulatory Authorisation
-        capability_ids:
-          - BC-3420
-          - BC-3470
-        process_ids: []
-        industry_variant: Automotive
-        notes: ALKS / ADS approval submission under UN R157; ADS permit and authorisation management
-      - id: VS-630.60
-        stage_order: 6
-        stage_name: Deployment Monitoring
-        capability_ids:
-          - BC-3470
-        process_ids: []
-        industry_variant: Automotive
-        notes: ODD conformance monitoring and SPI tracking
-      - id: VS-630.70
-        stage_order: 7
-        stage_name: Incident Reporting & Iteration
-        capability_ids:
-          - BC-3470
-        process_ids: []
-        industry_variant: Automotive
-        notes: Incident reporting to regulators and feedback into safety case
-  - id: VS-640
-    name: Visa-to-Admission
-    industries:
-      - Public Sector & Government
-    stages:
-      - id: VS-640.10
-        stage_order: 1
-        stage_name: Visa Application
-        capability_ids:
-          - BC-3300
-        process_ids: []
-        notes: Receipt and validation of visa applications across categories
-      - id: VS-640.20
-        stage_order: 2
-        stage_name: Visa Decisioning
-        capability_ids:
-          - BC-3300
-        process_ids: []
-        notes: Adjudication of visa applications and fraud screening
-      - id: VS-640.30
-        stage_order: 3
-        stage_name: Pre-Travel Authorisation
-        capability_ids:
-          - BC-3300
-        process_ids: []
-        notes: ETA-style pre-travel authorisation and API/PNR processing
-      - id: VS-640.40
-        stage_order: 4
-        stage_name: Border Inspection
-        capability_ids:
-          - BC-3300
-        process_ids: []
-        notes: Primary and secondary inspection at ports of entry
-      - id: VS-640.50
-        stage_order: 5
-        stage_name: Admission Decision
-        capability_ids:
-          - BC-3300
-        process_ids: []
-        notes: Decisioning on admission, refusal, and conditions of entry
-      - id: VS-640.60
-        stage_order: 6
-        stage_name: Status Maintenance
-        capability_ids:
-          - BC-3300
-        process_ids: []
-        notes: Residence permits, work authorisations, and naturalisation administration
-      - id: VS-640.70
-        stage_order: 7
-        stage_name: Removal & Return
-        capability_ids:
-          - BC-3300
-        process_ids: []
-        notes: Detention, removal-order execution, and voluntary return
+- id: VS-10
+  name: Acquire-to-Retire
+  industries:
+  - Cross-Industry
+  stages:
+  - id: VS-10.10
+    stage_order: 1
+    stage_name: Asset Need & Justification
+    capability_ids:
+    - BC-1040
+    - BC-230
+    process_ids: []
+    notes: Asset strategy / lifecycle plan; CAPEX business case
+  - id: VS-10.20
+    stage_order: 1
+    stage_name: Asset Need & Justification
+    capability_ids:
+    - BC-3540
+    process_ids: []
+    industry_variant: Agriculture
+    notes: Land acquisition or lease and equipment fleet planning
+  - id: VS-10.30
+    stage_order: 1
+    stage_name: Asset Need & Justification
+    capability_ids:
+    - BC-3480
+    process_ids: []
+    industry_variant: Automotive
+    notes: Charging site selection and business case
+  - id: VS-10.40
+    stage_order: 1
+    stage_name: Asset Need & Justification
+    capability_ids:
+    - BC-3000
+    - BC-3010
+    process_ids: []
+    industry_variant: Oil & Gas
+    notes: License and seismic acquisition decision; Field development plan and FID
+  - id: VS-10.50
+    stage_order: 1
+    stage_name: Asset Need & Justification
+    capability_ids:
+    - BC-2350
+    process_ids: []
+    industry_variant: Retail & Consumer Goods
+    notes: Catchment, format, and network business case
+  - id: VS-10.60
+    stage_order: 1
+    stage_name: Asset Need & Justification
+    capability_ids:
+    - BC-2610
+    process_ids: []
+    industry_variant: Telecommunications
+    notes: Site identification and rollout business case
+  - id: VS-10.70
+    stage_order: 1
+    stage_name: Asset Need & Justification
+    capability_ids:
+    - BC-2430
+    process_ids: []
+    industry_variant: Transportation & Logistics
+    notes: Fleet specification and renewal plan
+  - id: VS-10.80
+    stage_order: 1
+    stage_name: Asset Need & Justification
+    capability_ids:
+    - BC-3900
+    process_ids: []
+    industry_variant: Utilities
+    notes: RAB-aligned network investment plan and CBA
+  - id: VS-10.90
+    stage_order: 2
+    stage_name: Acquisition
+    capability_ids:
+    - BC-500
+    process_ids: []
+    notes: Capital procurement
+  - id: VS-10.100
+    stage_order: 2
+    stage_name: Acquisition
+    capability_ids:
+    - BC-3540
+    process_ids: []
+    industry_variant: Agriculture
+    notes: Land lease, equipment purchase, and irrigation infrastructure build
+  - id: VS-10.110
+    stage_order: 2
+    stage_name: Acquisition
+    capability_ids:
+    - BC-3480
+    process_ids: []
+    industry_variant: Automotive
+    notes: Charger installation and grid connection
+  - id: VS-10.120
+    stage_order: 2
+    stage_name: Acquisition
+    capability_ids:
+    - BC-4610
+    process_ids: []
+    industry_variant: Chemicals
+    notes: Chemical plant FEED and basic engineering
+  - id: VS-10.130
+    stage_order: 2
+    stage_name: Acquisition
+    capability_ids:
+    - BC-1110
+    process_ids: []
+    industry_variant: Engineering Services
+    notes: Project engineering for build assets
+  - id: VS-10.140
+    stage_order: 2
+    stage_name: Acquisition
+    capability_ids:
+    - BC-2020
+    process_ids: []
+    industry_variant: HVAC & Building Automation Systems
+    notes: Project-level HVAC integration during build
+  - id: VS-10.150
+    stage_order: 2
+    stage_name: Acquisition
+    capability_ids:
+    - BC-3020
+    process_ids: []
+    industry_variant: Oil & Gas
+    notes: Capex execution to drill and complete wells
+  - id: VS-10.160
+    stage_order: 2
+    stage_name: Acquisition
+    capability_ids:
+    - BC-2610
+    process_ids: []
+    industry_variant: Telecommunications
+    notes: Site acquisition, build approval, and rollout scheduling
+  - id: VS-10.170
+    stage_order: 2
+    stage_name: Acquisition
+    capability_ids:
+    - BC-2430
+    process_ids: []
+    industry_variant: Transportation & Logistics
+    notes: Fleet procurement, lease, and charter
+  - id: VS-10.180
+    stage_order: 2
+    stage_name: Acquisition
+    capability_ids:
+    - BC-3900
+    process_ids: []
+    industry_variant: Utilities
+    notes: Network capital procurement and project execution
+  - id: VS-10.190
+    stage_order: 3
+    stage_name: Commissioning & Capitalisation
+    capability_ids:
+    - BC-200
+    process_ids: []
+    notes: Capitalisation / fixed asset register
+  - id: VS-10.200
+    stage_order: 3
+    stage_name: Commissioning & Capitalisation
+    capability_ids:
+    - BC-1960
+    process_ids: []
+    industry_variant: Electrical Components & Equipment
+    notes: OEM-led FAT / SAT / energisation
+  - id: VS-10.210
+    stage_order: 3
+    stage_name: Commissioning & Capitalisation
+    capability_ids:
+    - BC-1160
+    process_ids: []
+    industry_variant: Engineering Services
+    notes: Commissioning & handover
+  - id: VS-10.220
+    stage_order: 3
+    stage_name: Commissioning & Capitalisation
+    capability_ids:
+    - BC-2050
+    process_ids: []
+    industry_variant: HVAC & Building Automation Systems
+    notes: HVAC/BAS Cx, retro-Cx, MBCx
+  - id: VS-10.230
+    stage_order: 3
+    stage_name: Commissioning & Capitalisation
+    capability_ids:
+    - BC-3030
+    process_ids: []
+    industry_variant: Oil & Gas
+    notes: Field/facility startup and first oil/gas
+  - id: VS-10.240
+    stage_order: 4
+    stage_name: Operate & Maintain
+    capability_ids:
+    - BC-1030
+    - BC-1040
+    process_ids: []
+    notes: Preventive maintenance; Predictive maintenance; Asset performance monitoring
+  - id: VS-10.250
+    stage_order: 4
+    stage_name: Operate & Maintain
+    capability_ids:
+    - BC-3540
+    process_ids: []
+    industry_variant: Agriculture
+    notes: Day-to-day operation of farm assets and ISOBUS telemetry
+  - id: VS-10.260
+    stage_order: 4
+    stage_name: Operate & Maintain
+    capability_ids:
+    - BC-3480
+    process_ids: []
+    industry_variant: Automotive
+    notes: Charge-point operations and uptime
+  - id: VS-10.270
+    stage_order: 4
+    stage_name: Operate & Maintain
+    capability_ids:
+    - BC-4620
+    process_ids: []
+    industry_variant: Chemicals
+    notes: Day-to-day chemical plant operation
+  - id: VS-10.280
+    stage_order: 4
+    stage_name: Operate & Maintain
+    capability_ids:
+    - BC-1960
+    process_ids: []
+    industry_variant: Electrical Components & Equipment
+    notes: Remote condition monitoring services
+  - id: VS-10.290
+    stage_order: 4
+    stage_name: Operate & Maintain
+    capability_ids:
+    - BC-2060
+    - BC-2070
+    process_ids: []
+    industry_variant: HVAC & Building Automation Systems
+    notes: OEM/contractor service on installed HVAC + BAS; Continuous M&V, FDD, performance improvement
+  - id: VS-10.300
+    stage_order: 4
+    stage_name: Operate & Maintain
+    capability_ids:
+    - BC-3030
+    - BC-3060
+    - BC-3070
+    - BC-3080
+    process_ids: []
+    industry_variant: Oil & Gas
+    notes: Producing-asset operations; Pipeline operations and integrity; Gas plant and LNG operations; Refinery operations
+  - id: VS-10.310
+    stage_order: 4
+    stage_name: Operate & Maintain
+    capability_ids:
+    - BC-2600
+    process_ids: []
+    industry_variant: Telecommunications
+    notes: Network fault, change, performance, and optimisation
+  - id: VS-10.320
+    stage_order: 4
+    stage_name: Operate & Maintain
+    capability_ids:
+    - BC-2430
+    process_ids: []
+    industry_variant: Transportation & Logistics
+    notes: Fleet utilisation, telematics, and maintenance
+  - id: VS-10.330
+    stage_order: 4
+    stage_name: Operate & Maintain
+    capability_ids:
+    - BC-3800
+    - BC-3810
+    - BC-3820
+    - BC-3870
+    - BC-3880
+    - BC-3890
+    process_ids: []
+    industry_variant: Utilities
+    notes: Generation fleet operations and surveillance; Transmission grid operation, switching, and substation surveillance; Distribution network operation, vegetation, and inspection; Water treatment plant operation and process control; Water distribution network operation and mains repair; Sewer network and wastewater treatment plant operation
+  - id: VS-10.340
+    stage_order: 5
+    stage_name: Risk & Reliability
+    capability_ids:
+    - BC-1030
+    - BC-1040
+    process_ids: []
+    notes: Reliability engineering; Criticality / risk
+  - id: VS-10.350
+    stage_order: 5
+    stage_name: Risk & Reliability
+    capability_ids:
+    - BC-3480
+    process_ids: []
+    industry_variant: Automotive
+    notes: Charger reliability and uptime engineering
+  - id: VS-10.360
+    stage_order: 5
+    stage_name: Risk & Reliability
+    capability_ids:
+    - BC-4640
+    process_ids: []
+    industry_variant: Chemicals
+    notes: Mechanical integrity and SIS reliability assurance
+  - id: VS-10.370
+    stage_order: 5
+    stage_name: Risk & Reliability
+    capability_ids:
+    - BC-1780
+    process_ids: []
+    industry_variant: Defense
+    notes: RAM engineering
+  - id: VS-10.380
+    stage_order: 5
+    stage_name: Risk & Reliability
+    capability_ids:
+    - BC-1970
+    process_ids: []
+    industry_variant: Electrical Components & Equipment
+    notes: Reliability & MTBF on installed base
+  - id: VS-10.390
+    stage_order: 5
+    stage_name: Risk & Reliability
+    capability_ids:
+    - BC-3050
+    process_ids: []
+    industry_variant: Oil & Gas
+    notes: SCE assurance and mechanical integrity
+  - id: VS-10.400
+    stage_order: 5
+    stage_name: Risk & Reliability
+    capability_ids:
+    - BC-2430
+    process_ids: []
+    industry_variant: Transportation & Logistics
+    notes: Mandatory inspection and airworthiness or seaworthiness
+  - id: VS-10.410
+    stage_order: 5
+    stage_name: Risk & Reliability
+    capability_ids:
+    - BC-3900
+    process_ids: []
+    industry_variant: Utilities
+    notes: Asset health scoring, criticality, and monetised risk
+  - id: VS-10.420
+    stage_order: 6
+    stage_name: Asset Information Maintenance
+    capability_ids:
+    - BC-1040
+    process_ids: []
+    notes: Asset master data
+  - id: VS-10.430
+    stage_order: 6
+    stage_name: Asset Information Maintenance
+    capability_ids:
+    - BC-3540
+    process_ids: []
+    industry_variant: Agriculture
+    notes: Field, parcel, and equipment master data
+  - id: VS-10.440
+    stage_order: 6
+    stage_name: Asset Information Maintenance
+    capability_ids:
+    - BC-3710
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Metadata, identifier, and version lineage stewardship
+  - id: VS-10.450
+    stage_order: 6
+    stage_name: Asset Information Maintenance
+    capability_ids:
+    - BC-3900
+    process_ids: []
+    industry_variant: Utilities
+    notes: Network asset register, GIS, and as-built records
+  - id: VS-10.460
+    stage_order: 7
+    stage_name: Decommissioning & Disposal
+    capability_ids:
+    - BC-1040
+    - BC-740
+    process_ids: []
+    notes: Decommissioning / disposal; Circular economy / recycling
+  - id: VS-10.470
+    stage_order: 7
+    stage_name: Decommissioning & Disposal
+    capability_ids:
+    - BC-3540
+    process_ids: []
+    industry_variant: Agriculture
+    notes: Equipment disposal and lease end-of-term
+  - id: VS-10.480
+    stage_order: 7
+    stage_name: Decommissioning & Disposal
+    capability_ids:
+    - BC-1980
+    process_ids: []
+    industry_variant: Electrical Components & Equipment
+    notes: WEEE take-back, remanufacture, reuse
+  - id: VS-10.490
+    stage_order: 7
+    stage_name: Decommissioning & Disposal
+    capability_ids:
+    - BC-3710
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Archive sunset, master deletion, and rights-driven take-down
+  - id: VS-10.500
+    stage_order: 7
+    stage_name: Decommissioning & Disposal
+    capability_ids:
+    - BC-4470
+    process_ids: []
+    industry_variant: Mining & Metals
+    notes: Mine site dismantling, asset disposal, clean-up, and post-closure stewardship
+  - id: VS-10.510
+    stage_order: 7
+    stage_name: Decommissioning & Disposal
+    capability_ids:
+    - BC-3120
+    process_ids: []
+    industry_variant: Oil & Gas
+    notes: Well plug and abandonment, facility removal
+  - id: VS-10.520
+    stage_order: 7
+    stage_name: Decommissioning & Disposal
+    capability_ids:
+    - BC-2610
+    process_ids: []
+    industry_variant: Telecommunications
+    notes: Legacy network decommissioning and technology sunset
+  - id: VS-10.530
+    stage_order: 7
+    stage_name: Decommissioning & Disposal
+    capability_ids:
+    - BC-2430
+    process_ids: []
+    industry_variant: Transportation & Logistics
+    notes: Fleet end-of-life disposal and resale
+  - id: VS-10.540
+    stage_order: 7
+    stage_name: Decommissioning & Disposal
+    capability_ids:
+    - BC-3900
+    process_ids: []
+    industry_variant: Utilities
+    notes: Network decommissioning, abandonment, and reinstatement planning
+- id: VS-20
+  name: Adverse-Event-to-Action
+  industries:
+  - Pharmaceuticals & Life Sciences
+  stages:
+  - id: VS-20.10
+    stage_order: 1
+    stage_name: Case Intake
+    capability_ids:
+    - BC-1540
+    process_ids: []
+    industry_variant: Pharma
+    notes: Adverse event capture
+  - id: VS-20.20
+    stage_order: 2
+    stage_name: Case Triage & Coding
+    capability_ids:
+    - BC-1540
+    process_ids: []
+    industry_variant: Pharma
+    notes: MedDRA coding, seriousness assessment
+  - id: VS-20.30
+    stage_order: 3
+    stage_name: Causality & Medical Review
+    capability_ids:
+    - BC-1580
+    process_ids: []
+    industry_variant: Pharma
+    notes: Medical affairs review
+  - id: VS-20.40
+    stage_order: 4
+    stage_name: Signal Detection
+    capability_ids:
+    - BC-1540
+    process_ids: []
+    industry_variant: Pharma
+    notes: Signal detection & evaluation
+  - id: VS-20.50
+    stage_order: 5
+    stage_name: Risk Assessment & RMP Update
+    capability_ids:
+    - BC-1540
+    process_ids: []
+    industry_variant: Pharma
+    notes: Risk management plan
+  - id: VS-20.60
+    stage_order: 6
+    stage_name: Regulatory Reporting
+    capability_ids:
+    - BC-1530
+    - BC-1540
+    process_ids: []
+    industry_variant: Pharma
+    notes: Agency notification; Periodic safety reports
+  - id: VS-20.70
+    stage_order: 7
+    stage_name: Label & Communication Updates
+    capability_ids:
+    - BC-850
+    process_ids: []
+    notes: Stakeholder communications
+  - id: VS-20.80
+    stage_order: 7
+    stage_name: Label & Communication Updates
+    capability_ids:
+    - BC-1530
+    process_ids: []
+    industry_variant: Pharma
+    notes: Labelling change
+  - id: VS-20.90
+    stage_order: 8
+    stage_name: Audit & Inspection Readiness
+    capability_ids:
+    - BC-1540
+    process_ids: []
+    industry_variant: Pharma
+    notes: PV audit
+- id: VS-30
+  name: Application-to-Benefit
+  industries:
+  - Public Sector & Government
+  stages:
+  - id: VS-30.10
+    stage_order: 1
+    stage_name: Programme Configuration
+    capability_ids:
+    - BC-3230
+    process_ids: []
+    notes: Eligibility rules, benefit formulae, and indexation parameters
+  - id: VS-30.20
+    stage_order: 2
+    stage_name: Application Intake
+    capability_ids:
+    - BC-3230
+    - BC-3220
+    process_ids: []
+    notes: Receipt of benefit applications across channels; Citizen-service channels supporting assisted application
+  - id: VS-30.30
+    stage_order: 3
+    stage_name: Eligibility Determination
+    capability_ids:
+    - BC-3230
+    process_ids: []
+    notes: Means testing, categorical eligibility, decision and notification
+  - id: VS-30.40
+    stage_order: 4
+    stage_name: Award Calculation
+    capability_ids:
+    - BC-3230
+    process_ids: []
+    notes: Contribution-record assessment, award calculation, and issuance
+  - id: VS-30.50
+    stage_order: 5
+    stage_name: Disbursement
+    capability_ids:
+    - BC-3230
+    process_ids: []
+    notes: Payment runs across bank, prepaid card, and in-kind channels
+  - id: VS-30.60
+    stage_order: 6
+    stage_name: Continuing Eligibility
+    capability_ids:
+    - BC-3230
+    process_ids: []
+    notes: Change of circumstances, periodic redetermination, conditionality
+  - id: VS-30.70
+    stage_order: 7
+    stage_name: Overpayment & Recovery
+    capability_ids:
+    - BC-3230
+    process_ids: []
+    notes: Overpayment detection, recovery plans, and debt collection
+  - id: VS-30.80
+    stage_order: 8
+    stage_name: Fraud Investigation
+    capability_ids:
+    - BC-3230
+    process_ids: []
+    notes: Fraud detection, investigation, and sanction
+- id: VS-40
+  name: Application-to-Funding
+  industries:
+  - Banking & Capital Markets
+  - Real Estate
+  stages:
+  - id: VS-40.10
+    stage_order: 1
+    stage_name: Application Capture
+    capability_ids:
+    - BC-1300
+    - BC-1320
+    process_ids: []
+    industry_variant: Banking
+    notes: Channel intake (digital, branch); Origination intake
+  - id: VS-40.20
+    stage_order: 1
+    stage_name: Application Capture
+    capability_ids:
+    - BC-4980
+    process_ids: []
+    industry_variant: Real Estate
+    notes: CRE debt origination intake — senior, mezz, construction, and bridge loans
+  - id: VS-40.30
+    stage_order: 2
+    stage_name: KYC & Due Diligence
+    capability_ids:
+    - BC-1300
+    - BC-1400
+    process_ids: []
+    industry_variant: Banking
+    notes: KYC / CDD; Sanctions screening
+  - id: VS-40.40
+    stage_order: 3
+    stage_name: Underwriting & Decisioning
+    capability_ids:
+    - BC-1320
+    process_ids: []
+    industry_variant: Banking
+    notes: Credit decisioning; Credit risk model scoring
+  - id: VS-40.50
+    stage_order: 3
+    stage_name: Underwriting & Decisioning
+    capability_ids:
+    - BC-4980
+    process_ids: []
+    industry_variant: Real Estate
+    notes: CRE loan underwriting against asset and sponsor
+  - id: VS-40.60
+    stage_order: 4
+    stage_name: Pricing & Offer
+    capability_ids:
+    - BC-440
+    process_ids: []
+    notes: Discount / promotional pricing
+  - id: VS-40.70
+    stage_order: 4
+    stage_name: Pricing & Offer
+    capability_ids:
+    - BC-1310
+    process_ids: []
+    industry_variant: Banking
+    notes: Banking product configuration
+  - id: VS-40.80
+    stage_order: 5
+    stage_name: Documentation & Booking
+    capability_ids:
+    - BC-150
+    process_ids: []
+    notes: Loan agreement drafting
+  - id: VS-40.90
+    stage_order: 5
+    stage_name: Documentation & Booking
+    capability_ids:
+    - BC-1320
+    process_ids: []
+    industry_variant: Banking
+    notes: Loan booking
+  - id: VS-40.100
+    stage_order: 5
+    stage_name: Documentation & Booking
+    capability_ids:
+    - BC-4980
+    process_ids: []
+    industry_variant: Real Estate
+    notes: CRE loan boarding and servicing setup
+  - id: VS-40.110
+    stage_order: 6
+    stage_name: Disbursement
+    capability_ids:
+    - BC-1340
+    process_ids: []
+    industry_variant: Banking
+    notes: Payment initiation; Payment processing
+  - id: VS-40.120
+    stage_order: 7
+    stage_name: Servicing & Collections
+    capability_ids:
+    - BC-1320
+    process_ids: []
+    industry_variant: Banking
+    notes: Loan servicing; Collections & recoveries
+  - id: VS-40.130
+    stage_order: 7
+    stage_name: Servicing & Collections
+    capability_ids:
+    - BC-4980
+    process_ids: []
+    industry_variant: Real Estate
+    notes: CRE loan servicing and special-servicing coordination
+  - id: VS-40.140
+    stage_order: 8
+    stage_name: Portfolio Monitoring
+    capability_ids:
+    - BC-1320
+    - BC-1410
+    process_ids: []
+    industry_variant: Banking
+    notes: Loan portfolio health; Banking risk overview
+  - id: VS-40.150
+    stage_order: 8
+    stage_name: Portfolio Monitoring
+    capability_ids:
+    - BC-4980
+    process_ids: []
+    industry_variant: Real Estate
+    notes: Covenant, DSCR, and LTV monitoring across CRE loan portfolio
+- id: VS-50
+  name: Application-to-Licence
+  industries:
+  - Public Sector & Government
+  stages:
+  - id: VS-50.10
+    stage_order: 1
+    stage_name: Application Intake
+    capability_ids:
+    - BC-3240
+    - BC-3220
+    process_ids: []
+    notes: Submission, completeness check, and fee assessment; Citizen-service channels for licence applications
+  - id: VS-50.20
+    stage_order: 2
+    stage_name: Eligibility & Qualification Assessment
+    capability_ids:
+    - BC-3240
+    process_ids: []
+    notes: Fit and proper, qualification, and background checks
+  - id: VS-50.30
+    stage_order: 3
+    stage_name: Licensing Decision
+    capability_ids:
+    - BC-3240
+    process_ids: []
+    notes: Decisioning on grant, refusal, or conditional grant
+  - id: VS-50.40
+    stage_order: 4
+    stage_name: Credential Issuance
+    capability_ids:
+    - BC-3240
+    process_ids: []
+    notes: Production and issuance of physical and digital credentials
+  - id: VS-50.50
+    stage_order: 5
+    stage_name: Inspection & Compliance Monitoring
+    capability_ids:
+    - BC-3240
+    process_ids: []
+    notes: Risk-based inspection and compliance reporting review
+  - id: VS-50.60
+    stage_order: 6
+    stage_name: Enforcement & Sanction
+    capability_ids:
+    - BC-3240
+    process_ids: []
+    notes: Suspension, revocation, civil penalties, and sanctions
+  - id: VS-50.70
+    stage_order: 7
+    stage_name: Renewal
+    capability_ids:
+    - BC-3240
+    process_ids: []
+    notes: Renewal processing and continuing-eligibility checks
+  - id: VS-50.80
+    stage_order: 8
+    stage_name: Register Disclosure
+    capability_ids:
+    - BC-3240
+    process_ids: []
+    notes: Public register search and credential verification services
+- id: VS-60
+  name: Apply-to-Graduate
+  industries:
+  - Education
+  stages:
+  - id: VS-60.10
+    stage_order: 1
+    stage_name: Outreach & Recruitment
+    capability_ids:
+    - BC-4710
+    process_ids: []
+    notes: Prospect outreach and recruitment campaigns
+  - id: VS-60.20
+    stage_order: 2
+    stage_name: Application & Admissions
+    capability_ids:
+    - BC-4710
+    process_ids: []
+    notes: Application processing and admissions decisioning
+  - id: VS-60.30
+    stage_order: 3
+    stage_name: Enrolment & Registration
+    capability_ids:
+    - BC-4720
+    process_ids: []
+    notes: Enrolment, registration, and course allocation
+  - id: VS-60.40
+    stage_order: 4
+    stage_name: Teaching & Learning Delivery
+    capability_ids:
+    - BC-4730
+    - BC-4790
+    process_ids: []
+    notes: Delivery of teaching across in-person, online, and blended modes; Educational content and learning resources delivered to students
+  - id: VS-60.50
+    stage_order: 5
+    stage_name: Student Support
+    capability_ids:
+    - BC-4770
+    process_ids: []
+    notes: Academic advising, accommodations, and pastoral support during study
+  - id: VS-60.60
+    stage_order: 6
+    stage_name: Assessment & Examination
+    capability_ids:
+    - BC-4740
+    process_ids: []
+    notes: Assessment design, examination delivery, and marking
+  - id: VS-60.70
+    stage_order: 7
+    stage_name: Award & Credentialing
+    capability_ids:
+    - BC-4720
+    process_ids: []
+    notes: Graduation eligibility audit, award conferral, and credential issuance
+- id: VS-70
+  name: Appoint-to-Operate
+  industries:
+  - Automotive & Mobility
+  stages:
+  - id: VS-70.10
+    stage_order: 1
+    stage_name: Network Strategy & Coverage
+    capability_ids:
+    - BC-3430
+    process_ids: []
+    industry_variant: Automotive
+    notes: Market coverage planning and footprint optimisation
+  - id: VS-70.20
+    stage_order: 2
+    stage_name: Application & Vetting
+    capability_ids:
+    - BC-3430
+    process_ids: []
+    industry_variant: Automotive
+    notes: Dealer application, financial and operational due diligence
+  - id: VS-70.30
+    stage_order: 3
+    stage_name: Agreement Execution
+    capability_ids:
+    - BC-150
+    process_ids: []
+    notes: Legal terms and competition-law review
+  - id: VS-70.40
+    stage_order: 3
+    stage_name: Agreement Execution
+    capability_ids:
+    - BC-3430
+    process_ids: []
+    industry_variant: Automotive
+    notes: Dealer agreement drafting and territory rights
+  - id: VS-70.50
+    stage_order: 4
+    stage_name: Onboarding & Certification
+    capability_ids:
+    - BC-3430
+    process_ids: []
+    industry_variant: Automotive
+    notes: Dealer training, certification, and DMS integration
+  - id: VS-70.60
+    stage_order: 5
+    stage_name: Standards Compliance
+    capability_ids:
+    - BC-3430
+    process_ids: []
+    industry_variant: Automotive
+    notes: Brand and facility standards auditing and corrective action
+  - id: VS-70.70
+    stage_order: 6
+    stage_name: Performance Management
+    capability_ids:
+    - BC-3430
+    process_ids: []
+    industry_variant: Automotive
+    notes: Scorecard, performance reviews, and incentive programmes
+  - id: VS-70.80
+    stage_order: 7
+    stage_name: Termination & Transition
+    capability_ids:
+    - BC-3430
+    process_ids: []
+    industry_variant: Automotive
+    notes: Dealer termination, run-out, and territory reassignment
+- id: VS-80
+  name: Audit-to-Action
+  industries:
+  - Cross-Industry
+  stages:
+  - id: VS-80.10
+    stage_order: 1
+    stage_name: Audit Universe & Plan
+    capability_ids:
+    - BC-140
+    process_ids: []
+    notes: Risk-based annual plan
+  - id: VS-80.20
+    stage_order: 1
+    stage_name: Audit Universe & Plan
+    capability_ids:
+    - BC-4750
+    process_ids: []
+    industry_variant: Education
+    notes: Programme review and accreditation cycle planning
+  - id: VS-80.30
+    stage_order: 2
+    stage_name: Engagement Scoping
+    capability_ids:
+    - BC-140
+    process_ids: []
+    notes: Scope, criteria, resources
+  - id: VS-80.40
+    stage_order: 3
+    stage_name: Fieldwork
+    capability_ids:
+    - BC-140
+    - BC-4970
+    process_ids: []
+    notes: Testing & evidence; Valuation QA sampling and peer review fieldwork
+  - id: VS-80.50
+    stage_order: 3
+    stage_name: Fieldwork
+    capability_ids:
+    - BC-3590
+    process_ids: []
+    industry_variant: Agriculture
+    notes: Farm assurance and certification audit readiness
+  - id: VS-80.60
+    stage_order: 3
+    stage_name: Fieldwork
+    capability_ids:
+    - BC-4750
+    process_ids: []
+    industry_variant: Education
+    notes: Accreditation site visits and inspection
+  - id: VS-80.70
+    stage_order: 3
+    stage_name: Fieldwork
+    capability_ids:
+    - BC-2840
+    process_ids: []
+    industry_variant: Healthcare Providers
+    notes: Accreditation surveys and tracer methodology
+  - id: VS-80.80
+    stage_order: 3
+    stage_name: Fieldwork
+    capability_ids:
+    - BC-1540
+    process_ids: []
+    industry_variant: Pharma
+    notes: GxP audit & inspection readiness
+  - id: VS-80.90
+    stage_order: 3
+    stage_name: Fieldwork
+    capability_ids:
+    - BC-4340
+    process_ids: []
+    industry_variant: Professional Services
+    notes: External practice-inspection fieldwork response (PCAOB / FRC / ICAEW)
+  - id: VS-80.100
+    stage_order: 3
+    stage_name: Fieldwork
+    capability_ids:
+    - BC-2380
+    process_ids: []
+    industry_variant: Retail & Consumer Goods
+    notes: Food-safety audit & inspection readiness
+  - id: VS-80.110
+    stage_order: 3
+    stage_name: Fieldwork
+    capability_ids:
+    - BC-4290
+    process_ids: []
+    industry_variant: Software & Technology
+    notes: External service-attestation audits (SOC 2, ISO 27001)
+  - id: VS-80.120
+    stage_order: 4
+    stage_name: Findings & Reporting
+    capability_ids:
+    - BC-140
+    process_ids: []
+    notes: Findings, ratings, report
+  - id: VS-80.130
+    stage_order: 4
+    stage_name: Findings & Reporting
+    capability_ids:
+    - BC-4750
+    process_ids: []
+    industry_variant: Education
+    notes: Accreditation outcome and conditions
+  - id: VS-80.140
+    stage_order: 5
+    stage_name: Remediation Tracking
+    capability_ids:
+    - BC-140
+    - BC-4990
+    process_ids: []
+    notes: Action plan follow-up; Remediation tracking of RESPA, AML, and fair-housing audit findings
+  - id: VS-80.150
+    stage_order: 5
+    stage_name: Remediation Tracking
+    capability_ids:
+    - BC-4750
+    process_ids: []
+    industry_variant: Education
+    notes: Quality improvement action tracking
+  - id: VS-80.160
+    stage_order: 5
+    stage_name: Remediation Tracking
+    capability_ids:
+    - BC-4340
+    process_ids: []
+    industry_variant: Professional Services
+    notes: Remediation of inspection findings and deficiency closure
+  - id: VS-80.170
+    stage_order: 5
+    stage_name: Remediation Tracking
+    capability_ids:
+    - BC-4290
+    process_ids: []
+    industry_variant: Software & Technology
+    notes: Remediation of attestation findings
+  - id: VS-80.180
+    stage_order: 6
+    stage_name: Audit Quality Assurance
+    capability_ids:
+    - BC-140
+    process_ids: []
+    notes: QA review & maturation
+- id: VS-90
+  name: Bill-to-Statute
+  industries:
+  - Public Sector & Government
+  stages:
+  - id: VS-90.10
+    stage_order: 1
+    stage_name: Drafting Instruction
+    capability_ids:
+    - BC-3200
+    - BC-3210
+    process_ids: []
+    notes: Policy decision converted into drafting instructions; Receipt and clarification of drafting instructions by parliamentary counsel
+  - id: VS-90.20
+    stage_order: 2
+    stage_name: Drafting
+    capability_ids:
+    - BC-3210
+    process_ids: []
+    notes: Drafting of bills, regulations, and statutory instruments
+  - id: VS-90.30
+    stage_order: 3
+    stage_name: Legal Vetting
+    capability_ids:
+    - BC-3210
+    - BC-150
+    process_ids: []
+    notes: Constitutional, human-rights, and international-law review; Government legal services advisory review
+  - id: VS-90.40
+    stage_order: 4
+    stage_name: Impact Assessment
+    capability_ids:
+    - BC-3210
+    process_ids: []
+    notes: Regulatory impact assessment and small-business test
+  - id: VS-90.50
+    stage_order: 5
+    stage_name: Legislative Passage
+    capability_ids:
+    - BC-3210
+    process_ids: []
+    notes: Parliamentary liaison, committee evidence, amendment tracking
+  - id: VS-90.60
+    stage_order: 6
+    stage_name: Promulgation
+    capability_ids:
+    - BC-3210
+    process_ids: []
+    notes: Royal assent or executive signature and effective-date setting
+  - id: VS-90.70
+    stage_order: 7
+    stage_name: Codification & Publication
+    capability_ids:
+    - BC-3210
+    process_ids: []
+    notes: Official gazette publication and statutory codification
+- id: VS-100
+  name: Brief-to-Campaign
+  industries:
+  - Media, Entertainment & Telecom Content
+  stages:
+  - id: VS-100.10
+    stage_order: 1
+    stage_name: Brief Intake
+    capability_ids:
+    - BC-3760
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Advertiser and agency brief capture and qualification
+  - id: VS-100.20
+    stage_order: 2
+    stage_name: Audience & Avail Planning
+    capability_ids:
+    - BC-3760
+    - BC-3770
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Avail forecasting and inventory shaping against the brief; Audience definition and reach modelling informing the plan
+  - id: VS-100.30
+    stage_order: 3
+    stage_name: Media Plan Development
+    capability_ids:
+    - BC-3760
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Multi-surface media plan, packaging, and pricing development
+  - id: VS-100.40
+    stage_order: 4
+    stage_name: Booking & Insertion Order
+    capability_ids:
+    - BC-3760
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Insertion-order capture, deal-ID provisioning, and inventory reservation
+  - id: VS-100.50
+    stage_order: 5
+    stage_name: Creative Onboarding & Trafficking
+    capability_ids:
+    - BC-3760
+    - BC-3780
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Creative ingest, technical QC, decisioning rules, and trafficking; Advertising-code review and creative-classification compliance
+  - id: VS-100.60
+    stage_order: 6
+    stage_name: Campaign Delivery
+    capability_ids:
+    - BC-3760
+    - BC-3740
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Spot scheduling, ad insertion, pacing, and brand-safety enforcement; Server-side and client-side ad delivery on linear, OTT, and IPTV surfaces
+  - id: VS-100.70
+    stage_order: 7
+    stage_name: Measurement & Reconciliation
+    capability_ids:
+    - BC-3760
+    - BC-3770
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Delivery reporting, make-good and credit-memo handling; Currency-grade audience measurement and post-campaign analytics
+  - id: VS-100.80
+    stage_order: 8
+    stage_name: Billing & Settlement
+    capability_ids:
+    - BC-3760
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Advertiser and agency billing, agency-discount and commission settlement
+- id: VS-110
+  name: Capture-to-Contract
+  industries:
+  - Defense & Aerospace
+  stages:
+  - id: VS-110.10
+    stage_order: 1
+    stage_name: Customer Intelligence
+    capability_ids:
+    - BC-1730
+    - BC-1750
+    process_ids: []
+    industry_variant: Defense
+    notes: Intelligence operations input; Defense customer intel
+  - id: VS-110.20
+    stage_order: 2
+    stage_name: Capture Strategy
+    capability_ids:
+    - BC-1750
+    process_ids: []
+    industry_variant: Defense
+    notes: Capture management
+  - id: VS-110.30
+    stage_order: 3
+    stage_name: Teaming & Subcontracting
+    capability_ids:
+    - BC-1750
+    - BC-1810
+    process_ids: []
+    industry_variant: Defense
+    notes: Teaming strategy; Cleared subcontractor vetting
+  - id: VS-110.40
+    stage_order: 4
+    stage_name: Bid & Proposal
+    capability_ids:
+    - BC-1750
+    process_ids: []
+    industry_variant: Defense
+    notes: Bid management; Proposal development
+  - id: VS-110.50
+    stage_order: 5
+    stage_name: Pricing & Cost Estimation
+    capability_ids:
+    - BC-440
+    process_ids: []
+    notes: Pricing strategy
+  - id: VS-110.60
+    stage_order: 5
+    stage_name: Pricing & Cost Estimation
+    capability_ids:
+    - BC-1140
+    process_ids: []
+    industry_variant: Defense
+    notes: Tendering & estimation
+  - id: VS-110.70
+    stage_order: 6
+    stage_name: Compliance & Export Review
+    capability_ids:
+    - BC-130
+    process_ids: []
+    notes: Regulatory compliance
+  - id: VS-110.80
+    stage_order: 6
+    stage_name: Compliance & Export Review
+    capability_ids:
+    - BC-1790
+    process_ids: []
+    industry_variant: Defense
+    notes: ITAR / EAR / export control
+  - id: VS-110.90
+    stage_order: 7
+    stage_name: Contract Negotiation & Award
+    capability_ids:
+    - BC-150
+    process_ids: []
+    notes: Contract negotiation
+  - id: VS-110.100
+    stage_order: 7
+    stage_name: Contract Negotiation & Award
+    capability_ids:
+    - BC-1760
+    process_ids: []
+    industry_variant: Defense
+    notes: Programme handover
+- id: VS-120
+  name: Claim-to-Reimbursement
+  industries:
+  - Healthcare Providers
+  stages:
+  - id: VS-120.10
+    stage_order: 1
+    stage_name: Charge Capture
+    capability_ids:
+    - BC-2870
+    process_ids: []
+    notes: Charge capture from clinical documentation and ancillary systems
+  - id: VS-120.20
+    stage_order: 2
+    stage_name: Coding
+    capability_ids:
+    - BC-2870
+    process_ids: []
+    notes: Medical coding, CDI queries, and DRG / APC assignment
+  - id: VS-120.30
+    stage_order: 3
+    stage_name: Claim Production & Submission
+    capability_ids:
+    - BC-2870
+    process_ids: []
+    notes: Claim assembly, edits, and payer submission
+  - id: VS-120.40
+    stage_order: 4
+    stage_name: Adjudication & Denial Management
+    capability_ids:
+    - BC-2870
+    process_ids: []
+    notes: Remittance handling, denial work, and appeals
+  - id: VS-120.50
+    stage_order: 5
+    stage_name: Cash Posting & Reconciliation
+    capability_ids:
+    - BC-2870
+    - BC-200
+    process_ids: []
+    notes: ERA / EOB posting and contract variance analysis; Patient AR accounting and bank reconciliation
+  - id: VS-120.60
+    stage_order: 6
+    stage_name: Patient Billing & Collections
+    capability_ids:
+    - BC-2870
+    process_ids: []
+    notes: Patient statements, payment plans, and collections
+  - id: VS-120.70
+    stage_order: 7
+    stage_name: Underpayment Recovery
+    capability_ids:
+    - BC-2870
+    process_ids: []
+    notes: Underpayment identification and payer recovery actions
+- id: VS-130
+  name: Concept-to-Manufacture
+  industries:
+  - Manufacturing & Industrial
+  - Engineering Services
+  - Electrical Components & Equipment
+  - HVAC & Building Automation Systems
+  - Defense & Aerospace
+  - Automotive & Mobility
+  stages:
+  - id: VS-130.10
+    stage_order: 1
+    stage_name: Concept Design
+    capability_ids:
+    - BC-3400
+    process_ids: []
+    industry_variant: Automotive
+    notes: Vehicle concept and architecture
+  - id: VS-130.20
+    stage_order: 1
+    stage_name: Concept Design
+    capability_ids:
+    - BC-1900
+    process_ids: []
+    industry_variant: Electrical Components & Equipment
+    notes: Concept-stage circuit & topology design
+  - id: VS-130.30
+    stage_order: 1
+    stage_name: Concept Design
+    capability_ids:
+    - BC-1120
+    process_ids: []
+    industry_variant: Engineering Services
+    notes: Conceptual design
+  - id: VS-130.40
+    stage_order: 1
+    stage_name: Concept Design
+    capability_ids:
+    - BC-2000
+    - BC-2010
+    process_ids: []
+    industry_variant: HVAC & Building Automation Systems
+    notes: HVAC equipment concept-stage cycle & topology; BAS controller & supervisor concept
+  - id: VS-130.50
+    stage_order: 2
+    stage_name: FEED & Specification
+    capability_ids:
+    - BC-820
+    process_ids: []
+    notes: Product specification
+  - id: VS-130.60
+    stage_order: 2
+    stage_name: FEED & Specification
+    capability_ids:
+    - BC-3400
+    process_ids: []
+    industry_variant: Automotive
+    notes: Vehicle attribute and subsystem specification
+  - id: VS-130.70
+    stage_order: 2
+    stage_name: FEED & Specification
+    capability_ids:
+    - BC-1900
+    process_ids: []
+    industry_variant: Electrical Components & Equipment
+    notes: Front-end electrical engineering
+  - id: VS-130.80
+    stage_order: 2
+    stage_name: FEED & Specification
+    capability_ids:
+    - BC-1120
+    process_ids: []
+    industry_variant: Engineering Services
+    notes: Front-end engineering design
+  - id: VS-130.90
+    stage_order: 2
+    stage_name: FEED & Specification
+    capability_ids:
+    - BC-2000
+    - BC-2020
+    process_ids: []
+    industry_variant: HVAC & Building Automation Systems
+    notes: HVAC equipment FEED; Project-level HVAC system spec & sizing
+  - id: VS-130.100
+    stage_order: 3
+    stage_name: Detailed Design
+    capability_ids:
+    - BC-3400
+    process_ids: []
+    industry_variant: Automotive
+    notes: Multi-domain vehicle engineering
+  - id: VS-130.110
+    stage_order: 3
+    stage_name: Detailed Design
+    capability_ids:
+    - BC-1900
+    process_ids: []
+    industry_variant: Electrical Components & Equipment
+    notes: Detailed electrical/electronic design
+  - id: VS-130.120
+    stage_order: 3
+    stage_name: Detailed Design
+    capability_ids:
+    - BC-1100
+    - BC-1120
+    process_ids: []
+    industry_variant: Engineering Services
+    notes: Multi-discipline engineering; Detailed design
+  - id: VS-130.130
+    stage_order: 3
+    stage_name: Detailed Design
+    capability_ids:
+    - BC-2000
+    - BC-2010
+    - BC-2020
+    process_ids: []
+    industry_variant: HVAC & Building Automation Systems
+    notes: Detailed HVAC equipment engineering; Detailed BAS product engineering; Project-level integration design
+  - id: VS-130.140
+    stage_order: 4
+    stage_name: Design Review
+    capability_ids:
+    - BC-3400
+    - BC-3420
+    process_ids: []
+    industry_variant: Automotive
+    notes: ISO 26262 / 21434 / 21448 reviews; Type-approval readiness review
+  - id: VS-130.150
+    stage_order: 4
+    stage_name: Design Review
+    capability_ids:
+    - BC-1770
+    process_ids: []
+    industry_variant: Defense
+    notes: Defense V&V
+  - id: VS-130.160
+    stage_order: 4
+    stage_name: Design Review
+    capability_ids:
+    - BC-1910
+    - BC-1920
+    - BC-1970
+    process_ids: []
+    industry_variant: Electrical Components & Equipment
+    notes: Certification readiness review; Type-test sign-off on first articles; Safety case & FMEA review
+  - id: VS-130.170
+    stage_order: 4
+    stage_name: Design Review
+    capability_ids:
+    - BC-1120
+    process_ids: []
+    industry_variant: Engineering Services
+    notes: Verification & validation
+  - id: VS-130.180
+    stage_order: 4
+    stage_name: Design Review
+    capability_ids:
+    - BC-2000
+    - BC-2010
+    - BC-2030
+    process_ids: []
+    industry_variant: HVAC & Building Automation Systems
+    notes: HVAC equipment design verification; BAS conformance & interoperability review; Performance & safety listing readiness
+  - id: VS-130.190
+    stage_order: 5
+    stage_name: Manufacturing Engineering
+    capability_ids:
+    - BC-820
+    process_ids: []
+    notes: Configuration / variants
+  - id: VS-130.200
+    stage_order: 5
+    stage_name: Manufacturing Engineering
+    capability_ids:
+    - BC-3410
+    process_ids: []
+    industry_variant: Automotive
+    notes: Programme governance over industrialisation
+  - id: VS-130.210
+    stage_order: 5
+    stage_name: Manufacturing Engineering
+    capability_ids:
+    - BC-1930
+    process_ids: []
+    industry_variant: Electrical Components & Equipment
+    notes: Preferred parts feed manufacturing engineering
+  - id: VS-130.220
+    stage_order: 5
+    stage_name: Manufacturing Engineering
+    capability_ids:
+    - BC-1020
+    process_ids: []
+    industry_variant: Manufacturing
+    notes: Process design / industrialisation
+  - id: VS-130.230
+    stage_order: 6
+    stage_name: Production Ramp-Up
+    capability_ids:
+    - BC-3410
+    process_ids: []
+    industry_variant: Automotive
+    notes: SOP readiness and ramp coordination
+  - id: VS-130.240
+    stage_order: 6
+    stage_name: Production Ramp-Up
+    capability_ids:
+    - BC-1000
+    - BC-1010
+    process_ids: []
+    industry_variant: Manufacturing
+    notes: Production planning; Shop floor execution
+  - id: VS-130.250
+    stage_order: 7
+    stage_name: Quality & Yield Stabilisation
+    capability_ids:
+    - BC-720
+    process_ids: []
+    notes: QC ramp-up
+  - id: VS-130.260
+    stage_order: 7
+    stage_name: Quality & Yield Stabilisation
+    capability_ids:
+    - BC-1000
+    process_ids: []
+    industry_variant: Manufacturing
+    notes: Production performance
+  - id: VS-130.270
+    stage_order: 8
+    stage_name: Configuration Baseline
+    capability_ids:
+    - BC-3410
+    - BC-3420
+    process_ids: []
+    industry_variant: Automotive
+    notes: Vehicle programme configuration baseline at SOP; Type-approved configuration baseline
+  - id: VS-130.280
+    stage_order: 8
+    stage_name: Configuration Baseline
+    capability_ids:
+    - BC-1770
+    process_ids: []
+    industry_variant: Defense
+    notes: Configuration management
+  - id: VS-130.290
+    stage_order: 8
+    stage_name: Configuration Baseline
+    capability_ids:
+    - BC-1940
+    process_ids: []
+    industry_variant: Electrical Components & Equipment
+    notes: Saleable variant baseline
+  - id: VS-130.300
+    stage_order: 8
+    stage_name: Configuration Baseline
+    capability_ids:
+    - BC-1130
+    process_ids: []
+    industry_variant: Engineering Services
+    notes: Engineering document control
+- id: VS-140
+  name: Crisis-to-Recovery
+  industries:
+  - Cross-Industry
+  stages:
+  - id: VS-140.10
+    stage_order: 1
+    stage_name: Continuity Planning
+    capability_ids:
+    - BC-160
+    process_ids: []
+    notes: BIA & continuity plans
+  - id: VS-140.20
+    stage_order: 1
+    stage_name: Continuity Planning
+    capability_ids:
+    - BC-4460
+    process_ids: []
+    industry_variant: Mining & Metals
+    notes: Tailings emergency preparedness plans
+  - id: VS-140.30
+    stage_order: 1
+    stage_name: Continuity Planning
+    capability_ids:
+    - BC-3310
+    process_ids: []
+    industry_variant: Public Sector
+    notes: Hazard analysis and emergency planning under Sendai Framework
+  - id: VS-140.40
+    stage_order: 1
+    stage_name: Continuity Planning
+    capability_ids:
+    - BC-3830
+    process_ids: []
+    industry_variant: Utilities
+    notes: Black-start contracts and system restoration plans
+  - id: VS-140.50
+    stage_order: 2
+    stage_name: Resilience Testing
+    capability_ids:
+    - BC-160
+    - BC-4220
+    process_ids: []
+    notes: Exercises & drills; Disaster-recovery exercises and game-days for the SaaS service
+  - id: VS-140.60
+    stage_order: 2
+    stage_name: Resilience Testing
+    capability_ids:
+    - BC-1280
+    process_ids: []
+    industry_variant: ATC
+    notes: Aviation safety performance drills
+  - id: VS-140.70
+    stage_order: 2
+    stage_name: Resilience Testing
+    capability_ids:
+    - BC-3310
+    process_ids: []
+    industry_variant: Public Sector
+    notes: Tabletop, functional, and full-scale exercises
+  - id: VS-140.80
+    stage_order: 3
+    stage_name: Detection & Activation
+    capability_ids:
+    - BC-160
+    - BC-620
+    process_ids: []
+    notes: Crisis declaration; Cyber incident trigger
+  - id: VS-140.90
+    stage_order: 3
+    stage_name: Detection & Activation
+    capability_ids:
+    - BC-4460
+    process_ids: []
+    industry_variant: Mining & Metals
+    notes: Tailings facility instrumentation triggers
+  - id: VS-140.100
+    stage_order: 3
+    stage_name: Detection & Activation
+    capability_ids:
+    - BC-3310
+    process_ids: []
+    industry_variant: Public Sector
+    notes: 911/112 emergency call taking; disaster declaration
+  - id: VS-140.110
+    stage_order: 3
+    stage_name: Detection & Activation
+    capability_ids:
+    - BC-2630
+    process_ids: []
+    industry_variant: Telecommunications
+    notes: Major service outage declaration
+  - id: VS-140.120
+    stage_order: 3
+    stage_name: Detection & Activation
+    capability_ids:
+    - BC-3820
+    process_ids: []
+    industry_variant: Utilities
+    notes: Major distribution event activation and storm protocol
+  - id: VS-140.130
+    stage_order: 4
+    stage_name: Crisis Response
+    capability_ids:
+    - BC-160
+    - BC-850
+    process_ids: []
+    notes: Crisis management cell; Crisis communications
+  - id: VS-140.140
+    stage_order: 4
+    stage_name: Crisis Response
+    capability_ids:
+    - BC-4770
+    process_ids: []
+    industry_variant: Education
+    notes: Student mental-health crisis response coordination
+  - id: VS-140.150
+    stage_order: 4
+    stage_name: Crisis Response
+    capability_ids:
+    - BC-2810
+    process_ids: []
+    industry_variant: Healthcare Providers
+    notes: Mass-casualty and surge response activation
+  - id: VS-140.160
+    stage_order: 4
+    stage_name: Crisis Response
+    capability_ids:
+    - BC-4460
+    process_ids: []
+    industry_variant: Mining & Metals
+    notes: Dam-safety emergency response coordination
+  - id: VS-140.170
+    stage_order: 4
+    stage_name: Crisis Response
+    capability_ids:
+    - BC-3050
+    process_ids: []
+    industry_variant: Oil & Gas
+    notes: Major-accident response (loss of containment, blowout, fire)
+  - id: VS-140.180
+    stage_order: 4
+    stage_name: Crisis Response
+    capability_ids:
+    - BC-3310
+    process_ids: []
+    industry_variant: Public Sector
+    notes: NIMS / ICS incident command; police, fire, EMS field response
+  - id: VS-140.190
+    stage_order: 4
+    stage_name: Crisis Response
+    capability_ids:
+    - BC-2380
+    process_ids: []
+    industry_variant: Retail & Consumer Goods
+    notes: Major food recall response
+  - id: VS-140.200
+    stage_order: 4
+    stage_name: Crisis Response
+    capability_ids:
+    - BC-2700
+    process_ids: []
+    industry_variant: Telecommunications
+    notes: Emergency call routing and public-warning broadcast
+  - id: VS-140.210
+    stage_order: 4
+    stage_name: Crisis Response
+    capability_ids:
+    - BC-3820
+    - BC-3890
+    process_ids: []
+    industry_variant: Utilities
+    notes: Storm and major-event distribution response with mutual assistance; Sewage pollution incident containment and remediation
+  - id: VS-140.220
+    stage_order: 5
+    stage_name: Disaster Recovery
+    capability_ids:
+    - BC-160
+    - BC-600
+    - BC-4220
+    process_ids: []
+    notes: IT/site DR; IT operations failover; Failover orchestration and backup restoration for the SaaS service
+  - id: VS-140.230
+    stage_order: 5
+    stage_name: Disaster Recovery
+    capability_ids:
+    - BC-3310
+    process_ids: []
+    industry_variant: Public Sector
+    notes: Individual and public assistance administration
+  - id: VS-140.240
+    stage_order: 6
+    stage_name: Restoration
+    capability_ids:
+    - BC-1030
+    process_ids: []
+    industry_variant: Manufacturing
+    notes: Asset / line restart
+  - id: VS-140.250
+    stage_order: 6
+    stage_name: Restoration
+    capability_ids:
+    - BC-3310
+    process_ids: []
+    industry_variant: Public Sector
+    notes: Long-term recovery coordination
+  - id: VS-140.260
+    stage_order: 6
+    stage_name: Restoration
+    capability_ids:
+    - BC-2600
+    process_ids: []
+    industry_variant: Telecommunications
+    notes: Network restoration coordination
+  - id: VS-140.270
+    stage_order: 6
+    stage_name: Restoration
+    capability_ids:
+    - BC-3830
+    process_ids: []
+    industry_variant: Utilities
+    notes: Black start and bulk-system restoration coordination
+  - id: VS-140.280
+    stage_order: 7
+    stage_name: Post-Crisis Review
+    capability_ids:
+    - BC-120
+    - BC-830
+    process_ids: []
+    notes: Risk reassessment; Lessons learned
+  - id: VS-140.290
+    stage_order: 7
+    stage_name: Post-Crisis Review
+    capability_ids:
+    - BC-3310
+    process_ids: []
+    industry_variant: Public Sector
+    notes: After-action review and lessons learned
+- id: VS-150
+  name: Discover-to-Automate
+  industries:
+  - Cross-Industry
+  stages:
+  - id: VS-150.10
+    stage_order: 1
+    stage_name: Process Discovery
+    capability_ids:
+    - BC-930
+    process_ids: []
+    notes: Process elicitation; BPMN authoring; documentation publication
+  - id: VS-150.20
+    stage_order: 2
+    stage_name: Process Measurement
+    capability_ids:
+    - BC-930
+    process_ids: []
+    notes: KPI definition; performance monitoring
+  - id: VS-150.30
+    stage_order: 3
+    stage_name: Process Mining
+    capability_ids:
+    - BC-930
+    process_ids: []
+    notes: Event log acquisition; discovery analysis; conformance checking
+  - id: VS-150.40
+    stage_order: 4
+    stage_name: Process Redesign
+    capability_ids:
+    - BC-930
+    process_ids: []
+    notes: Bottleneck analysis; simulation; to-be design
+  - id: VS-150.50
+    stage_order: 5
+    stage_name: Process Automation
+    capability_ids:
+    - BC-930
+    process_ids: []
+    notes: Automation portfolio; orchestration governance; RPA programme; control & audit
+- id: VS-160
+  name: Discovery-to-Approval
+  industries:
+  - Pharmaceuticals & Life Sciences
+  stages:
+  - id: VS-160.10
+    stage_order: 1
+    stage_name: Target Discovery
+    capability_ids:
+    - BC-1500
+    process_ids: []
+    industry_variant: Pharma
+    notes: Target identification & validation
+  - id: VS-160.20
+    stage_order: 2
+    stage_name: Hit & Lead Discovery
+    capability_ids:
+    - BC-1500
+    process_ids: []
+    industry_variant: Pharma
+    notes: Hit discovery; Lead optimisation
+  - id: VS-160.30
+    stage_order: 3
+    stage_name: Pre-Clinical Development
+    capability_ids:
+    - BC-1500
+    - BC-1510
+    process_ids: []
+    industry_variant: Pharma
+    notes: Candidate selection; Pre-clinical studies; CMC development
+  - id: VS-160.40
+    stage_order: 4
+    stage_name: Clinical Trial Design
+    capability_ids:
+    - BC-1520
+    - BC-1530
+    process_ids: []
+    industry_variant: Pharma
+    notes: Protocol design; Regulatory strategy
+  - id: VS-160.50
+    stage_order: 5
+    stage_name: Clinical Trials Execution
+    capability_ids:
+    - BC-1520
+    process_ids: []
+    industry_variant: Pharma
+    notes: Site management; Subject management; Clinical data management; Trial supply
+  - id: VS-160.60
+    stage_order: 6
+    stage_name: Phase Progression
+    capability_ids:
+    - BC-1510
+    process_ids: []
+    industry_variant: Pharma
+    notes: Phase I; Phase II; Phase III
+  - id: VS-160.70
+    stage_order: 7
+    stage_name: Regulatory Submission
+    capability_ids:
+    - BC-1530
+    process_ids: []
+    industry_variant: Pharma
+    notes: NDA / MAA submission; Agency interaction; Labelling
+  - id: VS-160.80
+    stage_order: 8
+    stage_name: Approval & Launch Readiness
+    capability_ids:
+    - BC-1580
+    - BC-1590
+    - BC-1600
+    process_ids: []
+    industry_variant: Pharma
+    notes: Medical affairs preparation; Commercial readiness; Market access & reimbursement
+  - id: VS-160.90
+    stage_order: 9
+    stage_name: Post-Marketing Surveillance
+    capability_ids:
+    - BC-1510
+    - BC-1530
+    process_ids: []
+    industry_variant: Pharma
+    notes: Phase IV; Lifecycle maintenance
+- id: VS-170
+  name: Disruption-to-Recovery
+  industries:
+  - Travel & Hospitality
+  stages:
+  - id: VS-170.10
+    stage_order: 1
+    stage_name: Disruption Detection
+    capability_ids:
+    - BC-4080
+    process_ids: []
+    industry_variant: Airline
+    notes: OCC detection of weather, mechanical, and ATC events
+  - id: VS-170.20
+    stage_order: 1
+    stage_name: Disruption Detection
+    capability_ids:
+    - BC-4090
+    process_ids: []
+    industry_variant: Cruise
+    notes: Voyage-level detection of weather, medical, and port events
+  - id: VS-170.30
+    stage_order: 1
+    stage_name: Disruption Detection
+    capability_ids:
+    - BC-4100
+    process_ids: []
+    industry_variant: Tour
+    notes: In-destination disruption detection by escort and operator
+  - id: VS-170.40
+    stage_order: 2
+    stage_name: Operational Decision
+    capability_ids:
+    - BC-4080
+    process_ids: []
+    industry_variant: Airline
+    notes: Diversion, cancellation, and fleet and crew recovery decisions
+  - id: VS-170.50
+    stage_order: 2
+    stage_name: Operational Decision
+    capability_ids:
+    - BC-4090
+    process_ids: []
+    industry_variant: Cruise
+    notes: Itinerary substitution and port-call change decisions
+  - id: VS-170.60
+    stage_order: 2
+    stage_name: Operational Decision
+    capability_ids:
+    - BC-4100
+    process_ids: []
+    industry_variant: Tour
+    notes: Force-majeure itinerary recovery decisions
+  - id: VS-170.70
+    stage_order: 3
+    stage_name: Traveller Reaccommodation
+    capability_ids:
+    - BC-4020
+    process_ids: []
+    notes: Schedule-change and mass-disruption reaccommodation
+  - id: VS-170.80
+    stage_order: 4
+    stage_name: Communications
+    capability_ids:
+    - BC-4040
+    - BC-4020
+    process_ids: []
+    notes: Outbound disruption communications using traveller record and consent; Booking-level reaccommodation communications
+  - id: VS-170.90
+    stage_order: 5
+    stage_name: Care of Passengers
+    capability_ids:
+    - BC-4060
+    - BC-4070
+    process_ids: []
+    notes: Hotel rooming and care services for stranded travellers; Meal vouchers and traveller catering during disruption
+  - id: VS-170.100
+    stage_order: 6
+    stage_name: Compensation Closure
+    capability_ids:
+    - BC-4020
+    process_ids: []
+    notes: Compensation eligibility determination and refund or voucher issuance
+  - id: VS-170.110
+    stage_order: 7
+    stage_name: Post-Event Review
+    capability_ids:
+    - BC-4030
+    process_ids: []
+    notes: Revenue impact analysis and forecast adjustment
+  - id: VS-170.120
+    stage_order: 7
+    stage_name: Post-Event Review
+    capability_ids:
+    - BC-4080
+    process_ids: []
+    industry_variant: Airline
+    notes: Operational safety investigation support and lessons
+- id: VS-180
+  name: Encounter-to-Discharge
+  industries:
+  - Healthcare Providers
+  stages:
+  - id: VS-180.10
+    stage_order: 1
+    stage_name: Pre-Encounter Access
+    capability_ids:
+    - BC-2800
+    process_ids: []
+    notes: Scheduling, eligibility verification, and financial counselling
+  - id: VS-180.20
+    stage_order: 2
+    stage_name: Registration & Admission
+    capability_ids:
+    - BC-2800
+    process_ids: []
+    notes: Patient registration, admission, and bed assignment
+  - id: VS-180.30
+    stage_order: 3
+    stage_name: Clinical Care Delivery
+    capability_ids:
+    - BC-2810
+    process_ids: []
+    notes: Inpatient, outpatient, emergency, and procedural care delivery
+  - id: VS-180.40
+    stage_order: 4
+    stage_name: Diagnostic & Therapeutic Services
+    capability_ids:
+    - BC-2860
+    - BC-2850
+    process_ids: []
+    notes: Laboratory, imaging, and ancillary diagnostic services; Medication ordering, dispensing, and administration
+  - id: VS-180.50
+    stage_order: 5
+    stage_name: Clinical Documentation
+    capability_ids:
+    - BC-2830
+    process_ids: []
+    notes: Notes, orders, results review, and decision support
+  - id: VS-180.60
+    stage_order: 6
+    stage_name: Care Coordination
+    capability_ids:
+    - BC-2820
+    process_ids: []
+    notes: Multidisciplinary coordination, transitions, and case management
+  - id: VS-180.70
+    stage_order: 7
+    stage_name: Discharge & Transition
+    capability_ids:
+    - BC-2810
+    - BC-2820
+    process_ids: []
+    notes: Discharge planning, instructions, and disposition; Post-discharge follow-up and onward care handoff
+- id: VS-190
+  name: Engagement-to-Realisation
+  industries:
+  - Professional Services
+  - Real Estate
+  stages:
+  - id: VS-190.10
+    stage_order: 1
+    stage_name: Engagement Acceptance
+    capability_ids:
+    - BC-4300
+    - BC-4350
+    process_ids: []
+    notes: Client and engagement acceptance, scoping, and engagement-letter execution; Independence, conflicts, and integrity clearance feeding acceptance
+  - id: VS-190.20
+    stage_order: 1
+    stage_name: Engagement Acceptance
+    capability_ids:
+    - BC-4970
+    process_ids: []
+    industry_variant: Real Estate
+    notes: Valuation engagement intake, scoping, conflict and independence checks
+  - id: VS-190.30
+    stage_order: 2
+    stage_name: Mobilisation
+    capability_ids:
+    - BC-4300
+    - BC-4320
+    process_ids: []
+    notes: Engagement team formation, kickoff, and data-access setup; Engagement staffing and leverage allocation
+  - id: VS-190.40
+    stage_order: 3
+    stage_name: Delivery
+    capability_ids:
+    - BC-4310
+    - BC-4320
+    - BC-4330
+    process_ids: []
+    notes: Fieldwork, advisory analysis, drafting, and working-paper capture; Utilisation tracking and bench redeployment during delivery; Timekeeping and disbursement capture against the engagement
+  - id: VS-190.50
+    stage_order: 3
+    stage_name: Delivery
+    capability_ids:
+    - BC-4970
+    process_ids: []
+    industry_variant: Real Estate
+    notes: Valuation approach application and report drafting
+  - id: VS-190.60
+    stage_order: 4
+    stage_name: Quality Review
+    capability_ids:
+    - BC-4340
+    process_ids: []
+    notes: EQR, file review, and technical consultation before issuance
+  - id: VS-190.70
+    stage_order: 4
+    stage_name: Quality Review
+    capability_ids:
+    - BC-4970
+    process_ids: []
+    industry_variant: Real Estate
+    notes: Reviewer sign-off and quality control
+  - id: VS-190.80
+    stage_order: 5
+    stage_name: Issuance
+    capability_ids:
+    - BC-4310
+    - BC-4300
+    process_ids: []
+    notes: Final report, opinion, or deliverable issuance to the client; Engagement closure communication and post-issuance handover
+  - id: VS-190.90
+    stage_order: 5
+    stage_name: Issuance
+    capability_ids:
+    - BC-4970
+    process_ids: []
+    industry_variant: Real Estate
+    notes: Valuation report issuance to client and lender
+  - id: VS-190.100
+    stage_order: 6
+    stage_name: Billing & Realisation
+    capability_ids:
+    - BC-4330
+    process_ids: []
+    notes: Invoicing, WIP write-up/down, realisation tracking, and write-off control
+  - id: VS-190.110
+    stage_order: 7
+    stage_name: File Lock-Down & Retention
+    capability_ids:
+    - BC-4310
+    - BC-4300
+    process_ids: []
+    notes: Engagement file assembly and post-issuance lock-down; Retention configuration and engagement-file archival
+- id: VS-200
+  name: ESG-to-Disclosure
+  industries:
+  - Cross-Industry
+  stages:
+  - id: VS-200.10
+    stage_order: 1
+    stage_name: ESG Strategy & Materiality
+    capability_ids:
+    - BC-740
+    process_ids: []
+    notes: ESG strategy & materiality
+  - id: VS-200.20
+    stage_order: 1
+    stage_name: ESG Strategy & Materiality
+    capability_ids:
+    - BC-4500
+    process_ids: []
+    industry_variant: Mining & Metals
+    notes: Social materiality input to mining ESG strategy
+  - id: VS-200.30
+    stage_order: 2
+    stage_name: Data Collection
+    capability_ids:
+    - BC-510
+    - BC-740
+    - BC-4920
+    process_ids: []
+    notes: Supplier sustainability ratings; Emissions / energy data; Circular economy metrics; Sustainable sourcing data; Asset-level energy, water, waste, and carbon intensity data collection
+  - id: VS-200.40
+    stage_order: 2
+    stage_name: Data Collection
+    capability_ids:
+    - BC-3600
+    - BC-3590
+    process_ids: []
+    industry_variant: Agriculture
+    notes: Soil carbon, water, biodiversity, and farm GHG data; Animal welfare and provenance indicator data
+  - id: VS-200.50
+    stage_order: 2
+    stage_name: Data Collection
+    capability_ids:
+    - BC-1980
+    process_ids: []
+    industry_variant: Electrical Components & Equipment
+    notes: Substance & product footprint data
+  - id: VS-200.60
+    stage_order: 2
+    stage_name: Data Collection
+    capability_ids:
+    - BC-2040
+    - BC-2070
+    process_ids: []
+    industry_variant: HVAC & Building Automation Systems
+    notes: Refrigerant leak rate & charge accounting data; Building energy & operational carbon telemetry
+  - id: VS-200.70
+    stage_order: 2
+    stage_name: Data Collection
+    capability_ids:
+    - BC-2200
+    process_ids: []
+    industry_variant: Insurance
+    notes: Investment portfolio climate data
+  - id: VS-200.80
+    stage_order: 2
+    stage_name: Data Collection
+    capability_ids:
+    - BC-3780
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Accessibility coverage and content-moderation transparency data
+  - id: VS-200.90
+    stage_order: 2
+    stage_name: Data Collection
+    capability_ids:
+    - BC-4460
+    - BC-4450
+    - BC-4500
+    process_ids: []
+    industry_variant: Mining & Metals
+    notes: Water, tailings, and mine-waste indicator data; Smelter SO2, particulate, and acid-plant emissions data; Community investment, local content, and social KPI data
+  - id: VS-200.100
+    stage_order: 2
+    stage_name: Data Collection
+    capability_ids:
+    - BC-3030
+    process_ids: []
+    industry_variant: Oil & Gas
+    notes: Methane and flare emissions data capture
+  - id: VS-200.110
+    stage_order: 2
+    stage_name: Data Collection
+    capability_ids:
+    - BC-3800
+    - BC-3890
+    process_ids: []
+    industry_variant: Utilities
+    notes: Generation emissions, CO2, and renewables share data; Storm-overflow event-duration monitoring data
+  - id: VS-200.120
+    stage_order: 3
+    stage_name: Data Collection
+    capability_ids:
+    - BC-4650
+    process_ids: []
+    industry_variant: Chemicals
+    notes: Hazard, SVHC, and product carbon footprint data collection
+  - id: VS-200.130
+    stage_order: 3
+    stage_name: Data Quality & Assurance
+    capability_ids:
+    - BC-140
+    - BC-610
+    process_ids: []
+    notes: Internal assurance; Data quality controls
+  - id: VS-200.140
+    stage_order: 4
+    stage_name: Reporting & Disclosure
+    capability_ids:
+    - BC-200
+    - BC-740
+    - BC-4920
+    - BC-4990
+    process_ids: []
+    notes: Statutory ESG filings; Sustainability report; GRESB asset and entity submission; EPC, MEES, LL97, and EPBD building energy disclosure
+  - id: VS-200.150
+    stage_order: 4
+    stage_name: Reporting & Disclosure
+    capability_ids:
+    - BC-3600
+    process_ids: []
+    industry_variant: Agriculture
+    notes: Agri-environmental scheme reporting and soil-carbon credit issuance
+  - id: VS-200.160
+    stage_order: 4
+    stage_name: Reporting & Disclosure
+    capability_ids:
+    - BC-1980
+    process_ids: []
+    industry_variant: Electrical Components & Equipment
+    notes: Environmental product declarations & digital product passport
+  - id: VS-200.170
+    stage_order: 4
+    stage_name: Reporting & Disclosure
+    capability_ids:
+    - BC-2040
+    - BC-2070
+    process_ids: []
+    industry_variant: HVAC & Building Automation Systems
+    notes: F-Gas / EPA / Kigali refrigerant disclosures; Mandatory benchmarking & green certification reporting
+  - id: VS-200.180
+    stage_order: 4
+    stage_name: Reporting & Disclosure
+    capability_ids:
+    - BC-3780
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: DSA transparency and accessibility compliance reporting
+  - id: VS-200.190
+    stage_order: 4
+    stage_name: Reporting & Disclosure
+    capability_ids:
+    - BC-4400
+    - BC-4410
+    - BC-4460
+    - BC-4470
+    - BC-4490
+    - BC-4500
+    process_ids: []
+    industry_variant: Mining & Metals
+    notes: Public exploration results disclosure under JORC, NI 43-101, and SAMREC; Annual public mineral resources and ore reserves statement; GISTM conformance disclosure; Closure provisions and post-closure stewardship disclosure; Payments-to-governments and EITI disclosure; Social performance, community, and human-rights disclosure
+  - id: VS-200.200
+    stage_order: 4
+    stage_name: Reporting & Disclosure
+    capability_ids:
+    - BC-3120
+    process_ids: []
+    industry_variant: Oil & Gas
+    notes: Decommissioning provisions and post-closure disclosures
+  - id: VS-200.210
+    stage_order: 4
+    stage_name: Reporting & Disclosure
+    capability_ids:
+    - BC-3920
+    process_ids: []
+    industry_variant: Utilities
+    notes: Utility regulator ESG, performance, and price-control disclosures
+  - id: VS-200.220
+    stage_order: 5
+    stage_name: Stakeholder Engagement
+    capability_ids:
+    - BC-240
+    - BC-740
+    process_ids: []
+    notes: Investor relations briefings; Investor / NGO engagement
+  - id: VS-200.230
+    stage_order: 5
+    stage_name: Stakeholder Engagement
+    capability_ids:
+    - BC-4500
+    process_ids: []
+    industry_variant: Mining & Metals
+    notes: Investor and community engagement on social performance
+  - id: VS-200.240
+    stage_order: 6
+    stage_name: Improvement Targets
+    capability_ids:
+    - BC-100
+    process_ids: []
+    notes: Strategy execution feedback
+- id: VS-210
+  name: Event-to-Record
+  industries:
+  - Public Sector & Government
+  stages:
+  - id: VS-210.10
+    stage_order: 1
+    stage_name: Event Notification
+    capability_ids:
+    - BC-3290
+    process_ids: []
+    notes: Notification of births, deaths, marriages, business events, and land transactions
+  - id: VS-210.20
+    stage_order: 2
+    stage_name: Registration
+    capability_ids:
+    - BC-3290
+    process_ids: []
+    notes: Authoritative registration and identifier assignment
+  - id: VS-210.30
+    stage_order: 3
+    stage_name: Certification & Issuance
+    capability_ids:
+    - BC-3290
+    process_ids: []
+    notes: Issuance of certificates, credentials, and registry extracts
+  - id: VS-210.40
+    stage_order: 4
+    stage_name: Authentication
+    capability_ids:
+    - BC-3290
+    process_ids: []
+    notes: Document authentication and apostille issuance under the Hague Convention
+  - id: VS-210.50
+    stage_order: 5
+    stage_name: Disclosure & Search
+    capability_ids:
+    - BC-3290
+    process_ids: []
+    notes: Public-facing search services and certified-copy provision
+  - id: VS-210.60
+    stage_order: 6
+    stage_name: Record Maintenance & Privacy
+    capability_ids:
+    - BC-3290
+    process_ids: []
+    notes: Ongoing maintenance, restricted disclosure, and privacy controls
+- id: VS-220
+  name: Filing-to-Disposition
+  industries:
+  - Public Sector & Government
+  stages:
+  - id: VS-220.10
+    stage_order: 1
+    stage_name: Case Filing
+    capability_ids:
+    - BC-3320
+    process_ids: []
+    notes: Case initiation, e-filing, classification, and fee assessment
+  - id: VS-220.20
+    stage_order: 2
+    stage_name: Docket & Scheduling
+    capability_ids:
+    - BC-3320
+    process_ids: []
+    notes: Docket maintenance, hearing scheduling, and judicial assignment
+  - id: VS-220.30
+    stage_order: 3
+    stage_name: Hearing & Trial
+    capability_ids:
+    - BC-3320
+    process_ids: []
+    notes: Jury management, courtroom operations, and witness support
+  - id: VS-220.40
+    stage_order: 4
+    stage_name: Judgment & Sentencing
+    capability_ids:
+    - BC-3320
+    process_ids: []
+    notes: Recording of judgments, sentences, and dispositional orders
+  - id: VS-220.50
+    stage_order: 5
+    stage_name: Order Enforcement
+    capability_ids:
+    - BC-3320
+    process_ids: []
+    notes: Fines, restitution, civil judgment enforcement, and warrants
+  - id: VS-220.60
+    stage_order: 6
+    stage_name: Custody & Supervision
+    capability_ids:
+    - BC-3320
+    process_ids: []
+    notes: Corrections custody, probation, and parole supervision
+  - id: VS-220.70
+    stage_order: 7
+    stage_name: Records & Public Access
+    capability_ids:
+    - BC-3320
+    process_ids: []
+    notes: Court records maintenance, public access, sealing, and expungement
+- id: VS-230
+  name: Firmware-to-Field
+  industries:
+  - Electrical Components & Equipment
+  stages:
+  - id: VS-230.10
+    stage_order: 1
+    stage_name: Firmware Build & Sign
+    capability_ids:
+    - BC-1950
+    process_ids: []
+    notes: Firmware build pipelines, code signing, and artefact governance
+  - id: VS-230.20
+    stage_order: 2
+    stage_name: Release Authorisation
+    capability_ids:
+    - BC-1950
+    process_ids: []
+    notes: Release-train governance, change approval, and release-note authoring
+  - id: VS-230.30
+    stage_order: 3
+    stage_name: Staged Rollout & Pilot
+    capability_ids:
+    - BC-1950
+    process_ids: []
+    notes: Canary rings, pilot fleets, and rollback gating
+  - id: VS-230.40
+    stage_order: 4
+    stage_name: OTA Distribution
+    capability_ids:
+    - BC-1950
+    process_ids: []
+    notes: Over-the-air delivery, device-side update orchestration, and verification
+  - id: VS-230.50
+    stage_order: 5
+    stage_name: Field Telemetry & Health
+    capability_ids:
+    - BC-1950
+    process_ids: []
+    notes: Device telemetry ingestion and fleet health monitoring
+  - id: VS-230.60
+    stage_order: 6
+    stage_name: Vulnerability & Incident Response
+    capability_ids:
+    - BC-1950
+    - BC-620
+    process_ids: []
+    notes: Product PSIRT, CVE triage, and emergency patch issuance; Enterprise cybersecurity coordination for product incidents
+  - id: VS-230.70
+    stage_order: 7
+    stage_name: Decommission & Sunset
+    capability_ids:
+    - BC-1950
+    process_ids: []
+    notes: End-of-support declaration, key revocation, and device retirement
+- id: VS-240
+  name: First-Notice-to-Settlement
+  industries:
+  - Insurance
+  stages:
+  - id: VS-240.10
+    stage_order: 1
+    stage_name: FNOL Intake
+    capability_ids:
+    - BC-2160
+    - BC-2120
+    process_ids: []
+    notes: Multi-channel first notice of loss capture and registration; Policyholder identification and contact verification at FNOL
+  - id: VS-240.20
+    stage_order: 2
+    stage_name: Triage & Coverage
+    capability_ids:
+    - BC-2160
+    process_ids: []
+    notes: Severity triage, coverage verification, and assignment
+  - id: VS-240.30
+    stage_order: 3
+    stage_name: Investigation & Adjustment
+    capability_ids:
+    - BC-2160
+    process_ids: []
+    notes: Investigation, liability assessment, and loss adjustment
+  - id: VS-240.40
+    stage_order: 4
+    stage_name: Reserving
+    capability_ids:
+    - BC-2160
+    - BC-2180
+    process_ids: []
+    notes: Case reserve setting and revision through claim life; IBNR and bulk reserve estimation feeding portfolio reserves
+  - id: VS-240.50
+    stage_order: 5
+    stage_name: Settlement
+    capability_ids:
+    - BC-2160
+    process_ids: []
+    notes: Settlement negotiation, payment, and litigation closure
+  - id: VS-240.60
+    stage_order: 6
+    stage_name: Recovery & Subrogation
+    capability_ids:
+    - BC-2160
+    - BC-2170
+    process_ids: []
+    notes: Salvage, subrogation, and third-party recovery; Reinsurance recoveries against ceded claims
+- id: VS-250
+  name: Flight-to-Settle
+  industries:
+  - Air Traffic Control
+  stages:
+  - id: VS-250.10
+    stage_order: 1
+    stage_name: Flight Plan Filing
+    capability_ids:
+    - BC-1230
+    process_ids: []
+    industry_variant: ATC
+    notes: Aeronautical information / flight plan
+  - id: VS-250.20
+    stage_order: 2
+    stage_name: Flight Operations
+    capability_ids:
+    - BC-1210
+    - BC-1220
+    process_ids: []
+    industry_variant: ATC
+    notes: En-route control; Flow management
+  - id: VS-250.30
+    stage_order: 3
+    stage_name: Charge Determination
+    capability_ids:
+    - BC-1270
+    process_ids: []
+    industry_variant: ATC
+    notes: Charging zone resolution; Route charge calculation
+  - id: VS-250.40
+    stage_order: 4
+    stage_name: Invoicing
+    capability_ids:
+    - BC-200
+    process_ids: []
+    notes: AR processing
+  - id: VS-250.50
+    stage_order: 4
+    stage_name: Invoicing
+    capability_ids:
+    - BC-1270
+    process_ids: []
+    industry_variant: ATC
+    notes: Airline billing
+  - id: VS-250.60
+    stage_order: 5
+    stage_name: Collection
+    capability_ids:
+    - BC-1270
+    process_ids: []
+    industry_variant: ATC
+    notes: Charges collection
+  - id: VS-250.70
+    stage_order: 6
+    stage_name: Reconciliation & Reporting
+    capability_ids:
+    - BC-200
+    process_ids: []
+    notes: GL posting
+  - id: VS-250.80
+    stage_order: 6
+    stage_name: Reconciliation & Reporting
+    capability_ids:
+    - BC-1270
+    process_ids: []
+    industry_variant: ATC
+    notes: Charges reporting
+- id: VS-260
+  name: Generate-to-Settle
+  industries:
+  - Power & Water Utilities
+  stages:
+  - id: VS-260.10
+    stage_order: 1
+    stage_name: Generation Scheduling
+    capability_ids:
+    - BC-3800
+    - BC-3850
+    process_ids: []
+    industry_variant: Utilities
+    notes: Unit commitment and economic dispatch against forecast load; Forward and bilateral position pre-scheduling
+  - id: VS-260.20
+    stage_order: 2
+    stage_name: Wholesale Trading & Position Management
+    capability_ids:
+    - BC-3850
+    process_ids: []
+    industry_variant: Utilities
+    notes: Day-ahead, intraday, capacity, and environmental commodity trading
+  - id: VS-260.30
+    stage_order: 3
+    stage_name: Generation Operations
+    capability_ids:
+    - BC-3800
+    process_ids: []
+    industry_variant: Utilities
+    notes: Thermal, hydro, nuclear, renewable, and storage plant operations
+  - id: VS-260.40
+    stage_order: 4
+    stage_name: System Balancing & Dispatch
+    capability_ids:
+    - BC-3830
+    process_ids: []
+    industry_variant: Utilities
+    notes: Real-time system ops, frequency, reserves, and ancillary services
+  - id: VS-260.50
+    stage_order: 5
+    stage_name: Distributed Energy Coordination
+    capability_ids:
+    - BC-3840
+    process_ids: []
+    industry_variant: Utilities
+    notes: VPP, demand response, EV grid integration, and microgrid dispatch
+  - id: VS-260.60
+    stage_order: 6
+    stage_name: Physical Delivery
+    capability_ids:
+    - BC-3810
+    - BC-3820
+    process_ids: []
+    industry_variant: Utilities
+    notes: Transmission grid operation and inter-area flow; Distribution-network delivery to point of use
+  - id: VS-260.70
+    stage_order: 7
+    stage_name: Metering & Imbalance Calculation
+    capability_ids:
+    - BC-3910
+    - BC-3830
+    process_ids: []
+    industry_variant: Utilities
+    notes: AMI data acquisition, validation, and aggregation by BRP; Imbalance volume, price calculation, and BRP notification
+  - id: VS-260.80
+    stage_order: 8
+    stage_name: Trade Settlement & Reporting
+    capability_ids:
+    - BC-3850
+    process_ids: []
+    industry_variant: Utilities
+    notes: Trade confirmation, settlement, and REMIT / EMIR / Dodd-Frank reporting
+- id: VS-270
+  name: Greenlight-to-Premiere
+  industries:
+  - Media, Entertainment & Telecom Content
+  stages:
+  - id: VS-270.10
+    stage_order: 1
+    stage_name: Concept & Pitch Intake
+    capability_ids:
+    - BC-3700
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Concept evaluation, slate planning, and incoming pitch triage
+  - id: VS-270.20
+    stage_order: 2
+    stage_name: Greenlight Decision
+    capability_ids:
+    - BC-3700
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Greenlight authority, commissioning brief, budget and creative envelope
+  - id: VS-270.30
+    stage_order: 3
+    stage_name: Pre-Production
+    capability_ids:
+    - BC-3700
+    - BC-3790
+    - BC-3720
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Script development, production budgeting, scheduling, and location planning; Casting and talent contracting; Inbound rights and underlying material clearance for production
+  - id: VS-270.40
+    stage_order: 4
+    stage_name: Production
+    capability_ids:
+    - BC-3700
+    - BC-3710
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Principal photography, studio production, live and news production; On-set ingest of source material into the asset platform
+  - id: VS-270.50
+    stage_order: 5
+    stage_name: Post-Production & Mastering
+    capability_ids:
+    - BC-3700
+    - BC-3710
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Picture edit, audio post, colour, conform, and master delivery; Mezzanine generation, distribution renditions, and identifier assignment
+  - id: VS-270.60
+    stage_order: 6
+    stage_name: Rights & Compliance Clearance
+    capability_ids:
+    - BC-3720
+    - BC-3780
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Chain-of-title verification and clearance against territorial rights; Classification submission, editorial review, and accessibility compliance
+  - id: VS-270.70
+    stage_order: 7
+    stage_name: Schedule & Catalogue Placement
+    capability_ids:
+    - BC-3730
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Schedule slot, EPG publication, and on-demand catalogue exposure
+  - id: VS-270.80
+    stage_order: 8
+    stage_name: Distribution & Premiere
+    capability_ids:
+    - BC-3740
+    - BC-3750
+    - BC-3760
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Linear, OTT, IPTV, and syndication delivery for first-window release; Viewer activation and entitlement at premiere; Promotional inventory and sponsorship activation around the launch
+  - id: VS-270.90
+    stage_order: 9
+    stage_name: Performance Feedback
+    capability_ids:
+    - BC-3770
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Title performance, engagement funnel, and recommendation feedback to commissioning
+- id: VS-280
+  name: Hire-to-Retire
+  industries:
+  - Cross-Industry
+  stages:
+  - id: VS-280.10
+    stage_order: 1
+    stage_name: Workforce Planning
+    capability_ids:
+    - BC-300
+    process_ids:
+    - BP-70.10
+    notes: Demand planning
+  - id: VS-280.20
+    stage_order: 1
+    stage_name: Workforce Planning
+    capability_ids:
+    - BC-4760
+    process_ids:
+    - BP-70.10
+    industry_variant: Education
+    notes: Faculty workforce and teaching-load planning
+  - id: VS-280.30
+    stage_order: 2
+    stage_name: Sourcing & Attraction
+    capability_ids:
+    - BC-300
+    - BC-400
+    process_ids:
+    - BP-70.20
+    notes: Sourcing; Employer brand
+  - id: VS-280.40
+    stage_order: 2
+    stage_name: Sourcing & Attraction
+    capability_ids:
+    - BC-3790
+    process_ids:
+    - BP-70.20
+    industry_variant: Media & Entertainment
+    notes: Talent search and casting briefs
+  - id: VS-280.50
+    stage_order: 3
+    stage_name: Selection & Hire
+    capability_ids:
+    - BC-300
+    process_ids:
+    - BP-70.20
+    notes: Selection
+  - id: VS-280.60
+    stage_order: 3
+    stage_name: Selection & Hire
+    capability_ids:
+    - BC-1810
+    process_ids:
+    - BP-70.20
+    industry_variant: Defense
+    notes: Clearance verification
+  - id: VS-280.70
+    stage_order: 3
+    stage_name: Selection & Hire
+    capability_ids:
+    - BC-4760
+    process_ids:
+    - BP-70.20
+    industry_variant: Education
+    notes: Academic search and credentialed appointment
+  - id: VS-280.80
+    stage_order: 3
+    stage_name: Selection & Hire
+    capability_ids:
+    - BC-2890
+    process_ids:
+    - BP-70.20
+    industry_variant: Healthcare Providers
+    notes: Practitioner credentialing and initial privileging
+  - id: VS-280.90
+    stage_order: 3
+    stage_name: Selection & Hire
+    capability_ids:
+    - BC-3790
+    process_ids:
+    - BP-70.20
+    industry_variant: Media & Entertainment
+    notes: Casting decision, talent contracting, loan-out structures
+  - id: VS-280.100
+    stage_order: 3
+    stage_name: Selection & Hire
+    capability_ids:
+    - BC-4380
+    process_ids:
+    - BP-70.20
+    industry_variant: Professional Services
+    notes: Practising-certificate and bar-admission verification at hire
+  - id: VS-280.110
+    stage_order: 3
+    stage_name: Selection & Hire
+    capability_ids:
+    - BC-4960
+    process_ids:
+    - BP-70.20
+    industry_variant: Real Estate
+    notes: Agent licence and brokerage sponsorship verification at hire
+  - id: VS-280.120
+    stage_order: 3
+    stage_name: Selection & Hire
+    capability_ids:
+    - BC-2440
+    process_ids:
+    - BP-70.20
+    industry_variant: Transportation & Logistics
+    notes: Driver and crew licence and rating verification at hire
+  - id: VS-280.130
+    stage_order: 4
+    stage_name: Onboarding
+    capability_ids:
+    - BC-300
+    process_ids:
+    - BP-70.30
+    notes: Onboarding programme; Records, payroll setup
+  - id: VS-280.140
+    stage_order: 5
+    stage_name: Performance & Development
+    capability_ids:
+    - BC-300
+    process_ids:
+    - BP-70.30
+    notes: Performance reviews; Training
+  - id: VS-280.150
+    stage_order: 5
+    stage_name: Performance & Development
+    capability_ids:
+    - BC-1290
+    process_ids:
+    - BP-70.30
+    industry_variant: ATC
+    notes: ATCO licensing track
+  - id: VS-280.160
+    stage_order: 5
+    stage_name: Performance & Development
+    capability_ids:
+    - BC-4760
+    process_ids:
+    - BP-70.30
+    industry_variant: Education
+    notes: Pedagogy development and teaching peer review
+  - id: VS-280.170
+    stage_order: 5
+    stage_name: Performance & Development
+    capability_ids:
+    - BC-2890
+    process_ids:
+    - BP-70.30
+    industry_variant: Healthcare Providers
+    notes: Ongoing and focused practitioner performance evaluation
+  - id: VS-280.180
+    stage_order: 5
+    stage_name: Performance & Development
+    capability_ids:
+    - BC-1560
+    process_ids:
+    - BP-70.30
+    industry_variant: Pharma
+    notes: GxP training records
+  - id: VS-280.190
+    stage_order: 5
+    stage_name: Performance & Development
+    capability_ids:
+    - BC-4380
+    process_ids:
+    - BP-70.30
+    industry_variant: Professional Services
+    notes: CPD / CPE tracking and shortfall remediation
+  - id: VS-280.200
+    stage_order: 5
+    stage_name: Performance & Development
+    capability_ids:
+    - BC-4990
+    process_ids:
+    - BP-70.30
+    industry_variant: Real Estate
+    notes: Agent continuing education tracking
+  - id: VS-280.210
+    stage_order: 5
+    stage_name: Performance & Development
+    capability_ids:
+    - BC-2440
+    process_ids:
+    - BP-70.30
+    industry_variant: Transportation & Logistics
+    notes: Recurrent training; HOS and fatigue compliance
+  - id: VS-280.220
+    stage_order: 6
+    stage_name: Compensation & Benefits Administration
+    capability_ids:
+    - BC-300
+    process_ids:
+    - BP-70.40
+    - BP-90.50
+    notes: Pay design; Payroll execution
+  - id: VS-280.230
+    stage_order: 6
+    stage_name: Compensation & Benefits Administration
+    capability_ids:
+    - BC-3790
+    process_ids:
+    - BP-70.40
+    - BP-90.50
+    industry_variant: Media & Entertainment
+    notes: Residuals, royalty distribution, guild pension and health contributions
+  - id: VS-280.240
+    stage_order: 7
+    stage_name: Employee Experience & Engagement
+    capability_ids:
+    - BC-300
+    process_ids:
+    - BP-70.40
+    - BP-70.70
+    notes: Engagement; Grievances, works councils
+  - id: VS-280.250
+    stage_order: 8
+    stage_name: Internal Mobility & Career
+    capability_ids:
+    - BC-300
+    process_ids:
+    - BP-70.30
+    - BP-70.50
+    notes: Internal moves; Succession
+  - id: VS-280.260
+    stage_order: 8
+    stage_name: Internal Mobility & Career
+    capability_ids:
+    - BC-4760
+    process_ids:
+    - BP-70.30
+    - BP-70.50
+    industry_variant: Education
+    notes: Tenure track and academic promotion
+  - id: VS-280.270
+    stage_order: 9
+    stage_name: Offboarding & Alumni
+    capability_ids:
+    - BC-300
+    process_ids:
+    - BP-70.50
+    notes: Separation processing
+- id: VS-290
+  name: Idea-to-Market
+  industries:
+  - Cross-Industry
+  stages:
+  - id: VS-290.10
+    stage_order: 1
+    stage_name: Idea Capture
+    capability_ids:
+    - BC-800
+    process_ids:
+    - BP-20.20
+    notes: Idea & opportunity intake; Open innovation / external sourcing
+  - id: VS-290.20
+    stage_order: 1
+    stage_name: Idea Capture
+    capability_ids:
+    - BC-4700
+    process_ids:
+    - BP-20.20
+    industry_variant: Education
+    notes: Programme idea intake
+  - id: VS-290.30
+    stage_order: 1
+    stage_name: Idea Capture
+    capability_ids:
+    - BC-3700
+    process_ids:
+    - BP-20.20
+    industry_variant: Media & Entertainment
+    notes: Concept and pitch intake
+  - id: VS-290.40
+    stage_order: 2
+    stage_name: Concept & Feasibility
+    capability_ids:
+    - BC-230
+    - BC-800
+    - BC-820
+    - BC-4200
+    process_ids:
+    - BP-20.20
+    notes: Business case; Incubation / acceleration; Product concept definition; Software product discovery and feasibility
+  - id: VS-290.50
+    stage_order: 2
+    stage_name: Concept & Feasibility
+    capability_ids:
+    - BC-3700
+    process_ids:
+    - BP-20.20
+    industry_variant: Media & Entertainment
+    notes: Greenlight evaluation
+  - id: VS-290.60
+    stage_order: 3
+    stage_name: Research & Prototyping
+    capability_ids:
+    - BC-810
+    - BC-4200
+    process_ids:
+    - BP-20.30
+    notes: Research; Experimentation & prototyping; Software prototyping and validation
+  - id: VS-290.70
+    stage_order: 3
+    stage_name: Research & Prototyping
+    capability_ids:
+    - BC-4600
+    process_ids:
+    - BP-20.30
+    industry_variant: Chemicals
+    notes: Chemical R&D, kinetics, and synthesis route screening
+  - id: VS-290.80
+    stage_order: 3
+    stage_name: Research & Prototyping
+    capability_ids:
+    - BC-1500
+    process_ids:
+    - BP-20.30
+    industry_variant: Pharma
+    notes: Hit discovery
+  - id: VS-290.90
+    stage_order: 4
+    stage_name: Portfolio Selection
+    capability_ids:
+    - BC-800
+    - BC-810
+    process_ids:
+    - BP-20.10
+    notes: Innovation portfolio; R&D portfolio
+  - id: VS-290.100
+    stage_order: 5
+    stage_name: Design & Development
+    capability_ids:
+    - BC-810
+    - BC-820
+    - BC-4200
+    process_ids:
+    - BP-20.30
+    notes: Applied development; Product design; Software product engineering
+  - id: VS-290.110
+    stage_order: 5
+    stage_name: Design & Development
+    capability_ids:
+    - BC-3400
+    process_ids:
+    - BP-20.30
+    industry_variant: Automotive
+    notes: Vehicle product design and development
+  - id: VS-290.120
+    stage_order: 5
+    stage_name: Design & Development
+    capability_ids:
+    - BC-4600
+    process_ids:
+    - BP-20.30
+    industry_variant: Chemicals
+    notes: Pilot scale-up to commercial process definition
+  - id: VS-290.130
+    stage_order: 5
+    stage_name: Design & Development
+    capability_ids:
+    - BC-4700
+    - BC-4790
+    process_ids:
+    - BP-20.30
+    industry_variant: Education
+    notes: Programme structure and curriculum design; Courseware and learning-resource authoring
+  - id: VS-290.140
+    stage_order: 5
+    stage_name: Design & Development
+    capability_ids:
+    - BC-1900
+    - BC-1920
+    - BC-1970
+    process_ids:
+    - BP-20.30
+    industry_variant: Electrical Components & Equipment
+    notes: Electrical/electronic product design; Type-test & qualification on prototypes; Functional-safety & reliability analysis
+  - id: VS-290.150
+    stage_order: 5
+    stage_name: Design & Development
+    capability_ids:
+    - BC-2000
+    - BC-2010
+    process_ids:
+    - BP-20.30
+    industry_variant: HVAC & Building Automation Systems
+    notes: HVAC equipment NPD; BAS product NPD
+  - id: VS-290.160
+    stage_order: 5
+    stage_name: Design & Development
+    capability_ids:
+    - BC-2100
+    process_ids:
+    - BP-20.30
+    industry_variant: Insurance
+    notes: Insurance product design & wording
+  - id: VS-290.170
+    stage_order: 5
+    stage_name: Design & Development
+    capability_ids:
+    - BC-3710
+    - BC-3700
+    process_ids:
+    - BP-20.30
+    industry_variant: Media & Entertainment
+    notes: Mezzanine and master generation; Pre-production, production, post-production
+  - id: VS-290.180
+    stage_order: 5
+    stage_name: Design & Development
+    capability_ids:
+    - BC-1510
+    process_ids:
+    - BP-20.30
+    industry_variant: Pharma
+    notes: Drug development phases
+  - id: VS-290.190
+    stage_order: 5
+    stage_name: Design & Development
+    capability_ids:
+    - BC-2300
+    process_ids:
+    - BP-20.30
+    industry_variant: Retail & Consumer Goods
+    notes: Private-label NPD specification
+  - id: VS-290.200
+    stage_order: 5
+    stage_name: Design & Development
+    capability_ids:
+    - BC-2650
+    process_ids:
+    - BP-20.30
+    industry_variant: Telecommunications
+    notes: Tariff, plan, and bundle design
+  - id: VS-290.210
+    stage_order: 6
+    stage_name: IP Protection
+    capability_ids:
+    - BC-840
+    process_ids:
+    - BP-20.30
+    - BP-120.40
+    notes: Patents, trademarks
+  - id: VS-290.220
+    stage_order: 6
+    stage_name: IP Protection
+    capability_ids:
+    - BC-3720
+    process_ids:
+    - BP-20.30
+    - BP-120.40
+    industry_variant: Media & Entertainment
+    notes: Chain-of-title and rights documentation
+  - id: VS-290.230
+    stage_order: 7
+    stage_name: Launch Readiness
+    capability_ids:
+    - BC-400
+    - BC-820
+    - BC-4210
+    - BC-4270
+    process_ids:
+    - BP-20.40
+    - BP-20.50
+    notes: Demand generation; Release & launch; Release engineering and environment readiness; Public API and SDK release readiness
+  - id: VS-290.240
+    stage_order: 7
+    stage_name: Launch Readiness
+    capability_ids:
+    - BC-3410
+    process_ids:
+    - BP-20.40
+    - BP-20.50
+    industry_variant: Automotive
+    notes: Vehicle programme launch readiness gating
+  - id: VS-290.250
+    stage_order: 7
+    stage_name: Launch Readiness
+    capability_ids:
+    - BC-4650
+    - BC-4660
+    process_ids:
+    - BP-20.40
+    - BP-20.50
+    industry_variant: Chemicals
+    notes: SDS, GHS labels, and exposure scenarios pre-launch; Substance registration ahead of placement on market
+  - id: VS-290.260
+    stage_order: 7
+    stage_name: Launch Readiness
+    capability_ids:
+    - BC-4700
+    process_ids:
+    - BP-20.40
+    - BP-20.50
+    industry_variant: Education
+    notes: Programme catalogue publication and approval
+  - id: VS-290.270
+    stage_order: 7
+    stage_name: Launch Readiness
+    capability_ids:
+    - BC-1940
+    process_ids:
+    - BP-20.40
+    - BP-20.50
+    industry_variant: Electrical Components & Equipment
+    notes: Saleable catalogue activation
+  - id: VS-290.280
+    stage_order: 7
+    stage_name: Launch Readiness
+    capability_ids:
+    - BC-2100
+    process_ids:
+    - BP-20.40
+    - BP-20.50
+    industry_variant: Insurance
+    notes: Filing & channel readiness
+  - id: VS-290.290
+    stage_order: 7
+    stage_name: Launch Readiness
+    capability_ids:
+    - BC-3730
+    process_ids:
+    - BP-20.40
+    - BP-20.50
+    industry_variant: Media & Entertainment
+    notes: Schedule slot and EPG readiness
+  - id: VS-290.300
+    stage_order: 7
+    stage_name: Launch Readiness
+    capability_ids:
+    - BC-2370
+    process_ids:
+    - BP-20.40
+    - BP-20.50
+    industry_variant: Retail & Consumer Goods
+    notes: Channel content readiness
+  - id: VS-290.310
+    stage_order: 7
+    stage_name: Launch Readiness
+    capability_ids:
+    - BC-2650
+    process_ids:
+    - BP-20.40
+    - BP-20.50
+    industry_variant: Telecommunications
+    notes: Multi-channel catalogue publication
+  - id: VS-290.320
+    stage_order: 8
+    stage_name: Market Introduction
+    capability_ids:
+    - BC-410
+    - BC-4210
+    process_ids:
+    - BP-30.40
+    - BP-30.50
+    notes: Sales strategy / GTM; Progressive production rollout
+  - id: VS-290.330
+    stage_order: 8
+    stage_name: Market Introduction
+    capability_ids:
+    - BC-3420
+    process_ids:
+    - BP-30.40
+    - BP-30.50
+    industry_variant: Automotive
+    notes: Type approval as market-entry gate
+  - id: VS-290.340
+    stage_order: 8
+    stage_name: Market Introduction
+    capability_ids:
+    - BC-4700
+    process_ids:
+    - BP-30.40
+    - BP-30.50
+    industry_variant: Education
+    notes: Programme launch into student recruitment
+  - id: VS-290.350
+    stage_order: 8
+    stage_name: Market Introduction
+    capability_ids:
+    - BC-1910
+    process_ids:
+    - BP-30.40
+    - BP-30.50
+    industry_variant: Electrical Components & Equipment
+    notes: Type approval & agency mark issuance
+  - id: VS-290.360
+    stage_order: 8
+    stage_name: Market Introduction
+    capability_ids:
+    - BC-2030
+    process_ids:
+    - BP-30.40
+    - BP-30.50
+    industry_variant: HVAC & Building Automation Systems
+    notes: Performance & safety mark issuance for HVAC equipment
+  - id: VS-290.370
+    stage_order: 8
+    stage_name: Market Introduction
+    capability_ids:
+    - BC-2100
+    process_ids:
+    - BP-30.40
+    - BP-30.50
+    industry_variant: Insurance
+    notes: Regulatory rate filing & approval
+  - id: VS-290.380
+    stage_order: 8
+    stage_name: Market Introduction
+    capability_ids:
+    - BC-3740
+    process_ids:
+    - BP-30.40
+    - BP-30.50
+    industry_variant: Media & Entertainment
+    notes: First-window release
+  - id: VS-290.390
+    stage_order: 8
+    stage_name: Market Introduction
+    capability_ids:
+    - BC-1530
+    process_ids:
+    - BP-30.40
+    - BP-30.50
+    industry_variant: Pharma
+    notes: Regulatory submission & approval
+  - id: VS-290.400
+    stage_order: 8
+    stage_name: Market Introduction
+    capability_ids:
+    - BC-2360
+    process_ids:
+    - BP-30.40
+    - BP-30.50
+    industry_variant: Retail & Consumer Goods
+    notes: Trade-event launch activation
+  - id: VS-290.410
+    stage_order: 8
+    stage_name: Market Introduction
+    capability_ids:
+    - BC-2650
+    process_ids:
+    - BP-30.40
+    - BP-30.50
+    industry_variant: Telecommunications
+    notes: Telecom offer launch and channel activation
+  - id: VS-290.420
+    stage_order: 9
+    stage_name: Post-Launch Performance
+    capability_ids:
+    - BC-820
+    - BC-4280
+    - BC-4220
+    process_ids:
+    - BP-20.10
+    notes: Performance & feedback; End-of-life planning; Telemetry, A/B tests, and feature engagement reporting; Reliability and performance of the launched service
+  - id: VS-290.430
+    stage_order: 9
+    stage_name: Post-Launch Performance
+    capability_ids:
+    - BC-3450
+    process_ids:
+    - BP-20.10
+    industry_variant: Automotive
+    notes: Field-quality feedback into product
+  - id: VS-290.440
+    stage_order: 9
+    stage_name: Post-Launch Performance
+    capability_ids:
+    - BC-4700
+    process_ids:
+    - BP-20.10
+    industry_variant: Education
+    notes: Periodic curriculum review and improvement
+  - id: VS-290.450
+    stage_order: 9
+    stage_name: Post-Launch Performance
+    capability_ids:
+    - BC-1940
+    process_ids:
+    - BP-20.10
+    industry_variant: Electrical Components & Equipment
+    notes: Phase-in / phase-out, last-buy windows
+  - id: VS-290.460
+    stage_order: 9
+    stage_name: Post-Launch Performance
+    capability_ids:
+    - BC-2100
+    process_ids:
+    - BP-20.10
+    industry_variant: Insurance
+    notes: Product performance review
+  - id: VS-290.470
+    stage_order: 9
+    stage_name: Post-Launch Performance
+    capability_ids:
+    - BC-3770
+    process_ids:
+    - BP-20.10
+    industry_variant: Media & Entertainment
+    notes: Title performance feedback to commissioning
+  - id: VS-290.480
+    stage_order: 9
+    stage_name: Post-Launch Performance
+    capability_ids:
+    - BC-2650
+    process_ids:
+    - BP-20.10
+    industry_variant: Telecommunications
+    notes: Offer modification, retirement, and grandfathering
+- id: VS-300
+  name: Insight-to-Reuse
+  industries:
+  - Professional Services
+  stages:
+  - id: VS-300.10
+    stage_order: 1
+    stage_name: Asset Identification
+    capability_ids:
+    - BC-4310
+    - BC-4370
+    process_ids: []
+    notes: Engagement deliverables and working papers identified as candidate assets; Reusable asset selection from completed engagements
+  - id: VS-300.20
+    stage_order: 2
+    stage_name: Sanitisation & Redaction
+    capability_ids:
+    - BC-4370
+    - BC-4350
+    process_ids: []
+    notes: Removal of client-confidential content before reuse; Information-barrier and confidentiality compliance during redaction
+  - id: VS-300.30
+    stage_order: 3
+    stage_name: Curation & Versioning
+    capability_ids:
+    - BC-4370
+    process_ids: []
+    notes: Precedent curation and methodology versioning
+  - id: VS-300.40
+    stage_order: 4
+    stage_name: Cataloguing
+    capability_ids:
+    - BC-4370
+    - BC-720
+    process_ids: []
+    notes: Asset tagging, metadata enrichment, and library catalogue placement; Enterprise knowledge taxonomy and search alignment
+  - id: VS-300.50
+    stage_order: 5
+    stage_name: Distribution & Community
+    capability_ids:
+    - BC-4370
+    process_ids: []
+    notes: Practice-group, community-of-practice, and knowledge-champion distribution
+  - id: VS-300.60
+    stage_order: 6
+    stage_name: Reuse & Analytics
+    capability_ids:
+    - BC-4370
+    process_ids: []
+    notes: Library usage analytics and reuse-impact tracking
+- id: VS-310
+  name: Issue-to-Resolution
+  industries:
+  - Cross-Industry
+  stages:
+  - id: VS-310.10
+    stage_order: 1
+    stage_name: Issue Capture (ADS Incident)
+    capability_ids:
+    - BC-3470
+    process_ids: []
+    industry_variant: Automotive
+    notes: ADS disengagement and incident intake
+  - id: VS-310.20
+    stage_order: 1
+    stage_name: Issue Capture (Agri-Food Compliance)
+    capability_ids:
+    - BC-3590
+    process_ids: []
+    industry_variant: Agriculture
+    notes: Farm assurance, organic, welfare, MRL non-conformance intake
+  - id: VS-310.30
+    stage_order: 1
+    stage_name: Issue Capture (Audit)
+    capability_ids:
+    - BC-140
+    process_ids: []
+  - id: VS-310.40
+    stage_order: 1
+    stage_name: Issue Capture (Aviation Safety - Carrier)
+    capability_ids:
+    - BC-4080
+    process_ids: []
+    industry_variant: Travel & Hospitality
+    notes: Air safety reports captured by carrier operations
+  - id: VS-310.50
+    stage_order: 1
+    stage_name: Issue Capture (Aviation Safety)
+    capability_ids:
+    - BC-1280
+    process_ids: []
+    industry_variant: ATC
+  - id: VS-310.60
+    stage_order: 1
+    stage_name: Issue Capture (Banking Fin Crime)
+    capability_ids:
+    - BC-1400
+    process_ids: []
+    industry_variant: Banking
+  - id: VS-310.70
+    stage_order: 1
+    stage_name: Issue Capture (Cargo Claim)
+    capability_ids:
+    - BC-2530
+    process_ids: []
+    industry_variant: Transportation & Logistics
+    notes: Cargo loss and damage claim intake
+  - id: VS-310.80
+    stage_order: 1
+    stage_name: Issue Capture (Chemical Reg)
+    capability_ids:
+    - BC-4660
+    process_ids: []
+    industry_variant: Chemicals
+    notes: Restriction triggers and substance non-compliance intake
+  - id: VS-310.90
+    stage_order: 1
+    stage_name: Issue Capture (Citizen Service)
+    capability_ids:
+    - BC-3220
+    process_ids: []
+    industry_variant: Public Sector
+    notes: Citizen complaint, FOI request, and ombudsman intake
+  - id: VS-310.100
+    stage_order: 1
+    stage_name: Issue Capture (Community Grievance)
+    capability_ids:
+    - BC-4500
+    process_ids: []
+    industry_variant: Mining & Metals
+    notes: Operational community grievance mechanism intake
+  - id: VS-310.110
+    stage_order: 1
+    stage_name: Issue Capture (Content Compliance)
+    capability_ids:
+    - BC-3780
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Editorial complaints, takedown notices, classification challenges
+  - id: VS-310.120
+    stage_order: 1
+    stage_name: Issue Capture (Cruise Health)
+    capability_ids:
+    - BC-4090
+    process_ids: []
+    industry_variant: Travel & Hospitality
+    notes: Onboard outbreak detection and reporting
+  - id: VS-310.130
+    stage_order: 1
+    stage_name: Issue Capture (Customer)
+    capability_ids:
+    - BC-430
+    process_ids: []
+  - id: VS-310.140
+    stage_order: 1
+    stage_name: Issue Capture (Defense Security)
+    capability_ids:
+    - BC-1810
+    process_ids: []
+    industry_variant: Defense
+  - id: VS-310.150
+    stage_order: 1
+    stage_name: Issue Capture (DG Incident)
+    capability_ids:
+    - BC-2490
+    process_ids: []
+    industry_variant: Transportation & Logistics
+    notes: Dangerous-goods incident, spill, and release intake
+  - id: VS-310.160
+    stage_order: 1
+    stage_name: Issue Capture (Drinking Water Quality)
+    capability_ids:
+    - BC-3870
+    process_ids: []
+    industry_variant: Utilities
+    notes: Drinking-water quality incident and exceedance intake
+  - id: VS-310.170
+    stage_order: 1
+    stage_name: Issue Capture (Engagement Quality)
+    capability_ids:
+    - BC-4340
+    process_ids: []
+    industry_variant: Professional Services
+    notes: Quality deficiencies from EQR, hot review, and cold review
+  - id: VS-310.180
+    stage_order: 1
+    stage_name: Issue Capture (Food Safety)
+    capability_ids:
+    - BC-2380
+    process_ids: []
+    industry_variant: Retail & Consumer Goods
+    notes: Food-safety incident intake
+  - id: VS-310.190
+    stage_order: 1
+    stage_name: Issue Capture (Guest Service)
+    capability_ids:
+    - BC-4040
+    process_ids: []
+    industry_variant: Travel & Hospitality
+    notes: Guest service incident and complaint logging
+  - id: VS-310.200
+    stage_order: 1
+    stage_name: Issue Capture (HSE)
+    capability_ids:
+    - BC-730
+    process_ids: []
+  - id: VS-310.210
+    stage_order: 1
+    stage_name: Issue Capture (HVAC Product Compliance)
+    capability_ids:
+    - BC-2030
+    process_ids: []
+    industry_variant: HVAC & Building Automation Systems
+    notes: Field safety / non-compliance intake
+  - id: VS-310.220
+    stage_order: 1
+    stage_name: Issue Capture (IT/Security)
+    capability_ids:
+    - BC-600
+    - BC-620
+    process_ids: []
+  - id: VS-310.230
+    stage_order: 1
+    stage_name: Issue Capture (Mine Safety)
+    capability_ids:
+    - BC-4430
+    process_ids: []
+    industry_variant: Mining & Metals
+    notes: Geotechnical TARP, ground-control, and mine atmosphere alarms
+  - id: VS-310.240
+    stage_order: 1
+    stage_name: Issue Capture (Mobility Trust & Safety)
+    capability_ids:
+    - BC-3490
+    process_ids: []
+    industry_variant: Automotive
+    notes: Rider and driver safety incident intake
+  - id: VS-310.250
+    stage_order: 1
+    stage_name: Issue Capture (Patient Safety)
+    capability_ids:
+    - BC-2840
+    process_ids: []
+    industry_variant: Healthcare Providers
+    notes: Patient safety and adverse-event intake
+  - id: VS-310.260
+    stage_order: 1
+    stage_name: Issue Capture (Pharma Reg)
+    capability_ids:
+    - BC-1530
+    process_ids: []
+    industry_variant: Pharma
+  - id: VS-310.270
+    stage_order: 1
+    stage_name: Issue Capture (Pharmacovigilance)
+    capability_ids:
+    - BC-1540
+    process_ids: []
+    industry_variant: Pharma
+  - id: VS-310.280
+    stage_order: 1
+    stage_name: Issue Capture (Process Conformance)
+    capability_ids:
+    - BC-930
+    process_ids: []
+    notes: Process mining and conformance reporting surface execution issues
+  - id: VS-310.290
+    stage_order: 1
+    stage_name: Issue Capture (Process Safety)
+    capability_ids:
+    - BC-4640
+    process_ids: []
+    industry_variant: Chemicals
+    notes: Tier 1 / 2 chemical process safety event capture
+  - id: VS-310.300
+    stage_order: 1
+    stage_name: Issue Capture (Process Safety)
+    capability_ids:
+    - BC-4440
+    - BC-4450
+    process_ids: []
+    industry_variant: Mining & Metals
+    notes: Cyanide release, reagent leak, and process plant safety events; Smelter and refinery process safety events
+  - id: VS-310.310
+    stage_order: 1
+    stage_name: Issue Capture (Process Safety)
+    capability_ids:
+    - BC-3050
+    process_ids: []
+    industry_variant: Oil & Gas
+    notes: Tier 1/2 process safety event capture
+  - id: VS-310.320
+    stage_order: 1
+    stage_name: Issue Capture (Product Compliance)
+    capability_ids:
+    - BC-1910
+    process_ids: []
+    industry_variant: Electrical Components & Equipment
+    notes: Field non-compliance reports
+  - id: VS-310.330
+    stage_order: 1
+    stage_name: Issue Capture (Professional Conduct)
+    capability_ids:
+    - BC-4380
+    process_ids: []
+    industry_variant: Professional Services
+    notes: Professional conduct breach intake
+  - id: VS-310.340
+    stage_order: 1
+    stage_name: Issue Capture (Property Tenant Service)
+    capability_ids:
+    - BC-4940
+    process_ids: []
+    notes: Tenant service request and complaint capture on commercial and residential properties
+  - id: VS-310.350
+    stage_order: 1
+    stage_name: Issue Capture (Quality)
+    capability_ids:
+    - BC-720
+    process_ids: []
+  - id: VS-310.360
+    stage_order: 1
+    stage_name: Issue Capture (Retail Loss Prevention)
+    capability_ids:
+    - BC-2340
+    process_ids: []
+    industry_variant: Retail & Consumer Goods
+    notes: Shrink, theft, POS fraud intake
+  - id: VS-310.370
+    stage_order: 1
+    stage_name: Issue Capture (SaaS Service)
+    capability_ids:
+    - BC-4220
+    process_ids: []
+    industry_variant: Software & Technology
+    notes: Production incident detection from telemetry and customer reports
+  - id: VS-310.380
+    stage_order: 1
+    stage_name: Issue Capture (Shipment Exception)
+    capability_ids:
+    - BC-2510
+    process_ids: []
+    industry_variant: Transportation & Logistics
+    notes: Shipment exception and disruption alerts
+  - id: VS-310.390
+    stage_order: 1
+    stage_name: Issue Capture (Student Wellbeing)
+    capability_ids:
+    - BC-4770
+    process_ids: []
+    notes: Pastoral, conduct, and grievance intake
+  - id: VS-310.400
+    stage_order: 1
+    stage_name: Issue Capture (Tailings)
+    capability_ids:
+    - BC-4460
+    process_ids: []
+    industry_variant: Mining & Metals
+    notes: TSF instrumentation alarm, dam-safety, and water-exceedance events
+  - id: VS-310.410
+    stage_order: 1
+    stage_name: Issue Capture (Telecom Fraud)
+    capability_ids:
+    - BC-2690
+    process_ids: []
+    industry_variant: Telecommunications
+    notes: Fraud alert and customer-reported fraud intake
+  - id: VS-310.420
+    stage_order: 1
+    stage_name: Issue Capture (Telecom Service)
+    capability_ids:
+    - BC-2630
+    process_ids: []
+    industry_variant: Telecommunications
+    notes: Customer-impacting service incident intake
+  - id: VS-310.430
+    stage_order: 1
+    stage_name: Issue Capture (Title IX)
+    capability_ids:
+    - BC-4810
+    process_ids: []
+    notes: Title IX and education civil-rights complaint intake
+  - id: VS-310.440
+    stage_order: 1
+    stage_name: Issue Capture (Travel F&B Safety)
+    capability_ids:
+    - BC-4070
+    process_ids: []
+    industry_variant: Travel & Hospitality
+    notes: Food-borne illness and allergen incidents
+  - id: VS-310.450
+    stage_order: 1
+    stage_name: Issue Capture (Utility Billing)
+    capability_ids:
+    - BC-3910
+    process_ids: []
+    industry_variant: Utilities
+    notes: Bill exception, dispute, and complaint intake
+  - id: VS-310.460
+    stage_order: 1
+    stage_name: Issue Capture (Vehicle Aftersales)
+    capability_ids:
+    - BC-3450
+    process_ids: []
+    industry_variant: Automotive
+    notes: Warranty claim and field-quality intake
+  - id: VS-310.470
+    stage_order: 1
+    stage_name: Issue Capture (Viewer Service)
+    capability_ids:
+    - BC-3750
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Viewer-reported playback, billing, and entitlement issues
+  - id: VS-310.480
+    stage_order: 1
+    stage_name: Issue Capture (Wastewater Pollution)
+    capability_ids:
+    - BC-3890
+    process_ids: []
+    industry_variant: Utilities
+    notes: Pollution incident and discharge non-compliance intake
+  - id: VS-310.490
+    stage_order: 3
+    stage_name: Investigation (Agri-Food Compliance)
+    capability_ids:
+    - BC-3590
+    process_ids: []
+    industry_variant: Agriculture
+    notes: Compliance and certification non-conformance investigation
+  - id: VS-310.500
+    stage_order: 3
+    stage_name: Investigation (Audit)
+    capability_ids:
+    - BC-140
+    process_ids: []
+  - id: VS-310.510
+    stage_order: 3
+    stage_name: Investigation (Aviation Safety)
+    capability_ids:
+    - BC-1280
+    process_ids: []
+    industry_variant: ATC
+  - id: VS-310.520
+    stage_order: 3
+    stage_name: Investigation (Banking Fin Crime)
+    capability_ids:
+    - BC-1400
+    process_ids: []
+    industry_variant: Banking
+  - id: VS-310.530
+    stage_order: 3
+    stage_name: Investigation (Cargo Claim)
+    capability_ids:
+    - BC-2530
+    process_ids: []
+    industry_variant: Transportation & Logistics
+    notes: Liability assessment under transport conventions
+  - id: VS-310.540
+    stage_order: 3
+    stage_name: Investigation (Chemical Reg)
+    capability_ids:
+    - BC-4660
+    process_ids: []
+    industry_variant: Chemicals
+    notes: Regulatory non-compliance investigation
+  - id: VS-310.550
+    stage_order: 3
+    stage_name: Investigation (Content Compliance)
+    capability_ids:
+    - BC-3780
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Content review and complaint investigation
+  - id: VS-310.560
+    stage_order: 3
+    stage_name: Investigation (Customer)
+    capability_ids:
+    - BC-430
+    process_ids: []
+  - id: VS-310.570
+    stage_order: 3
+    stage_name: Investigation (Defense Security)
+    capability_ids:
+    - BC-1810
+    process_ids: []
+    industry_variant: Defense
+  - id: VS-310.580
+    stage_order: 3
+    stage_name: Investigation (DG Incident)
+    capability_ids:
+    - BC-2490
+    process_ids: []
+    industry_variant: Transportation & Logistics
+    notes: DG incident investigation and authority notification
+  - id: VS-310.590
+    stage_order: 3
+    stage_name: Investigation (Food Safety)
+    capability_ids:
+    - BC-2380
+    process_ids: []
+    industry_variant: Retail & Consumer Goods
+    notes: Lot trace and root-cause analysis
+  - id: VS-310.600
+    stage_order: 3
+    stage_name: Investigation (HSE)
+    capability_ids:
+    - BC-730
+    process_ids: []
+  - id: VS-310.610
+    stage_order: 3
+    stage_name: Investigation (HVAC Product Compliance)
+    capability_ids:
+    - BC-2030
+    process_ids: []
+    industry_variant: HVAC & Building Automation Systems
+    notes: Certifier liaison & root cause for HVAC equipment
+  - id: VS-310.620
+    stage_order: 3
+    stage_name: Investigation (IT/Security)
+    capability_ids:
+    - BC-620
+    process_ids: []
+  - id: VS-310.630
+    stage_order: 3
+    stage_name: Investigation (Patient Safety)
+    capability_ids:
+    - BC-2840
+    process_ids: []
+    industry_variant: Healthcare Providers
+    notes: Root-cause analysis and just-culture review
+  - id: VS-310.640
+    stage_order: 3
+    stage_name: Investigation (Pharma Reg)
+    capability_ids:
+    - BC-1560
+    process_ids: []
+    industry_variant: Pharma
+  - id: VS-310.650
+    stage_order: 3
+    stage_name: Investigation (Pharmacovigilance)
+    capability_ids:
+    - BC-1540
+    process_ids: []
+    industry_variant: Pharma
+  - id: VS-310.660
+    stage_order: 3
+    stage_name: Investigation (Process Safety)
+    capability_ids:
+    - BC-4640
+    process_ids: []
+    industry_variant: Chemicals
+    notes: Root-cause investigation of major chemical incidents
+  - id: VS-310.670
+    stage_order: 3
+    stage_name: Investigation (Process Safety)
+    capability_ids:
+    - BC-3050
+    process_ids: []
+    industry_variant: Oil & Gas
+    notes: Root-cause investigation of major-hazard events
+  - id: VS-310.680
+    stage_order: 3
+    stage_name: Investigation (Product Compliance)
+    capability_ids:
+    - BC-1910
+    process_ids: []
+    industry_variant: Electrical Components & Equipment
+    notes: Root-cause investigation, certifier liaison
+  - id: VS-310.690
+    stage_order: 3
+    stage_name: Investigation (Quality)
+    capability_ids:
+    - BC-720
+    process_ids: []
+    notes: CAPA
+  - id: VS-310.700
+    stage_order: 3
+    stage_name: Investigation (Retail Loss Prevention)
+    capability_ids:
+    - BC-2340
+    process_ids: []
+    industry_variant: Retail & Consumer Goods
+    notes: LP casework, ORC investigation
+  - id: VS-310.710
+    stage_order: 3
+    stage_name: Investigation (SaaS Service)
+    capability_ids:
+    - BC-4220
+    process_ids: []
+    industry_variant: Software & Technology
+    notes: Incident coordination and blameless postmortem authoring
+  - id: VS-310.720
+    stage_order: 3
+    stage_name: Investigation (Telecom Fraud)
+    capability_ids:
+    - BC-2690
+    process_ids: []
+    industry_variant: Telecommunications
+    notes: Telecom fraud case investigation
+  - id: VS-310.730
+    stage_order: 3
+    stage_name: Investigation (Telecom Service)
+    capability_ids:
+    - BC-2630
+    process_ids: []
+    industry_variant: Telecommunications
+    notes: Root cause analysis and customer-incident investigation
+  - id: VS-310.740
+    stage_order: 3
+    stage_name: Investigation (Title IX)
+    capability_ids:
+    - BC-4810
+    process_ids: []
+    notes: Statutory civil-rights investigation
+  - id: VS-310.750
+    stage_order: 4
+    stage_name: Resolution (Audit)
+    capability_ids:
+    - BC-140
+    process_ids: []
+  - id: VS-310.760
+    stage_order: 4
+    stage_name: Resolution (Aviation Safety)
+    capability_ids:
+    - BC-1280
+    process_ids: []
+    industry_variant: ATC
+  - id: VS-310.770
+    stage_order: 4
+    stage_name: Resolution (Banking Fin Crime)
+    capability_ids:
+    - BC-1400
+    process_ids: []
+    industry_variant: Banking
+  - id: VS-310.780
+    stage_order: 4
+    stage_name: Resolution (Cargo Claim)
+    capability_ids:
+    - BC-2530
+    process_ids: []
+    industry_variant: Transportation & Logistics
+    notes: Claim settlement, recourse, and subrogation
+  - id: VS-310.790
+    stage_order: 4
+    stage_name: Resolution (Chemical Reg)
+    capability_ids:
+    - BC-4660
+    process_ids: []
+    industry_variant: Chemicals
+    notes: Remediation submissions and authority response
+  - id: VS-310.800
+    stage_order: 4
+    stage_name: Resolution (Citizen Service)
+    capability_ids:
+    - BC-3220
+    process_ids: []
+    industry_variant: Public Sector
+    notes: Case resolution, ombudsman determination, appeals outcome
+  - id: VS-310.810
+    stage_order: 4
+    stage_name: Resolution (Content Compliance)
+    capability_ids:
+    - BC-3780
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Edits, takedowns, on-air corrections, counter-notice handling
+  - id: VS-310.820
+    stage_order: 4
+    stage_name: Resolution (Customer)
+    capability_ids:
+    - BC-720
+    - BC-910
+    process_ids: []
+  - id: VS-310.830
+    stage_order: 4
+    stage_name: Resolution (Food Safety)
+    capability_ids:
+    - BC-2380
+    process_ids: []
+    industry_variant: Retail & Consumer Goods
+    notes: Recall execution and effectiveness verification
+  - id: VS-310.840
+    stage_order: 4
+    stage_name: Resolution (HVAC Product Compliance)
+    capability_ids:
+    - BC-2030
+    process_ids: []
+    industry_variant: HVAC & Building Automation Systems
+    notes: Field modification, recall, mark withdrawal
+  - id: VS-310.850
+    stage_order: 4
+    stage_name: Resolution (Patient Safety)
+    capability_ids:
+    - BC-2840
+    process_ids: []
+    industry_variant: Healthcare Providers
+    notes: Corrective action and clinical risk mitigation
+  - id: VS-310.860
+    stage_order: 4
+    stage_name: Resolution (Pharma Reg)
+    capability_ids:
+    - BC-1560
+    process_ids: []
+    industry_variant: Pharma
+  - id: VS-310.870
+    stage_order: 4
+    stage_name: Resolution (Pharmacovigilance)
+    capability_ids:
+    - BC-1540
+    process_ids: []
+    industry_variant: Pharma
+  - id: VS-310.880
+    stage_order: 4
+    stage_name: Resolution (Process Safety)
+    capability_ids:
+    - BC-4640
+    process_ids: []
+    industry_variant: Chemicals
+    notes: Corrective actions and barrier rebuild
+  - id: VS-310.890
+    stage_order: 4
+    stage_name: Resolution (Process Safety)
+    capability_ids:
+    - BC-3050
+    process_ids: []
+    industry_variant: Oil & Gas
+    notes: Corrective actions and barrier rebuild
+  - id: VS-310.900
+    stage_order: 4
+    stage_name: Resolution (Product Compliance)
+    capability_ids:
+    - BC-1910
+    process_ids: []
+    industry_variant: Electrical Components & Equipment
+    notes: Recall / stop-ship coordination
+  - id: VS-310.910
+    stage_order: 4
+    stage_name: Resolution (Property Service Recovery)
+    capability_ids:
+    - BC-4060
+    process_ids: []
+    industry_variant: Travel & Hospitality
+    notes: Service-recovery actions, compensation, and follow-up
+  - id: VS-310.920
+    stage_order: 4
+    stage_name: Resolution (Property Tenant Service)
+    capability_ids:
+    - BC-4940
+    process_ids: []
+    notes: Tenant service recovery and incident closure on commercial and residential properties
+  - id: VS-310.930
+    stage_order: 4
+    stage_name: Resolution (Quality)
+    capability_ids:
+    - BC-720
+    process_ids: []
+  - id: VS-310.940
+    stage_order: 4
+    stage_name: Resolution (Retail Loss Prevention)
+    capability_ids:
+    - BC-2340
+    process_ids: []
+    industry_variant: Retail & Consumer Goods
+    notes: Recovery and disciplinary follow-through
+  - id: VS-310.950
+    stage_order: 4
+    stage_name: Resolution (SaaS Service)
+    capability_ids:
+    - BC-4220
+    process_ids: []
+    industry_variant: Software & Technology
+    notes: Reliability action tracking to closure
+  - id: VS-310.960
+    stage_order: 4
+    stage_name: Resolution (Student Wellbeing)
+    capability_ids:
+    - BC-4770
+    process_ids: []
+    notes: Wellbeing case resolution and remediation
+  - id: VS-310.970
+    stage_order: 4
+    stage_name: Resolution (Telecom Fraud)
+    capability_ids:
+    - BC-2690
+    process_ids: []
+    industry_variant: Telecommunications
+    notes: Fraudulent-charge recovery and account remediation
+  - id: VS-310.980
+    stage_order: 4
+    stage_name: Resolution (Telecom Service)
+    capability_ids:
+    - BC-2630
+    process_ids: []
+    industry_variant: Telecommunications
+    notes: Service restoration and customer remediation
+  - id: VS-310.990
+    stage_order: 4
+    stage_name: Resolution (Title IX)
+    capability_ids:
+    - BC-4810
+    process_ids: []
+    notes: Sanctioning and statutory closure
+  - id: VS-310.1000
+    stage_order: 4
+    stage_name: Resolution (Viewer Service)
+    capability_ids:
+    - BC-3750
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Entitlement, billing, and playback remediation
+  - id: VS-310.1010
+    stage_order: 6
+    stage_name: Lessons Learned (Aviation Safety)
+    capability_ids:
+    - BC-1280
+    process_ids: []
+    industry_variant: ATC
+  - id: VS-310.1020
+    stage_order: 6
+    stage_name: Lessons Learned (Chemical Reg)
+    capability_ids:
+    - BC-4660
+    process_ids: []
+    industry_variant: Chemicals
+    notes: Surveillance loop into regulatory horizon scanning
+  - id: VS-310.1030
+    stage_order: 6
+    stage_name: Lessons Learned (Generic)
+    capability_ids:
+    - BC-830
+    process_ids: []
+  - id: VS-310.1040
+    stage_order: 6
+    stage_name: Lessons Learned (Patient Safety)
+    capability_ids:
+    - BC-2840
+    process_ids: []
+    industry_variant: Healthcare Providers
+    notes: High-reliability organisational learning
+  - id: VS-310.1050
+    stage_order: 6
+    stage_name: Lessons Learned (Pharma Reg)
+    capability_ids:
+    - BC-1560
+    process_ids: []
+    industry_variant: Pharma
+  - id: VS-310.1060
+    stage_order: 6
+    stage_name: Lessons Learned (Process Safety)
+    capability_ids:
+    - BC-4640
+    process_ids: []
+    industry_variant: Chemicals
+    notes: Industry-wide chemical process-safety lessons sharing
+  - id: VS-310.1070
+    stage_order: 6
+    stage_name: Lessons Learned (Process Safety)
+    capability_ids:
+    - BC-3050
+    process_ids: []
+    industry_variant: Oil & Gas
+    notes: Industry-wide lessons-learned sharing
+  - id: VS-310.1080
+    stage_order: 6
+    stage_name: Lessons Learned (Quality)
+    capability_ids:
+    - BC-830
+    process_ids: []
+- id: VS-320
+  name: Lead-to-Event
+  industries:
+  - Travel & Hospitality
+  stages:
+  - id: VS-320.10
+    stage_order: 1
+    stage_name: Lead Qualification
+    capability_ids:
+    - BC-4110
+    process_ids: []
+    notes: Inbound group lead qualification
+  - id: VS-320.20
+    stage_order: 2
+    stage_name: Proposal & Contract
+    capability_ids:
+    - BC-4110
+    - BC-4030
+    process_ids: []
+    notes: Group proposal authoring and contract execution; Group pricing and concession against revenue guidance
+  - id: VS-320.30
+    stage_order: 3
+    stage_name: Block & Event Setup
+    capability_ids:
+    - BC-4110
+    - BC-4020
+    process_ids: []
+    notes: BEO authoring and function-space allocation; Group room block contract and rooming list
+  - id: VS-320.40
+    stage_order: 4
+    stage_name: Event Execution
+    capability_ids:
+    - BC-4110
+    - BC-4070
+    - BC-4060
+    process_ids: []
+    notes: Setup, service, AV, and group servicing; Banquet and catering service; Property security, engineering, and concierge support to event
+  - id: VS-320.50
+    stage_order: 5
+    stage_name: Settlement
+    capability_ids:
+    - BC-4110
+    process_ids: []
+    notes: Master account settlement and reconciliation
+  - id: VS-320.60
+    stage_order: 6
+    stage_name: Post-Event
+    capability_ids:
+    - BC-4110
+    process_ids: []
+    notes: Block-vs-pickup, financial, attendee feedback, and renewal tracking
+- id: VS-330
+  name: Lease-to-Production
+  industries:
+  - Oil & Gas
+  - Mining & Metals
+  stages:
+  - id: VS-330.10
+    stage_order: 1
+    stage_name: Acreage Acquisition
+    capability_ids:
+    - BC-3000
+    - BC-3110
+    process_ids: []
+    notes: License round entry, concession bidding, farm-in; JOA negotiation and AFE setup at entry
+  - id: VS-330.20
+    stage_order: 1
+    stage_name: Acreage Acquisition
+    capability_ids:
+    - BC-4490
+    process_ids: []
+    industry_variant: Mining & Metals
+    notes: Mineral tenement application, lease, and acquisition due diligence
+  - id: VS-330.30
+    stage_order: 2
+    stage_name: Prospect Maturation
+    capability_ids:
+    - BC-3000
+    process_ids: []
+    notes: Seismic acquisition, prospect evaluation and risking
+  - id: VS-330.40
+    stage_order: 2
+    stage_name: Prospect Maturation
+    capability_ids:
+    - BC-4400
+    process_ids: []
+    industry_variant: Mining & Metals
+    notes: Geoscientific surveys, target generation, and prospect ranking
+  - id: VS-330.50
+    stage_order: 3
+    stage_name: Exploration Drilling
+    capability_ids:
+    - BC-3020
+    - BC-3000
+    process_ids: []
+    notes: Wildcat and appraisal drilling execution; Post-well evaluation and prospect inventory update
+  - id: VS-330.60
+    stage_order: 3
+    stage_name: Exploration Drilling
+    capability_ids:
+    - BC-4400
+    process_ids: []
+    industry_variant: Mining & Metals
+    notes: Reverse-circulation and diamond core drilling, sample assay, discovery reporting
+  - id: VS-330.70
+    stage_order: 4
+    stage_name: Reserves Maturation
+    capability_ids:
+    - BC-3010
+    process_ids: []
+    notes: Reservoir characterisation and SPE-PRMS classification
+  - id: VS-330.80
+    stage_order: 4
+    stage_name: Reserves Maturation
+    capability_ids:
+    - BC-4410
+    process_ids: []
+    industry_variant: Mining & Metals
+    notes: Geological modelling, resource estimation, reserve classification
+  - id: VS-330.90
+    stage_order: 5
+    stage_name: Field Development Sanction
+    capability_ids:
+    - BC-3010
+    - BC-3110
+    process_ids: []
+    notes: Concept selection and field development plan authoring; Partner approvals via OPCOM and host-government FDP submission
+  - id: VS-330.100
+    stage_order: 5
+    stage_name: Field Development Sanction
+    capability_ids:
+    - BC-4420
+    process_ids: []
+    industry_variant: Mining & Metals
+    notes: Mine design, life-of-mine planning, and capital project sequencing
+  - id: VS-330.110
+    stage_order: 6
+    stage_name: Development Execution
+    capability_ids:
+    - BC-3020
+    - BC-1110
+    process_ids: []
+    notes: Development drilling and completions; Project engineering for surface facility EPC
+  - id: VS-330.120
+    stage_order: 7
+    stage_name: First Production
+    capability_ids:
+    - BC-3030
+    - BC-1160
+    process_ids: []
+    notes: Startup, ramp-up, and first oil/gas; Facility commissioning and handover
+  - id: VS-330.130
+    stage_order: 7
+    stage_name: First Production
+    capability_ids:
+    - BC-4430
+    process_ids: []
+    industry_variant: Mining & Metals
+    notes: Production ramp-up across open-pit and underground operations
+  - id: VS-330.140
+    stage_order: 8
+    stage_name: Operations Handover
+    capability_ids:
+    - BC-3030
+    - BC-3010
+    process_ids: []
+    notes: Handover to steady-state operate phase; Production forecasting handover and reservoir surveillance
+  - id: VS-330.150
+    stage_order: 8
+    stage_name: Operations Handover
+    capability_ids:
+    - BC-4430
+    - BC-4410
+    process_ids: []
+    industry_variant: Mining & Metals
+    notes: Handover to steady-state mining operations; Resource and reserve reconciliation handover
+- id: VS-340
+  name: Listing-to-Closing
+  industries:
+  - Real Estate
+  stages:
+  - id: VS-340.10
+    stage_order: 1
+    stage_name: Listing Pursuit & Win
+    capability_ids:
+    - BC-4960
+    process_ids: []
+    notes: Listing pitch, CMA, and win of the listing mandate
+  - id: VS-340.20
+    stage_order: 2
+    stage_name: Listing Setup & Marketing
+    capability_ids:
+    - BC-4960
+    process_ids: []
+    notes: Listing agreement, MLS capture, media production, and syndication
+  - id: VS-340.30
+    stage_order: 3
+    stage_name: Showing & Engagement
+    capability_ids:
+    - BC-4960
+    process_ids: []
+    notes: Showings, open houses, and prospect engagement
+  - id: VS-340.40
+    stage_order: 4
+    stage_name: Offer & Negotiation
+    capability_ids:
+    - BC-4960
+    process_ids: []
+    notes: Offer drafting, counter-offers, and multiple-offer handling
+  - id: VS-340.50
+    stage_order: 5
+    stage_name: Contingency & Closing Coordination
+    capability_ids:
+    - BC-4960
+    process_ids: []
+    notes: Contingency tracking and coordination with escrow / conveyancing
+  - id: VS-340.60
+    stage_order: 6
+    stage_name: Closing Execution
+    capability_ids:
+    - BC-4960
+    process_ids: []
+    notes: Closing-day coordination and key handover
+  - id: VS-340.70
+    stage_order: 7
+    stage_name: Commission Settlement
+    capability_ids:
+    - BC-4960
+    process_ids: []
+    notes: Cooperating-broker settlement, commission disbursement, and referral fees
+- id: VS-350
+  name: Maintenance-Request-to-Closure
+  industries:
+  - Manufacturing & Industrial
+  - HVAC & Building Automation Systems
+  - Electrical Components & Equipment
+  - Transportation & Logistics
+  - Oil & Gas
+  - Real Estate
+  stages:
+  - id: VS-350.10
+    stage_order: 1
+    stage_name: Notification / Request
+    capability_ids:
+    - BC-1050
+    process_ids: []
+    notes: Service request (field)
+  - id: VS-350.20
+    stage_order: 1
+    stage_name: Notification / Request
+    capability_ids:
+    - BC-2060
+    process_ids: []
+    industry_variant: HVAC & Building Automation Systems
+    notes: HVAC service request intake
+  - id: VS-350.30
+    stage_order: 1
+    stage_name: Notification / Request
+    capability_ids:
+    - BC-1030
+    process_ids: []
+    industry_variant: Manufacturing
+    notes: Corrective maintenance notification
+  - id: VS-350.40
+    stage_order: 1
+    stage_name: Notification / Request
+    capability_ids:
+    - BC-4940
+    process_ids: []
+    industry_variant: Real Estate
+    notes: Tenant work-order intake on commercial and residential properties
+  - id: VS-350.50
+    stage_order: 1
+    stage_name: Notification / Request
+    capability_ids:
+    - BC-2430
+    process_ids: []
+    industry_variant: Transportation & Logistics
+    notes: Fleet defect notification, mandatory-inspection trigger
+  - id: VS-350.60
+    stage_order: 2
+    stage_name: Triage & Planning
+    capability_ids:
+    - BC-1050
+    process_ids: []
+    notes: Dispatch & scheduling
+  - id: VS-350.70
+    stage_order: 2
+    stage_name: Triage & Planning
+    capability_ids:
+    - BC-1960
+    process_ids: []
+    industry_variant: Electrical Components & Equipment
+    notes: Retrofit & service contract planning
+  - id: VS-350.80
+    stage_order: 2
+    stage_name: Triage & Planning
+    capability_ids:
+    - BC-2060
+    process_ids: []
+    industry_variant: HVAC & Building Automation Systems
+    notes: Reactive triage; remote diagnostic triage
+  - id: VS-350.90
+    stage_order: 2
+    stage_name: Triage & Planning
+    capability_ids:
+    - BC-1030
+    process_ids: []
+    industry_variant: Manufacturing
+    notes: Maintenance work order planning
+  - id: VS-350.100
+    stage_order: 2
+    stage_name: Triage & Planning
+    capability_ids:
+    - BC-4940
+    process_ids: []
+    industry_variant: Real Estate
+    notes: Preventive and reactive maintenance triage
+  - id: VS-350.110
+    stage_order: 2
+    stage_name: Triage & Planning
+    capability_ids:
+    - BC-2430
+    process_ids: []
+    industry_variant: Transportation & Logistics
+    notes: Preventive-maintenance scheduling and defect triage
+  - id: VS-350.120
+    stage_order: 3
+    stage_name: Execution
+    capability_ids:
+    - BC-1050
+    process_ids: []
+    notes: Field service execution
+  - id: VS-350.130
+    stage_order: 3
+    stage_name: Execution
+    capability_ids:
+    - BC-1960
+    process_ids: []
+    industry_variant: Electrical Components & Equipment
+    notes: OEM service execution on installed base
+  - id: VS-350.140
+    stage_order: 3
+    stage_name: Execution
+    capability_ids:
+    - BC-2060
+    process_ids: []
+    industry_variant: HVAC & Building Automation Systems
+    notes: On-site HVAC repair; BAS reprogramming
+  - id: VS-350.150
+    stage_order: 3
+    stage_name: Execution
+    capability_ids:
+    - BC-1030
+    process_ids: []
+    industry_variant: Manufacturing
+    notes: Corrective maintenance execution
+  - id: VS-350.160
+    stage_order: 3
+    stage_name: Execution
+    capability_ids:
+    - BC-4940
+    process_ids: []
+    industry_variant: Real Estate
+    notes: Maintenance execution including statutory and compliance inspections
+  - id: VS-350.170
+    stage_order: 3
+    stage_name: Execution
+    capability_ids:
+    - BC-2430
+    process_ids: []
+    industry_variant: Transportation & Logistics
+    notes: Fleet maintenance and overhaul execution
+  - id: VS-350.180
+    stage_order: 4
+    stage_name: Parts & Logistics
+    capability_ids:
+    - BC-1050
+    process_ids: []
+    notes: Service parts
+  - id: VS-350.190
+    stage_order: 4
+    stage_name: Parts & Logistics
+    capability_ids:
+    - BC-2060
+    process_ids: []
+    industry_variant: HVAC & Building Automation Systems
+    notes: Refrigerant, filters, sensors, replacement parts
+  - id: VS-350.200
+    stage_order: 4
+    stage_name: Parts & Logistics
+    capability_ids:
+    - BC-1030
+    process_ids: []
+    industry_variant: Manufacturing
+    notes: Maintenance spares
+  - id: VS-350.210
+    stage_order: 4
+    stage_name: Parts & Logistics
+    capability_ids:
+    - BC-2430
+    process_ids: []
+    industry_variant: Transportation & Logistics
+    notes: Spare parts for fleet maintenance
+  - id: VS-350.220
+    stage_order: 5
+    stage_name: Verification & Closure
+    capability_ids:
+    - BC-720
+    process_ids: []
+    notes: Quality control sign-off
+  - id: VS-350.230
+    stage_order: 5
+    stage_name: Verification & Closure
+    capability_ids:
+    - BC-2060
+    process_ids: []
+    industry_variant: HVAC & Building Automation Systems
+    notes: Retrofit validation, post-service tests
+  - id: VS-350.240
+    stage_order: 5
+    stage_name: Verification & Closure
+    capability_ids:
+    - BC-1030
+    process_ids: []
+    industry_variant: Manufacturing
+    notes: Reliability data update
+  - id: VS-350.250
+    stage_order: 5
+    stage_name: Verification & Closure
+    capability_ids:
+    - BC-4940
+    process_ids: []
+    industry_variant: Real Estate
+    notes: Work-order verification and closure with tenant
+  - id: VS-350.260
+    stage_order: 5
+    stage_name: Verification & Closure
+    capability_ids:
+    - BC-2430
+    process_ids: []
+    industry_variant: Transportation & Logistics
+    notes: Roadworthiness, airworthiness, or seaworthiness sign-off
+  - id: VS-350.270
+    stage_order: 6
+    stage_name: Performance & Cost Analysis
+    capability_ids:
+    - BC-1050
+    - BC-200
+    process_ids: []
+    notes: Field service KPIs; Maintenance cost posting
+  - id: VS-350.280
+    stage_order: 6
+    stage_name: Performance & Cost Analysis
+    capability_ids:
+    - BC-2060
+    process_ids: []
+    industry_variant: HVAC & Building Automation Systems
+    notes: Service KPIs, SLA reporting
+- id: VS-360
+  name: Mandate-to-Distribution
+  industries:
+  - Real Estate
+  stages:
+  - id: VS-360.10
+    stage_order: 1
+    stage_name: Mandate & Strategy Definition
+    capability_ids:
+    - BC-4910
+    process_ids: []
+    notes: Fund / mandate definition and investment strategy
+  - id: VS-360.20
+    stage_order: 2
+    stage_name: Vehicle Formation
+    capability_ids:
+    - BC-4910
+    process_ids: []
+    notes: Fund structuring, vehicle setup, and tax-efficient holding
+  - id: VS-360.30
+    stage_order: 3
+    stage_name: Capital Raising
+    capability_ids:
+    - BC-4910
+    process_ids: []
+    notes: Investor targeting, subscription, and fund closing
+  - id: VS-360.40
+    stage_order: 4
+    stage_name: Capital Deployment
+    capability_ids:
+    - BC-4910
+    process_ids: []
+    notes: Pipeline pacing, allocation across vehicles, and capital calls
+  - id: VS-360.50
+    stage_order: 5
+    stage_name: NAV & Performance Management
+    capability_ids:
+    - BC-4910
+    process_ids: []
+    notes: NAV computation, attribution, and fee / waterfall calculation
+  - id: VS-360.60
+    stage_order: 6
+    stage_name: LP Reporting
+    capability_ids:
+    - BC-4910
+    process_ids: []
+    notes: LP reporting and INREV / NCREIF / EPRA index submission
+  - id: VS-360.70
+    stage_order: 7
+    stage_name: Distribution & Wind-Down
+    capability_ids:
+    - BC-4910
+    process_ids: []
+    notes: Periodic distributions and end-of-life fund wind-down
+- id: VS-370
+  name: Network-Plan-to-Service
+  industries:
+  - Transportation & Logistics
+  stages:
+  - id: VS-370.10
+    stage_order: 1
+    stage_name: Demand Forecast
+    capability_ids:
+    - BC-2410
+    process_ids: []
+    notes: Lane-level demand forecasting and modal mix analysis
+  - id: VS-370.20
+    stage_order: 2
+    stage_name: Network Design
+    capability_ids:
+    - BC-2410
+    process_ids: []
+    notes: Hub, gateway, lane, and modal-mix design decisions
+  - id: VS-370.30
+    stage_order: 3
+    stage_name: Capacity & Schedule Plan
+    capability_ids:
+    - BC-2410
+    - BC-2400
+    process_ids: []
+    notes: Schedule and slot planning across the service portfolio; Capacity commitments and equipment / vessel allocation
+  - id: VS-370.40
+    stage_order: 4
+    stage_name: Service Publication
+    capability_ids:
+    - BC-2410
+    process_ids: []
+    notes: Service catalogue publication and channel distribution
+  - id: VS-370.50
+    stage_order: 5
+    stage_name: Service Operations
+    capability_ids:
+    - BC-2420
+    process_ids: []
+    notes: Day-to-day execution of the published service
+  - id: VS-370.60
+    stage_order: 6
+    stage_name: Performance Monitoring & Re-plan
+    capability_ids:
+    - BC-2410
+    process_ids: []
+    notes: Service KPIs, gap analysis, and feedback into the next planning cycle
+- id: VS-380
+  name: Opportunity-to-Order
+  industries:
+  - Cross-Industry
+  stages:
+  - id: VS-380.10
+    stage_order: 1
+    stage_name: Opportunity Qualification
+    capability_ids:
+    - BC-410
+    - BC-420
+    process_ids: []
+    notes: BANT/MEDDIC qualification; Account ownership; Customer record lookup
+  - id: VS-380.20
+    stage_order: 1
+    stage_name: Opportunity Qualification
+    capability_ids:
+    - BC-3440
+    process_ids: []
+    industry_variant: Automotive
+    notes: Fleet and B2B opportunity qualification
+  - id: VS-380.30
+    stage_order: 1
+    stage_name: Opportunity Qualification
+    capability_ids:
+    - BC-3720
+    - BC-3760
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Outbound licence opportunity qualification; Advertiser opportunity qualification
+  - id: VS-380.40
+    stage_order: 1
+    stage_name: Opportunity Qualification
+    capability_ids:
+    - BC-4360
+    - BC-4350
+    process_ids: []
+    industry_variant: Professional Services
+    notes: Pursuit qualification and pre-clearance; Independence and conflicts pre-clearance during pursuit
+  - id: VS-380.50
+    stage_order: 2
+    stage_name: Solution Scoping
+    capability_ids:
+    - BC-410
+    process_ids: []
+    notes: Solution design within opportunity
+  - id: VS-380.60
+    stage_order: 2
+    stage_name: Solution Scoping
+    capability_ids:
+    - BC-3440
+    process_ids: []
+    industry_variant: Automotive
+    notes: Fleet vehicle specification scoping
+  - id: VS-380.70
+    stage_order: 2
+    stage_name: Solution Scoping
+    capability_ids:
+    - BC-1750
+    process_ids: []
+    industry_variant: Defense
+    notes: Capture management
+  - id: VS-380.80
+    stage_order: 2
+    stage_name: Solution Scoping
+    capability_ids:
+    - BC-1110
+    - BC-1140
+    process_ids: []
+    industry_variant: Engineering Services
+    notes: Project engineering scoping; Tendering & estimation
+  - id: VS-380.90
+    stage_order: 2
+    stage_name: Solution Scoping
+    capability_ids:
+    - BC-2020
+    process_ids: []
+    industry_variant: HVAC & Building Automation Systems
+    notes: Project-level HVAC/BAS solution scoping
+  - id: VS-380.100
+    stage_order: 2
+    stage_name: Solution Scoping
+    capability_ids:
+    - BC-2680
+    process_ids: []
+    industry_variant: Telecommunications
+    notes: Wholesale solution scoping for carrier and MVNO orders
+  - id: VS-380.110
+    stage_order: 3
+    stage_name: Quote & Configuration
+    capability_ids:
+    - BC-410
+    - BC-440
+    - BC-4240
+    process_ids: []
+    notes: CPQ; Price list application; Subscription quote management
+  - id: VS-380.120
+    stage_order: 3
+    stage_name: Quote & Configuration
+    capability_ids:
+    - BC-1940
+    process_ids: []
+    industry_variant: Electrical Components & Equipment
+    notes: Variant configurator for engineered orders
+  - id: VS-380.130
+    stage_order: 3
+    stage_name: Quote & Configuration
+    capability_ids:
+    - BC-2650
+    process_ids: []
+    industry_variant: Telecommunications
+    notes: Catalogue-driven enterprise CPQ
+  - id: VS-380.140
+    stage_order: 4
+    stage_name: Pricing & Approvals
+    capability_ids:
+    - BC-440
+    process_ids: []
+    notes: Pricing strategy / deal desk; Discount & promotional pricing; Price realisation / exception approval
+  - id: VS-380.150
+    stage_order: 5
+    stage_name: Proposal Development
+    capability_ids:
+    - BC-410
+    process_ids: []
+    notes: Proposal authoring
+  - id: VS-380.160
+    stage_order: 5
+    stage_name: Proposal Development
+    capability_ids:
+    - BC-1750
+    process_ids: []
+    industry_variant: Defense
+    notes: Defense proposal
+  - id: VS-380.170
+    stage_order: 5
+    stage_name: Proposal Development
+    capability_ids:
+    - BC-3760
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Media plan and proposal development
+  - id: VS-380.180
+    stage_order: 5
+    stage_name: Proposal Development
+    capability_ids:
+    - BC-4360
+    process_ids: []
+    industry_variant: Professional Services
+    notes: Proposal and pitch authoring
+  - id: VS-380.190
+    stage_order: 6
+    stage_name: Negotiation
+    capability_ids:
+    - BC-150
+    - BC-410
+    process_ids: []
+    notes: Legal terms negotiation; Executive negotiation
+  - id: VS-380.200
+    stage_order: 6
+    stage_name: Negotiation
+    capability_ids:
+    - BC-1750
+    process_ids: []
+    industry_variant: Defense
+    notes: Bid management & negotiation
+  - id: VS-380.210
+    stage_order: 6
+    stage_name: Negotiation
+    capability_ids:
+    - BC-3760
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Upfront and scatter negotiation
+  - id: VS-380.220
+    stage_order: 6
+    stage_name: Negotiation
+    capability_ids:
+    - BC-4360
+    process_ids: []
+    industry_variant: Professional Services
+    notes: Engagement-letter and fee negotiation
+  - id: VS-380.230
+    stage_order: 6
+    stage_name: Negotiation
+    capability_ids:
+    - BC-2680
+    process_ids: []
+    industry_variant: Telecommunications
+    notes: Wholesale, interconnect, and roaming agreement negotiation
+  - id: VS-380.240
+    stage_order: 7
+    stage_name: Contract & Order Booking
+    capability_ids:
+    - BC-150
+    - BC-410
+    - BC-4240
+    process_ids: []
+    notes: Master agreement execution; Order entry; Order form generation and subscription contract capture
+  - id: VS-380.250
+    stage_order: 7
+    stage_name: Contract & Order Booking
+    capability_ids:
+    - BC-3720
+    - BC-3760
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Outbound licence deal booking; IO booking against avail plan
+  - id: VS-380.260
+    stage_order: 8
+    stage_name: Handover to Fulfilment
+    capability_ids:
+    - BC-410
+    - BC-420
+    - BC-4230
+    process_ids: []
+    notes: Sales-to-delivery handover; Sales performance / commission booking; Customer lifecycle activation; Tenant provisioning handover
+- id: VS-390
+  name: Order-to-Cash
+  industries:
+  - Cross-Industry
+  stages:
+  - id: VS-390.10
+    stage_order: 1
+    stage_name: Lead Capture & Qualification
+    capability_ids:
+    - BC-410
+    - BC-420
+    process_ids:
+    - BP-30.10
+    - BP-30.50
+    notes: Lead intake, qualification; Customer record creation
+  - id: VS-390.20
+    stage_order: 1
+    stage_name: Lead Capture & Qualification
+    capability_ids:
+    - BC-3760
+    process_ids:
+    - BP-30.10
+    - BP-30.50
+    industry_variant: Media & Entertainment
+    notes: Advertiser lead capture
+  - id: VS-390.30
+    stage_order: 1
+    stage_name: Lead Capture & Qualification
+    capability_ids:
+    - BC-3910
+    process_ids:
+    - BP-30.10
+    - BP-30.50
+    industry_variant: Utilities
+    notes: Supply-point registration and customer onboarding
+  - id: VS-390.40
+    stage_order: 2
+    stage_name: Quote & Configuration
+    capability_ids:
+    - BC-410
+    - BC-440
+    process_ids:
+    - BP-30.50
+    notes: CPQ; Pricing application
+  - id: VS-390.50
+    stage_order: 2
+    stage_name: Quote & Configuration
+    capability_ids:
+    - BC-3570
+    process_ids:
+    - BP-30.50
+    industry_variant: Agriculture
+    notes: Cash and basis quotes with hedge-aligned pricing
+  - id: VS-390.60
+    stage_order: 2
+    stage_name: Quote & Configuration
+    capability_ids:
+    - BC-3440
+    process_ids:
+    - BP-30.50
+    industry_variant: Automotive
+    notes: Vehicle CPQ and configurator
+  - id: VS-390.70
+    stage_order: 2
+    stage_name: Quote & Configuration
+    capability_ids:
+    - BC-1940
+    process_ids:
+    - BP-30.50
+    industry_variant: Electrical Components & Equipment
+    notes: Configurator-driven CPQ for electrical variants
+  - id: VS-390.80
+    stage_order: 2
+    stage_name: Quote & Configuration
+    capability_ids:
+    - BC-3760
+    process_ids:
+    - BP-30.50
+    industry_variant: Media & Entertainment
+    notes: Campaign quote and avail planning
+  - id: VS-390.90
+    stage_order: 2
+    stage_name: Quote & Configuration
+    capability_ids:
+    - BC-3090
+    process_ids:
+    - BP-30.50
+    industry_variant: Oil & Gas
+    notes: Trade quote and term-contract pricing
+  - id: VS-390.100
+    stage_order: 2
+    stage_name: Quote & Configuration
+    capability_ids:
+    - BC-2520
+    - BC-2450
+    process_ids:
+    - BP-30.50
+    industry_variant: Transportation & Logistics
+    notes: Freight rate quotation; Forwarder quote to shipper
+  - id: VS-390.110
+    stage_order: 3
+    stage_name: Contract & Order Capture
+    capability_ids:
+    - BC-150
+    - BC-410
+    - BC-4240
+    process_ids:
+    - BP-30.50
+    notes: Master agreement, T&Cs; Order entry; Subscription contracting and order forms
+  - id: VS-390.120
+    stage_order: 3
+    stage_name: Contract & Order Capture
+    capability_ids:
+    - BC-3570
+    process_ids:
+    - BP-30.50
+    industry_variant: Agriculture
+    notes: Forward and production contract capture
+  - id: VS-390.130
+    stage_order: 3
+    stage_name: Contract & Order Capture
+    capability_ids:
+    - BC-3440
+    process_ids:
+    - BP-30.50
+    industry_variant: Automotive
+    notes: Customer and dealer vehicle order capture
+  - id: VS-390.140
+    stage_order: 3
+    stage_name: Contract & Order Capture
+    capability_ids:
+    - BC-4690
+    process_ids:
+    - BP-30.50
+    industry_variant: Chemicals
+    notes: Bulk offtake and index-linked chemical contract capture
+  - id: VS-390.150
+    stage_order: 3
+    stage_name: Contract & Order Capture
+    capability_ids:
+    - BC-3720
+    - BC-3750
+    - BC-3760
+    process_ids:
+    - BP-30.50
+    industry_variant: Media & Entertainment
+    notes: Outbound licence deal capture; Subscription enrolment and entitlement grant; IO and linear spot order capture
+  - id: VS-390.160
+    stage_order: 3
+    stage_name: Contract & Order Capture
+    capability_ids:
+    - BC-4480
+    process_ids:
+    - BP-30.50
+    industry_variant: Mining & Metals
+    notes: Spot and term concentrate and metal sales contracting
+  - id: VS-390.170
+    stage_order: 3
+    stage_name: Contract & Order Capture
+    capability_ids:
+    - BC-3090
+    process_ids:
+    - BP-30.50
+    industry_variant: Oil & Gas
+    notes: Trade capture into ETRM
+  - id: VS-390.180
+    stage_order: 3
+    stage_name: Contract & Order Capture
+    capability_ids:
+    - BC-4300
+    process_ids:
+    - BP-30.50
+    industry_variant: Professional Services
+    notes: Engagement acceptance and engagement-letter execution
+  - id: VS-390.190
+    stage_order: 3
+    stage_name: Contract & Order Capture
+    capability_ids:
+    - BC-2320
+    process_ids:
+    - BP-30.50
+    industry_variant: Retail & Consumer Goods
+    notes: POS basket capture
+  - id: VS-390.200
+    stage_order: 3
+    stage_name: Contract & Order Capture
+    capability_ids:
+    - BC-2620
+    process_ids:
+    - BP-30.50
+    industry_variant: Telecommunications
+    notes: Service order capture, feasibility, and credit gating
+  - id: VS-390.210
+    stage_order: 3
+    stage_name: Contract & Order Capture
+    capability_ids:
+    - BC-2400
+    process_ids:
+    - BP-30.50
+    industry_variant: Transportation & Logistics
+    notes: Booking acceptance against capacity
+  - id: VS-390.220
+    stage_order: 4
+    stage_name: Order Promising & Allocation
+    capability_ids:
+    - BC-520
+    - BC-530
+    process_ids:
+    - BP-40.10
+    notes: ATP/CTP, allocation; Stock reservation
+  - id: VS-390.230
+    stage_order: 4
+    stage_name: Order Promising & Allocation
+    capability_ids:
+    - BC-3440
+    process_ids:
+    - BP-40.10
+    industry_variant: Automotive
+    notes: Build-slot allocation and ATP
+  - id: VS-390.240
+    stage_order: 4
+    stage_name: Order Promising & Allocation
+    capability_ids:
+    - BC-4320
+    process_ids:
+    - BP-40.10
+    industry_variant: Professional Services
+    notes: Engagement staffing and leverage allocation
+  - id: VS-390.250
+    stage_order: 4
+    stage_name: Order Promising & Allocation
+    capability_ids:
+    - BC-2330
+    process_ids:
+    - BP-40.10
+    industry_variant: Retail & Consumer Goods
+    notes: Cross-channel order routing
+  - id: VS-390.260
+    stage_order: 4
+    stage_name: Order Promising & Allocation
+    capability_ids:
+    - BC-2620
+    process_ids:
+    - BP-40.10
+    industry_variant: Telecommunications
+    notes: Network resource allocation against orders
+  - id: VS-390.270
+    stage_order: 4
+    stage_name: Order Promising & Allocation
+    capability_ids:
+    - BC-2400
+    process_ids:
+    - BP-40.10
+    industry_variant: Transportation & Logistics
+    notes: Capacity allocation and ATP for cargo
+  - id: VS-390.280
+    stage_order: 5
+    stage_name: Production / Service Delivery
+    capability_ids:
+    - BC-4230
+    process_ids:
+    - BP-40.30
+    - BP-50.30
+    notes: Tenant provisioning as service-delivery fulfilment
+  - id: VS-390.290
+    stage_order: 5
+    stage_name: Production / Service Delivery
+    capability_ids:
+    - BC-3580
+    process_ids:
+    - BP-40.30
+    - BP-50.30
+    industry_variant: Agriculture
+    notes: Food and beverage manufacturing as the service product
+  - id: VS-390.300
+    stage_order: 5
+    stage_name: Production / Service Delivery
+    capability_ids:
+    - BC-3440
+    - BC-3460
+    - BC-3490
+    process_ids:
+    - BP-40.30
+    - BP-50.30
+    industry_variant: Automotive
+    notes: Build-to-order coordination; Connected service activation at delivery; Trip dispatch and ride delivery
+  - id: VS-390.310
+    stage_order: 5
+    stage_name: Production / Service Delivery
+    capability_ids:
+    - BC-4620
+    - BC-4630
+    process_ids:
+    - BP-40.30
+    - BP-50.30
+    industry_variant: Chemicals
+    notes: Bulk chemical production execution; Specialty formulation and finishing
+  - id: VS-390.320
+    stage_order: 5
+    stage_name: Production / Service Delivery
+    capability_ids:
+    - BC-1960
+    process_ids:
+    - BP-40.30
+    - BP-50.30
+    industry_variant: Electrical Components & Equipment
+    notes: OEM commissioning & energisation
+  - id: VS-390.330
+    stage_order: 5
+    stage_name: Production / Service Delivery
+    capability_ids:
+    - BC-1110
+    process_ids:
+    - BP-40.30
+    - BP-50.30
+    industry_variant: Engineering Services
+  - id: VS-390.340
+    stage_order: 5
+    stage_name: Production / Service Delivery
+    capability_ids:
+    - BC-1000
+    - BC-1050
+    process_ids:
+    - BP-40.30
+    - BP-50.30
+    industry_variant: Manufacturing
+  - id: VS-390.350
+    stage_order: 5
+    stage_name: Production / Service Delivery
+    capability_ids:
+    - BC-3740
+    - BC-3760
+    process_ids:
+    - BP-40.30
+    - BP-50.30
+    industry_variant: Media & Entertainment
+    notes: Syndication, licensee delivery, and OTT playback delivery; Ad decisioning, trafficking, and insertion
+  - id: VS-390.360
+    stage_order: 5
+    stage_name: Production / Service Delivery
+    capability_ids:
+    - BC-1550
+    process_ids:
+    - BP-40.30
+    - BP-50.30
+    industry_variant: Pharma
+  - id: VS-390.370
+    stage_order: 5
+    stage_name: Production / Service Delivery
+    capability_ids:
+    - BC-4310
+    process_ids:
+    - BP-40.30
+    - BP-50.30
+    industry_variant: Professional Services
+    notes: Engagement execution against work plan
+  - id: VS-390.380
+    stage_order: 5
+    stage_name: Production / Service Delivery
+    capability_ids:
+    - BC-2310
+    - BC-2330
+    process_ids:
+    - BP-40.30
+    - BP-50.30
+    industry_variant: Retail & Consumer Goods
+    notes: In-store sale delivery; Omnichannel fulfilment
+  - id: VS-390.390
+    stage_order: 5
+    stage_name: Production / Service Delivery
+    capability_ids:
+    - BC-2620
+    process_ids:
+    - BP-40.30
+    - BP-50.30
+    industry_variant: Telecommunications
+    notes: Service provisioning, activation, and acceptance testing
+  - id: VS-390.400
+    stage_order: 5
+    stage_name: Production / Service Delivery
+    capability_ids:
+    - BC-2420
+    - BC-2470
+    - BC-2460
+    process_ids:
+    - BP-40.30
+    - BP-50.30
+    industry_variant: Transportation & Logistics
+    notes: Multimodal carriage execution; Terminal handling within service delivery; 3PL fulfilment as the service product
+  - id: VS-390.410
+    stage_order: 5
+    stage_name: Production / Service Delivery
+    capability_ids:
+    - BC-3820
+    - BC-3880
+    process_ids:
+    - BP-40.30
+    - BP-50.30
+    industry_variant: Utilities
+    notes: Electricity supply at customer point of use; Treated water supply at customer point of use
+  - id: VS-390.420
+    stage_order: 6
+    stage_name: Outbound Logistics
+    capability_ids:
+    - BC-520
+    process_ids:
+    - BP-40.40
+    notes: Shipping
+  - id: VS-390.430
+    stage_order: 6
+    stage_name: Outbound Logistics
+    capability_ids:
+    - BC-3440
+    process_ids:
+    - BP-40.40
+    industry_variant: Automotive
+    notes: Vehicle distribution to dealer or customer
+  - id: VS-390.440
+    stage_order: 6
+    stage_name: Outbound Logistics
+    capability_ids:
+    - BC-4680
+    process_ids:
+    - BP-40.40
+    industry_variant: Chemicals
+    notes: Bulk and hazmat outbound chemical logistics
+  - id: VS-390.450
+    stage_order: 6
+    stage_name: Outbound Logistics
+    capability_ids:
+    - BC-4480
+    process_ids:
+    - BP-40.40
+    industry_variant: Mining & Metals
+    notes: Bulk shipment nomination and IMSBC Code compliance
+  - id: VS-390.460
+    stage_order: 6
+    stage_name: Outbound Logistics
+    capability_ids:
+    - BC-3100
+    process_ids:
+    - BP-40.40
+    industry_variant: Oil & Gas
+    notes: Marine cargo lifting and terminal load-out
+  - id: VS-390.470
+    stage_order: 6
+    stage_name: Outbound Logistics
+    capability_ids:
+    - BC-1570
+    process_ids:
+    - BP-40.40
+    industry_variant: Pharma
+    notes: Cold-chain variant
+  - id: VS-390.480
+    stage_order: 6
+    stage_name: Outbound Logistics
+    capability_ids:
+    - BC-2330
+    process_ids:
+    - BP-40.40
+    industry_variant: Retail & Consumer Goods
+    notes: BOPIS, kerbside, ship-from-store, last-mile slots
+  - id: VS-390.490
+    stage_order: 6
+    stage_name: Outbound Logistics
+    capability_ids:
+    - BC-2420
+    - BC-2480
+    - BC-2500
+    - BC-2510
+    process_ids:
+    - BP-40.40
+    industry_variant: Transportation & Logistics
+    notes: Last-mile delivery to consignee; Customs clearance during outbound move; Bill of lading and air waybill issuance; Track-and-trace and ETA in transit
+  - id: VS-390.500
+    stage_order: 7
+    stage_name: Customer Invoicing
+    capability_ids:
+    - BC-200
+    - BC-4250
+    - BC-4940
+    process_ids:
+    - BP-90.20
+    notes: Invoice generation; Subscription invoicing; Tenant rent and recoveries billing
+  - id: VS-390.510
+    stage_order: 7
+    stage_name: Customer Invoicing
+    capability_ids:
+    - BC-3570
+    process_ids:
+    - BP-90.20
+    industry_variant: Agriculture
+    notes: Settlement statement with grade-based discounts
+  - id: VS-390.520
+    stage_order: 7
+    stage_name: Customer Invoicing
+    capability_ids:
+    - BC-3480
+    - BC-3490
+    process_ids:
+    - BP-90.20
+    industry_variant: Automotive
+    notes: Charge-session rating and invoicing; Trip fare invoicing and receipt
+  - id: VS-390.530
+    stage_order: 7
+    stage_name: Customer Invoicing
+    capability_ids:
+    - BC-2150
+    process_ids:
+    - BP-90.20
+    industry_variant: Insurance
+    notes: Premium invoicing
+  - id: VS-390.540
+    stage_order: 7
+    stage_name: Customer Invoicing
+    capability_ids:
+    - BC-3720
+    - BC-3750
+    - BC-3760
+    process_ids:
+    - BP-90.20
+    industry_variant: Media & Entertainment
+    notes: Licensee invoicing; Viewer subscription billing; Advertiser and agency billing
+  - id: VS-390.550
+    stage_order: 7
+    stage_name: Customer Invoicing
+    capability_ids:
+    - BC-4480
+    process_ids:
+    - BP-90.20
+    industry_variant: Mining & Metals
+    notes: Provisional invoicing under quotational-period terms
+  - id: VS-390.560
+    stage_order: 7
+    stage_name: Customer Invoicing
+    capability_ids:
+    - BC-3040
+    - BC-3060
+    process_ids:
+    - BP-90.20
+    industry_variant: Oil & Gas
+    notes: Fiscal-meter-based invoice volumes; Pipeline shipper billing
+  - id: VS-390.570
+    stage_order: 7
+    stage_name: Customer Invoicing
+    capability_ids:
+    - BC-4330
+    process_ids:
+    - BP-90.20
+    industry_variant: Professional Services
+    notes: Pro-forma, narrative, and e-billing-compliant invoicing
+  - id: VS-390.580
+    stage_order: 7
+    stage_name: Customer Invoicing
+    capability_ids:
+    - BC-2320
+    process_ids:
+    - BP-90.20
+    industry_variant: Retail & Consumer Goods
+    notes: POS receipt issuance
+  - id: VS-390.590
+    stage_order: 7
+    stage_name: Customer Invoicing
+    capability_ids:
+    - BC-2660
+    process_ids:
+    - BP-90.20
+    industry_variant: Telecommunications
+    notes: Telecom bill cycle, calculation, and presentment
+  - id: VS-390.600
+    stage_order: 7
+    stage_name: Customer Invoicing
+    capability_ids:
+    - BC-2530
+    process_ids:
+    - BP-90.20
+    industry_variant: Transportation & Logistics
+    notes: Freight and accessorial invoice issuance
+  - id: VS-390.610
+    stage_order: 7
+    stage_name: Customer Invoicing
+    capability_ids:
+    - BC-3910
+    process_ids:
+    - BP-90.20
+    industry_variant: Utilities
+    notes: Utility bill calculation, presentment, and prepayment top-up
+  - id: VS-390.620
+    stage_order: 8
+    stage_name: Cash Collection & Application
+    capability_ids:
+    - BC-200
+    - BC-210
+    - BC-4250
+    - BC-4940
+    process_ids:
+    - BP-90.20
+    - BP-90.70
+    notes: Collections; Cash positioning; Payment collection, dunning, and involuntary churn recovery; Tenant rent collection and application against AR
+  - id: VS-390.630
+    stage_order: 8
+    stage_name: Cash Collection & Application
+    capability_ids:
+    - BC-3570
+    process_ids:
+    - BP-90.20
+    - BP-90.70
+    industry_variant: Agriculture
+    notes: Settlement collection and counterparty position
+  - id: VS-390.640
+    stage_order: 8
+    stage_name: Cash Collection & Application
+    capability_ids:
+    - BC-3480
+    - BC-3490
+    process_ids:
+    - BP-90.20
+    - BP-90.70
+    industry_variant: Automotive
+    notes: Charging payment capture and roaming settlement; Rider payment capture and driver payout
+  - id: VS-390.650
+    stage_order: 8
+    stage_name: Cash Collection & Application
+    capability_ids:
+    - BC-2150
+    process_ids:
+    - BP-90.20
+    - BP-90.70
+    industry_variant: Insurance
+    notes: Premium collection
+  - id: VS-390.660
+    stage_order: 8
+    stage_name: Cash Collection & Application
+    capability_ids:
+    - BC-3750
+    - BC-3760
+    process_ids:
+    - BP-90.20
+    - BP-90.70
+    industry_variant: Media & Entertainment
+    notes: Viewer dunning and suspension; Advertiser collections and make-goods
+  - id: VS-390.670
+    stage_order: 8
+    stage_name: Cash Collection & Application
+    capability_ids:
+    - BC-4330
+    process_ids:
+    - BP-90.20
+    - BP-90.70
+    industry_variant: Professional Services
+    notes: Realisation, write-off, and trust-account application
+  - id: VS-390.680
+    stage_order: 8
+    stage_name: Cash Collection & Application
+    capability_ids:
+    - BC-2320
+    process_ids:
+    - BP-90.20
+    - BP-90.70
+    industry_variant: Retail & Consumer Goods
+    notes: Tender acceptance & end-of-day reconciliation
+  - id: VS-390.690
+    stage_order: 8
+    stage_name: Cash Collection & Application
+    capability_ids:
+    - BC-2660
+    process_ids:
+    - BP-90.20
+    - BP-90.70
+    industry_variant: Telecommunications
+    notes: Telecom dunning, suspension, and disconnection
+  - id: VS-390.700
+    stage_order: 8
+    stage_name: Cash Collection & Application
+    capability_ids:
+    - BC-2530
+    process_ids:
+    - BP-90.20
+    - BP-90.70
+    industry_variant: Transportation & Logistics
+    notes: Freight collection
+  - id: VS-390.710
+    stage_order: 8
+    stage_name: Cash Collection & Application
+    capability_ids:
+    - BC-3910
+    process_ids:
+    - BP-90.20
+    - BP-90.70
+    industry_variant: Utilities
+    notes: Utility collections, dunning, and disconnection-for-non-payment
+  - id: VS-390.720
+    stage_order: 9
+    stage_name: Revenue Recognition
+    capability_ids:
+    - BC-200
+    - BC-4250
+    - BC-4940
+    process_ids:
+    - BP-90.20
+    - BP-90.30
+    notes: Revenue posting; Reporting; Subscription revenue recognition under ASC 606 / IFRS 15; Lease revenue recognition under IFRS 16 / ASC 842
+  - id: VS-390.730
+    stage_order: 9
+    stage_name: Revenue Recognition
+    capability_ids:
+    - BC-2150
+    process_ids:
+    - BP-90.20
+    - BP-90.30
+    industry_variant: Insurance
+    notes: Earned-premium recognition
+  - id: VS-390.740
+    stage_order: 9
+    stage_name: Revenue Recognition
+    capability_ids:
+    - BC-3720
+    - BC-3760
+    process_ids:
+    - BP-90.20
+    - BP-90.30
+    industry_variant: Media & Entertainment
+    notes: Licensing revenue recognition; Ad delivery-based revenue recognition
+  - id: VS-390.750
+    stage_order: 9
+    stage_name: Revenue Recognition
+    capability_ids:
+    - BC-4480
+    process_ids:
+    - BP-90.20
+    - BP-90.30
+    industry_variant: Mining & Metals
+    notes: Final settlement after umpire assay and quotational-period pricing
+  - id: VS-390.760
+    stage_order: 9
+    stage_name: Revenue Recognition
+    capability_ids:
+    - BC-2660
+    process_ids:
+    - BP-90.20
+    - BP-90.30
+    industry_variant: Telecommunications
+    notes: Usage-based revenue recognition and revenue assurance
+  - id: VS-390.770
+    stage_order: 9
+    stage_name: Revenue Recognition
+    capability_ids:
+    - BC-2530
+    process_ids:
+    - BP-90.20
+    - BP-90.30
+    industry_variant: Transportation & Logistics
+    notes: Freight revenue recognition
+  - id: VS-390.780
+    stage_order: 9
+    stage_name: Revenue Recognition
+    capability_ids:
+    - BC-3910
+    process_ids:
+    - BP-90.20
+    - BP-90.30
+    industry_variant: Utilities
+    notes: Usage-based and standing-charge revenue recognition
+- id: VS-400
+  name: Plan-to-Inventory
+  industries:
+  - Cross-Industry
+  stages:
+  - id: VS-400.10
+    stage_order: 1
+    stage_name: Demand Planning
+    capability_ids:
+    - BC-400
+    - BC-520
+    process_ids: []
+    notes: Market intelligence input; Statistical forecast + consensus
+  - id: VS-400.20
+    stage_order: 1
+    stage_name: Demand Planning
+    capability_ids:
+    - BC-3440
+    process_ids: []
+    industry_variant: Automotive
+    notes: Wholesale vehicle volume planning
+  - id: VS-400.30
+    stage_order: 1
+    stage_name: Demand Planning
+    capability_ids:
+    - BC-2300
+    process_ids: []
+    industry_variant: Retail & Consumer Goods
+    notes: Cluster assortment & range demand
+  - id: VS-400.40
+    stage_order: 1
+    stage_name: Demand Planning
+    capability_ids:
+    - BC-2610
+    process_ids: []
+    industry_variant: Telecommunications
+    notes: Subscriber growth and traffic demand forecasting
+  - id: VS-400.50
+    stage_order: 2
+    stage_name: Supply Planning
+    capability_ids:
+    - BC-520
+    process_ids: []
+    notes: Capacity / material plan
+  - id: VS-400.60
+    stage_order: 2
+    stage_name: Supply Planning
+    capability_ids:
+    - BC-3500
+    - BC-3510
+    - BC-3520
+    - BC-3580
+    process_ids: []
+    industry_variant: Agriculture
+    notes: Crop production planning; Livestock production planning; Aquaculture production planning; Food and beverage manufacturing planning
+  - id: VS-400.70
+    stage_order: 2
+    stage_name: Supply Planning
+    capability_ids:
+    - BC-3410
+    process_ids: []
+    industry_variant: Automotive
+    notes: Programme volume cadence into supply plan
+  - id: VS-400.80
+    stage_order: 2
+    stage_name: Supply Planning
+    capability_ids:
+    - BC-4620
+    process_ids: []
+    industry_variant: Chemicals
+    notes: Campaign and continuous-mode chemical supply planning
+  - id: VS-400.90
+    stage_order: 2
+    stage_name: Supply Planning
+    capability_ids:
+    - BC-1930
+    process_ids: []
+    industry_variant: Electrical Components & Equipment
+    notes: Semiconductor allocation forecasting
+  - id: VS-400.100
+    stage_order: 2
+    stage_name: Supply Planning
+    capability_ids:
+    - BC-1000
+    process_ids: []
+    industry_variant: Manufacturing
+    notes: Production planning
+  - id: VS-400.110
+    stage_order: 2
+    stage_name: Supply Planning
+    capability_ids:
+    - BC-4420
+    - BC-4430
+    - BC-4440
+    - BC-4450
+    process_ids: []
+    industry_variant: Mining & Metals
+    notes: Short-term mine schedule defining plant feed supply; Mine production execution against schedule; Concentrator throughput and recovery planning; Smelter and refinery throughput planning
+  - id: VS-400.120
+    stage_order: 3
+    stage_name: S&OP Reconciliation
+    capability_ids:
+    - BC-230
+    - BC-520
+    process_ids: []
+    notes: Financial forecast alignment; Executive S&OP cycle
+  - id: VS-400.130
+    stage_order: 4
+    stage_name: Inventory Positioning
+    capability_ids:
+    - BC-530
+    process_ids: []
+    notes: Stock level targets; Allocation across nodes
+  - id: VS-400.140
+    stage_order: 4
+    stage_name: Inventory Positioning
+    capability_ids:
+    - BC-3560
+    process_ids: []
+    industry_variant: Agriculture
+    notes: On-farm storage and processor receival positioning
+  - id: VS-400.150
+    stage_order: 4
+    stage_name: Inventory Positioning
+    capability_ids:
+    - BC-3440
+    process_ids: []
+    industry_variant: Automotive
+    notes: Dealer stock and CPO inventory positioning
+  - id: VS-400.160
+    stage_order: 4
+    stage_name: Inventory Positioning
+    capability_ids:
+    - BC-4680
+    process_ids: []
+    industry_variant: Chemicals
+    notes: Tank-farm and hazmat warehouse positioning
+  - id: VS-400.170
+    stage_order: 4
+    stage_name: Inventory Positioning
+    capability_ids:
+    - BC-2850
+    process_ids: []
+    industry_variant: Healthcare Providers
+    notes: Drug inventory positioning across pharmacies and automated dispensing cabinets
+  - id: VS-400.180
+    stage_order: 4
+    stage_name: Inventory Positioning
+    capability_ids:
+    - BC-4480
+    process_ids: []
+    industry_variant: Mining & Metals
+    notes: Concentrate stockpile and exchange-warrant positioning
+  - id: VS-400.190
+    stage_order: 4
+    stage_name: Inventory Positioning
+    capability_ids:
+    - BC-2300
+    process_ids: []
+    industry_variant: Retail & Consumer Goods
+    notes: Allocation across store clusters
+  - id: VS-400.200
+    stage_order: 4
+    stage_name: Inventory Positioning
+    capability_ids:
+    - BC-2600
+    process_ids: []
+    industry_variant: Telecommunications
+    notes: Logical and physical network inventory
+  - id: VS-400.210
+    stage_order: 4
+    stage_name: Inventory Positioning
+    capability_ids:
+    - BC-2460
+    process_ids: []
+    industry_variant: Transportation & Logistics
+    notes: 3PL inventory positioning across nodes
+  - id: VS-400.220
+    stage_order: 5
+    stage_name: Replenishment Execution
+    capability_ids:
+    - BC-530
+    process_ids: []
+    notes: Auto-replenishment triggers
+  - id: VS-400.230
+    stage_order: 5
+    stage_name: Replenishment Execution
+    capability_ids:
+    - BC-2460
+    process_ids: []
+    industry_variant: Transportation & Logistics
+    notes: 3PL replenishment picking and dispatch
+  - id: VS-400.240
+    stage_order: 6
+    stage_name: Inventory Health Monitoring
+    capability_ids:
+    - BC-520
+    - BC-530
+    process_ids: []
+    notes: Supply chain risk; Accuracy / cycle counting; Slow-moving / obsolete review
+  - id: VS-400.250
+    stage_order: 6
+    stage_name: Inventory Health Monitoring
+    capability_ids:
+    - BC-1930
+    process_ids: []
+    industry_variant: Electrical Components & Equipment
+    notes: Component lifecycle & obsolescence risk
+  - id: VS-400.260
+    stage_order: 6
+    stage_name: Inventory Health Monitoring
+    capability_ids:
+    - BC-4480
+    process_ids: []
+    industry_variant: Mining & Metals
+    notes: Warehouse warrant and finished metal stock health monitoring
+  - id: VS-400.270
+    stage_order: 6
+    stage_name: Inventory Health Monitoring
+    capability_ids:
+    - BC-2600
+    process_ids: []
+    industry_variant: Telecommunications
+    notes: Inventory reconciliation and network discovery
+  - id: VS-400.280
+    stage_order: 6
+    stage_name: Inventory Health Monitoring
+    capability_ids:
+    - BC-2460
+    process_ids: []
+    industry_variant: Transportation & Logistics
+    notes: Cycle counting and accuracy in 3PL warehouses
+- id: VS-410
+  name: Population-Health-to-Outcome
+  industries:
+  - Healthcare Providers
+  stages:
+  - id: VS-410.10
+    stage_order: 1
+    stage_name: Population Identification
+    capability_ids:
+    - BC-2880
+    process_ids: []
+    notes: Attribution, empanelment, and population definition
+  - id: VS-410.20
+    stage_order: 2
+    stage_name: Risk Stratification
+    capability_ids:
+    - BC-2880
+    process_ids: []
+    notes: Predictive risk modelling and rising-risk identification
+  - id: VS-410.30
+    stage_order: 3
+    stage_name: Care Gap Identification
+    capability_ids:
+    - BC-2880
+    process_ids: []
+    notes: HEDIS / quality-measure gap detection across the panel
+  - id: VS-410.40
+    stage_order: 4
+    stage_name: Outreach & Intervention
+    capability_ids:
+    - BC-2880
+    - BC-2820
+    process_ids: []
+    notes: Outreach campaigns, preventive care, and chronic-disease programmes; Care management coordination for high-risk cohorts
+  - id: VS-410.50
+    stage_order: 5
+    stage_name: Care Delivery
+    capability_ids:
+    - BC-2810
+    process_ids: []
+    notes: Clinical care delivery aligned to the intervention plan
+  - id: VS-410.60
+    stage_order: 6
+    stage_name: Outcomes Measurement
+    capability_ids:
+    - BC-2880
+    process_ids: []
+    notes: Outcome tracking, value-based-care reporting, and feedback loop
+- id: VS-420
+  name: Procure-to-Pay
+  industries:
+  - Cross-Industry
+  stages:
+  - id: VS-420.10
+    stage_order: 1
+    stage_name: Need Identification & Requisition
+    capability_ids:
+    - BC-500
+    process_ids:
+    - BP-40.20
+    notes: Requisition intake
+  - id: VS-420.20
+    stage_order: 1
+    stage_name: Need Identification & Requisition
+    capability_ids:
+    - BC-3550
+    process_ids:
+    - BP-40.20
+    industry_variant: Agriculture
+    notes: Seed, fertilizer, crop-protection, and vet-medicine requisition
+  - id: VS-420.30
+    stage_order: 1
+    stage_name: Need Identification & Requisition
+    capability_ids:
+    - BC-4690
+    process_ids:
+    - BP-40.20
+    industry_variant: Chemicals
+    notes: Feedstock and chemical raw material need identification
+  - id: VS-420.40
+    stage_order: 1
+    stage_name: Need Identification & Requisition
+    capability_ids:
+    - BC-2040
+    process_ids:
+    - BP-40.20
+    industry_variant: HVAC & Building Automation Systems
+    notes: Refrigerant requisition by region/quota
+  - id: VS-420.50
+    stage_order: 1
+    stage_name: Need Identification & Requisition
+    capability_ids:
+    - BC-3270
+    process_ids:
+    - BP-40.20
+    industry_variant: Public Sector
+    notes: Acquisition planning; market research; independent government cost estimate
+  - id: VS-420.60
+    stage_order: 2
+    stage_name: Sourcing
+    capability_ids:
+    - BC-500
+    process_ids:
+    - BP-40.20
+    notes: RFx, sourcing events; Category strategy
+  - id: VS-420.70
+    stage_order: 2
+    stage_name: Sourcing
+    capability_ids:
+    - BC-3550
+    process_ids:
+    - BP-40.20
+    industry_variant: Agriculture
+    notes: Sourcing through licensed agri-input channels
+  - id: VS-420.80
+    stage_order: 2
+    stage_name: Sourcing
+    capability_ids:
+    - BC-4690
+    process_ids:
+    - BP-40.20
+    industry_variant: Chemicals
+    notes: Feedstock, aromatic, and bio-feedstock sourcing
+  - id: VS-420.90
+    stage_order: 2
+    stage_name: Sourcing
+    capability_ids:
+    - BC-2040
+    process_ids:
+    - BP-40.20
+    industry_variant: HVAC & Building Automation Systems
+    notes: Refrigerant sourcing & quota management
+  - id: VS-420.100
+    stage_order: 2
+    stage_name: Sourcing
+    capability_ids:
+    - BC-3720
+    process_ids:
+    - BP-40.20
+    industry_variant: Media & Entertainment
+    notes: Rights and content sourcing
+  - id: VS-420.110
+    stage_order: 2
+    stage_name: Sourcing
+    capability_ids:
+    - BC-3270
+    process_ids:
+    - BP-40.20
+    industry_variant: Public Sector
+    notes: Solicitation drafting and publication under FAR / EU procurement directives
+  - id: VS-420.120
+    stage_order: 3
+    stage_name: Supplier Selection & Onboarding
+    capability_ids:
+    - BC-510
+    process_ids:
+    - BP-40.20
+    notes: Qualification; Pre-award risk check
+  - id: VS-420.130
+    stage_order: 3
+    stage_name: Supplier Selection & Onboarding
+    capability_ids:
+    - BC-3550
+    process_ids:
+    - BP-40.20
+    industry_variant: Agriculture
+    notes: Agri-input supplier qualification with stewardship checks
+  - id: VS-420.140
+    stage_order: 3
+    stage_name: Supplier Selection & Onboarding
+    capability_ids:
+    - BC-4670
+    process_ids:
+    - BP-40.20
+    industry_variant: Chemicals
+    notes: Chemical raw material and toller supplier qualification
+  - id: VS-420.150
+    stage_order: 3
+    stage_name: Supplier Selection & Onboarding
+    capability_ids:
+    - BC-1810
+    process_ids:
+    - BP-40.20
+    industry_variant: Defense
+    notes: Cleared subcontractors
+  - id: VS-420.160
+    stage_order: 3
+    stage_name: Supplier Selection & Onboarding
+    capability_ids:
+    - BC-1930
+    process_ids:
+    - BP-40.20
+    industry_variant: Electrical Components & Equipment
+    notes: Distributor & broker onboarding; component qualification
+  - id: VS-420.170
+    stage_order: 3
+    stage_name: Supplier Selection & Onboarding
+    capability_ids:
+    - BC-1560
+    process_ids:
+    - BP-40.20
+    industry_variant: Pharma
+    notes: GxP supplier qualification
+  - id: VS-420.180
+    stage_order: 3
+    stage_name: Supplier Selection & Onboarding
+    capability_ids:
+    - BC-3270
+    process_ids:
+    - BP-40.20
+    industry_variant: Public Sector
+    notes: Source selection, responsibility determination, set-aside compliance
+  - id: VS-420.190
+    stage_order: 4
+    stage_name: Contract & Purchase Order
+    capability_ids:
+    - BC-500
+    process_ids:
+    - BP-40.20
+    notes: Contracting; PO issuance
+  - id: VS-420.200
+    stage_order: 4
+    stage_name: Contract & Purchase Order
+    capability_ids:
+    - BC-1790
+    process_ids:
+    - BP-40.20
+    industry_variant: Defense
+    notes: ITAR/EAR screening
+  - id: VS-420.210
+    stage_order: 4
+    stage_name: Contract & Purchase Order
+    capability_ids:
+    - BC-3720
+    process_ids:
+    - BP-40.20
+    industry_variant: Media & Entertainment
+    notes: Rights acquisition contracting
+  - id: VS-420.220
+    stage_order: 4
+    stage_name: Contract & Purchase Order
+    capability_ids:
+    - BC-3270
+    process_ids:
+    - BP-40.20
+    industry_variant: Public Sector
+    notes: Award, debriefing, contract formation, obligation of funds
+  - id: VS-420.230
+    stage_order: 5
+    stage_name: Goods/Services Receipt
+    capability_ids:
+    - BC-500
+    - BC-4940
+    process_ids:
+    - BP-40.20
+    notes: GR/SR; Property vendor service receipt and verification
+  - id: VS-420.240
+    stage_order: 5
+    stage_name: Goods/Services Receipt
+    capability_ids:
+    - BC-3550
+    process_ids:
+    - BP-40.20
+    industry_variant: Agriculture
+    notes: Input receival with batch and stewardship recording
+  - id: VS-420.250
+    stage_order: 5
+    stage_name: Goods/Services Receipt
+    capability_ids:
+    - BC-1010
+    process_ids:
+    - BP-40.20
+    industry_variant: Manufacturing
+  - id: VS-420.260
+    stage_order: 5
+    stage_name: Goods/Services Receipt
+    capability_ids:
+    - BC-3270
+    process_ids:
+    - BP-40.20
+    industry_variant: Public Sector
+    notes: Deliverable acceptance and contract administration
+  - id: VS-420.270
+    stage_order: 6
+    stage_name: Invoice Receipt & Verification
+    capability_ids:
+    - BC-200
+    process_ids:
+    - BP-90.60
+    notes: 3-way match
+  - id: VS-420.280
+    stage_order: 6
+    stage_name: Invoice Receipt & Verification
+    capability_ids:
+    - BC-3720
+    process_ids:
+    - BP-90.60
+    industry_variant: Media & Entertainment
+    notes: Inbound royalty statement reconciliation
+  - id: VS-420.290
+    stage_order: 7
+    stage_name: Payment Execution
+    capability_ids:
+    - BC-200
+    - BC-210
+    - BC-4940
+    process_ids:
+    - BP-90.60
+    - BP-90.70
+    notes: Payment run; Payment funding; Property vendor payment execution
+  - id: VS-420.300
+    stage_order: 8
+    stage_name: Reconciliation
+    capability_ids:
+    - BC-200
+    process_ids:
+    - BP-90.30
+    - BP-90.60
+    notes: GL posting; Vendor account
+  - id: VS-420.310
+    stage_order: 9
+    stage_name: Supplier Performance Monitoring
+    capability_ids:
+    - BC-510
+    process_ids:
+    - BP-40.20
+    notes: Post-transaction loop; Strategic suppliers
+  - id: VS-420.320
+    stage_order: 9
+    stage_name: Supplier Performance Monitoring
+    capability_ids:
+    - BC-1930
+    process_ids:
+    - BP-40.20
+    industry_variant: Electrical Components & Equipment
+    notes: Distributor performance, PCN/EOL handling
+  - id: VS-420.330
+    stage_order: 9
+    stage_name: Supplier Performance Monitoring
+    capability_ids:
+    - BC-3270
+    process_ids:
+    - BP-40.20
+    industry_variant: Public Sector
+    notes: Past performance recording; suspension and debarment
+- id: VS-430
+  name: Proposal-to-Impact
+  industries:
+  - Education
+  stages:
+  - id: VS-430.10
+    stage_order: 1
+    stage_name: Opportunity Identification
+    capability_ids:
+    - BC-4780
+    process_ids: []
+    notes: Grant and funding opportunity scanning and identification
+  - id: VS-430.20
+    stage_order: 2
+    stage_name: Proposal Development
+    capability_ids:
+    - BC-4780
+    process_ids: []
+    notes: Pre-award proposal authoring, costing, and submission
+  - id: VS-430.30
+    stage_order: 3
+    stage_name: Award & Setup
+    capability_ids:
+    - BC-4780
+    process_ids: []
+    notes: Post-award setup, account creation, and compliance onboarding
+  - id: VS-430.40
+    stage_order: 4
+    stage_name: Ethics & Integrity Oversight
+    capability_ids:
+    - BC-4780
+    process_ids: []
+    notes: Independent ethics review and integrity oversight during conduct
+  - id: VS-430.50
+    stage_order: 4
+    stage_name: Research Conduct
+    capability_ids:
+    - BC-4780
+    process_ids: []
+    notes: Research execution against the funded plan
+  - id: VS-430.60
+    stage_order: 5
+    stage_name: Output & Dissemination
+    capability_ids:
+    - BC-4780
+    process_ids: []
+    notes: Publication, open-access, and persistent identifier management
+  - id: VS-430.70
+    stage_order: 6
+    stage_name: Impact Assessment
+    capability_ids:
+    - BC-4780
+    process_ids: []
+    notes: Bibliometric, altmetric, and case-study impact assessment
+- id: VS-440
+  name: Prospect-to-Customer
+  industries:
+  - Cross-Industry
+  stages:
+  - id: VS-440.10
+    stage_order: 1
+    stage_name: Market & Segment Strategy
+    capability_ids:
+    - BC-400
+    - BC-420
+    process_ids: []
+    notes: Marketing strategy; Customer segmentation
+  - id: VS-440.20
+    stage_order: 2
+    stage_name: Brand & Positioning
+    capability_ids:
+    - BC-400
+    - BC-850
+    process_ids: []
+    notes: Brand management; Corporate communications
+  - id: VS-440.30
+    stage_order: 3
+    stage_name: Demand Generation
+    capability_ids:
+    - BC-400
+    - BC-4950
+    - BC-4960
+    process_ids: []
+    notes: Campaigns, content syndication; Digital marketing; Content marketing; Vacancy listing and marketing for landlord-side leasing; Listing marketing across MLS, portals, and syndication
+  - id: VS-440.40
+    stage_order: 3
+    stage_name: Demand Generation
+    capability_ids:
+    - BC-4710
+    process_ids: []
+    industry_variant: Education
+    notes: Student recruitment campaigns and outreach
+  - id: VS-440.50
+    stage_order: 3
+    stage_name: Demand Generation
+    capability_ids:
+    - BC-2360
+    process_ids: []
+    industry_variant: Retail & Consumer Goods
+    notes: Trade-event-driven sell-through
+  - id: VS-440.60
+    stage_order: 4
+    stage_name: Lead Capture & Nurture
+    capability_ids:
+    - BC-400
+    - BC-410
+    - BC-4950
+    - BC-4960
+    process_ids: []
+    notes: Marketing operations / MarOps; Pipeline handoff; Tenant prospect inquiry capture and qualification; Buyer and tenant engagement on representation mandates
+  - id: VS-440.70
+    stage_order: 4
+    stage_name: Lead Capture & Nurture
+    capability_ids:
+    - BC-4710
+    process_ids: []
+    industry_variant: Education
+    notes: Prospect lead management for education applicants
+  - id: VS-440.80
+    stage_order: 4
+    stage_name: Lead Capture & Nurture
+    capability_ids:
+    - BC-2110
+    process_ids: []
+    industry_variant: Insurance
+    notes: Quote / submission intake via producers
+  - id: VS-440.90
+    stage_order: 4
+    stage_name: Lead Capture & Nurture
+    capability_ids:
+    - BC-3750
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Free-trial and prospect viewer capture
+  - id: VS-440.100
+    stage_order: 5
+    stage_name: Conversion
+    capability_ids:
+    - BC-410
+    - BC-4950
+    - BC-4960
+    process_ids: []
+    notes: Quote / CPQ; Tenant application screening and lease execution; Offer, negotiation, and brokered closing
+  - id: VS-440.110
+    stage_order: 5
+    stage_name: Conversion
+    capability_ids:
+    - BC-1300
+    process_ids: []
+    industry_variant: Banking
+    notes: Customer onboarding
+  - id: VS-440.120
+    stage_order: 5
+    stage_name: Conversion
+    capability_ids:
+    - BC-4710
+    process_ids: []
+    industry_variant: Education
+    notes: Admissions decisioning and offer acceptance
+  - id: VS-440.130
+    stage_order: 5
+    stage_name: Conversion
+    capability_ids:
+    - BC-2120
+    process_ids: []
+    industry_variant: Insurance
+    notes: Policyholder conversion
+  - id: VS-440.140
+    stage_order: 5
+    stage_name: Conversion
+    capability_ids:
+    - BC-3750
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Subscription conversion
+  - id: VS-440.150
+    stage_order: 5
+    stage_name: Conversion
+    capability_ids:
+    - BC-2640
+    process_ids: []
+    industry_variant: Telecommunications
+    notes: Subscriber identity creation and SIM/eSIM activation
+  - id: VS-440.160
+    stage_order: 6
+    stage_name: Customer Onboarding
+    capability_ids:
+    - BC-420
+    - BC-4260
+    process_ids: []
+    notes: Customer lifecycle activation; Customer onboarding and activation
+  - id: VS-440.170
+    stage_order: 6
+    stage_name: Customer Onboarding
+    capability_ids:
+    - BC-1300
+    process_ids: []
+    industry_variant: Banking
+    notes: KYC & due diligence
+  - id: VS-440.180
+    stage_order: 6
+    stage_name: Customer Onboarding
+    capability_ids:
+    - BC-4710
+    process_ids: []
+    industry_variant: Education
+    notes: Pre-enrolment onboarding of admitted students
+  - id: VS-440.190
+    stage_order: 6
+    stage_name: Customer Onboarding
+    capability_ids:
+    - BC-2120
+    process_ids: []
+    industry_variant: Insurance
+    notes: Policyholder onboarding & KYC
+  - id: VS-440.200
+    stage_order: 6
+    stage_name: Customer Onboarding
+    capability_ids:
+    - BC-3750
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Viewer activation and onboarding journeys
+  - id: VS-440.210
+    stage_order: 6
+    stage_name: Customer Onboarding
+    capability_ids:
+    - BC-2640
+    process_ids: []
+    industry_variant: Telecommunications
+    notes: Subscriber enrolment, AAA, and device binding
+  - id: VS-440.220
+    stage_order: 6
+    stage_name: Customer Onboarding
+    capability_ids:
+    - BC-4040
+    - BC-4050
+    process_ids: []
+    industry_variant: Travel & Hospitality
+    notes: Guest profile creation, preference capture, and consent at first interaction; Loyalty enrolment and welcome programme activation
+  - id: VS-440.230
+    stage_order: 7
+    stage_name: Retention & Advocacy
+    capability_ids:
+    - BC-420
+    - BC-430
+    - BC-4260
+    - BC-4950
+    process_ids: []
+    notes: Loyalty & retention; Customer feedback loop; Retention, NPS, references, and expansion advocacy; Renewal pipeline and retention programmes
+  - id: VS-440.240
+    stage_order: 7
+    stage_name: Retention & Advocacy
+    capability_ids:
+    - BC-4800
+    process_ids: []
+    industry_variant: Education
+    notes: Alumni engagement and giving programmes
+  - id: VS-440.250
+    stage_order: 7
+    stage_name: Retention & Advocacy
+    capability_ids:
+    - BC-2120
+    process_ids: []
+    industry_variant: Insurance
+    notes: Policyholder retention
+  - id: VS-440.260
+    stage_order: 7
+    stage_name: Retention & Advocacy
+    capability_ids:
+    - BC-3750
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Engagement and win-back programmes
+  - id: VS-440.270
+    stage_order: 7
+    stage_name: Retention & Advocacy
+    capability_ids:
+    - BC-2630
+    process_ids: []
+    industry_variant: Telecommunications
+    notes: Customer experience following service events
+- id: VS-450
+  name: Quote-to-Bind
+  industries:
+  - Insurance
+  stages:
+  - id: VS-450.10
+    stage_order: 1
+    stage_name: Submission Intake
+    capability_ids:
+    - BC-2110
+    - BC-2130
+    process_ids: []
+    notes: Producer / broker submission capture and routing; Submission triage and risk data collection
+  - id: VS-450.20
+    stage_order: 2
+    stage_name: Risk Evaluation & Pricing
+    capability_ids:
+    - BC-2130
+    - BC-2180
+    process_ids: []
+    notes: Risk evaluation, exposure rating, and underwriting authority enforcement; Pricing model application and rate adequacy support
+  - id: VS-450.30
+    stage_order: 3
+    stage_name: Quote Production
+    capability_ids:
+    - BC-2130
+    process_ids: []
+    notes: Quote generation, indication letters, and broker negotiation support
+  - id: VS-450.40
+    stage_order: 4
+    stage_name: Reinsurance Check
+    capability_ids:
+    - BC-2170
+    process_ids: []
+    notes: Facultative reinsurance enquiry and treaty capacity check
+  - id: VS-450.50
+    stage_order: 5
+    stage_name: Underwriting Decision
+    capability_ids:
+    - BC-2130
+    process_ids: []
+    notes: Acceptance, declination, or referral with conditions
+  - id: VS-450.60
+    stage_order: 6
+    stage_name: Bind
+    capability_ids:
+    - BC-2130
+    - BC-2110
+    process_ids: []
+    notes: Binding of agreed terms and conditions; Broker / producer bind confirmation and commission setup
+  - id: VS-450.70
+    stage_order: 7
+    stage_name: Policy Issuance
+    capability_ids:
+    - BC-2140
+    - BC-2150
+    process_ids: []
+    notes: Policy document generation, schedule assembly, and activation; Initial premium booking and instalment schedule setup
+  - id: VS-450.80
+    stage_order: 8
+    stage_name: Reinsurance Cession Setup
+    capability_ids:
+    - BC-2170
+    process_ids: []
+    notes: Cession to treaty programme and bordereau preparation
+- id: VS-460
+  name: Record-to-Report
+  industries:
+  - Cross-Industry
+  stages:
+  - id: VS-460.10
+    stage_order: 1
+    stage_name: Transaction Capture
+    capability_ids:
+    - BC-200
+    - BC-4940
+    process_ids:
+    - BP-90.10
+    - BP-90.30
+    notes: GL posting from sub-ledgers; Cost accounting allocations; Property-level GL transaction capture
+  - id: VS-460.20
+    stage_order: 1
+    stage_name: Transaction Capture
+    capability_ids:
+    - BC-3280
+    process_ids:
+    - BP-90.10
+    - BP-90.30
+    industry_variant: Public Sector
+    notes: Appropriations execution; commitment, obligation, and outlay posting
+  - id: VS-460.30
+    stage_order: 1
+    stage_name: Transaction Capture
+    capability_ids:
+    - BC-2660
+    process_ids:
+    - BP-90.10
+    - BP-90.30
+    industry_variant: Telecommunications
+    notes: Telecom billing and usage transactions feeding GL
+  - id: VS-460.40
+    stage_order: 1
+    stage_name: Transaction Capture
+    capability_ids:
+    - BC-3910
+    process_ids:
+    - BP-90.10
+    - BP-90.30
+    industry_variant: Utilities
+    notes: Meter-to-cash usage transactions feeding the GL
+  - id: VS-460.50
+    stage_order: 2
+    stage_name: Sub-Ledger Close
+    capability_ids:
+    - BC-200
+    process_ids:
+    - BP-90.20
+    - BP-90.30
+    - BP-90.40
+    - BP-90.60
+    notes: AP cut-off; AR cut-off; Fixed asset depreciation run
+  - id: VS-460.60
+    stage_order: 2
+    stage_name: Sub-Ledger Close
+    capability_ids:
+    - BC-2150
+    process_ids:
+    - BP-90.20
+    - BP-90.30
+    - BP-90.40
+    - BP-90.60
+    industry_variant: Insurance
+    notes: Premium earnings & DAC close
+  - id: VS-460.70
+    stage_order: 2
+    stage_name: Sub-Ledger Close
+    capability_ids:
+    - BC-3280
+    process_ids:
+    - BP-90.20
+    - BP-90.30
+    - BP-90.40
+    - BP-90.60
+    industry_variant: Public Sector
+    notes: Government fund accounting close
+  - id: VS-460.80
+    stage_order: 3
+    stage_name: Reconciliation & Adjustments
+    capability_ids:
+    - BC-200
+    - BC-210
+    process_ids:
+    - BP-90.30
+    notes: Account reconciliations; Bank reconciliation
+  - id: VS-460.90
+    stage_order: 4
+    stage_name: Consolidation
+    capability_ids:
+    - BC-200
+    - BC-220
+    - BC-4910
+    process_ids:
+    - BP-90.30
+    - BP-90.100
+    notes: Group consolidation; Transfer pricing adjustments; Fund NAV consolidation across vehicles
+  - id: VS-460.100
+    stage_order: 4
+    stage_name: Consolidation
+    capability_ids:
+    - BC-3280
+    process_ids:
+    - BP-90.30
+    - BP-90.100
+    industry_variant: Public Sector
+    notes: Whole-of-government consolidation
+  - id: VS-460.110
+    stage_order: 5
+    stage_name: Management Reporting
+    capability_ids:
+    - BC-230
+    - BC-4910
+    - BC-4940
+    process_ids:
+    - BP-90.10
+    - BP-90.30
+    notes: Internal management pack; Variance / performance analysis; LP and investor reporting; Owner reporting pack
+  - id: VS-460.120
+    stage_order: 5
+    stage_name: Management Reporting
+    capability_ids:
+    - BC-4250
+    process_ids:
+    - BP-90.10
+    - BP-90.30
+    industry_variant: Software & Technology
+    notes: ARR, MRR, NRR, GRR, and cohort recurring-revenue reporting
+  - id: VS-460.130
+    stage_order: 6
+    stage_name: Statutory & Regulatory Reporting
+    capability_ids:
+    - BC-200
+    - BC-220
+    - BC-240
+    - BC-4910
+    - BC-4980
+    process_ids:
+    - BP-90.30
+    - BP-90.90
+    notes: Statutory filings; Tax filings; Investor relations disclosures; INREV, NCREIF, and EPRA index submission; CREFC IRP investor reporting on CMBS pools
+  - id: VS-460.140
+    stage_order: 6
+    stage_name: Statutory & Regulatory Reporting
+    capability_ids:
+    - BC-4810
+    process_ids:
+    - BP-90.30
+    - BP-90.90
+    industry_variant: Education
+    notes: IPEDS, HESA, and equivalent statutory education returns
+  - id: VS-460.150
+    stage_order: 6
+    stage_name: Statutory & Regulatory Reporting
+    capability_ids:
+    - BC-2180
+    process_ids:
+    - BP-90.30
+    - BP-90.90
+    industry_variant: Insurance
+    notes: IFRS 17 & Solvency II reporting
+  - id: VS-460.160
+    stage_order: 6
+    stage_name: Statutory & Regulatory Reporting
+    capability_ids:
+    - BC-3280
+    process_ids:
+    - BP-90.30
+    - BP-90.90
+    industry_variant: Public Sector
+    notes: IPSAS financial statements; GFSM and COFOG statistical reporting
+  - id: VS-460.170
+    stage_order: 6
+    stage_name: Statutory & Regulatory Reporting
+    capability_ids:
+    - BC-3920
+    process_ids:
+    - BP-90.30
+    - BP-90.90
+    industry_variant: Utilities
+    notes: Utility regulatory accounts and price-control performance reporting
+  - id: VS-460.180
+    stage_order: 7
+    stage_name: Audit & Sign-Off
+    capability_ids:
+    - BC-130
+    - BC-140
+    process_ids:
+    - BP-90.80
+    notes: Regulatory compliance sign-off; Internal audit review
+- id: VS-470
+  name: Refrigerant-to-Reclaim
+  industries:
+  - HVAC & Building Automation Systems
+  stages:
+  - id: VS-470.10
+    stage_order: 1
+    stage_name: Procurement & Inventory
+    capability_ids:
+    - BC-2040
+    process_ids: []
+    notes: Refrigerant sourcing, allocation, and storage
+  - id: VS-470.20
+    stage_order: 2
+    stage_name: Charge & Install
+    capability_ids:
+    - BC-2040
+    - BC-2060
+    process_ids: []
+    notes: Asset-level charge accounting on installed equipment; Field charging activity during install and service visits
+  - id: VS-470.30
+    stage_order: 3
+    stage_name: Leak Detection & Repair
+    capability_ids:
+    - BC-2040
+    process_ids: []
+    notes: Leak rate tracking, repair triggers, and rate reporting
+  - id: VS-470.40
+    stage_order: 4
+    stage_name: Recovery & Reclaim
+    capability_ids:
+    - BC-2040
+    process_ids: []
+    notes: Field recovery, reclamation, and recycled-refrigerant quality control
+  - id: VS-470.50
+    stage_order: 5
+    stage_name: Regulatory Reporting
+    capability_ids:
+    - BC-2040
+    process_ids: []
+    notes: F-Gas, EPA Section 608, and Kigali Amendment reporting
+  - id: VS-470.60
+    stage_order: 6
+    stage_name: Phase-Out & Substitution
+    capability_ids:
+    - BC-2040
+    process_ids: []
+    notes: Refrigerant transition planning and low-GWP substitution roadmap
+  - id: VS-470.70
+    stage_order: 7
+    stage_name: End-of-Life Disposition
+    capability_ids:
+    - BC-2040
+    process_ids: []
+    notes: Certified destruction, disposal, and chain-of-custody evidence
+- id: VS-480
+  name: Registration-to-Certification
+  industries:
+  - Public Sector & Government
+  stages:
+  - id: VS-480.10
+    stage_order: 1
+    stage_name: Voter Registration
+    capability_ids:
+    - BC-3330
+    process_ids: []
+    notes: Voter enrolment, list maintenance, and eligibility verification
+  - id: VS-480.20
+    stage_order: 2
+    stage_name: Boundary & Polling Place Setup
+    capability_ids:
+    - BC-3330
+    process_ids: []
+    notes: Electoral district maintenance and polling-place designation
+  - id: VS-480.30
+    stage_order: 3
+    stage_name: Candidate Nomination
+    capability_ids:
+    - BC-3330
+    process_ids: []
+    notes: Party registration, candidate filing, and ballot access determination
+  - id: VS-480.40
+    stage_order: 4
+    stage_name: Ballot Production
+    capability_ids:
+    - BC-3330
+    process_ids: []
+    notes: Ballot design, translation, accessibility, and secure distribution
+  - id: VS-480.50
+    stage_order: 5
+    stage_name: Polling
+    capability_ids:
+    - BC-3330
+    process_ids: []
+    notes: Poll-worker management, voter check-in, and absentee voting
+  - id: VS-480.60
+    stage_order: 6
+    stage_name: Counting & Tabulation
+    capability_ids:
+    - BC-3330
+    process_ids: []
+    notes: Ballot counting, results aggregation, and post-election audit
+  - id: VS-480.70
+    stage_order: 7
+    stage_name: Certification
+    capability_ids:
+    - BC-3330
+    process_ids: []
+    notes: Statutory certification of election results
+  - id: VS-480.80
+    stage_order: 8
+    stage_name: Campaign Finance Disclosure
+    capability_ids:
+    - BC-3330
+    process_ids: []
+    notes: Political-committee registration, donation reporting, and enforcement
+- id: VS-490
+  name: Return-to-Collection
+  industries:
+  - Public Sector & Government
+  stages:
+  - id: VS-490.10
+    stage_order: 1
+    stage_name: Taxpayer Registration
+    capability_ids:
+    - BC-3250
+    process_ids: []
+    notes: Registration and TIN issuance; taxpayer master data
+  - id: VS-490.20
+    stage_order: 2
+    stage_name: Return Lodgement
+    capability_ids:
+    - BC-3250
+    process_ids: []
+    notes: Receipt and validation of tax returns
+  - id: VS-490.30
+    stage_order: 3
+    stage_name: Assessment
+    capability_ids:
+    - BC-3250
+    process_ids: []
+    notes: Self-assessment processing and default assessments
+  - id: VS-490.40
+    stage_order: 4
+    stage_name: Payment Collection
+    capability_ids:
+    - BC-3250
+    process_ids: []
+    notes: Payment channel operations, withholding, instalment plans
+  - id: VS-490.50
+    stage_order: 5
+    stage_name: Refund & Credit
+    capability_ids:
+    - BC-3250
+    process_ids: []
+    notes: Refund validation, issuance, and fraud screening
+  - id: VS-490.60
+    stage_order: 6
+    stage_name: Audit & Examination
+    capability_ids:
+    - BC-3250
+    process_ids: []
+    notes: Risk-based audit, fieldwork, and reassessment issuance
+  - id: VS-490.70
+    stage_order: 7
+    stage_name: Debt Enforcement
+    capability_ids:
+    - BC-3250
+    process_ids: []
+    notes: Tax debt portfolio management, statutory enforcement, prosecution referral
+- id: VS-500
+  name: Risk-to-Mitigation
+  industries:
+  - Cross-Industry
+  stages:
+  - id: VS-500.10
+    stage_order: 1
+    stage_name: Risk Appetite & Framework
+    capability_ids:
+    - BC-120
+    process_ids: []
+    notes: Appetite statements
+  - id: VS-500.20
+    stage_order: 1
+    stage_name: Risk Appetite & Framework
+    capability_ids:
+    - BC-4350
+    process_ids: []
+    industry_variant: Professional Services
+    notes: Independence policy and conflicts framework
+  - id: VS-500.30
+    stage_order: 2
+    stage_name: Risk Identification
+    capability_ids:
+    - BC-120
+    - BC-520
+    process_ids: []
+    notes: Top-down + bottom-up scan; Supply chain risk feed
+  - id: VS-500.40
+    stage_order: 2
+    stage_name: Risk Identification
+    capability_ids:
+    - BC-3590
+    process_ids: []
+    industry_variant: Agriculture
+    notes: Agri-food compliance risk taxonomy (zoonosis, MRL, welfare)
+  - id: VS-500.50
+    stage_order: 2
+    stage_name: Risk Identification
+    capability_ids:
+    - BC-1410
+    process_ids: []
+    industry_variant: Banking
+    notes: Banking risk taxonomy
+  - id: VS-500.60
+    stage_order: 2
+    stage_name: Risk Identification
+    capability_ids:
+    - BC-2840
+    process_ids: []
+    industry_variant: Healthcare Providers
+    notes: Clinical risk taxonomy
+  - id: VS-500.70
+    stage_order: 2
+    stage_name: Risk Identification
+    capability_ids:
+    - BC-2190
+    process_ids: []
+    industry_variant: Insurance
+    notes: Insurance risk taxonomy
+  - id: VS-500.80
+    stage_order: 2
+    stage_name: Risk Identification
+    capability_ids:
+    - BC-3780
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Content risk identification across editorial, legal, and reputational
+  - id: VS-500.90
+    stage_order: 2
+    stage_name: Risk Identification
+    capability_ids:
+    - BC-4460
+    - BC-4500
+    process_ids: []
+    industry_variant: Mining & Metals
+    notes: Tailings and dam-safety risk identification under GISTM; Human-rights and social risk identification
+  - id: VS-500.100
+    stage_order: 2
+    stage_name: Risk Identification
+    capability_ids:
+    - BC-4350
+    process_ids: []
+    industry_variant: Professional Services
+    notes: Conflict and independence threat identification
+  - id: VS-500.110
+    stage_order: 2
+    stage_name: Risk Identification
+    capability_ids:
+    - BC-2700
+    process_ids: []
+    industry_variant: Telecommunications
+    notes: Telecom regulatory and licence-conditions risk taxonomy
+  - id: VS-500.120
+    stage_order: 2
+    stage_name: Risk Identification
+    capability_ids:
+    - BC-3850
+    process_ids: []
+    industry_variant: Utilities
+    notes: Energy market, credit, and operational risk taxonomy for trading
+  - id: VS-500.130
+    stage_order: 3
+    stage_name: Risk Assessment
+    capability_ids:
+    - BC-120
+    - BC-4920
+    process_ids: []
+    notes: Likelihood / impact scoring; Asset physical, climate, market, and tenant credit risk assessment
+  - id: VS-500.140
+    stage_order: 3
+    stage_name: Risk Assessment
+    capability_ids:
+    - BC-3590
+    process_ids: []
+    industry_variant: Agriculture
+    notes: Compliance and food-safety risk assessment
+  - id: VS-500.150
+    stage_order: 3
+    stage_name: Risk Assessment
+    capability_ids:
+    - BC-1280
+    process_ids: []
+    industry_variant: ATC
+    notes: Aviation safety risk assessment
+  - id: VS-500.160
+    stage_order: 3
+    stage_name: Risk Assessment
+    capability_ids:
+    - BC-1970
+    process_ids: []
+    industry_variant: Electrical Components & Equipment
+    notes: Functional-safety risk assessment for products
+  - id: VS-500.170
+    stage_order: 3
+    stage_name: Risk Assessment
+    capability_ids:
+    - BC-2840
+    process_ids: []
+    industry_variant: Healthcare Providers
+    notes: Clinical and patient-safety risk assessment
+  - id: VS-500.180
+    stage_order: 3
+    stage_name: Risk Assessment
+    capability_ids:
+    - BC-2180
+    process_ids: []
+    industry_variant: Insurance
+    notes: Capital & solvency modelling
+  - id: VS-500.190
+    stage_order: 3
+    stage_name: Risk Assessment
+    capability_ids:
+    - BC-3850
+    process_ids: []
+    industry_variant: Utilities
+    notes: VaR, earnings-at-risk, and stress-test analysis
+  - id: VS-500.200
+    stage_order: 4
+    stage_name: Treatment & Control Design
+    capability_ids:
+    - BC-120
+    - BC-4990
+    process_ids: []
+    notes: Controls & mitigations; Insurance transfer; Real-estate compliance controls including fair housing, AML, RESPA, and MEES
+  - id: VS-500.210
+    stage_order: 4
+    stage_name: Treatment & Control Design
+    capability_ids:
+    - BC-2840
+    process_ids: []
+    industry_variant: Healthcare Providers
+    notes: Clinical risk mitigation planning
+  - id: VS-500.220
+    stage_order: 4
+    stage_name: Treatment & Control Design
+    capability_ids:
+    - BC-2170
+    process_ids: []
+    industry_variant: Insurance
+    notes: Reinsurance as risk transfer
+  - id: VS-500.230
+    stage_order: 4
+    stage_name: Treatment & Control Design
+    capability_ids:
+    - BC-3780
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Editorial guidelines and pre-transmission compliance review controls
+  - id: VS-500.240
+    stage_order: 4
+    stage_name: Treatment & Control Design
+    capability_ids:
+    - BC-4350
+    process_ids: []
+    industry_variant: Professional Services
+    notes: Information-barrier design and prohibited-service controls
+  - id: VS-500.250
+    stage_order: 5
+    stage_name: Monitoring
+    capability_ids:
+    - BC-120
+    - BC-4980
+    process_ids: []
+    notes: KRIs / dashboards; CRE loan portfolio LTV / DSCR concentration and stress-test monitoring
+  - id: VS-500.260
+    stage_order: 5
+    stage_name: Monitoring
+    capability_ids:
+    - BC-1320
+    process_ids: []
+    industry_variant: Banking
+    notes: Credit risk modelling
+  - id: VS-500.270
+    stage_order: 5
+    stage_name: Monitoring
+    capability_ids:
+    - BC-2190
+    process_ids: []
+    industry_variant: Insurance
+    notes: ORSA monitoring
+  - id: VS-500.280
+    stage_order: 5
+    stage_name: Monitoring
+    capability_ids:
+    - BC-3780
+    process_ids: []
+    industry_variant: Media & Entertainment
+    notes: Ongoing content compliance monitoring
+  - id: VS-500.290
+    stage_order: 5
+    stage_name: Monitoring
+    capability_ids:
+    - BC-4480
+    process_ids: []
+    industry_variant: Mining & Metals
+    notes: Trading book price and counterparty risk monitoring
+  - id: VS-500.300
+    stage_order: 5
+    stage_name: Monitoring
+    capability_ids:
+    - BC-3850
+    process_ids: []
+    industry_variant: Utilities
+    notes: Position, exposure, and limit-utilisation monitoring
+  - id: VS-500.310
+    stage_order: 6
+    stage_name: Reporting & Escalation
+    capability_ids:
+    - BC-120
+    - BC-130
+    process_ids: []
+    notes: Risk reporting to board; Regulatory disclosure where required
+  - id: VS-500.320
+    stage_order: 6
+    stage_name: Reporting & Escalation
+    capability_ids:
+    - BC-2700
+    process_ids: []
+    industry_variant: Telecommunications
+    notes: Telecom regulator filings and licence-conditions reporting
+- id: VS-510
+  name: Settle-Inter-Operator
+  industries:
+  - Telecommunications
+  stages:
+  - id: VS-510.10
+    stage_order: 1
+    stage_name: Wholesale Agreement
+    capability_ids:
+    - BC-2680
+    process_ids: []
+    notes: Wholesale, interconnect, and roaming agreement negotiation
+  - id: VS-510.20
+    stage_order: 2
+    stage_name: Usage Capture
+    capability_ids:
+    - BC-2680
+    - BC-2600
+    process_ids: []
+    notes: TAP/RAP file exchange and inter-operator usage record collection; Network-side CDR generation and mediation feed
+  - id: VS-510.30
+    stage_order: 3
+    stage_name: Rating & Charging
+    capability_ids:
+    - BC-2680
+    process_ids: []
+    notes: Wholesale rating against contracted tariffs and discount schemes
+  - id: VS-510.40
+    stage_order: 4
+    stage_name: Inter-Operator Settlement
+    capability_ids:
+    - BC-2680
+    - BC-2660
+    process_ids: []
+    notes: Net settlement, invoicing, and clearing-house exchange; Wholesale revenue assurance and accounting integration
+  - id: VS-510.50
+    stage_order: 5
+    stage_name: Dispute & Reconciliation
+    capability_ids:
+    - BC-2680
+    process_ids: []
+    notes: Discrepancy investigation, dispute resolution, and adjustment posting
+- id: VS-520
+  name: Shop-to-Stay
+  industries:
+  - Travel & Hospitality
+  stages:
+  - id: VS-520.10
+    stage_order: 1
+    stage_name: Inspire & Discover
+    capability_ids:
+    - BC-4010
+    - BC-4030
+    process_ids: []
+    notes: Channel exposure across direct, OTA, and metasearch; Promotion and offer surfacing
+  - id: VS-520.20
+    stage_order: 2
+    stage_name: Shop & Compare
+    capability_ids:
+    - BC-4000
+    - BC-4030
+    - BC-4010
+    process_ids: []
+    notes: Product content, taxonomy, and merchandising; Live pricing and dynamic offer; Channel-specific shopping and parity
+  - id: VS-520.30
+    stage_order: 3
+    stage_name: Book & Confirm
+    capability_ids:
+    - BC-4020
+    - BC-4040
+    process_ids: []
+    notes: Reservation capture, confirmation, and payment; Profile creation; consent and travel-document capture at booking
+  - id: VS-520.40
+    stage_order: 4
+    stage_name: Pre-Arrival
+    capability_ids:
+    - BC-4040
+    - BC-4060
+    process_ids: []
+    notes: Pre-arrival recognition cueing; Pre-arrival room and amenity preparation
+  - id: VS-520.50
+    stage_order: 5
+    stage_name: Travel & Stay
+    capability_ids:
+    - BC-4070
+    - BC-4020
+    process_ids: []
+    notes: Restaurant, in-room dining, and bar service; In-stay rebook and IROPS reaccommodation
+  - id: VS-520.60
+    stage_order: 5
+    stage_name: Travel & Stay
+    capability_ids:
+    - BC-4080
+    process_ids: []
+    industry_variant: Airline
+    notes: On-the-day flight operations including IROPS
+  - id: VS-520.70
+    stage_order: 5
+    stage_name: Travel & Stay
+    capability_ids:
+    - BC-4090
+    process_ids: []
+    industry_variant: Cruise
+    notes: Onboard cruise operations during voyage
+  - id: VS-520.80
+    stage_order: 5
+    stage_name: Travel & Stay
+    capability_ids:
+    - BC-4060
+    process_ids: []
+    industry_variant: Lodging
+    notes: Front office, housekeeping, and concierge during the stay
+  - id: VS-520.90
+    stage_order: 5
+    stage_name: Travel & Stay
+    capability_ids:
+    - BC-4100
+    process_ids: []
+    industry_variant: Tour
+    notes: In-destination tour delivery
+  - id: VS-520.100
+    stage_order: 6
+    stage_name: Settle & Recognise
+    capability_ids:
+    - BC-4020
+    - BC-4060
+    - BC-4050
+    process_ids: []
+    notes: Booking settlement and final charge capture; Folio settlement at check-out; Earn engine accrual on completed activity
+  - id: VS-520.110
+    stage_order: 7
+    stage_name: Post-Stay & Retain
+    capability_ids:
+    - BC-4040
+    - BC-4050
+    - BC-4030
+    process_ids: []
+    notes: Feedback capture, segmentation, and lifetime-value update; Recognition delivery and member communications; Revenue performance analysis and forecast tuning
+- id: VS-530
+  name: Site-to-Stabilisation
+  industries:
+  - Real Estate
+  stages:
+  - id: VS-530.10
+    stage_order: 1
+    stage_name: Site Sourcing & Origination
+    capability_ids:
+    - BC-4900
+    process_ids: []
+    notes: Site identification, off-market origination, and pipeline tracking
+  - id: VS-530.20
+    stage_order: 2
+    stage_name: Feasibility & Underwriting
+    capability_ids:
+    - BC-4900
+    process_ids: []
+    notes: Highest & best use, programme studies, pro forma, and land underwriting
+  - id: VS-530.30
+    stage_order: 3
+    stage_name: Entitlement & Permitting
+    capability_ids:
+    - BC-4900
+    process_ids: []
+    notes: Zoning, planning consent, environmental review, and building permits
+  - id: VS-530.40
+    stage_order: 4
+    stage_name: Development Capitalisation
+    capability_ids:
+    - BC-4900
+    - BC-4980
+    process_ids: []
+    notes: Equity, construction loans, JV, and public incentives sourcing; Construction and bridge loan origination
+  - id: VS-530.50
+    stage_order: 5
+    stage_name: Design & Construction Execution
+    capability_ids:
+    - BC-4900
+    - BC-1150
+    process_ids: []
+    notes: Design oversight and owner-side construction monitoring; Construction execution by GC and trades
+  - id: VS-530.60
+    stage_order: 6
+    stage_name: Lease-Up & Stabilisation
+    capability_ids:
+    - BC-4900
+    - BC-4950
+    process_ids: []
+    notes: Pre-leasing, opening, and ramp to stabilised performance; Pre-leasing campaigns and initial lease execution
+  - id: VS-530.70
+    stage_order: 7
+    stage_name: Operational Handover
+    capability_ids:
+    - BC-4940
+    process_ids: []
+    notes: Handover into ongoing property management operations
+- id: VS-540
+  name: Solicitation-to-Closeout
+  industries:
+  - Public Sector & Government
+  stages:
+  - id: VS-540.10
+    stage_order: 1
+    stage_name: Programme Design
+    capability_ids:
+    - BC-3260
+    process_ids: []
+    notes: Objectives, allocation modelling, evaluation criteria
+  - id: VS-540.20
+    stage_order: 2
+    stage_name: Solicitation Publication
+    capability_ids:
+    - BC-3260
+    process_ids: []
+    notes: Funding opportunity publication and applicant outreach
+  - id: VS-540.30
+    stage_order: 3
+    stage_name: Application Review
+    capability_ids:
+    - BC-3260
+    process_ids: []
+    notes: Eligibility screening and merit review with conflict-of-interest controls
+  - id: VS-540.40
+    stage_order: 4
+    stage_name: Award & Agreement
+    capability_ids:
+    - BC-3260
+    process_ids: []
+    notes: Award selection, grant agreement issuance, and obligation
+  - id: VS-540.50
+    stage_order: 5
+    stage_name: Recipient Monitoring
+    capability_ids:
+    - BC-3260
+    process_ids: []
+    notes: Performance, financial, and site monitoring of recipients
+  - id: VS-540.60
+    stage_order: 6
+    stage_name: Closeout & Audit Resolution
+    capability_ids:
+    - BC-3260
+    process_ids: []
+    notes: Final reporting, single-audit resolution, and disallowed-cost recovery
+- id: VS-550
+  name: Source-to-Tap
+  industries:
+  - Power & Water Utilities
+  stages:
+  - id: VS-550.10
+    stage_order: 1
+    stage_name: Resource Planning & Authorisation
+    capability_ids:
+    - BC-3860
+    process_ids: []
+    industry_variant: Utilities
+    notes: Supply-demand balance, drought planning, abstraction licence administration
+  - id: VS-550.20
+    stage_order: 2
+    stage_name: Catchment Stewardship
+    capability_ids:
+    - BC-3860
+    process_ids: []
+    industry_variant: Utilities
+    notes: Catchment risk assessment, source protection zones, stakeholder engagement
+  - id: VS-550.30
+    stage_order: 3
+    stage_name: Raw Water Abstraction
+    capability_ids:
+    - BC-3860
+    process_ids: []
+    industry_variant: Utilities
+    notes: Surface intake, groundwater borehole, and raw-water pumping operations
+  - id: VS-550.40
+    stage_order: 4
+    stage_name: Treatment
+    capability_ids:
+    - BC-3870
+    process_ids: []
+    industry_variant: Utilities
+    notes: Treatment-works shift operations and unit-process control
+  - id: VS-550.50
+    stage_order: 5
+    stage_name: Drinking Water Quality Assurance
+    capability_ids:
+    - BC-3870
+    process_ids: []
+    industry_variant: Utilities
+    notes: Statutory sampling, online monitoring, incident response, and DWI/EPA reporting
+  - id: VS-550.60
+    stage_order: 6
+    stage_name: Bulk Storage & Transmission
+    capability_ids:
+    - BC-3870
+    - BC-3880
+    process_ids: []
+    industry_variant: Utilities
+    notes: Service reservoir and contact-tank operations; Trunk-main and pumping-station operations between zones
+  - id: VS-550.70
+    stage_order: 7
+    stage_name: Distribution
+    capability_ids:
+    - BC-3880
+    process_ids: []
+    industry_variant: Utilities
+    notes: Distribution control, leakage, pressure, network quality, and mains repair
+  - id: VS-550.80
+    stage_order: 8
+    stage_name: Customer Supply & Metering
+    capability_ids:
+    - BC-3880
+    - BC-3910
+    process_ids: []
+    industry_variant: Utilities
+    notes: New service connection installation and commissioning; Customer account, AMI data acquisition, meter reading, and M2C inputs
+- id: VS-560
+  name: Sourcing-to-Onboarding
+  industries:
+  - Real Estate
+  stages:
+  - id: VS-560.10
+    stage_order: 1
+    stage_name: Deal Sourcing
+    capability_ids:
+    - BC-4930
+    process_ids: []
+    notes: Acquisition lead sourcing across direct, broker, and off-market channels
+  - id: VS-560.20
+    stage_order: 2
+    stage_name: Underwriting
+    capability_ids:
+    - BC-4930
+    process_ids: []
+    notes: Cash flow, comparables, sensitivity, and scenario underwriting
+  - id: VS-560.30
+    stage_order: 3
+    stage_name: Due Diligence
+    capability_ids:
+    - BC-4930
+    process_ids: []
+    notes: Physical, environmental, title, lease, and financial diligence
+  - id: VS-560.40
+    stage_order: 4
+    stage_name: Structuring & Negotiation
+    capability_ids:
+    - BC-4930
+    process_ids: []
+    notes: Bid strategy, LOI, PSA, and tax / vehicle structuring
+  - id: VS-560.50
+    stage_order: 5
+    stage_name: Closing & Settlement
+    capability_ids:
+    - BC-4930
+    process_ids: []
+    notes: Escrow, settlement statement, and recording
+  - id: VS-560.60
+    stage_order: 6
+    stage_name: Operational Onboarding
+    capability_ids:
+    - BC-4930
+    process_ids: []
+    notes: Asset and lease data migration and vendor contract novation
+  - id: VS-560.70
+    stage_order: 7
+    stage_name: Asset Management Handover
+    capability_ids:
+    - BC-4920
+    process_ids: []
+    notes: Handover to ongoing asset stewardship and business plan execution
+- id: VS-570
+  name: Spectrum-to-Deployment
+  industries:
+  - Telecommunications
+  stages:
+  - id: VS-570.10
+    stage_order: 1
+    stage_name: Spectrum Strategy
+    capability_ids:
+    - BC-2670
+    process_ids: []
+    notes: Spectrum portfolio strategy and technology-band roadmap
+  - id: VS-570.20
+    stage_order: 2
+    stage_name: Licence Acquisition
+    capability_ids:
+    - BC-2670
+    - BC-2700
+    process_ids: []
+    notes: Auction participation, licence purchase, and trading; Regulatory engagement and licence-condition negotiation
+  - id: VS-570.30
+    stage_order: 3
+    stage_name: Frequency Assignment & Coordination
+    capability_ids:
+    - BC-2670
+    process_ids: []
+    notes: Frequency planning, cell-level assignment, and cross-border coordination
+  - id: VS-570.40
+    stage_order: 4
+    stage_name: Network Deployment
+    capability_ids:
+    - BC-2610
+    - BC-2600
+    process_ids: []
+    notes: RAN and transport build-out aligned to the spectrum plan; Activation, optimisation, and acceptance of new spectrum carriers
+  - id: VS-570.50
+    stage_order: 5
+    stage_name: Interference & Compliance
+    capability_ids:
+    - BC-2670
+    - BC-2700
+    process_ids: []
+    notes: Interference monitoring, mitigation, and shared-access spectrum operations; Licence-condition compliance and regulatory reporting
+  - id: VS-570.60
+    stage_order: 6
+    stage_name: Renewal & Reframing
+    capability_ids:
+    - BC-2670
+    process_ids: []
+    notes: Licence renewal, reframing, and end-of-life return
+- id: VS-580
+  name: Strategy-to-Execution
+  industries:
+  - Cross-Industry
+  stages:
+  - id: VS-580.10
+    stage_order: 1
+    stage_name: Strategy Formulation
+    capability_ids:
+    - BC-100
+    - BC-170
+    - BC-4910
+    process_ids: []
+    notes: Strategic planning; Business model design; Capability and operating model translate strategy into structure; Real-estate fund mandate and investment strategy formulation
+  - id: VS-580.20
+    stage_order: 1
+    stage_name: Strategy Formulation
+    capability_ids:
+    - BC-3200
+    process_ids: []
+    industry_variant: Public Sector
+    notes: Policy options analysis and decision support
+  - id: VS-580.30
+    stage_order: 2
+    stage_name: Portfolio Definition
+    capability_ids:
+    - BC-100
+    - BC-170
+    - BC-900
+    - BC-4910
+    process_ids: []
+    notes: Strategic portfolio; Capability heatmap and gap analysis drive investment prioritisation; Project portfolio prioritisation; Real-estate portfolio construction, pacing, and allocation
+  - id: VS-580.40
+    stage_order: 3
+    stage_name: Programme & Project Setup
+    capability_ids:
+    - BC-900
+    process_ids: []
+    notes: Programme establishment; Project initiation
+  - id: VS-580.50
+    stage_order: 4
+    stage_name: Delivery & Governance
+    capability_ids:
+    - BC-900
+    - BC-920
+    - BC-930
+    - BC-4920
+    process_ids: []
+    notes: Project governance; PMO operations; Transformation programme execution; Process redesign and conformance during transformation delivery; Asset business plan delivery and governance
+  - id: VS-580.60
+    stage_order: 4
+    stage_name: Delivery & Governance
+    capability_ids:
+    - BC-3200
+    process_ids: []
+    industry_variant: Public Sector
+    notes: Cross-agency policy implementation coordination
+  - id: VS-580.70
+    stage_order: 5
+    stage_name: Change Adoption
+    capability_ids:
+    - BC-910
+    process_ids: []
+    notes: Stakeholder engagement; Communications & training; Adoption & reinforcement
+  - id: VS-580.80
+    stage_order: 6
+    stage_name: Benefits Realisation
+    capability_ids:
+    - BC-100
+    - BC-170
+    - BC-920
+    - BC-4920
+    process_ids: []
+    notes: Strategy execution review; Target-state capability assessment validates strategic outcomes; Benefits tracking; Realisation against asset value-creation thesis
+  - id: VS-580.90
+    stage_order: 6
+    stage_name: Benefits Realisation
+    capability_ids:
+    - BC-3200
+    process_ids: []
+    industry_variant: Public Sector
+    notes: Policy evaluation and ex-post review
+- id: VS-590
+  name: Sustain-to-Disposition
+  industries:
+  - Defense & Aerospace
+  stages:
+  - id: VS-590.10
+    stage_order: 1
+    stage_name: Sustainment Planning
+    capability_ids:
+    - BC-1780
+    process_ids: []
+    industry_variant: Defense
+    notes: In-service support plan; RAM engineering
+  - id: VS-590.20
+    stage_order: 2
+    stage_name: Operate & Maintain
+    capability_ids:
+    - BC-1720
+    - BC-1780
+    process_ids: []
+    industry_variant: Defense
+    notes: Defense logistics; Depot maintenance
+  - id: VS-590.30
+    stage_order: 3
+    stage_name: Spares & Repairs
+    capability_ids:
+    - BC-1060
+    process_ids: []
+    notes: Aftermarket parts
+  - id: VS-590.40
+    stage_order: 3
+    stage_name: Spares & Repairs
+    capability_ids:
+    - BC-1780
+    process_ids: []
+    industry_variant: Defense
+    notes: Spares & repair pipeline
+  - id: VS-590.50
+    stage_order: 4
+    stage_name: Technical Documentation
+    capability_ids:
+    - BC-1780
+    process_ids: []
+    industry_variant: Defense
+    notes: Technical publications
+  - id: VS-590.60
+    stage_order: 5
+    stage_name: Obsolescence Management
+    capability_ids:
+    - BC-1780
+    process_ids: []
+    industry_variant: Defense
+    notes: DMSMS / obsolescence
+  - id: VS-590.70
+    stage_order: 6
+    stage_name: Capability Upgrades
+    capability_ids:
+    - BC-1770
+    - BC-1800
+    process_ids: []
+    industry_variant: Defense
+    notes: Configuration management; Test & evaluation
+  - id: VS-590.80
+    stage_order: 7
+    stage_name: Disposal & Disposition
+    capability_ids:
+    - BC-1040
+    process_ids: []
+    notes: Decommissioning
+  - id: VS-590.90
+    stage_order: 7
+    stage_name: Disposal & Disposition
+    capability_ids:
+    - BC-1810
+    process_ids: []
+    industry_variant: Defense
+    notes: Classified material destruction
+- id: VS-600
+  name: Threat-to-Mitigation
+  industries:
+  - Cross-Industry
+  stages:
+  - id: VS-600.10
+    stage_order: 1
+    stage_name: Security Posture Definition
+    capability_ids:
+    - BC-620
+    process_ids: []
+    notes: Strategy & governance; Reference architecture
+  - id: VS-600.20
+    stage_order: 2
+    stage_name: Threat Intelligence
+    capability_ids:
+    - BC-620
+    process_ids: []
+    notes: Threat feeds & intel
+  - id: VS-600.30
+    stage_order: 2
+    stage_name: Threat Intelligence
+    capability_ids:
+    - BC-3460
+    process_ids: []
+    industry_variant: Automotive
+    notes: Vehicle threat intelligence feeds
+  - id: VS-600.40
+    stage_order: 2
+    stage_name: Threat Intelligence
+    capability_ids:
+    - BC-1740
+    process_ids: []
+    industry_variant: Defense
+    notes: Cyber operations intel
+  - id: VS-600.50
+    stage_order: 2
+    stage_name: Threat Intelligence
+    capability_ids:
+    - BC-1950
+    process_ids: []
+    industry_variant: Electrical Components & Equipment
+    notes: Product CVE feeds & supplier advisories
+  - id: VS-600.60
+    stage_order: 3
+    stage_name: Vulnerability Discovery
+    capability_ids:
+    - BC-620
+    process_ids: []
+    notes: Scanning, pen test, bug bounty
+  - id: VS-600.70
+    stage_order: 3
+    stage_name: Vulnerability Discovery
+    capability_ids:
+    - BC-1950
+    process_ids: []
+    industry_variant: Electrical Components & Equipment
+    notes: Coordinated product vulnerability disclosure
+  - id: VS-600.80
+    stage_order: 3
+    stage_name: Vulnerability Discovery
+    capability_ids:
+    - BC-2010
+    process_ids: []
+    industry_variant: HVAC & Building Automation Systems
+    notes: BAS product vulnerability disclosure
+  - id: VS-600.90
+    stage_order: 4
+    stage_name: Detection
+    capability_ids:
+    - BC-620
+    process_ids: []
+    notes: SIEM / SOC monitoring
+  - id: VS-600.100
+    stage_order: 4
+    stage_name: Detection
+    capability_ids:
+    - BC-3460
+    process_ids: []
+    industry_variant: Automotive
+    notes: Vehicle SOC fleet-wide threat detection
+  - id: VS-600.110
+    stage_order: 4
+    stage_name: Detection
+    capability_ids:
+    - BC-2060
+    process_ids: []
+    industry_variant: HVAC & Building Automation Systems
+    notes: Connected-service anomaly detection on BAS
+  - id: VS-600.120
+    stage_order: 4
+    stage_name: Detection
+    capability_ids:
+    - BC-2600
+    process_ids: []
+    industry_variant: Telecommunications
+    notes: Signalling, transport, and core network threat monitoring
+  - id: VS-600.130
+    stage_order: 4
+    stage_name: Detection
+    capability_ids:
+    - BC-3810
+    process_ids: []
+    industry_variant: Utilities
+    notes: NERC CIP and OT-network threat detection on bulk-electric system
+  - id: VS-600.140
+    stage_order: 5
+    stage_name: Incident Response
+    capability_ids:
+    - BC-160
+    - BC-620
+    process_ids: []
+    notes: Disaster recovery activation; Containment & eradication
+  - id: VS-600.150
+    stage_order: 5
+    stage_name: Incident Response
+    capability_ids:
+    - BC-3460
+    process_ids: []
+    industry_variant: Automotive
+    notes: Vehicle incident response and OTA remediation
+  - id: VS-600.160
+    stage_order: 5
+    stage_name: Incident Response
+    capability_ids:
+    - BC-1950
+    process_ids: []
+    industry_variant: Electrical Components & Equipment
+    notes: OTA patch deployment for product CVEs
+  - id: VS-600.170
+    stage_order: 5
+    stage_name: Incident Response
+    capability_ids:
+    - BC-2060
+    process_ids: []
+    industry_variant: HVAC & Building Automation Systems
+    notes: OTA patching of BAS controllers
+  - id: VS-600.180
+    stage_order: 5
+    stage_name: Incident Response
+    capability_ids:
+    - BC-2600
+    process_ids: []
+    industry_variant: Telecommunications
+    notes: Network security incident response and DDoS mitigation
+  - id: VS-600.190
+    stage_order: 5
+    stage_name: Incident Response
+    capability_ids:
+    - BC-3810
+    process_ids: []
+    industry_variant: Utilities
+    notes: Bulk-electric-system cyber incident response and CIP-008 reporting
+  - id: VS-600.200
+    stage_order: 6
+    stage_name: Identity & Access Hardening
+    capability_ids:
+    - BC-620
+    process_ids: []
+    notes: IAM tightening
+  - id: VS-600.210
+    stage_order: 7
+    stage_name: Awareness & Lessons Learned
+    capability_ids:
+    - BC-620
+    - BC-830
+    process_ids: []
+    notes: Awareness campaigns; Best-practice capture
+- id: VS-610
+  name: Trade-Plan-to-Settle
+  industries:
+  - Retail & Consumer Goods
+  stages:
+  - id: VS-610.10
+    stage_order: 1
+    stage_name: Trade Plan Development
+    capability_ids:
+    - BC-2360
+    process_ids: []
+    notes: Annual trade plan, joint business plans, and customer-level investment strategy
+  - id: VS-610.20
+    stage_order: 2
+    stage_name: Fund Allocation
+    capability_ids:
+    - BC-2360
+    process_ids: []
+    notes: Trade-spend budgeting and accrual setup
+  - id: VS-610.30
+    stage_order: 3
+    stage_name: Promotion Execution
+    capability_ids:
+    - BC-2360
+    process_ids: []
+    notes: In-store event execution, slotting, and feature scheduling
+  - id: VS-610.40
+    stage_order: 4
+    stage_name: Deduction & Claim Handling
+    capability_ids:
+    - BC-2360
+    - BC-200
+    process_ids: []
+    notes: Customer deduction validation, claim resolution, and chargeback management; Trade-spend accruals, deduction accounting, and AR clearing
+  - id: VS-610.50
+    stage_order: 5
+    stage_name: Post-Event Lift Measurement
+    capability_ids:
+    - BC-2360
+    process_ids: []
+    notes: Lift analytics, ROI evaluation, and feedback into next plan
+- id: VS-620
+  name: Trial-to-Renewal
+  industries:
+  - Software & Technology
+  stages:
+  - id: VS-620.10
+    stage_order: 1
+    stage_name: Trial Initiation
+    capability_ids:
+    - BC-4240
+    - BC-4230
+    process_ids: []
+    notes: Trial sign-up and trial subscription provisioning; Tenant provisioning for trial accounts
+  - id: VS-620.20
+    stage_order: 2
+    stage_name: Trial Activation
+    capability_ids:
+    - BC-4260
+    process_ids: []
+    notes: Onboarding and activation milestone tracking during trial
+  - id: VS-620.30
+    stage_order: 3
+    stage_name: Conversion to Paid
+    capability_ids:
+    - BC-4240
+    - BC-4250
+    process_ids: []
+    notes: Trial-to-paid subscription conversion; Initial invoicing and payment authorisation on conversion
+  - id: VS-620.40
+    stage_order: 4
+    stage_name: Adoption
+    capability_ids:
+    - BC-4260
+    - BC-4280
+    process_ids: []
+    notes: Adoption programmes, power-user enablement; Product telemetry and feature engagement reporting that drive adoption
+  - id: VS-620.50
+    stage_order: 5
+    stage_name: Health & Risk Monitoring
+    capability_ids:
+    - BC-4260
+    process_ids: []
+    notes: Customer health scoring and at-risk account intervention
+  - id: VS-620.60
+    stage_order: 6
+    stage_name: Renewal
+    capability_ids:
+    - BC-4240
+    - BC-4260
+    process_ids: []
+    notes: Auto-renewal processing and renewal negotiation; Renewal advocacy, save motions, renewal forecasting
+  - id: VS-620.70
+    stage_order: 7
+    stage_name: Expansion
+    capability_ids:
+    - BC-4260
+    - BC-4240
+    process_ids: []
+    notes: Expansion opportunity identification and upsell qualification; Plan upgrade, seat adjustment, and add-on activation
+  - id: VS-620.80
+    stage_order: 8
+    stage_name: Churn or Wind-Down
+    capability_ids:
+    - BC-4240
+    process_ids: []
+    notes: Cancellation processing and service wind-down coordination
+- id: VS-630
+  name: Validate-to-Authorise
+  industries:
+  - Automotive & Mobility
+  stages:
+  - id: VS-630.10
+    stage_order: 1
+    stage_name: ODD Definition
+    capability_ids:
+    - BC-3470
+    process_ids: []
+    industry_variant: Automotive
+    notes: Operational design domain definition
+  - id: VS-630.20
+    stage_order: 2
+    stage_name: Scenario Coverage Build
+    capability_ids:
+    - BC-3470
+    process_ids: []
+    industry_variant: Automotive
+    notes: Scenario library curation and edge-case capture
+  - id: VS-630.30
+    stage_order: 3
+    stage_name: Validation Execution
+    capability_ids:
+    - BC-3470
+    process_ids: []
+    industry_variant: Automotive
+    notes: Simulation, closed-course, and public-road validation
+  - id: VS-630.40
+    stage_order: 4
+    stage_name: Safety Case Authoring
+    capability_ids:
+    - BC-3470
+    process_ids: []
+    industry_variant: Automotive
+    notes: Authoring and assurance of the ADS safety case
+  - id: VS-630.50
+    stage_order: 5
+    stage_name: Regulatory Authorisation
+    capability_ids:
+    - BC-3420
+    - BC-3470
+    process_ids: []
+    industry_variant: Automotive
+    notes: ALKS / ADS approval submission under UN R157; ADS permit and authorisation management
+  - id: VS-630.60
+    stage_order: 6
+    stage_name: Deployment Monitoring
+    capability_ids:
+    - BC-3470
+    process_ids: []
+    industry_variant: Automotive
+    notes: ODD conformance monitoring and SPI tracking
+  - id: VS-630.70
+    stage_order: 7
+    stage_name: Incident Reporting & Iteration
+    capability_ids:
+    - BC-3470
+    process_ids: []
+    industry_variant: Automotive
+    notes: Incident reporting to regulators and feedback into safety case
+- id: VS-640
+  name: Visa-to-Admission
+  industries:
+  - Public Sector & Government
+  stages:
+  - id: VS-640.10
+    stage_order: 1
+    stage_name: Visa Application
+    capability_ids:
+    - BC-3300
+    process_ids: []
+    notes: Receipt and validation of visa applications across categories
+  - id: VS-640.20
+    stage_order: 2
+    stage_name: Visa Decisioning
+    capability_ids:
+    - BC-3300
+    process_ids: []
+    notes: Adjudication of visa applications and fraud screening
+  - id: VS-640.30
+    stage_order: 3
+    stage_name: Pre-Travel Authorisation
+    capability_ids:
+    - BC-3300
+    process_ids: []
+    notes: ETA-style pre-travel authorisation and API/PNR processing
+  - id: VS-640.40
+    stage_order: 4
+    stage_name: Border Inspection
+    capability_ids:
+    - BC-3300
+    process_ids: []
+    notes: Primary and secondary inspection at ports of entry
+  - id: VS-640.50
+    stage_order: 5
+    stage_name: Admission Decision
+    capability_ids:
+    - BC-3300
+    process_ids: []
+    notes: Decisioning on admission, refusal, and conditions of entry
+  - id: VS-640.60
+    stage_order: 6
+    stage_name: Status Maintenance
+    capability_ids:
+    - BC-3300
+    process_ids: []
+    notes: Residence permits, work authorisations, and naturalisation administration
+  - id: VS-640.70
+    stage_order: 7
+    stage_name: Removal & Return
+    capability_ids:
+    - BC-3300
+    process_ids: []
+    notes: Detention, removal-order execution, and voluntary return

--- a/scripts/wire_process_ids.py
+++ b/scripts/wire_process_ids.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""One-shot wiring of process_ids into the 5 canonical Cross-Industry value
+streams: Hire-to-Retire, Idea-to-Market, Order-to-Cash, Procure-to-Pay,
+Record-to-Report.
+
+Maps each stage by `stage_name` to one or more APQC PCF BP2 ids that realise
+the work. Industry-variant stages inherit the same cross-industry process
+mapping — industry-specific PCFs (Banking BIAN, Telecom eTOM, etc.) are not
+yet imported and would land in a follow-up PR.
+
+Run once, commit the resulting catalogue/_value-streams.yaml, then archive
+this script under scripts/_archive/ in a follow-up PR.
+"""
+import os
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PATH = os.path.join(REPO_ROOT, "catalogue", "_value-streams.yaml")
+
+# (stream_id, stage_name) -> [BP ids]
+# Matching is by exact stage_name string; all industry-variant rows for the
+# same (stream, stage_name) get the same mapping unless explicitly overridden.
+MAPPING = {
+    # ---------------------------------------------------------------- Hire-to-Retire
+    ("VS-280", "Workforce Planning"): ["BP-70.10"],
+    ("VS-280", "Sourcing & Attraction"): ["BP-70.20"],
+    ("VS-280", "Selection & Hire"): ["BP-70.20"],
+    ("VS-280", "Onboarding"): ["BP-70.30"],
+    ("VS-280", "Performance & Development"): ["BP-70.30"],
+    ("VS-280", "Compensation & Benefits Administration"): ["BP-70.40", "BP-90.50"],
+    ("VS-280", "Employee Experience & Engagement"): ["BP-70.40", "BP-70.70"],
+    ("VS-280", "Internal Mobility & Career"): ["BP-70.30", "BP-70.50"],
+    ("VS-280", "Offboarding & Alumni"): ["BP-70.50"],
+
+    # ---------------------------------------------------------------- Idea-to-Market
+    ("VS-290", "Idea Capture"): ["BP-20.20"],
+    ("VS-290", "Concept & Feasibility"): ["BP-20.20"],
+    ("VS-290", "Research & Prototyping"): ["BP-20.30"],
+    ("VS-290", "Portfolio Selection"): ["BP-20.10"],
+    ("VS-290", "Design & Development"): ["BP-20.30"],
+    ("VS-290", "IP Protection"): ["BP-20.30", "BP-120.40"],
+    ("VS-290", "Launch Readiness"): ["BP-20.40", "BP-20.50"],
+    ("VS-290", "Market Introduction"): ["BP-30.40", "BP-30.50"],
+    ("VS-290", "Post-Launch Performance"): ["BP-20.10"],
+
+    # ---------------------------------------------------------------- Order-to-Cash
+    ("VS-390", "Lead Capture & Qualification"): ["BP-30.10", "BP-30.50"],
+    ("VS-390", "Quote & Configuration"): ["BP-30.50"],
+    ("VS-390", "Contract & Order Capture"): ["BP-30.50"],
+    ("VS-390", "Order Promising & Allocation"): ["BP-40.10"],
+    ("VS-390", "Production / Service Delivery"): ["BP-40.30", "BP-50.30"],
+    ("VS-390", "Outbound Logistics"): ["BP-40.40"],
+    ("VS-390", "Customer Invoicing"): ["BP-90.20"],
+    ("VS-390", "Cash Collection & Application"): ["BP-90.20", "BP-90.70"],
+    ("VS-390", "Revenue Recognition"): ["BP-90.20", "BP-90.30"],
+
+    # ---------------------------------------------------------------- Procure-to-Pay
+    ("VS-420", "Need Identification & Requisition"): ["BP-40.20"],
+    ("VS-420", "Sourcing"): ["BP-40.20"],
+    ("VS-420", "Supplier Selection & Onboarding"): ["BP-40.20"],
+    ("VS-420", "Contract & Purchase Order"): ["BP-40.20"],
+    ("VS-420", "Goods/Services Receipt"): ["BP-40.20"],
+    ("VS-420", "Invoice Receipt & Verification"): ["BP-90.60"],
+    ("VS-420", "Payment Execution"): ["BP-90.60", "BP-90.70"],
+    ("VS-420", "Reconciliation"): ["BP-90.30", "BP-90.60"],
+    ("VS-420", "Supplier Performance Monitoring"): ["BP-40.20"],
+
+    # ---------------------------------------------------------------- Record-to-Report
+    ("VS-460", "Transaction Capture"): ["BP-90.10", "BP-90.30"],
+    ("VS-460", "Sub-Ledger Close"): ["BP-90.20", "BP-90.30", "BP-90.40", "BP-90.60"],
+    ("VS-460", "Reconciliation & Adjustments"): ["BP-90.30"],
+    ("VS-460", "Consolidation"): ["BP-90.30", "BP-90.100"],
+    ("VS-460", "Management Reporting"): ["BP-90.10", "BP-90.30"],
+    ("VS-460", "Statutory & Regulatory Reporting"): ["BP-90.30", "BP-90.90"],
+    ("VS-460", "Audit & Sign-Off"): ["BP-90.80"],
+}
+
+
+def main():
+    with open(PATH) as f:
+        data = yaml.safe_load(f)
+
+    target_stream_ids = {sid for (sid, _) in MAPPING.keys()}
+    stages_updated = 0
+    stages_skipped_mapped = 0  # already had process_ids
+    stage_keys_seen = set()
+
+    for stream in data["value_streams"]:
+        if stream["id"] not in target_stream_ids:
+            continue
+        for stage in stream["stages"]:
+            key = (stream["id"], stage["stage_name"])
+            if key not in MAPPING:
+                continue
+            stage_keys_seen.add(key)
+            existing = stage.get("process_ids") or []
+            if existing:
+                stages_skipped_mapped += 1
+                continue
+            stage["process_ids"] = list(MAPPING[key])
+            stages_updated += 1
+
+    unmapped = set(MAPPING.keys()) - stage_keys_seen
+    if unmapped:
+        print("⚠ Mapping keys with no matching stage:")
+        for k in sorted(unmapped):
+            print(f"   {k}")
+        raise SystemExit(1)
+
+    # Re-emit with the same preamble we use in migrate_value_streams.ts.
+    preamble = (
+        "# Value Streams (orthogonal artefact, not part of the capability hierarchy).\n"
+        "# Each stream has a stable VS-<n> id (sparse 10/20/30 numbering); each stage\n"
+        "# has a stable VS-<n>.<m> id and links to L1 capabilities (`capability_ids`)\n"
+        "# and to business processes (`process_ids`) that realize the work. The site\n"
+        "# auto-expands an L1 to its descendants when filtering. Use 'notes' to capture\n"
+        "# sub-scope detail.\n"
+        "#\n"
+        "# Each stream declares an `industries` array using the canonical L1 industry\n"
+        "# vocabulary. `Cross-Industry`, when present, must stand alone.\n"
+    )
+    body = yaml.safe_dump({"value_streams": data["value_streams"]}, sort_keys=False, width=10**9, allow_unicode=True)
+    with open(PATH, "w", encoding="utf-8") as f:
+        f.write(preamble + body)
+
+    print(f"✔ Updated {stages_updated} stage(s) across {len(target_stream_ids)} stream(s).")
+    if stages_skipped_mapped:
+        print(f"  Skipped {stages_skipped_mapped} stage(s) that already had process_ids.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Populates 204 stage-level `process_ids` across the **five canonical Cross-Industry value streams** whose APQC PCF mappings are unambiguous. First PR that fully exercises the three-layer architecture (BC ↔ VS ↔ BP) end-to-end: BP detail pages now render the *Used in Value Streams* section, and capability detail pages get richer *Realized by Processes* coverage.

| Stream | id | Stages mapped | BP families |
|---|---|---|---|
| Hire-to-Retire   | `VS-280` | 27 | `BP-70` (Develop and Manage Human Capital) |
| Idea-to-Market   | `VS-290` | 48 | `BP-20` (Develop Products and Services) + `BP-30.40/50` + `BP-120.40` |
| Order-to-Cash    | `VS-390` | 78 | `BP-30` + `BP-40` + `BP-50` + `BP-90` |
| Procure-to-Pay   | `VS-420` | 33 | `BP-40.20` + `BP-90.30/60/70` |
| Record-to-Report | `VS-460` | 18 | `BP-90` |

204 stages total (the per-stream counts include all industry-variant rows).

## Mapping rule

Each stage is matched by `(stream_id, stage_name)`. All industry-variant rows for the same stage_name share the cross-industry process baseline — the variant stays meaningful (different capability_ids, different notes) but the underlying APQC PCF process is the same. Industry-specific PCFs (Banking BIAN for `Application-to-Funding`, Telecom eTOM for `Spectrum-to-Deployment`, Insurance ACORD for `Quote-to-Bind`, etc.) aren't in the catalogue yet — those streams stay with empty `process_ids[]` and land in follow-up PRs.

## Generator script

`scripts/wire_process_ids.py` is the one-shot mapping table used to produce the diff. Should be archived under `scripts/_archive/` alongside the previous one-shots (`migrate_value_streams.ts`, `import_apqc_pcf.py`) in a single housekeeping PR.

## Test plan

- [x] `npm run lint` passes (320 L1 + 9329 caps + 12 BP1 + 71 BPs + 64 VS + 2240 sidecars)
- [x] `npm run build` succeeds (9738 pages)
- [x] Python smoke: `BP-90.20` *Perform Revenue Accounting* correctly reports both `VS-390` (Order-to-Cash) and `VS-460` (Record-to-Report) via `get_value_streams_for_process()`
- [ ] Spot-check a BP detail page (e.g. `/business-process/BP-70.20` Recruit, Source, and Select Employees) — *Used in Value Streams* section should now show Hire-to-Retire stages
- [ ] Spot-check `/value-streams` — Order-to-Cash card should show the new BP refs alongside capability_ids
- [ ] Spot-check a capability page (e.g. `/capability/BC-300` HCM) — *Realized by Processes* should still render

## Next steps after merge

- BP3 drill-down for Cross-Industry PCF, one PR per BP1 (suggest starting with `BP-90` Finance and `BP-70` HR — cleanest BC mappings).
- Industry-specific PCFs (BIAN / eTOM / ACORD) as separate BP1 files; each unblocks `process_ids` wiring for its industry-specific value streams.
- Single housekeeping PR to archive `scripts/migrate_value_streams.ts`, `scripts/import_apqc_pcf.py`, `scripts/wire_process_ids.py` under `scripts/_archive/`.

https://claude.ai/code/session_01KAHq1ASy4kzYuAGXJYxQrF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAHq1ASy4kzYuAGXJYxQrF)_