### PR TITLE
fix: widen FrameworkRef.framework Literal to match the JSON Schema

### DIFF
--- a/packages/py/src/turbo_ea_capabilities/_models.py
+++ b/packages/py/src/turbo_ea_capabilities/_models.py
@@ -115,7 +115,23 @@ class FrameworkRef(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    framework: Literal["APQC-PCF", "BIAN", "eTOM", "ITIL", "SCOR"]
+    framework: Literal[
+        "APQC-PCF",
+        "BIAN",
+        "eTOM",
+        "ITIL",
+        "SCOR",
+        "DCOR",
+        "COBIT",
+        "SHRM-BoCK",
+        "ISO-55000",
+        "ISO-31000",
+        "COSO-ERM",
+        "TOGAF",
+        "BIZBOK",
+        "ACORD",
+        "ICMM",
+    ]
     external_id: str
     version: Optional[str] = None
     url: Optional[str] = None


### PR DESCRIPTION
## Summary

`FrameworkRef.framework` in [`packages/py/src/turbo_ea_capabilities/_models.py`](packages/py/src/turbo_ea_capabilities/_models.py) is a `Literal[...]` of just the original five codes (APQC-PCF, BIAN, eTOM, ITIL, SCOR), but the JSON Schema at [`schema/business-process.schema.json`](schema/business-process.schema.json) and recent content drops have added 10 more (DCOR, COBIT, SHRM-BoCK, ISO-55000, ISO-31000, COSO-ERM, TOGAF, BIZBOK, ACORD, ICMM). `load_business_processes()` now raises `ValidationError` on every call because the model rejects the new framework codes.

## Reproduce on `main`

\`\`\`bash
pip install turbo-ea-capabilities
python -c "import turbo_ea_capabilities as p; p.load_business_processes()"
# → ValidationError: Input should be 'APQC-PCF', 'BIAN', 'eTOM', 'ITIL' or 'SCOR'
#   [input_value='SHRM-BoCK', input_type=str]
\`\`\`

## Fix

Widen the Python `Literal` to the same 15-value set the JSON Schema already declares. The schema's \`framework\` description is the documented source of truth — the Pydantic model now mirrors it.

## Found by

Turbo EA consumer (\`turbo-ea\`), where the bundled-package import crashes the \`/process-catalogue\` endpoint on every request and the catalogue browser shows 500.