### PR TITLE
Implement dual licensing: CC BY 4.0 for catalogue, MIT for tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,12 @@ dist/
 packages/py/src/turbo_ea_capabilities/data/*.json
 packages/py/src/turbo_ea_capabilities/data/i18n/
 
+# Licence files staged into the Python package by scripts/build_pkg.ts;
+# the canonical copies live at the repo root.
+packages/py/LICENSE
+packages/py/LICENSE-CODE
+packages/py/NOTICE
+
 # Node
 node_modules/
 npm-debug.log*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,15 @@ Always-on guardrails for any Claude Code session in this repo. Procedural workfl
 
 An open-source Business Architecture Reference Catalogue with **three orthogonal artefacts**: capabilities (BC) describe WHAT, business processes (BP) describe HOW, value streams (VS) describe end-to-end value delivery. YAML files in `catalogue/` are the **single source of truth**. Everything else (`dist/api/*.json`, the bundled Python package data, the Astro site) is built from those YAML files.
 
+## Licensing — dual, split along the data/code seam
+
+The repo is **not** single-licensed. Never collapse it back to one licence.
+
+- **CC BY 4.0** (`LICENSE`) — `catalogue/**`, the JSON artefacts generated from it (`dist/api/**`, the bundled package data), `README.md`, and `business-capability-governance-model.md`.
+- **MIT** (`LICENSE-CODE`) — `scripts/**`, `schema/**`, `site/**`, `packages/py/src/**/*.py`, `packages/py/tests/**`, `.claude/**`, this file, `.github/**`, root config.
+
+[`LICENSING.md`](LICENSING.md) is the authoritative path map. New files on the MIT side carry an `SPDX-License-Identifier: MIT` header where the format allows one; files on the CC BY side carry **no** header — keep `catalogue/*.yaml` free of licence boilerplate. The attribution string CC BY requires also ships in `dist/api/version.json` (`attribution`), emitted by `scripts/build_api.ts`.
+
 ## Invariants — capabilities (BC-)
 
 - **Source of truth:** edit only `catalogue/*.yaml` and `schema/capability.schema.json`. Never hand-edit `dist/api/**` or `packages/py/src/turbo_ea_capabilities/data/**`. Both are build artefacts and are wiped by the next `npm run build`.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,6 +8,12 @@ business-capability-governance-model.md  @vincentmakes/ea-leads
 CLAUDE.md                                @vincentmakes/ea-leads
 .claude/                                 @vincentmakes/ea-leads
 
+# Licence terms - never changed without EA lead review
+LICENSE                                  @vincentmakes/ea-leads
+LICENSE-CODE                             @vincentmakes/ea-leads
+LICENSING.md                             @vincentmakes/ea-leads
+NOTICE                                   @vincentmakes/ea-leads
+
 # Catalogue files - one owning team per L1
 catalogue/_index.yaml                    @vincentmakes/ea-leads
 catalogue/L1-customer-management.yaml    @vincentmakes/customer-architects

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,412 @@
-MIT License
+Turbo EA Capabilities — Reference Business Architecture Catalogue
+Copyright (c) 2026 Vincent Verdet — Turbo EA
 
-Copyright (c) 2026 Vincent
+This repository is dual-licensed. The catalogue content and documentation are
+licensed under CC BY 4.0 (below). The tooling — scripts, schemas, site source,
+Python modules, Claude skills — is licensed under MIT (see LICENSE-CODE).
+The authoritative path-by-path mapping is in LICENSING.md.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+SPDX-License-Identifier: CC-BY-4.0 AND MIT
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+When you share or adapt this catalogue, credit:
+    "Turbo EA Capabilities by Vincent Verdet — Turbo EA,
+     https://github.com/vincentmakes/turbo-ea-capabilities, CC BY 4.0"
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+-----------------------------------------------------------------------
+
+
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+     wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+     wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public licenses.
+Notwithstanding, Creative Commons may elect to apply one of its public
+licenses to material it publishes and in those instances will be
+considered the “Licensor.” The text of the Creative Commons public
+licenses is dedicated to the public domain under the CC0 Public Domain
+Dedication. Except for the limited purpose of indicating that material
+is shared under a Creative Commons public license or as otherwise
+permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the public
+licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/LICENSE-CODE
+++ b/LICENSE-CODE
@@ -1,0 +1,33 @@
+Turbo EA Capabilities — tooling licence
+
+This licence covers the functional parts of the repository only: build and CLI
+scripts, JSON Schemas, the Astro site source, the Python library modules, the
+Claude skills, and root configuration. The catalogue content and documentation
+are licensed separately under CC BY 4.0 (see LICENSE). The authoritative
+path-by-path mapping is in LICENSING.md.
+
+SPDX-License-Identifier: MIT
+
+-----------------------------------------------------------------------
+
+MIT License
+
+Copyright (c) 2026 Vincent Verdet — Turbo EA
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,51 @@
+# Licensing
+
+This repository is **dual-licensed**, split along the data/code seam.
+
+The **catalogue** — the capability, process and value-stream records, and the reference model
+that documents them — is curated reference *content*. It is licensed under
+**[Creative Commons Attribution 4.0 International](LICENSE)** (CC BY 4.0): free to use, adapt
+and redistribute, including commercially, provided you credit the source.
+
+The **tooling** — build scripts, CLIs, JSON Schemas, the Astro site, the Python library, the
+Claude skills — is ordinary software and is licensed under **[MIT](LICENSE-CODE)**.
+
+`SPDX-License-Identifier: CC-BY-4.0 AND MIT`
+
+## Which licence applies to which path
+
+| Path | Licence |
+| --- | --- |
+| `catalogue/**` (including `catalogue/i18n/**`) | CC BY 4.0 |
+| `dist/api/**` and `packages/py/src/turbo_ea_capabilities/data/**` — generated from `catalogue/` | CC BY 4.0 |
+| `README.md`, `business-capability-governance-model.md` | CC BY 4.0 |
+| `scripts/**`, `schema/**`, `site/**` | MIT |
+| `packages/py/src/turbo_ea_capabilities/*.py`, `packages/py/tests/**` | MIT |
+| `.claude/**`, `CLAUDE.md`, `.github/**` | MIT |
+| Root configuration — `package.json`, `tsconfig.json`, `style.css` | MIT |
+
+Files on the MIT side carry an `SPDX-License-Identifier: MIT` header where the format allows
+one. Files on the CC BY side carry no header — this table is authoritative for them, so that
+the YAML source of truth stays free of boilerplate.
+
+## Required attribution
+
+When you share or adapt the catalogue, credit:
+
+> Turbo EA Capabilities by Vincent Verdet — Turbo EA,
+> <https://github.com/vincentmakes/turbo-ea-capabilities>, CC BY 4.0
+
+The same string is served in `dist/api/version.json` (`attribution`) so downstream consumers
+of the JSON API receive it programmatically.
+
+You must also indicate if you made changes, and you may not apply legal terms or technological
+measures that legally restrict others from doing anything the licence permits. You may not
+imply endorsement by Turbo EA or Vincent Verdet.
+
+## Third-party attributions
+
+[`NOTICE`](NOTICE) lists the third-party frameworks this catalogue cross-walks to — APQC PCF®,
+BIAN, TM Forum eTOM, ITIL®, SCOR®/DCOR, COBIT®, SHRM-BoCK, ISO 55000, ISO 31000, COSO ERM,
+TOGAF®, BIZBOK®, ACORD, ICMM. None of them are redistributed here; the catalogue cites their
+identifiers only. `NOTICE` applies regardless of which side of the split a file falls on, and
+CC BY 4.0 § 3(a)(1) requires you to retain it when redistributing the catalogue.

--- a/NOTICE
+++ b/NOTICE
@@ -1,9 +1,24 @@
 Turbo EA Capabilities — Reference Business Architecture Catalogue
-Copyright (c) 2026 Vincent and contributors. Released under the MIT License (see LICENSE).
+Copyright (c) 2026 Vincent Verdet — Turbo EA, and contributors.
+
+Dual-licensed: the catalogue content and documentation under CC BY 4.0 (see
+LICENSE); the tooling — scripts, schemas, site source, Python modules, Claude
+skills — under the MIT License (see LICENSE-CODE). The authoritative
+path-by-path mapping is in LICENSING.md.
+
+When you share or adapt the catalogue, CC BY 4.0 requires you to credit:
+
+    Turbo EA Capabilities by Vincent Verdet — Turbo EA,
+    https://github.com/vincentmakes/turbo-ea-capabilities, CC BY 4.0
+
+You must also indicate if you made changes. The same attribution string is
+served in dist/api/version.json for programmatic consumers.
 
 This product includes references to and attribution-based use of third-party
 frameworks. Inclusion of an attribution below does not imply endorsement by
-the framework owner.
+the framework owner. This NOTICE applies regardless of which side of the
+licence split a file falls on, and CC BY 4.0 § 3(a)(1) requires you to retain
+it when redistributing the catalogue.
 
 ================================================================================
 Cross-Industry business processes — generated from BC + VS

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Business Architecture Reference Catalogue
 
+[![Catalogue: CC BY 4.0](https://img.shields.io/badge/catalogue-CC%20BY%204.0-blue.svg)](LICENSE)
+[![Code: MIT](https://img.shields.io/badge/code-MIT-green.svg)](LICENSE-CODE)
+
 An **open-source Business Architecture Reference Catalogue** covering three orthogonal artefacts: **business capabilities** (BC — what the enterprise does), **business processes** (BP — how it does it), and **value streams** (VS — end-to-end value delivery). An optional **macro-capability** overlay (MC — executive navigation grouping L1s) is provided for catalogues where the L1 layer is larger than the 10–20 sweet spot. It is intentionally tool-agnostic and can be used in any Enterprise Architecture management solution — well beyond [Turbo EA](https://www.turbo-ea.org). This site exists to help enterprise architects get started with the implementation of an EA function, by providing a curated, opinionated baseline that teams can adopt, adapt, and extend.
 
 <img width="1424" height="678" alt="Screenshot 2026-04-28 at 07 39 44" src="https://github.com/user-attachments/assets/f8deb601-74f2-4b39-92ba-d234ee0494b8" />
@@ -306,4 +309,15 @@ All responses are static, immutable per build, and cacheable by Cloudflare's edg
 
 ## Licence
 
-[MIT](LICENSE). Cross-Industry business processes are generated from value streams and the capabilities each stage exercises (BC + VS authoritative); APQC PCF® is retained as a secondary cross-walk on those nodes. Industry-specific business processes anchor on BIAN, TM Forum eTOM, ITIL®, SCOR®, ACORD, ICMM, COSO ERM, ISO 31000, ISO 55000, COBIT, SHRM-BoCK, TOGAF, BIZBOK, DCOR and the relevant APQC industry PCFs. All third-party framework attributions are listed in [NOTICE](NOTICE).
+This repository is **dual-licensed**, split along the data/code seam — see [LICENSING.md](LICENSING.md) for the authoritative path-by-path mapping.
+
+- **Catalogue content and documentation** — `catalogue/`, the generated JSON artefacts, this README, and the governance model — are licensed under [CC BY 4.0](LICENSE). Free to use, adapt, and redistribute commercially, provided you credit the source and indicate changes.
+- **Tooling** — `scripts/`, `schema/`, `site/`, the Python library modules, and the Claude skills — is licensed under [MIT](LICENSE-CODE).
+
+When you share or adapt the catalogue, credit:
+
+> Turbo EA Capabilities by Vincent Verdet — Turbo EA, <https://github.com/vincentmakes/turbo-ea-capabilities>, CC BY 4.0
+
+The same string is served in `/api/version.json` (`attribution`) for programmatic consumers.
+
+Cross-Industry business processes are generated from value streams and the capabilities each stage exercises (BC + VS authoritative); APQC PCF® is retained as a secondary cross-walk on those nodes. Industry-specific business processes anchor on BIAN, TM Forum eTOM, ITIL®, SCOR®, ACORD, ICMM, COSO ERM, ISO 31000, ISO 55000, COBIT, SHRM-BoCK, TOGAF, BIZBOK, DCOR and the relevant APQC industry PCFs. All third-party framework attributions are listed in [NOTICE](NOTICE).

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "description": "Reference Business Capability catalogue for Turbo EA - YAML source of truth, JSON build artifacts, Astro site, and Python package.",
-  "license": "MIT",
+  "license": "CC-BY-4.0 AND MIT",
   "type": "module",
   "engines": {
     "node": ">=20.0.0"

--- a/packages/py/README.md
+++ b/packages/py/README.md
@@ -107,3 +107,21 @@ Pin against `SCHEMA_VERSION` to detect breaking shape changes; pin against `VERS
 ## Source
 
 The catalogue YAML and build pipeline live at <https://github.com/vincentmakes/turbo-ea-capabilities>.
+
+## License
+
+Dual-licensed, split along the data/code seam:
+
+- The **bundled catalogue data** (`turbo_ea_capabilities/data/*.json`) is licensed under
+  [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). Free to use, adapt, and
+  redistribute commercially, provided you credit the source and indicate changes.
+- The **library code** is licensed under MIT.
+
+When you share or adapt the catalogue, credit:
+
+> Turbo EA Capabilities by Vincent Verdet — Turbo EA,
+> <https://github.com/vincentmakes/turbo-ea-capabilities>, CC BY 4.0
+
+The same string is available programmatically — the bundled `version.json` carries `license`,
+`license_url`, and `attribution` fields. Full terms:
+[LICENSING.md](https://github.com/vincentmakes/turbo-ea-capabilities/blob/main/LICENSING.md).

--- a/packages/py/pyproject.toml
+++ b/packages/py/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.21"]
+requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
 [project]
@@ -8,13 +8,15 @@ dynamic = ["version"]
 description = "Reference Business Capability catalogue for Turbo EA - bundled JSON, no network access required."
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "MIT" }
+# Dual-licensed: the bundled JSON catalogue under data/ is CC BY 4.0, the
+# library modules are MIT. See LICENSING.md at the repository root.
+license = "CC-BY-4.0 AND MIT"
+license-files = ["LICENSE", "LICENSE-CODE", "NOTICE"]
 authors = [{ name = "Turbo EA Maintainers" }]
 keywords = ["enterprise-architecture", "business-capability", "togaf", "catalogue"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
@@ -61,6 +63,9 @@ include = [
     "/src",
     "/tests",
     "/README.md",
+    "/LICENSE",
+    "/LICENSE-CODE",
+    "/NOTICE",
 ]
 
 [tool.pytest.ini_options]

--- a/packages/py/src/turbo_ea_capabilities/__init__.py
+++ b/packages/py/src/turbo_ea_capabilities/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Reference Business Architecture catalogue.
 
 Three artefact types are exposed: capabilities (BC), business processes (BP),

--- a/packages/py/src/turbo_ea_capabilities/_loader.py
+++ b/packages/py/src/turbo_ea_capabilities/_loader.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Load the bundled JSON catalogue via importlib.resources.
 
 `importlib.resources.files()` works correctly with wheels, editable installs,

--- a/packages/py/src/turbo_ea_capabilities/_models.py
+++ b/packages/py/src/turbo_ea_capabilities/_models.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Pydantic v2 models for the catalogue artefacts (capabilities, business
 processes, value streams).
 

--- a/packages/py/src/turbo_ea_capabilities/_version.py
+++ b/packages/py/src/turbo_ea_capabilities/_version.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Hatch version source.
 
 Reads the catalogue version from the bundled `data/version.json` file. Falls

--- a/schema/business-process.schema.json
+++ b/schema/business-process.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "SPDX-License-Identifier: MIT",
   "$id": "https://business-capabilities.turbo-ea.org/schema/business-process.schema.json",
   "title": "BusinessProcess",
   "description": "Reference schema for a Business Process node. Source files are YAML; this schema validates the parsed structure for a single BP1 file (a tree rooted at one BP1 process category). Business processes describe HOW work is done, anchored on APQC PCF's Category → Process Group → Process → Activity hierarchy. They are an artefact orthogonal to capabilities (BC) and value streams (VS); cross-references go via `realizes_capability_ids` and via VS-stage `process_ids`.",

--- a/schema/capability.schema.json
+++ b/schema/capability.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "SPDX-License-Identifier: MIT",
   "$id": "https://business-capabilities.turbo-ea.org/schema/capability.schema.json",
   "title": "BusinessCapability",
   "description": "Reference schema for a Business Capability node. Source files are YAML; this schema validates the parsed structure for a single L1 file (a tree rooted at one L1 capability).",

--- a/schema/i18n.schema.json
+++ b/schema/i18n.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "SPDX-License-Identifier: MIT",
   "$id": "https://business-capabilities.turbo-ea.org/schema/i18n.schema.json",
   "title": "ArtefactTranslations",
   "description": "Sidecar translation file. One file per (locale, source) tuple. The optional `kind` field selects the artefact this sidecar translates (capability | value-stream | business-process | macro-capability). Default is 'capability' for back-compat with pre-VS/BP sidecars. Identifiers, levels, industry tags, references, framework refs, and lifecycle metadata stay locale-neutral in the source YAML.",

--- a/schema/macro-capability.schema.json
+++ b/schema/macro-capability.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "SPDX-License-Identifier: MIT",
   "$id": "https://business-capabilities.turbo-ea.org/schema/macro-capability.schema.json",
   "title": "MacroCapabilityCatalogue",
   "description": "Reference schema for catalogue/_macro-capabilities.yaml. Macro capabilities are an executive-friendly navigation overlay above L1: each macro names a small set of L1 Business Capabilities it groups. Macros do not enter the BC tree (the L1 trees are unchanged) and do not participate in value-stream or business-process links. Same orthogonal-artefact pattern as value streams.",

--- a/schema/value-stream.schema.json
+++ b/schema/value-stream.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "SPDX-License-Identifier: MIT",
   "$id": "https://business-capabilities.turbo-ea.org/schema/value-stream.schema.json",
   "title": "ValueStreamCatalogue",
   "description": "Reference schema for catalogue/_value-streams.yaml. Value streams are an artefact orthogonal to the capability hierarchy: each stream describes an end-to-end flow whose stages link to L1 capabilities (`capability_ids`) and to business processes that realize the work (`process_ids`).",

--- a/scripts/build_api.ts
+++ b/scripts/build_api.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// SPDX-License-Identifier: MIT
 /**
  * Build the static JSON API artefacts from the YAML source. Outputs:
  *   dist/api/version.json
@@ -244,6 +245,14 @@ const version = {
   generated_at: new Date().toISOString(),
   node_count: flatSorted.length,
   process_count: bpFlatSorted.length,
+  // Terms for the catalogue data these endpoints serve. CC BY 4.0 requires
+  // attribution to travel with the data, so it ships in the payload rather
+  // than living only in the repo. The tooling is MIT — see LICENSING.md.
+  license: "CC-BY-4.0",
+  code_license: "MIT",
+  license_url: "https://creativecommons.org/licenses/by/4.0/",
+  attribution:
+    "Turbo EA Capabilities by Vincent Verdet — Turbo EA (https://github.com/vincentmakes/turbo-ea-capabilities), CC BY 4.0",
   ...(commit && { commit }),
   ...(commitCount !== undefined && { commit_count: commitCount }),
 };

--- a/scripts/build_pkg.ts
+++ b/scripts/build_pkg.ts
@@ -1,11 +1,16 @@
 #!/usr/bin/env tsx
+// SPDX-License-Identifier: MIT
 /**
  * Populate the Python package's data directory from the YAML source.
  * Runs build_api.ts first (so dist/api/version.json drives both outputs),
  * then copies the runtime files. Translation data is copied additively under
  * data/i18n/<locale>.json and only when present.
  *
- * `data/**` is gitignored. Re-run before `python -m build`.
+ * Also stages the root LICENSE / LICENSE-CODE / NOTICE into packages/py/ so
+ * hatchling's `license-files` can resolve them.
+ *
+ * `data/**` and the staged licence files are gitignored. Re-run before
+ * `python -m build`.
  */
 import { execSync } from "node:child_process";
 import { copyFileSync, existsSync, mkdirSync, readdirSync } from "node:fs";
@@ -46,6 +51,19 @@ for (const f of filesToCopy) {
   copyFileSync(src, dst);
 }
 
+// Licence files. `license-files` in pyproject.toml resolves relative to
+// packages/py/, but the canonical copies live at the repo root — so stage them
+// here (gitignored, like data/) before `python -m build` runs.
+const PKG_ROOT = join(REPO_ROOT, "packages", "py");
+const licenceFiles = ["LICENSE", "LICENSE-CODE", "NOTICE"];
+for (const f of licenceFiles) {
+  const src = join(REPO_ROOT, f);
+  if (!existsSync(src)) {
+    throw new Error(`Expected ${src} to exist (required by pyproject license-files)`);
+  }
+  copyFileSync(src, join(PKG_ROOT, f));
+}
+
 // Optional: macro-capabilities.json. Older snapshots may not have it; the
 // wheel uses _read_optional_json to load it, so missing-on-disk is fine.
 const macroSrc = join(DIST_API, "macro-capabilities.json");
@@ -82,3 +100,4 @@ if (macrosCopied) {
 if (localeFiles.length) {
   console.log(`  + locales: ${localeFiles.join(", ")}`);
 }
+console.log(`  + ${licenceFiles.join(", ")} → packages/py/`);

--- a/scripts/cli/_shared.ts
+++ b/scripts/cli/_shared.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import YAML from "yaml";

--- a/scripts/cli/add.ts
+++ b/scripts/cli/add.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// SPDX-License-Identifier: MIT
 /**
  * Add a new capability under an existing parent.
  *

--- a/scripts/cli/bp_add.ts
+++ b/scripts/cli/bp_add.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// SPDX-License-Identifier: MIT
 /**
  * Add a new business process under an existing parent.
  *

--- a/scripts/cli/bp_bootstrap_bp1.ts
+++ b/scripts/cli/bp_bootstrap_bp1.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// SPDX-License-Identifier: MIT
 /**
  * Create a new BP1 file (root of a process category) and register it in
  * `catalogue/processes/_index.yaml`. Used by /generate-process when

--- a/scripts/cli/bp_deprecate.ts
+++ b/scripts/cli/bp_deprecate.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// SPDX-License-Identifier: MIT
 /**
  * Mark a business process deprecated.
  *

--- a/scripts/cli/bp_mv.ts
+++ b/scripts/cli/bp_mv.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// SPDX-License-Identifier: MIT
 /**
  * Move a business-process subtree under a new parent. Whole subtree is
  * renumbered to fit under the new parent. The old id is recorded in

--- a/scripts/cli/bp_relink_vs.ts
+++ b/scripts/cli/bp_relink_vs.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// SPDX-License-Identifier: MIT
 /**
  * Rewrite `process_ids` in `catalogue/_value-streams.yaml` according to
  * a {oldBpId: newBpId | null} mapping. Used after Cross-Industry BPs are

--- a/scripts/cli/bp_wipe_cross_industry_oneoff.ts
+++ b/scripts/cli/bp_wipe_cross_industry_oneoff.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// SPDX-License-Identifier: MIT
 /**
  * One-off: delete the 13 Cross-Industry BP1 files (BP-10..BP-120, BP-370),
  * their entries in `processes/_index.yaml`, and their sidecar translations

--- a/scripts/cli/check_bc_coverage.ts
+++ b/scripts/cli/check_bc_coverage.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// SPDX-License-Identifier: MIT
 /**
  * BC coverage check: every Cross-Industry BC L1 should have at least one
  * BP node with `realizes_capability_ids` claiming it. Reports orphans

--- a/scripts/cli/check_i18n_coverage.ts
+++ b/scripts/cli/check_i18n_coverage.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// SPDX-License-Identifier: MIT
 /**
  * i18n coverage check: report which (BP1 × locale) sidecar files are
  * missing and which locales are missing capability or value-stream

--- a/scripts/cli/check_macro_coverage.ts
+++ b/scripts/cli/check_macro_coverage.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// SPDX-License-Identifier: MIT
 /**
  * Macro coverage check: every Cross-Industry BC L1 should belong to exactly
  * one macro capability in catalogue/_macro-capabilities.yaml. Reports:

--- a/scripts/cli/deprecate.ts
+++ b/scripts/cli/deprecate.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// SPDX-License-Identifier: MIT
 /**
  * Mark a capability deprecated.
  *

--- a/scripts/cli/fix_slash_names_oneoff.ts
+++ b/scripts/cli/fix_slash_names_oneoff.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// SPDX-License-Identifier: MIT
 /**
  * One-off cleanup: fix APQC's slash-and-virgule names that read awkwardly
  * ("Produce/Assemble Product", "Service/solution", "Set/Develop Long-term

--- a/scripts/cli/i18n_stamp.ts
+++ b/scripts/cli/i18n_stamp.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// SPDX-License-Identifier: MIT
 /**
  * Stamp `source_hash` on every sidecar entry whose source can be resolved.
  *

--- a/scripts/cli/mc_add.ts
+++ b/scripts/cli/mc_add.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// SPDX-License-Identifier: MIT
 /**
  * Add a new macro capability to catalogue/_macro-capabilities.yaml.
  *

--- a/scripts/cli/mv.ts
+++ b/scripts/cli/mv.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// SPDX-License-Identifier: MIT
 /**
  * Move a capability subtree under a new parent. The whole subtree is renumbered
  * to fit under the new parent. The old id is recorded in metadata.replaces so

--- a/scripts/cli/relink_vs_explicit_oneoff.ts
+++ b/scripts/cli/relink_vs_explicit_oneoff.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// SPDX-License-Identifier: MIT
 /**
  * Third pass: apply explicit per-VS-stage-id overrides to set
  * `process_ids` on residual orphan stages whose stage_name doesn't match

--- a/scripts/cli/relink_vs_oneoff.ts
+++ b/scripts/cli/relink_vs_oneoff.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// SPDX-License-Identifier: MIT
 /**
  * One-off: re-point VS stage `process_ids` at the new BP tree where the
  * existing references are broken (i.e. point at deleted Cross-Industry

--- a/scripts/cli/relink_vs_orphans_oneoff.ts
+++ b/scripts/cli/relink_vs_orphans_oneoff.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// SPDX-License-Identifier: MIT
 /**
  * Second pass: relink the residual orphan VS stages — stages whose
  * `process_ids` are still empty after the first relink_vs_oneoff pass.

--- a/scripts/cli/strip_aliases_oneoff.ts
+++ b/scripts/cli/strip_aliases_oneoff.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// SPDX-License-Identifier: MIT
 /**
  * One-off cleanup: strip `aliases` from every node in every Cross-Industry
  * BP1 file. Use after Phase 2 renaming concludes; leaves names, descriptions,

--- a/scripts/cli/vs_add.ts
+++ b/scripts/cli/vs_add.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// SPDX-License-Identifier: MIT
 /**
  * Add a new value stream to catalogue/_value-streams.yaml.
  *

--- a/scripts/cli/vs_add_stage.ts
+++ b/scripts/cli/vs_add_stage.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// SPDX-License-Identifier: MIT
 /**
  * Add a stage to an existing value stream.
  *

--- a/scripts/cli/vs_deprecate.ts
+++ b/scripts/cli/vs_deprecate.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// SPDX-License-Identifier: MIT
 /**
  * Mark a value stream deprecated.
  *

--- a/scripts/lib/i18n_hash.ts
+++ b/scripts/lib/i18n_hash.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /**
  * Canonical hash of an artefact node's translatable surface.
  *

--- a/scripts/lib/load.ts
+++ b/scripts/lib/load.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 import { readFileSync, readdirSync, existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 import YAML from "yaml";

--- a/scripts/lint.ts
+++ b/scripts/lint.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// SPDX-License-Identifier: MIT
 /**
  * Lint the YAML catalogue. Validates capabilities (BC), value streams (VS),
  * business processes (BP), and translation sidecars against their JSON

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 import { defineConfig } from "astro/config";
 import react from "@astrojs/react";
 import { fileURLToPath } from "node:url";

--- a/site/package.json
+++ b/site/package.json
@@ -2,6 +2,7 @@
   "name": "turbo-ea-capabilities-site",
   "version": "0.1.0",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "astro dev",

--- a/site/src/components/CatalogueBrowser.tsx
+++ b/site/src/components/CatalogueBrowser.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /**
  * Backwards-compatible wrapper around the generic catalogue browser.
  * Existing callers (`/`, `/l1/[slug]`) keep working unchanged; the heavy

--- a/site/src/components/HeroTessellation.astro
+++ b/site/src/components/HeroTessellation.astro
@@ -1,4 +1,5 @@
 ---
+// SPDX-License-Identifier: MIT
 interface Props {
   badge?: string;
   title: string;

--- a/site/src/components/catalog/CatalogBrowser.tsx
+++ b/site/src/components/catalog/CatalogBrowser.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 import { useEffect, useMemo, useRef, useState } from "react";
 import { FilterBar } from "./FilterBar";
 import {

--- a/site/src/components/catalog/FilterBar.tsx
+++ b/site/src/components/catalog/FilterBar.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 import { useEffect, useRef, useState } from "react";
 
 interface FilterBarProps {

--- a/site/src/components/catalog/exporters.ts
+++ b/site/src/components/catalog/exporters.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 import type { FlatNode } from "./types";
 
 /** Compare ids by their numeric segments after the leading `XX-` prefix.

--- a/site/src/components/catalog/types.ts
+++ b/site/src/components/catalog/types.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /**
  * Shared types for the generic catalogue browser. All three artefacts
  * (capabilities, business processes, value streams) flatten into the same

--- a/site/src/data/load.ts
+++ b/site/src/data/load.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /**
  * Build-time data loader: reads the JSON artefacts produced by
  * `scripts/build_api.ts`. The Astro site fails fast at build time if these
@@ -29,6 +30,10 @@ export interface VersionMeta {
   node_count: number;
   process_count?: number;
   commit?: string;
+  license?: string;
+  code_license?: string;
+  license_url?: string;
+  attribution?: string;
 }
 
 export interface ValueStreamStage {

--- a/site/src/data/value-streams-as-tree.ts
+++ b/site/src/data/value-streams-as-tree.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /**
  * Adapter: flatten the value-stream catalogue into the same `FlatNode` shape
  * the generic `CatalogBrowser` consumes. Each stream becomes an L1 node.

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -1,4 +1,5 @@
 ---
+// SPDX-License-Identifier: MIT
 import "../styles/global.css";
 import "../styles/catalogue.css";
 import { valueStreams, version } from "../data/load.ts";
@@ -20,6 +21,11 @@ const pageDescription =
   "Open Enterprise Architecture Reference Catalog — capabilities, business processes, and value streams in one searchable, exportable model.";
 const navClass = navTransparent ? "nav nav-transparent" : "nav";
 const generatedDate = version.generated_at.slice(0, 10);
+// Licence terms travel in version.json (build_api.ts). Fall back for older
+// snapshots that pre-date those fields.
+const dataLicense = version.license === "CC-BY-4.0" ? "CC BY 4.0" : (version.license ?? "CC BY 4.0");
+const codeLicense = version.code_license ?? "MIT";
+const licenseUrl = version.license_url ?? "https://creativecommons.org/licenses/by/4.0/";
 ---
 
 <!doctype html>
@@ -40,6 +46,7 @@ const generatedDate = version.generated_at.slice(0, 10);
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,500,0,0&icon_names=account_tree,add,arrow_upward,chevron_right,close,expand_more,label_important,menu,remove,route"
     />
     <link rel="icon" type="image/png" href="/favicon.png" />
+    <link rel="license" href={licenseUrl} />
     <meta property="og:title" content={pageTitle} />
     <meta property="og:description" content={pageDescription} />
     <meta property="og:type" content="website" />
@@ -160,6 +167,11 @@ const generatedDate = version.generated_at.slice(0, 10);
             target="_blank"
             rel="noopener">PyPI</a
           >
+          <a
+            href="https://github.com/vincentmakes/turbo-ea-capabilities/blob/main/LICENSING.md"
+            target="_blank"
+            rel="license noopener">Licence</a
+          >
           <iframe
             src="https://github.com/sponsors/vincentmakes/button"
             title="Sponsor vincentmakes"
@@ -173,6 +185,11 @@ const generatedDate = version.generated_at.slice(0, 10);
           {version.node_count} capabilities{version.process_count ? ` · ${version.process_count} processes` : ""}
           {streamCount > 0 ? ` · ${streamCount} value streams` : ""} ·
           generated {generatedDate}
+        </div>
+        <div class="footer-copy">
+          © 2026 Vincent Verdet — Turbo EA · catalogue
+          <a href={licenseUrl} target="_blank" rel="license noopener">{dataLicense}</a> ·
+          code {codeLicense}
         </div>
       </div>
     </footer>

--- a/site/src/pages/404.astro
+++ b/site/src/pages/404.astro
@@ -1,4 +1,5 @@
 ---
+// SPDX-License-Identifier: MIT
 import Base from "../layouts/Base.astro";
 ---
 

--- a/site/src/pages/api/capabilities.json.ts
+++ b/site/src/pages/api/capabilities.json.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 import type { APIRoute } from "astro";
 import { flat } from "../../data/load.ts";
 

--- a/site/src/pages/api/macro-capabilities.json.ts
+++ b/site/src/pages/api/macro-capabilities.json.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 import type { APIRoute } from "astro";
 import { macros } from "../../data/load.ts";
 

--- a/site/src/pages/api/tree.json.ts
+++ b/site/src/pages/api/tree.json.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 import type { APIRoute } from "astro";
 import { tree } from "../../data/load.ts";
 

--- a/site/src/pages/api/version.json.ts
+++ b/site/src/pages/api/version.json.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 import type { APIRoute } from "astro";
 import { version } from "../../data/load.ts";
 

--- a/site/src/pages/bp1/[slug].astro
+++ b/site/src/pages/bp1/[slug].astro
@@ -1,4 +1,5 @@
 ---
+// SPDX-License-Identifier: MIT
 import Base from "../../layouts/Base.astro";
 import { bp1List, bpFlat, getBpById } from "../../data/load.ts";
 

--- a/site/src/pages/business-process/[id].astro
+++ b/site/src/pages/business-process/[id].astro
@@ -1,4 +1,5 @@
 ---
+// SPDX-License-Identifier: MIT
 import Base from "../../layouts/Base.astro";
 import { bpFlat, getBpById, getBpAncestors, getStageById, getById } from "../../data/load.ts";
 

--- a/site/src/pages/business-processes.astro
+++ b/site/src/pages/business-processes.astro
@@ -1,4 +1,5 @@
 ---
+// SPDX-License-Identifier: MIT
 import Base from "../layouts/Base.astro";
 import HeroTessellation from "../components/HeroTessellation.astro";
 import CatalogBrowser from "../components/catalog/CatalogBrowser.tsx";

--- a/site/src/pages/capabilities.astro
+++ b/site/src/pages/capabilities.astro
@@ -1,4 +1,5 @@
 ---
+// SPDX-License-Identifier: MIT
 import Base from "../layouts/Base.astro";
 import HeroTessellation from "../components/HeroTessellation.astro";
 import CatalogueBrowser from "../components/CatalogueBrowser.tsx";

--- a/site/src/pages/capability/[id].astro
+++ b/site/src/pages/capability/[id].astro
@@ -1,4 +1,5 @@
 ---
+// SPDX-License-Identifier: MIT
 import Base from "../../layouts/Base.astro";
 import { flat, getById, getAncestors, getBpById, getMacroById, getStageById } from "../../data/load.ts";
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+// SPDX-License-Identifier: MIT
 import Base from "../layouts/Base.astro";
 import HeroTessellation from "../components/HeroTessellation.astro";
 import { bpFlat, flat, macros, valueStreams, version } from "../data/load.ts";

--- a/site/src/pages/l1/[slug].astro
+++ b/site/src/pages/l1/[slug].astro
@@ -1,4 +1,5 @@
 ---
+// SPDX-License-Identifier: MIT
 import Base from "../../layouts/Base.astro";
 import CatalogueBrowser from "../../components/CatalogueBrowser.tsx";
 import { l1List, flat, valueStreams } from "../../data/load.ts";

--- a/site/src/pages/macro/[slug].astro
+++ b/site/src/pages/macro/[slug].astro
@@ -1,4 +1,5 @@
 ---
+// SPDX-License-Identifier: MIT
 import Base from "../../layouts/Base.astro";
 import CatalogueBrowser from "../../components/CatalogueBrowser.tsx";
 import {

--- a/site/src/pages/search.astro
+++ b/site/src/pages/search.astro
@@ -1,4 +1,5 @@
 ---
+// SPDX-License-Identifier: MIT
 import Base from "../layouts/Base.astro";
 import CatalogueBrowser from "../components/CatalogueBrowser.tsx";
 import { flat, valueStreams } from "../data/load.ts";

--- a/site/src/pages/value-streams.astro
+++ b/site/src/pages/value-streams.astro
@@ -1,4 +1,5 @@
 ---
+// SPDX-License-Identifier: MIT
 import Base from "../layouts/Base.astro";
 import HeroTessellation from "../components/HeroTessellation.astro";
 import CatalogBrowser from "../components/catalog/CatalogBrowser.tsx";

--- a/site/src/styles/catalogue.css
+++ b/site/src/styles/catalogue.css
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT */
 /* Catalog-specific UI built on top of global.css design tokens. */
 
 /* Material Symbols (icon font) — matches the Material UI convention */

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT */
 /* ============================================
    Architecting Tomorrow - Unified Stylesheet
    https://www.turbo-ea.org/blog

--- a/style.css
+++ b/style.css
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT */
 /* ============================================
    Architecting Tomorrow - Unified Stylesheet
    https://www.turbo-ea.org/blog


### PR DESCRIPTION
## Summary

Restructure the repository's licensing model to reflect the dual nature of the project: the **catalogue content** (YAML source, JSON API, bundled data) is now licensed under **CC BY 4.0**, while the **tooling** (build scripts, schemas, site source, Python library, Claude skills) remains under **MIT**. This change clarifies licensing intent and enables broader reuse of the reference model while protecting the codebase.

## Key Changes

- **LICENSE** → replaced with full CC BY 4.0 text; added dual-licensing header and required attribution string
- **LICENSE-CODE** (new) → MIT license for tooling; mirrors the original LICENSE structure
- **LICENSING.md** (new) → authoritative path-by-path mapping table; specifies which files fall under which license; documents required attribution for catalogue consumers
- **NOTICE** → updated to reflect dual licensing and clarify attribution requirements for CC BY 4.0 compliance
- **SPDX headers** → added `// SPDX-License-Identifier: MIT` to all TypeScript/JavaScript/Python source files and JSON schemas; CSS files use `/* SPDX-License-Identifier: MIT */`
- **build_api.ts** → now populates `version.json` with `license`, `code_license`, `license_url`, and `attribution` fields for programmatic consumption by downstream consumers
- **build_pkg.ts** → stages root LICENSE/LICENSE-CODE/NOTICE files into `packages/py/` so hatchling's `license-files` can resolve them during Python package build
- **pyproject.toml** → updated license field to `"CC-BY-4.0 AND MIT"` with explanatory comment; bumped hatchling requirement to ≥1.27 for proper dual-license support
- **site/src/layouts/Base.astro** → reads licence terms from `version.json` with fallback to CC BY 4.0 for older snapshots
- **packages/py/README.md** → added License section documenting dual licensing and attribution requirements
- **.gitignore** → added entries for staged licence files in `packages/py/`
- **CODEOWNERS** → added licence files to EA lead review requirement
- **README.md** → added dual-license badges (CC BY 4.0 for catalogue, MIT for code)
- **site/package.json** → added explicit `"license": "MIT"` field

## Implementation Details

- The catalogue content (YAML, generated JSON, bundled Python data) is identified as CC BY 4.0 in LICENSING.md; all other paths default to MIT
- Attribution string (`"Turbo EA Capabilities by Vincent Verdet — Turbo EA, https://github.com/vincentmakes/turbo-ea-capabilities, CC BY 4.0"`) is embedded in `version.json` and documented in LICENSING.md for easy discovery by API consumers
- Licence files are staged into the Python package at build time (not committed) to satisfy hatchling's `license-files` glob without duplicating canonical copies
- SPDX identifiers follow standard format: single-line headers in source files, `$comment` field in JSON schemas
- No changes to catalogue YAML files themselves — they remain the single source of truth and carry no headers per LICENSING.md (the table is authoritative)

https://claude.ai/code/session_01TGawE3dzcriY6KqZZPjH3z